### PR TITLE
fix(linker): discard losing weak function bodies

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1654,8 +1654,9 @@ fun atom_resume_align(off: u32, section_align: u32) u32 {
 }
 
 # physical relocation shape supplied by the active ISA's relocatable-object seam
-fun atom_reloc_traits(kind: of.RelocKind, arch: *isa.IsaVTable) rel.RelocTraits {
-    ret arch.reloc.reloc_traits::rel.RelocTraitsFn(kind);
+fun atom_reloc_traits(r: *of.Relocation, section: *of.Section,
+                      arch: *isa.IsaVTable) rel.RelocTraits {
+    ret arch.reloc.reloc_traits::rel.RelocTraitsFn(r.kind, section.kind);
 }
 
 # whether a second symbol is the exact synthetic section anchor emitted by COFF
@@ -1712,11 +1713,9 @@ fun atom_reloc_crosses_candidate(modules: *of.ObjectImage, reference: *AtomReloc
     if (target.offset > modules[candidate_module].sections[candidate_section].len) { ret false; }
 
     # a resolved entry inside the atom disappears regardless of relocation kind.
-    # pc-relative field biases are otherwise not S-relative addends: a normal
-    # call to the next global function carries -4 and must not look like it
-    # points four bytes backward into this candidate. A biased relocation through
-    # any local in this section is retained conservatively because foreign
-    # containers may encode an anchor-relative target behind that bias.
+    # field-biased kinds carry an ISA-owned range: x64 plt32 is exactly +4, while
+    # ambiguous text pc32 includes both a raw symbol delta and every possible
+    # instruction-end bias.
     if (target.offset >= start && target.offset < end) { ret true; }
     if (reference.addend_mode == rel.RELOC_ADDEND_IGNORED) { ret false; }
 
@@ -2015,8 +2014,18 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 refs[rw].target_symbol = 0xFFFFFFFF;
                 refs[rw].source_module = m;
                 refs[rw].reloc = ri;
-                val traits: rel.RelocTraits =
-                    atom_reloc_traits(modules[m].relocations[ri].kind, arch);
+                val relocation: *of.Relocation = ?modules[m].relocations[ri];
+                var traits: rel.RelocTraits;
+                if (relocation.section < modules[m].section_count) {
+                    traits = atom_reloc_traits(
+                        relocation, ?modules[m].sections[relocation.section], arch);
+                }
+                or {
+                    # the normal patch pass reports the corrupt section index;
+                    # width is irrelevant until then, but keep this index build
+                    # bounded and initialized.
+                    traits = rel.traits(0, rel.RELOC_ADDEND_IGNORED, 0, 0);
+                }
                 refs[rw].width = traits.field_width;
                 refs[rw].addend_mode = traits.addend_mode;
                 refs[rw].text_bias_min = traits.text_bias_min;
@@ -2125,8 +2134,9 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             val r: *of.Relocation = ?modules[cm].relocations[ri];
             if (r.section == sym.section) {
                 val rstart: u64 = r.offset::u64;
-                val rend: u64 =
-                    rstart + atom_reloc_traits(r.kind, arch).field_width::u64;
+                val rend: u64 = rstart
+                    + atom_reloc_traits(r, ?modules[cm].sections[r.section],
+                                        arch).field_width::u64;
                 if (rstart < end::u64 && rend > start::u64
                     && (rstart < start::u64 || rend > end::u64)) {
                     safe = false;
@@ -2820,7 +2830,9 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         if (r.section >= modules[m].section_count) {
             ret R.err[bool, str]("linker: relocation names an out-of-range section");
         }
-        if (r.offset::u64 + atom_reloc_traits(r.kind, arch).field_width::u64
+        if (r.offset::u64
+            + atom_reloc_traits(r, ?modules[m].sections[r.section],
+                                arch).field_width::u64
             > modules[m].sections[r.section].len::u64) {
             ret R.err[bool, str]("linker: relocation offset is past the end of its section");
         }
@@ -4433,17 +4445,21 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     val base: intern.StrId = lt_name(?s, "section_base");
     val tail: intern.StrId = lt_name(?s, "tail");
     val text: intern.StrId = lt_name(?s, ".text");
+    val data: intern.StrId = lt_name(?s, ".data");
     val weak_flags: u32 =
         of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
     val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
     var a_bytes: [8]u8;
     var b_bytes: [24]u8;
+    var b_data: [4]u8;
     var a_sec: [1]of.Section;
-    var b_sec: [1]of.Section;
+    var b_secs: [2]of.Section;
     a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
     a_sec[0].len = 8; a_sec[0].align = 1;
-    b_sec[0].name = text; b_sec[0].kind = of.SK_TEXT; b_sec[0].bytes = ?b_bytes[0];
-    b_sec[0].len = 24; b_sec[0].align = 1;
+    b_secs[0].name = text; b_secs[0].kind = of.SK_TEXT; b_secs[0].bytes = ?b_bytes[0];
+    b_secs[0].len = 24; b_secs[0].align = 1;
+    b_secs[1].name = data; b_secs[1].kind = of.SK_DATA; b_secs[1].bytes = ?b_data[0];
+    b_secs[1].len = 4; b_secs[1].align = 4;
 
     var a_syms: [1]of.Symbol;
     var b_syms: [3]of.Symbol;
@@ -4462,43 +4478,53 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
                        nil::*of.Relocation, 0);
-    mods[1] = lt_image(?s, lt_name(?s, "loser"), ?b_sec[0], 1, ?b_syms[0], 3,
+    mods[1] = lt_image(?s, lt_name(?s, "loser"), ?b_secs[0], 2, ?b_syms[0], 3,
                        ?reloc[0], 1);
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val crossing: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](crossing) || plan.active) { ret 1; }
 
     # a target that remains before the candidate does not cross it and leaves the
     # duplicate eligible, proving retention is caused by the addend relationship.
     reloc[0].addend = 4;
     val same_side: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](same_side) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
-    # raw PC addends include an instruction-field bias. retain a local-anchor
-    # reference conservatively, but do not mistake a normal -4 call to the next
-    # global function for a pointer back into the candidate.
+    # text pc32 remains ambiguous even when the preceding byte looks like a call
+    # opcode: data can contain 0xe8 too, so bias zero stays in the possible range.
+    b_bytes[3] = 0xE8;
+    reloc[0].offset = 4;
     reloc[0].kind = of.RK_PC32;
     reloc[0].addend = -4;
     val pc_local: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](pc_local) || plan.active) { ret 1; }
     reloc[0].symbol = tail;
     reloc[0].kind = of.RK_PLT32;
     val pc_global: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](pc_global) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     # darwin arm64 CALL26 preserves its S-relative addend: tail-4 lands inside
     # the candidate. x64's canonical field bias above instead reaches tail.
     val arm_global: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, arm64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, arm64, ?plan);
     if (R.is_err[bool, str](arm_global) || plan.active) { ret 1; }
+
+    # non-text pc32 has no instruction bias: tail-4 reaches the candidate and
+    # therefore retains it.
+    reloc[0].section = 1;
+    reloc[0].offset = 0;
+    reloc[0].kind = of.RK_PC32;
+    val data_pc: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+    if (R.is_err[bool, str](data_pc) || plan.active) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -26,6 +26,7 @@
 
 use std.allocator.page;
 use std.collections.map;
+use std.collections.sort;
 use fs: std.filesystem;
 use std.collections.vector;
 use std.collections.vector.Vector;
@@ -123,6 +124,51 @@ rec MergedSection {
 rec SymbolLoc {
     vaddr: u64;
     weak:  bool;
+}
+
+# one losing weak function's byte interval in a flat input section. final-image
+# links remove [start,end); resume is the compressed offset at which the first
+# surviving byte after the interval lands
+rec AtomDrop {
+    section: u32;
+    start:   u32;
+    end:     u32;
+    resume:  u32;
+}
+
+# one input section's slice of the sorted drop array and its compressed length
+rec AtomSection {
+    first:    u32;
+    count:    u32;
+    live_len: u32;
+}
+
+# transient final-link function-atom liveness. it exists only inside the internal
+# executable/shared-object linker; relocatable objects and their native weak/group
+# encodings never consult it. an inactive plan is the exact legacy byte path
+rec AtomPlan {
+    drops:         *AtomDrop;
+    drop_count:    u32;
+    drop_cap:      u32;
+    sections:      *AtomSection;
+    section_count: u32;
+    removed_bytes: u64;
+    active:        bool;
+}
+
+# the current winning definition while the atom planner mirrors global
+# weak/strong resolution. module+symbol identify an earlier weak when a later
+# strong definition displaces it
+rec AtomWinner {
+    module: u32;
+    symbol: u32;
+    weak:   bool;
+}
+
+# a weak definition proven to lose global name resolution
+rec AtomCandidate {
+    module: u32;
+    symbol: u32;
 }
 
 # the linker's mutable dynamic-link state: the format-neutral plan (`of.DynamicInfo`)
@@ -422,6 +468,8 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # in-place-patched modes (executable, shared object) dedup; a relocatable output
     # gets an inactive StrMerge and keeps the classic concatenation (#1708).
     val patching: bool = (mode == LINK_EXE) || shared;
+    var atoms: AtomPlan;
+    init_atom_plan(?atoms);
     var strm: StrMerge;
     val sm_r: R.Result[StrMerge, str] = build_str_merge(s, modules, module_count, patching);
     if (R.is_err[StrMerge, str](sm_r)) {
@@ -455,7 +503,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (sec_total > 0) {
         val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
         if (R.is_err[*Placement, str](pr)) {
-            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
             ret R.err[bool, str](R.unwrap_err[*Placement, str](pr));
         }
         placements = R.unwrap_ok[*Placement, str](pr);
@@ -465,15 +513,26 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     var sec_base: *u32 = nil;
     val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
     if (R.is_err[*u32, str](br)) {
-        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[*u32, str](br));
     }
     sec_base = R.unwrap_ok[*u32, str](br);
 
+    # Final executable/shared links may discard only function atoms whose weak
+    # definition actually lost global resolution. A relocatable link receives an
+    # inert plan and preserves its native weak/group representation byte-for-byte.
+    val atom_r: R.Result[bool, str] =
+        build_atom_plan(s, modules, module_count, sec_base, sec_total, patching, ?atoms);
+    if (R.is_err[bool, str](atom_r)) {
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        ret R.err[bool, str](R.unwrap_err[bool, str](atom_r));
+    }
+
     val acc_r: R.Result[bool, str] =
-        accumulate_sections(s, modules, module_count, merged, debug_names, debug_count, placements, sec_base, ?strm);
+        accumulate_sections(s, modules, module_count, merged, debug_names, debug_count,
+                            placements, sec_base, ?strm, ?atoms);
     if (R.is_err[bool, str](acc_r)) {
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
@@ -493,10 +552,11 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
 
     val collect_r: R.Result[bool, str] =
-        collect_symbols(s, modules, module_count, placements, sec_base, ?sym_locs, assign_vaddrs);
+        collect_symbols(s, modules, module_count, placements, sec_base, ?sym_locs,
+                        assign_vaddrs, ?atoms);
     if (R.is_err[bool, str](collect_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](collect_r));
     }
 
@@ -506,7 +566,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val img_r: R.Result[of.ObjectImage, str] = obj.init(alloc, ?s.interner, image_name(modules, module_count));
     if (R.is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](img_r));
     }
     out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
@@ -517,17 +577,18 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[*u32, str](mto_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[*u32, str](mto_r));
     }
     merged_to_out = R.unwrap_ok[*u32, str](mto_r);
 
     val build_r: R.Result[bool, str] =
-        build_merged_image(s, ?out_img, modules, module_count, merged, merged_count, placements, sec_base, merged_to_out, ?strm);
+        build_merged_image(s, ?out_img, modules, module_count, merged, merged_count,
+                           placements, sec_base, merged_to_out, ?strm, ?atoms);
     if (R.is_err[bool, str](build_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
@@ -548,23 +609,25 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         dyn.info.pie = position_independent;
         if (dynamic) {
             val dr: R.Result[bool, str] =
-                build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs, sonames, soname_count);
+                build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs,
+                                   sonames, soname_count, sec_base, ?atoms);
             if (R.is_err[bool, str](dr)) {
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
             }
         }
 
         val patch_r: R.Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, merged_to_out, ?sym_locs, ?dyn, ?strm, tgt.isa);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base,
+                              merged_to_out, ?sym_locs, ?dyn, ?strm, tgt.isa, ?atoms);
         if (R.is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
             ret R.err[bool, str](R.unwrap_err[bool, str](patch_r));
         }
 
@@ -582,7 +645,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         free_dynstate(alloc, ?dyn);
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
 
         if (R.is_err[bool, str](emit_r)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
@@ -597,7 +660,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[bool, str](carry_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](carry_r));
     }
 
@@ -605,7 +668,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
 
     obj.dnit(?out_img);
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm);
+    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
 
     if (R.is_err[bool, str](obj_r)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](obj_r));
@@ -1507,6 +1570,412 @@ fun free_str_merge(sm: *StrMerge) {
     enc.buf_dnit(?sm.buf);
 }
 
+# reset a final-link atom plan to its inert state
+fun init_atom_plan(plan: *AtomPlan) {
+    plan.drops         = nil;
+    plan.drop_count    = 0;
+    plan.drop_cap      = 0;
+    plan.sections      = nil;
+    plan.section_count = 0;
+    plan.removed_bytes = 0;
+    plan.active        = false;
+}
+
+# release a final-link atom plan's sorted ranges and section index
+fun free_atom_plan(alloc: *A.Allocator, plan: *AtomPlan) {
+    if (plan == nil) { ret; }
+    if (plan.drops != nil && plan.drop_cap > 0) {
+        A.deallocate[AtomDrop](alloc, plan.drops, plan.drop_cap::usize);
+    }
+    if (plan.sections != nil && plan.section_count > 0) {
+        A.deallocate[AtomSection](alloc, plan.sections, plan.section_count::usize);
+    }
+    init_atom_plan(plan);
+}
+
+# order discarded atoms by flat input section and source interval
+fun atom_drop_cmp(a: *AtomDrop, b: *AtomDrop) i64 {
+    if (a.section < b.section) { ret -1; }
+    if (a.section > b.section) { ret 1; }
+    if (a.start < b.start)     { ret -1; }
+    if (a.start > b.start)     { ret 1; }
+    if (a.end < b.end)         { ret -1; }
+    if (a.end > b.end)         { ret 1; }
+    ret 0;
+}
+
+# largest power-of-two alignment required by the source byte at `off`, capped
+# at the input section's declared alignment
+fun atom_resume_align(off: u32, section_align: u32) u32 {
+    var limit: u32 = section_align;
+    if (limit == 0) { limit = 1; }
+    var p: u32 = 1;
+    for ((off & p) == 0 && p < limit && p < 0x40000000) { p = p << 1; }
+    ret p;
+}
+
+# byte width patched by an abstract relocation kind
+fun atom_reloc_width(kind: of.RelocKind) u32 {
+    if (kind == of.RK_ABS64)   { ret 8; }
+    if (kind == of.RK_SECTION) { ret 2; }
+    ret 4;
+}
+
+# fill each module's base in the flat input-section array
+fun fill_section_bases(modules: *of.ObjectImage, module_count: u32, sec_base: *u32) {
+    var flat: u32 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        sec_base[m] = flat;
+        flat = flat + modules[m].section_count;
+        m = m + 1;
+    }
+}
+
+# whether `off` lies in a discarded atom of flat input section `section`
+fun atom_offset_dead(plan: *AtomPlan, section: u32, off: u32) bool {
+    if (plan == nil || !plan.active || section >= plan.section_count) { ret false; }
+    val meta: *AtomSection = ?plan.sections[section];
+    var i: u32 = meta.first;
+    val end: u32 = meta.first + meta.count;
+    for (i < end) {
+        val drop: *AtomDrop = ?plan.drops[i];
+        if (off < drop.start) { ret false; }
+        if (off < drop.end)   { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# map a live source offset into its compressed input-section offset. callers
+# test atom_offset_dead first; an offset inside a dead interval maps to its
+# resume point defensively
+fun atom_live_offset(plan: *AtomPlan, section: u32, off: u32) u32 {
+    if (plan == nil || !plan.active || section >= plan.section_count) { ret off; }
+    val meta: *AtomSection = ?plan.sections[section];
+    var src_cursor: u32 = 0;
+    var dst_cursor: u32 = 0;
+    var i: u32 = meta.first;
+    val end: u32 = meta.first + meta.count;
+    for (i < end) {
+        val drop: *AtomDrop = ?plan.drops[i];
+        if (off < drop.start) { ret dst_cursor + (off - src_cursor); }
+        if (off < drop.end)   { ret drop.resume; }
+        src_cursor = drop.end;
+        dst_cursor = drop.resume;
+        i = i + 1;
+    }
+    ret dst_cursor + (off - src_cursor);
+}
+
+# compressed byte length of a flat input section, or the original length on
+# the inert path
+fun atom_live_len(plan: *AtomPlan, section: u32, original_len: u32) u32 {
+    if (plan == nil || !plan.active || section >= plan.section_count) { ret original_len; }
+    ret plan.sections[section].live_len;
+}
+
+# copy one input section while omitting its discarded atom intervals. output
+# storage is zero-initialized, so alignment gaps inserted at resume points need
+# no explicit writes
+fun copy_live_section(dst: *u8, src: *u8, src_len: u32, plan: *AtomPlan, section: u32) {
+    if (plan == nil || !plan.active || section >= plan.section_count
+        || plan.sections[section].count == 0) {
+        memory.copy[u8](dst, src, src_len::usize);
+        ret;
+    }
+
+    val meta: *AtomSection = ?plan.sections[section];
+    var src_cursor: u32 = 0;
+    var dst_cursor: u32 = 0;
+    var i: u32 = meta.first;
+    val end: u32 = meta.first + meta.count;
+    for (i < end) {
+        val drop: *AtomDrop = ?plan.drops[i];
+        val n: u32 = drop.start - src_cursor;
+        if (n > 0) {
+            memory.copy[u8](?dst[dst_cursor], ?src[src_cursor], n::usize);
+            dst_cursor = dst_cursor + n;
+        }
+        src_cursor = drop.end;
+        dst_cursor = drop.resume;
+        i = i + 1;
+    }
+    if (src_cursor < src_len) {
+        memory.copy[u8](?dst[dst_cursor], ?src[src_cursor], (src_len - src_cursor)::usize);
+    }
+}
+
+# build transient function-atom liveness for a final internal link. global
+# definitions are first resolved with the same first-weak/strong-override rules
+# as collect_symbols. only a weak GLOBAL FUNCTION in SK_TEXT that actually loses
+# is eligible. its extent runs to the next global function entry (or section end);
+# another symbol inside the interval or a relocation field crossing its boundary
+# keeps the interval conservatively live
+fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
+                    sec_base: *u32, sec_total: u32, enabled: bool,
+                    plan: *AtomPlan) R.Result[bool, str] {
+    fill_section_bases(modules, module_count, sec_base);
+    if (!enabled) { ret R.ok[bool, str](true); }
+
+    var symbol_total64: u64 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        symbol_total64 = symbol_total64 + modules[m].symbol_count::u64;
+        if (symbol_total64 > 0xFFFFFFFF) {
+            ret R.err[bool, str]("linker: input symbol count exceeds the u32 limit");
+        }
+        m = m + 1;
+    }
+    val symbol_total: u32 = symbol_total64::u32;
+
+    var candidates: *AtomCandidate = nil;
+    if (symbol_total > 0) {
+        val cr: R.Result[*AtomCandidate, str] =
+            A.zallocate[AtomCandidate](s.alloc, symbol_total::usize);
+        if (R.is_err[*AtomCandidate, str](cr)) {
+            ret R.err[bool, str](R.unwrap_err[*AtomCandidate, str](cr));
+        }
+        candidates = R.unwrap_ok[*AtomCandidate, str](cr);
+    }
+
+    var winners: map.Map[intern.StrId, AtomWinner] =
+        map.init[intern.StrId, AtomWinner](s.alloc, map.hash_u32, map.eq_u32);
+    var candidate_count: u32 = 0;
+    m = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (sym.section == of.SECTION_EXTERNAL) { sy = sy + 1; cnt; }
+            if (sym.section >= modules[m].section_count) {
+                map.dnit[intern.StrId, AtomWinner](?winners);
+                if (candidates != nil) {
+                    A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+                }
+                ret R.err[bool, str](oor_section_message(s, sym.name, modules[m].name));
+            }
+            if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { sy = sy + 1; cnt; }
+
+            val weak: bool = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
+            val existing: R.Result[*AtomWinner, str] =
+                map.get[intern.StrId, AtomWinner](?winners, ?sym.name);
+            if (R.is_ok[*AtomWinner, str](existing)) {
+                val cur: *AtomWinner = R.unwrap_ok[*AtomWinner, str](existing);
+                if (weak) {
+                    candidates[candidate_count].module = m;
+                    candidates[candidate_count].symbol = sy;
+                    candidate_count = candidate_count + 1;
+                    sy = sy + 1;
+                    cnt;
+                }
+                if (!cur.weak) {
+                    map.dnit[intern.StrId, AtomWinner](?winners);
+                    if (candidates != nil) {
+                        A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+                    }
+                    ret R.err[bool, str](dup_message(s, sym.name));
+                }
+                # a later strong definition displaces the earlier weak winner.
+                candidates[candidate_count].module = cur.module;
+                candidates[candidate_count].symbol = cur.symbol;
+                candidate_count = candidate_count + 1;
+                cur.module = m;
+                cur.symbol = sy;
+                cur.weak = false;
+                sy = sy + 1;
+                cnt;
+            }
+
+            var winner: AtomWinner;
+            winner.module = m;
+            winner.symbol = sy;
+            winner.weak = weak;
+            val ins: R.Result[bool, str] =
+                map.insert[intern.StrId, AtomWinner](?winners, sym.name, winner);
+            if (R.is_err[bool, str](ins)) {
+                map.dnit[intern.StrId, AtomWinner](?winners);
+                if (candidates != nil) {
+                    A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+                }
+                ret R.err[bool, str](R.unwrap_err[bool, str](ins));
+            }
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    map.dnit[intern.StrId, AtomWinner](?winners);
+
+    if (candidate_count == 0) {
+        if (candidates != nil) {
+            A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+        }
+        ret R.ok[bool, str](true);
+    }
+
+    val dr: R.Result[*AtomDrop, str] =
+        A.zallocate[AtomDrop](s.alloc, candidate_count::usize);
+    if (R.is_err[*AtomDrop, str](dr)) {
+        A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+        ret R.err[bool, str](R.unwrap_err[*AtomDrop, str](dr));
+    }
+    val drops: *AtomDrop = R.unwrap_ok[*AtomDrop, str](dr);
+    var drop_count: u32 = 0;
+
+    var ci: u32 = 0;
+    for (ci < candidate_count) {
+        val cm: u32 = candidates[ci].module;
+        val cy: u32 = candidates[ci].symbol;
+        val sym: *of.Symbol = ?modules[cm].symbols[cy];
+        val sec: *of.Section = ?modules[cm].sections[sym.section];
+        val need: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+        if ((sym.flags & need) != need || sec.kind != of.SK_TEXT || sec.bytes == nil
+            || sym.offset >= sec.len) {
+            ci = ci + 1;
+            cnt;
+        }
+
+        val start: u32 = sym.offset;
+        var end: u32 = sec.len;
+        var sy: u32 = 0;
+        for (sy < modules[cm].symbol_count) {
+            val other: *of.Symbol = ?modules[cm].symbols[sy];
+            if (other.section == sym.section
+                && (other.flags & (of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION))
+                    == (of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION)
+                && other.offset > start && other.offset < end) {
+                end = other.offset;
+            }
+            sy = sy + 1;
+        }
+        if (end <= start) { ci = ci + 1; cnt; }
+
+        # A second symbol in the candidate interval may be addressable from live
+        # code. Keep the whole atom rather than needing a target-reachability
+        # closure; normal generated generic bodies have only their entry symbol.
+        var safe: bool = true;
+        sy = 0;
+        for (sy < modules[cm].symbol_count) {
+            if (sy != cy) {
+                val other: *of.Symbol = ?modules[cm].symbols[sy];
+                if (other.section == sym.section && other.offset >= start && other.offset < end) {
+                    safe = false;
+                }
+            }
+            sy = sy + 1;
+        }
+
+        # A patch field wholly inside the losing body dies with it. A field that
+        # crosses either boundary makes the inferred function extent unsafe.
+        var ri: u32 = 0;
+        for (safe && ri < modules[cm].reloc_count) {
+            val r: *of.Relocation = ?modules[cm].relocations[ri];
+            if (r.section == sym.section) {
+                val rstart: u64 = r.offset::u64;
+                val rend: u64 = rstart + atom_reloc_width(r.kind)::u64;
+                if (rstart < end::u64 && rend > start::u64
+                    && (rstart < start::u64 || rend > end::u64)) {
+                    safe = false;
+                }
+            }
+            ri = ri + 1;
+        }
+        if (safe) {
+            drops[drop_count].section = sec_base[cm] + sym.section;
+            drops[drop_count].start = start;
+            drops[drop_count].end = end;
+            drops[drop_count].resume = 0;
+            drop_count = drop_count + 1;
+        }
+        ci = ci + 1;
+    }
+    A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+
+    if (drop_count == 0) {
+        A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
+        ret R.ok[bool, str](true);
+    }
+
+    sort.sort[AtomDrop](drops, drop_count::usize, atom_drop_cmp);
+
+    # Merge adjacent/overlapping losing functions before alignment is restored,
+    # so no padding is inserted between two bytes ranges that both disappear.
+    var merged_count: u32 = 0;
+    var di: u32 = 0;
+    for (di < drop_count) {
+        if (merged_count > 0
+            && drops[merged_count - 1].section == drops[di].section
+            && drops[di].start <= drops[merged_count - 1].end) {
+            if (drops[di].end > drops[merged_count - 1].end) {
+                drops[merged_count - 1].end = drops[di].end;
+            }
+        }
+        or {
+            drops[merged_count] = drops[di];
+            merged_count = merged_count + 1;
+        }
+        di = di + 1;
+    }
+
+    val sr: R.Result[*AtomSection, str] =
+        A.zallocate[AtomSection](s.alloc, sec_total::usize);
+    if (R.is_err[*AtomSection, str](sr)) {
+        A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
+        ret R.err[bool, str](R.unwrap_err[*AtomSection, str](sr));
+    }
+    val sections: *AtomSection = R.unwrap_ok[*AtomSection, str](sr);
+
+    di = 0;
+    var flat: u32 = 0;
+    m = 0;
+    for (m < module_count) {
+        var sc: u32 = 0;
+        for (sc < modules[m].section_count) {
+            val sec: *of.Section = ?modules[m].sections[sc];
+            val meta: *AtomSection = ?sections[flat];
+            meta.first = di;
+            var src_cursor: u32 = 0;
+            var dst_cursor: u32 = 0;
+            for (di < merged_count && drops[di].section == flat) {
+                dst_cursor = dst_cursor + (drops[di].start - src_cursor);
+                if (drops[di].end < sec.len) {
+                    val a: u32 = atom_resume_align(drops[di].end, sec.align);
+                    dst_cursor = bin.align_up_u64(dst_cursor::u64, a::u64)::u32;
+                }
+                drops[di].resume = dst_cursor;
+                src_cursor = drops[di].end;
+                di = di + 1;
+            }
+            meta.count = di - meta.first;
+            meta.live_len = dst_cursor + (sec.len - src_cursor);
+            flat = flat + 1;
+            sc = sc + 1;
+        }
+        m = m + 1;
+    }
+
+    plan.drops = drops;
+    plan.drop_count = merged_count;
+    plan.drop_cap = candidate_count;
+    plan.sections = sections;
+    plan.section_count = sec_total;
+    plan.removed_bytes = 0;
+    flat = 0;
+    m = 0;
+    for (m < module_count) {
+        var sc: u32 = 0;
+        for (sc < modules[m].section_count) {
+            plan.removed_bytes = plan.removed_bytes
+                + (modules[m].sections[sc].len - sections[flat].live_len)::u64;
+            flat = flat + 1;
+            sc = sc + 1;
+        }
+        m = m + 1;
+    }
+    plan.active = true;
+    ret R.ok[bool, str](true);
+}
+
 # whether the NUL-terminated string at `src[src_off..]` byte-equals the one at
 # `ded[ded_off..]`, both bounded by their buffer lengths. the load-bearing guard on the
 # `.debug_str` dedup remap (#1708): a wrong-but-valid strp offset is invisible to
@@ -1566,7 +2035,8 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 # ret:          ok(true) on success, or an error string
 fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32,
-                        placements: *Placement, sec_base: *u32, strm: *StrMerge) R.Result[bool, str] {
+                        placements: *Placement, sec_base: *u32, strm: *StrMerge,
+                        atoms: *AtomPlan) R.Result[bool, str] {
     # .debug_abbrev is byte-identical across every module (a deterministic, complete
     # build_abbrev) and every CU references it at offset 0, so only the first copy is
     # ever read. dedup it: a later object's table shares the first at offset 0 and adds
@@ -1642,7 +2112,8 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                 # rejected rather than wrapping the u32 length into a tiny value that
                 # later truncates the output.
                 val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
-                val newlen: u64 = off64 + sec.len::u64;
+                val contribution_len: u32 = atom_live_len(atoms, flat, sec.len);
+                val newlen: u64 = off64 + contribution_len::u64;
                 if (newlen > 0xFFFFFFFF) {
                     ret R.err[bool, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
                 }
@@ -1732,7 +2203,8 @@ fun finalize_placement_vaddrs(merged: *MergedSection, placements: *Placement, se
 # ret:          ok(true) on success, or an error string
 fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                     placements: *Placement, sec_base: *u32,
-                    sym_locs: *map.Map[intern.StrId, SymbolLoc], have_vaddrs: bool) R.Result[bool, str] {
+                    sym_locs: *map.Map[intern.StrId, SymbolLoc], have_vaddrs: bool,
+                    atoms: *AtomPlan) R.Result[bool, str] {
     var m: u32 = 0;
     for (m < module_count) {
         var sy: u32 = 0;
@@ -1748,11 +2220,14 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
             if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { sy = sy + 1; cnt; }
 
             val flat: u32 = sec_base[m] + sym.section;
+            if (atom_offset_dead(atoms, flat, sym.offset)) { sy = sy + 1; cnt; }
             val pl: *Placement = ?placements[flat];
 
             val is_weak: bool = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
             var vaddr: u64 = 0;
-            if (have_vaddrs) { vaddr = pl.vaddr + sym.offset::u64; }
+            if (have_vaddrs) {
+                vaddr = pl.vaddr + atom_live_offset(atoms, flat, sym.offset)::u64;
+            }
 
             val existing: R.Result[*SymbolLoc, str] =
                 map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
@@ -1808,7 +2283,8 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
 fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
                        modules: *of.ObjectImage, module_count: u32,
                        merged: *MergedSection, merged_count: u32, placements: *Placement, sec_base: *u32,
-                       merged_to_out: *u32, strm: *StrMerge) R.Result[bool, str] {
+                       merged_to_out: *u32, strm: *StrMerge,
+                       atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
     # map each used merged slot to its output-section index so symbols/relocations
@@ -1871,7 +2347,9 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 
             val dst: *u8 = out_img.sections[out_ix].bytes;
             val off: u32 = placements[flat].offset;
-            memory.copy[u8](?dst[off], src.bytes, src.len::usize);
+            if (atom_live_len(atoms, flat, src.len) > 0) {
+                copy_live_section(?dst[off], src.bytes, src.len, atoms, flat);
+            }
 
             sc = sc + 1;
         }
@@ -1892,6 +2370,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             }
 
             val flat: u32 = sec_base[m] + isym.section;
+            if (atom_offset_dead(atoms, flat, isym.offset)) { sy = sy + 1; cnt; }
             val ki: u32 = placements[flat].merged_index;
             val out_ix: u32 = merged_to_out[ki];
             if (out_ix == 0xFFFFFFFF) { sy = sy + 1; cnt; }
@@ -1899,7 +2378,8 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             var osym: of.Symbol;
             osym.name    = isym.name;
             osym.section = out_ix;
-            osym.offset  = placements[flat].offset + isym.offset;
+            osym.offset  = placements[flat].offset
+                + atom_live_offset(atoms, flat, isym.offset);
             osym.size    = isym.size;
             osym.flags   = isym.flags;
 
@@ -1944,7 +2424,8 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
                      modules: *of.ObjectImage, module_count: u32,
                      placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                     dyn: *DynState, strm: *StrMerge, arch: *isa.IsaVTable) R.Result[bool, str] {
+                     dyn: *DynState, strm: *StrMerge, arch: *isa.IsaVTable,
+                     atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
     var m: u32 = 0;
@@ -1956,14 +2437,16 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
         # module's relocations are patched, regardless of outcome.
         var local_map: map.Map[intern.StrId, u64] =
             map.init[intern.StrId, u64](alloc, map.hash_u32, map.eq_u32);
-        val br: R.Result[bool, str] = build_local_index(modules, m, placements, sec_base, ?local_map);
+        val br: R.Result[bool, str] =
+            build_local_index(modules, m, placements, sec_base, ?local_map, atoms);
         if (R.is_err[bool, str](br)) {
             map.dnit[intern.StrId, u64](?local_map);
             ret R.err[bool, str](R.unwrap_err[bool, str](br));
         }
 
         val pr: R.Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, strm, arch);
+            placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, strm,
+            arch, atoms);
         map.dnit[intern.StrId, u64](?local_map);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
 
@@ -1984,7 +2467,8 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
 # out:        out - the local-name -> virtual-address index to fill
 # ret:        ok(true) on success, or an error string
 fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, sec_base: *u32,
-                      out: *map.Map[intern.StrId, u64]) R.Result[bool, str] {
+                      out: *map.Map[intern.StrId, u64],
+                      atoms: *AtomPlan) R.Result[bool, str] {
     var sy: u32 = 0;
     for (sy < modules[m].symbol_count) {
         val sym: *of.Symbol = ?modules[m].symbols[sy];
@@ -1994,7 +2478,9 @@ fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, 
 
         if (R.is_err[*u64, str](map.get[intern.StrId, u64](out, ?sym.name))) {
             val flat: u32 = sec_base[m] + sym.section;
-            val va: u64 = placements[flat].vaddr + sym.offset::u64;
+            if (atom_offset_dead(atoms, flat, sym.offset)) { sy = sy + 1; cnt; }
+            val va: u64 = placements[flat].vaddr
+                + atom_live_offset(atoms, flat, sym.offset)::u64;
             val ins: R.Result[bool, str] = map.insert[intern.StrId, u64](out, sym.name, va);
             if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
         }
@@ -2026,7 +2512,8 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
                              local_map: *map.Map[intern.StrId, u64], strm: *StrMerge,
-                             arch: *isa.IsaVTable) R.Result[bool, str] {
+                             arch: *isa.IsaVTable,
+                             atoms: *AtomPlan) R.Result[bool, str] {
     # locate module m's .debug_str section and its anchor symbol once: a strp
     # relocation is exactly one whose target is that anchor. resolving it remaps the
     # string to its deduped offset rather than the concatenated placement (#1708).
@@ -2057,7 +2544,8 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         if (r.section >= modules[m].section_count) {
             ret R.err[bool, str]("linker: relocation names an out-of-range section");
         }
-        if (r.offset > modules[m].sections[r.section].len) {
+        if (r.offset::u64 + atom_reloc_width(r.kind)::u64
+            > modules[m].sections[r.section].len::u64) {
             ret R.err[bool, str]("linker: relocation offset is past the end of its section");
         }
 
@@ -2065,8 +2553,13 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         # merged_index selects a merged slot (kind or debug-name); map it to the
         # output-section index the merge assigned.
         val flat: u32 = sec_base[m] + r.section;
+        # A relocation field wholly owned by a discarded function atom has no
+        # output patch site and must not retain its target through a PLT/GOT/base
+        # relocation side effect.
+        if (atom_offset_dead(atoms, flat, r.offset)) { ri = ri + 1; cnt; }
         val pl: *Placement = ?placements[flat];
-        val patch_va: u64 = pl.vaddr + r.offset::u64;
+        val live_off: u32 = atom_live_offset(atoms, flat, r.offset);
+        val patch_va: u64 = pl.vaddr + live_off::u64;
         val out_ix: u32 = merged_to_out[pl.merged_index];
         # a relocation in a section with no merged output, or one whose patch site
         # lands in a (byteless) BSS section, cannot be applied - that is a contract
@@ -2078,7 +2571,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         if (dst == nil) {
             ret R.err[bool, str]("linker: relocation patch site lands in a BSS section");
         }
-        val patch_off: u32 = pl.offset + r.offset;
+        val patch_off: u32 = pl.offset + live_off;
 
         # a strp into .debug_str: remap it to the string's deduped offset instead of
         # resolving the anchor's placement. skips the normal apply_one below (#1708).
@@ -2253,13 +2746,49 @@ fun free_dynstate(alloc: *A.Allocator, dyn: *DynState) {
     init_dynstate(dyn);
 }
 
-fun has_call_reloc(modules: *of.ObjectImage, module_count: u32, symbol_name: intern.StrId) bool {
+# whether a relocation's source field survives the atom plan. malformed section
+# references remain live here so relocation patching reports the input error
+fun reloc_source_live(modules: *of.ObjectImage, m: u32, r: *of.Relocation,
+                      sec_base: *u32, atoms: *AtomPlan) bool {
+    if (atoms == nil || !atoms.active) { ret true; }
+    if (r.section >= modules[m].section_count) { ret true; }
+    ret !atom_offset_dead(atoms, sec_base[m] + r.section, r.offset);
+}
+
+# an undefined name remains an import unless it is referenced exclusively from
+# discarded atoms. an unused declaration (no relocations at all) retains the
+# legacy import behavior
+fun import_symbol_live(modules: *of.ObjectImage, module_count: u32,
+                       symbol_name: intern.StrId, sec_base: *u32,
+                       atoms: *AtomPlan) bool {
+    if (atoms == nil || !atoms.active) { ret true; }
+    var saw: bool = false;
     var m: u32 = 0;
     for (m < module_count) {
         var ri: u32 = 0;
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
-            if (r.symbol == symbol_name && is_call_kind(r.kind)) {
+            if (r.symbol == symbol_name) {
+                saw = true;
+                if (reloc_source_live(modules, m, r, sec_base, atoms)) { ret true; }
+            }
+            ri = ri + 1;
+        }
+        m = m + 1;
+    }
+    ret !saw;
+}
+
+fun has_call_reloc(modules: *of.ObjectImage, module_count: u32,
+                   symbol_name: intern.StrId, sec_base: *u32,
+                   atoms: *AtomPlan) bool {
+    var m: u32 = 0;
+    for (m < module_count) {
+        var ri: u32 = 0;
+        for (ri < modules[m].reloc_count) {
+            val r: *of.Relocation = ?modules[m].relocations[ri];
+            if (r.symbol == symbol_name && is_call_kind(r.kind)
+                && reloc_source_live(modules, m, r, sec_base, atoms)) {
                 ret true;
             }
             ri = ri + 1;
@@ -2297,7 +2826,8 @@ fun has_call_reloc(modules: *of.ObjectImage, module_count: u32, symbol_name: int
 fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
                        modules: *of.ObjectImage, module_count: u32,
                        sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                       sonames: *intern.StrId, soname_count: u32) R.Result[bool, str] {
+                       sonames: *intern.StrId, soname_count: u32,
+                       sec_base: *u32, atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
@@ -2353,6 +2883,7 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (!is_undefined_extern(sym))                                                       { sy = sy + 1; cnt; }
             if (R.is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name))) { sy = sy + 1; cnt; }
+            if (!import_symbol_live(modules, module_count, sym.name, sec_base, atoms))            { sy = sy + 1; cnt; }
             if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name)))                { sy = sy + 1; cnt; }
             val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?seen, sym.name, n_imports);
             if (R.is_err[bool, str](ins)) { map.dnit[intern.StrId, u32](?seen); ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
@@ -2377,6 +2908,7 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (!is_undefined_extern(sym))                                                       { sy = sy + 1; cnt; }
             if (R.is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name))) { sy = sy + 1; cnt; }
+            if (!import_symbol_live(modules, module_count, sym.name, sec_base, atoms))            { sy = sy + 1; cnt; }
             if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?dyn.import_map, ?sym.name)))      { sy = sy + 1; cnt; }
 
             val idx: u32 = dyn.info.import_count;
@@ -2404,7 +2936,9 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             # flag) is recorded but not yet bound - its abs reference still hits
             # the undefined-symbol error in patch_relocations, since data imports
             # (GLOB_DAT) are deferred.
-            dyn.info.imports[idx].is_func   = ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0) || has_call_reloc(modules, module_count, sym.name);
+            dyn.info.imports[idx].is_func   =
+                ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0)
+                || has_call_reloc(modules, module_count, sym.name, sec_base, atoms);
             val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?dyn.import_map, sym.name, idx);
             if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
             dyn.info.import_count = idx + 1;
@@ -3051,11 +3585,12 @@ fun free_placements(alloc: *A.Allocator, placements: *Placement, sec_total: u32)
 # debug_count:   length of the debug-name array
 # merged_to_out: the merged-slot -> output-section map to release (may be nil)
 # strm:          the deduped .debug_str table to release (may be nil)
+# atoms:         the transient final-link atom plan to release (may be nil)
 fun free_scratch(alloc: *A.Allocator, placements: *Placement, sec_total: u32,
                 sec_base: *u32, module_count: u32,
                 merged: *MergedSection, merged_count: u32,
                 debug_names: *intern.StrId, debug_count: u32,
-                merged_to_out: *u32, strm: *StrMerge) {
+                merged_to_out: *u32, strm: *StrMerge, atoms: *AtomPlan) {
     free_placements(alloc, placements, sec_total);
     if (sec_base != nil && module_count > 0) {
         A.deallocate[u32](alloc, sec_base, module_count::usize);
@@ -3070,6 +3605,7 @@ fun free_scratch(alloc: *A.Allocator, placements: *Placement, sec_total: u32,
         A.deallocate[u32](alloc, merged_to_out, merged_count::usize);
     }
     free_str_merge(strm);
+    free_atom_plan(alloc, atoms);
 }
 
 # tear down every parsed input image and release the image array.
@@ -3128,7 +3664,9 @@ fun lt_link(s: *session.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbo
 
     var locs: map.Map[intern.StrId, SymbolLoc] =
         map.init[intern.StrId, SymbolLoc](s.alloc, map.hash_u32, map.eq_u32);
-    val cr: R.Result[bool, str] = collect_symbols(s, ?mods[0], 2, ?placements[0], ?sec_base[0], ?locs, true);
+    val cr: R.Result[bool, str] =
+        collect_symbols(s, ?mods[0], 2, ?placements[0], ?sec_base[0],
+                        ?locs, true, nil::*AtomPlan);
     if (R.is_err[bool, str](cr)) {
         map.dnit[intern.StrId, SymbolLoc](?locs);
         ret R.err[u64, str](R.unwrap_err[bool, str](cr));

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1643,14 +1643,14 @@ fun atom_reloc_ref_lower(refs: *AtomRelocRef, count: u32, section: u32) u32 {
     ret lo;
 }
 
-# largest power-of-two alignment required by the source byte at `off`, capped
-# at the input section's declared alignment
-fun atom_resume_align(off: u32, section_align: u32) u32 {
-    var limit: u32 = section_align;
-    if (limit == 0) { limit = 1; }
-    var p: u32 = 1;
-    for ((off & p) == 0 && p < limit && p < 0x40000000) { p = p << 1; }
-    ret p;
+# earliest destination offset at or after `dst` that preserves `end`'s residue
+# modulo the input section alignment. every suffix offset is translated by
+# `resume - end`, so this keeps all later aligned symbols aligned
+fun atom_resume_offset(dst: u32, end: u32, section_align: u32) u32 {
+    if (end <= dst) { ret dst; }
+    var a: u32 = section_align;
+    if (a == 0) { a = 1; }
+    ret dst + (end - dst) % a;
 }
 
 # physical relocation shape supplied by the active ISA's relocatable-object seam
@@ -2221,8 +2221,8 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             for (di < merged_count && drops[di].section == flat) {
                 dst_cursor = dst_cursor + (drops[di].start - src_cursor);
                 if (drops[di].end < sec.len) {
-                    val a: u32 = atom_resume_align(drops[di].end, sec.align);
-                    dst_cursor = bin.align_up_u64(dst_cursor::u64, a::u64)::u32;
+                    dst_cursor =
+                        atom_resume_offset(dst_cursor, drops[di].end, sec.align);
                 }
                 drops[di].resume = dst_cursor;
                 src_cursor = drops[di].end;
@@ -4356,6 +4356,82 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     val covered: R.Result[bool, str] =
         build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](covered) || plan.active) { ret 1; }
+    ret 0;
+}
+
+# a non-alignment-sized weak body may shift the suffix only by a whole section
+# alignment unit. the later function therefore keeps its original alignment
+test "mach.lang.be.linker.atom_plan:suffix_alignment_grid" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "alignedI3u64E");
+    val head: intern.StrId = lt_name(?s, "aligned_head");
+    val tail: intern.StrId = lt_name(?s, "aligned_tail");
+    val text: intern.StrId = lt_name(?s, ".text");
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var winner_bytes: [21]u8;
+    var loser_bytes: [64]u8;
+    var winner_sec: [1]of.Section;
+    var loser_sec: [1]of.Section;
+    winner_sec[0].name = text;
+    winner_sec[0].kind = of.SK_TEXT;
+    winner_sec[0].bytes = ?winner_bytes[0];
+    winner_sec[0].len = 21;
+    winner_sec[0].align = 16;
+    loser_sec[0].name = text;
+    loser_sec[0].kind = of.SK_TEXT;
+    loser_sec[0].bytes = ?loser_bytes[0];
+    loser_sec[0].len = 64;
+    loser_sec[0].align = 16;
+
+    var winner_syms: [1]of.Symbol;
+    var loser_syms: [3]of.Symbol;
+    winner_syms[0].name = dup;
+    winner_syms[0].section = 0;
+    winner_syms[0].offset = 0;
+    winner_syms[0].size = 21;
+    winner_syms[0].flags = weak_flags;
+    loser_syms[0].name = head;
+    loser_syms[0].section = 0;
+    loser_syms[0].offset = 0;
+    loser_syms[0].size = 16;
+    loser_syms[0].flags = strong_flags;
+    loser_syms[1].name = dup;
+    loser_syms[1].section = 0;
+    loser_syms[1].offset = 16;
+    loser_syms[1].size = 21;
+    loser_syms[1].flags = weak_flags;
+    loser_syms[2].name = tail;
+    loser_syms[2].section = 0;
+    loser_syms[2].offset = 48;
+    loser_syms[2].size = 16;
+    loser_syms[2].flags = strong_flags;
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "winner"), ?winner_sec[0], 1,
+                       ?winner_syms[0], 1, nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "loser"), ?loser_sec[0], 1,
+                       ?loser_syms[0], 3, nil::*of.Relocation, 0);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val pr: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true,
+                        nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (plan.drops[0].start != 16 || plan.drops[0].end != 37
+        || plan.drops[0].resume != 21 || plan.sections[1].live_len != 48
+        || plan.removed_bytes != 16) { ret 1; }
+    if (atom_live_offset(?plan, 1, 48) != 32
+        || (atom_live_offset(?plan, 1, 48) & 15) != 0) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
     ret 0;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4608,10 +4608,12 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
         build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](parsed_plt_data) || plan.active) { ret 1; }
 
-    # a foreign PLT32 displacement can also precede a trailing immediate. an
-    # eight-byte field-to-next-ip distance is possible, but provenance alone
-    # cannot select that bias from the full legal x64 range.
-    reloc[0].addend = -8;
+    # a foreign PLT32 displacement can also precede a trailing immediate. with
+    # the anchor before [8,16), addend three plus the canonical four-byte bias
+    # remains at seven, while an eight-byte field-to-next-ip bias reaches eleven
+    # inside the candidate. this therefore requires the parsed upper bound.
+    reloc[0].symbol = base;
+    reloc[0].addend = 3;
     val parsed_plt_trailing: R.Result[bool, str] =
         build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](parsed_plt_trailing) || plan.active) { ret 1; }
@@ -4619,6 +4621,7 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     # with two compiler-produced images, module 1's PC32 is known to hold an
     # instruction relocation. its field-to-next-ip bias is at least four, so
     # tail-4 cannot reach backward into the candidate.
+    reloc[0].symbol = tail;
     reloc[0].addend = -4;
     reloc[0].kind = of.RK_PC32;
     val codegen_pc: R.Result[bool, str] =

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -180,6 +180,9 @@ rec AtomRelocRef {
     source_module:  u32;
     reloc:           u32;
     width:           u32;
+    addend_mode:     rel.RelocAddendMode;
+    text_bias_min:   i32;
+    text_bias_max:   i32;
 }
 
 # the linker's mutable dynamic-link state: the format-neutral plan (`of.DynamicInfo`)
@@ -1650,14 +1653,9 @@ fun atom_resume_align(off: u32, section_align: u32) u32 {
     ret p;
 }
 
-# byte width patched by an abstract relocation kind
-fun atom_reloc_width(kind: of.RelocKind, arch: *isa.IsaVTable) u32 {
-    if (kind == of.RK_ABS64)   { ret 8; }
-    if (kind == of.RK_SECTION) { ret 2; }
-    # rv64's abstract PLT32 is an AUIPC+JALR pair, patched as one 8-byte site.
-    # x64 and AArch64 patch one 4-byte instruction/field for the same kind.
-    if (kind == of.RK_PLT32 && arch != nil && arch.id == isa.ARCH_RISCV64) { ret 8; }
-    ret 4;
+# physical relocation shape supplied by the active ISA's relocatable-object seam
+fun atom_reloc_traits(kind: of.RelocKind, arch: *isa.IsaVTable) rel.RelocTraits {
+    ret arch.reloc.reloc_traits::rel.RelocTraitsFn(kind);
 }
 
 # whether a second symbol is the exact synthetic section anchor emitted by COFF
@@ -1685,15 +1683,6 @@ fun atom_effective_offset(base: u32, addend: i64, out: *u32) bool {
     }
     if (addend < -(base::i64)) { ret false; }
     @out = (base::i64 + addend)::u32;
-    ret true;
-}
-
-# whether a relocation's addend is a true offset from S rather than an
-# instruction-field bias such as x64 PC32/PLT32's -4
-fun atom_addend_is_symbol_relative(kind: of.RelocKind) bool {
-    if (kind == of.RK_PC32 || kind == of.RK_PLT32 || kind == of.RK_GOTPCREL
-        || kind == of.RK_GOT_PAGE21 || kind == of.RK_GOT_LO12
-        || kind == of.RK_SECTION) { ret false; }
     ret true;
 }
 
@@ -1729,18 +1718,33 @@ fun atom_reloc_crosses_candidate(modules: *of.ObjectImage, reference: *AtomReloc
     # any local in this section is retained conservatively because foreign
     # containers may encode an anchor-relative target behind that bias.
     if (target.offset >= start && target.offset < end) { ret true; }
-    if (!atom_addend_is_symbol_relative(r.kind)) {
-        ret (target.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0;
+    if (reference.addend_mode == rel.RELOC_ADDEND_IGNORED) { ret false; }
+
+    var bias_min: i64 = 0;
+    var bias_max: i64 = 0;
+    if (reference.addend_mode == rel.RELOC_ADDEND_FIELD_BIAS
+        && r.section < modules[source_module].section_count
+        && modules[source_module].sections[r.section].kind == of.SK_TEXT) {
+        bias_min = reference.text_bias_min::i64;
+        bias_max = reference.text_bias_max::i64;
+    }
+    if ((bias_min > 0 && r.addend > 9223372036854775807 - bias_min)
+        || (bias_min < 0 && r.addend < (-9223372036854775807 - 1) - bias_min)
+        || (bias_max > 0 && r.addend > 9223372036854775807 - bias_max)
+        || (bias_max < 0 && r.addend < (-9223372036854775807 - 1) - bias_max)) {
+        ret true;
     }
 
-    var effective: u32 = 0;
-    if (!atom_effective_offset(target.offset, r.addend, ?effective)) { ret false; }
-    if (effective > modules[candidate_module].sections[candidate_section].len) { ret false; }
-
-    # source anchor and effective target must remain on the same side of the
-    # removed interval.
-    if (target.offset < start && effective >= start)   { ret true; }
-    if (target.offset >= end && effective < end)       { ret true; }
+    var effective_min: u32 = 0;
+    var effective_max: u32 = 0;
+    if (!atom_effective_offset(target.offset, r.addend + bias_min, ?effective_min)
+        || !atom_effective_offset(target.offset, r.addend + bias_max, ?effective_max)) {
+        ret true;
+    }
+    # the anchor and every possible effective target must remain on one side of
+    # the removed interval.
+    if (target.offset < start && effective_max >= start) { ret true; }
+    if (target.offset >= end && effective_min < end)     { ret true; }
     ret false;
 }
 
@@ -1963,6 +1967,12 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
     val reloc_total: u32 = reloc_total64::u32;
     var refs: *AtomRelocRef = nil;
     if (reloc_total > 0) {
+        if (arch == nil || arch.reloc == nil || arch.reloc.reloc_traits == nil) {
+            map.dnit[intern.StrId, AtomWinner](?winners);
+            A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+            A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
+            ret R.err[bool, str]("linker: target cannot describe relocations");
+        }
         val rr: R.Result[*AtomRelocRef, str] =
             A.zallocate[AtomRelocRef](s.alloc, reloc_total::usize);
         if (R.is_err[*AtomRelocRef, str](rr)) {
@@ -2005,7 +2015,12 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 refs[rw].target_symbol = 0xFFFFFFFF;
                 refs[rw].source_module = m;
                 refs[rw].reloc = ri;
-                refs[rw].width = atom_reloc_width(modules[m].relocations[ri].kind, arch);
+                val traits: rel.RelocTraits =
+                    atom_reloc_traits(modules[m].relocations[ri].kind, arch);
+                refs[rw].width = traits.field_width;
+                refs[rw].addend_mode = traits.addend_mode;
+                refs[rw].text_bias_min = traits.text_bias_min;
+                refs[rw].text_bias_max = traits.text_bias_max;
 
                 val r: *of.Relocation = ?modules[m].relocations[ri];
                 val lr: R.Result[*u32, str] =
@@ -2110,7 +2125,8 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             val r: *of.Relocation = ?modules[cm].relocations[ri];
             if (r.section == sym.section) {
                 val rstart: u64 = r.offset::u64;
-                val rend: u64 = rstart + atom_reloc_width(r.kind, arch)::u64;
+                val rend: u64 =
+                    rstart + atom_reloc_traits(r.kind, arch).field_width::u64;
                 if (rstart < end::u64 && rend > start::u64
                     && (rstart < start::u64 || rend > end::u64)) {
                     safe = false;
@@ -2793,6 +2809,10 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
         val r: *of.Relocation = ?modules[m].relocations[ri];
+        if (arch == nil || arch.reloc == nil || arch.reloc.reloc_traits == nil
+            || arch.reloc.apply_reloc == nil) {
+            ret R.err[bool, str](unsupported_message(s, r.kind));
+        }
         # a corrupt object can name an out-of-range section, or an offset past the
         # end of its own section (which would wrap the u32 patch cursor and scribble
         # outside the merged buffer). reject both loudly instead of silently dropping
@@ -2800,7 +2820,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         if (r.section >= modules[m].section_count) {
             ret R.err[bool, str]("linker: relocation names an out-of-range section");
         }
-        if (r.offset::u64 + atom_reloc_width(r.kind, arch)::u64
+        if (r.offset::u64 + atom_reloc_traits(r.kind, arch).field_width::u64
             > modules[m].sections[r.section].len::u64) {
             ret R.err[bool, str]("linker: relocation offset is past the end of its section");
         }
@@ -3962,9 +3982,11 @@ fun lt_image(s: *session.Session, name: intern.StrId,
     ret img;
 }
 
-# construct a description-only ISA vtable for architecture-sensitive linker tests
-fun lt_isa(id: u32) isa.IsaVTable {
-    ret isa.machine_isa(id, "test", 0, 8, nil, nil, nil);
+# look up one production ISA vtable from a populated test registry
+fun lt_isa(reg: *target.TargetRegistry, name: str) *isa.IsaVTable {
+    val found: O.Option[*isa.IsaVTable] = isa.lookup(?reg.isa, name);
+    if (!O.is_some[*isa.IsaVTable](found)) { ret nil; }
+    ret O.unwrap[*isa.IsaVTable](found);
 }
 
 # weak/strong symbol resolution is order-independent (#1257)
@@ -4110,6 +4132,10 @@ test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    if (x64 == nil) { ret 1; }
 
     val wa: intern.StrId = lt_name(?s, "waI3u64E");
     val wb: intern.StrId = lt_name(?s, "wbI3u64E");
@@ -4176,7 +4202,7 @@ test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val pr: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
 
     # [8,16) and [16,24) merge, leaving head then tail packed at an 8-byte
@@ -4330,6 +4356,10 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    if (x64 == nil) { ret 1; }
 
     val dup: intern.StrId = lt_name(?s, "coffI3u64E");
     val text: intern.StrId = lt_name(?s, ".text");
@@ -4371,7 +4401,7 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val inert_anchor: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](inert_anchor) || !plan.active || plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].section != 1 || plan.drops[0].start != 0
         || plan.drops[0].end != 8) { ret 1; }
@@ -4379,7 +4409,7 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
 
     mods[1].reloc_count = 1;
     val referenced_anchor: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](referenced_anchor) || plan.active) { ret 1; }
     ret 0;
 }
@@ -4393,6 +4423,11 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    val arm64: *isa.IsaVTable = lt_isa(?reg, "aarch64");
+    if (x64 == nil || arm64 == nil) { ret 1; }
 
     val dup: intern.StrId = lt_name(?s, "crossI3u64E");
     val base: intern.StrId = lt_name(?s, "section_base");
@@ -4433,14 +4468,14 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val crossing: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](crossing) || plan.active) { ret 1; }
 
     # a target that remains before the candidate does not cross it and leaves the
     # duplicate eligible, proving retention is caused by the addend relationship.
     reloc[0].addend = 4;
     val same_side: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](same_side) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
@@ -4450,13 +4485,20 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     reloc[0].kind = of.RK_PC32;
     reloc[0].addend = -4;
     val pc_local: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](pc_local) || plan.active) { ret 1; }
     reloc[0].symbol = tail;
+    reloc[0].kind = of.RK_PLT32;
     val pc_global: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](pc_global) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
+
+    # darwin arm64 CALL26 preserves its S-relative addend: tail-4 lands inside
+    # the candidate. x64's canonical field bias above instead reaches tail.
+    val arm_global: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, arm64, ?plan);
+    if (R.is_err[bool, str](arm_global) || plan.active) { ret 1; }
     ret 0;
 }
 
@@ -4469,6 +4511,12 @@ test "mach.lang.be.linker.atom_plan:rv64_plt_pair_boundary" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    val arm64: *isa.IsaVTable = lt_isa(?reg, "aarch64");
+    val rv64: *isa.IsaVTable = lt_isa(?reg, "riscv64");
+    if (x64 == nil || arm64 == nil || rv64 == nil) { ret 1; }
 
     val dup: intern.StrId = lt_name(?s, "rvpairI3u64E");
     val ext: intern.StrId = lt_name(?s, "callee");
@@ -4504,17 +4552,20 @@ test "mach.lang.be.linker.atom_plan:rv64_plt_pair_boundary" {
                        ?reloc[0], 1);
     var bases: [2]u32;
     var plan: AtomPlan;
-    var x64: isa.IsaVTable = lt_isa(isa.ARCH_X86_64);
-    var rv64: isa.IsaVTable = lt_isa(isa.ARCH_RISCV64);
     init_atom_plan(?plan);
 
     val x: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, ?x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](x) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
+    val arm: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, arm64, ?plan);
+    if (R.is_err[bool, str](arm) || !plan.active || plan.drop_count != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
     val rv: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, ?rv64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, rv64, ?plan);
     if (R.is_err[bool, str](rv) || plan.active) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -289,7 +289,8 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     # the parsed images are owned here (read from disk), so they are torn down
     # after linking regardless of outcome.
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, modules, module_count, sonames, soname_count, out_path, name, mode, pie);
+        link_modules(s, tgt, modules, module_count, 0, sonames, soname_count,
+                     out_path, name, mode, pie);
     free_modules(alloc, modules, module_count);
     ret r;
 }
@@ -326,7 +327,8 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     if (images == nil || image_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
-    ret link_modules(s, tgt, images, image_count, sonames, soname_count, out_path, name, mode, pie);
+    ret link_modules(s, tgt, images, image_count, image_count, sonames,
+                     soname_count, out_path, name, mode, pie);
 }
 
 # combine the project's in-memory codegen images with on-disk external link
@@ -403,7 +405,8 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
     for (j < ext_count) { combined[image_count + j] = ext[j]; j = j + 1; }
 
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, combined, total, sonames, soname_count, out_path, name, mode, pie);
+        link_modules(s, tgt, combined, total, image_count, sonames, soname_count,
+                     out_path, name, mode, pie);
 
     # tear down only the parsed external images (the project images are caller-owned)
     # and free the `combined` wrapper without dnit'ing its shallow-copied slots.
@@ -433,6 +436,7 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 # tgt:          active target - selects OS base address, entry symbol, and writers
 # modules:      the input module images (caller-owned)
 # module_count: number of modules
+# codegen_count: number of leading in-memory compiler images; the rest were parsed
 # sonames:      interned shared-library sonames to depend on dynamically (or nil)
 # soname_count: number of shared-library dependencies
 # out_path:     null-terminated output file path
@@ -441,7 +445,8 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 # pie_opt_in:   the build opted into a position-independent executable (`--pie`)
 # ret:          true once the artifact is written, or an error string
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
-                 module_count: u32, sonames: *intern.StrId, soname_count: u32,
+                 module_count: u32, codegen_count: u32,
+                 sonames: *intern.StrId, soname_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     # a shared object is always position-independent: the loader maps it at an
@@ -466,6 +471,9 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # nothing to link, so reject rather than emit an empty artifact.
     if (module_count == 0) {
         ret R.err[bool, str]("link: no input objects");
+    }
+    if (codegen_count > module_count) {
+        ret R.err[bool, str]("link: codegen image count exceeds module count");
     }
 
     # discover the distinct debug-section names (first-encounter order) so the merge
@@ -536,8 +544,8 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # definition actually lost global resolution. A relocatable link receives an
     # inert plan and preserves its native weak/group representation byte-for-byte.
     val atom_r: R.Result[bool, str] =
-        build_atom_plan(s, modules, module_count, sec_base, sec_total, patching,
-                        tgt.isa, ?atoms);
+        build_atom_plan(s, modules, module_count, codegen_count, sec_base,
+                        sec_total, patching, tgt.isa, ?atoms);
     if (R.is_err[bool, str](atom_r)) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](atom_r));
@@ -636,8 +644,9 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         }
 
         val patch_r: R.Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base,
-                              merged_to_out, ?sym_locs, ?dyn, ?strm, tgt.isa, ?atoms);
+            patch_relocations(s, ?out_img, modules, module_count, codegen_count,
+                              placements, sec_base, merged_to_out, ?sym_locs,
+                              ?dyn, ?strm, tgt.isa, ?atoms);
         if (R.is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
@@ -1655,8 +1664,10 @@ fun atom_resume_offset(dst: u32, end: u32, section_align: u32) u32 {
 
 # physical relocation shape supplied by the active ISA's relocatable-object seam
 fun atom_reloc_traits(r: *of.Relocation, section: *of.Section,
-                      arch: *isa.IsaVTable) rel.RelocTraits {
-    ret arch.reloc.reloc_traits::rel.RelocTraitsFn(r.kind, section.kind);
+                      arch: *isa.IsaVTable,
+                      codegen_image: bool) rel.RelocTraits {
+    ret arch.reloc.reloc_traits::rel.RelocTraitsFn(
+        r.kind, section.kind, codegen_image);
 }
 
 # whether a second symbol is the exact synthetic section anchor emitted by COFF
@@ -1837,10 +1848,14 @@ fun copy_live_section(dst: *u8, src: *u8, src_len: u32, plan: *AtomPlan, section
 # as collect_symbols. only a weak GLOBAL FUNCTION in SK_TEXT that actually loses
 # is eligible. its extent runs to the next global function entry (or section end);
 # another symbol inside the interval or a relocation field crossing its boundary
-# keeps the interval conservatively live
+# keeps the interval conservatively live. the leading `codegen_count` modules
+# came directly from this compiler; remaining modules came through an object parser
 fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
-                    sec_base: *u32, sec_total: u32, enabled: bool,
+                    codegen_count: u32, sec_base: *u32, sec_total: u32, enabled: bool,
                     arch: *isa.IsaVTable, plan: *AtomPlan) R.Result[bool, str] {
+    if (codegen_count > module_count) {
+        ret R.err[bool, str]("linker: codegen image count exceeds module count");
+    }
     fill_section_bases(modules, module_count, sec_base);
     if (!enabled) { ret R.ok[bool, str](true); }
 
@@ -2018,7 +2033,8 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 var traits: rel.RelocTraits;
                 if (relocation.section < modules[m].section_count) {
                     traits = atom_reloc_traits(
-                        relocation, ?modules[m].sections[relocation.section], arch);
+                        relocation, ?modules[m].sections[relocation.section],
+                        arch, m < codegen_count);
                 }
                 or {
                     # the normal patch pass reports the corrupt section index;
@@ -2136,7 +2152,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 val rstart: u64 = r.offset::u64;
                 val rend: u64 = rstart
                     + atom_reloc_traits(r, ?modules[cm].sections[r.section],
-                                        arch).field_width::u64;
+                                        arch, cm < codegen_count).field_width::u64;
                 if (rstart < end::u64 && rend > start::u64
                     && (rstart < start::u64 || rend > end::u64)) {
                     safe = false;
@@ -2694,6 +2710,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 # out_img:      the merged image whose section bytes are patched in place
 # modules:      the input image array (source of the relocations)
 # module_count: number of input images
+# codegen_count: number of leading in-memory compiler images; the rest were parsed
 # placements:    per-input-section placement (merged index + offset + vaddr)
 # sec_base:      per-module prefix offset into `placements`
 # merged_to_out: per-merged-slot output-section index (from build_merged_image)
@@ -2703,7 +2720,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 # arch:          active instruction-set vtable, owning the relocation packer
 # ret:           ok(true) on success, or an error string
 fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
-                     modules: *of.ObjectImage, module_count: u32,
+                     modules: *of.ObjectImage, module_count: u32, codegen_count: u32,
                      placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
                      dyn: *DynState, strm: *StrMerge, arch: *isa.IsaVTable,
@@ -2728,7 +2745,7 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
 
         val pr: R.Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
             placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, strm,
-            arch, atoms);
+            arch, m < codegen_count, atoms);
         map.dnit[intern.StrId, u64](?local_map);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
 
@@ -2788,13 +2805,14 @@ fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, 
 # local_map:     module `m`'s LOCAL-name -> virtual-address index
 # strm:          the deduped .debug_str table, for strp remap (inactive to skip)
 # arch:          active instruction-set vtable, owning the relocation packer
+# codegen_image: true when module `m` is an in-memory compiler image
 # ret:           ok(true) on success, or an error string
 fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
                              placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
                              local_map: *map.Map[intern.StrId, u64], strm: *StrMerge,
-                             arch: *isa.IsaVTable,
+                             arch: *isa.IsaVTable, codegen_image: bool,
                              atoms: *AtomPlan) R.Result[bool, str] {
     # locate module m's .debug_str section and its anchor symbol once: a strp
     # relocation is exactly one whose target is that anchor. resolving it remaps the
@@ -2832,7 +2850,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
         if (r.offset::u64
             + atom_reloc_traits(r, ?modules[m].sections[r.section],
-                                arch).field_width::u64
+                                arch, codegen_image).field_width::u64
             > modules[m].sections[r.section].len::u64) {
             ret R.err[bool, str]("linker: relocation offset is past the end of its section");
         }
@@ -4093,12 +4111,12 @@ test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val disabled: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, false, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, false, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](disabled) || plan.active) { ret 1; }
 
     # weak/weak: first wins, later body is the one discarded.
     val ww: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](ww) || !plan.active || plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].section != 1 || plan.drops[0].start != 0
         || plan.drops[0].end != 8 || plan.removed_bytes != 8) { ret 1; }
@@ -4107,7 +4125,7 @@ test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
     # a later strong replaces and discards the earlier weak winner.
     syms1[0].flags = strong_flags;
     val ws: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](ws) || !plan.active || plan.drops[0].section != 0) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
@@ -4115,14 +4133,14 @@ test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
     syms0[0].flags = strong_flags;
     syms1[0].flags = weak_flags;
     val sw: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](sw) || !plan.active || plan.drops[0].section != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     # two strong definitions remain a hard error.
     syms1[0].flags = strong_flags;
     val ss: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (!R.is_err[bool, str](ss)) { ret 1; }
 
     # distinct weak names have no loser: the plan stays wholly inert.
@@ -4130,7 +4148,7 @@ test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
     syms1[0].flags = weak_flags;
     syms1[0].name = other;
     val unique: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](unique) || plan.active) { ret 1; }
     ret 0;
 }
@@ -4214,7 +4232,7 @@ test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val pr: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
 
     # [8,16) and [16,24) merge, leaving head then tail packed at an 8-byte
@@ -4284,7 +4302,7 @@ test "mach.lang.be.linker.atom_plan:shared_symbol_retains_loser" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val pr: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](pr) || plan.active || plan.drop_count != 0) { ret 1; }
     ret 0;
 }
@@ -4334,7 +4352,7 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val sized: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](sized) || !plan.active || plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].start != 0 || plan.drops[0].end != 8
         || plan.sections[1].live_len != 8) { ret 1; }
@@ -4354,7 +4372,7 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     b_syms[1].offset = 0;
     b_syms[1].size = 16;
     val covered: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](covered) || plan.active) { ret 1; }
     ret 0;
 }
@@ -4423,7 +4441,7 @@ test "mach.lang.be.linker.atom_plan:suffix_alignment_grid" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val pr: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true,
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true,
                         nil::*isa.IsaVTable, ?plan);
     if (R.is_err[bool, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].start != 16 || plan.drops[0].end != 37
@@ -4489,7 +4507,7 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val inert_anchor: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](inert_anchor) || !plan.active || plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].section != 1 || plan.drops[0].start != 0
         || plan.drops[0].end != 8) { ret 1; }
@@ -4497,7 +4515,7 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
 
     mods[1].reloc_count = 1;
     val referenced_anchor: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](referenced_anchor) || plan.active) { ret 1; }
     ret 0;
 }
@@ -4560,37 +4578,58 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val crossing: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](crossing) || plan.active) { ret 1; }
 
     # a target that remains before the candidate does not cross it and leaves the
     # duplicate eligible, proving retention is caused by the addend relationship.
     reloc[0].addend = 4;
     val same_side: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](same_side) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
-    # text pc32 remains ambiguous even when the preceding byte looks like a call
-    # opcode: data can contain 0xe8 too, so bias zero stays in the possible range.
+    # parsed text pc32 remains ambiguous even when the preceding byte looks like a
+    # call opcode: data can contain 0xe8 too, so bias zero stays possible.
     b_bytes[3] = 0xE8;
     reloc[0].offset = 4;
     reloc[0].kind = of.RK_PC32;
     reloc[0].addend = -4;
     val pc_local: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](pc_local) || plan.active) { ret 1; }
     reloc[0].symbol = tail;
     reloc[0].kind = of.RK_PLT32;
-    val pc_global: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[bool, str](pc_global) || !plan.active || plan.drop_count != 1) { ret 1; }
+
+    # link_mixed places compiler images first. module 1 is therefore parsed when
+    # codegen_count is one: its PLT32 may be a raw `.long tail@PLT-4`, so bias
+    # zero reaches the candidate and conservatively retains it.
+    val parsed_plt_data: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
+    if (R.is_err[bool, str](parsed_plt_data) || plan.active) { ret 1; }
+
+    # a foreign PLT32 displacement can also precede a trailing immediate. an
+    # eight-byte field-to-next-ip distance is possible, but provenance alone
+    # cannot select that bias from the full legal x64 range.
+    reloc[0].addend = -8;
+    val parsed_plt_trailing: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
+    if (R.is_err[bool, str](parsed_plt_trailing) || plan.active) { ret 1; }
+
+    # with two compiler-produced images, module 1's PC32 is known to hold an
+    # instruction relocation. its field-to-next-ip bias is at least four, so
+    # tail-4 cannot reach backward into the candidate.
+    reloc[0].addend = -4;
+    reloc[0].kind = of.RK_PC32;
+    val codegen_pc: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, 2, ?bases[0], 3, true, x64, ?plan);
+    if (R.is_err[bool, str](codegen_pc) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     # darwin arm64 CALL26 preserves its S-relative addend: tail-4 lands inside
-    # the candidate. x64's canonical field bias above instead reaches tail.
+    # the candidate, regardless of image provenance.
     val arm_global: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, arm64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 2, ?bases[0], 3, true, arm64, ?plan);
     if (R.is_err[bool, str](arm_global) || plan.active) { ret 1; }
 
     # non-text pc32 has no instruction bias: tail-4 reaches the candidate and
@@ -4599,7 +4638,7 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     reloc[0].offset = 0;
     reloc[0].kind = of.RK_PC32;
     val data_pc: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 2, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](data_pc) || plan.active) { ret 1; }
     ret 0;
 }
@@ -4657,17 +4696,17 @@ test "mach.lang.be.linker.atom_plan:rv64_plt_pair_boundary" {
     init_atom_plan(?plan);
 
     val x: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, x64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](x) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     val arm: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, arm64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, arm64, ?plan);
     if (R.is_err[bool, str](arm) || !plan.active || plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     val rv: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, rv64, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, rv64, ?plan);
     if (R.is_err[bool, str](rv) || plan.active) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -171,6 +171,17 @@ rec AtomCandidate {
     symbol: u32;
 }
 
+# one relocation indexed by its already-resolved target section for candidate
+# reachability checks
+rec AtomRelocRef {
+    target_section: u32;
+    target_module:  u32;
+    target_symbol:  u32;
+    source_module:  u32;
+    reloc:           u32;
+    width:           u32;
+}
+
 # the linker's mutable dynamic-link state: the format-neutral plan (`of.DynamicInfo`)
 # being assembled plus the import call-site fixups (`of.PltFixup`) collected during
 # relocation patching, and the map from an imported symbol name to its index in the
@@ -522,7 +533,8 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # definition actually lost global resolution. A relocatable link receives an
     # inert plan and preserves its native weak/group representation byte-for-byte.
     val atom_r: R.Result[bool, str] =
-        build_atom_plan(s, modules, module_count, sec_base, sec_total, patching, ?atoms);
+        build_atom_plan(s, modules, module_count, sec_base, sec_total, patching,
+                        tgt.isa, ?atoms);
     if (R.is_err[bool, str](atom_r)) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](atom_r));
@@ -1604,6 +1616,30 @@ fun atom_drop_cmp(a: *AtomDrop, b: *AtomDrop) i64 {
     ret 0;
 }
 
+# order relocation references by resolved flat target section, then source site
+fun atom_reloc_ref_cmp(a: *AtomRelocRef, b: *AtomRelocRef) i64 {
+    if (a.target_section < b.target_section) { ret -1; }
+    if (a.target_section > b.target_section) { ret 1; }
+    if (a.source_module < b.source_module)   { ret -1; }
+    if (a.source_module > b.source_module)   { ret 1; }
+    if (a.reloc < b.reloc)                   { ret -1; }
+    if (a.reloc > b.reloc)                   { ret 1; }
+    ret 0;
+}
+
+# first relocation-reference index whose flat target section is not less than
+# `section`
+fun atom_reloc_ref_lower(refs: *AtomRelocRef, count: u32, section: u32) u32 {
+    var lo: u32 = 0;
+    var hi: u32 = count;
+    for (lo < hi) {
+        val mid: u32 = lo + (hi - lo) / 2;
+        if (refs[mid].target_section < section) { lo = mid + 1; }
+        or                                      { hi = mid; }
+    }
+    ret lo;
+}
+
 # largest power-of-two alignment required by the source byte at `off`, capped
 # at the input section's declared alignment
 fun atom_resume_align(off: u32, section_align: u32) u32 {
@@ -1615,10 +1651,97 @@ fun atom_resume_align(off: u32, section_align: u32) u32 {
 }
 
 # byte width patched by an abstract relocation kind
-fun atom_reloc_width(kind: of.RelocKind) u32 {
+fun atom_reloc_width(kind: of.RelocKind, arch: *isa.IsaVTable) u32 {
     if (kind == of.RK_ABS64)   { ret 8; }
     if (kind == of.RK_SECTION) { ret 2; }
+    # rv64's abstract PLT32 is an AUIPC+JALR pair, patched as one 8-byte site.
+    # x64 and AArch64 patch one 4-byte instruction/field for the same kind.
+    if (kind == of.RK_PLT32 && arch != nil && arch.id == isa.ARCH_RISCV64) { ret 8; }
     ret 4;
+}
+
+# whether a second symbol is the exact synthetic section anchor emitted by COFF
+# for a full-section weak COMDAT carrier. the parser surfaces that STATIC record
+# as a local zero-sized symbol at offset zero, named for the section. relocation
+# reachability is checked separately, so this exemption removes only the inert
+# bookkeeping symbol, never an addressable label
+fun atom_is_carrier_anchor(m: *of.ObjectImage, owner: *of.Symbol,
+                           other: *of.Symbol, start: u32, end: u32) bool {
+    if (start != 0 || owner.offset != 0) { ret false; }
+    if (owner.section >= m.section_count || end != m.sections[owner.section].len) { ret false; }
+    if (other.section != owner.section || other.offset != 0 || other.size != 0)   { ret false; }
+    if (other.flags != 0 || other.name != m.sections[owner.section].name)          { ret false; }
+    ret true;
+}
+
+# apply a signed relocation addend to a section offset without overflow. offsets
+# one-past-the-section are representable so end-marker references can be audited
+fun atom_effective_offset(base: u32, addend: i64, out: *u32) bool {
+    if (addend >= 0) {
+        val plus: u64 = addend::u64;
+        if (plus > 0xFFFFFFFF - base::u64) { ret false; }
+        @out = base + plus::u32;
+        ret true;
+    }
+    if (addend < -(base::i64)) { ret false; }
+    @out = (base::i64 + addend)::u32;
+    ret true;
+}
+
+# whether a relocation's addend is a true offset from S rather than an
+# instruction-field bias such as x64 PC32/PLT32's -4
+fun atom_addend_is_symbol_relative(kind: of.RelocKind) bool {
+    if (kind == of.RK_PC32 || kind == of.RK_PLT32 || kind == of.RK_GOTPCREL
+        || kind == of.RK_GOT_PAGE21 || kind == of.RK_GOT_LO12
+        || kind == of.RK_SECTION) { ret false; }
+    ret true;
+}
+
+# whether a relocation whose patch field survives `candidate` resolves through
+# a local or winning-global anchor across the candidate boundary. symbol offsets
+# are remapped but relocation addends are not; crossing the removed interval
+# would therefore silently retarget the relocation, so the candidate must stay
+# live. a relocation to the losing weak name resolves to the winner recorded in
+# `winners`, not to the discarded definition
+fun atom_reloc_crosses_candidate(modules: *of.ObjectImage, reference: *AtomRelocRef,
+                                 r: *of.Relocation,
+                                 candidate_module: u32, candidate_section: u32,
+                                 start: u32, end: u32) bool {
+    val source_module: u32 = reference.source_module;
+    val width: u64 = reference.width::u64;
+    if (source_module == candidate_module && r.section == candidate_section
+        && r.offset::u64 >= start::u64
+        && r.offset::u64 + width <= end::u64) {
+        ret false;
+    }
+
+    val target_module: u32 = reference.target_module;
+    val target_symbol: u32 = reference.target_symbol;
+
+    val target: *of.Symbol = ?modules[target_module].symbols[target_symbol];
+    if (target_module != candidate_module || target.section != candidate_section) { ret false; }
+    if (target.offset > modules[candidate_module].sections[candidate_section].len) { ret false; }
+
+    # a resolved entry inside the atom disappears regardless of relocation kind.
+    # pc-relative field biases are otherwise not S-relative addends: a normal
+    # call to the next global function carries -4 and must not look like it
+    # points four bytes backward into this candidate. A biased relocation through
+    # any local in this section is retained conservatively because foreign
+    # containers may encode an anchor-relative target behind that bias.
+    if (target.offset >= start && target.offset < end) { ret true; }
+    if (!atom_addend_is_symbol_relative(r.kind)) {
+        ret (target.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0;
+    }
+
+    var effective: u32 = 0;
+    if (!atom_effective_offset(target.offset, r.addend, ?effective)) { ret false; }
+    if (effective > modules[candidate_module].sections[candidate_section].len) { ret false; }
+
+    # source anchor and effective target must remain on the same side of the
+    # removed interval.
+    if (target.offset < start && effective >= start)   { ret true; }
+    if (target.offset >= end && effective < end)       { ret true; }
+    ret false;
 }
 
 # fill each module's base in the flat input-section array
@@ -1714,7 +1837,7 @@ fun copy_live_section(dst: *u8, src: *u8, src_len: u32, plan: *AtomPlan, section
 # keeps the interval conservatively live
 fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                     sec_base: *u32, sec_total: u32, enabled: bool,
-                    plan: *AtomPlan) R.Result[bool, str] {
+                    arch: *isa.IsaVTable, plan: *AtomPlan) R.Result[bool, str] {
     fill_section_bases(modules, module_count, sec_base);
     if (!enabled) { ret R.ok[bool, str](true); }
 
@@ -1804,9 +1927,8 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         }
         m = m + 1;
     }
-    map.dnit[intern.StrId, AtomWinner](?winners);
-
     if (candidate_count == 0) {
+        map.dnit[intern.StrId, AtomWinner](?winners);
         if (candidates != nil) {
             A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
         }
@@ -1816,11 +1938,108 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
     val dr: R.Result[*AtomDrop, str] =
         A.zallocate[AtomDrop](s.alloc, candidate_count::usize);
     if (R.is_err[*AtomDrop, str](dr)) {
+        map.dnit[intern.StrId, AtomWinner](?winners);
         A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
         ret R.err[bool, str](R.unwrap_err[*AtomDrop, str](dr));
     }
     val drops: *AtomDrop = R.unwrap_ok[*AtomDrop, str](dr);
     var drop_count: u32 = 0;
+
+    # index relocation targets once. candidate checks then inspect only references
+    # to symbols in that candidate's section instead of rescanning every relocation
+    # for every duplicate weak body.
+    var reloc_total64: u64 = 0;
+    m = 0;
+    for (m < module_count) {
+        reloc_total64 = reloc_total64 + modules[m].reloc_count::u64;
+        if (reloc_total64 > 0xFFFFFFFF) {
+            map.dnit[intern.StrId, AtomWinner](?winners);
+            A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+            A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
+            ret R.err[bool, str]("linker: input relocation count exceeds the u32 limit");
+        }
+        m = m + 1;
+    }
+    val reloc_total: u32 = reloc_total64::u32;
+    var refs: *AtomRelocRef = nil;
+    if (reloc_total > 0) {
+        val rr: R.Result[*AtomRelocRef, str] =
+            A.zallocate[AtomRelocRef](s.alloc, reloc_total::usize);
+        if (R.is_err[*AtomRelocRef, str](rr)) {
+            map.dnit[intern.StrId, AtomWinner](?winners);
+            A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+            A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
+            ret R.err[bool, str](R.unwrap_err[*AtomRelocRef, str](rr));
+        }
+        refs = R.unwrap_ok[*AtomRelocRef, str](rr);
+        var rw: u32 = 0;
+        m = 0;
+        for (m < module_count) {
+            var locals: map.Map[intern.StrId, u32] =
+                map.init[intern.StrId, u32](s.alloc, map.hash_u32, map.eq_u32);
+            var sy: u32 = 0;
+            for (sy < modules[m].symbol_count) {
+                val local: *of.Symbol = ?modules[m].symbols[sy];
+                if (local.section != of.SECTION_EXTERNAL
+                    && local.section < modules[m].section_count
+                    && (local.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0
+                    && R.is_err[*u32, str](map.get[intern.StrId, u32](?locals, ?local.name))) {
+                    val li: R.Result[bool, str] =
+                        map.insert[intern.StrId, u32](?locals, local.name, sy);
+                    if (R.is_err[bool, str](li)) {
+                        map.dnit[intern.StrId, u32](?locals);
+                        map.dnit[intern.StrId, AtomWinner](?winners);
+                        A.deallocate[AtomRelocRef](s.alloc, refs, reloc_total::usize);
+                        A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
+                        A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
+                        ret R.err[bool, str](R.unwrap_err[bool, str](li));
+                    }
+                }
+                sy = sy + 1;
+            }
+
+            var ri: u32 = 0;
+            for (ri < modules[m].reloc_count) {
+                refs[rw].target_section = 0xFFFFFFFF;
+                refs[rw].target_module = 0xFFFFFFFF;
+                refs[rw].target_symbol = 0xFFFFFFFF;
+                refs[rw].source_module = m;
+                refs[rw].reloc = ri;
+                refs[rw].width = atom_reloc_width(modules[m].relocations[ri].kind, arch);
+
+                val r: *of.Relocation = ?modules[m].relocations[ri];
+                val lr: R.Result[*u32, str] =
+                    map.get[intern.StrId, u32](?locals, ?r.symbol);
+                if (R.is_ok[*u32, str](lr)) {
+                    refs[rw].target_module = m;
+                    refs[rw].target_symbol = @R.unwrap_ok[*u32, str](lr);
+                }
+                or {
+                    val wr: R.Result[*AtomWinner, str] =
+                        map.get[intern.StrId, AtomWinner](?winners, ?r.symbol);
+                    if (R.is_ok[*AtomWinner, str](wr)) {
+                        val winner: *AtomWinner = R.unwrap_ok[*AtomWinner, str](wr);
+                        refs[rw].target_module = winner.module;
+                        refs[rw].target_symbol = winner.symbol;
+                    }
+                }
+                if (refs[rw].target_module != 0xFFFFFFFF) {
+                    val target: *of.Symbol =
+                        ?modules[refs[rw].target_module].symbols[refs[rw].target_symbol];
+                    if (target.section != of.SECTION_EXTERNAL
+                        && target.section < modules[refs[rw].target_module].section_count) {
+                        refs[rw].target_section =
+                            sec_base[refs[rw].target_module] + target.section;
+                    }
+                }
+                rw = rw + 1;
+                ri = ri + 1;
+            }
+            map.dnit[intern.StrId, u32](?locals);
+            m = m + 1;
+        }
+        sort.sort[AtomRelocRef](refs, reloc_total::usize, atom_reloc_ref_cmp);
+    }
 
     var ci: u32 = 0;
     for (ci < candidate_count) {
@@ -1836,30 +2055,49 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         }
 
         val start: u32 = sym.offset;
-        var end: u32 = sec.len;
-        var sy: u32 = 0;
-        for (sy < modules[cm].symbol_count) {
-            val other: *of.Symbol = ?modules[cm].symbols[sy];
-            if (other.section == sym.section
-                && (other.flags & (of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION))
-                    == (of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION)
-                && other.offset > start && other.offset < end) {
-                end = other.offset;
+        var end: u32 = 0;
+        if (sym.size > 0) {
+            # a validated producer size is authoritative. foreign objects may put
+            # unsymbolized literal/island bytes after the function; an inferred
+            # section-tail extent would incorrectly delete those bytes.
+            val sized_end: u64 = start::u64 + sym.size::u64;
+            if (sized_end > sec.len::u64) { ci = ci + 1; cnt; }
+            end = sized_end::u32;
+        }
+        or {
+            end = sec.len;
+            var nsy: u32 = 0;
+            for (nsy < modules[cm].symbol_count) {
+                val other: *of.Symbol = ?modules[cm].symbols[nsy];
+                if (other.section == sym.section
+                    && (other.flags & (of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION))
+                        == (of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION)
+                    && other.offset > start && other.offset < end) {
+                    end = other.offset;
+                }
+                nsy = nsy + 1;
             }
-            sy = sy + 1;
         }
         if (end <= start) { ci = ci + 1; cnt; }
 
-        # A second symbol in the candidate interval may be addressable from live
-        # code. Keep the whole atom rather than needing a target-reachability
-        # closure; normal generated generic bodies have only their entry symbol.
+        # a second symbol entry or nonzero extent overlapping the candidate may
+        # remain addressable from live code. The sole exception is COFF's exact
+        # synthetic section anchor for a full COMDAT carrier; relocation
+        # reachability through that anchor is audited below.
         var safe: bool = true;
-        sy = 0;
+        var sy: u32 = 0;
         for (sy < modules[cm].symbol_count) {
             if (sy != cy) {
                 val other: *of.Symbol = ?modules[cm].symbols[sy];
-                if (other.section == sym.section && other.offset >= start && other.offset < end) {
-                    safe = false;
+                if (other.section == sym.section
+                    && !atom_is_carrier_anchor(?modules[cm], sym, other, start, end)) {
+                    if (other.offset >= start && other.offset < end) { safe = false; }
+                    if (other.size > 0) {
+                        val other_end: u64 = other.offset::u64 + other.size::u64;
+                        if (other.offset < end && other_end > start::u64) {
+                            safe = false;
+                        }
+                    }
                 }
             }
             sy = sy + 1;
@@ -1872,13 +2110,29 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             val r: *of.Relocation = ?modules[cm].relocations[ri];
             if (r.section == sym.section) {
                 val rstart: u64 = r.offset::u64;
-                val rend: u64 = rstart + atom_reloc_width(r.kind)::u64;
+                val rend: u64 = rstart + atom_reloc_width(r.kind, arch)::u64;
                 if (rstart < end::u64 && rend > start::u64
                     && (rstart < start::u64 || rend > end::u64)) {
                     safe = false;
                 }
             }
             ri = ri + 1;
+        }
+
+        # a surviving relocation through a local/section anchor (or through the
+        # actual winning global) must not span the removed interval: the target
+        # symbol is remapped but its raw addend is not.
+        val candidate_flat: u32 = sec_base[cm] + sym.section;
+        var ref_i: u32 = atom_reloc_ref_lower(refs, reloc_total, candidate_flat);
+        for (safe && ref_i < reloc_total
+            && refs[ref_i].target_section == candidate_flat) {
+            val rm: u32 = refs[ref_i].source_module;
+            val rx: u32 = refs[ref_i].reloc;
+            if (atom_reloc_crosses_candidate(modules, ?refs[ref_i],
+                ?modules[rm].relocations[rx], cm, sym.section, start, end)) {
+                safe = false;
+            }
+            ref_i = ref_i + 1;
         }
         if (safe) {
             drops[drop_count].section = sec_base[cm] + sym.section;
@@ -1889,6 +2143,8 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         }
         ci = ci + 1;
     }
+    map.dnit[intern.StrId, AtomWinner](?winners);
+    if (refs != nil) { A.deallocate[AtomRelocRef](s.alloc, refs, reloc_total::usize); }
     A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
 
     if (drop_count == 0) {
@@ -2544,7 +2800,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         if (r.section >= modules[m].section_count) {
             ret R.err[bool, str]("linker: relocation names an out-of-range section");
         }
-        if (r.offset::u64 + atom_reloc_width(r.kind)::u64
+        if (r.offset::u64 + atom_reloc_width(r.kind, arch)::u64
             > modules[m].sections[r.section].len::u64) {
             ret R.err[bool, str]("linker: relocation offset is past the end of its section");
         }
@@ -3681,6 +3937,36 @@ fun lt_link(s: *session.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbo
     ret R.ok[u64, str](v);
 }
 
+# intern a test symbol name, returning STR_NIL only on allocation failure
+fun lt_name(s: *session.Session, name: str) intern.StrId {
+    val r: R.Result[intern.StrId, str] = intern.intern(?s.interner, name);
+    if (R.is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](r);
+}
+
+# construct one test object image over borrowed section/symbol/relocation arrays
+fun lt_image(s: *session.Session, name: intern.StrId,
+             sections: *of.Section, section_count: u32,
+             symbols: *of.Symbol, symbol_count: u32,
+             relocations: *of.Relocation, reloc_count: u32) of.ObjectImage {
+    var img: of.ObjectImage;
+    img.alloc = s.alloc;
+    img.interner = ?s.interner;
+    img.name = name;
+    img.sections = sections;
+    img.section_count = section_count;
+    img.symbols = symbols;
+    img.symbol_count = symbol_count;
+    img.relocations = relocations;
+    img.reloc_count = reloc_count;
+    ret img;
+}
+
+# construct a description-only ISA vtable for architecture-sensitive linker tests
+fun lt_isa(id: u32) isa.IsaVTable {
+    ret isa.machine_isa(id, "test", 0, 8, nil, nil, nil);
+}
+
 # weak/strong symbol resolution is order-independent (#1257)
 test "mach.lang.be.linker.collect_symbols:weak_strong_order_independent" {
     var alloc: A.Allocator;
@@ -3717,5 +4003,518 @@ test "mach.lang.be.linker.collect_symbols:weak_strong_order_independent" {
     # strong-then-strong: still a multiple-definition error.
     val r3: R.Result[u64, str] = lt_link(?s, nm, ?strong, ?strong2);
     if (!R.is_err[u64, str](r3)) { ret 1; }
+    ret 0;
+}
+
+# final-link atomization activates only for a real losing weak definition, accepts
+# byte-different semantic copies, and mirrors strong-over-weak resolution in both
+# input orders. the disabled plan is the relocatable-link control
+test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "dupI3u64E");
+    val other: intern.StrId = lt_name(?s, "otherI3u64E");
+    val text: intern.StrId = lt_name(?s, ".text");
+    if (dup == intern.STR_NIL || other == intern.STR_NIL || text == intern.STR_NIL) { ret 1; }
+
+    # deliberately divergent bytes: weak resolution is semantic, not a byte-equality
+    # fold, and whichever definition loses must be removable.
+    var bytes0: [8]u8;
+    var bytes1: [8]u8;
+    var i: u32 = 0;
+    for (i < 8) {
+        bytes0[i] = (0x10 + i)::u8;
+        bytes1[i] = (0x80 + i)::u8;
+        i = i + 1;
+    }
+    var secs0: [1]of.Section;
+    var secs1: [1]of.Section;
+    secs0[0].name = text; secs0[0].kind = of.SK_TEXT; secs0[0].bytes = ?bytes0[0];
+    secs0[0].len = 8; secs0[0].align = 1;
+    secs1[0].name = text; secs1[0].kind = of.SK_TEXT; secs1[0].bytes = ?bytes1[0];
+    secs1[0].len = 8; secs1[0].align = 1;
+
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    var syms0: [1]of.Symbol;
+    var syms1: [1]of.Symbol;
+    syms0[0].name = dup; syms0[0].section = 0; syms0[0].offset = 0;
+    syms0[0].size = 0; syms0[0].flags = weak_flags;
+    syms1[0].name = dup; syms1[0].section = 0; syms1[0].offset = 0;
+    syms1[0].size = 0; syms1[0].flags = weak_flags;
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "m0"), ?secs0[0], 1, ?syms0[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "m1"), ?secs1[0], 1, ?syms1[0], 1,
+                       nil::*of.Relocation, 0);
+    var bases: [2]u32;
+
+    # relocatable/native-group output never atomizes.
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val disabled: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, false, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](disabled) || plan.active) { ret 1; }
+
+    # weak/weak: first wins, later body is the one discarded.
+    val ww: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](ww) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (plan.drops[0].section != 1 || plan.drops[0].start != 0
+        || plan.drops[0].end != 8 || plan.removed_bytes != 8) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    # a later strong replaces and discards the earlier weak winner.
+    syms1[0].flags = strong_flags;
+    val ws: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](ws) || !plan.active || plan.drops[0].section != 0) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    # a strong seen first remains the winner and the later weak is discarded.
+    syms0[0].flags = strong_flags;
+    syms1[0].flags = weak_flags;
+    val sw: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](sw) || !plan.active || plan.drops[0].section != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    # two strong definitions remain a hard error.
+    syms1[0].flags = strong_flags;
+    val ss: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (!R.is_err[bool, str](ss)) { ret 1; }
+
+    # distinct weak names have no loser: the plan stays wholly inert.
+    syms0[0].flags = weak_flags;
+    syms1[0].flags = weak_flags;
+    syms1[0].name = other;
+    val unique: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](unique) || plan.active) { ret 1; }
+    ret 0;
+}
+
+# adjacent losing atoms coalesce, surviving bytes/symbol sites are remapped with
+# alignment intact, and relocations owned only by dead bodies cannot retain an
+# import. a live relocation to another import remains visible
+test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val wa: intern.StrId = lt_name(?s, "waI3u64E");
+    val wb: intern.StrId = lt_name(?s, "wbI3u64E");
+    val head: intern.StrId = lt_name(?s, "head");
+    val tail: intern.StrId = lt_name(?s, "tail");
+    val dead_ext: intern.StrId = lt_name(?s, "dead_ext");
+    val live_ext: intern.StrId = lt_name(?s, "live_ext");
+    val text: intern.StrId = lt_name(?s, ".text");
+    if (wa == intern.STR_NIL || wb == intern.STR_NIL || head == intern.STR_NIL
+        || tail == intern.STR_NIL || dead_ext == intern.STR_NIL
+        || live_ext == intern.STR_NIL || text == intern.STR_NIL) { ret 1; }
+
+    var win_bytes: [16]u8;
+    var lose_bytes: [32]u8;
+    var i: u32 = 0;
+    for (i < 16) { win_bytes[i] = (0x20 + i)::u8; i = i + 1; }
+    i = 0;
+    for (i < 32) { lose_bytes[i] = (0x80 + i)::u8; i = i + 1; }
+
+    var win_sec: [1]of.Section;
+    var lose_sec: [1]of.Section;
+    win_sec[0].name = text; win_sec[0].kind = of.SK_TEXT;
+    win_sec[0].bytes = ?win_bytes[0]; win_sec[0].len = 16; win_sec[0].align = 8;
+    lose_sec[0].name = text; lose_sec[0].kind = of.SK_TEXT;
+    lose_sec[0].bytes = ?lose_bytes[0]; lose_sec[0].len = 32; lose_sec[0].align = 8;
+
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    var win_syms: [2]of.Symbol;
+    win_syms[0].name = wa; win_syms[0].section = 0; win_syms[0].offset = 0;
+    win_syms[0].size = 0; win_syms[0].flags = weak_flags;
+    win_syms[1].name = wb; win_syms[1].section = 0; win_syms[1].offset = 8;
+    win_syms[1].size = 0; win_syms[1].flags = weak_flags;
+
+    var lose_syms: [6]of.Symbol;
+    lose_syms[0].name = head; lose_syms[0].section = 0; lose_syms[0].offset = 0;
+    lose_syms[0].size = 0; lose_syms[0].flags = strong_flags;
+    lose_syms[1].name = wa; lose_syms[1].section = 0; lose_syms[1].offset = 8;
+    lose_syms[1].size = 0; lose_syms[1].flags = weak_flags;
+    lose_syms[2].name = wb; lose_syms[2].section = 0; lose_syms[2].offset = 16;
+    lose_syms[2].size = 0; lose_syms[2].flags = weak_flags;
+    lose_syms[3].name = tail; lose_syms[3].section = 0; lose_syms[3].offset = 24;
+    lose_syms[3].size = 0; lose_syms[3].flags = strong_flags;
+    lose_syms[4].name = dead_ext; lose_syms[4].section = of.SECTION_EXTERNAL;
+    lose_syms[4].offset = 0; lose_syms[4].size = 0;
+    lose_syms[4].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION;
+    lose_syms[5].name = live_ext; lose_syms[5].section = of.SECTION_EXTERNAL;
+    lose_syms[5].offset = 0; lose_syms[5].size = 0;
+    lose_syms[5].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var relocs: [2]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 10; relocs[0].kind = of.RK_PC32;
+    relocs[0].symbol = dead_ext; relocs[0].addend = -4;
+    relocs[1].section = 0; relocs[1].offset = 26; relocs[1].kind = of.RK_PC32;
+    relocs[1].symbol = live_ext; relocs[1].addend = -4;
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "winners"), ?win_sec[0], 1,
+                       ?win_syms[0], 2, nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "losers"), ?lose_sec[0], 1,
+                       ?lose_syms[0], 6, ?relocs[0], 2);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val pr: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
+
+    # [8,16) and [16,24) merge, leaving head then tail packed at an 8-byte
+    # boundary. no alignment padding is needed and 16 bytes disappear.
+    if (plan.drops[0].section != 1 || plan.drops[0].start != 8
+        || plan.drops[0].end != 24 || plan.drops[0].resume != 8
+        || plan.sections[1].live_len != 16 || plan.removed_bytes != 16) { ret 1; }
+    if (!atom_offset_dead(?plan, 1, 10) || !atom_offset_dead(?plan, 1, 20)) { ret 1; }
+    if (atom_offset_dead(?plan, 1, 24) || atom_live_offset(?plan, 1, 24) != 8) { ret 1; }
+
+    var copied: [16]u8;
+    copy_live_section(?copied[0], ?lose_bytes[0], 32, ?plan, 1);
+    i = 0;
+    for (i < 8) {
+        if (copied[i] != lose_bytes[i]) { ret 1; }
+        if (copied[8 + i] != lose_bytes[24 + i]) { ret 1; }
+        i = i + 1;
+    }
+
+    if (import_symbol_live(?mods[0], 2, dead_ext, ?bases[0], ?plan)) { ret 1; }
+    if (has_call_reloc(?mods[0], 2, dead_ext, ?bases[0], ?plan))     { ret 1; }
+    if (!import_symbol_live(?mods[0], 2, live_ext, ?bases[0], ?plan)) { ret 1; }
+    if (!has_call_reloc(?mods[0], 2, live_ext, ?bases[0], ?plan))     { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+    ret 0;
+}
+
+# a second symbol inside a losing function interval keeps that interval live;
+# this is the conservative control for an exposed local/shared label that a live
+# relocation could still address
+test "mach.lang.be.linker.atom_plan:shared_symbol_retains_loser" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "dupI3u64E");
+    val local: intern.StrId = lt_name(?s, "inside_label");
+    val text: intern.StrId = lt_name(?s, ".text");
+    var a_bytes: [8]u8;
+    var b_bytes: [8]u8;
+    var a_sec: [1]of.Section;
+    var b_sec: [1]of.Section;
+    a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
+    a_sec[0].len = 8; a_sec[0].align = 1;
+    b_sec[0].name = text; b_sec[0].kind = of.SK_TEXT; b_sec[0].bytes = ?b_bytes[0];
+    b_sec[0].len = 8; b_sec[0].align = 1;
+
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    var a_syms: [1]of.Symbol;
+    var b_syms: [2]of.Symbol;
+    a_syms[0].name = dup; a_syms[0].section = 0; a_syms[0].offset = 0;
+    a_syms[0].size = 0; a_syms[0].flags = weak_flags;
+    b_syms[0].name = dup; b_syms[0].section = 0; b_syms[0].offset = 0;
+    b_syms[0].size = 0; b_syms[0].flags = weak_flags;
+    b_syms[1].name = local; b_syms[1].section = 0; b_syms[1].offset = 4;
+    b_syms[1].size = 0; b_syms[1].flags = of.SYM_OBJ_FLAG_FUNCTION;
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "a"), ?a_sec[0], 1, ?a_syms[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "b"), ?b_sec[0], 1, ?b_syms[0], 2,
+                       nil::*of.Relocation, 0);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val pr: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](pr) || plan.active || plan.drop_count != 0) { ret 1; }
+    ret 0;
+}
+
+# a validated nonzero function size bounds the discarded bytes exactly, preserving
+# unsymbolized trailing islands. another symbol whose nonzero extent covers the
+# candidate from an earlier entry keeps it live
+test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "sizedI3u64E");
+    val cover: intern.StrId = lt_name(?s, "cover");
+    val text: intern.StrId = lt_name(?s, ".text");
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var a_bytes: [8]u8;
+    var b_bytes: [16]u8;
+    var i: u32 = 0;
+    for (i < 16) { b_bytes[i] = (0x50 + i)::u8; i = i + 1; }
+    var a_sec: [1]of.Section;
+    var b_sec: [1]of.Section;
+    a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
+    a_sec[0].len = 8; a_sec[0].align = 1;
+    b_sec[0].name = text; b_sec[0].kind = of.SK_TEXT; b_sec[0].bytes = ?b_bytes[0];
+    b_sec[0].len = 16; b_sec[0].align = 1;
+
+    var a_syms: [1]of.Symbol;
+    var b_syms: [2]of.Symbol;
+    a_syms[0].name = dup; a_syms[0].section = 0; a_syms[0].offset = 0;
+    a_syms[0].size = 8; a_syms[0].flags = weak_flags;
+    b_syms[0].name = dup; b_syms[0].section = 0; b_syms[0].offset = 0;
+    b_syms[0].size = 8; b_syms[0].flags = weak_flags;
+    b_syms[1].name = cover; b_syms[1].section = 0; b_syms[1].offset = 16;
+    b_syms[1].size = 0; b_syms[1].flags = 0;
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "a"), ?a_sec[0], 1, ?a_syms[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "b"), ?b_sec[0], 1, ?b_syms[0], 2,
+                       nil::*of.Relocation, 0);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val sized: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](sized) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (plan.drops[0].start != 0 || plan.drops[0].end != 8
+        || plan.sections[1].live_len != 8) { ret 1; }
+    var copied: [8]u8;
+    copy_live_section(?copied[0], ?b_bytes[0], 16, ?plan, 1);
+    i = 0;
+    for (i < 8) {
+        if (copied[i] != b_bytes[8 + i]) { ret 1; }
+        i = i + 1;
+    }
+    free_atom_plan(?alloc, ?plan);
+
+    # move the losing function behind an earlier symbol whose declared extent
+    # covers it. The earlier entry is outside [8,16), but its bytes are not.
+    b_syms[0].offset = 8;
+    b_syms[0].size = 8;
+    b_syms[1].offset = 0;
+    b_syms[1].size = 16;
+    val covered: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](covered) || plan.active) { ret 1; }
+    ret 0;
+}
+
+# coff's parser surfaces a weak COMDAT carrier's STATIC section symbol beside
+# its weak global. that exact unreferenced bookkeeping anchor does not retain the
+# loser; a live relocation through it does
+test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "coffI3u64E");
+    val text: intern.StrId = lt_name(?s, ".text");
+    val data: intern.StrId = lt_name(?s, ".data");
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    var a_bytes: [8]u8;
+    var b_text: [8]u8;
+    var b_data: [8]u8;
+    var a_sec: [1]of.Section;
+    var b_secs: [2]of.Section;
+    a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
+    a_sec[0].len = 8; a_sec[0].align = 1;
+    b_secs[0].name = text; b_secs[0].kind = of.SK_TEXT; b_secs[0].bytes = ?b_text[0];
+    b_secs[0].len = 8; b_secs[0].align = 1;
+    b_secs[1].name = data; b_secs[1].kind = of.SK_DATA; b_secs[1].bytes = ?b_data[0];
+    b_secs[1].len = 8; b_secs[1].align = 8;
+
+    var a_syms: [1]of.Symbol;
+    var b_syms: [2]of.Symbol;
+    a_syms[0].name = dup; a_syms[0].section = 0; a_syms[0].offset = 0;
+    a_syms[0].size = 0; a_syms[0].flags = weak_flags;
+    # parser shape: the section symbol precedes the image symbol, is local,
+    # zero-sized, and shares the carrier section's name and offset zero.
+    b_syms[0].name = text; b_syms[0].section = 0; b_syms[0].offset = 0;
+    b_syms[0].size = 0; b_syms[0].flags = 0;
+    b_syms[1].name = dup; b_syms[1].section = 0; b_syms[1].offset = 0;
+    b_syms[1].size = 0; b_syms[1].flags = weak_flags;
+
+    var refs: [1]of.Relocation;
+    refs[0].section = 1; refs[0].offset = 0; refs[0].kind = of.RK_ABS64;
+    refs[0].symbol = text; refs[0].addend = 0;
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "carrier"), ?b_secs[0], 2, ?b_syms[0], 2,
+                       ?refs[0], 0);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val inert_anchor: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](inert_anchor) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (plan.drops[0].section != 1 || plan.drops[0].start != 0
+        || plan.drops[0].end != 8) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    mods[1].reloc_count = 1;
+    val referenced_anchor: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 3, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](referenced_anchor) || plan.active) { ret 1; }
+    ret 0;
+}
+
+# a live relocation through a local/section anchor before a losing atom keeps the
+# atom when its unchanged addend reaches across the removed interval. this covers
+# effective targets after the atom as well as targets inside it
+test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "crossI3u64E");
+    val base: intern.StrId = lt_name(?s, "section_base");
+    val tail: intern.StrId = lt_name(?s, "tail");
+    val text: intern.StrId = lt_name(?s, ".text");
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    var a_bytes: [8]u8;
+    var b_bytes: [24]u8;
+    var a_sec: [1]of.Section;
+    var b_sec: [1]of.Section;
+    a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
+    a_sec[0].len = 8; a_sec[0].align = 1;
+    b_sec[0].name = text; b_sec[0].kind = of.SK_TEXT; b_sec[0].bytes = ?b_bytes[0];
+    b_sec[0].len = 24; b_sec[0].align = 1;
+
+    var a_syms: [1]of.Symbol;
+    var b_syms: [3]of.Symbol;
+    a_syms[0].name = dup; a_syms[0].section = 0; a_syms[0].offset = 0;
+    a_syms[0].size = 8; a_syms[0].flags = weak_flags;
+    b_syms[0].name = base; b_syms[0].section = 0; b_syms[0].offset = 0;
+    b_syms[0].size = 0; b_syms[0].flags = 0;
+    b_syms[1].name = dup; b_syms[1].section = 0; b_syms[1].offset = 8;
+    b_syms[1].size = 8; b_syms[1].flags = weak_flags;
+    b_syms[2].name = tail; b_syms[2].section = 0; b_syms[2].offset = 16;
+    b_syms[2].size = 8; b_syms[2].flags = strong_flags;
+
+    var reloc: [1]of.Relocation;
+    reloc[0].section = 0; reloc[0].offset = 0; reloc[0].kind = of.RK_ABS64;
+    reloc[0].symbol = base; reloc[0].addend = 16;
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "loser"), ?b_sec[0], 1, ?b_syms[0], 3,
+                       ?reloc[0], 1);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val crossing: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](crossing) || plan.active) { ret 1; }
+
+    # a target that remains before the candidate does not cross it and leaves the
+    # duplicate eligible, proving retention is caused by the addend relationship.
+    reloc[0].addend = 4;
+    val same_side: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](same_side) || !plan.active || plan.drop_count != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    # raw PC addends include an instruction-field bias. retain a local-anchor
+    # reference conservatively, but do not mistake a normal -4 call to the next
+    # global function for a pointer back into the candidate.
+    reloc[0].kind = of.RK_PC32;
+    reloc[0].addend = -4;
+    val pc_local: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](pc_local) || plan.active) { ret 1; }
+    reloc[0].symbol = tail;
+    val pc_global: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+    if (R.is_err[bool, str](pc_global) || !plan.active || plan.drop_count != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+    ret 0;
+}
+
+# rk_plt32 is one 4-byte field on x64/aarch64 but an 8-byte auipc+jalr pair on
+# rv64. a pair starting before a losing atom and ending inside it must retain the
+# atom so the live JALR instruction is never discarded
+test "mach.lang.be.linker.atom_plan:rv64_plt_pair_boundary" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val dup: intern.StrId = lt_name(?s, "rvpairI3u64E");
+    val ext: intern.StrId = lt_name(?s, "callee");
+    val text: intern.StrId = lt_name(?s, ".text");
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    var a_bytes: [8]u8;
+    var b_bytes: [16]u8;
+    var a_sec: [1]of.Section;
+    var b_sec: [1]of.Section;
+    a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
+    a_sec[0].len = 8; a_sec[0].align = 1;
+    b_sec[0].name = text; b_sec[0].kind = of.SK_TEXT; b_sec[0].bytes = ?b_bytes[0];
+    b_sec[0].len = 16; b_sec[0].align = 1;
+
+    var a_syms: [1]of.Symbol;
+    var b_syms: [2]of.Symbol;
+    a_syms[0].name = dup; a_syms[0].section = 0; a_syms[0].offset = 0;
+    a_syms[0].size = 8; a_syms[0].flags = weak_flags;
+    b_syms[0].name = dup; b_syms[0].section = 0; b_syms[0].offset = 8;
+    b_syms[0].size = 8; b_syms[0].flags = weak_flags;
+    b_syms[1].name = ext; b_syms[1].section = of.SECTION_EXTERNAL;
+    b_syms[1].offset = 0; b_syms[1].size = 0;
+    b_syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var reloc: [1]of.Relocation;
+    reloc[0].section = 0; reloc[0].offset = 4; reloc[0].kind = of.RK_PLT32;
+    reloc[0].symbol = ext; reloc[0].addend = 0;
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "loser"), ?b_sec[0], 1, ?b_syms[0], 2,
+                       ?reloc[0], 1);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    var x64: isa.IsaVTable = lt_isa(isa.ARCH_X86_64);
+    var rv64: isa.IsaVTable = lt_isa(isa.ARCH_RISCV64);
+    init_atom_plan(?plan);
+
+    val x: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, ?x64, ?plan);
+    if (R.is_err[bool, str](x) || !plan.active || plan.drop_count != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    val rv: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, ?bases[0], 2, true, ?rv64, ?plan);
+    if (R.is_err[bool, str](rv) || plan.active) { ret 1; }
     ret 0;
 }

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -45,6 +45,7 @@ use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.target;
 use mach.lang.target.of;
 
 # one test build's collection state, threaded from the emit phase into the
@@ -464,4 +465,198 @@ fun test_source_path(p: *driver.Project, mod_idx: u32) *u8 {
     val opt_file: O.Option[*source.SourceFile] = source.get(?p.s.sources, m.file_id);
     if (O.is_none[*source.SourceFile](opt_file)) { ret "<unknown>"; }
     ret O.unwrap[*source.SourceFile](opt_file).path::*u8;
+}
+
+# intern a test-only object name
+fun testing_name(s: *session.Session, name: str) intern.StrId {
+    val r: R.Result[intern.StrId, str] = intern.intern(?s.interner, name);
+    if (R.is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](r);
+}
+
+# remove the three already-closed files used by the COFF final-link regression
+fun remove_coff_atom_files(a: *fs.TempFile, b: *fs.TempFile, out: *fs.TempFile) {
+    fs.temp_remove(a);
+    fs.temp_remove(b);
+    fs.temp_remove(out);
+}
+
+# a real COFF emit/parse/final-link round trip drops a losing weak COMDAT body.
+# linking the winner object alone and linking it with a byte-different losing
+# object must produce identical PE bytes
+test "mach.lang.build.testing:coff_final_link_discards_losing_weak_body" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) {
+        session.dnit(?s);
+        ret 1;
+    }
+    val tr: R.Result[target.Target, str] =
+        target.select(?reg, "x86_64", "windows", "win64");
+    if (R.is_err[target.Target, str](tr)) {
+        session.dnit(?s);
+        ret 1;
+    }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    val text: intern.StrId = testing_name(?s, ".text");
+    val entry: intern.StrId = testing_name(?s, "mainCRTStartup");
+    val weak: intern.StrId = testing_name(?s, "dedupI3u64E");
+    val winner_name: intern.StrId = testing_name(?s, "coff-winner");
+    val loser_name: intern.StrId = testing_name(?s, "coff-loser");
+    if (text == intern.STR_NIL || entry == intern.STR_NIL || weak == intern.STR_NIL
+        || winner_name == intern.STR_NIL || loser_name == intern.STR_NIL) {
+        session.dnit(?s);
+        ret 1;
+    }
+
+    var winner_bytes: [16]u8;
+    var loser_bytes: [8]u8;
+    var i: u32 = 0;
+    for (i < 8) {
+        winner_bytes[i] = 0xC3;
+        winner_bytes[8 + i] = (0x40 + i)::u8;
+        loser_bytes[i] = (0xA0 + i)::u8;
+        i = i + 1;
+    }
+
+    var winner_sections: [1]of.Section;
+    var loser_sections: [1]of.Section;
+    winner_sections[0].name = text;
+    winner_sections[0].kind = of.SK_TEXT;
+    winner_sections[0].bytes = ?winner_bytes[0];
+    winner_sections[0].len = 16;
+    winner_sections[0].align = 8;
+    loser_sections[0].name = text;
+    loser_sections[0].kind = of.SK_TEXT;
+    loser_sections[0].bytes = ?loser_bytes[0];
+    loser_sections[0].len = 8;
+    loser_sections[0].align = 8;
+
+    val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    var winner_symbols: [2]of.Symbol;
+    var loser_symbols: [1]of.Symbol;
+    winner_symbols[0].name = entry;
+    winner_symbols[0].section = 0;
+    winner_symbols[0].offset = 0;
+    winner_symbols[0].size = 8;
+    winner_symbols[0].flags = strong_flags;
+    winner_symbols[1].name = weak;
+    winner_symbols[1].section = 0;
+    winner_symbols[1].offset = 8;
+    winner_symbols[1].size = 8;
+    winner_symbols[1].flags = weak_flags;
+    loser_symbols[0].name = weak;
+    loser_symbols[0].section = 0;
+    loser_symbols[0].offset = 0;
+    loser_symbols[0].size = 8;
+    loser_symbols[0].flags = weak_flags;
+
+    var winner: of.ObjectImage;
+    winner.alloc = ?alloc;
+    winner.interner = ?s.interner;
+    winner.name = winner_name;
+    winner.sections = ?winner_sections[0];
+    winner.section_count = 1;
+    winner.symbols = ?winner_symbols[0];
+    winner.symbol_count = 2;
+    winner.relocations = nil;
+    winner.reloc_count = 0;
+    var loser: of.ObjectImage;
+    loser.alloc = ?alloc;
+    loser.interner = ?s.interner;
+    loser.name = loser_name;
+    loser.sections = ?loser_sections[0];
+    loser.section_count = 1;
+    loser.symbols = ?loser_symbols[0];
+    loser.symbol_count = 1;
+    loser.relocations = nil;
+    loser.reloc_count = 0;
+
+    val ar: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_coff_atom_a");
+    if (R.is_err[fs.TempFile, str](ar)) { session.dnit(?s); ret 1; }
+    var af: fs.TempFile = R.unwrap_ok[fs.TempFile, str](ar);
+    val br: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_coff_atom_b");
+    if (R.is_err[fs.TempFile, str](br)) {
+        fs.temp_close_and_remove(?af);
+        session.dnit(?s);
+        ret 1;
+    }
+    var bf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](br);
+    val er: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_coff_atom_exe");
+    if (R.is_err[fs.TempFile, str](er)) {
+        fs.temp_close_and_remove(?af);
+        fs.temp_close_and_remove(?bf);
+        session.dnit(?s);
+        ret 1;
+    }
+    var ef: fs.TempFile = R.unwrap_ok[fs.TempFile, str](er);
+    val apath: str = fs.temp_path(?af);
+    val bpath: str = fs.temp_path(?bf);
+    val epath: str = fs.temp_path(?ef);
+    val ac: O.Option[str] = fs.temp_close(?af);
+    val bc: O.Option[str] = fs.temp_close(?bf);
+    val ec: O.Option[str] = fs.temp_close(?ef);
+    if (O.is_some[str](ac) || O.is_some[str](bc) || O.is_some[str](ec)) {
+        remove_coff_atom_files(?af, ?bf, ?ef);
+        session.dnit(?s);
+        ret 1;
+    }
+
+    var bad: i32 = 0;
+    if (R.is_err[bool, str](obj.emit(?winner, ?tgt, apath::*u8))) { bad = 1; }
+    if (bad == 0 && R.is_err[bool, str](obj.emit(?loser, ?tgt, bpath::*u8))) { bad = 1; }
+
+    var control: Vector[u8];
+    var combined: Vector[u8];
+    var have_control: bool = false;
+    var have_combined: bool = false;
+    var one: [1]*u8;
+    one[0] = apath::*u8;
+    if (bad == 0) {
+        val lr: R.Result[bool, str] =
+            linker.link(?s, ?tgt, ?one[0], 1, nil, 0, epath::*u8,
+                        "coff-atom-test", linker.LINK_EXE, false);
+        if (R.is_err[bool, str](lr)) { bad = 1; }
+    }
+    if (bad == 0) {
+        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, epath);
+        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
+        or { control = R.unwrap_ok[Vector[u8], str](rr); have_control = true; }
+    }
+
+    var both: [2]*u8;
+    both[0] = apath::*u8;
+    both[1] = bpath::*u8;
+    if (bad == 0) {
+        val lr: R.Result[bool, str] =
+            linker.link(?s, ?tgt, ?both[0], 2, nil, 0, epath::*u8,
+                        "coff-atom-test", linker.LINK_EXE, false);
+        if (R.is_err[bool, str](lr)) { bad = 1; }
+    }
+    if (bad == 0) {
+        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, epath);
+        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
+        or { combined = R.unwrap_ok[Vector[u8], str](rr); have_combined = true; }
+    }
+
+    if (bad == 0 && control.len != combined.len) { bad = 1; }
+    var at: usize = 0;
+    for (bad == 0 && at < control.len) {
+        if (control.data[at] != combined.data[at]) { bad = 1; }
+        at = at + 1;
+    }
+
+    if (have_control)  { vector.dnit[u8](?control); }
+    if (have_combined) { vector.dnit[u8](?combined); }
+    remove_coff_atom_files(?af, ?bf, ?ef);
+    session.dnit(?s);
+    ret bad;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -655,7 +655,7 @@ test "mach.lang.target:registry_enumeration_agrees_with_lookup" {
 # the family cannot express one; asserting it here proves the constructor really
 # leaves the slot clear rather than reading whatever the frame held.
 #
-# To see it fail, pass nil for `apply_reloc` in any arch's `isa.reloc_seam` call
+# to see it fail, pass nil for a required hook in any arch's `isa.reloc_seam` call
 # (say `riscv64/register.mach`) and re-run: this test alone reports the count.
 test "mach.lang.target:elf_capable_isa_declares_a_reloc_seam" {
     var reg: TargetRegistry = registry_init();
@@ -675,6 +675,7 @@ test "mach.lang.target:elf_capable_isa_declares_a_reloc_seam" {
         if (vt.elf_machine != 0) {
             if (!isa.emits_relocations(vt))      { unpaired = unpaired + 1; }
             or (vt.reloc.apply_reloc == nil)     { unpaired = unpaired + 1; }
+            or (vt.reloc.reloc_traits == nil)    { unpaired = unpaired + 1; }
             or (vt.reloc.elf_reloc_type == nil)  { unpaired = unpaired + 1; }
         }
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -671,7 +671,7 @@ test "mach.lang.target:elf_capable_isa_declares_a_reloc_seam" {
         val vt: *isa.IsaVTable = O.unwrap[*isa.IsaVTable](isa.registered(?reg.isa, i));
 
         # an ELF machine type is a claim to emit ELF relocatable objects, so the
-        # seam and both of its required members must be there to back it.
+        # seam and all of its required members must be there to back it.
         if (vt.elf_machine != 0) {
             if (!isa.emits_relocations(vt))      { unpaired = unpaired + 1; }
             or (vt.reloc.apply_reloc == nil)     { unpaired = unpaired + 1; }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -589,7 +589,8 @@ pub rec ModuleEmitter {
 #                 REQUIRED: an arch that emits relocations must be able to resolve
 #                 them
 # reloc_traits:   describe the relocation's physical field width and raw-addend
-#                 semantics (cast back to `of.reloc.RelocTraitsFn`). REQUIRED:
+#                 semantics, including whether its image came directly from this
+#                 compiler (cast back to `of.reloc.RelocTraitsFn`). REQUIRED:
 #                 the linker uses the same arch-owned packing shape to validate
 #                 and transform relocation sites before calling `apply_reloc`
 # elf_reloc_type: map an abstract `of.RelocKind` to this arch's ELF machine
@@ -1365,7 +1366,7 @@ fun t_is_reg_move(opcode: u32) bool {
     ret false;
 }
 
-# a relocatable-object contract with both required members supplied and no optional
+# a relocatable-object contract with all required members supplied and no optional
 # capability, the shortest a relocating arch can be (test helper)
 fun t_reloc() RelocSeam {
     var hook: u8;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -588,6 +588,10 @@ pub rec ModuleEmitter {
 #                 into the merged bytes (cast back to `of.reloc.ApplyRelocFn`).
 #                 REQUIRED: an arch that emits relocations must be able to resolve
 #                 them
+# reloc_traits:   describe the relocation's physical field width and raw-addend
+#                 semantics (cast back to `of.reloc.RelocTraitsFn`). REQUIRED:
+#                 the linker uses the same arch-owned packing shape to validate
+#                 and transform relocation sites before calling `apply_reloc`
 # elf_reloc_type: map an abstract `of.RelocKind` to this arch's ELF machine
 #                 relocation type number (cast back to the ELF writer's
 #                 `ElfRelocTypeFn`); returns 0 (R_*_NONE) for a kind the arch has
@@ -603,6 +607,7 @@ pub rec ModuleEmitter {
 #                 set; nil for an arch that emits none
 pub rec RelocSeam {
     apply_reloc:    *u8;
+    reloc_traits:   *u8;
     elf_reloc_type: *u8;
     elf_attributes: *u8;
 }
@@ -780,12 +785,16 @@ pub fun module_emitter(emit_module: *u8) ModuleEmitter {
 # reading stack garbage (`var` does not zero).
 # ---
 # apply_reloc:    the relocation applier, erased (`of.reloc.ApplyRelocFn`)
+# reloc_traits:   the relocation-traits source, erased
+#                 (`of.reloc.RelocTraitsFn`)
 # elf_reloc_type: the abstract-kind to ELF-type map, erased (the ELF writer's
 #                 `ElfRelocTypeFn`)
 # ret:            the contract, with its optional capability unset
-pub fun reloc_seam(apply_reloc: *u8, elf_reloc_type: *u8) RelocSeam {
+pub fun reloc_seam(apply_reloc: *u8, reloc_traits: *u8,
+                   elf_reloc_type: *u8) RelocSeam {
     var s: RelocSeam;
     s.apply_reloc    = apply_reloc;
+    s.reloc_traits   = reloc_traits;
     s.elf_reloc_type = elf_reloc_type;
 
     s.elf_attributes = nil;
@@ -1360,7 +1369,7 @@ fun t_is_reg_move(opcode: u32) bool {
 # capability, the shortest a relocating arch can be (test helper)
 fun t_reloc() RelocSeam {
     var hook: u8;
-    ret reloc_seam(?hook, ?hook);
+    ret reloc_seam(?hook, ?hook, ?hook);
 }
 
 test "mach.lang.target.isa.register:write_once_and_enumerate" {
@@ -1431,6 +1440,7 @@ test "mach.lang.target.isa.family:payloads_are_exclusive" {
 test "mach.lang.target.isa.reloc_seam:required_then_optional" {
     var s: RelocSeam = t_reloc();
     if (s.apply_reloc == nil)    { ret 1; }
+    if (s.reloc_traits == nil)   { ret 1; }
     if (s.elf_reloc_type == nil) { ret 1; }
     if (s.elf_attributes != nil) { ret 1; }
 
@@ -1440,8 +1450,9 @@ test "mach.lang.target.isa.reloc_seam:required_then_optional" {
 
     # an arch whose relocatable objects are not ELF passes a deliberate nil for the
     # ELF map and still owes the applier
-    var s2: RelocSeam = reloc_seam(?hook, nil);
+    var s2: RelocSeam = reloc_seam(?hook, ?hook, nil);
     if (s2.apply_reloc == nil)    { ret 1; }
+    if (s2.reloc_traits == nil)   { ret 1; }
     if (s2.elf_reloc_type != nil) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -216,7 +216,8 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # and resolves them at link time, and both halves are declared here rather than
     # attached to the vtable afterwards by a subsystem that knows the arch's name.
     # no build-attributes descriptor: aarch64 emits none.
-    arm64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, arm64_elf_reloc_type::*u8);
+    arm64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, reloc.reloc_traits::*u8,
+                                 arm64_elf_reloc_type::*u8);
 
     # elf_machine 183 is EM_AARCH64
     arm64_vtable = isa.machine_isa(isa.ARCH_AARCH64, "aarch64", 183, 8,

--- a/src/lang/target/isa/arm64/reloc.mach
+++ b/src/lang/target/isa/arm64/reloc.mach
@@ -15,6 +15,7 @@
 # recovered by decoding the instruction word.
 
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 
@@ -26,11 +27,13 @@ use rel: mach.lang.target.of.reloc;
 
 # describe an aarch64 relocation's patch width and raw-addend semantics
 # ---
-# kind:         the abstract relocation kind to describe
-# section_kind: kind of section containing the patch site
-# ret:          its physical field width and addend mode
+# kind:          the abstract relocation kind to describe
+# section_kind:  kind of section containing the patch site
+# codegen_image: true only for an in-memory image from this compiler
+# ret:           its physical field width and addend mode
 pub fun reloc_traits(kind: of.RelocKind,
-                     section_kind: of.SectionKind) rel.RelocTraits {
+                     section_kind: of.SectionKind,
+                     codegen_image: bool) rel.RelocTraits {
     var width: u32 = 4;
     if (kind == of.RK_ABS64)   { width = 8; }
     if (kind == of.RK_SECTION) { width = 2; }
@@ -131,7 +134,7 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 # addend
 test "mach.lang.target.isa.arm64.reloc.reloc_traits:plt32" {
     val t: rel.RelocTraits =
-        reloc_traits(of.RK_PLT32, of.SK_TEXT);
+        reloc_traits(of.RK_PLT32, of.SK_TEXT, false);
     if (t.field_width != 4 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
         || t.text_bias_min != 0 || t.text_bias_max != 0) { ret 1; }
     ret 0;

--- a/src/lang/target/isa/arm64/reloc.mach
+++ b/src/lang/target/isa/arm64/reloc.mach
@@ -26,9 +26,11 @@ use rel: mach.lang.target.of.reloc;
 
 # describe an aarch64 relocation's patch width and raw-addend semantics
 # ---
-# kind: the abstract relocation kind to describe
-# ret:  its physical field width and addend mode
-pub fun reloc_traits(kind: of.RelocKind) rel.RelocTraits {
+# kind:         the abstract relocation kind to describe
+# section_kind: kind of section containing the patch site
+# ret:          its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind,
+                     section_kind: of.SectionKind) rel.RelocTraits {
     var width: u32 = 4;
     if (kind == of.RK_ABS64)   { width = 8; }
     if (kind == of.RK_SECTION) { width = 2; }
@@ -128,7 +130,8 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 # aarch64's call relocation patches one instruction and preserves an S-relative
 # addend
 test "mach.lang.target.isa.arm64.reloc.reloc_traits:plt32" {
-    val t: rel.RelocTraits = reloc_traits(of.RK_PLT32);
+    val t: rel.RelocTraits =
+        reloc_traits(of.RK_PLT32, of.SK_TEXT);
     if (t.field_width != 4 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
         || t.text_bias_min != 0 || t.text_bias_max != 0) { ret 1; }
     ret 0;

--- a/src/lang/target/isa/arm64/reloc.mach
+++ b/src/lang/target/isa/arm64/reloc.mach
@@ -24,6 +24,20 @@ use mach.lang.target.of;
 use mach.lang.target.of.bin;
 use rel: mach.lang.target.of.reloc;
 
+# describe an aarch64 relocation's patch width and raw-addend semantics
+# ---
+# kind: the abstract relocation kind to describe
+# ret:  its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind) rel.RelocTraits {
+    var width: u32 = 4;
+    if (kind == of.RK_ABS64)   { width = 8; }
+    if (kind == of.RK_SECTION) { width = 2; }
+
+    var mode: rel.RelocAddendMode = rel.RELOC_ADDEND_SYMBOL;
+    if (kind == of.RK_SECTION) { mode = rel.RELOC_ADDEND_IGNORED; }
+    ret rel.traits(width, mode, 0, 0);
+}
+
 # apply one aarch64 relocation
 # ---
 # kind:      the relocation kind to apply
@@ -109,6 +123,15 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
     }
 
     ret R.err[bool, rel.RelocError](rel.RELOC_UNSUPPORTED);
+}
+
+# aarch64's call relocation patches one instruction and preserves an S-relative
+# addend
+test "mach.lang.target.isa.arm64.reloc.reloc_traits:plt32" {
+    val t: rel.RelocTraits = reloc_traits(of.RK_PLT32);
+    if (t.field_width != 4 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
+        || t.text_bias_min != 0 || t.text_bias_max != 0) { ret 1; }
+    ret 0;
 }
 
 # the access-width shift {0,1,2,3,4} carried by a per-width

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -257,7 +257,8 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the relocatable-object contract: riscv64 names its relocations in an ELF object
     # and resolves them at link time, and both halves are declared here rather than
     # attached to the vtable afterwards by a subsystem that knows the arch's name.
-    riscv64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, riscv64_elf_reloc_type::*u8);
+    riscv64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, reloc.reloc_traits::*u8,
+                                   riscv64_elf_reloc_type::*u8);
     isa.with_elf_attributes(?riscv64_reloc, riscv64_elf_attributes::*u8);
 
     # elf_machine 243 is EM_RISCV

--- a/src/lang/target/isa/riscv64/reloc.mach
+++ b/src/lang/target/isa/riscv64/reloc.mach
@@ -27,9 +27,11 @@ use rel: mach.lang.target.of.reloc;
 
 # describe a riscv64 relocation's patch width and raw-addend semantics
 # ---
-# kind: the abstract relocation kind to describe
-# ret:  its physical field width and addend mode
-pub fun reloc_traits(kind: of.RelocKind) rel.RelocTraits {
+# kind:         the abstract relocation kind to describe
+# section_kind: kind of section containing the patch site
+# ret:          its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind,
+                     section_kind: of.SectionKind) rel.RelocTraits {
     var width: u32 = 4;
     if (kind == of.RK_ABS64 || kind == of.RK_PLT32) { width = 8; }
     if (kind == of.RK_SECTION)                      { width = 2; }
@@ -126,7 +128,8 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 # riscv64's call relocation patches the complete auipc+jalr pair and preserves an
 # symbol-relative addend
 test "mach.lang.target.isa.riscv64.reloc.reloc_traits:plt32" {
-    val t: rel.RelocTraits = reloc_traits(of.RK_PLT32);
+    val t: rel.RelocTraits =
+        reloc_traits(of.RK_PLT32, of.SK_TEXT);
     if (t.field_width != 8 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
         || t.text_bias_min != 0 || t.text_bias_max != 0) { ret 1; }
     ret 0;

--- a/src/lang/target/isa/riscv64/reloc.mach
+++ b/src/lang/target/isa/riscv64/reloc.mach
@@ -25,6 +25,20 @@ use mach.lang.target.of;
 use mach.lang.target.of.bin;
 use rel: mach.lang.target.of.reloc;
 
+# describe a riscv64 relocation's patch width and raw-addend semantics
+# ---
+# kind: the abstract relocation kind to describe
+# ret:  its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind) rel.RelocTraits {
+    var width: u32 = 4;
+    if (kind == of.RK_ABS64 || kind == of.RK_PLT32) { width = 8; }
+    if (kind == of.RK_SECTION)                      { width = 2; }
+
+    var mode: rel.RelocAddendMode = rel.RELOC_ADDEND_SYMBOL;
+    if (kind == of.RK_SECTION) { mode = rel.RELOC_ADDEND_IGNORED; }
+    ret rel.traits(width, mode, 0, 0);
+}
+
 # the byte gap from a riscv pc-relative low-12 instruction back to its paired auipc in
 # the `la` (load-address) sequence. the auipc immediately precedes the low instruction
 # (load / addi / store), so the low instruction's patch_va minus this gap recovers the
@@ -107,6 +121,15 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
     }
 
     ret R.err[bool, rel.RelocError](rel.RELOC_UNSUPPORTED);
+}
+
+# riscv64's call relocation patches the complete auipc+jalr pair and preserves an
+# symbol-relative addend
+test "mach.lang.target.isa.riscv64.reloc.reloc_traits:plt32" {
+    val t: rel.RelocTraits = reloc_traits(of.RK_PLT32);
+    if (t.field_width != 8 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
+        || t.text_bias_min != 0 || t.text_bias_max != 0) { ret 1; }
+    ret 0;
 }
 
 # whether a 32-bit pc-relative displacement fits the riscv auipc + low-12 split. the

--- a/src/lang/target/isa/riscv64/reloc.mach
+++ b/src/lang/target/isa/riscv64/reloc.mach
@@ -16,6 +16,7 @@
 # from the paired auipc one word back.
 
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 
@@ -27,11 +28,13 @@ use rel: mach.lang.target.of.reloc;
 
 # describe a riscv64 relocation's patch width and raw-addend semantics
 # ---
-# kind:         the abstract relocation kind to describe
-# section_kind: kind of section containing the patch site
-# ret:          its physical field width and addend mode
+# kind:          the abstract relocation kind to describe
+# section_kind:  kind of section containing the patch site
+# codegen_image: true only for an in-memory image from this compiler
+# ret:           its physical field width and addend mode
 pub fun reloc_traits(kind: of.RelocKind,
-                     section_kind: of.SectionKind) rel.RelocTraits {
+                     section_kind: of.SectionKind,
+                     codegen_image: bool) rel.RelocTraits {
     var width: u32 = 4;
     if (kind == of.RK_ABS64 || kind == of.RK_PLT32) { width = 8; }
     if (kind == of.RK_SECTION)                      { width = 2; }
@@ -129,7 +132,7 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 # symbol-relative addend
 test "mach.lang.target.isa.riscv64.reloc.reloc_traits:plt32" {
     val t: rel.RelocTraits =
-        reloc_traits(of.RK_PLT32, of.SK_TEXT);
+        reloc_traits(of.RK_PLT32, of.SK_TEXT, false);
     if (t.field_width != 8 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
         || t.text_bias_min != 0 || t.text_bias_max != 0) { ret 1; }
     ret 0;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -264,7 +264,8 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # and resolves them at link time, and both halves are declared here rather than
     # attached to the vtable afterwards by a subsystem that knows the arch's name.
     # no build-attributes descriptor: x86-64 emits none.
-    x64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, x64_elf_reloc_type::*u8);
+    x64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, reloc.reloc_traits::*u8,
+                               x64_elf_reloc_type::*u8);
 
     # elf_machine 62 is EM_X86_64
     x64_vtable = isa.machine_isa(isa.ARCH_X86_64, "x86_64", 62, 8,

--- a/src/lang/target/isa/x64/reloc.mach
+++ b/src/lang/target/isa/x64/reloc.mach
@@ -20,6 +20,30 @@ use mach.lang.target.of;
 use mach.lang.target.of.bin;
 use rel: mach.lang.target.of.reloc;
 
+# describe an x86_64 relocation's patch width and raw-addend semantics
+# ---
+# kind: the abstract relocation kind to describe
+# ret:  its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind) rel.RelocTraits {
+    var width: u32 = 4;
+    if (kind == of.RK_ABS64)   { width = 8; }
+    if (kind == of.RK_SECTION) { width = 2; }
+
+    var mode: rel.RelocAddendMode = rel.RELOC_ADDEND_SYMBOL;
+    if (kind == of.RK_PC32 || kind == of.RK_PLT32 || kind == of.RK_GOTPCREL) {
+        mode = rel.RELOC_ADDEND_FIELD_BIAS;
+    }
+    if (kind == of.RK_SECTION) { mode = rel.RELOC_ADDEND_IGNORED; }
+    if (mode == rel.RELOC_ADDEND_FIELD_BIAS) {
+        # the relocation names a field within a text instruction. supported x64
+        # instructions are at most 15 bytes; four is the canonical rel32 field
+        # width and preserves the normal A=-4 call without retaining its target's
+        # preceding atom.
+        ret rel.traits(width, mode, 4, 15);
+    }
+    ret rel.traits(width, mode, 0, 0);
+}
+
 # apply one x86_64 relocation
 #
 # RK_ABS64 is a 64-bit absolute, RK_ABS32 an unsigned 32-bit absolute, RK_PC32 /
@@ -70,6 +94,15 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
     }
 
     ret R.err[bool, rel.RelocError](rel.RELOC_UNSUPPORTED);
+}
+
+# x86_64's call relocation patches one 4-byte field and carries a field-relative
+# addend bias
+test "mach.lang.target.isa.x64.reloc.reloc_traits:plt32" {
+    val t: rel.RelocTraits = reloc_traits(of.RK_PLT32);
+    if (t.field_width != 4 || t.addend_mode != rel.RELOC_ADDEND_FIELD_BIAS
+        || t.text_bias_min != 4 || t.text_bias_max != 15) { ret 1; }
+    ret 0;
 }
 
 # the pc-relative 32-bit field is bounded: a displacement at the signed 32-bit

--- a/src/lang/target/isa/x64/reloc.mach
+++ b/src/lang/target/isa/x64/reloc.mach
@@ -11,6 +11,7 @@
 # absolute.
 
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 
@@ -22,39 +23,35 @@ use rel: mach.lang.target.of.reloc;
 
 # describe an x86_64 relocation's patch width and raw-addend semantics
 # ---
-# kind:         the abstract relocation kind to describe
-# section_kind: kind of section containing the patch site
-# ret:          its physical field width and addend mode
+# kind:          the abstract relocation kind to describe
+# section_kind:  kind of section containing the patch site
+# codegen_image: true only for an in-memory image from this compiler
+# ret:           its physical field width and addend mode
 pub fun reloc_traits(kind: of.RelocKind,
-                     section_kind: of.SectionKind) rel.RelocTraits {
+                     section_kind: of.SectionKind,
+                     codegen_image: bool) rel.RelocTraits {
     var width: u32 = 4;
     if (kind == of.RK_ABS64)   { width = 8; }
     if (kind == of.RK_SECTION) { width = 2; }
 
     var mode: rel.RelocAddendMode = rel.RELOC_ADDEND_SYMBOL;
-    if (kind == of.RK_PLT32
-        || (kind == of.RK_GOTPCREL && section_kind == of.SK_TEXT)) {
-        mode = rel.RELOC_ADDEND_FIELD_BIAS;
-    }
-    if (kind == of.RK_PC32 && section_kind == of.SK_TEXT) {
+    if (section_kind == of.SK_TEXT
+        && (kind == of.RK_PC32 || kind == of.RK_PLT32
+            || kind == of.RK_GOTPCREL)) {
         mode = rel.RELOC_ADDEND_FIELD_BIAS;
     }
     if (kind == of.RK_SECTION) { mode = rel.RELOC_ADDEND_IGNORED; }
     if (mode == rel.RELOC_ADDEND_FIELD_BIAS) {
-        if (kind == of.RK_PC32) {
-            # text can contain either a rel32 instruction field or an
-            # address-difference word/jump-table entry with no next-instruction
-            # bias. nearby opcode bytes are not proof because data can equal an
-            # opcode, so keep both possibilities.
-            ret rel.traits(width, mode, 0, 15);
-        }
-        if (kind == of.RK_GOTPCREL) {
-            # the displacement field may be followed by an immediate in a foreign
-            # instruction, but the complete instruction cannot exceed 15 bytes.
+        if (codegen_image) {
+            # the x64 encoder records a text relocation only for an instruction
+            # field, correcting A by the field-to-next-ip distance. the field
+            # contributes at least four bytes and an instruction at most 15.
             ret rel.traits(width, mode, 4, 15);
         }
-        # plt32 branch fields end at their 4-byte field.
-        ret rel.traits(width, mode, 4, 4);
+        # a parsed text relocation has no trustworthy instruction provenance:
+        # foreign objects can use pc32/plt32 for address-difference data, or put
+        # a trailing immediate after a displacement. retain every legal x64 bias.
+        ret rel.traits(width, mode, 0, 15);
     }
     ret rel.traits(width, mode, 0, 0);
 }
@@ -115,20 +112,26 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 # addend bias
 test "mach.lang.target.isa.x64.reloc.reloc_traits:plt32" {
     val t: rel.RelocTraits =
-        reloc_traits(of.RK_PLT32, of.SK_TEXT);
+        reloc_traits(of.RK_PLT32, of.SK_TEXT, true);
     if (t.field_width != 4 || t.addend_mode != rel.RELOC_ADDEND_FIELD_BIAS
-        || t.text_bias_min != 4 || t.text_bias_max != 4) { ret 1; }
+        || t.text_bias_min != 4 || t.text_bias_max != 15) { ret 1; }
 
     val text_pc32: rel.RelocTraits =
-        reloc_traits(of.RK_PC32, of.SK_TEXT);
+        reloc_traits(of.RK_PC32, of.SK_TEXT, false);
     if (text_pc32.text_bias_min != 0 || text_pc32.text_bias_max != 15) { ret 1; }
+    val parsed_plt: rel.RelocTraits =
+        reloc_traits(of.RK_PLT32, of.SK_TEXT, false);
+    if (parsed_plt.text_bias_min != 0 || parsed_plt.text_bias_max != 15) { ret 1; }
 
     val data: rel.RelocTraits =
-        reloc_traits(of.RK_PC32, of.SK_DATA);
+        reloc_traits(of.RK_PC32, of.SK_DATA, true);
     if (data.addend_mode != rel.RELOC_ADDEND_SYMBOL) { ret 1; }
     val data_got: rel.RelocTraits =
-        reloc_traits(of.RK_GOTPCREL, of.SK_DATA);
+        reloc_traits(of.RK_GOTPCREL, of.SK_DATA, false);
     if (data_got.addend_mode != rel.RELOC_ADDEND_SYMBOL) { ret 1; }
+    val data_plt: rel.RelocTraits =
+        reloc_traits(of.RK_PLT32, of.SK_DATA, true);
+    if (data_plt.addend_mode != rel.RELOC_ADDEND_SYMBOL) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/x64/reloc.mach
+++ b/src/lang/target/isa/x64/reloc.mach
@@ -22,24 +22,39 @@ use rel: mach.lang.target.of.reloc;
 
 # describe an x86_64 relocation's patch width and raw-addend semantics
 # ---
-# kind: the abstract relocation kind to describe
-# ret:  its physical field width and addend mode
-pub fun reloc_traits(kind: of.RelocKind) rel.RelocTraits {
+# kind:         the abstract relocation kind to describe
+# section_kind: kind of section containing the patch site
+# ret:          its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind,
+                     section_kind: of.SectionKind) rel.RelocTraits {
     var width: u32 = 4;
     if (kind == of.RK_ABS64)   { width = 8; }
     if (kind == of.RK_SECTION) { width = 2; }
 
     var mode: rel.RelocAddendMode = rel.RELOC_ADDEND_SYMBOL;
-    if (kind == of.RK_PC32 || kind == of.RK_PLT32 || kind == of.RK_GOTPCREL) {
+    if (kind == of.RK_PLT32
+        || (kind == of.RK_GOTPCREL && section_kind == of.SK_TEXT)) {
+        mode = rel.RELOC_ADDEND_FIELD_BIAS;
+    }
+    if (kind == of.RK_PC32 && section_kind == of.SK_TEXT) {
         mode = rel.RELOC_ADDEND_FIELD_BIAS;
     }
     if (kind == of.RK_SECTION) { mode = rel.RELOC_ADDEND_IGNORED; }
     if (mode == rel.RELOC_ADDEND_FIELD_BIAS) {
-        # the relocation names a field within a text instruction. supported x64
-        # instructions are at most 15 bytes; four is the canonical rel32 field
-        # width and preserves the normal A=-4 call without retaining its target's
-        # preceding atom.
-        ret rel.traits(width, mode, 4, 15);
+        if (kind == of.RK_PC32) {
+            # text can contain either a rel32 instruction field or an
+            # address-difference word/jump-table entry with no next-instruction
+            # bias. nearby opcode bytes are not proof because data can equal an
+            # opcode, so keep both possibilities.
+            ret rel.traits(width, mode, 0, 15);
+        }
+        if (kind == of.RK_GOTPCREL) {
+            # the displacement field may be followed by an immediate in a foreign
+            # instruction, but the complete instruction cannot exceed 15 bytes.
+            ret rel.traits(width, mode, 4, 15);
+        }
+        # plt32 branch fields end at their 4-byte field.
+        ret rel.traits(width, mode, 4, 4);
     }
     ret rel.traits(width, mode, 0, 0);
 }
@@ -99,9 +114,21 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 # x86_64's call relocation patches one 4-byte field and carries a field-relative
 # addend bias
 test "mach.lang.target.isa.x64.reloc.reloc_traits:plt32" {
-    val t: rel.RelocTraits = reloc_traits(of.RK_PLT32);
+    val t: rel.RelocTraits =
+        reloc_traits(of.RK_PLT32, of.SK_TEXT);
     if (t.field_width != 4 || t.addend_mode != rel.RELOC_ADDEND_FIELD_BIAS
-        || t.text_bias_min != 4 || t.text_bias_max != 15) { ret 1; }
+        || t.text_bias_min != 4 || t.text_bias_max != 4) { ret 1; }
+
+    val text_pc32: rel.RelocTraits =
+        reloc_traits(of.RK_PC32, of.SK_TEXT);
+    if (text_pc32.text_bias_min != 0 || text_pc32.text_bias_max != 15) { ret 1; }
+
+    val data: rel.RelocTraits =
+        reloc_traits(of.RK_PC32, of.SK_DATA);
+    if (data.addend_mode != rel.RELOC_ADDEND_SYMBOL) { ret 1; }
+    val data_got: rel.RelocTraits =
+        reloc_traits(of.RK_GOTPCREL, of.SK_DATA);
+    if (data_got.addend_mode != rel.RELOC_ADDEND_SYMBOL) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4249,15 +4249,16 @@ fun t_isa(id: u32, elf_machine: u32, reloc: *isa.RelocSeam) isa.IsaVTable {
 
 # a relocatable-object contract for the writer tests
 #
-# Carries the ELF forward map under test and a deliberate nil applier: a writer test
-# emits relocations, it never resolves them, and resolving is the linker's side of
-# the seam. The optional build-attributes descriptor is added by the one test that
-# asserts the attributes section.
+# carries the ELF forward map under test and nonnil placeholders for the two
+# required packing hooks: writer tests emit relocations but invoke neither hook.
+# the optional build-attributes descriptor is added by the one test that asserts
+# the attributes section.
 # ---
 # elf_reloc_type: the forward map the test emits through
 # ret:            the contract
 fun t_seam(elf_reloc_type: *u8) isa.RelocSeam {
-    ret isa.reloc_seam(nil, elf_reloc_type);
+    var hook: u8;
+    ret isa.reloc_seam(?hook, ?hook, elf_reloc_type);
 }
 
 # a test-only x86_64 forward reloc map, wired onto a test `IsaVTable` seam

--- a/src/lang/target/of/reloc.mach
+++ b/src/lang/target/of/reloc.mach
@@ -89,9 +89,10 @@ pub fun traits(field_width: u32, addend_mode: RelocAddendMode,
 # the hook is held erased on `isa.RelocSeam.reloc_traits`: `isa` cannot name this
 # signature because it mentions `of.RelocKind` and `of` imports `isa`.
 # ---
-# kind: the abstract relocation kind to describe
-# ret:  its physical field width and raw-addend semantics
-pub def RelocTraitsFn: fun(of.RelocKind) RelocTraits;
+# kind:         the abstract relocation kind to describe
+# section_kind: kind of section containing the patch site
+# ret:          its physical field width and raw-addend semantics
+pub def RelocTraitsFn: fun(of.RelocKind, of.SectionKind) RelocTraits;
 
 # apply one relocation for an architecture
 #

--- a/src/lang/target/of/reloc.mach
+++ b/src/lang/target/of/reloc.mach
@@ -1,9 +1,10 @@
 # the relocation-applier contract and its format-neutral packing bodies
 #
-# An ISA that emits relocatable objects owes exactly one relocation entry point,
-# `ApplyRelocFn`, which patches one resolved relocation into the merged bytes. The
-# arch owns its complete kind-set behind that one hook, so the linker's patch loop
-# carries no per-kind and no per-arch handling.
+# An ISA that emits relocatable objects owns two link-time relocation entry
+# points: `RelocTraitsFn` describes a relocation's physical shape and
+# `ApplyRelocFn` patches one resolved relocation into the merged bytes. The arch
+# owns its complete kind-set behind those hooks, so the linker carries no
+# per-kind and no per-arch handling.
 #
 # The contract deliberately names NO session and NO interner. A relocation applier
 # is arch knowledge, so it lives beside the arch it belongs to, under
@@ -89,14 +90,15 @@ pub fun traits(field_width: u32, addend_mode: RelocAddendMode,
 # the hook is held erased on `isa.RelocSeam.reloc_traits`: `isa` cannot name this
 # signature because it mentions `of.RelocKind` and `of` imports `isa`.
 # ---
-# kind:         the abstract relocation kind to describe
-# section_kind: kind of section containing the patch site
-# ret:          its physical field width and raw-addend semantics
-pub def RelocTraitsFn: fun(of.RelocKind, of.SectionKind) RelocTraits;
+# kind:          the abstract relocation kind to describe
+# section_kind:  kind of section containing the patch site
+# codegen_image: true only for an in-memory image from this compiler
+# ret:           its physical field width and raw-addend semantics
+pub def RelocTraitsFn: fun(of.RelocKind, of.SectionKind, bool) RelocTraits;
 
 # apply one relocation for an architecture
 #
-# The one hook an ISA that emits relocatable objects owes, held erased (`*u8`) on
+# The patching hook an ISA that emits relocatable objects owes, held erased (`*u8`) on
 # `isa.RelocSeam.apply_reloc` and cast back here by the linker: `isa` cannot name
 # this signature, because it mentions `of.RelocKind` and `of` imports `isa`.
 # ---

--- a/src/lang/target/of/reloc.mach
+++ b/src/lang/target/of/reloc.mach
@@ -41,6 +41,58 @@ pub val RELOC_OVERFLOW: RelocError = 0;
 # the arch has no packing for this relocation kind
 pub val RELOC_UNSUPPORTED: RelocError = 1;
 
+# how an object relocation's raw addend relates to its named symbol
+pub def RelocAddendMode: u8;
+
+# the raw addend is an offset from the named symbol (`S + A`)
+pub val RELOC_ADDEND_SYMBOL: RelocAddendMode = 0;
+
+# in text, the raw addend contains an instruction-field bias described by the
+# trait's inclusive bias range; outside text it remains a plain symbol offset
+pub val RELOC_ADDEND_FIELD_BIAS: RelocAddendMode = 1;
+
+# the relocation does not use its addend for target reachability
+pub val RELOC_ADDEND_IGNORED: RelocAddendMode = 2;
+
+# architecture-owned physical traits of one abstract relocation kind
+# ---
+# field_width:  number of consecutive bytes the relocation packer reads or writes
+# addend_mode:  how the raw object addend relates to the named symbol
+# text_bias_min: least field-to-next-instruction bias for text relocations
+# text_bias_max: greatest field-to-next-instruction bias for text relocations
+pub rec RelocTraits {
+    field_width:   u32;
+    addend_mode:   RelocAddendMode;
+    text_bias_min: i32;
+    text_bias_max: i32;
+}
+
+# construct a complete relocation-traits value
+# ---
+# field_width:   number of consecutive bytes the relocation packer reads or writes
+# addend_mode:   how the raw object addend relates to the named symbol
+# text_bias_min: least field bias to add for a text relocation
+# text_bias_max: greatest field bias to add for a text relocation
+# ret:           the completed traits value
+pub fun traits(field_width: u32, addend_mode: RelocAddendMode,
+               text_bias_min: i32, text_bias_max: i32) RelocTraits {
+    var t: RelocTraits;
+    t.field_width   = field_width;
+    t.addend_mode   = addend_mode;
+    t.text_bias_min = text_bias_min;
+    t.text_bias_max = text_bias_max;
+    ret t;
+}
+
+# describe one relocation kind for an architecture
+#
+# the hook is held erased on `isa.RelocSeam.reloc_traits`: `isa` cannot name this
+# signature because it mentions `of.RelocKind` and `of` imports `isa`.
+# ---
+# kind: the abstract relocation kind to describe
+# ret:  its physical field width and raw-addend semantics
+pub def RelocTraitsFn: fun(of.RelocKind) RelocTraits;
+
 # apply one relocation for an architecture
 #
 # The one hook an ISA that emits relocatable objects owes, held erased (`*u8`) on


### PR DESCRIPTION
Closes #2386

## Summary

- derive transient function-atom liveness from the final link's existing weak/strong resolution order
- omit only proven losing weak function byte ranges and their dead-origin relocations from executable/shared output
- remap every surviving symbol, relocation, import, GOT/PLT fixup, and base relocation while preserving suffix alignment
- keep relocatable output and native ELF/COFF/Mach-O weak encodings unchanged
- distinguish compiler-produced images from parsed foreign objects so x86_64 addend ambiguity is conservative without sacrificing compiler-output pruning
- keep relocation width/addend semantics ISA-owned; AArch64 and RISC-V remain symbol-relative

## Compiler-scale result

Measured on the 216-module release compiler with the 4.3.2 seed, mach-std `11d8f618`, and `--verify-ir`:

| Measure | `dev` baseline | Fixed | Delta |
|---|---:|---:|---:|
| compiler file | 8,884,224 | 8,200,192 | **-684,032 (-7.70%)** |
| executable RX load | 8,586,254 | 7,905,038 | **-681,216 (-7.93%)** |
| clean link phase | 181-182 ms | 295-313 ms | about +0.12 s |

The baseline contains 4,117 redundant copies spanning 741,895 bytes in current winner order. The fixed RX image removes 681,216 bytes (91.8% of that theoretical extent); conservative symbol/relocation anchors retain the remainder.

Release self-host stages B and C are byte-identical at 8,200,192 bytes:

`700f9eea5214ec40b7b03ee5d170882d59824b84e3461665dd71229b1ef0e895`

A one-module fixture with no weak definitions remains byte-identical before/after (4,104 bytes, SHA-256 `7453ece297ec597c9383fb0730fee349c3223862cb43177fe6d021178194f88a`).

## Verification

- focused linker, relocation-trait, seam, and real COFF disk-roundtrip tests
- mutation checks for parsed x86_64 lower and upper relocation-bias bounds
- local full suite: 986/986
- all six declared build targets
- 18 emit -> parse -> final-link combinations across `link`, `link_images`, and `link_mixed`:
  - ELF x86_64, AArch64, and RV64
  - COFF x86_64
  - Mach-O x86_64 and AArch64
- [PR CI](https://github.com/briar-systems/mach/actions/runs/30529962161): fixpoint, release, tests, incremental checks, and integration all green on Linux x86_64/AArch64/RV64 and Windows x86_64
- [native Darwin fixpoint and self-test](https://github.com/briar-systems/mach/actions/runs/30530172271): green on arm64 and native Intel x86_64
- [native Darwin integration](https://github.com/briar-systems/mach/actions/runs/30530173838): green on arm64 and x86_64
- two independent read-only reviews found no blocker

No CI workflow files changed.
