### PR TITLE
test(layout): recover generic differential coverage

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4997,19 +4997,37 @@ fun ut_sema_rejects(text: str) bool { ret ut_sema_errs(text) > 0; }
 # ---
 # s:    the session whose type universe to scan
 # name: the declared record / union name
-# ret:  some(TypeId) for the first nominal with that name, none when absent
+# ret:  some(TypeId) for an instance of that nominal when present, otherwise the
+#       nominal itself; none when absent
 fun ut_nominal_typeid(s: *session.Session, name: str) O.Option[type.TypeId] {
     val ir: R.Result[intern.StrId, str] = intern.intern(?s.interner, name);
     if (R.is_err[intern.StrId, str](ir)) { ret O.none[type.TypeId](); }
     val want: intern.StrId = R.unwrap_ok[intern.StrId, str](ir);
 
+    # an instance has no name of its own, so match it through the nominal it
+    # specializes. prefer it to the bare declaration so a generic corpus row
+    # measures the concrete shape the source instantiated (#2239).
     var i: u32 = 0;
     for (i < s.types.type_len) {
         val t: *type.Type = ?s.types.types[i];
-        if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
-            if (t.data.nominal.name == want) { ret O.some[type.TypeId](i::type.TypeId); }
+        val tid: type.TypeId = i::type.TypeId;
+        if (t.kind == type.TYPE_INSTANCE) {
+            val nom: type.TypeId = type.aggregate_nominal(?s.types, tid);
+            val on: O.Option[*type.Type] = type.get(?s.types, nom);
+            if (O.is_some[*type.Type](on) &&
+                O.unwrap[*type.Type](on).data.nominal.name == want) {
+                ret O.some[type.TypeId](tid);
+            }
         }
         i = i + 1;
+    }
+    var j: u32 = 0;
+    for (j < s.types.type_len) {
+        val t: *type.Type = ?s.types.types[j];
+        if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
+            if (t.data.nominal.name == want) { ret O.some[type.TypeId](j::type.TypeId); }
+        }
+        j = j + 1;
     }
     ret O.none[type.TypeId]();
 }
@@ -5052,6 +5070,34 @@ fun ut_sema_extent_is(text: str, name: str, size: u32, align: u32) i32 {
     project.dnit_project(?p);
     session.dnit(?s);
     ret bad;
+}
+
+# whether a lowered function parameter has exactly the expected IR layout
+#
+# Looking up the parameter through the lowered IRT_FN makes this a direct assertion
+# on the IR describer consumed by the backend. Merely compiling a runtime comparison
+# would leave its failure return unexecuted and prove only that lowering succeeded.
+fun ut_ir_param_extent_is(
+    s:      *session.Session,
+    m:      *ir.Module,
+    tgt:    *target.Target,
+    symbol: str,
+    param:  u32,
+    size:   u32,
+    align:  u32
+) bool {
+    val nr: R.Result[intern.StrId, str] = intern.intern(?s.interner, symbol);
+    if (R.is_err[intern.StrId, str](nr)) { ret false; }
+    val fi: O.Option[u32] = ir.function_lookup(m, R.unwrap_ok[intern.StrId, str](nr));
+    if (O.is_none[u32](fi)) { ret false; }
+    val f: *ir.Function = ?m.functions[O.unwrap[u32](fi)];
+    val st: O.Option[*ir_type.IrType] = ir_type.get(?m.types, f.sig);
+    if (O.is_none[*ir_type.IrType](st)) { ret false; }
+    val sig: *ir_type.IrType = O.unwrap[*ir_type.IrType](st);
+    if (sig.kind != ir_type.IRT_FN || param >= sig.data.fn.param_count) { ret false; }
+    val ty: ir_type.IrTypeId = sig.data.fn.params[param];
+    ret ir_type.byte_size(?m.types, ty, tgt) == size
+        && ir_type.byte_align(?m.types, ty, tgt) == align;
 }
 
 # whether `text` is rejected by a sema error whose message contains `needle`
@@ -5388,14 +5434,16 @@ test "mach.lang.driver:recursive_union_reports_its_real_defect" {
 # so the rule itself cannot drift - a mutation of it moves BOTH consumers at once. What
 # remains is the seam: each side DESCRIBES its own type universe to that policy, and two
 # describers can disagree even when the policy is shared. This test pins exactly that.
-# Each row asserts sema's extent through the sema describer, and `$size_of` / `$align_of`
-# - which fold at LOWERING, through the IR describer - assert the same numbers in a
-# program that must compile clean. A describer that mis-reports a shape moves one side
-# and fails here.
+# Each row asserts sema's extent through the sema describer. The same shapes are then
+# lowered as function parameters and their concrete IRT_FN parameter types are measured
+# through the IR describer. A describer that mis-reports a shape moves one side and
+# fails here.
 #
 # The corpus covers every shape the fold distinguishes: scalar widths, the natural
 # alignment padding a mixed record takes, a nested aggregate, an array, a union's
-# overlap, a pointer field, and an `#[align(...)]` override raising both.
+# overlap, a pointer field, and an `#[align(...)]` override raising both. A generic
+# union instance pins the historically divergent classification (#2239), with a
+# generic record instance pinning its false side.
 test "mach.lang.driver:secrecy_layout_matches_lowering" {
     var bad: i32 = 0;
 
@@ -5412,10 +5460,54 @@ test "mach.lang.driver:secrecy_layout_matches_lowering" {
     # `^` has no runtime representation, so a secret field measures as its public base
     if (ut_sema_extent_is("rec R { a: ^u8; b: ^u32; }\nfun main() i32 { ret 0; }\n", "R", 8, 4) != 0)          { bad = 1; }
 
-    # [2] THE SAME NUMBERS through the lowering layout, via `$size_of` / `$align_of`.
-    # each mismatch would fold the guard true and fail the compile with `$error`.
-    val probe: str = "rec R1 { a: u8; }\nrec R2 { a: u8; b: u32; }\nrec R3 { a: u32; b: u8; }\nrec R4 { a: u8; b: u64; }\nrec I  { a: u8; b: u32; }\nrec R5 { x: I; y: u8; }\nrec R6 { a: [3]u16; b: u8; }\nuni U1 { a: u8; b: u32; }\nrec R7 { a: *u8; b: u8; }\n#[align(16)]\nrec R8 { a: u32; }\nrec R9 { a: ^u8; b: ^u32; }\nfun main() i32 {\n  if ($size_of(R1) != 1  || $align_of(R1) != 1)  { ret 1; }\n  if ($size_of(R2) != 8  || $align_of(R2) != 4)  { ret 1; }\n  if ($size_of(R3) != 8  || $align_of(R3) != 4)  { ret 1; }\n  if ($size_of(R4) != 16 || $align_of(R4) != 8)  { ret 1; }\n  if ($size_of(R5) != 12 || $align_of(R5) != 4)  { ret 1; }\n  if ($size_of(R6) != 8  || $align_of(R6) != 2)  { ret 1; }\n  if ($size_of(U1) != 4  || $align_of(U1) != 4)  { ret 1; }\n  if ($size_of(R7) != 16 || $align_of(R7) != 8)  { ret 1; }\n  if ($size_of(R8) != 16 || $align_of(R8) != 16) { ret 1; }\n  if ($size_of(R9) != 8  || $align_of(R9) != 4)  { ret 1; }\n  ret 0;\n}\n";
-    if (ut_lower_ok(probe) != 0) { bad = 1; }
+    # the generic instance is found through the nominal it carries; without that
+    # classification G[u64] is laid out sequentially at 16 bytes instead of 8.
+    if (ut_sema_extent_is("uni G[T] { a: T; b: u8; }\nfun f(g: G[u64]) i32 { ret 0; }\nfun main() i32 { ret 0; }\n", "G", 8, 8) != 0)  { bad = 1; }
+    if (ut_sema_extent_is("uni G[T] { a: T; b: T; }\nfun f(g: G[u32]) i32 { ret 0; }\nfun main() i32 { ret 0; }\n", "G", 4, 4) != 0)   { bad = 1; }
+    if (ut_sema_extent_is("rec P[T] { a: T; b: u8; }\nfun f(p: P[u64]) i32 { ret 0; }\nfun main() i32 { ret 0; }\n", "P", 16, 8) != 0) { bad = 1; }
+
+    # [2] the same numbers through the lowered IR parameter types. This reads the
+    # backend's actual layout descriptor; no unexecuted runtime guard can pass.
+    val probe: str = "rec R1 { a: u8; }\nrec R2 { a: u8; b: u32; }\nrec R3 { a: u32; b: u8; }\nrec R4 { a: u8; b: u64; }\nrec I  { a: u8; b: u32; }\nrec R5 { x: I; y: u8; }\nrec R6 { a: [3]u16; b: u8; }\nuni U1 { a: u8; b: u32; }\nrec R7 { a: *u8; b: u8; }\n#[align(16)]\nrec R8 { a: u32; }\nrec R9 { a: ^u8; b: ^u32; }\nuni G1[T] { a: T; b: u8; }\nrec P1[T] { a: T; b: u8; }\n#[symbol(\"layout_probe\")]\nfun layout_probe(r1: R1, r2: R2, r3: R3, r4: R4, r5: R5, r6: R6, u1: U1, r7: R7, r8: R8, r9: R9, g64: G1[u64], g32: G1[u32], p64: P1[u64]) { }\nfun main() i32 { ret 0; }\n";
+
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = probe;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (R.is_err[bool, outcome.Fail](passes.run_sema_pass(?p)) ||
+        R.is_err[bool, outcome.Fail](passes.run_lower_pass(?p))) {
+        project.dnit_project(?p);
+        session.dnit(?s);
+        ret 1;
+    }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL || p.modules[mid::u32].ir_module == nil) { bad = 1; }
+    or {
+        val m: *ir.Module = p.modules[mid::u32].ir_module;
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 0, 1, 1))    { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 1, 8, 4))    { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 2, 8, 4))    { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 3, 16, 8))   { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 4, 12, 4))   { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 5, 8, 2))    { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 6, 4, 4))    { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 7, 16, 8))   { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 8, 16, 16))  { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 9, 8, 4))    { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 10, 8, 8))   { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 11, 4, 4))   { bad = 1; }
+        if (!ut_ir_param_extent_is(?s, m, ?p.target, "layout_probe", 12, 16, 8))  { bad = 1; }
+    }
+    project.dnit_project(?p);
+    session.dnit(?s);
     ret bad;
 }
 


### PR DESCRIPTION
Closes #2416

## Summary

- recover the post-merge generic union and record rows from the preserved layout coverage
- resolve semantic generic instances through their carried nominal before measuring them
- replace the compile-only lowering half with direct size and alignment checks on lowered IR parameter types

The generic union row discriminates at 8 bytes versus 16 bytes if it is described as a record. The generic record row pins the opposite classification.

## Validation

- filtered layout test: debug 1/1, release 1/1
- semantic generic-instance-only union mutation: filtered test fails 0/1
- IR generic-instance-only union mutation: filtered test fails 0/1
- full debug suite: 969/969
- full release suite: 969/969
- release self-host fixpoint: stage 2 equals stage 3 at f0843577e86a0ea7a692f07084de9bdd28ca2e90dd1f9f7f3a603b40cd170688
- git diff --check clean