### PR TITLE
fix(build): omit test bodies from production IR

### DIFF
--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -43,9 +43,11 @@ function body.
 
 ## Semantics
 
-Each `test` lowers to a zero-parameter, `i32`-returning function tagged as
-a test entry point so the runner can iterate it. The label is interned and
-becomes the lowered function's name.
+Every build resolves and type-checks each `test` body. Under `mach test`, each
+test also lowers to a zero-parameter, `i32`-returning function tagged as a test
+entry point so the runner can iterate it. The label is interned and becomes the
+lowered function's name. Ordinary builds omit test bodies from IR and object
+files.
 
 The body is checked against an `i32` return type. A test reports its result
 through that return value, treated as a process-style status:

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -577,15 +577,16 @@ val BACK_HALF_TEST_BIT: u64 = 0x100000000;
 
 # the packed Q_LOWER / Q_CODEGEN key for module `stable` under build mode
 # `test_mode`: the stable id in the low 32 bits, the test-mode flag in bit 32. A
-# test build (its `main` neutralized) and a normal build cache under distinct keys,
-# so the query-owned IR is never mutated in place to switch variants (#1858)
+# test build (tests present, `main` neutralized) and a normal build (tests absent)
+# cache under distinct keys, so query-owned IR is never mutated to switch variants
+# (#1858, #2320)
 pub fun back_half_key(stable: session.StableModuleId, test_mode: bool) u64 {
     var k: u64 = stable::u64;
     if (test_mode) { k = k | BACK_HALF_TEST_BIT; }
     ret k;
 }
 
-# whether a packed back-half key names the test-mode (neutralized-main) variant
+# whether a packed back-half key names the test-mode (tests present, `main` neutralized) variant
 fun back_half_key_is_test(key: u64) bool {
     ret (key & BACK_HALF_TEST_BIT) != 0;
 }
@@ -608,9 +609,9 @@ pub fun codegen_reusable(p: *project.Project, mid: session.ModuleId) bool {
     ret query.peek_valid(?p.s.queries, query.Q_CODEGEN, back_half_key(m.stable_id, test_build(p)));
 }
 
-# whether this build lowers the test variant (the module's `main` neutralized) -
-# the request's goal, folded into the back-half query keys so the test and
-# normal variants cache independently (#1858)
+# whether this build lowers the test variant (tests present, `main` neutralized) -
+# the request's goal, folded into the back-half query keys so it caches independently
+# from normal test-free IR (#1858, #2320)
 fun test_build(p: *project.Project) bool {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     ret request.test_goal(ctx.req.goal);
@@ -1232,9 +1233,9 @@ fun run_codegen_one(p: *project.Project, mid: session.ModuleId) R.Result[bool, s
 #                      hash-and-skip);
 #   - Q_TARGET:        a build-config change re-codegens every module.
 # the key is the same packed (stable id, test-mode) key as Q_LOWER, so the Q_LOWER
-# dep names the matching variant and a test build codegens the neutralized IR while a
-# normal build codegens the untouched IR (#1858). emits no assembly side-channel (the
-# `.s` debug artifact is rendered by the CLI from the borrowed IR when requested)
+# dep names the matching variant. a test build codegens tests with `main` neutralized;
+# a normal build codegens test-free IR (#1858, #2320). emits no assembly side-channel
+# (the `.s` debug artifact is rendered by the CLI from the borrowed IR when requested)
 pub fun q_codegen_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
     val ctx: *qctx.QueryCtx = db.ctx::*qctx.QueryCtx;
     if (ctx == nil) { ret R.err[query.QueryOutput, str]("Q_CODEGEN: query db has no context"); }

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -783,12 +783,13 @@ fun run_lower_one(p: *project.Project, mid: session.ModuleId) R.Result[bool, str
 # the Q_LOWERED_SURFACE derived compute - a deterministic byte fingerprint of the
 # module material that can monomorphize into an importer's IR (#1859). records a dep
 # on Q_RESOLVE(module), so any parse/resolve change refreshes it, then fingerprints
-# the module's whole source text MINUS the bodies of regular (non-generic,
-# non-comptime-param) functions: those bodies are emitted extern in importers and
-# never flow in, so an impl-only edit to one reproduces identical bytes and importers
-# reuse their lowered IR (the firewall). a generic-body, comptime-value, type-layout,
-# signature, or decorator edit changes these bytes and re-lowers importers. a plain
-# byte-valued derived kind (early-cutoff ON), keyed by StableModuleId
+# the module's whole source text MINUS bodies that cannot flow into an importer:
+# regular (non-generic, non-comptime-param) functions are emitted extern there,
+# and test declarations cannot be named outside their own test build. an edit to
+# either kind of body therefore reproduces identical bytes and importers reuse their
+# lowered IR (the firewall). a generic-body, comptime-value, type-layout, signature,
+# or decorator edit changes these bytes and re-lowers importers. a plain byte-valued
+# derived kind (early-cutoff ON), keyed by StableModuleId
 pub fun q_lowered_surface_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
     val ctx: *qctx.QueryCtx = db.ctx::*qctx.QueryCtx;
     if (ctx == nil) { ret R.err[query.QueryOutput, str]("Q_LOWERED_SURFACE: query db has no context"); }
@@ -826,12 +827,13 @@ pub fun q_lowered_surface_compute(db: *query.QueryDb, key: u64, alloc: *A.Alloca
 }
 
 # append the module's lowered surface to `fb`: the whole source text minus the byte
-# ranges of regular (non-generic, non-comptime-param) function bodies. the module's
-# top-level decls are walked in source order; each such body span is skipped, so its
-# contents never enter the fingerprint. everything else - signatures, generic and
-# comptime-param bodies, comptime values, record/union layouts, decorators, use/fwd -
-# is included verbatim. body spans nest inside their decls and decls do not overlap,
-# so the skipped ranges are strictly increasing and non-overlapping
+# ranges of bodies that cannot flow into an importer - regular (non-generic,
+# non-comptime-param) functions and tests. the module's declaration tree is walked
+# in source order; each such body span is skipped, so its contents never enter the
+# fingerprint. everything else - signatures, generic and comptime-param bodies,
+# comptime values, record/union layouts, decorators, use/fwd - is included verbatim.
+# body spans nest inside their decls and decls do not overlap, so the skipped ranges
+# are strictly increasing and non-overlapping
 fun fp_lowered_surface(fb: *dq.FpBuf, a: *ast.Ast, text: str) R.Result[bool, str] {
     val base:  *u8    = text::*u8;
     val total: usize  = str_len(text);
@@ -844,36 +846,83 @@ fun fp_lowered_surface(fb: *dq.FpBuf, a: *ast.Ast, text: str) R.Result[bool, str
     var i: u32 = 0;
     for (i < mod_node.decls_len) {
         val did: id.DeclId = a.decl_ids[mod_node.decls_start + i];
-        val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, did);
-        if (O.is_some[*decl.Decl](d_opt)) {
-            val bs_o: O.Option[token.Span] = regular_fn_body_span(a, O.unwrap[*decl.Decl](d_opt));
-            if (O.is_some[token.Span](bs_o)) {
-                val bs: token.Span = O.unwrap[token.Span](bs_o);
-                val w: R.Result[bool, str] = dq.fp_bytes(fb, ?base[cursor], (bs.offset - cursor)::u32);
-                if (R.is_err[bool, str](w)) { ret w; }
-                cursor = bs.offset + bs.len;
-            }
-        }
+        val w: R.Result[bool, str] = fp_non_flowing_decl_bodies(fb, a, base, did, ?cursor);
+        if (R.is_err[bool, str](w)) { ret w; }
         i = i + 1;
     }
     ret dq.fp_bytes(fb, ?base[cursor], (total - cursor)::u32);
 }
 
-# the source span of a regular function's body - the bytes to EXCLUDE from the lowered
-# surface - or none when `d` is not a body-carrying regular function. a function's body
-# flows into importers (and stays in the fingerprint) when the function is generic or
-# takes a comptime parameter; otherwise its body is emitted extern in importers and
-# excluded. non-function decls and body-less (extern/forward) functions yield none
-fun regular_fn_body_span(a: *ast.Ast, d: *decl.Decl) O.Option[token.Span] {
-    if (d.kind != decl.DECL_KIND_FUN) { ret O.none[token.Span](); }
-    if (d.data.fun_.body == id.STMT_NIL) { ret O.none[token.Span](); }
-    if (d.data.fun_.generics_len > 0) { ret O.none[token.Span](); }
-    var pi: u32 = 0;
-    for (pi < d.data.fun_.params_len) {
-        if (a.typed_names[d.data.fun_.params_start + pi].comptime) { ret O.none[token.Span](); }
-        pi = pi + 1;
+# append through the source before every non-flowing body under declaration `did`,
+# advancing `cursor` past each body. declaration-level comptime branches recurse
+# over every arm: inactive syntax remains part of the surface, but a regular
+# function or test body in any arm still cannot flow into an importer
+fun fp_non_flowing_decl_bodies(fb: *dq.FpBuf, a: *ast.Ast, base: *u8,
+                               did: id.DeclId, cursor: *usize) R.Result[bool, str] {
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, did);
+    if (O.is_none[*decl.Decl](d_opt)) {
+        ret R.err[bool, str]("Q_LOWERED_SURFACE: declaration id out of range");
     }
-    val st_o: O.Option[*stmt.Stmt] = ast.get_stmt(a, d.data.fun_.body);
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+
+    val bs_o: O.Option[token.Span] = non_flowing_body_span(a, d);
+    if (O.is_some[token.Span](bs_o)) {
+        val bs: token.Span = O.unwrap[token.Span](bs_o);
+        if (bs.offset < @cursor) {
+            ret R.err[bool, str]("Q_LOWERED_SURFACE: declaration body spans overlap");
+        }
+        val w: R.Result[bool, str] = dq.fp_bytes(fb, ?base[@cursor], (bs.offset - @cursor)::u32);
+        if (R.is_err[bool, str](w)) { ret w; }
+        @cursor = bs.offset + bs.len;
+        ret R.ok[bool, str](true);
+    }
+
+    if (d.kind != decl.DECL_KIND_COMPTIME_IF) { ret R.ok[bool, str](true); }
+    var bi: u32 = 0;
+    for (bi < d.data.comptime_if.branches_len) {
+        val branch_ix: u32 = d.data.comptime_if.branches_start + bi;
+        if (branch_ix::usize >= a.comptime_branch_len) {
+            ret R.err[bool, str]("Q_LOWERED_SURFACE: comptime branch index out of range");
+        }
+        val branch: *decl.ComptimeBranch = ?a.comptime_branches[branch_ix];
+        var di: u32 = 0;
+        for (di < branch.body_len) {
+            val pool_ix: u32 = branch.body_start + di;
+            if (pool_ix::usize >= a.decl_id_len) {
+                ret R.err[bool, str]("Q_LOWERED_SURFACE: comptime declaration index out of range");
+            }
+            val w: R.Result[bool, str] = fp_non_flowing_decl_bodies(fb, a, base, a.decl_ids[pool_ix], cursor);
+            if (R.is_err[bool, str](w)) { ret w; }
+            di = di + 1;
+        }
+        bi = bi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the source span of a body that cannot flow into an importer's IR - the bytes to
+# EXCLUDE from the lowered surface - or none. every test body is module-local and
+# belongs only to the test variant. a function body flows into importers (and stays
+# in the fingerprint) when the function is generic or takes a comptime parameter;
+# otherwise it is emitted extern there and excluded. other declarations and
+# body-less (extern/forward) functions yield none
+fun non_flowing_body_span(a: *ast.Ast, d: *decl.Decl) O.Option[token.Span] {
+    var body: id.StmtId = id.STMT_NIL;
+    if (d.kind == decl.DECL_KIND_TEST) {
+        body = d.data.test_.body;
+    }
+    or (d.kind == decl.DECL_KIND_FUN) {
+        if (d.data.fun_.generics_len > 0) { ret O.none[token.Span](); }
+        var pi: u32 = 0;
+        for (pi < d.data.fun_.params_len) {
+            if (a.typed_names[d.data.fun_.params_start + pi].comptime) { ret O.none[token.Span](); }
+            pi = pi + 1;
+        }
+        body = d.data.fun_.body;
+    }
+    if (body == id.STMT_NIL) { ret O.none[token.Span](); }
+
+    val st_o: O.Option[*stmt.Stmt] = ast.get_stmt(a, body);
     if (O.is_none[*stmt.Stmt](st_o)) { ret O.none[token.Span](); }
     ret O.some[token.Span](O.unwrap[*stmt.Stmt](st_o).span);
 }
@@ -894,10 +943,11 @@ fun regular_fn_body_span(a: *ast.Ast, d: *decl.Decl) O.Option[token.Span] {
 #     lowering firewall: an inlined instance can originate in a transitively-
 #     imported module the direct closure omits (#1618).
 # the key packs the module's stable id with the test-mode flag (back_half_key): the
-# test-mode variant neutralizes the module's `main` on its own freshly-lowered IR
-# before caching, so the two variants cache independently and query-owned IR is never
-# mutated in place (#1858). the deps below key on the stable id alone (test-mode does
-# not fan a module's typing)
+# test-mode variant includes test declarations and neutralizes the module's `main`
+# on its own freshly-lowered IR before caching; the normal variant omits test IR.
+# the two variants cache independently and query-owned IR is never mutated in place
+# (#1858, #2320). the deps below key on the stable id alone (test-mode does not fan
+# a module's typing)
 pub fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
     val ctx: *qctx.QueryCtx = db.ctx::*qctx.QueryCtx;
     if (ctx == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: query db has no context"); }
@@ -957,7 +1007,7 @@ pub fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Res
     }
     free_lower_closure(s.alloc, ?cl);
 
-    val res_lower: R.Result[ir.Module, str] = lower.lower_module(s, ?p.target, a, m.fqn, mid, sr, m.resolve_result, ?m.ctx, ctx.req.debug);
+    val res_lower: R.Result[ir.Module, str] = lower.lower_module(s, ?p.target, a, m.fqn, mid, sr, m.resolve_result, ?m.ctx, test_mode, ctx.req.debug);
     if (R.is_err[ir.Module, str](res_lower)) { ret R.err[query.QueryOutput, str](R.unwrap_err[ir.Module, str](res_lower)); }
     var irmod: ir.Module = R.unwrap_ok[ir.Module, str](res_lower);
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -3098,6 +3098,28 @@ fun ut_mod_main_neutralized(s: *session.Session, m: *ir.Module) i32 {
     ret -1;
 }
 
+# count functions tagged as test declarations in a borrowed IR module
+fun ut_mod_test_count(m: *ir.Module) u32 {
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        if ((m.functions[i].flags & ir.FN_FLAG_TEST) != 0) { count = count + 1; }
+        i = i + 1;
+    }
+    ret count;
+}
+
+# count functions carrying `flag` in a borrowed IR module
+fun ut_mod_flag_count(m: *ir.Module, flag: u32) u32 {
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        if ((m.functions[i].flags & flag) != 0) { count = count + 1; }
+        i = i + 1;
+    }
+    ret count;
+}
+
 # the last_changed revision of the project's Q_LINK entry on session `s`, or a
 # sentinel when absent. Q_LINK's value folds its inputs' revisions, so an unchanged
 # value means no link input changed - the link reuse probe (#1618)
@@ -4377,6 +4399,61 @@ test "mach.lang.driver:incremental_lower_surface_firewall" {
     ret bad;
 }
 
+# driver incremental: a dependency's test body cannot flow into an importer and
+# is therefore excluded from the lowered-surface fingerprint. editing only that
+# body re-lowers the declaring module but reuses the importer's normal variant
+# (#2320)
+test "mach.lang.driver:incremental_lower_surface_excludes_test_body" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.plain;\nfun main() i32 { ret plain(); }\n";
+    texts[1] = "pub fun plain() i32 { ret 1; }\n$if ($mach.build.pointer_width == 8) {\n    test \"leaf probe\" { val x: i32 = 1; if (plain() != x) { ret 1; } ret 0; }\n}\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val p1r: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
+    if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val st_leaf: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.leaf");
+    val lo_main_1: query.Revision = ut_lower_lc(?sA, st_main);
+    val lo_leaf_1: query.Revision = ut_lower_lc(?sA, st_leaf);
+    val sf_leaf_1: query.Revision = ut_surface_lc(?sA, st_leaf);
+    project.dnit_project(?p1);
+
+    val src_dir:   str = ut_cc3(?alloc, root, "/", "src");
+    val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
+    val leaf_v2: str = "pub fun plain() i32 { ret 1; }\n$if ($mach.build.pointer_width == 8) {\n    test \"leaf probe\" { val x: i32 = 2 - 1; if (plain() != x) { ret 1; } ret 0; }\n}\n";
+    if (O.is_some[str](fs.write_bytes(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+
+    val p2r: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
+    if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
+    val lo_main_2: query.Revision = ut_lower_lc(?sA, st_main);
+    val lo_leaf_2: query.Revision = ut_lower_lc(?sA, st_leaf);
+    val sf_leaf_2: query.Revision = ut_surface_lc(?sA, st_leaf);
+    project.dnit_project(?p2);
+
+    if (sf_leaf_2 != sf_leaf_1) { bad = 1; }
+    if (lo_leaf_2 == lo_leaf_1) { bad = 1; }
+    if (lo_main_2 != lo_main_1) { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
 # driver incremental: editing a dependency's pub comptime value advances its lowered
 # surface - the value is constant-folded into importers - so the importer re-lowers
 # (the comptime-value arm of the surface firewall, #1859)
@@ -4824,11 +4901,12 @@ test "mach.lang.driver:incremental_lower_verify_ir_toggle_relowers" {
     ret bad;
 }
 
-# driver incremental: test-mode `main`-neutralization is a variant of Q_LOWER keyed
-# on (module, test-mode), not an in-place mutation of the cached IR. A warm session
-# that lowers the test variant (its `main` neutralized) then the normal variant of the
-# same module yields correct IR for both, and the test variant's cached value is never
-# rewritten by the normal build - query-owned IR is immutable by construction (#1858)
+# driver incremental: test-mode IR is a variant of Q_LOWER keyed on
+# (module, test-mode), not an in-place mutation of the cached IR. A warm session
+# that lowers the test variant (its tests present and `main` neutralized) then the
+# normal variant (tests absent and `main` intact) of the same module yields correct
+# IR for both, and the test variant's cached value is never rewritten by the normal
+# build - query-owned IR is immutable by construction (#1858, #2320)
 test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -4843,7 +4921,7 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     var names: [2]str;
     names[0] = "main.mach"; names[1] = "leaf.mach";
     var texts: [2]str;
-    texts[0] = "use uniontest.leaf.fa;\n#[symbol(\"main\")]\nfun main() i32 { ret fa(); }\n";
+    texts[0] = "use uniontest.leaf.fa;\n#[symbol(\"main\")]\nfun main() i32 { ret fa(); }\nfun test_only[T](x: T) T { ret x; }\n$if ($mach.build.pointer_width == 8) {\n    test \"variant probe\" { if (test_only[i32](7) != 7) { ret 1; } ret 0; }\n}\n";
     texts[1] = "pub fun fa() i32 { ret 1; }\n";
     val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
     if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
@@ -4865,6 +4943,8 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     val mid1: session.ModuleId = ut_mid(?p1, ?sA, "uniontest.main");
     if (mid1 == session.MODULE_NIL) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (ut_mod_main_neutralized(?sA, p1.modules[mid1::u32].ir_module) != 1) { bad = 2; }
+    if (ut_mod_test_count(p1.modules[mid1::u32].ir_module) != 1) { bad = 6; }
+    if (ut_mod_flag_count(p1.modules[mid1::u32].ir_module, ir.FN_FLAG_WEAK) != 1) { bad = 8; }
     val key_test: u64 = passes.back_half_key(st_main, true);
     val key_norm: u64 = passes.back_half_key(st_main, false);
     val lc_test1: query.Revision = ut_lower_lc_key(?sA, key_test);
@@ -4884,6 +4964,8 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     val mid2: session.ModuleId = ut_mid(?p2, ?sA, "uniontest.main");
     if (mid2 == session.MODULE_NIL) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (ut_mod_main_neutralized(?sA, p2.modules[mid2::u32].ir_module) != 0) { bad = 3; }
+    if (ut_mod_test_count(p2.modules[mid2::u32].ir_module) != 0) { bad = 7; }
+    if (ut_mod_flag_count(p2.modules[mid2::u32].ir_module, ir.FN_FLAG_WEAK) != 0) { bad = 9; }
     # the test variant's cached entry is still present and un-recomputed by the normal
     # build (owned-handle shards never early-cut, so an unchanged revision means it was
     # not re-lowered - it holds the same neutralized module build 1 produced).

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -69,6 +69,7 @@ fwd context.symbol_of;
 # sema_result: typing output for the same module
 # rr:          name-resolution output for the same module
 # ctx:         comptime context (folded global initialisers)
+# test_mode:   true to lower test declarations; false to omit their IR
 # debug:       the build's settled debug-info decision (gates the scope tree)
 # ret:         the lowered IR module, or an error
 pub fun lower_module(
@@ -80,6 +81,7 @@ pub fun lower_module(
     sema_result: *sema.SemaResult,
     rr:          *resolve.ResolveResult,
     ctx:         *comptime.ComptimeCtx,
+    test_mode:   bool,
     debug:       bool
 ) R.Result[ir.Module, str] {
     val res_module: R.Result[ir.Module, str] = ir.init(s.alloc, fqn);
@@ -91,7 +93,7 @@ pub fun lower_module(
     # init_context cleans up its own partial allocations on failure, so the early
     # error path releases only the module.
     var lc: context.LowerContext;
-    val res_init: R.Result[bool, str] = context.init_context(?lc, s, tgt, a, fqn, own_module, sema_result, rr, ctx, debug, ?m);
+    val res_init: R.Result[bool, str] = context.init_context(?lc, s, tgt, a, fqn, own_module, sema_result, rr, ctx, test_mode, debug, ?m);
     if (R.is_err[bool, str](res_init)) {
         ir.dnit(?m);
         ret R.err[ir.Module, str](R.unwrap_err[bool, str](res_init));

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -191,6 +191,7 @@ pub rec PackInstance {
 # sema_result:   typing output parallel to the AST
 # rr:            name-resolution output parallel to the AST
 # ctx:           comptime context supplying folded global initialisers
+# test_mode:     true when test declarations belong in the emitted IR
 # m:             the IR module being built
 # builder:       insertion cursor into `m`
 # locals:        source SymbolId -> the Value naming its current storage (an
@@ -268,6 +269,9 @@ pub rec LowerContext {
     sema_result: *sema.SemaResult;
     rr:          *resolve.ResolveResult;
     ctx:         *comptime.ComptimeCtx;
+    # test declarations are semantically checked in every build, but only the
+    # test variant lowers their bodies into IR
+    test_mode:   bool;
     # the build's settled debug-info decision: gate the scope tree and the
     # per-local source metadata the DWARF producer consumes downstream
     debug:       bool;
@@ -329,6 +333,7 @@ pub rec LowerContext {
 # sema_result: typing output
 # rr:          name resolution
 # ctx:         comptime context
+# test_mode:   true when test declarations belong in the emitted IR
 # debug:       the build's settled debug-info decision
 # m:           IR module being built
 # ret:         true on success, or an allocation error
@@ -342,6 +347,7 @@ pub fun init_context(
     sema_result: *sema.SemaResult,
     rr:          *resolve.ResolveResult,
     ctx:         *comptime.ComptimeCtx,
+    test_mode:   bool,
     debug:       bool,
     m:           *ir.Module
 ) R.Result[bool, str] {
@@ -353,6 +359,7 @@ pub fun init_context(
     lc.sema_result = sema_result;
     lc.rr          = rr;
     lc.ctx         = ctx;
+    lc.test_mode   = test_mode;
     lc.debug       = debug;
     lc.m           = m;
     lc.builder     = builder.init(m);

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -177,9 +177,10 @@ pub rec PackInstance {
 
 # per-module lowering state, threaded through every decl / stmt / expr
 #
-# The leading fields are the phase inputs and the IR being built; the trailing
+# The leading fields are the phase inputs and the IR being built; the following
 # fields are the working state for the function currently being lowered (reset
-# by `begin_function`).
+# by `begin_function`). `test_mode` remains appended to preserve every existing
+# field offset.
 # ---
 # s:             shared session (allocator, interner, type universe)
 # tgt:           selected target -- drives IR type sizing
@@ -191,7 +192,7 @@ pub rec PackInstance {
 # sema_result:   typing output parallel to the AST
 # rr:            name-resolution output parallel to the AST
 # ctx:           comptime context supplying folded global initialisers
-# test_mode:     true when test declarations belong in the emitted IR
+# debug:         the build's settled debug-info decision
 # m:             the IR module being built
 # builder:       insertion cursor into `m`
 # locals:        source SymbolId -> the Value naming its current storage (an
@@ -260,6 +261,8 @@ pub rec PackInstance {
 #                by every deferred-`$each` body re-inference so a generic reached
 #                only from inside one is re-validated under its concrete type
 #                arguments, and each distinct instance exactly once
+# test_mode:     true when test declarations belong in the emitted IR; appended
+#                to keep the existing working-field offsets stable
 pub rec LowerContext {
     s:           *session.Session;
     tgt:         *target.Target;
@@ -269,9 +272,6 @@ pub rec LowerContext {
     sema_result: *sema.SemaResult;
     rr:          *resolve.ResolveResult;
     ctx:         *comptime.ComptimeCtx;
-    # test declarations are semantically checked in every build, but only the
-    # test variant lowers their bodies into IR
-    test_mode:   bool;
     # the build's settled debug-info decision: gate the scope tree and the
     # per-local source metadata the DWARF producer consumes downstream
     debug:       bool;
@@ -317,6 +317,9 @@ pub rec LowerContext {
     pack_ret_type: type.TypeId;
 
     ct_insts: *sema.InstWorklist;
+
+    # appended so the build variant does not perturb existing working-field offsets
+    test_mode: bool;
 }
 
 

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -66,7 +66,12 @@ pub fun lower_decl(ctx: *context.LowerContext, did: id.DeclId) R.Result[bool, st
     val k: decl.DeclKind = d.kind;
 
     if (k == decl.DECL_KIND_FUN)         { ret lower_fun(ctx, did, d, false); }
-    if (k == decl.DECL_KIND_TEST)        { ret lower_test(ctx, did, d); }
+    if (k == decl.DECL_KIND_TEST) {
+        # resolve and sema still check every test body. only test-mode lowering
+        # admits it to IR, where it can enqueue instances and affect optimisation.
+        if (!ctx.test_mode) { ret R.ok[bool, str](true); }
+        ret lower_test(ctx, did, d);
+    }
     if (k == decl.DECL_KIND_VAL)         { ret lower_global(ctx, did, d, false); }
     if (k == decl.DECL_KIND_VAR)         { ret lower_global(ctx, did, d, true); }
     if (k == decl.DECL_KIND_COMPTIME_IF) { ret lower_comptime_if(ctx, d); }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -91,10 +91,10 @@ pub val Q_SEMA: QueryKind = 9;
 # and neutralizes the module's `main`; the normal variant omits test IR. the two cache
 # independently and query-owned IR is never mutated in place (#1858, #2320)
 #
-# Reads Q_SEMA(module), Q_TARGET, Q_LOWER_FLAGS, and Q_SEMA of every module in this
-# module's transitive import closure: a generic/comptime instance declared in
-# another module is monomorphized into THIS module's IR, so that module's typing
-# feeds this lowered output and a change there must re-lower this module (#1618).
+# Reads Q_SEMA(module), Q_TARGET, Q_LOWER_FLAGS, and Q_LOWERED_SURFACE for every
+# module in this module's transitive import closure: a generic/comptime instance
+# declared in another module can be monomorphized into THIS module's IR, so a change
+# to that dependency's flowing surface must re-lower this module (#1618, #1859).
 pub val Q_LOWER: QueryKind = 10;
 # derived (owned handle): a module's of.ObjectImage, keyed on sess.StableModuleId
 # packed with the test-mode flag (the same key as Q_LOWER), so an unchanged module's

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -87,9 +87,9 @@ pub val Q_SEMA: QueryKind = 9;
 # sess.StableModuleId in the low 32 bits with the test-mode flag in bit 32, so an
 # unchanged module's lowered IR is reused across rebuilds even when a graph reshape
 # renumbers per-build ModuleIds. mangled linkage names are FQN-derived, so a cached
-# module stays valid across a reshape. the test-mode variant neutralizes the module's
-# `main` on its own freshly-lowered IR, so a test build and a normal build of the same
-# module cache independently and query-owned IR is never mutated in place (#1858)
+# module stays valid across a reshape. the test-mode variant includes test declarations
+# and neutralizes the module's `main`; the normal variant omits test IR. the two cache
+# independently and query-owned IR is never mutated in place (#1858, #2320)
 #
 # Reads Q_SEMA(module), Q_TARGET, Q_LOWER_FLAGS, and Q_SEMA of every module in this
 # module's transitive import closure: a generic/comptime instance declared in
@@ -98,8 +98,9 @@ pub val Q_SEMA: QueryKind = 9;
 pub val Q_LOWER: QueryKind = 10;
 # derived (owned handle): a module's of.ObjectImage, keyed on sess.StableModuleId
 # packed with the test-mode flag (the same key as Q_LOWER), so an unchanged module's
-# codegen output is reused across rebuilds and a test build codegens the neutralized
-# variant independently of the normal build (#1858)
+# codegen output is reused across rebuilds. a test build codegens tests with `main`
+# neutralized; a normal build codegens the test-free variant independently
+# (#1858, #2320)
 #
 # Reads Q_LOWER(module) and Q_TARGET. an unchanged lowered IR reuses the cached
 # image (and its on-disk `.o`) instead of re-emitting - the per-module
@@ -163,9 +164,10 @@ pub val Q_LOWER_FLAGS: QueryKind = 16;
 # depends on this fingerprint (per transitive-closure module) instead of the full
 # Q_SEMA, so a change to a regular function's body - which is emitted extern in
 # importers and never flows into their IR - reproduces identical bytes and importers
-# reuse their lowered IR, while a generic-body or comptime-value edit advances it and
-# re-lowers them (#1859). Fingerprinted from source: the whole module text minus the
-# bodies of regular (non-generic, non-comptime-param) functions.
+# reuse their lowered IR. test bodies likewise cannot flow into importers and are
+# excluded, including under declaration-level comptime branches. a generic-body or
+# comptime-value edit advances the fingerprint and re-lowers importers (#1859, #2320).
+# fingerprinted from source: the whole module text minus those non-flowing bodies.
 pub val Q_LOWERED_SURFACE: QueryKind = 17;
 
 # monotonic counter owned by the QueryDb, bumped on every set_input. cached


### PR DESCRIPTION
Closes #2320

## Summary

- omit `test` declarations at lowering entry for non-test builds, before test-only generic, comptime-value, or pack instances can enter the worklists or optimizer
- retain distinct test/non-test `Q_LOWER` and `Q_CODEGEN` keys; tests exist only in the test variant, while semantic checking remains shared and still checks every test body
- exclude test bodies from the importer-facing lowered-surface fingerprint, including declarations nested under comptime branches
- append the mode bit to `LowerContext`, preserving every pre-existing field offset
- pin the variant boundary with a nested test that is the sole caller of a generic helper: test IR contains both the test and weak instance; normal IR contains neither

## Intentional optimizer effect

Production output from a module containing tests is not expected to remain byte-identical to the old build. Test-only call sites previously affected production inliner call-count decisions. For example, old `std.memory.raw_zero` calls `raw_fill`; after test callers are omitted, the production-only call graph inlines `raw_fill` into `raw_zero`. That difference is intentional: shipped optimization decisions now depend only on shipped callers.

A runtime-toggle benchmark would be needed to isolate build-time savings because the two self-hosted compiler executables themselves have different inlining. This PR therefore makes no build-time claim.

## Linux x86_64 release measurement

Controlled clean self-hosted comparison:

- baseline: `dev` at `1ed712e2ce081fadce8d38d06a84875c29823e07`
- branch: `fix/2320` at `05586395f39d9dadee525be2b4bc44c429f96f40`
- stage-0 compiler: Mach 4.3.2
- dependency: mach-std `11d8f618c2e3cbf7307526432a4bde74ab96e9f6` in both detached worktrees
- every generation used explicit `--profile release`

`dev` converged immediately (`a == b == c`) at SHA-256 `a6320dbbe3b15f2e3de7cd33d28945c9f6abbf6712beb61f3f2fd77b2418be78`. The branch converged at `b == c`, SHA-256 `0f8af02fb69d2d780fd13b4e09917b549f07d6d08bb7f6ffe4e1a7fe7856a652`.

Both final object trees contain the same 216 paths.

- compiler: 11,177,984 → 8,884,224 bytes (−2,293,760; 20.52%)
- objects: 16,309,144 → 13,146,288 bytes (−3,162,856; 19.39%)
- aggregate `.text`: 10,827,396 → 8,584,700 bytes (−2,242,696; 20.71%)
- linked executable LOAD: 10,828,926 → 8,586,158 bytes (−2,242,768; 20.71%)
- linked read-only data LOAD: 320,681 → 268,473 bytes (−52,208; 16.28%)

Largest absolute `.text` reductions are `std/format.o` (108,064 bytes), `me/analysis/loops.o` (98,516), `manifest.o` (92,046), and `target/of/elf.o` (81,004). Of 133 byte-different objects, 130 source modules contain tests; the other three are the changed implementation modules `me/lower.o`, `me/lower/context.o`, and `me/lower/decl.o`.

## Artifact controls

- test-free one-module release object: byte-identical, 552 bytes, SHA-256 `694541ca24d9db6501486d9cc1592ff301996b0095502a9d1c6dca4ffe5831d0` under both compilers
- same control with one test: normal object 952 → 560 bytes; `MACH_2320_TEST_BODY_SENTINEL` is present once under `dev` and absent under this branch
- that control test is still discovered and executes successfully under `mach test`
- a deliberate type error inside that test still fails a normal release build during semantic checking

## Verification

- focused test/non-test variant regression, debug/O0 and release/O2 with `--verify-ir`: passed
- focused lowered-surface regression, including a nested test-body edit, debug/O0 and release/O2 with `--verify-ir`: passed
- compiler suite debug/O0 with `--verify-ir`: 973 passed, 0 failed
- compiler suite release/O2 with `--verify-ir`: 973 passed, 0 failed
- debug and release test-name enumerations are identical within each tree; versus `dev`, all 972 existing `(module, label)` identities remain and only `mach.lang.driver:incremental_lower_surface_excludes_test_body` is added
- mach-std at `11d8f618c2e3cbf7307526432a4bde74ab96e9f6`, `-O0` and `-O2` with `--verify-ir`: 680 passed, 0 failed each
- release fixpoint: final two branch generations are byte-identical at SHA-256 `0f8af02fb69d2d780fd13b4e09917b549f07d6d08bb7f6ffe4e1a7fe7856a652`
- compiler cross-builds with `--profile release --verify-ir`: valid x86_64 and arm64 Mach-O executables
- `git diff --check`: clean
- no workflow changes
- refreshed CI: green\n\nIndependent review completed with no blocking findings.