### PR TITLE
fix(git): ignore root dependency symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 Thumbs.db
 out
 # dep checkouts are realized by `mach dep pull`, not version-controlled
-dep
+/dep

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 Thumbs.db
 out
 # dep checkouts are realized by `mach dep pull`, not version-controlled
-/dep/
+dep


### PR DESCRIPTION
/dep/ only dir, `ln -sf ../dep/ dep` is file can't ignore
I ofen use `ln -sf` generat dep, So ... 