### PR TITLE
fix(verify): accept unavailable aggregate debug values

### DIFF
--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -25,6 +25,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.intern;
+use semtype: mach.lang.type;
 use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
@@ -61,7 +62,9 @@ pub val VC_REACHABILITY:    VerifyCheck = 9;
 # a parameter, or the result of an address-producing instruction
 # (alloca/gep/load/call/bitcast). a VAL_CONST_* tagged aggregate, or an aggregate
 # value produced by a non-address op, is a dropped retype that miscompiles into an
-# 8-byte move instead of a sized copy
+# 8-byte move instead of a sized copy. The sole constant exception is
+# VAL_CONST_NULL on OP_DBG_VALUE: debug salvage uses that typed-null pseudo-operand
+# as its optimized-out/unavailable sentinel, and no runtime instruction consumes it
 pub val VC_AGG_ADDRESS:     VerifyCheck = 10;
 
 # an operand carries a type id that does not resolve in the module's type table
@@ -515,8 +518,13 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
                     if (R.is_err[bool, str](rr)) { ret rr; }
                 }
             }
-            # VC_AGG_ADDRESS: an aggregate-typed operand must name storage by address.
-            if (type.is_aggregate(?m.types, op.ty) && !agg_value_is_address_producing(fn, op)) {
+            # VC_AGG_ADDRESS: an aggregate-typed runtime operand must name storage by
+            # address. A dbg-value's typed null is the canonical optimized-out
+            # metadata sentinel, not aggregate data consumed by the program.
+            val dbg_unavailable: bool = ins.kind == instruction.OP_DBG_VALUE
+                && op.kind == value.VAL_CONST_NULL;
+            if (type.is_aggregate(?m.types, op.ty) && !dbg_unavailable
+                && !agg_value_is_address_producing(fn, op)) {
                 val rr: R.Result[bool, str] = push(r, fi, bid, iid, VC_AGG_ADDRESS);
                 if (R.is_err[bool, str](rr)) { ret rr; }
             }
@@ -1922,6 +1930,37 @@ test "mach.lang.me.ir.verify.agg_value_is_address_producing:add_result" {
     if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))                { ret 1; }
 
     if (t_count(?env, false, true, VC_AGG_ADDRESS) < 1)   { ret 1; }
+    if (t_count(?env, false, false, VC_AGG_ADDRESS) != 0) { ret 1; }
+    ret 0;
+}
+
+# repr accepts the typed-null optimized-out sentinel only as an OP_DBG_VALUE
+# operand; the same aggregate-typed null used by a real store remains a
+# VC_AGG_ADDRESS violation
+test "mach.lang.me.ir.verify.agg_value_is_address_producing:debug_null_sentinel" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    val sr: R.Result[type.IrTypeId, str] = type.intern_struct(?env.m.types, ?env.i64ty, 1, 0);
+    if (R.is_err[type.IrTypeId, str](sr)) { ret 1; }
+    val stty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](sr);
+
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+    builder.set_block(?env.bld, b0);
+
+    val ar: R.Result[value.Value, str] = builder.emit_alloca(?env.bld, stty, t_ci(?env, 1));
+    if (R.is_err[value.Value, str](ar)) { ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](ar);
+    val unavailable: value.Value = value.const_null(stty);
+
+    if (R.is_err[bool, str](builder.emit_dbg_value(?env.bld, unavailable, intern.STR_NIL,
+                                                   stty, semtype.TYPE_NIL, false, 0))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?env.bld, unavailable, slot))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))                 { ret 1; }
+
+    # the only violation is the real store operand; the debug pseudo-op is exempt.
+    if (t_count(?env, false, true, VC_AGG_ADDRESS) != 1)  { ret 1; }
     if (t_count(?env, false, false, VC_AGG_ADDRESS) != 0) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #2419

## Summary

- distinguish the typed-null `OP_DBG_VALUE` unavailable sentinel from runtime aggregate operands
- preserve `VC_AGG_ADDRESS` for the same malformed aggregate null on real instructions
- add a focused verifier regression covering both sides of that boundary

## Root cause

The first failure is immediately after `sroa.run` in `std.types.option`, function/test `option: some creates value with is_some true`, block 5, instruction 3. SROA removes the aggregate storage for the source local `opt` (`mach-std/src/types/option.mach:69`), and debug salvage represents the unavailable binding as `OP_DBG_VALUE` with an aggregate-typed `VAL_CONST_NULL`. `VC_AGG_ADDRESS` treated that metadata pseudo-operand as runtime aggregate flow.

The exception is deliberately use-site narrow: only typed null on `OP_DBG_VALUE` is unavailable metadata. The same aggregate-typed null on a real store still reports `VC_AGG_ADDRESS`.

## Verification

Refreshed from `dev` at `624ca863` with merge commit `0ef327e6`; all evidence below is from that synchronized head.

- focused verifier regression and existing real-operand control: O0 and O2 pass
- mutation: removing `!dbg_unavailable` makes the regression fail 0/1 and restores the original release `-g --verify-ir` failure; the no-`-g` verifier control still passes
- full compiler source suite: 974/974 at O0 and 974/974 at O2
- release self-host fixpoint: stage B == stage C byte-for-byte (`6ca368fe73ce008b4d9c010dcccfc9ba899ad0fcaba7f67470048aa43bd00546`, 8,884,224 bytes)
- exact `vectorize-emit` release reproduction and no-`-g` control pass with `--verify-ir` on x86_64, aarch64, and riscv64 ELF targets
- `vectorize-emit` emission integration passes on all three ELF ISAs
- debuginfo integration passes in debug and release on all three ELF ISAs (`llvm-dwarfdump --verify` clean; loadable bytes additive)
- whole-compiler release `-g`/no-`-g` comparison: all five PT_LOAD segments identical and DWARF verifies clean on x86_64, aarch64, and riscv64
- release `-g --verify-ir` compiler cross-builds produce valid PE x86_64, Mach-O x86_64, and Mach-O arm64 executables
- synchronized-head CI: all 16 required checks pass; the dev-target Darwin release gate is expectedly skipped

No workflow files changed.