### PR TITLE
fix(macho): correct __DWARF section layout and bump mach-std v0.20.1 (#2327)

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "1b031862d0d993cafe4adf30609e63a9cd3ccd95"
+commit = "6954e6717bdaa5594f8e000bf750c699a68a1750"


### PR DESCRIPTION
Fixes issue #2327 for Mach-O debug layout and updates mach-std pin to v0.20.1.