### PR TITLE
fix(darwin): enable PIE for x86_64 darwin executables (#2327)

### DIFF
--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -26,14 +26,13 @@ pub val DARWIN_BASE_ADDR: u64 = 0x100000000;
 # virtual-memory page size in bytes; segment vaddrs are page-aligned to it
 pub val DARWIN_PAGE_SIZE: u64 = 4096;
 
-# Darwin requires position-independent (PIE) main executables on arm64 - the Apple
-# Silicon kernel refuses to exec a non-PIE image. x86_64 Darwin tolerates a fixed
-# image, so it stays on the non-PIE layout
+# Darwin requires position-independent (PIE) main executables on both x86_64 and
+# arm64 (dyld / macOS kernel require PIE layout for dynamic linking)
 # ---
 # arch_id: the target architecture id (one of isa.ARCH_*)
-# ret:     true for aarch64 (PIE required), false otherwise
+# ret:     true for supported Darwin architectures (x86_64 and arm64)
 fun darwin_pie_exec(arch_id: u32) bool {
-    ret arch_id == isa.ARCH_AARCH64;
+    ret arch_id == isa.ARCH_X86_64 || arch_id == isa.ARCH_AARCH64;
 }
 
 # Darwin maps memory in 16 KiB pages on arm64 (the Apple Silicon kernel rejects a


### PR DESCRIPTION
Enables position-independent executable (PIE) mode by default for x86_64-darwin targets in `darwin_pie_exec`. This routes x86_64-darwin builds through `emit_dyn_exec`, matching the dynamic linking contract required on macOS.