### PR TITLE
feat(asm): add the x86-64 indirect `call` forms, and give `.byte` its own bound

### DIFF
--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -42,6 +42,47 @@ pub fun add_via_asm(a: i64, b: i64) i64 {
 }
 ```
 
+## Calls (x86-64)
+
+`call` takes three shapes, and which one a statement means is read off the
+operand:
+
+```mach
+asm x86_64 {
+    call some_symbol     # direct: E8 rel32, relocated against the symbol
+    call rax             # indirect through a register: FF /2, mod=11
+    call [0x100018]      # indirect through an absolute address: ff 14 25 <disp32>
+    call [rax + 8]       # indirect through a computed address
+}
+```
+
+The absolute form exists for a fixed-address ABI — one whose entry points are
+addresses rather than symbols, like BareMetal's kernel call table at
+`0x100010..0x100040`. Its displacement is sign-extended to 64 bits, so an address
+outside signed 32-bit range is refused rather than silently truncated. `call
+[symbol]` is refused too: the rip-relative form would mean "call the pointer
+*stored* at the symbol", which is not what the `call symbol` beside it means.
+
+An indirect call clobbers exactly as a direct one does — the callee's caller-saved
+registers, which the surrounding block's barrier already covers. The register or
+memory holding the target is **read**, not written.
+
+## Raw bytes
+
+`.byte` emits its values verbatim, for an encoding the ISA's mnemonic table does
+not name:
+
+```mach
+asm x86_64 {
+    .byte 0x0f, 0x01, 0xd0    # xgetbv
+}
+```
+
+One directive carries a whole sequence (up to 256 values), not four. A value that
+does not fit in a byte is refused. Raw bytes are an instruction stream the parser
+cannot read, so the block's clobber set becomes **every register in every bank** —
+which is why a real mnemonic is always preferable where one exists.
+
 ## What the compiler infers
 
 - **Operand direction.** Position within an instruction determines whether

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -119,6 +119,7 @@ pub val AOF_HAS_INDEX: u8 = 0x04;  # a memory operand carries an index register
 pub val AOF_WRITEBACK: u8 = 0x08;  # the access writes its updated base register back
 pub val AOF_STACK_PTR: u8 = 0x10;  # the register names the stack pointer, not the zero register
 pub val AOF_WIDE:      u8 = 0x20;  # the index register is the wide (64-bit) form
+pub val AOF_MEM_ABS:   u8 = 0x40;  # a memory operand addresses an absolute constant (`imm` set, no base, no index)
 
 # a parsed inline-asm operand
 #
@@ -743,18 +744,60 @@ fun split_ops(c: *Cursor, lo: usize, hi: usize, s: *Stmt) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# decode a raw byte directive's payload, claiming each value and separator
-fun parse_bytes(c: *Cursor, s: *Stmt, item: *Item) R.Result[bool, str] {
+# decode a raw byte directive's payload from `body[lo..hi)`, claiming each value and
+# separator
+#
+# `.byte` is a directive, not an instruction: its payload is a byte sequence, not an
+# operand list, so it splits here rather than through `split_ops` and is bounded by
+# `BYTES_MAX` rather than by `MAX_OPS`. Routing it through the operand splitter is
+# what capped a byte sequence at four (#2398) - a limit that belongs to instruction
+# operands, where four is a real machine fact, and means nothing here.
+#
+# A value outside a byte's range is refused rather than truncated: `.byte 0x1FF`
+# naming one byte is a typo, and silently emitting 0xFF makes it an instruction
+# stream nobody wrote.
+fun parse_bytes(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[bool, str] {
     item.kind = AI_BYTES;
-    var i: u32 = 0;
-    for (i < s.nargs) {
-        val v: O.Option[i64] = region_i64(c.body, s.arg_lo[i::usize], s.arg_hi[i::usize]);
-        if (!O.is_some[i64](v)) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
-        item.bytes[item.byte_count] = O.unwrap[i64](v)::u8;
-        item.byte_count = item.byte_count + 1;
+
+    var a: usize = lo;
+    for (a < hi && is_space(c.body[a])) { a = a + 1; }
+
+    var start: usize = a;
+    var i: usize = a;
+    for (i <= hi) {
+        var sep: bool = false;
+        if (i == hi)                    { sep = true; }
+        or (c.body[i] == ','::char)     { sep = true; }
+
+        if (sep) {
+            if (item.byte_count >= BYTES_MAX) {
+                ret R.err[bool, str](span_message(c,
+                    "encode: inline-asm directive '", lo, hi, "' names more bytes than a statement can carry",
+                    "encode: an inline-asm .byte directive names more bytes than a statement can carry"));
+            }
+            var ta: usize = start;
+            var tb: usize = i;
+            for (ta < tb && is_space(c.body[ta])) { ta = ta + 1; }
+            for (tb > ta && is_space(c.body[tb - 1])) { tb = tb - 1; }
+            if (tb <= ta) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
+
+            val v: O.Option[i64] = region_i64(c.body, ta, tb);
+            if (!O.is_some[i64](v)) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
+            val b: i64 = O.unwrap[i64](v);
+            if (b < -128 || b > 255) { ret R.err[bool, str]("encode: inline-asm .byte value does not fit in a byte"); }
+
+            val cr: R.Result[bool, str] = claim(c, ta, tb - ta);
+            if (R.is_err[bool, str](cr)) { ret cr; }
+            item.bytes[item.byte_count] = b::u8;
+            item.byte_count = item.byte_count + 1;
+            if (i < hi) {
+                val cc: R.Result[bool, str] = claim(c, i, 1);
+                if (R.is_err[bool, str](cc)) { ret cc; }
+            }
+            start = i + 1;
+        }
         i = i + 1;
     }
-    if (item.byte_count == 0) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
     ret R.ok[bool, str](true);
 }
 
@@ -844,15 +887,17 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
     item.implicit = s.m.implicit;
     item.words    = s.m.words;
 
+    # a raw byte payload is not an operand list, so it never reaches the operand
+    # splitter and is bounded by `BYTES_MAX` instead of `MAX_OPS`.
+    if (s.m.form == AF_BYTES) {
+        val br: R.Result[bool, str] = parse_bytes(c, lo + mlen, hi, item);
+        if (R.is_err[bool, str](br)) { ret R.err[usize, str](R.unwrap_err[bool, str](br)); }
+        ret R.ok[usize, str](hi);
+    }
+
     if (s.m.form != AF_NONE) {
         val sr: R.Result[bool, str] = split_ops(c, lo + mlen, hi, ?s);
         if (R.is_err[bool, str](sr)) { ret R.err[usize, str](R.unwrap_err[bool, str](sr)); }
-    }
-
-    if (s.m.form == AF_BYTES) {
-        val br: R.Result[bool, str] = parse_bytes(c, ?s, item);
-        if (R.is_err[bool, str](br)) { ret R.err[usize, str](R.unwrap_err[bool, str](br)); }
-        ret R.ok[usize, str](hi);
     }
 
     item.nops = s.nargs;

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -324,6 +324,21 @@ pub val FLAG_REP:      EncFlag = 8;
 # the memory operand is an indirect access through the named register
 pub val FLAG_INDIRECT: EncFlag = 16;
 
+# the `isa.Operand.base` value naming x86-64's second register-less addressing form
+#
+# x86-64 has two memory forms that name no base register, and `base` is where they
+# are told apart. The shared model's "no base" (-1) is the RIP-RELATIVE form
+# `[rip + disp32]` - what lowering produces for every symbol reference, encoded
+# mod=00 rm=101. `MEM_BASE_ABS` is the ABSOLUTE form `[disp32]`, which cannot reuse
+# that encoding and takes the SIB escape instead (mod=00 rm=100, SIB base=101
+# index=100), giving the `<opcode> 14 25 <disp32>` shape. The displacement is
+# sign-extended to 64 bits, so only a signed-32-bit address is reachable.
+#
+# Only inline asm builds one: a Mach-level address is a symbol the linker relocates,
+# never a bare constant. It exists because a fixed-address ABI (BareMetal's kernel
+# call table at 0x100010..0x100040) is reachable no other way.
+pub val MEM_BASE_ABS: i32 = -2;
+
 # report whether an opcode operates on the SSE register file
 #
 # the floating-point opcodes occupy two contiguous ranges (the MOVSS..DIVSD

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -169,8 +169,8 @@ fun needs_rex_for_byte_reg(reg: i32) bool {
 }
 
 # emit ModR/M + optional SIB + displacement for a memory
-# operand. handles the RBP/R13 disp-0 (mod=1, disp8=0), RSP/R12 forced-SIB, and
-# rip-relative (mod=0, rm=5) special cases
+# operand. handles the RBP/R13 disp-0 (mod=1, disp8=0), RSP/R12 forced-SIB,
+# rip-relative (mod=0, rm=5), and absolute (mod=0, rm=4 + SIB 0x25) special cases
 # ---
 # buf: byte sink
 # reg: value for the ModR/M reg field (register id or opcode extension)
@@ -184,12 +184,25 @@ fun encode_mem_operand(buf: *enc.ByteBuf, reg: i32, op: *isa.Operand) {
     # a memory base / scaled index is always a general-purpose register: x86-64 has
     # no SSE-register addressing form. an XMM-class base or index reaching here is a
     # register-allocation / lowering bug (it would silently encode the GP register
-    # that aliases the XMM index), rejected loudly rather than mis-encoded.
-    if (base != -1 && isa.regid_class(base) != isa.REG_CLASS_ID_GP) {
+    # that aliases the XMM index), rejected loudly rather than mis-encoded. the two
+    # register-less bases (-1 rip-relative, MEM_BASE_ABS absolute) name no register
+    # at all, so neither carries a class to check.
+    if (base != -1 && base != x64.MEM_BASE_ABS && isa.regid_class(base) != isa.REG_CLASS_ID_GP) {
         panic("encode: memory base register is not general-purpose\n");
     }
     if (has_index && isa.regid_class(index) != isa.REG_CLASS_ID_GP) {
         panic("encode: memory index register is not general-purpose\n");
+    }
+
+    # an absolute address: mod=00 rm=100 escapes to a SIB naming neither base
+    # (base=101 with mod=00) nor index (index=100), leaving a bare sign-extended
+    # disp32. mod=00 rm=101 cannot be reused - in 64-bit mode that is rip-relative.
+    if (base == x64.MEM_BASE_ABS) {
+        if (has_index) { panic("encode: absolute memory operand carries an index register\n"); }
+        enc.emit_byte(buf, encode_modrm(0, reg_bits(reg), 4));
+        enc.emit_byte(buf, encode_sib(0, 4, 5));
+        enc.emit_u32(buf, disp::u32);
+        ret;
     }
 
     if (base == -1 && !has_index) {
@@ -2340,7 +2353,9 @@ fun emit_epilogue(st: *enc.EncodeState, frame_size: u32, callee_mask: u32, calle
 # true when a memory operand is the rip-relative form `[rip + disp32]`
 # - a base of -1 with no scaled index, which `encode_mem_operand` encodes as the
 # mod=0, rm=5 displacement-only addressing mode. a symbol reference lowers to this
-# form (see `mir_to_operand`), so its disp32 is the relocation patch site
+# form (see `mir_to_operand`), so its disp32 is the relocation patch site.
+# x86-64's other register-less base, `x64.MEM_BASE_ABS`, is deliberately not this:
+# an absolute address is a constant the linker never patches
 fun is_rip_mem(op: *isa.Operand) bool {
     ret op.kind == isa.OPK_MEM && op.base == -1 && op.index == -1;
 }
@@ -4885,12 +4900,21 @@ val X64P_NONE:   u16 = 1;  # the mnemonic is the whole statement
 val X64P_ONE:    u16 = 2;  # one operand
 val X64P_TWO:    u16 = 3;  # `dst, src`
 val X64P_BRANCH: u16 = 4;  # a branch target: a symbol or a numeric local label
+val X64P_CALL:   u16 = 5;  # a call target: a branch target, a register, or a memory operand
 
 # the mnemonic carries a LOCK prefix, in `Mnemonic.flags[15:8]`
 #
 # Private to this grammar; the emitter translates it to the encoder's own
 # `x64.FLAG_LOCK`, whose value sits in the pattern's byte and must not be mixed here.
 val X64F_LOCK: u16 = 0x0100;
+
+# the statement resolved to an indirect form, in `Mnemonic.flags[15:8]`
+#
+# The one per-STATEMENT bit in a field that otherwise carries per-mnemonic facts:
+# `call` names one mnemonic but two encodings, and which one a statement takes is a
+# property of its operand, not of the name. `x64_call_target` sets it and `x64_build`
+# translates it to the encoder's `x64.FLAG_INDIRECT`.
+val X64F_INDIRECT: u16 = 0x0200;
 
 # the registers the syscall ABI destroys: the kernel's return register plus the two
 # the instruction itself overwrites (RAX, RCX, R11)
@@ -4929,8 +4953,10 @@ val X64_MNEMONICS: [X64_MNEMONIC_COUNT]iasm.Mnemonic = [X64_MNEMONIC_COUNT]iasm.
     iasm.Mnemonic{ name: "nop",     code: x64.NOP::u32,     form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
 
     # control transfers. a call's caller-saved clobbers are already covered by the
-    # asm block's own barrier, and no branch form writes a register itself.
-    iasm.Mnemonic{ name: "call", code: x64.CALL::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    # asm block's own barrier, and no branch form writes a register itself - an
+    # indirect call no more than a direct one: it READS the register or memory
+    # holding its target, and what the callee destroys is the barrier's business.
+    iasm.Mnemonic{ name: "call", code: x64.CALL::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_CALL, words: 0 },
     iasm.Mnemonic{ name: "jmp",  code: x64.JMP::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
     iasm.Mnemonic{ name: "je",   code: x64.JE::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
     iasm.Mnemonic{ name: "jz",   code: x64.JE::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
@@ -5110,9 +5136,10 @@ fun x64_operand(c: *iasm.Cursor, lo: usize, hi: usize, role: str, op: *iasm.Oper
 # parse the `[...]` memory operand spanning `body[lo..hi)`
 #
 # Handles `[base]`, `[base+disp]`, `[base-disp]`, `[base+index*scale]`,
-# `[base+index*scale+disp]`, and `[symbol]` (a rip-relative reference the caller
-# relocates). A `{name}` binding inside the brackets is a stack slot used as an
-# address, which no addressing mode expresses - it is refused with the fix.
+# `[base+index*scale+disp]`, `[symbol]` (a rip-relative reference the caller
+# relocates), and `[constant]` (an absolute address). A `{name}` binding inside the
+# brackets is a stack slot used as an address, which no addressing mode expresses -
+# it is refused with the fix.
 fun x64_mem(c: *iasm.Cursor, lo: usize, hi: usize, role: str, op: *iasm.Operand) R.Result[bool, str] {
     @op = iasm.op_none();
     op.kind = iasm.AOP_MEM;
@@ -5190,13 +5217,33 @@ fun x64_mem(c: *iasm.Cursor, lo: usize, hi: usize, role: str, op: *iasm.Operand)
         if (x64_reg((?buf[0])::str, ?base_op)) {
             op.reg = base_op.reg;
         } or {
-            # a bare name in brackets is a rip-relative symbol reference, valid only
-            # without a displacement term.
-            if (has_sep) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
             var a: usize = inner_lo;
             var b: usize = bi_hi;
             for (a < b && iasm.is_space(c.body[a])) { a = a + 1; }
             for (b > a && iasm.is_space(c.body[b - 1])) { b = b - 1; }
+
+            # a bare constant in brackets is an absolute address - the only way to
+            # reach a fixed-address ABI, whose slots are not symbols to relocate. it
+            # takes no displacement term of its own: the constant IS the address.
+            val av: O.Option[i64] = iasm.region_i64(c.body, a, b);
+            if (O.is_some[i64](av)) {
+                if (has_sep) { ret R.err[bool, str]("encode: inline-asm absolute memory address takes no displacement term"); }
+                val addr: i64 = O.unwrap[i64](av);
+                # the disp32 is sign-extended to 64 bits, so an address outside signed
+                # 32-bit range is unreachable in this form; refused rather than
+                # silently truncated to a different address.
+                if (addr < -2147483648 || addr > 2147483647) {
+                    ret R.err[bool, str]("encode: inline-asm absolute memory address does not fit a signed 32-bit displacement");
+                }
+                op.flags = iasm.AOF_MEM_ABS;
+                op.reg   = -1;
+                op.imm   = addr;
+                ret R.ok[bool, str](true);
+            }
+
+            # a bare name in brackets is a rip-relative symbol reference, valid only
+            # without a displacement term.
+            if (has_sep) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
             if (!iasm.is_sym_region(c.body, a, b)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
             op.flags    = iasm.AOF_MEM_SYM;
             op.reg      = -1;
@@ -5248,6 +5295,10 @@ fun x64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, s
         if (n != 1) { ret R.err[bool, str]("encode: inline-asm branch expects one target"); }
         ret x64_branch_target(c, s, item);
     }
+    if (pat == X64P_CALL) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm call expects one target"); }
+        ret x64_call_target(c, s, item);
+    }
 
     var i: u32 = 0;
     for (i < n) {
@@ -5289,7 +5340,49 @@ fun x64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, s
     ret R.ok[bool, str](true);
 }
 
-# resolve a CALL / JMP / Jcc target: a numeric local label or a named symbol
+# resolve a CALL target, which is one of three things
+#
+# `call [...]` calls through memory and `call <reg>` through a register - both the
+# `FF /2` indirect encoding, which the ABI clobbers exactly as a direct call does.
+# Anything else is a direct `E8 rel32` to a label or symbol, resolved by
+# `x64_branch_target` unchanged. The fork is on the operand's SHAPE, so a register
+# named `call` could never take is a malformed branch target rather than a silently
+# accepted indirect call.
+#
+# `call [symbol]` is refused: the rip-relative form would need a relocation whose
+# meaning (call the pointer STORED at the symbol) differs from the direct
+# `call symbol` beside it, and nothing in the language produces it today.
+fun x64_call_target(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
+    val lo: usize = s.arg_lo[0];
+    val hi: usize = s.arg_hi[0];
+
+    if (hi - lo >= 3 && c.body[lo] == '['::char && c.body[hi - 1] == ']'::char) {
+        val r: R.Result[bool, str] = x64_mem(c, lo, hi, "", ?item.ops[0]);
+        if (R.is_err[bool, str](r)) { ret r; }
+        if ((item.ops[0].flags & iasm.AOF_MEM_SYM) != 0) {
+            ret R.err[bool, str]("encode: inline-asm indirect call through a symbol's address is unsupported; use `call <symbol>` for a direct call, or load the address into a register");
+        }
+        item.flags = item.flags | X64F_INDIRECT;
+        ret R.ok[bool, str](true);
+    }
+
+    var buf: [32]u8;
+    var reg_op: iasm.Operand = iasm.op_none();
+    if (iasm.copy_region(c.body, lo, hi, ?buf[0], 32) && x64_reg((?buf[0])::str, ?reg_op)) {
+        # `FF /2` in 64-bit mode has a fixed 64-bit operand size; a narrower register
+        # name cannot be encoded and is refused rather than widened behind the author.
+        if (reg_op.size != 8) {
+            ret R.err[bool, str]("encode: inline-asm indirect call requires a 64-bit register");
+        }
+        item.ops[0] = reg_op;
+        item.flags  = item.flags | X64F_INDIRECT;
+        ret R.ok[bool, str](true);
+    }
+
+    ret x64_branch_target(c, s, item);
+}
+
+# resolve a JMP / Jcc target: a numeric local label or a named symbol
 fun x64_branch_target(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
     val lo: usize = s.arg_lo[0];
     val hi: usize = s.arg_hi[0];
@@ -5318,12 +5411,15 @@ fun x64_branch_target(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result
 # convert a parsed operand into the `isa.Operand` the encoder takes
 #
 # A rip-relative `[symbol]` becomes the `[rip + disp32]` form (no base, no index)
-# whose disp32 the caller patches with a PC32 relocation.
+# whose disp32 the caller patches with a PC32 relocation. An absolute `[constant]`
+# becomes the `MEM_BASE_ABS` form, whose disp32 is the address itself and which no
+# relocation touches.
 fun x64_to_isa(op: *iasm.Operand, size: u8) isa.Operand {
     if (op.kind == iasm.AOP_REG) { ret isa.make_reg(op.reg, size); }
     if (op.kind == iasm.AOP_IMM) { ret isa.make_imm(op.imm, size); }
     if (op.kind == iasm.AOP_MEM) {
         if ((op.flags & iasm.AOF_MEM_SYM) != 0) { ret isa.make_mem(-1, 0, -1, 0, size); }
+        if ((op.flags & iasm.AOF_MEM_ABS) != 0) { ret isa.make_mem(x64.MEM_BASE_ABS, op.imm::i32, -1, 0, size); }
         ret isa.make_mem(op.reg, op.imm::i32, op.index, op.scale, size);
     }
     ret isa.make_none();
@@ -5342,6 +5438,19 @@ fun x64_build(item: *iasm.Item) isa.Inst {
     val pat: u16 = x64_pattern(item.flags);
     if (pat == X64P_NONE || pat == X64P_BRANCH) {
         mi.flags = enc_flags;
+        ret mi;
+    }
+    if (pat == X64P_CALL) {
+        # a direct call carries its target as a relocation or a local-label fixup, not
+        # as an operand, so it builds like any other branch.
+        if ((item.flags & X64F_INDIRECT) == 0) {
+            mi.flags = enc_flags;
+            ret mi;
+        }
+        # `FF /2` is fixed 64-bit in long mode: it takes no REX.W and no width flag.
+        mi.size  = 8;
+        mi.flags = enc_flags | x64.FLAG_INDIRECT::u16;
+        mi.dst   = x64_to_isa(?item.ops[0], 8);
         ret mi;
     }
 
@@ -5482,6 +5591,208 @@ fun u64_to_dec(n: u64, dst: *u8) usize {
     var k: usize = 0;
     for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
     ret len;
+}
+
+# assemble an inline-asm body and compare its bytes against `want` (test helper)
+#
+# Runs the whole block path a real body takes - `iasm.run` over the same grammar the
+# codegen installs - so a test states the machine bytes a spelling produces rather
+# than a property of an intermediate. A statement needing a relocation is out of
+# scope here: the interner is nil, so only self-contained encodings are asserted.
+# ---
+# body: the inline-asm body text
+# want: the expected encoding, as bytes
+# n:    number of expected bytes
+# ret:  true when the body encodes to exactly those bytes
+fun t_asm_bytes(body: str, want: *u8, n: usize) bool {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var st: enc.EncodeState;
+    st.alloc    = ?alloc;
+    st.buf      = enc.buf_init(?alloc);
+    st.interner = nil;
+
+    var g: iasm.Grammar = x64_grammar();
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, body, ?alloc, nil, nil, nil);
+
+    val rr: R.Result[bool, str] = iasm.run(?st, ?g, ?c, ?labels);
+    if (R.is_err[bool, str](rr)) { ret false; }
+
+    if (st.buf.len != n) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        if (st.buf.data[i] != want[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# true when parsing one inline-asm statement fails with a message naming `want`
+# (test helper)
+#
+# Matching on a substring of the diagnostic, not merely on failure, is what keeps a
+# refusal test from passing on the wrong refusal.
+# ---
+# body: the inline-asm statement text
+# want: a substring the diagnostic must contain
+# ret:  true when the statement is refused and the message names `want`
+fun t_asm_refused(body: str, want: str) bool {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var g: iasm.Grammar = x64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, body, ?alloc, nil, nil, nil);
+
+    var item: iasm.Item;
+    val pr: R.Result[bool, str] = iasm.next(?c, ?item);
+    if (!R.is_err[bool, str](pr)) { ret false; }
+    ret str_contains(R.unwrap_err[bool, str](pr), want);
+}
+
+# every indirect `call` shape encodes to the exact bytes an independent assembler
+# produces for the same spelling
+#
+# `FF /2` with the absolute form is what a fixed-address kernel ABI needs
+# (BareMetal's call table at 0x100010..0x100040, #2396): mod=00 rm=100 escapes to a
+# SIB naming neither base nor index, so the seven bytes are `ff 14 25 <disp32>`.
+# These are byte-for-byte the nasm encodings of the same statements, so the SIB
+# escape and the REX.B on an extended register are asserted, not assumed.
+test "mach.lang.target.isa.x64.encode.x64_call_target:indirect_forms_byte_exact" {
+    var bad: i32 = 0;
+
+    # `call [0x100018]` - the absolute form. a wrong SIB (or a mod=00 rm=101 that
+    # reused the rip-relative encoding) changes these bytes.
+    var abs_want: [7]u8;
+    abs_want[0] = 0xFF; abs_want[1] = 0x14; abs_want[2] = 0x25;
+    abs_want[3] = 0x18; abs_want[4] = 0x00; abs_want[5] = 0x10; abs_want[6] = 0x00;
+    if (!t_asm_bytes("call [0x100018]", ?abs_want[0], 7)) { bad = 1; }
+
+    # `call rax` - register-indirect, mod=11, no REX.
+    var rax_want: [2]u8;
+    rax_want[0] = 0xFF; rax_want[1] = 0xD0;
+    if (!t_asm_bytes("call rax", ?rax_want[0], 2)) { bad = 1; }
+
+    # `call r11` - the extended register takes REX.B.
+    var r11_want: [3]u8;
+    r11_want[0] = 0x41; r11_want[1] = 0xFF; r11_want[2] = 0xD3;
+    if (!t_asm_bytes("call r11", ?r11_want[0], 3)) { bad = 1; }
+
+    # the register-based memory forms, which the shared addressing encoder already
+    # produced and which the new fork must not disturb.
+    var m0_want: [2]u8;
+    m0_want[0] = 0xFF; m0_want[1] = 0x10;
+    if (!t_asm_bytes("call [rax]", ?m0_want[0], 2)) { bad = 1; }
+
+    var m8_want: [3]u8;
+    m8_want[0] = 0xFF; m8_want[1] = 0x50; m8_want[2] = 0x08;
+    if (!t_asm_bytes("call [rax + 8]", ?m8_want[0], 3)) { bad = 1; }
+
+    var mi_want: [4]u8;
+    mi_want[0] = 0xFF; mi_want[1] = 0x54; mi_want[2] = 0xD8; mi_want[3] = 0x10;
+    if (!t_asm_bytes("call [rax + rbx*8 + 16]", ?mi_want[0], 4)) { bad = 1; }
+
+    # a direct call is untouched: it still resolves as a branch target, carrying its
+    # symbol as a relocation rather than as an operand, and takes no indirect flag.
+    var g: iasm.Grammar = x64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, "call main", nil, nil, nil, nil);
+    var item: iasm.Item;
+    if (R.is_err[bool, str](iasm.next(?c, ?item)))                  { ret 1; }
+    if (item.ref != iasm.AR_SYM)                                    { bad = 1; }
+    val dm: isa.Inst = x64_build(?item);
+    if (dm.opcode != x64.CALL)                                      { bad = 1; }
+    if ((dm.flags & x64.FLAG_INDIRECT::u16) != 0)                   { bad = 1; }
+    if (dm.dst.kind != isa.OPK_NONE)                                { bad = 1; }
+
+    ret bad;
+}
+
+# an indirect call reads its target and writes nothing: the callee's caller-saved
+# clobbers are the asm block's barrier, exactly as for a direct call
+#
+# The register holding the target must NOT be reported as written - that would be
+# the opaque model #2258 removed - and the block must not become opaque either.
+test "mach.lang.target.isa.x64.encode.asm_clobbers:indirect_call_is_not_opaque" {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var bad: i32 = 0;
+
+    asm_clobbers("call rax", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
+    asm_clobbers("call [0x100018]", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
+    # for contrast: the raw-byte spelling this replaces IS opaque, reaching every
+    # register in every bank, because the parser cannot read the stream.
+    asm_clobbers(".byte 0xff, 0x14, 0x25, 0x18, 0x00, 0x10, 0x00", ?gp, ?fp);
+    if (gp != X64_ALL_GP) { bad = 1; }
+    if (fp != X64_ALL_FP) { bad = 1; }
+
+    ret bad;
+}
+
+# a `.byte` directive carries a whole byte sequence in one statement, bounded by
+# `BYTES_MAX` rather than by the four-operand instruction limit
+#
+# The seven bytes of an indirect call were the case that exposed the conflation
+# (#2398): a directive is not an instruction, so its payload never reaches the
+# operand splitter. A value outside a byte's range is refused rather than truncated.
+test "mach.lang.target.isa.x64.encode.parse_bytes:sequence_is_not_an_operand_list" {
+    var bad: i32 = 0;
+
+    # seven values in one statement - one more than the four-operand instruction
+    # limit, and exactly the shape that needed two statements before.
+    var want: [7]u8;
+    want[0] = 0xFF; want[1] = 0x14; want[2] = 0x25;
+    want[3] = 0x18; want[4] = 0x00; want[5] = 0x10; want[6] = 0x00;
+    if (!t_asm_bytes(".byte 0xff, 0x14, 0x25, 0x18, 0x00, 0x10, 0x00", ?want[0], 7)) { bad = 1; }
+
+    # a single value still works, and so does a negative one (a signed byte).
+    var one: [1]u8;
+    one[0] = 0x90;
+    if (!t_asm_bytes(".byte 0x90", ?one[0], 1)) { bad = 1; }
+    var neg: [1]u8;
+    neg[0] = 0xFF;
+    if (!t_asm_bytes(".byte -1", ?neg[0], 1)) { bad = 1; }
+
+    # a value too wide for a byte is refused, not truncated to 0xFF.
+    if (!t_asm_refused(".byte 0x1ff", "byte"))   { bad = 1; }
+    if (!t_asm_refused(".byte -129", "byte"))    { bad = 1; }
+    # a bare `.byte` is not the directive at all: the mnemonic matcher requires a
+    # following space for any form that takes operands, so it never reaches the
+    # payload parser.
+    if (!t_asm_refused(".byte", "unknown"))      { bad = 1; }
+    # a payload that is only a separator names no value.
+    if (!t_asm_refused(".byte ,", "value"))      { bad = 1; }
+
+    # a four-operand INSTRUCTION limit still holds: the cap moved off `.byte`, it
+    # was not removed from the operand splitter.
+    if (!t_asm_refused("mov rax, rbx, rcx, rdx, rsi", "too many operands")) { bad = 1; }
+
+    ret bad;
+}
+
+# the indirect-call forms the grammar refuses, each by name
+test "mach.lang.target.isa.x64.encode.x64_call_target:refused_forms" {
+    var bad: i32 = 0;
+
+    # a symbol's address is the rip-relative form, whose meaning (call the pointer
+    # STORED there) differs from the `call <symbol>` beside it.
+    if (!t_asm_refused("call [main]", "symbol"))                { bad = 1; }
+    # `FF /2` is fixed 64-bit; a narrower register cannot be encoded.
+    if (!t_asm_refused("call eax", "64-bit"))                   { bad = 1; }
+    # the disp32 is sign-extended, so a wider address would land elsewhere.
+    if (!t_asm_refused("call [0x100000000]", "32-bit"))         { bad = 1; }
+    # an absolute address is the whole operand; it takes no displacement term.
+    if (!t_asm_refused("call [0x100018 + 8]", "displacement"))  { bad = 1; }
+
+    ret bad;
 }
 
 # a `{name}` binding inside a memory operand yields an actionable diagnostic

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -241,7 +241,9 @@ fun render_operand_body(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand) R.Re
 #
 # A base of -1 is the rip-relative form a symbol reference lowers to; its symbol
 # id rides on the operand so the target is named rather than shown as a zero
-# displacement the linker later fills in.
+# displacement the linker later fills in. A base of `x64.MEM_BASE_ABS` is the
+# absolute form, which names no symbol at all - its displacement IS the address,
+# so it renders as the bare number.
 # ---
 # buf: the encoder byte sink carrying the assembly sink
 # mi:  the owning instruction (supplies the fallback width)
@@ -254,6 +256,12 @@ fun render_mem(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand) R.Result[bool
     if (R.is_err[bool, str](res_size)) { ret res_size; }
     val res_open: R.Result[bool, str] = emit_str(out, "[");
     if (R.is_err[bool, str](res_open)) { ret res_open; }
+
+    if (op.base == x64.MEM_BASE_ABS) {
+        val res_abs: R.Result[bool, str] = emit_i64(out, op.disp::i64);
+        if (R.is_err[bool, str](res_abs)) { ret res_abs; }
+        ret emit_str(out, "]");
+    }
 
     if (op.base < 0) {
         val res_rip: R.Result[bool, str] = emit_str(out, "rip + ");


### PR DESCRIPTION
Closes #2398.

x86-64 `call` in inline asm was branch-only, so an ABI whose entry points are fixed addresses rather than symbols — BareMetal's kernel call table at `0x100010..0x100040` (#2396) — was reachable only as raw `.byte`s. That is unreviewable at stdlib scale, and it is *opaque to the effect model*: a raw byte payload makes the block clobber every register in every bank, because the parser cannot read it.

## The three shapes

`call` becomes its own operand pattern, forking on the operand's shape:

```mach
asm x86_64 {
    call some_symbol     # direct:   E8 rel32, relocated — unchanged
    call rax             # register: FF /2, mod=11
    call [0x100018]      # absolute: ff 14 25 <disp32>
    call [rax + 8]       # computed
}
```

The encoder already had both indirect paths behind `FLAG_INDIRECT`; only the grammar could not reach them.

## The absolute form needed a real addressing mode

x86-64 has **two** register-less memory forms, and `isa.Operand.base` is where they are told apart. The shared model's `-1` already means rip-relative (`mod=00 rm=101`) — that is what lowering produces for every symbol reference — so it cannot also mean absolute. `x64.MEM_BASE_ABS` names the second one, which takes the SIB escape (`mod=00 rm=100`, SIB `base=101 index=100`), giving `ff 14 25 <disp32>`. Its displacement is sign-extended to 64 bits, so an address outside signed 32-bit range is refused rather than truncated to a different address.

## The effect model is unchanged, and deliberately not opaque

An indirect `call` **reads** its target and writes nothing. What the callee destroys is the asm block's own call barrier — exactly as for a direct call. `writes: AW_NONE, implicit: 0`, same row as before (#2258).

## `.byte`'s cap: load-bearing elsewhere, so it did not move

`MAX_OPS = 4` is documented as, and is, a real machine fact about **instructions** — "the widest form any supported target spells: aarch64's post-index `ldp Xa, Xb, [Xn], #imm`". Raising it would weaken a genuine refusal. The conflation was that a *directive* was being routed through the *operand* splitter at all: `.byte` now splits on its own, bounded by the `BYTES_MAX` (256) that was already derived and already the array's size. An instruction naming five operands is still refused.

Two behaviours change beyond the cap, both flagged: a value outside a byte's range was **silently truncated** (`.byte 0x1ff` emitted `0xFF`) and is now refused; and a bare `.byte` was already an unknown-mnemonic error before the payload parser ran, so an unreachable empty-payload guard came out rather than going in.

## Verification

See the comment below for the full numbers: byte-exact assertions against nasm, a disassembler round-trip *after* confirming the disassembler reads the format, seven mutations, 1296/1296 byte-identical outputs across six targets, and a three-generation fixpoint.