### PR TITLE
fix(darwin): restore x86_64 init and debug executables

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "6954e6717bdaa5594f8e000bf750c699a68a1750"
+commit = "11d8f618c2e3cbf7307526432a4bde74ab96e9f6"

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1568,18 +1568,21 @@ fun macho_dwarf_cmd_bytes(debug_count: u32) usize {
     ret SEGMENT_CMD_64_SIZE + debug_count::usize * SECTION_64_SIZE;
 }
 
-# plan the __DWARF segment's file region starting at offset `base` (past the linker
-# segments, below the code signature). allocates the per-section offset array on
+# plan the __DWARF segment's file region after offset `base` (past the linker
+# segments, below the code signature). every Mach-O segment's file offset must be
+# page-aligned even when its vm size is zero, so the debug region starts at the
+# target's segment alignment (#2327). allocates the per-section offset array on
 # success; the caller frees it through `macho_dwarf_free`. an empty plan (no debug)
 # allocates nothing
 # ---
 # alloc:       allocator backing the plan's offset array
 # debug:       the non-allocated debug sections
 # debug_count: number of debug sections
-# base:        file offset where the segment's bytes begin
+# base:        file offset after the preceding segment's bytes
+# segment_align: target page alignment required for an LC_SEGMENT_64 file offset
 # ret:         the layout plan, or an allocation error
 fun macho_dwarf_plan(alloc: *A.Allocator, debug: *of.Section, debug_count: u32,
-                     base: usize) R.Result[MachoDwarf, str] {
+                     base: usize, segment_align: usize) R.Result[MachoDwarf, str] {
     var d: MachoDwarf;
     d.present = false; d.seg_foff = 0; d.seg_size = 0; d.end = base; d.sec_offs = nil;
     if (debug_count == 0) { ret R.ok[MachoDwarf, str](d); }
@@ -1588,7 +1591,7 @@ fun macho_dwarf_plan(alloc: *A.Allocator, debug: *of.Section, debug_count: u32,
     if (R.is_err[*usize, str](ro)) { ret R.err[MachoDwarf, str](R.unwrap_err[*usize, str](ro)); }
     d.sec_offs = R.unwrap_ok[*usize, str](ro);
 
-    val seg_foff: usize = bin.align_up(base, 8);
+    val seg_foff: usize = bin.align_up(base, segment_align);
     var cur: usize = seg_foff;
     var di: u32 = 0;
     for (di < debug_count) {
@@ -1798,7 +1801,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # the __DWARF segment's byte region follows the linker segments (below the code
     # signature so the signature covers it). extends total_size when present.
     var dw: MachoDwarf;
-    val dwp: R.Result[MachoDwarf, str] = macho_dwarf_plan(alloc, debug, debug_count, total_size);
+    val dwp: R.Result[MachoDwarf, str] =
+        macho_dwarf_plan(alloc, debug, debug_count, total_size, macho_page_size(arch_id)::usize);
     if (R.is_err[MachoDwarf, str](dwp)) {
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str](R.unwrap_err[MachoDwarf, str](dwp));
@@ -2949,7 +2953,8 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # the non-mapped __DWARF segment's byte region, below __LINKEDIT (and thus below
     # the code signature, which covers it). extends `file` when present.
     var dw: MachoDwarf;
-    val dwp: R.Result[MachoDwarf, str] = macho_dwarf_plan(alloc, debug, debug_count, file);
+    val dwp: R.Result[MachoDwarf, str] =
+        macho_dwarf_plan(alloc, debug, debug_count, file, page);
     if (R.is_err[MachoDwarf, str](dwp)) {
         A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
         ret R.err[bool, str](R.unwrap_err[MachoDwarf, str](dwp));
@@ -3708,6 +3713,23 @@ fun t_find_lc(buf: *u8, cmd: u32) usize {
     ret 0;
 }
 
+# locate the file offset of the LC_SEGMENT_64 named `name`; returns 0 when absent
+# ---
+# buf:  the Mach-O bytes
+# name: the segment name to match
+# ret:  the load command's file offset, or 0 if not present
+fun t_find_seg(buf: *u8, name: str) usize {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64 && fixed16_equals(buf, off + 8, name)) { ret off; }
+        off = off + bin.read_u32_le(buf, off + 4)::usize;
+        c = c + 1;
+    }
+    ret 0;
+}
+
 # an x86_64 ObjectImage round-trips through emit_object / parse_object: the header,
 # sections, symbols, and relocations (PLT32, PC32, ABS64) survive, and the
 # in-place addends are recovered in the abstract field-relative convention
@@ -4404,13 +4426,20 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     fx[0].seg_index = 0; fx[0].seg_offset = fixup_off; fx[0].import_index = 0;
     fx[0].patch_vaddr = base + fixup_off::u64; fx[0].addend = fixup_add;
 
+    var debug_bytes: [3]u8;
+    debug_bytes[0] = 0x11; debug_bytes[1] = 0x22; debug_bytes[2] = 0x33;
+    var dbg: [1]of.Section;
+    dbg[0].name = t_intern(?itn, ".debug_info"); dbg[0].kind = of.SK_DEBUG;
+    dbg[0].bytes = ?debug_bytes[0]; dbg[0].len = 3; dbg[0].align = 1;
+
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_dyn");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
-                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, nil::*of.Section, 0, tpath::*u8, "machodyn"::*u8);
+                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1,
+                                                ?dbg[0], 1, tpath::*u8, "machodyn"::*u8);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4421,6 +4450,12 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     if (bin.read_u32_le(buf.data, 0) != MH_MAGIC_64)                       { ret 1; }
     if (bin.read_u32_le(buf.data, 12) != MH_EXECUTE)                       { ret 1; }
     if (bin.read_u32_le(buf.data, 24) != (MH_DYLDLINK | MH_TWOLEVEL))      { ret 1; }
+
+    # XNU validates every segment's file offset before skipping a zero-vmsize
+    # segment, so the non-mapped __DWARF still starts on the architecture's page.
+    val dw: usize = t_find_seg(buf.data, "__DWARF");
+    if (dw == 0) { ret 1; }
+    if ((bin.read_u64_le(buf.data, dw + 40) % macho_page_size(arch_id)) != 0) { ret 1; }
 
     # the loader, the dependency, and the dyld bind stream.
     val dl: usize = t_find_lc(buf.data, LC_LOAD_DYLINKER);
@@ -4461,23 +4496,6 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     val sig_off: usize = bin.read_u32_le(buf.data, cs + 8)::usize;
     if (bin.read_u32_be(buf.data, sig_off) != CSMAGIC_EMBEDDED_SIGNATURE) { ret 1; }
     if (bin.read_u32_be(buf.data, sig_off + SUPERBLOB_HEADER_SIZE) != CSMAGIC_CODEDIRECTORY) { ret 1; }
-    ret 0;
-}
-
-# locate the file offset of the LC_SEGMENT_64 named `name`; returns 0 when absent
-# ---
-# buf:  the Mach-O bytes
-# name: the segment name to match
-# ret:  the load command's file offset, or 0 if not present
-fun t_find_seg(buf: *u8, name: str) usize {
-    val ncmds: u32 = bin.read_u32_le(buf, 16);
-    var off: usize = MACH_HEADER_64_SIZE;
-    var c: u32 = 0;
-    for (c < ncmds) {
-        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64 && fixed16_equals(buf, off + 8, name)) { ret off; }
-        off = off + bin.read_u32_le(buf, off + 4)::usize;
-        c = c + 1;
-    }
     ret 0;
 }
 
@@ -5039,6 +5057,12 @@ fun ts_exec_debug_roundtrip() u8 {
     # the emitted __DWARF sections carry the Mach-O spelling, not the ELF-canonical one.
     if (!t_bytes_contain(buf.data, 0, buf.len, "__debug_info")) { ret 1; }
     if (!t_bytes_contain(buf.data, 0, buf.len, "__debug_line")) { ret 1; }
+
+    # the kernel applies its segment file-offset alignment check before accepting
+    # __DWARF's zero vm size, so this non-mapped segment still starts on a page.
+    val dw: usize = t_find_seg(buf.data, "__DWARF");
+    if (dw == 0) { ret 1; }
+    if ((bin.read_u64_le(buf.data, dw + 40) % macho_page_size(isa.ARCH_X86_64)) != 0) { ret 1; }
 
     # re-read the emitted executable through the mach-o parser.
     var img: of.ObjectImage;


### PR DESCRIPTION
Closes #2327

## Summary

- update the mach-std lock to v0.20.2 so Darwin `current_dir` uses the released `F_GETPATH` implementation
- page-align executable `__DWARF` file offsets using each Darwin architecture page size
- cover static x86_64 and dynamic x86_64/aarch64 writer paths without adding CI workflow runners

## Root cause

Issue #2327 combines two independent failures:

1. The repository still pinned mach-std v0.20.1, before the Darwin `current_dir` fix shipped.
2. Executable debug segments were aligned to 8 bytes. XNU validates every segment file offset against the architecture page size before it skips zero-`vmsize` segments, so small debug executables could be rejected as malformed. Non-debug executables omit this segment, which explains the profile-specific behavior.

The writer now passes the existing per-architecture page size into the shared DWARF planner: 4 KiB for x86_64 and 16 KiB for aarch64. It does not re-enable the previously reverted x86_64 PIE path.

## Validation

- targeted Mach-O tests: 5/5
- full debug unit suite: 969/969
- full release unit suite: 969/969
- cross-built debug x86_64 fixture: `__DWARF.fileoff` is 4 KiB aligned; `llvm-dwarfdump --verify` passes
- cross-built debug aarch64 fixture: `__DWARF.fileoff` is 16 KiB aligned; `llvm-dwarfdump --verify` passes
- no-debug x86_64 and aarch64 outputs are byte-identical before and after the Mach-O change
- `git diff --check` passes

Native Darwin execution is not available in the local environment, so this remains a draft pending macOS runtime confirmation. No CI workflow changes are included.

## Follow-up

- briar-systems/mach-std#409 tracks capacity-safe handling for direct callers of Darwin `getcwd`; the `current_dir` path used here supplies a full 4096-byte buffer.
