### PR TITLE
fix(link): preserve Darwin framework and dylib semantics

### DIFF
--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -180,8 +180,11 @@ pub ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 ```
 
 Body-less, ends in `;`, C ABI is the contract. Provide the definition at link
-time (`mach build . -l c`, manifest `libs`, or an explicit `.o`/`.a`/`.so`).
-On PE targets pin imports to their DLL with `#[library("ws2_32.dll")]`.
+time (`mach build . -l c`, a `[link.X]` manifest requirement, or an explicit
+`.o`/`.a`/`.so`/`.dylib`/`.dll`). On PE and Mach-O targets, pin each dynamic
+import with `#[library("name")]`. The value is the requirement's stable
+`library` identity (defaulting to the `[link.X]` table name); exact loader names
+remain accepted.
 
 ### `val` / `var`
 
@@ -432,7 +435,7 @@ immediately following declaration. Closed set:
 | Decorator | Applies to | Argument | Purpose |
 |---|---|---|---|
 | `#[symbol("name")]` | fun, ext fun, val/var | string | linker name override |
-| `#[library("x.dll")]` | ext fun | string | PE import DLL pin |
+| `#[library("name")]` | ext import | string | dynamic import dependency pin |
 | `#[inline]` | fun | none | force inlining |
 | `#[align(expr)]` | val/var, rec/uni | comptime int | alignment override |
 | `#[section(".name")]` | fun, ext fun, val/var | string | object section placement |

--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -184,7 +184,8 @@ time (`mach build . -l c`, a `[link.X]` manifest requirement, or an explicit
 `.o`/`.a`/`.so`/`.dylib`/`.dll`). On PE and Mach-O targets, pin each dynamic
 import with `#[library("name")]`. The value is the requirement's stable
 `library` identity (defaulting to the `[link.X]` table name); exact loader names
-remain accepted.
+remain accepted. A discovered Darwin `@rpath/` install name retains its selected
+library directory as an `LC_RPATH` command.
 
 ### `val` / `var`
 

--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -452,10 +452,12 @@ pub var cache_line: u8 = 0;
 ```
 
 `align` takes any comptime expression (`#[align($align_of(T))]`). A `library`
-pin must name a DLL in the target's `libs` set - pinning to an absent library
-is a link error; on ELF the pin is validated but has no binary effect. Beware:
-a line comment starting `#[` with no space parses as a decorator - write
-`# [...]` in prose comments.
+pin must name a selected dynamic dependency by its stable logical identity or
+exact loader name; pinning to an absent library is a link error. PE and Mach-O
+require attribution, while ELF validates the pin but emits global-search
+binding. Logical identities may not collide with a different dependency's
+loader name. Beware: a line comment starting `#[` with no space parses as a
+decorator - write `# [...]` in prose comments.
 
 `#[oblivious]` marks a constant-time boundary: the backend may not introduce a
 secret-dependent branch, a variable-latency op on a secret, or eliminate a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ to 8,200,192 bytes.
   (#2419).
 - link: manifest requirements retain their `local`, `system`, and `framework`
   source semantics through direct and cascading links. Darwin resolves
-  frameworks and `.dylib` install names for native and cross-target plans, and
-  the optional `[link.X].library` identity makes `#[library]` attribution
-  portable across platform loader names (#2424).
+  version-independent framework paths and `.dylib` install names for native and
+  cross-target plans, and the optional `[link.X].library` identity makes
+  `#[library]` attribution portable across platform loader names without
+  order-dependent identity collisions (#2424).
 - linker: final executable links discard proven losing weak function bodies and
   their dead relocations across ELF, COFF, and Mach-O; ELF shared links do
   likewise. Relocatable output and target-specific relocation semantics remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ to 8,200,192 bytes.
 - link: manifest requirements retain their `local`, `system`, and `framework`
   source semantics through direct and cascading links. Darwin resolves
   version-independent framework paths and `.dylib` install names for native and
-  cross-target plans, and the optional `[link.X].library` identity makes
+  cross-target plans, retaining resolved `@rpath/` search directories in Mach-O
+  executables, and the optional `[link.X].library` identity makes
   `#[library]` attribution portable across platform loader names without
   order-dependent identity collisions (#2424).
 - linker: final executable links discard proven losing weak function bodies and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ to 8,200,192 bytes.
 - verify: `-g --verify-ir` accepts aggregate locals that SROA made unavailable
   to debug metadata, while retaining the runtime aggregate-address check
   (#2419).
+- link: manifest requirements retain their `local`, `system`, and `framework`
+  source semantics through direct and cascading links. Darwin resolves
+  frameworks and `.dylib` install names for native and cross-target plans, and
+  the optional `[link.X].library` identity makes `#[library]` attribution
+  portable across platform loader names (#2424).
 - linker: final executable links discard proven losing weak function bodies and
   their dead relocations across ELF, COFF, and Mach-O; ELF shared links do
   likewise. Relocatable output and target-specific relocation semantics remain

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -114,9 +114,9 @@ unit's inputs — prints it, and exits without compiling or linking.
 | `--jobs <n>`   | count          | codegen worker threads (default: host CPUs; `1` serialises) |
 | `--pie`        | —              | emit a position-independent (ET_DYN) executable for ASLR instead of the default fixed-address one; opt-in (see below) |
 | `-L <dir>`     | dir            | add a search directory for `-l`-resolved inputs; repeatable |
-| `-l <name>`    | name           | link a named object, archive, or shared library, resolved through the `-L` dirs (see below); repeatable |
+| `-l <name>`    | name           | link a named object, archive, or target-format shared library, resolved through the `-L` dirs (see below); repeatable |
 | `--explain`    | —              | print the resolved build plan and exit without building |
-| *(positional)* | input path     | a bare argument that contains `/`, ends in `.o` / `.a`, or names a `.so` is linked verbatim |
+| *(positional)* | input path     | a bare argument that contains `/`, ends in `.o` / `.a`, or names a `.so`, `.dylib`, or `.dll` is linked explicitly |
 
 Plus the global flags above.
 
@@ -131,14 +131,15 @@ dependency is rejected.
 
 `ext fun` declarations are forward references whose definitions are supplied at
 link time by external precompiled code — a loose `.o` object, a static `.a`
-archive, or a shared `.so` library. Those inputs come from the command line and
+archive, or a target-format shared library. Those inputs come from the command line and
 from the manifest's matching `[link.X]` entries — an artifact's referenced entries
 plus exported dependency entries whose `os`/`isa`/`abi` filters match the build
 (see [manifest.md](manifest.md)); both sets are linked. An input that resolves to no
 existing file is a hard error, so a typo never silently drops a dependency.
 
 - **Explicit input path** — a bare (non-flag) argument that contains a `/`, ends
-  in `.o` (object) or `.a` (archive), or names a `.so` (shared library) is
+  in `.o` (object) or `.a` (archive), or names an ELF `.so`, Mach-O `.dylib`,
+  or PE `.dll` is
   treated as an input path. The first non-flag positional after `build` is the
   project root and is skipped; remaining input-path positionals are link inputs.
   A relative path is tried verbatim against the working directory first, then
@@ -147,10 +148,11 @@ existing file is a hard error, so a typo never silently drops a dependency.
   `-L <dir>` is searched for `<dir>/lib<name>.o`, `<dir>/<name>.o`,
   `<dir>/lib<name>.a`, then `<dir>/<name>.a`; if none hit, the same four
   candidates relative to the working directory are tried. Only if no static
-  object or archive is found does resolution fall back to a shared
-  `lib<name>.so` (searched in the `-L` dirs, the target OS's default library
-  directory, then the common system library directories `/lib64`, `/usr/lib64`,
-  the multiarch dirs, `/usr/lib`, `/lib`).
+  object or archive is found does resolution fall back to the selected target's
+  shared-library spelling: `lib<name>.so[.N]` for ELF or
+  `lib<name>[.<N>].dylib` for Mach-O. The `-L` directories are searched first,
+  followed by the selected target OS's system library directories; cross-target
+  planning does not consume a host library of another format.
 - **`-L <dir>`** — adds a search directory for the `-l` resolution above. Both
   `-L` and `-l` may be repeated.
 
@@ -163,21 +165,20 @@ How an input resolves decides whether the link is static or dynamic:
   member objects (all members are pulled, not just those satisfying an undefined
   symbol). With only static inputs the output is a fully static binary, and any
   undefined `ext` that no input defines is a hard error.
-- A shared **`.so`** library is a **dynamic** dependency. Its `DT_SONAME` (read
-  from the library, e.g. `libc.so.6` for `-l c`) is recorded as a run-time
-  dependency, and any undefined `ext` left after merging is bound against it at
-  load time through a PLT the linker emits — producing a dynamically-linked ELF
-  with a `PT_INTERP` (the OS dynamic loader) and a `.dynamic`/PLT/GOT. A static
-  definition of a symbol always wins over a dynamic import of the same name.
+- A shared **`.so`**, **`.dylib`**, or **`.dll`** is a **dynamic** dependency.
+  ELF records the library's `DT_SONAME`, Mach-O records its `LC_ID_DYLIB`
+  install name, and PE records the DLL basename. Darwin frameworks are declared
+  through `[link.X]` with `source = "framework"` and become their canonical
+  system install names. Undefined `ext` functions are then emitted as imports
+  for the target format. A static definition of the same symbol always wins.
 
-`-l <name>` prefers a static `.o`/`.a` over a shared `.so`, so an `-l name`
+`-l <name>` prefers a static `.o`/`.a` over a shared library, so an `-l name`
 that has a local object is resolved statically exactly as before; the `.so`
-fallback only applies when no static candidate exists (the common case for
-system libraries like libc). Manifest `libs` are resolved before the CLI inputs,
-giving a stable, deterministic link order.
-
-> Dynamic linking is implemented for the ELF (Linux) and PE (Windows) targets;
-> the Mach-O (Darwin) import path is not yet implemented (#1176).
+or `.dylib` fallback only applies when no static candidate exists. A bare `-l`
+name is also the logical identity accepted by `#[library("name")]`; manifest
+requirements can set a cross-platform logical identity explicitly with their
+`library` key. Manifest requirements are resolved before CLI inputs, giving a
+stable, deterministic link order.
 
 Exit codes: `0` ok, `1` user error (missing project path, no `mach.toml`,
 unknown target, compile errors, an unresolvable link input), `2` internal error.

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -167,10 +167,13 @@ How an input resolves decides whether the link is static or dynamic:
   undefined `ext` that no input defines is a hard error.
 - A shared **`.so`**, **`.dylib`**, or **`.dll`** is a **dynamic** dependency.
   ELF records the library's `DT_SONAME`, Mach-O records its `LC_ID_DYLIB`
-  install name, and PE records the DLL basename. Darwin frameworks are declared
-  through `[link.X]` with `source = "framework"` and become version-independent
-  system framework paths. Undefined `ext` functions are then emitted as imports
-  for the target format. A static definition of the same symbol always wins.
+  install name, and PE records the DLL basename. When a discovered Mach-O
+  install name starts with `@rpath/`, the resolved library directory is retained
+  as an `LC_RPATH`; an unresolved explicit `@rpath/...` input is rejected because
+  it supplies no usable search directory. Darwin frameworks are declared through
+  `[link.X]` with `source = "framework"` and become version-independent system
+  framework paths. Undefined `ext` functions are then emitted as imports for the
+  target format. A static definition of the same symbol always wins.
 
 `-l <name>` prefers a static `.o`/`.a` over a shared library, so an `-l name`
 that has a local object is resolved statically exactly as before; the `.so`

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -168,8 +168,8 @@ How an input resolves decides whether the link is static or dynamic:
 - A shared **`.so`**, **`.dylib`**, or **`.dll`** is a **dynamic** dependency.
   ELF records the library's `DT_SONAME`, Mach-O records its `LC_ID_DYLIB`
   install name, and PE records the DLL basename. Darwin frameworks are declared
-  through `[link.X]` with `source = "framework"` and become their canonical
-  system install names. Undefined `ext` functions are then emitted as imports
+  through `[link.X]` with `source = "framework"` and become version-independent
+  system framework paths. Undefined `ext` functions are then emitted as imports
   for the target format. A static definition of the same symbol always wins.
 
 `-l <name>` prefers a static `.o`/`.a` over a shared library, so an `-l name`

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -87,7 +87,8 @@ ext fun wsa_startup(ver: u16, data: *u8) i32;
 - The value normally names a `[link.X]` requirement's stable logical identity:
   its `library` value, or `X` when that key is omitted. A bare command-line
   `-l name` also exposes `name`. Exact canonical loader names remain accepted.
-  Pinning to an absent dependency is a link error, never a silent fallback.
+  Pinning to an absent dependency is a link error, never a silent fallback. A
+  logical identity may not equal a different dependency's loader name.
 - PE and Mach-O use two-level namespaces, so every dynamic import on those
   targets needs a `library` attribution.
 - On ELF (Linux) the loader resolves imports by global search, so `library`

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -2,7 +2,7 @@
 
 A decorator is a codegen directive attached to a declaration. It expresses
 metadata that influences how the compiler emits the symbol: its linker name,
-alignment, section placement, inlining, PE import routing, constant-time
+alignment, section placement, inlining, dynamic import attribution, constant-time
 obligations, or exclusion from auto-vectorization.
 
 Decorators are **codegen-only**. Visibility (`pub` / `ext`) is separate and
@@ -29,7 +29,7 @@ A decorator is written as an attribute:
 
 ```
 #[symbol("name")]    # linker name override
-#[library("dep")]    # PE import routing (ext only)
+#[library("dep")]    # dynamic import attribution (ext only)
 #[inline]            # force inlining (no arguments)
 #[noinline]          # forbid inlining (no arguments)
 #[align(expr)]       # alignment; expr is a comptime integer
@@ -74,27 +74,27 @@ ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 Without `symbol`, the compiler mangles the Mach name. `symbol` gives the
 exact name the linker sees.
 
-### `library(str)` — PE import routing
+### `library(str)` — dynamic import attribution
 
-Pins an `ext` import to a specific DLL in the link's dependency set. Applies
-to `ext` functions only.
+Pins an `ext` import to a specific dependency in the link set. Applies to
+`ext` functions only.
 
 ```mach
 #[library("ws2_32.dll")] #[symbol("WSAStartup")]
 ext fun wsa_startup(ver: u16, data: *u8) i32;
 ```
 
-- The named DLL must appear in the manifest's `[os.*].libs` for the target OS
-  (e.g. `[os.windows].libs = ["kernel32.dll", "ws2_32.dll", ...]`). Pinning
-  to an absent library is a link error, never a silent fallback.
-- Without `library`, an unattributed PE import binds to the **first** declared
-  dependency. Every import that belongs to a different DLL needs an explicit
-  `library` pin.
+- The value normally names a `[link.X]` requirement's stable logical identity:
+  its `library` value, or `X` when that key is omitted. A bare command-line
+  `-l name` also exposes `name`. Exact canonical loader names remain accepted.
+  Pinning to an absent dependency is a link error, never a silent fallback.
+- PE and Mach-O use two-level namespaces, so every dynamic import on those
+  targets needs a `library` attribution.
 - On ELF (Linux) the loader resolves imports by global search, so `library`
   has no effect on the emitted binary; the value is still validated against
   the link's dependency set.
 - `library` composes with `symbol`: the import is emitted under the renamed
-  symbol within the named DLL.
+  symbol within the named dependency.
 
 ### `inline` — force inlining
 

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -132,7 +132,9 @@ mach build . -l c
   finally the working directory is searched for the same four names (loose
   objects preferred over archives). Only if no static candidate exists does it
   fall back to the selected target's shared spelling: `lib<name>.so[.N]` for
-  ELF or `lib<name>[.<N>].dylib` for Mach-O. `-L` and `-l` may each be repeated.
+  ELF or `lib<name>[.<N>].dylib` for Mach-O. A resolved `@rpath/` dylib carries
+  its selected directory into the executable as `LC_RPATH`. `-L` and `-l` may
+  each be repeated.
 
 ### Manifest
 

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -56,7 +56,8 @@ ext fun WSAStartup(ver: u16, data: *u8) i32;
   accepted for compatibility. The named library **must** be among the link's
   dependencies; pinning to one that is not is a hard link error
   (`import '<sym>' pinned to library '<lib>' not among the link's dependencies`),
-  never a silent fallback.
+  never a silent fallback. A logical identity that equals a different
+  dependency's loader name is rejected as ambiguous.
 - An `ext` import with no `library` is unattributed. PE and Mach-O require every
   dynamic import to identify its provider, so an unattributed import is a hard
   link error on those targets.

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -41,33 +41,32 @@ Common reasons to rename:
 
 ## Library attribution
 
-On a dynamic format that attributes each import to a specific dependency — the
-PE (Windows) import directory — the `library` decorator pins an `ext` import to
-the DLL that exports it:
+On a two-level dynamic format — PE (Windows) or Mach-O (Darwin) — the `library`
+decorator pins an `ext` import to the dependency that exports it:
 
 ```mach
 #[library("ws2_32.dll")]
 ext fun WSAStartup(ver: u16, data: *u8) i32;
 ```
 
-- The value names one of the OS's dependency libraries (the manifest
-  `[os.*].libs` set, e.g. `[os.windows].libs = ["kernel32.dll", "ws2_32.dll"]`).
-  The named library **must** be among the link's dependencies; pinning to a
-  library that is not is a hard link error
+- The value names a link dependency's stable logical identity. A `[link.X]`
+  requirement supplies it through `library = "..."`, defaulting to `X`; a bare
+  command-line `-l name` uses `name`. The dependency's exact canonical loader
+  name (`libfoo.so.3`, an `LC_ID_DYLIB` install name, or `foo.dll`) is also
+  accepted for compatibility. The named library **must** be among the link's
+  dependencies; pinning to one that is not is a hard link error
   (`import '<sym>' pinned to library '<lib>' not among the link's dependencies`),
   never a silent fallback.
-- An `ext` import with no `library` is unattributed. On PE the loader has no
-  global search, so an unattributed import binds to the **first** declared
-  dependency. Pin every import that does not belong to that first library —
-  adding extra DLLs to `libs` without attribution only emits empty import
-  descriptors.
+- An `ext` import with no `library` is unattributed. PE and Mach-O require every
+  dynamic import to identify its provider, so an unattributed import is a hard
+  link error on those targets.
 
 `library` composes with `symbol`: the rename sets the imported symbol's name,
-`library` sets the DLL it is imported from. On one decl the import is emitted
+`library` sets the dependency it is imported from. On one decl the import is emitted
 under the renamed symbol within the named library.
 
 ```mach
-# imported as `socket` from ws2_32.dll, called as `ws2_socket` in Mach.
+# imported as `socket` from ws2_32.dll, called as `ws2_socket` in Mach
 #[library("ws2_32.dll")] #[symbol("socket")]
 ext fun ws2_socket(af: i32, kind: i32, proto: i32) i64;
 ```
@@ -113,8 +112,10 @@ C-toolchain-style flags, consumed by `mach build`:
 mach build . path/to/libfoo.o
 mach build . path/to/libfoo.a
 mach build . path/to/libfoo.so
+mach build . path/to/libfoo.dylib
+mach build . foo.dll
 
-# search dir + library name: resolves lib<name>.o / <name>.o / lib<name>.a / <name>.a, then lib<name>.so
+# search dir + library name: static candidates first, then the target's .so/.dylib spelling
 mach build . -L build/libs -l foo
 
 # link against a system shared library (libc) dynamically
@@ -122,42 +123,54 @@ mach build . -l c
 ```
 
 - A bare argument that contains a `/`, ends in `.o` (object) or `.a` (archive),
-  or names a `.so` (shared library) is treated as an explicit input path. A
+  or names a `.so`, `.dylib`, or `.dll` is treated as an explicit input. A
   relative path is tried first against the working directory, then against the
   project root.
 - `-l <name>` resolves to an object, archive, or shared library: each `-L <dir>`
   is searched for `lib<name>.o`, `<name>.o`, `lib<name>.a`, then `<name>.a`;
   finally the working directory is searched for the same four names (loose
   objects preferred over archives). Only if no static candidate exists does it
-  fall back to a shared `lib<name>.so` (in the `-L` dirs and the system library
-  directories). `-L` and `-l` may each be repeated.
+  fall back to the selected target's shared spelling: `lib<name>.so[.N]` for
+  ELF or `lib<name>[.<N>].dylib` for Mach-O. `-L` and `-l` may each be repeated.
 
 ### Manifest
 
-`[targets.*].libs` lists project-level link inputs, each an explicit object /
-archive / shared-library path (project-relative or absolute) or a bare
-`-l`-style name:
+Artifacts name typed `[link.X]` requirements. Use `system` for a named library,
+`framework` for a Darwin framework, or `local` for an object/archive/shared
+library path. Filters select the applicable target:
 
 ```toml
-[targets.linux]
-# ...
-libs = ["build/libs/libfoo.a", "bar", "c"]
+[link.foo-unix]
+source  = "system"
+name    = "foo"
+library = "foo"
+os      = ["linux", "darwin"]
+isa     = "*"
+abi     = "*"
+export  = false
+
+[link.foo-win]
+source  = "system"
+name    = "foo.dll"
+library = "foo"
+os      = "windows"
+isa     = "*"
+abi     = "*"
+export  = false
 ```
 
-`link` is accepted as an alias for `libs`. Manifest inputs and command-line
-inputs are both included; a name that resolves to no existing file is a hard
-error.
+Both entries expose the logical name `foo`, so `#[library("foo")]` is portable
+across the mutually exclusive target filters. Manifest and command-line inputs
+are both included; a name that cannot be resolved is a hard error.
 
 ### Scope
 
 Loose `.o` relocatable objects and static `.a` archives are linked **statically**
 (a `.a` contributes every one of its member objects — all members are pulled, not
-just those satisfying an undefined symbol). A shared `.so` library is a **dynamic**
-dependency: its `DT_SONAME` is recorded and undefined `ext` symbols are bound
-against it at load time through a `PT_INTERP`/PLT in the produced binary. A
-static definition always wins over a same-named dynamic import. Dynamic linking
-is currently implemented for the ELF (Linux) target; the PE (Windows) and Mach-O
-(Darwin) import paths are in progress.
+just those satisfying an undefined symbol). A shared `.so`, `.dylib`, framework,
+or `.dll` is a **dynamic** dependency: its format-specific canonical loader name
+is recorded and undefined `ext` functions become run-time imports. A static
+definition always wins over a same-named dynamic import.
 
 ## See also
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -365,15 +365,16 @@ project's modules, so a platform link requirement lives once — in the manifest
 needs it — and cascades to consumers. A standalone build and a consumed build use
 the same entries, so nothing behaves differently as a dependency.
 
-| Key      | Required | Meaning |
-|----------|----------|---------|
-| `source` | yes | `"system"` (a system library resolved by name), `"framework"` (a macOS framework), or `"local"` (a file on disk). |
-| `name`   | shape | Library/framework name — required for `source = "system"`/`"framework"`, forbidden for `"local"`. |
-| `path`   | shape | File path — required for `source = "local"`, forbidden otherwise. A template (see below). |
-| `os`     | yes | Filter axis: a canonical `os` value, `"*"` (any), an array of values, or `[]` (none). |
-| `isa`    | yes | Filter axis over `isa`, same forms. |
-| `abi`    | yes | Filter axis over `abi`, same forms. |
-| `export` | yes | `true` cascades this entry to consumers; `false` keeps it to this project's own builds. |
+| Key       | Required | Meaning |
+|-----------|----------|---------|
+| `source`  | yes | `"system"` (a system library resolved by name), `"framework"` (a macOS framework), or `"local"` (a file on disk). |
+| `name`    | shape | Library/framework name — required for `source = "system"`/`"framework"`, forbidden for `"local"`. |
+| `path`    | shape | File path — required for `source = "local"`, forbidden otherwise. A template (see below). |
+| `library` | no | Stable logical name used by `#[library("...")]`; defaults to the `[link.<name>]` table name. |
+| `os`      | yes | Filter axis: a canonical `os` value, `"*"` (any), an array of values, or `[]` (none). |
+| `isa`     | yes | Filter axis over `isa`, same forms. |
+| `abi`     | yes | Filter axis over `abi`, same forms. |
+| `export`  | yes | `true` cascades this entry to consumers; `false` keeps it to this project's own builds. |
 
 The `os`/`isa`/`abi` axes select the build cells an entry applies to. Each takes a
 single canonical value, `"*"` for any, or an array — `os = "linux"` and
@@ -385,9 +386,18 @@ A `local` entry's `path` must, at build time, either match a `[step.X]`'s `out`
 (which demands that step) or already exist on disk — anything else is an up-front
 error, so a typo never silently drops an input.
 
+`library` decouples source attribution from platform loader spelling. Give
+mutually exclusive platform entries the same logical value when they provide the
+same API; one unconditional `#[library("glfw")]` can then bind against
+`libglfw.so.3` on Linux, an `LC_ID_DYLIB` install name on Darwin, and
+`glfw3.dll` on Windows. Exact canonical loader names remain accepted for
+compatibility. Selecting two dependencies that map the same logical name to
+different loader names in one build is an error.
+
 Whether an input links **statically** or **dynamically** follows the resolved file
-— a loose `.o` or static `.a` links statically; a shared `.so` is recorded as a
-dynamic dependency by its `DT_SONAME`. See
+— a loose `.o` or static `.a` links statically; ELF `.so`, Mach-O `.dylib`,
+Darwin framework, and PE `.dll` inputs are recorded using their format's
+canonical loader name. See
 [cli.md](cli.md#static-vs-dynamic-resolution) for the resolution rules and
 [language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
 `ext fun` workflow that consumes these inputs.
@@ -644,6 +654,7 @@ out     = "out/{target.name}/{profile.name}"
 [link.glfw]
 source = "system"
 name   = "glfw"
+library = "glfw"
 os     = ["linux", "darwin"]
 isa    = "*"
 abi    = "*"
@@ -652,6 +663,7 @@ export = true
 [link.glfw-win]
 source = "system"
 name   = "glfw3.dll"
+library = "glfw"
 os     = ["windows"]
 isa    = "*"
 abi    = "*"
@@ -664,6 +676,14 @@ os     = ["darwin"]
 isa    = "*"
 abi    = "*"
 export = true
+```
+
+Both GLFW entries expose the logical name `glfw`, so the binding can use the
+same attribution on every target:
+
+```mach
+#[library("glfw")]
+pub ext fun glfwInit() i32;
 ```
 
 ## Worked example: a vendored-C dependency

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -399,7 +399,9 @@ attribution never depends on requirement order.
 Whether an input links **statically** or **dynamically** follows the resolved file
 — a loose `.o` or static `.a` links statically; ELF `.so`, Mach-O `.dylib`,
 and PE `.dll` inputs are recorded using their format's canonical loader name.
-Darwin frameworks use a version-independent system framework path. See
+An `@rpath/` Mach-O install name also retains the directory where resolution found
+the dylib, which the executable records as `LC_RPATH`. Darwin frameworks use a
+version-independent system framework path. See
 [cli.md](cli.md#static-vs-dynamic-resolution) for the resolution rules and
 [language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
 `ext fun` workflow that consumes these inputs.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -392,12 +392,14 @@ same API; one unconditional `#[library("glfw")]` can then bind against
 `libglfw.so.3` on Linux, an `LC_ID_DYLIB` install name on Darwin, and
 `glfw3.dll` on Windows. Exact canonical loader names remain accepted for
 compatibility. Selecting two dependencies that map the same logical name to
-different loader names in one build is an error.
+different loader names in one build is an error. A logical name that equals a
+different dependency's canonical loader name is likewise rejected, so
+attribution never depends on requirement order.
 
 Whether an input links **statically** or **dynamically** follows the resolved file
 — a loose `.o` or static `.a` links statically; ELF `.so`, Mach-O `.dylib`,
-Darwin framework, and PE `.dll` inputs are recorded using their format's
-canonical loader name. See
+and PE `.dll` inputs are recorded using their format's canonical loader name.
+Darwin frameworks use a version-independent system framework path. See
 [cli.md](cli.md#static-vs-dynamic-resolution) for the resolution rules and
 [language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
 `ext fun` workflow that consumes these inputs.

--- a/int/surface/pe-import-attribution/expect.windows.txt
+++ b/int/surface/pe-import-attribution/expect.windows.txt
@@ -1,1 +1,1 @@
-error: dynamic import 'some_unattributed_import' has no #[library] attribution; a two-level-namespace target requires every import to name its providing library - annotate the declaration with #[library("...")]; candidate libraries: kernel32.dll
+error: dynamic import 'some_unattributed_import' has no #[library] attribution; a two-level-namespace target requires every import to name its providing library - annotate the declaration with #[library("...")]; candidate libraries: kernel32 (kernel32.dll)

--- a/src/cli/args.mach
+++ b/src/cli/args.mach
@@ -282,7 +282,7 @@ pub fun parse(argc: usize, argv: **u8) R.Result[request.CliArgs, str] {
 # tokens (a marked value - `--filter foo.o` - must never read as a link input).
 # Captures the `-O<n>` level (first of `-O0`/`-O1`/`-O2` wins), the raw `--jobs`
 # value, `--include-deps`, the `-L` directories, and the link tokens (`-l`
-# values and bare object/archive path positionals) in invocation order. The
+# values and bare link-file path positionals) in invocation order. The
 # project-path positional is stepped over. Beyond this call, argv is dead to the
 # build flow: everything downstream reads the composed request.
 # ---

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -147,7 +147,7 @@ fun help_build() {
     render_flags(?args.JOBS[0],      args.JOBS_N);
     render_flags(?args.LINKIN[0],    args.LINKIN_N);
     render_flags(?args.BUILD_OWN[0], args.BUILD_OWN_N);
-    print.print("  <input>               a bare .o / .a / .so path or '/'-bearing path linked verbatim\n");
+    print.print("  <input>               a bare .o / .a / .so / .dylib / .dll or '/'-bearing path linked verbatim\n");
     print.print("\n");
     global_flags();
     print.print("\n");

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3135,16 +3135,6 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
                        sec_base: *u32, atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
-    var collision_first: u32 = 0;
-    var collision_second: u32 = 0;
-    var collision_identity: intern.StrId = intern.STR_NIL;
-    if (dynlib_identity_collision(dynlibs, dynlib_count, ?collision_first,
-                                  ?collision_second, ?collision_identity)) {
-        ret R.err[bool, str](dynlib_identity_conflict_message(
-            s, collision_identity, dynlibs[collision_first].soname,
-            dynlibs[collision_second].soname));
-    }
-
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
     # (ELF); a format that embeds the loader differently (PE's import directory,
     # Mach-O's dyld bind) supplies an empty path and the format writer ignores it.
@@ -3169,12 +3159,34 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         implicit = 1;
     }
 
-    # Emit each canonical loader dependency once even when several logical names
-    # alias it. Attribution below maps every alias back to this compact index.
-    val explicit_libs: u32 = unique_dynlib_count(dynlibs, dynlib_count);
+    # treat the implicit platform library as part of the same identity set used
+    # for validation and import attribution. Otherwise an explicit dependency
+    # could claim libSystem's loader name as its logical alias and capture an
+    # import before the implicit dependency was appended.
     if (implicit == 1 && dynlib_soname_present(dynlibs, dynlib_count, implicit_soname)) {
         implicit = 0;
     }
+    var implicit_lib: of.DynLib;
+    var implicit_ptr: *of.DynLib = nil::*of.DynLib;
+    if (implicit == 1) {
+        implicit_lib.name = implicit_soname;
+        implicit_lib.soname = implicit_soname;
+        implicit_lib.rpath = intern.STR_NIL;
+        implicit_ptr = ?implicit_lib;
+    }
+    var collision_first: intern.StrId = intern.STR_NIL;
+    var collision_second: intern.StrId = intern.STR_NIL;
+    var collision_identity: intern.StrId = intern.STR_NIL;
+    if (dynlib_identity_collision(dynlibs, dynlib_count, implicit_ptr,
+                                  ?collision_first, ?collision_second,
+                                  ?collision_identity)) {
+        ret R.err[bool, str](dynlib_identity_conflict_message(
+            s, collision_identity, collision_first, collision_second));
+    }
+
+    # Emit each canonical loader dependency once even when several logical names
+    # alias it. Attribution below maps every alias back to this compact index.
+    val explicit_libs: u32 = unique_dynlib_count(dynlibs, dynlib_count);
     val total_libs: u32 = explicit_libs + implicit;
     if (total_libs > 0) {
         val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, total_libs::usize);
@@ -3263,7 +3275,8 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             val lib_opt: O.Option[intern.StrId] = session.import_library(s, sym.name);
             if (O.is_some[intern.StrId](lib_opt)) {
                 val want: intern.StrId = O.unwrap[intern.StrId](lib_opt);
-                val li_opt: O.Option[u32] = dynlib_index_of(dynlibs, dynlib_count, want);
+                val li_opt: O.Option[u32] =
+                    dynlib_index_of(dynlibs, dynlib_count, implicit_ptr, want);
                 if (!O.is_some[u32](li_opt)) { ret R.err[bool, str](pinned_lib_message(s, sym.name, want)); }
                 dyn.info.imports[idx].lib_index = O.unwrap[u32](li_opt);
             }
@@ -3295,11 +3308,13 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
 # logical name or loader name. aliases sharing one loader name map to the same
 # compact index. names are interned in the session, so matching is by identity
 # ---
-# dynlibs:      the dependency logical and loader names
-# dynlib_count: number of dependencies
+# dynlibs:      the explicit dependency logical and loader names
+# dynlib_count: number of explicit dependencies
+# implicit:     optional trailing platform dependency
 # lib:          the interned library name to find
 # ret:          the dependency index, or none when no dependency carries that name
-fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32, lib: intern.StrId) O.Option[u32] {
+fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32,
+                    implicit: *of.DynLib, lib: intern.StrId) O.Option[u32] {
     var i: u32 = 0;
     for (i < dynlib_count) {
         if (dynlibs[i].name == lib || dynlibs[i].soname == lib) {
@@ -3317,40 +3332,52 @@ fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32, lib: intern.StrId) O
         }
         i = i + 1;
     }
+    if (implicit != nil && (implicit.name == lib || implicit.soname == lib)) {
+        ret O.some[u32](unique_dynlib_count(dynlibs, dynlib_count));
+    }
     ret O.none[u32]();
+}
+
+# whether two dynamic dependencies share an identity but not a loader
+fun dynlib_identity_pair(a: *of.DynLib, b: *of.DynLib,
+                         identity: *intern.StrId) bool {
+    if (a.soname == b.soname) { ret false; }
+    if (a.name == b.name || a.name == b.soname) {
+        @identity = a.name;
+        ret true;
+    }
+    if (a.soname == b.name) {
+        @identity = a.soname;
+        ret true;
+    }
+    ret false;
 }
 
 # find an identity that names two distinct loader dependencies
 #
 # a `#[library]` value may match either a logical name or an exact loader name.
 # those namespaces may overlap only when both spellings identify the same loader;
-# otherwise attribution would depend on requirement order.
+# otherwise attribution would depend on requirement order. the optional implicit
+# dependency participates in the same namespace as explicit requirements.
 fun dynlib_identity_collision(dynlibs: *of.DynLib, count: u32,
-                              first: *u32, second: *u32,
+                              implicit: *of.DynLib,
+                              first: *intern.StrId, second: *intern.StrId,
                               identity: *intern.StrId) bool {
     var i: u32 = 0;
     for (i < count) {
         var j: u32 = i + 1;
         for (j < count) {
-            if (dynlibs[i].soname != dynlibs[j].soname) {
-                var hit: intern.StrId = intern.STR_NIL;
-                if (dynlibs[i].name == dynlibs[j].name) {
-                    hit = dynlibs[i].name;
-                }
-                or (dynlibs[i].name == dynlibs[j].soname) {
-                    hit = dynlibs[i].name;
-                }
-                or (dynlibs[i].soname == dynlibs[j].name) {
-                    hit = dynlibs[i].soname;
-                }
-                if (hit != intern.STR_NIL) {
-                    @first = i;
-                    @second = j;
-                    @identity = hit;
-                    ret true;
-                }
+            if (dynlib_identity_pair(?dynlibs[i], ?dynlibs[j], identity)) {
+                @first = dynlibs[i].soname;
+                @second = dynlibs[j].soname;
+                ret true;
             }
             j = j + 1;
+        }
+        if (implicit != nil && dynlib_identity_pair(?dynlibs[i], implicit, identity)) {
+            @first = dynlibs[i].soname;
+            @second = implicit.soname;
+            ret true;
         }
         i = i + 1;
     }
@@ -4177,11 +4204,16 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     libs[2].soname = 74;
     libs[2].rpath = intern.STR_NIL;
 
-    val logical: O.Option[u32] = dynlib_index_of(?libs[0], 3, 41);
-    val alias: O.Option[u32] = dynlib_index_of(?libs[0], 3, 42);
-    val loader: O.Option[u32] = dynlib_index_of(?libs[0], 3, 73);
-    val other: O.Option[u32] = dynlib_index_of(?libs[0], 3, 74);
-    val missing: O.Option[u32] = dynlib_index_of(?libs[0], 3, 99);
+    val logical: O.Option[u32] =
+        dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 41);
+    val alias: O.Option[u32] =
+        dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 42);
+    val loader: O.Option[u32] =
+        dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 73);
+    val other: O.Option[u32] =
+        dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 74);
+    val missing: O.Option[u32] =
+        dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 99);
     if (!O.is_some[u32](logical) || O.unwrap[u32](logical) != 0) { ret 1; }
     if (!O.is_some[u32](alias) || O.unwrap[u32](alias) != 0)     { ret 1; }
     if (!O.is_some[u32](loader) || O.unwrap[u32](loader) != 0)   { ret 1; }
@@ -4197,17 +4229,85 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     collision[1].name = 73;
     collision[1].soname = 74;
     collision[1].rpath = intern.STR_NIL;
-    var first: u32 = 0;
-    var second: u32 = 0;
+    var first: intern.StrId = intern.STR_NIL;
+    var second: intern.StrId = intern.STR_NIL;
     var identity: intern.StrId = intern.STR_NIL;
-    if (!dynlib_identity_collision(?collision[0], 2, ?first, ?second, ?identity)) { ret 1; }
-    if (first != 0 || second != 1 || identity != 73) { ret 1; }
+    if (!dynlib_identity_collision(?collision[0], 2, nil::*of.DynLib,
+                                   ?first, ?second, ?identity)) { ret 1; }
+    if (first != 73 || second != 74 || identity != 73) { ret 1; }
 
     var reversed: [2]of.DynLib;
     reversed[0] = collision[1];
     reversed[1] = collision[0];
-    if (!dynlib_identity_collision(?reversed[0], 2, ?first, ?second, ?identity)) { ret 1; }
+    if (!dynlib_identity_collision(?reversed[0], 2, nil::*of.DynLib,
+                                   ?first, ?second, ?identity)) { ret 1; }
     if (identity != 73) { ret 1; }
+    ret 0;
+}
+
+# darwin's implicit libSystem participates in both alias validation and import
+# attribution before it is appended to the emitted dependency list.
+test "mach.lang.be.linker.build_dynamic_info:implicit_platform_identity" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] =
+        target.select(?reg, "aarch64", "darwin", "aapcs64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    val platform: intern.StrId = lt_name(?s, "/usr/lib/libSystem.B.dylib");
+    val other: intern.StrId = lt_name(?s, "@rpath/libother.dylib");
+    val symbol: intern.StrId = lt_name(?s, "_platform_call");
+    if (platform == intern.STR_NIL || other == intern.STR_NIL
+        || symbol == intern.STR_NIL) { ret 1; }
+
+    var locs: map.Map[intern.StrId, SymbolLoc] =
+        map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
+    var explicit: [1]of.DynLib;
+    explicit[0].name = platform;
+    explicit[0].soname = other;
+    explicit[0].rpath = intern.STR_NIL;
+    var collision_dyn: DynState;
+    init_dynstate(?collision_dyn);
+    collision_dyn.info.pie = true;
+    val collision: R.Result[bool, str] =
+        build_dynamic_info(?s, ?tgt, ?collision_dyn, nil::*of.ObjectImage, 0,
+                           ?locs, ?explicit[0], 1, nil::*u32, nil::*AtomPlan);
+    if (!R.is_err[bool, str](collision)) { ret 1; }
+    free_dynstate(?alloc, ?collision_dyn);
+
+    var sym: of.Symbol;
+    sym.name = symbol;
+    sym.section = of.SECTION_EXTERNAL;
+    sym.offset = 0;
+    sym.size = 0;
+    sym.flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN
+              | of.SYM_OBJ_FLAG_FUNCTION;
+    var module: of.ObjectImage =
+        lt_image(?s, lt_name(?s, "platform-user"), nil::*of.Section, 0,
+                 ?sym, 1, nil::*of.Relocation, 0);
+    if (R.is_err[bool, str](session.register_import_library(?s, symbol, platform))) {
+        ret 1;
+    }
+    var dyn: DynState;
+    init_dynstate(?dyn);
+    dyn.info.pie = true;
+    val built: R.Result[bool, str] =
+        build_dynamic_info(?s, ?tgt, ?dyn, ?module, 1, ?locs,
+                           nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
+    if (R.is_err[bool, str](built)) { ret 1; }
+    if (dyn.info.lib_count != 1 || dyn.info.libs[0].name != platform
+        || dyn.info.libs[0].soname != platform || dyn.info.import_count != 1
+        || dyn.info.imports[0].lib_index != 0) { ret 1; }
+
+    free_dynstate(?alloc, ?dyn);
+    map.dnit[intern.StrId, SymbolLoc](?locs);
+    session.dnit(?s);
     ret 0;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3107,18 +3107,17 @@ fun has_call_reloc(modules: *of.ObjectImage, module_count: u32,
 # assemble the dynamic-link plan from the shared dependencies
 # and the undefined `ext` symbols left after symbol merging
 #
-# every soname becomes a `DynLib` (a DT_NEEDED dependency, in input order). every
-# global `ext` symbol that no input object defines (not in `sym_locs`) becomes a
-# function `DynImport`, deduplicated by name through `import_map`; a relocation
-# targeting it is later bound to its PLT stub. an import is pinned to a specific
-# dependency when a `$<sym>.library` directive attributed it (the session's
-# `import_library` map, keyed by the import's link name); otherwise it stays
-# `DYNLIB_ANY` and the loader's global search resolves it (on PE: the first
-# dependency). a directive naming a library not among the link's dependencies is
-# a hard link error rather than a silent fallback. the interpreter path comes from
-# the OS vtable - a real loader path for ELF (PT_INTERP), or STR_NIL for a format
-# that embeds the loader differently (PE's import directory, Mach-O's dyld bind),
-# which the writer ignores.
+# every distinct loader name becomes a `DynLib` dependency in first-seen order;
+# additional logical aliases map to that same emitted index. every global `ext`
+# symbol that no input object defines (not in `sym_locs`) becomes a function
+# `DynImport`, deduplicated by name through `import_map`; a relocation targeting
+# it is later bound to its PLT stub. an import is pinned when `#[library]`
+# attributed it (the session's `import_library` map, keyed by the import's link
+# name). otherwise it stays `DYNLIB_ANY` on a global-search format and is rejected
+# on a two-level format. an attribution naming no dependency is a hard link error.
+# the interpreter path comes from the OS vtable - a real loader path for ELF
+# (PT_INTERP), or STR_NIL for a format that embeds the loader differently (PE's
+# import directory, Mach-O's dyld bind), which the writer ignores.
 # ---
 # s:            shared session (allocator, interner, import-library directives)
 # tgt:          active target - supplies the OS dynamic-linker path

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3185,6 +3185,19 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         for (i < dynlib_count) {
             if (!dynlib_soname_seen_before(dynlibs, i, dynlibs[i].soname)) {
                 dyn.info.libs[w] = dynlibs[i];
+                # aliases of one loader compact to one emitted dependency. retain
+                # the first available run path even if the first alias had none.
+                if (dyn.info.libs[w].rpath == intern.STR_NIL) {
+                    var j: u32 = i + 1;
+                    for (j < dynlib_count) {
+                        if (dynlibs[j].soname == dynlibs[i].soname
+                            && dynlibs[j].rpath != intern.STR_NIL) {
+                            dyn.info.libs[w].rpath = dynlibs[j].rpath;
+                            brk;
+                        }
+                        j = j + 1;
+                    }
+                }
                 w = w + 1;
             }
             i = i + 1;
@@ -3192,6 +3205,7 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         if (implicit == 1) {
             dyn.info.libs[explicit_libs].name   = implicit_soname;
             dyn.info.libs[explicit_libs].soname = implicit_soname;
+            dyn.info.libs[explicit_libs].rpath  = intern.STR_NIL;
         }
         dyn.info.lib_count = total_libs;
     }
@@ -4155,10 +4169,13 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     var libs: [3]of.DynLib;
     libs[0].name = 41;
     libs[0].soname = 73;
+    libs[0].rpath = intern.STR_NIL;
     libs[1].name = 42;
     libs[1].soname = 73;
+    libs[1].rpath = intern.STR_NIL;
     libs[2].name = 43;
     libs[2].soname = 74;
+    libs[2].rpath = intern.STR_NIL;
 
     val logical: O.Option[u32] = dynlib_index_of(?libs[0], 3, 41);
     val alias: O.Option[u32] = dynlib_index_of(?libs[0], 3, 42);
@@ -4176,8 +4193,10 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     var collision: [2]of.DynLib;
     collision[0].name = 41;
     collision[0].soname = 73;
+    collision[0].rpath = intern.STR_NIL;
     collision[1].name = 73;
     collision[1].soname = 74;
+    collision[1].rpath = intern.STR_NIL;
     var first: u32 = 0;
     var second: u32 = 0;
     var identity: intern.StrId = intern.STR_NIL;

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3160,21 +3160,29 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         implicit = 1;
     }
 
-    # copy the caller's dependencies in input order, then append the implicit
-    # platform library using its loader name as its logical identity.
-    val total_libs: u32 = dynlib_count + implicit;
+    # Emit each canonical loader dependency once even when several logical names
+    # alias it. Attribution below maps every alias back to this compact index.
+    val explicit_libs: u32 = unique_dynlib_count(dynlibs, dynlib_count);
+    if (implicit == 1 && dynlib_soname_present(dynlibs, dynlib_count, implicit_soname)) {
+        implicit = 0;
+    }
+    val total_libs: u32 = explicit_libs + implicit;
     if (total_libs > 0) {
         val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, total_libs::usize);
         if (R.is_err[*of.DynLib, str](lr)) { ret R.err[bool, str](R.unwrap_err[*of.DynLib, str](lr)); }
         dyn.info.libs = R.unwrap_ok[*of.DynLib, str](lr);
         var i: u32 = 0;
+        var w: u32 = 0;
         for (i < dynlib_count) {
-            dyn.info.libs[i] = dynlibs[i];
+            if (!dynlib_soname_seen_before(dynlibs, i, dynlibs[i].soname)) {
+                dyn.info.libs[w] = dynlibs[i];
+                w = w + 1;
+            }
             i = i + 1;
         }
         if (implicit == 1) {
-            dyn.info.libs[dynlib_count].name   = implicit_soname;
-            dyn.info.libs[dynlib_count].soname = implicit_soname;
+            dyn.info.libs[explicit_libs].name   = implicit_soname;
+            dyn.info.libs[explicit_libs].soname = implicit_soname;
         }
         dyn.info.lib_count = total_libs;
     }
@@ -3260,9 +3268,9 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     ret R.ok[bool, str](true);
 }
 
-# the index of `lib` in the dependency list, or none when no dependency carries
-# that logical name or loader name. names are interned in the session, so equal
-# names share a StrId and the match is an identity comparison
+# the emitted dependency index of `lib`, or none when no dependency carries that
+# logical name or loader name. aliases sharing one loader name map to the same
+# compact index. names are interned in the session, so matching is by identity
 # ---
 # dynlibs:      the dependency logical and loader names
 # dynlib_count: number of dependencies
@@ -3271,10 +3279,57 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
 fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32, lib: intern.StrId) O.Option[u32] {
     var i: u32 = 0;
     for (i < dynlib_count) {
-        if (dynlibs[i].name == lib || dynlibs[i].soname == lib) { ret O.some[u32](i); }
+        if (dynlibs[i].name == lib || dynlibs[i].soname == lib) {
+            var index: u32 = 0;
+            var j: u32 = 0;
+            for (j < dynlib_count) {
+                if (!dynlib_soname_seen_before(dynlibs, j, dynlibs[j].soname)) {
+                    if (dynlibs[j].soname == dynlibs[i].soname) {
+                        ret O.some[u32](index);
+                    }
+                    index = index + 1;
+                }
+                j = j + 1;
+            }
+        }
         i = i + 1;
     }
     ret O.none[u32]();
+}
+
+# whether `soname` appeared before index `end`
+fun dynlib_soname_seen_before(dynlibs: *of.DynLib, end: u32,
+                              soname: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < end) {
+        if (dynlibs[i].soname == soname) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# whether the dependency requirements contain a canonical loader name
+fun dynlib_soname_present(dynlibs: *of.DynLib, count: u32,
+                          soname: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < count) {
+        if (dynlibs[i].soname == soname) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# number of distinct canonical loader dependencies in the requirement list
+fun unique_dynlib_count(dynlibs: *of.DynLib, count: u32) u32 {
+    var unique: u32 = 0;
+    var i: u32 = 0;
+    for (i < count) {
+        if (!dynlib_soname_seen_before(dynlibs, i, dynlibs[i].soname)) {
+            unique = unique + 1;
+        }
+        i = i + 1;
+    }
+    ret unique;
 }
 
 # whether an object symbol is an undefined external - a
@@ -4035,16 +4090,24 @@ fun lt_isa(reg: *target.TargetRegistry, name: str) *isa.IsaVTable {
 # library attribution accepts both a portable logical name and the exact loader
 # name retained for compatibility
 test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
-    var libs: [1]of.DynLib;
+    var libs: [3]of.DynLib;
     libs[0].name = 41;
     libs[0].soname = 73;
+    libs[1].name = 42;
+    libs[1].soname = 73;
+    libs[2].name = 43;
+    libs[2].soname = 74;
 
-    val logical: O.Option[u32] = dynlib_index_of(?libs[0], 1, 41);
-    val loader: O.Option[u32] = dynlib_index_of(?libs[0], 1, 73);
-    val missing: O.Option[u32] = dynlib_index_of(?libs[0], 1, 99);
+    val logical: O.Option[u32] = dynlib_index_of(?libs[0], 3, 41);
+    val alias: O.Option[u32] = dynlib_index_of(?libs[0], 3, 42);
+    val loader: O.Option[u32] = dynlib_index_of(?libs[0], 3, 73);
+    val other: O.Option[u32] = dynlib_index_of(?libs[0], 3, 74);
+    val missing: O.Option[u32] = dynlib_index_of(?libs[0], 3, 99);
     if (!O.is_some[u32](logical) || O.unwrap[u32](logical) != 0) { ret 1; }
+    if (!O.is_some[u32](alias) || O.unwrap[u32](alias) != 0)     { ret 1; }
     if (!O.is_some[u32](loader) || O.unwrap[u32](loader) != 0)   { ret 1; }
-    if (O.is_some[u32](missing))                                 { ret 1; }
+    if (!O.is_some[u32](other) || O.unwrap[u32](other) != 1)     { ret 1; }
+    if (O.is_some[u32](missing) || unique_dynlib_count(?libs[0], 3) != 2) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3135,6 +3135,16 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
                        sec_base: *u32, atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
+    var collision_first: u32 = 0;
+    var collision_second: u32 = 0;
+    var collision_identity: intern.StrId = intern.STR_NIL;
+    if (dynlib_identity_collision(dynlibs, dynlib_count, ?collision_first,
+                                  ?collision_second, ?collision_identity)) {
+        ret R.err[bool, str](dynlib_identity_conflict_message(
+            s, collision_identity, dynlibs[collision_first].soname,
+            dynlibs[collision_second].soname));
+    }
+
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
     # (ELF); a format that embeds the loader differently (PE's import directory,
     # Mach-O's dyld bind) supplies an empty path and the format writer ignores it.
@@ -3294,6 +3304,59 @@ fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32, lib: intern.StrId) O
         i = i + 1;
     }
     ret O.none[u32]();
+}
+
+# find an identity that names two distinct loader dependencies
+#
+# a `#[library]` value may match either a logical name or an exact loader name.
+# those namespaces may overlap only when both spellings identify the same loader;
+# otherwise attribution would depend on requirement order.
+fun dynlib_identity_collision(dynlibs: *of.DynLib, count: u32,
+                              first: *u32, second: *u32,
+                              identity: *intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < count) {
+        var j: u32 = i + 1;
+        for (j < count) {
+            if (dynlibs[i].soname != dynlibs[j].soname) {
+                var hit: intern.StrId = intern.STR_NIL;
+                if (dynlibs[i].name == dynlibs[j].name) {
+                    hit = dynlibs[i].name;
+                }
+                or (dynlibs[i].name == dynlibs[j].soname) {
+                    hit = dynlibs[i].name;
+                }
+                or (dynlibs[i].soname == dynlibs[j].name) {
+                    hit = dynlibs[i].soname;
+                }
+                if (hit != intern.STR_NIL) {
+                    @first = i;
+                    @second = j;
+                    @identity = hit;
+                    ret true;
+                }
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# render a cross-namespace dynamic dependency collision
+fun dynlib_identity_conflict_message(s: *session.Session, identity: intern.StrId,
+                                     first: intern.StrId, second: intern.StrId) str {
+    val n: O.Option[str] = intern.lookup(?s.interner, identity);
+    val a: O.Option[str] = intern.lookup(?s.interner, first);
+    val b: O.Option[str] = intern.lookup(?s.interner, second);
+    if (!O.is_some[str](n) || !O.is_some[str](a) || !O.is_some[str](b)) {
+        ret "one link library identity names multiple loader dependencies";
+    }
+    val fallback: str = "one link library identity names multiple loader dependencies";
+    val head: str = join3(s, "link library identity '", O.unwrap[str](n),
+        "' names both loader dependencies '", fallback);
+    val middle: str = join3(s, head, O.unwrap[str](a), "' and '", fallback);
+    ret join3(s, middle, O.unwrap[str](b), "'", fallback);
 }
 
 # whether `soname` appeared before index `end`
@@ -4107,6 +4170,25 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     if (!O.is_some[u32](loader) || O.unwrap[u32](loader) != 0)   { ret 1; }
     if (!O.is_some[u32](other) || O.unwrap[u32](other) != 1)     { ret 1; }
     if (O.is_some[u32](missing) || unique_dynlib_count(?libs[0], 3) != 2) { ret 1; }
+
+    # a logical name may alias the same loader, but it may not equal another
+    # dependency's loader name: that spelling would select two providers.
+    var collision: [2]of.DynLib;
+    collision[0].name = 41;
+    collision[0].soname = 73;
+    collision[1].name = 73;
+    collision[1].soname = 74;
+    var first: u32 = 0;
+    var second: u32 = 0;
+    var identity: intern.StrId = intern.STR_NIL;
+    if (!dynlib_identity_collision(?collision[0], 2, ?first, ?second, ?identity)) { ret 1; }
+    if (first != 0 || second != 1 || identity != 73) { ret 1; }
+
+    var reversed: [2]of.DynLib;
+    reversed[0] = collision[1];
+    reversed[1] = collision[0];
+    if (!dynlib_identity_collision(?reversed[0], 2, ?first, ?second, ?identity)) { ret 1; }
+    if (identity != 73) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -239,7 +239,7 @@ rec StrMerge {
 # input relocations forward and writes a single merged object through `obj.emit`.
 #
 # DYNAMIC vs STATIC resolution of an undefined `ext` symbol: when no shared
-# dependencies are supplied (`soname_count == 0`) every undefined `ext` must be
+# dependencies are supplied (`dynlib_count == 0`) every undefined `ext` must be
 # satisfied by an input object/archive or the link fails - the fully static path,
 # emitted byte-for-byte as before through `emit_exec`. when shared dependencies
 # are supplied, any `ext` left undefined after merging is taken as a DYNAMIC
@@ -255,15 +255,15 @@ rec StrMerge {
 # tgt:          active target - selects OS base address, entry symbol, and writers
 # obj_paths:    array of null-terminated paths to the per-module object files
 # obj_count:    number of input object files
-# sonames:      interned shared-library sonames to depend on dynamically (or nil)
-# soname_count: number of shared-library dependencies
+# dynlibs:      logical names and loader names of dynamic dependencies (or nil)
+# dynlib_count: number of dynamic dependencies
 # out_path:     null-terminated output file path
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # pie:          the build opted into a position-independent executable (`--pie`)
 # ret:          true once the artifact is written, or an error string
 pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
-             obj_count: u32, sonames: *intern.StrId, soname_count: u32,
+             obj_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
              out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
@@ -289,7 +289,7 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     # the parsed images are owned here (read from disk), so they are torn down
     # after linking regardless of outcome.
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, modules, module_count, 0, sonames, soname_count,
+        link_modules(s, tgt, modules, module_count, 0, dynlibs, dynlib_count,
                      out_path, name, mode, pie);
     free_modules(alloc, modules, module_count);
     ret r;
@@ -310,15 +310,15 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
 # tgt:          active target - selects OS base address, entry symbol, and writers
 # images:       the in-memory codegen images, one per module
 # image_count:  number of images
-# sonames:      interned shared-library sonames to depend on dynamically (or nil)
-# soname_count: number of shared-library dependencies
+# dynlibs:      logical names and loader names of dynamic dependencies (or nil)
+# dynlib_count: number of dynamic dependencies
 # out_path:     null-terminated output file path
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # pie:          the build opted into a position-independent executable (`--pie`)
 # ret:          true once the artifact is written, or an error string
 pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
-                    image_count: u32, sonames: *intern.StrId, soname_count: u32,
+                    image_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
                     out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
@@ -327,8 +327,8 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     if (images == nil || image_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
-    ret link_modules(s, tgt, images, image_count, image_count, sonames,
-                     soname_count, out_path, name, mode, pie);
+    ret link_modules(s, tgt, images, image_count, image_count, dynlibs,
+                     dynlib_count, out_path, name, mode, pie);
 }
 
 # combine the project's in-memory codegen images with on-disk external link
@@ -354,8 +354,8 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
 # image_count:  number of project images
 # obj_paths:    null-terminated paths to external input objects/archives, or nil
 # obj_count:    number of external input paths
-# sonames:      interned shared-library sonames to depend on dynamically (or nil)
-# soname_count: number of shared-library dependencies
+# dynlibs:      logical names and loader names of dynamic dependencies (or nil)
+# dynlib_count: number of dynamic dependencies
 # out_path:     null-terminated output file path
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
@@ -364,7 +364,7 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
 pub fun link_mixed(s: *session.Session, tgt: *target.Target,
                    images: *of.ObjectImage, image_count: u32,
                    obj_paths: **u8, obj_count: u32,
-                   sonames: *intern.StrId, soname_count: u32,
+                   dynlibs: *of.DynLib, dynlib_count: u32,
                    out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
@@ -405,7 +405,7 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
     for (j < ext_count) { combined[image_count + j] = ext[j]; j = j + 1; }
 
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, combined, total, image_count, sonames, soname_count,
+        link_modules(s, tgt, combined, total, image_count, dynlibs, dynlib_count,
                      out_path, name, mode, pie);
 
     # tear down only the parsed external images (the project images are caller-owned)
@@ -437,8 +437,8 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 # modules:      the input module images (caller-owned)
 # module_count: number of modules
 # codegen_count: number of leading in-memory compiler images; the rest were parsed
-# sonames:      interned shared-library sonames to depend on dynamically (or nil)
-# soname_count: number of shared-library dependencies
+# dynlibs:      logical names and loader names of dynamic dependencies (or nil)
+# dynlib_count: number of dynamic dependencies
 # out_path:     null-terminated output file path
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
@@ -446,7 +446,7 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 # ret:          true once the artifact is written, or an error string
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
-                 sonames: *intern.StrId, soname_count: u32,
+                 dynlibs: *of.DynLib, dynlib_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     # a shared object is always position-independent: the loader maps it at an
@@ -461,7 +461,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # a dynamic link is requested when shared dependencies are present or the image
     # is position-independent, and the output is an executable; libraries/
     # relocatables ignore dependencies.
-    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0 || pie);
+    val dynamic: bool = (mode == LINK_EXE) && (dynlib_count > 0 || pie);
     # both a PIE executable and a shared object need a position-independent layout
     # (based a page above the OS base, with a base-relocation set collected during
     # patching).
@@ -633,7 +633,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         if (dynamic) {
             val dr: R.Result[bool, str] =
                 build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs,
-                                   sonames, soname_count, sec_base, ?atoms);
+                                   dynlibs, dynlib_count, sec_base, ?atoms);
             if (R.is_err[bool, str](dr)) {
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
@@ -3126,13 +3126,13 @@ fun has_call_reloc(modules: *of.ObjectImage, module_count: u32,
 # modules:      the input image array (source of the undefined externs)
 # module_count: number of input images
 # sym_locs:     the global symbol table; a name found here is not an import
-# sonames:      interned shared-library sonames to depend on
-# soname_count: number of shared-library dependencies
+# dynlibs:      logical names and loader names of dynamic dependencies
+# dynlib_count: number of dynamic dependencies
 # ret:          ok(true) on success, or an error string
 fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
                        modules: *of.ObjectImage, module_count: u32,
                        sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                       sonames: *intern.StrId, soname_count: u32,
+                       dynlibs: *of.DynLib, dynlib_count: u32,
                        sec_base: *u32, atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
@@ -3150,7 +3150,7 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
 
     # a PIE image implicitly links the OS platform library (darwin libSystem): a
     # dyld-loaded executable that names no LC_LOAD_DYLIB is rejected, so it is
-    # recorded as a trailing dependency after the manifest sonames.
+    # recorded as a trailing dependency after the manifest dependencies.
     var implicit: u32 = 0;
     var implicit_soname: intern.StrId = intern.STR_NIL;
     if (dyn.info.pie && !str_empty(tgt.os.platform_lib)) {
@@ -3160,18 +3160,22 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         implicit = 1;
     }
 
-    # one DynLib per soname, in input order, then the implicit platform library.
-    val total_libs: u32 = soname_count + implicit;
+    # copy the caller's dependencies in input order, then append the implicit
+    # platform library using its loader name as its logical identity.
+    val total_libs: u32 = dynlib_count + implicit;
     if (total_libs > 0) {
         val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, total_libs::usize);
         if (R.is_err[*of.DynLib, str](lr)) { ret R.err[bool, str](R.unwrap_err[*of.DynLib, str](lr)); }
         dyn.info.libs = R.unwrap_ok[*of.DynLib, str](lr);
         var i: u32 = 0;
-        for (i < soname_count) {
-            dyn.info.libs[i].soname = sonames[i];
+        for (i < dynlib_count) {
+            dyn.info.libs[i] = dynlibs[i];
             i = i + 1;
         }
-        if (implicit == 1) { dyn.info.libs[soname_count].soname = implicit_soname; }
+        if (implicit == 1) {
+            dyn.info.libs[dynlib_count].name   = implicit_soname;
+            dyn.info.libs[dynlib_count].soname = implicit_soname;
+        }
         dyn.info.lib_count = total_libs;
     }
 
@@ -3219,7 +3223,7 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
 
             val idx: u32 = dyn.info.import_count;
             dyn.info.imports[idx].symbol    = sym.name;
-            # pin the import to the library a `$<sym>.library` directive named, when
+            # pin the import to the library its `#[library]` attribution named, when
             # present. a directive naming a library not among this link's
             # dependencies is a hard error. an unattributed import stays DYNLIB_ANY
             # on a flat-namespace format (ELF), but is a hard error on a two-level
@@ -3228,12 +3232,12 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             val lib_opt: O.Option[intern.StrId] = session.import_library(s, sym.name);
             if (O.is_some[intern.StrId](lib_opt)) {
                 val want: intern.StrId = O.unwrap[intern.StrId](lib_opt);
-                val li_opt: O.Option[u32] = soname_index_of(sonames, soname_count, want);
+                val li_opt: O.Option[u32] = dynlib_index_of(dynlibs, dynlib_count, want);
                 if (!O.is_some[u32](li_opt)) { ret R.err[bool, str](pinned_lib_message(s, sym.name, want)); }
                 dyn.info.imports[idx].lib_index = O.unwrap[u32](li_opt);
             }
             or (tgt.of.two_level_namespace) {
-                ret R.err[bool, str](unattributed_import_message(s, sym.name, sonames, soname_count));
+                ret R.err[bool, str](unattributed_import_message(s, sym.name, dynlibs, dynlib_count));
             }
             or {
                 dyn.info.imports[idx].lib_index = of.DYNLIB_ANY;
@@ -3256,18 +3260,18 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     ret R.ok[bool, str](true);
 }
 
-# the index of `lib` in the dependency soname list, or none when
-# no dependency carries that name. names are interned in the session, so equal
+# the index of `lib` in the dependency list, or none when no dependency carries
+# that logical name or loader name. names are interned in the session, so equal
 # names share a StrId and the match is an identity comparison
 # ---
-# sonames:      the dependency soname list
-# soname_count: number of dependencies
+# dynlibs:      the dependency logical and loader names
+# dynlib_count: number of dependencies
 # lib:          the interned library name to find
 # ret:          the dependency index, or none when no dependency carries that name
-fun soname_index_of(sonames: *intern.StrId, soname_count: u32, lib: intern.StrId) O.Option[u32] {
+fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32, lib: intern.StrId) O.Option[u32] {
     var i: u32 = 0;
-    for (i < soname_count) {
-        if (sonames[i] == lib) { ret O.some[u32](i); }
+    for (i < dynlib_count) {
+        if (dynlibs[i].name == lib || dynlibs[i].soname == lib) { ret O.some[u32](i); }
         i = i + 1;
     }
     ret O.none[u32]();
@@ -3690,16 +3694,16 @@ fun pinned_lib_message(s: *session.Session, sym_name: intern.StrId, lib: intern.
 # build the diagnostic for a dynamic import with no `#[library]` attribution on a
 # two-level-namespace format (PE, Mach-O), where the image must name a providing
 # library per import. names the symbol, points at `#[library]`, and lists the
-# link's dependency sonames as the candidate libraries to attribute to. degrades
+# link's logical dependency names as candidate libraries to attribute to. degrades
 # to a symbol-less form when the name cannot be resolved
 # ---
 # s:            shared session holding the interner
 # sym_name:     interned name of the unattributed import
-# sonames:      the link's dependency soname list (candidate libraries)
-# soname_count: number of dependencies
+# dynlibs:      the link's dynamic dependencies
+# dynlib_count: number of dependencies
 # ret:          the diagnostic string
 fun unattributed_import_message(s: *session.Session, sym_name: intern.StrId,
-                                sonames: *intern.StrId, soname_count: u32) str {
+                                dynlibs: *of.DynLib, dynlib_count: u32) str {
     val sno: O.Option[str] = intern.lookup(?s.interner, sym_name);
     if (!O.is_some[str](sno)) {
         ret "dynamic import has no #[library] attribution; a two-level-namespace target requires every import to name its providing library with #[library(\"...\")]";
@@ -3707,26 +3711,35 @@ fun unattributed_import_message(s: *session.Session, sym_name: intern.StrId,
     val head: str = join3(s, "dynamic import '", O.unwrap[str](sno),
         "' has no #[library] attribution; a two-level-namespace target requires every import to name its providing library - annotate the declaration with #[library(\"...\")]",
         "dynamic import has no #[library] attribution");
-    val cands: str = join_sonames(s, sonames, soname_count);
+    val cands: str = join_dynlibs(s, dynlibs, dynlib_count);
     if (str_len(cands) == 0) { ret head; }
     val pre: str = join2(s, head, "; candidate libraries: ", head);
     ret join2(s, pre, cands, pre);
 }
 
-# join a link's dependency sonames into a "a, b, c" list for a diagnostic. an
-# unresolvable name is skipped; the empty list yields the empty string
+# join a link's dynamic dependencies into a "name (loader), ..." list for a
+# diagnostic. an unresolvable name is skipped; the empty list yields the empty
+# string. dependencies whose logical and loader names match display only once
 # ---
 # s:            shared session (allocator, interner)
-# sonames:      the dependency soname list
-# soname_count: number of dependencies
-# ret:          the comma-separated soname list, or "" when none resolve
-fun join_sonames(s: *session.Session, sonames: *intern.StrId, soname_count: u32) str {
+# dynlibs:      the dynamic dependencies
+# dynlib_count: number of dependencies
+# ret:          the comma-separated dependency list, or "" when none resolve
+fun join_dynlibs(s: *session.Session, dynlibs: *of.DynLib, dynlib_count: u32) str {
     var acc: str = "";
     var i: u32 = 0;
-    for (i < soname_count) {
-        val nm: O.Option[str] = intern.lookup(?s.interner, sonames[i]);
+    for (i < dynlib_count) {
+        val nm: O.Option[str] = intern.lookup(?s.interner, dynlibs[i].name);
         if (!O.is_some[str](nm)) { i = i + 1; cnt; }
-        val piece: str = O.unwrap[str](nm);
+        var piece: str = O.unwrap[str](nm);
+        if (dynlibs[i].soname != dynlibs[i].name) {
+            val so: O.Option[str] = intern.lookup(?s.interner, dynlibs[i].soname);
+            if (O.is_some[str](so)) {
+                val pre: str = join2(s, piece, " (", piece);
+                piece = join2(s, pre, O.unwrap[str](so), pre);
+                piece = join2(s, piece, ")", piece);
+            }
+        }
         if (str_len(acc) == 0) { acc = piece; }
         or {
             val sep: str = join2(s, acc, ", ", acc);
@@ -4017,6 +4030,22 @@ fun lt_isa(reg: *target.TargetRegistry, name: str) *isa.IsaVTable {
     val found: O.Option[*isa.IsaVTable] = isa.lookup(?reg.isa, name);
     if (!O.is_some[*isa.IsaVTable](found)) { ret nil; }
     ret O.unwrap[*isa.IsaVTable](found);
+}
+
+# library attribution accepts both a portable logical name and the exact loader
+# name retained for compatibility
+test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
+    var libs: [1]of.DynLib;
+    libs[0].name = 41;
+    libs[0].soname = 73;
+
+    val logical: O.Option[u32] = dynlib_index_of(?libs[0], 1, 41);
+    val loader: O.Option[u32] = dynlib_index_of(?libs[0], 1, 73);
+    val missing: O.Option[u32] = dynlib_index_of(?libs[0], 1, 99);
+    if (!O.is_some[u32](logical) || O.unwrap[u32](logical) != 0) { ret 1; }
+    if (!O.is_some[u32](loader) || O.unwrap[u32](loader) != 0)   { ret 1; }
+    if (O.is_some[u32](missing))                                 { ret 1; }
+    ret 0;
 }
 
 # weak/strong symbol resolution is order-independent (#1257)

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -8,9 +8,10 @@
 # dispatch drives these; the dispatcher-synthesis flow in `build.testing`
 # shares the object writer and the external-link-input assembly.
 
-use fs: std.filesystem;
+use std.allocator.page;
 use std.collections.vector;
 use std.collections.vector.Vector;
+use fs: std.filesystem;
 use std.io.writer;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -589,8 +590,15 @@ fun append_dynlib(p: *driver.Project, li: *plan.LinkInput,
     val res_intern: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, li.text);
     if (R.is_err[intern.StrId, str](res_intern)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
     val soname: intern.StrId = R.unwrap_ok[intern.StrId, str](res_intern);
-    var name: intern.StrId = li.library;
-    if (name == intern.STR_NIL) { name = soname; }
+    var name: intern.StrId = soname;
+    if (!str_empty(li.library)) {
+        val name_r: R.Result[intern.StrId, str] =
+            intern.intern(?p.s.interner, li.library);
+        if (R.is_err[intern.StrId, str](name_r)) {
+            ret R.err[bool, outcome.Fail](outcome.internal("out of memory"));
+        }
+        name = R.unwrap_ok[intern.StrId, str](name_r);
+    }
     var rpath: intern.StrId = intern.STR_NIL;
     if (!str_empty(li.rpath)) {
         val rp_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, li.rpath);
@@ -623,6 +631,41 @@ fun append_dynlib(p: *driver.Project, li: *plan.LinkInput,
     (@dynlibs)[old].rpath = rpath;
     @dynlib_len = old + 1;
     ret R.ok[bool, outcome.Fail](true);
+}
+
+# logical names cross the plan boundary as text and are interned by the active
+# execution session, never reused as ids from the planning session
+test "mach.lang.build.emit.append_dynlib:reinterns_logical_name" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var p: driver.Project;
+    p.s = ?s;
+    p.alloc = ?alloc;
+    var li: plan.LinkInput;
+    li.kind = plan.LINK_DYNAMIC;
+    li.text = "libfoo.so.1";
+    li.library = "foo";
+    li.rpath = "";
+    var libs: *of.DynLib = nil;
+    var len: u32 = 0;
+    val ar: R.Result[bool, outcome.Fail] = append_dynlib(?p, ?li, ?libs, ?len);
+    if (R.is_err[bool, outcome.Fail](ar) || len != 1) {
+        session.dnit(?s);
+        ret 1;
+    }
+    val name: O.Option[str] = intern.lookup(?s.interner, libs[0].name);
+    val loader: O.Option[str] = intern.lookup(?s.interner, libs[0].soname);
+    val bad: bool = !O.is_some[str](name) || !O.is_some[str](loader)
+        || !str_equals(O.unwrap[str](name), "foo")
+        || !str_equals(O.unwrap[str](loader), "libfoo.so.1");
+    free_dynlibs(?alloc, libs, len);
+    session.dnit(?s);
+    if (bad) { ret 1; }
+    ret 0;
 }
 
 # explain an ambiguous portable identity without losing the canonical loader

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -18,6 +18,7 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_copy;
+use std.types.string.str_empty;
 use std.types.string.str_equals;
 use std.types.string.str_join;
 use std.types.string.str_len;
@@ -575,8 +576,8 @@ fun shrink_paths(p: *driver.Project, paths: ***u8, len: *u32, written: u32, grow
     @len = grown;
 }
 
-# append a shared library's logical and loader names to the dynamic dependency
-# list, rejecting ambiguous logical identities and growing it one slot at a time
+# append a shared library's logical name, loader name, and optional Mach-O run
+# path to the dynamic dependency list, rejecting ambiguous logical identities
 # ---
 # p:          the project (for its interner and build allocator)
 # li:         the resolved dynamic link input
@@ -590,11 +591,22 @@ fun append_dynlib(p: *driver.Project, li: *plan.LinkInput,
     val soname: intern.StrId = R.unwrap_ok[intern.StrId, str](res_intern);
     var name: intern.StrId = li.library;
     if (name == intern.STR_NIL) { name = soname; }
+    var rpath: intern.StrId = intern.STR_NIL;
+    if (!str_empty(li.rpath)) {
+        val rp_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, li.rpath);
+        if (R.is_err[intern.StrId, str](rp_r)) {
+            ret R.err[bool, outcome.Fail](outcome.internal("out of memory"));
+        }
+        rpath = R.unwrap_ok[intern.StrId, str](rp_r);
+    }
 
     var i: u32 = 0;
     for (i < @dynlib_len) {
         if ((@dynlibs)[i].name == name) {
-            if ((@dynlibs)[i].soname == soname) { ret R.ok[bool, outcome.Fail](true); }
+            if ((@dynlibs)[i].soname == soname) {
+                if ((@dynlibs)[i].rpath == intern.STR_NIL) { (@dynlibs)[i].rpath = rpath; }
+                ret R.ok[bool, outcome.Fail](true);
+            }
             ret R.err[bool, outcome.Fail](outcome.user(dynlib_conflict_message(
                 p, name, (@dynlibs)[i].soname, soname)));
         }
@@ -608,6 +620,7 @@ fun append_dynlib(p: *driver.Project, li: *plan.LinkInput,
     @dynlibs = R.unwrap_ok[*of.DynLib, str](res_grow);
     (@dynlibs)[old].name = name;
     (@dynlibs)[old].soname = soname;
+    (@dynlibs)[old].rpath = rpath;
     @dynlib_len = old + 1;
     ret R.ok[bool, outcome.Fail](true);
 }

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -35,6 +35,7 @@ use mach.lang.be.linker;
 use mach.lang.be.obj;
 use mach.lang.driver;
 use mach.lang.intern;
+use mach.lang.manifest;
 use mach.lang.me.ir;
 use mach.lang.me.ir.printer;
 use mach.lang.session;
@@ -495,9 +496,7 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
     if (te != nil) {
         var i: u32 = 0;
         for (i < te.lib_count) {
-            val opt_lib: O.Option[str] = intern.lookup(?p.s.interner, te.libs[i]);
-            if (O.is_none[str](opt_lib)) { ret uninterned_lib_fail(); }
-            val rc: R.Result[bool, outcome.Fail] = resolve_and_store_input(p, O.unwrap[str](opt_lib)::*u8,
+            val rc: R.Result[bool, outcome.Fail] = resolve_and_store_input(p, ?te.libs[i],
                                                     @paths, ?written, sonames, soname_len);
             if (R.is_err[bool, outcome.Fail](rc)) { shrink_paths(p, paths, len, written, grown); ret rc; }
             i = i + 1;
@@ -506,9 +505,7 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
 
     var i: u32 = 0;
     for (i < p.config.cascade_lib_count) {
-        val opt_lib: O.Option[str] = intern.lookup(?p.s.interner, p.config.cascade_libs[i]);
-        if (O.is_none[str](opt_lib)) { ret uninterned_lib_fail(); }
-        val rc: R.Result[bool, outcome.Fail] = resolve_and_store_input(p, O.unwrap[str](opt_lib)::*u8,
+        val rc: R.Result[bool, outcome.Fail] = resolve_and_store_input(p, ?p.config.cascade_libs[i],
                                                 @paths, ?written, sonames, soname_len);
         if (R.is_err[bool, outcome.Fail](rc)) { shrink_paths(p, paths, len, written, grown); ret rc; }
         i = i + 1;
@@ -549,17 +546,6 @@ fun store_fact(p: *driver.Project, li: *plan.LinkInput, paths: **u8, written: *u
     paths[@written] = R.unwrap_ok[str, str](dup_r);
     @written = @written + 1;
     ret R.ok[bool, outcome.Fail](true);
-}
-
-# the internal bail for a manifest lib name that failed to intern-lookup
-#
-# a manifest lib name is always interned by config load, so this guards a
-# compiler invariant rather than a user condition; if it ever fires, the
-# message names the broken invariant instead of exiting silently
-# ---
-# ret: an internal Fail deriving exit code 2
-fun uninterned_lib_fail() R.Result[bool, outcome.Fail] {
-    ret R.err[bool, outcome.Fail](outcome.internal("manifest lib name not interned (compiler bug)"));
 }
 
 # shrink the over-grown object-path array to its true object count and set `*len`
@@ -634,10 +620,13 @@ pub fun free_sonames(a: *A.Allocator, sonames: *intern.StrId, soname_len: u32) {
 # sonames:    the dynamic-dependency soname array to grow
 # soname_len: the soname count
 # ret:        ok(true) on success, or the failure as a Fail
-fun resolve_and_store_input(p: *driver.Project, tok: *u8, paths: **u8, written: *u32,
+fun resolve_and_store_input(p: *driver.Project, req: *manifest.LinkRequirement,
+                            paths: **u8, written: *u32,
                             sonames: **intern.StrId, soname_len: *u32) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
-    val lr: R.Result[plan.LinkInput, outcome.Fail] = plan.resolve_token(p.alloc, ?p.target, ?ctx.req.lib_dirs, ctx.req.project_root, tok);
+    val lr: R.Result[plan.LinkInput, outcome.Fail] =
+        plan.resolve_requirement(p.alloc, ?p.s.interner, ?p.target,
+                                 ?ctx.req.lib_dirs, ctx.req.project_root, req);
     if (R.is_err[plan.LinkInput, outcome.Fail](lr)) {
         ret R.err[bool, outcome.Fail](R.unwrap_err[plan.LinkInput, outcome.Fail](lr));
     }

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -18,6 +18,7 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_copy;
+use std.types.string.str_equals;
 use std.types.string.str_join;
 use std.types.string.str_len;
 use std.types.string.str_replace;
@@ -525,9 +526,9 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
 
 # store one plan-resolved link fact into the right bucket
 #
-# A STATIC fact's path is duplicated onto the build allocator (the plan owns
-# its copy; `free_paths` frees these at their exact size); a DYNAMIC fact's
-# logical and loader names are interned.
+# A STATIC fact not already present is duplicated onto the build allocator (the
+# plan owns its copy; `free_paths` frees these at their exact size); a DYNAMIC
+# fact's logical and loader names are interned.
 # ---
 # p:          the project (for its build allocator and interner)
 # li:         the plan-resolved fact
@@ -540,6 +541,9 @@ fun store_fact(p: *driver.Project, li: *plan.LinkInput, paths: **u8, written: *u
                dynlibs: **of.DynLib, dynlib_len: *u32) R.Result[bool, outcome.Fail] {
     if (li.kind == plan.LINK_DYNAMIC) {
         ret append_dynlib(p, li, dynlibs, dynlib_len);
+    }
+    if (static_path_present(paths, @written, li.text)) {
+        ret R.ok[bool, outcome.Fail](true);
     }
     val dup_r: R.Result[str, str] = str_copy(p.alloc, li.text::*u8);
     if (R.is_err[str, str](dup_r)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
@@ -667,9 +671,33 @@ fun resolve_and_store_input(p: *driver.Project, req: *manifest.LinkRequirement,
         ret append_dynlib(p, ?li, dynlibs, dynlib_len);
     }
     # the STATIC text is already an exact-size copy on the build allocator.
+    if (static_path_present(paths, @written, li.text)) {
+        A.deallocate[u8](p.alloc, li.text::*u8, str_len(li.text) + 1);
+        ret R.ok[bool, outcome.Fail](true);
+    }
     paths[@written] = li.text::*u8;
     @written = @written + 1;
     ret R.ok[bool, outcome.Fail](true);
+}
+
+# whether an exact static input path is already in the written prefix
+fun static_path_present(paths: **u8, written: u32, candidate: str) bool {
+    var i: u32 = 0;
+    for (i < written) {
+        if (paths[i] != nil && str_equals(paths[i]::str, candidate)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+test "mach.lang.build.emit.static_path_present:deduplicates_exact_paths" {
+    var paths: [3]*u8;
+    paths[0] = "one.o"::*u8;
+    paths[1] = "libsame.a"::*u8;
+    paths[2] = nil;
+    if (!static_path_present(?paths[0], 2, "libsame.a")) { ret 1; }
+    if (static_path_present(?paths[0], 2, "other.a")) { ret 1; }
+    ret 0;
 }
 
 # write each per-module image to an object whose path mirrors the module FQN

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -640,12 +640,13 @@ pub fun free_dynlibs(a: *A.Allocator, dynlibs: *of.DynLib, dynlib_len: u32) {
 #
 # The manifest overlay and cascade libs resolve here, at link time (a build
 # step may have just produced them), through the planner-owned
-# `plan.resolve_token` - the same probing order and error text as the plan's
-# own tokens. A STATIC result is stored into `paths[*written]`; a DYNAMIC one
-# has its logical and loader names appended to `*dynlibs`.
+# `plan.resolve_requirement`, which preserves the typed source semantics while
+# sharing token probing and errors with the plan. A STATIC result is stored into
+# `paths[*written]`; a DYNAMIC one has its logical and loader names appended to
+# `*dynlibs`.
 # ---
 # p:          the project carrying the target, session, and settled request
-# tok:        the link-input token to resolve
+# req:        the typed manifest link requirement to resolve
 # paths:      the static object-path array to append into
 # written:    the next free index in `paths`, advanced on a static input
 # dynlibs:    the dynamic-dependency array to grow

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -305,7 +305,7 @@ pub fun emit_shared_library(p: *driver.Project, unit: *plan.BuildUnit, paths: **
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, nil::*intern.StrId, 0, solib, artifact_product_name(p), linker.LINK_SHARED, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, len, nil::*of.DynLib, 0, solib, artifact_product_name(p), linker.LINK_SHARED, ctx.req.pie);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -316,21 +316,21 @@ pub fun emit_shared_library(p: *driver.Project, unit: *plan.BuildUnit, paths: **
 # link the object set into the executable at `exe_path`
 #
 # The final emission step of the executable path: the caller assembled the
-# on-disk object paths and the dynamic-dependency sonames, and consulted the
+# on-disk object paths and the dynamic dependencies, and consulted the
 # link query; this call only drives the linker.
 # ---
 # p:          the project carrying the session, target, and settled request
 # paths:      the object/archive paths to link, in link order
 # len:        number of paths
-# sonames:    the dynamic-dependency soname list
-# soname_len: number of sonames
+# dynlibs:    the logical and loader names of dynamic dependencies
+# dynlib_len: number of dynamic dependencies
 # exe_path:   the executable path to link into
 # ret:        ok(true) on success, or the failure as a Fail
 pub fun link_executable(p: *driver.Project, paths: **u8, len: u32,
-                        sonames: *intern.StrId, soname_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
+                        dynlibs: *of.DynLib, dynlib_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, sonames, soname_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, len, dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -383,7 +383,7 @@ pub fun link_flat_images(p: *driver.Project, images: *of.ObjectImage, exe_path: 
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*intern.StrId, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
     A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
@@ -407,13 +407,13 @@ pub fun link_flat_images(p: *driver.Project, images: *of.ObjectImage, exe_path: 
 # images:     the per-module codegen images, indexed by module id
 # ext_paths:  external link-input paths (on-disk objects/archives), or nil
 # ext_count:  number of external link-input paths
-# sonames:    the dynamic-dependency soname list
-# soname_len: number of sonames
+# dynlibs:    the logical and loader names of dynamic dependencies
+# dynlib_len: number of dynamic dependencies
 # exe_path:   the executable path to link into
 # ret:        ok(true) on success, or the failure as a Fail
 pub fun link_mixed_images(p: *driver.Project, images: *of.ObjectImage,
                           ext_paths: **u8, ext_count: u32,
-                          sonames: *intern.StrId, soname_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
+                          dynlibs: *of.DynLib, dynlib_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
     val res_ord: R.Result[*of.ObjectImage, str] = gather_topo_images(p, images);
     if (R.is_err[*of.ObjectImage, str](res_ord)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
     val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
@@ -421,7 +421,7 @@ pub fun link_mixed_images(p: *driver.Project, images: *of.ObjectImage,
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
         linker.link_mixed(p.s, ?p.target, ordered, p.topo_len, ext_paths, ext_count,
-                          sonames, soname_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+                          dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
     A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
@@ -456,7 +456,7 @@ fun count_external_tokens(p: *driver.Project, unit: *plan.BuildUnit) u32 {
 # of link-input resolution; the request's own tokens are already facts on the
 # unit and are appended without re-probing. A STATIC input (a loose `.o` or
 # static `.a`) is appended to `*paths`; a DYNAMIC one (a shared library) has
-# its soname interned and appended to `*sonames`. `*paths` is pre-grown by the
+# its logical and canonical loader names appended to `*dynlibs`. `*paths` is pre-grown by the
 # input count (the worst case where every input is an object) and then shrunk
 # to the true object count `*len`, so the array is dense (no nil holes) and
 # `free_paths(.., len, len)` frees it correctly. An input that resolves to no
@@ -466,14 +466,14 @@ fun count_external_tokens(p: *driver.Project, unit: *plan.BuildUnit) u32 {
 # unit:       the resolved plan cell carrying the request's link facts
 # paths:      the static object-path array to grow and fill
 # len:        the static object-path count, updated to the true count
-# sonames:    the dynamic-dependency soname array to grow and fill
-# soname_len: the soname count
+# dynlibs:    the dynamic-dependency array to grow and fill
+# dynlib_len: the dynamic-dependency count
 # ret:        ok(true) on success, or the failure as a Fail
 pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
                                paths: ***u8, len: *u32,
-                               sonames: **intern.StrId, soname_len: *u32) R.Result[bool, outcome.Fail] {
-    @sonames    = nil;
-    @soname_len = 0;
+                               dynlibs: **of.DynLib, dynlib_len: *u32) R.Result[bool, outcome.Fail] {
+    @dynlibs    = nil;
+    @dynlib_len = 0;
     val extra: u32 = count_external_tokens(p, unit);
     if (extra == 0) { ret R.ok[bool, outcome.Fail](true); }
 
@@ -497,7 +497,7 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
         var i: u32 = 0;
         for (i < te.lib_count) {
             val rc: R.Result[bool, outcome.Fail] = resolve_and_store_input(p, ?te.libs[i],
-                                                    @paths, ?written, sonames, soname_len);
+                                                    @paths, ?written, dynlibs, dynlib_len);
             if (R.is_err[bool, outcome.Fail](rc)) { shrink_paths(p, paths, len, written, grown); ret rc; }
             i = i + 1;
         }
@@ -506,7 +506,7 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
     var i: u32 = 0;
     for (i < p.config.cascade_lib_count) {
         val rc: R.Result[bool, outcome.Fail] = resolve_and_store_input(p, ?p.config.cascade_libs[i],
-                                                @paths, ?written, sonames, soname_len);
+                                                @paths, ?written, dynlibs, dynlib_len);
         if (R.is_err[bool, outcome.Fail](rc)) { shrink_paths(p, paths, len, written, grown); ret rc; }
         i = i + 1;
     }
@@ -514,7 +514,7 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
     var ti: usize = 0;
     for (ti < unit.link_inputs.len) {
         val rc: R.Result[bool, outcome.Fail] = store_fact(p, ?unit.link_inputs.data[ti],
-                                                @paths, ?written, sonames, soname_len);
+                                                @paths, ?written, dynlibs, dynlib_len);
         if (R.is_err[bool, outcome.Fail](rc)) { shrink_paths(p, paths, len, written, grown); ret rc; }
         ti = ti + 1;
     }
@@ -527,19 +527,19 @@ pub fun append_external_inputs(p: *driver.Project, unit: *plan.BuildUnit,
 #
 # A STATIC fact's path is duplicated onto the build allocator (the plan owns
 # its copy; `free_paths` frees these at their exact size); a DYNAMIC fact's
-# soname is interned.
+# logical and loader names are interned.
 # ---
 # p:          the project (for its build allocator and interner)
 # li:         the plan-resolved fact
 # paths:      the static object-path array to append into
 # written:    the next free index in `paths`, advanced on a static input
-# sonames:    the dynamic-dependency soname array to grow
-# soname_len: the soname count
+# dynlibs:    the dynamic-dependency array to grow
+# dynlib_len: the dynamic-dependency count
 # ret:        ok(true) on success, or the failure as a Fail
 fun store_fact(p: *driver.Project, li: *plan.LinkInput, paths: **u8, written: *u32,
-               sonames: **intern.StrId, soname_len: *u32) R.Result[bool, outcome.Fail] {
+               dynlibs: **of.DynLib, dynlib_len: *u32) R.Result[bool, outcome.Fail] {
     if (li.kind == plan.LINK_DYNAMIC) {
-        ret append_soname(p, li.text::*u8, sonames, soname_len);
+        ret append_dynlib(p, li, dynlibs, dynlib_len);
     }
     val dup_r: R.Result[str, str] = str_copy(p.alloc, li.text::*u8);
     if (R.is_err[str, str](dup_r)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
@@ -571,37 +571,68 @@ fun shrink_paths(p: *driver.Project, paths: ***u8, len: *u32, written: u32, grow
     @len = grown;
 }
 
-# intern a shared library's soname and append it to the dynamic dependency list,
-# growing it one slot at a time
+# append a shared library's logical and loader names to the dynamic dependency
+# list, rejecting ambiguous logical identities and growing it one slot at a time
 # ---
 # p:          the project (for its interner and build allocator)
-# name:       the soname to intern
-# sonames:    the dynamic-dependency soname array to grow
-# soname_len: the soname count
+# li:         the resolved dynamic link input
+# dynlibs:    the dynamic-dependency array to grow
+# dynlib_len: the dynamic-dependency count
 # ret:        ok(true) on success, or the failure as a Fail
-fun append_soname(p: *driver.Project, name: *u8, sonames: **intern.StrId, soname_len: *u32) R.Result[bool, outcome.Fail] {
-    val res_intern: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, name);
+fun append_dynlib(p: *driver.Project, li: *plan.LinkInput,
+                  dynlibs: **of.DynLib, dynlib_len: *u32) R.Result[bool, outcome.Fail] {
+    val res_intern: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, li.text);
     if (R.is_err[intern.StrId, str](res_intern)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
-    val id: intern.StrId = R.unwrap_ok[intern.StrId, str](res_intern);
+    val soname: intern.StrId = R.unwrap_ok[intern.StrId, str](res_intern);
+    var name: intern.StrId = li.library;
+    if (name == intern.STR_NIL) { name = soname; }
 
-    val old: u32 = @soname_len;
-    val res_grow: R.Result[*intern.StrId, str] =
-        A.reallocate[intern.StrId](p.alloc, @sonames, old::usize, (old + 1)::usize);
-    if (R.is_err[*intern.StrId, str](res_grow)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
-    @sonames = R.unwrap_ok[*intern.StrId, str](res_grow);
-    (@sonames)[old] = id;
-    @soname_len = old + 1;
+    var i: u32 = 0;
+    for (i < @dynlib_len) {
+        if ((@dynlibs)[i].name == name) {
+            if ((@dynlibs)[i].soname == soname) { ret R.ok[bool, outcome.Fail](true); }
+            ret R.err[bool, outcome.Fail](outcome.user(dynlib_conflict_message(
+                p, name, (@dynlibs)[i].soname, soname)));
+        }
+        i = i + 1;
+    }
+
+    val old: u32 = @dynlib_len;
+    val res_grow: R.Result[*of.DynLib, str] =
+        A.reallocate[of.DynLib](p.alloc, @dynlibs, old::usize, (old + 1)::usize);
+    if (R.is_err[*of.DynLib, str](res_grow)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
+    @dynlibs = R.unwrap_ok[*of.DynLib, str](res_grow);
+    (@dynlibs)[old].name = name;
+    (@dynlibs)[old].soname = soname;
+    @dynlib_len = old + 1;
     ret R.ok[bool, outcome.Fail](true);
 }
 
-# release the dynamic-dependency soname array
+# explain an ambiguous portable identity without losing the canonical loader
+# names that exposed the conflict
+fun dynlib_conflict_message(p: *driver.Project, name: intern.StrId,
+                            first: intern.StrId, second: intern.StrId) str {
+    val n: O.Option[str] = intern.lookup(?p.s.interner, name);
+    val a: O.Option[str] = intern.lookup(?p.s.interner, first);
+    val b: O.Option[str] = intern.lookup(?p.s.interner, second);
+    if (!O.is_some[str](n) || !O.is_some[str](a) || !O.is_some[str](b)) {
+        ret "one logical link library resolves to multiple loader names";
+    }
+    val r: R.Result[str, str] = str_join(p.alloc,
+        "link library '", O.unwrap[str](n), "' resolves to both '",
+        O.unwrap[str](a), "' and '", O.unwrap[str](b), "'");
+    if (R.is_err[str, str](r)) { ret R.unwrap_err[str, str](r); }
+    ret R.unwrap_ok[str, str](r);
+}
+
+# release the dynamic-dependency array
 # ---
 # a:          allocator backing the array
-# sonames:    the soname array, or nil
-# soname_len: the soname count
-pub fun free_sonames(a: *A.Allocator, sonames: *intern.StrId, soname_len: u32) {
-    if (sonames != nil && soname_len > 0) {
-        A.deallocate[intern.StrId](a, sonames, soname_len::usize);
+# dynlibs:    the dynamic-dependency array, or nil
+# dynlib_len: the dynamic-dependency count
+pub fun free_dynlibs(a: *A.Allocator, dynlibs: *of.DynLib, dynlib_len: u32) {
+    if (dynlibs != nil && dynlib_len > 0) {
+        A.deallocate[of.DynLib](a, dynlibs, dynlib_len::usize);
     }
 }
 
@@ -611,18 +642,18 @@ pub fun free_sonames(a: *A.Allocator, sonames: *intern.StrId, soname_len: u32) {
 # step may have just produced them), through the planner-owned
 # `plan.resolve_token` - the same probing order and error text as the plan's
 # own tokens. A STATIC result is stored into `paths[*written]`; a DYNAMIC one
-# has its soname interned into `*sonames`.
+# has its logical and loader names appended to `*dynlibs`.
 # ---
 # p:          the project carrying the target, session, and settled request
 # tok:        the link-input token to resolve
 # paths:      the static object-path array to append into
 # written:    the next free index in `paths`, advanced on a static input
-# sonames:    the dynamic-dependency soname array to grow
-# soname_len: the soname count
+# dynlibs:    the dynamic-dependency array to grow
+# dynlib_len: the dynamic-dependency count
 # ret:        ok(true) on success, or the failure as a Fail
 fun resolve_and_store_input(p: *driver.Project, req: *manifest.LinkRequirement,
                             paths: **u8, written: *u32,
-                            sonames: **intern.StrId, soname_len: *u32) R.Result[bool, outcome.Fail] {
+                            dynlibs: **of.DynLib, dynlib_len: *u32) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val lr: R.Result[plan.LinkInput, outcome.Fail] =
         plan.resolve_requirement(p.alloc, ?p.s.interner, ?p.target,
@@ -632,7 +663,7 @@ fun resolve_and_store_input(p: *driver.Project, req: *manifest.LinkRequirement,
     }
     val li: plan.LinkInput = R.unwrap_ok[plan.LinkInput, outcome.Fail](lr);
     if (li.kind == plan.LINK_DYNAMIC) {
-        ret append_soname(p, li.text::*u8, sonames, soname_len);
+        ret append_dynlib(p, ?li, dynlibs, dynlib_len);
     }
     # the STATIC text is already an exact-size copy on the build allocator.
     paths[@written] = li.text::*u8;

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -81,7 +81,7 @@ use mach.lang.target.of;
 # obj_paths:    written per-module object paths (topo order), grown by the
 #               external link inputs on the executable path; owned strings
 # obj_len:      number of populated `obj_paths` entries
-# dynlibs:      logical and loader names of the dynamic dependencies
+# dynlibs:      logical names, loader names, and run paths of dynamic dependencies
 # dynlib_len:   number of dynamic dependencies
 # out_path:     the produced artifact path, or nil until a phase sets it
 # scope:        the test collection state (tests goals only)
@@ -1008,8 +1008,8 @@ fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product:
     # fingerprints a source file by its full text (Q_FILE_TEXT); the link folds a
     # sha256 of the content instead of the raw bytes, since a static archive can be
     # large. dynamic dependencies below are loaded at run time, not baked in, so
-    # both their logical and loader identities are fingerprinted - their content
-    # never changes this binary.
+    # their logical identity, loader identity, and runtime search path are
+    # fingerprinted - their content never changes this binary.
     val a4: R.Result[bool, str] = dq.fp_u32(fb, ext_count);           if (R.is_err[bool, str](a4)) { ret a4; }
     var i: u32 = 0;
     for (i < ext_count) {
@@ -1022,6 +1022,7 @@ fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product:
     for (j < dynlib_count) {
         val an: R.Result[bool, str] = dq.fp_u32(fb, dynlibs[j].name::u32);   if (R.is_err[bool, str](an)) { ret an; }
         val as: R.Result[bool, str] = dq.fp_u32(fb, dynlibs[j].soname::u32); if (R.is_err[bool, str](as)) { ret as; }
+        val ar: R.Result[bool, str] = dq.fp_u32(fb, dynlibs[j].rpath::u32);  if (R.is_err[bool, str](ar)) { ret ar; }
         j = j + 1;
     }
     ret R.ok[bool, str](true);

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -81,8 +81,8 @@ use mach.lang.target.of;
 # obj_paths:    written per-module object paths (topo order), grown by the
 #               external link inputs on the executable path; owned strings
 # obj_len:      number of populated `obj_paths` entries
-# sonames:      the dynamic-dependency soname list the link consumed
-# soname_len:   number of sonames
+# dynlibs:      logical and loader names of the dynamic dependencies
+# dynlib_len:   number of dynamic dependencies
 # out_path:     the produced artifact path, or nil until a phase sets it
 # scope:        the test collection state (tests goals only)
 # link_started: the link narration span is open (its begin fired)
@@ -95,8 +95,8 @@ rec UnitState {
 
     obj_paths:    **u8;
     obj_len:      u32;
-    sonames:      *intern.StrId;
-    soname_len:   u32;
+    dynlibs:      *of.DynLib;
+    dynlib_len:   u32;
 
     out_path:     *u8;
     scope:        btest.TestScope;
@@ -360,8 +360,8 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
     st.image_ready  = nil;
     st.obj_paths    = nil;
     st.obj_len      = 0;
-    st.sonames      = nil;
-    st.soname_len   = 0;
+    st.dynlibs      = nil;
+    st.dynlib_len   = 0;
     st.out_path     = nil;
     st.scope.have    = false;
     st.scope.sel     = nil;
@@ -791,7 +791,7 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     # append every external link input - the manifest's merged link overlay plus
     # the unit's plan-resolved `-L`/`-l`/explicit-object facts - to the object
     # set, then consult Q_LINK and link (or reuse the prior artifact).
-    val ext_r: R.Result[bool, outcome.Fail] = emit.append_external_inputs(p, unit, ?st.obj_paths, ?st.obj_len, ?st.sonames, ?st.soname_len);
+    val ext_r: R.Result[bool, outcome.Fail] = emit.append_external_inputs(p, unit, ?st.obj_paths, ?st.obj_len, ?st.dynlibs, ?st.dynlib_len);
     if (R.is_err[bool, outcome.Fail](ext_r)) { ret ext_r; }
 
     val artifact: str = unit.out_path;
@@ -807,7 +807,7 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     val ext_from:  u32 = p.topo_len;
     val ext_count: u32 = st.obj_len - p.topo_len;
     val cfg_r: R.Result[bool, outcome.Fail] = set_link_config_input(p, artifact::*u8, emit.artifact_product_name(p), linker.LINK_EXE::u32,
-                                                                    ?st.obj_paths[ext_from], ext_count, st.sonames, st.soname_len);
+                                                                    ?st.obj_paths[ext_from], ext_count, st.dynlibs, st.dynlib_len);
     if (R.is_err[bool, outcome.Fail](cfg_r)) { ret cfg_r; }
     val relink_r: R.Result[bool, outcome.Fail] = driver.run_link_pass(p);
     if (R.is_err[bool, outcome.Fail](relink_r)) { ret relink_r; }
@@ -826,10 +826,10 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     val from_image: bool = p.target.of.links_from_image;
     var res_link: R.Result[bool, outcome.Fail] = R.ok[bool, outcome.Fail](true);
     if (from_image) {
-        res_link = emit.link_mixed_images(p, st.images, ?st.obj_paths[ext_from], ext_count, st.sonames, st.soname_len, artifact::*u8);
+        res_link = emit.link_mixed_images(p, st.images, ?st.obj_paths[ext_from], ext_count, st.dynlibs, st.dynlib_len, artifact::*u8);
     }
     if (!from_image) {
-        res_link = emit.link_executable(p, st.obj_paths, st.obj_len, st.sonames, st.soname_len, artifact::*u8);
+        res_link = emit.link_executable(p, st.obj_paths, st.obj_len, st.dynlibs, st.dynlib_len, artifact::*u8);
     }
     if (R.is_err[bool, outcome.Fail](res_link)) { ret res_link; }
 
@@ -953,7 +953,7 @@ fun pcg_enabled(p: *driver.Project) bool {
 # to an input that does NOT flow through a module's Q_CODEGEN
 #
 # Captures the output path and product name, the output kind, the pie flag, and the
-# external link inputs (object/archive paths plus dynamic-dependency sonames). The
+# external link inputs (object/archive paths plus dynamic dependencies). The
 # ownership boundary: the CLI translates argv/manifest into these resolved inputs;
 # this records them into the query graph. set_input's byte-equality cutoff keeps the
 # link reused when the config is unchanged.
@@ -964,19 +964,19 @@ fun pcg_enabled(p: *driver.Project) bool {
 # out_kind:     the link output kind discriminator (exe / library / object)
 # ext_paths:    the external static link-input paths
 # ext_count:    number of external paths
-# sonames:      the dynamic-dependency soname ids
-# soname_count: number of sonames
+# dynlibs:      logical and loader names of the dynamic dependencies
+# dynlib_count: number of dynamic dependencies
 # ret:          true on success, or the first error
 pub fun set_link_config_input(p: *driver.Project, out_path: *u8, product: *u8, out_kind: u32,
                               ext_paths: **u8, ext_count: u32,
-                              sonames: *intern.StrId, soname_count: u32) R.Result[bool, outcome.Fail] {
+                              dynlibs: *of.DynLib, dynlib_count: u32) R.Result[bool, outcome.Fail] {
     var fb: dq.FpBuf;
     fb.alloc = p.alloc;
     fb.buf   = nil;
     fb.len   = 0;
     fb.cap   = 0;
 
-    val w: R.Result[bool, str] = write_link_config(?fb, p, out_path, product, out_kind, ext_paths, ext_count, sonames, soname_count);
+    val w: R.Result[bool, str] = write_link_config(?fb, p, out_path, product, out_kind, ext_paths, ext_count, dynlibs, dynlib_count);
     if (R.is_err[bool, str](w)) {
         if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](p.alloc, fb.buf, fb.cap::usize); }
         ret R.err[bool, outcome.Fail](outcome.internal(R.unwrap_err[bool, str](w)));
@@ -993,7 +993,7 @@ pub fun set_link_config_input(p: *driver.Project, out_path: *u8, product: *u8, o
 # so a change to any of them advances Q_LINK_CONFIG and re-links
 fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product: *u8, out_kind: u32,
                       ext_paths: **u8, ext_count: u32,
-                      sonames: *intern.StrId, soname_count: u32) R.Result[bool, str] {
+                      dynlibs: *of.DynLib, dynlib_count: u32) R.Result[bool, str] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val a0: R.Result[bool, str] = dq.fp_u32(fb, out_kind);            if (R.is_err[bool, str](a0)) { ret a0; }
     var pie_axis: u32 = 0;
@@ -1007,9 +1007,9 @@ fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product:
     # output binary, so its content must invalidate. mirrors the front half, which
     # fingerprints a source file by its full text (Q_FILE_TEXT); the link folds a
     # sha256 of the content instead of the raw bytes, since a static archive can be
-    # large. sonames below are DYNAMIC deps (DT_NEEDED, loaded at run time, not baked
-    # in), so they are fingerprinted by identity only - their content never changes
-    # this binary.
+    # large. dynamic dependencies below are loaded at run time, not baked in, so
+    # both their logical and loader identities are fingerprinted - their content
+    # never changes this binary.
     val a4: R.Result[bool, str] = dq.fp_u32(fb, ext_count);           if (R.is_err[bool, str](a4)) { ret a4; }
     var i: u32 = 0;
     for (i < ext_count) {
@@ -1017,10 +1017,11 @@ fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product:
         val ah: R.Result[bool, str] = dq.fp_file_content(fb, p.alloc, ext_paths[i]); if (R.is_err[bool, str](ah)) { ret ah; }
         i = i + 1;
     }
-    val a5: R.Result[bool, str] = dq.fp_u32(fb, soname_count);        if (R.is_err[bool, str](a5)) { ret a5; }
+    val a5: R.Result[bool, str] = dq.fp_u32(fb, dynlib_count);        if (R.is_err[bool, str](a5)) { ret a5; }
     var j: u32 = 0;
-    for (j < soname_count) {
-        val as: R.Result[bool, str] = dq.fp_u32(fb, sonames[j]::u32); if (R.is_err[bool, str](as)) { ret as; }
+    for (j < dynlib_count) {
+        val an: R.Result[bool, str] = dq.fp_u32(fb, dynlibs[j].name::u32);   if (R.is_err[bool, str](an)) { ret an; }
+        val as: R.Result[bool, str] = dq.fp_u32(fb, dynlibs[j].soname::u32); if (R.is_err[bool, str](as)) { ret as; }
         j = j + 1;
     }
     ret R.ok[bool, str](true);

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -55,6 +55,7 @@ use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.pipeline;
 use mach.lang.target;
+use mach.lang.target.isa;
 use mach.lang.target.of;
 
 # a phase in a unit's ordered execution list
@@ -98,13 +99,13 @@ pub val LINK_DYNAMIC: LinkInputKind = 1;
 # kind:    static (an on-disk object/archive) or dynamic (a loader dependency)
 # text:    absolute path (STATIC) or canonical loader name (DYNAMIC), owned by
 #          the plan allocator
-# library: stable logical `#[library]` attribution name; STR_NIL for an explicit
-#          path without a portable identity
+# library: borrowed stable logical `#[library]` attribution name; empty for an
+#          explicit path without a portable identity
 # rpath:   resolved root for a Mach-O `@rpath/` dependency; empty otherwise
 pub rec LinkInput {
     kind:    LinkInputKind;
     text:    str;
-    library: intern.StrId;
+    library: str;
     rpath:   str;
 }
 
@@ -372,14 +373,11 @@ fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
             ret R.err[BuildUnit, outcome.Fail](R.unwrap_err[LinkInput, outcome.Fail](lr));
         }
         var input: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](lr);
-        # a bare `-l` token is itself a stable logical library name. explicit paths
-        # retain only their canonical runtime name for backwards-compatible exact
-        # `#[library]` attribution.
+        # carry a bare `-l` token as text across the planning/execution session
+        # boundary; the active build session interns it when assembling dynlibs.
         if (!request.is_object_path(token::*u8) && !is_shared_path(token::*u8)
             && !is_dll_path(token::*u8) && !is_dylib_path(token::*u8)) {
-            val name_r: R.Result[intern.StrId, str] = intern.intern(itn, token);
-            if (R.is_err[intern.StrId, str](name_r)) { ret oom_unit(); }
-            input.library = R.unwrap_ok[intern.StrId, str](name_r);
+            input.library = token;
         }
         val pr: R.Result[usize, str] = vector.push[LinkInput](?u.link_inputs, input);
         if (R.is_err[usize, str](pr)) { ret oom_unit(); }
@@ -666,17 +664,22 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
         }
         if (exists) {
             var install_name: [4096]u8;
-            if (read_dylib_install_name(a, actual, ?install_name[0], 4096)) {
+            if (read_dylib_install_name(a, actual, tgt.arch_id, ?install_name[0], 4096)) {
                 ret dylib_copy(a, actual, ?install_name[0]);
             }
             ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", actual::str,
-                "' is not a loadable Mach-O dylib (missing a valid LC_ID_DYLIB)")));
+                "' is not a loadable Mach-O dylib for the selected architecture")));
         }
         if (str_starts_with(tok::str, "@rpath/")) {
             ret R.err[LinkInput, outcome.Fail](outcome.user(
                 "an @rpath dylib input must resolve to an existing file so its runtime search path can be retained"));
         }
         ret dyn_copy(a, tok);
+    }
+
+    if (is_shared_path(tok) && !str_equals(tgt.of.shared_input_ext, ".so")) {
+        ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", tok::str,
+            "' is an ELF shared object; .so inputs require an ELF target")));
     }
 
     var buf: [4096]u8;
@@ -728,7 +731,7 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
     var li: LinkInput;
     li.kind = LINK_STATIC;
     li.text = R.unwrap_ok[str, str](dup_r);
-    li.library = intern.STR_NIL;
+    li.library = "";
     li.rpath = "";
     ret R.ok[LinkInput, outcome.Fail](li);
 }
@@ -749,19 +752,24 @@ pub fun resolve_requirement(a: *A.Allocator, itn: *intern.Interner, tgt: *target
         ret R.err[LinkInput, outcome.Fail](outcome.internal("link requirement text not interned"));
     }
     val text: str = O.unwrap[str](text_opt);
+    val library_opt: O.Option[str] = intern.lookup(itn, req.library);
+    if (O.is_none[str](library_opt)) {
+        ret R.err[LinkInput, outcome.Fail](outcome.internal("link requirement library not interned"));
+    }
+    val library: str = O.unwrap[str](library_opt);
     if (req.source == manifest.LINK_FRAMEWORK) {
         val fr: R.Result[LinkInput, outcome.Fail] =
             resolve_framework(a, tgt, text::*u8);
         if (R.is_err[LinkInput, outcome.Fail](fr)) { ret fr; }
         var fi: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](fr);
-        fi.library = req.library;
+        fi.library = library;
         ret R.ok[LinkInput, outcome.Fail](fi);
     }
     var r: R.Result[LinkInput, outcome.Fail] =
         resolve_token(a, tgt, dirs, root, text::*u8);
     if (R.is_err[LinkInput, outcome.Fail](r)) { ret r; }
     var li: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](r);
-    li.library = req.library;
+    li.library = library;
     ret R.ok[LinkInput, outcome.Fail](li);
 }
 
@@ -784,7 +792,7 @@ fun resolve_framework(a: *A.Allocator, tgt: *target.Target,
     var li: LinkInput;
     li.kind    = LINK_DYNAMIC;
     li.text    = install_name;
-    li.library = intern.STR_NIL;
+    li.library = "";
     li.rpath   = "";
     ret R.ok[LinkInput, outcome.Fail](li);
 }
@@ -808,7 +816,7 @@ fun dyn_copy_with_rpath(a: *A.Allocator, name: *u8,
     var li: LinkInput;
     li.kind    = LINK_DYNAMIC;
     li.text    = R.unwrap_ok[str, str](dup_r);
-    li.library = intern.STR_NIL;
+    li.library = "";
     li.rpath   = run_path;
     ret R.ok[LinkInput, outcome.Fail](li);
 }
@@ -999,34 +1007,43 @@ fun extract_soname(buf: *u8, len: usize, out: *u8, cap: usize) bool {
 
 # read a Mach-O dylib's LC_ID_DYLIB install name into `out`
 #
-# Accepts a thin 64-bit Mach-O dylib or a 32/64-bit universal wrapper containing
-# one. Every supported Darwin target is 64-bit; universal slices are scanned in
-# declaration order and must carry a valid LC_ID_DYLIB command.
-fun read_dylib_install_name(a: *A.Allocator, dylib_path: *u8,
+# Accepts a thin 64-bit Mach-O dylib for the selected architecture or a 32/64-bit
+# universal wrapper containing a matching slice with a valid LC_ID_DYLIB command.
+fun read_dylib_install_name(a: *A.Allocator, dylib_path: *u8, arch_id: u32,
                             out: *u8, cap: usize) bool {
     val res_read: R.Result[Vector[u8], str] = fs.read_bytes(a, dylib_path);
     if (R.is_err[Vector[u8], str](res_read)) { ret false; }
     var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](res_read);
     var ok: bool = false;
+    val cpu_type: u32 = macho_cpu_type(arch_id);
+    if (cpu_type == 0) { vector.dnit[u8](?b); ret false; }
     if (b.len >= 4 && bin.read_u32_le(b.data, 0) == 0xFEEDFACF) {
-        ok = extract_dylib_id(b.data, b.len, 0, b.len, out, cap);
+        ok = extract_dylib_id(b.data, b.len, 0, b.len, cpu_type, out, cap);
     }
     or (b.len >= 8 && bin.read_u32_be(b.data, 0) == 0xCAFEBABE) {
-        ok = extract_fat_dylib_id(b.data, b.len, false, out, cap);
+        ok = extract_fat_dylib_id(b.data, b.len, false, cpu_type, out, cap);
     }
     or (b.len >= 8 && bin.read_u32_be(b.data, 0) == 0xCAFEBABF) {
-        ok = extract_fat_dylib_id(b.data, b.len, true, out, cap);
+        ok = extract_fat_dylib_id(b.data, b.len, true, cpu_type, out, cap);
     }
     vector.dnit[u8](?b);
     ret ok;
 }
 
+# the Mach-O cputype for a supported Darwin target architecture
+fun macho_cpu_type(arch_id: u32) u32 {
+    if (arch_id == isa.ARCH_X86_64)  { ret 0x01000007; }
+    if (arch_id == isa.ARCH_AARCH64) { ret 0x0100000C; }
+    ret 0;
+}
+
 # extract LC_ID_DYLIB from one thin 64-bit Mach-O slice
 fun extract_dylib_id(buf: *u8, len: usize, base: usize, slice_len: usize,
-                     out: *u8, cap: usize) bool {
+                     cpu_type: u32, out: *u8, cap: usize) bool {
     if (base > len || slice_len > len - base || slice_len < 32) { ret false; }
     val end: usize = base + slice_len;
     if (bin.read_u32_le(buf, base) != 0xFEEDFACF) { ret false; }
+    if (bin.read_u32_le(buf, base + 4) != cpu_type) { ret false; }
     if (bin.read_u32_le(buf, base + 12) != 6)     { ret false; } # MH_DYLIB
     val ncmds: u32 = bin.read_u32_le(buf, base + 16);
     val sizeofcmds: usize = bin.read_u32_le(buf, base + 20)::usize;
@@ -1062,7 +1079,7 @@ fun extract_dylib_id(buf: *u8, len: usize, base: usize, slice_len: usize,
 
 # extract LC_ID_DYLIB from the first valid slice of a universal Mach-O
 fun extract_fat_dylib_id(buf: *u8, len: usize, wide: bool,
-                         out: *u8, cap: usize) bool {
+                         cpu_type: u32, out: *u8, cap: usize) bool {
     val nfat: usize = bin.read_u32_be(buf, 4)::usize;
     var ent_size: usize = 20;
     if (wide) { ent_size = 32; }
@@ -1077,7 +1094,7 @@ fun extract_fat_dylib_id(buf: *u8, len: usize, wide: bool,
             off  = read_u64_be(buf, ent + 8)::usize;
             size = read_u64_be(buf, ent + 16)::usize;
         }
-        if (extract_dylib_id(buf, len, off, size, out, cap)) { ret true; }
+        if (extract_dylib_id(buf, len, off, size, cpu_type, out, cap)) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -1178,7 +1195,7 @@ fun resolve_dylib_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
                        rpath: *u8, rpath_cap: usize) bool {
     var i: usize = 0;
     for (i < dirs.len) {
-        if (try_dylib_in_dir(a, dirs.data[i]::*u8, name, buf, cap,
+        if (try_dylib_in_dir(a, dirs.data[i]::*u8, name, tgt.arch_id, buf, cap,
                              rpath, rpath_cap)) { ret true; }
         i = i + 1;
     }
@@ -1186,7 +1203,7 @@ fun resolve_dylib_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
         var li: u32 = 0;
         for (li < tgt.os.libdir_len) {
             val ld: str = tgt.os.libdirs[li];
-            if (!str_empty(ld) && try_dylib_in_dir(a, ld::*u8, name, buf, cap,
+            if (!str_empty(ld) && try_dylib_in_dir(a, ld::*u8, name, tgt.arch_id, buf, cap,
                                                    rpath, rpath_cap)) { ret true; }
             li = li + 1;
         }
@@ -1196,16 +1213,17 @@ fun resolve_dylib_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
 
 # probe `<dir>/lib<name>.dylib`, then `lib<name>.<N>.dylib` for N in 6..0
 fun try_dylib_in_dir(a: *A.Allocator, dir: *u8, name: *u8,
-                     buf: *u8, cap: usize, rpath: *u8, rpath_cap: usize) bool {
+                     arch_id: u32, buf: *u8, cap: usize,
+                     rpath: *u8, rpath_cap: usize) bool {
     var cand: [4096]u8;
     if (write_named_candidate(dir, "lib", name, "dylib", ?cand[0], 4096)
-        && accept_dylib(a, ?cand[0], buf, cap)) {
+        && accept_dylib(a, ?cand[0], arch_id, buf, cap)) {
         ret dylib_rpath_into(a, ?cand[0], buf, rpath, rpath_cap);
     }
     var v: i64 = 6;
     for (v >= 0) {
         if (write_named_dylib_version(dir, name, v::u32, ?cand[0], 4096)
-            && accept_dylib(a, ?cand[0], buf, cap)) {
+            && accept_dylib(a, ?cand[0], arch_id, buf, cap)) {
             ret dylib_rpath_into(a, ?cand[0], buf, rpath, rpath_cap);
         }
         v = v - 1;
@@ -1262,9 +1280,10 @@ fun resolve_from_cwd(a: *A.Allocator, p: str) R.Result[str, str] {
 }
 
 # accept an existing Mach-O dylib and retain its canonical install name
-fun accept_dylib(a: *A.Allocator, cand: *u8, buf: *u8, cap: usize) bool {
+fun accept_dylib(a: *A.Allocator, cand: *u8, arch_id: u32,
+                 buf: *u8, cap: usize) bool {
     if (!fs.is_file(cand)) { ret false; }
-    ret read_dylib_install_name(a, cand, buf, cap);
+    ret read_dylib_install_name(a, cand, arch_id, buf, cap);
 }
 
 # compose `<dir>/lib<name>.<v>.dylib` into `buf`
@@ -1485,24 +1504,31 @@ fun ut_path_eq(a: str, b: str) bool {
 }
 
 # write a minimal thin 64-bit Mach-O dylib carrying `install_name`
-fun ut_write_dylib(path_: str, install_name: str) bool {
+fun ut_write_dylib(path_: str, install_name: str, cpu_type: u32) bool {
     var buf: [160]u8;
     var i: usize = 0;
     for (i < 160) { buf[i] = 0; i = i + 1; }
+    if (!ut_fill_dylib(?buf[0], 0, install_name, cpu_type)) { ret false; }
+    ret O.is_none[str](fs.write_bytes(path_, ?buf[0], 128, 420));
+}
+
+# fill one 128-byte thin dylib slice at `off`
+fun ut_fill_dylib(buf: *u8, off: usize, install_name: str,
+                  cpu_type: u32) bool {
     val name_len: usize = str_len(install_name);
     if (name_len + 1 > 72) { ret false; }
 
-    bin.write_u32_le(?buf[0], 0, 0xFEEDFACF); # MH_MAGIC_64
-    bin.write_u32_le(?buf[0], 4, 0x01000007); # CPU_TYPE_X86_64
-    bin.write_u32_le(?buf[0], 8, 3);
-    bin.write_u32_le(?buf[0], 12, 6);         # MH_DYLIB
-    bin.write_u32_le(?buf[0], 16, 1);
-    bin.write_u32_le(?buf[0], 20, 96);
-    bin.write_u32_le(?buf[0], 32, 0xD);       # LC_ID_DYLIB
-    bin.write_u32_le(?buf[0], 36, 96);
-    bin.write_u32_le(?buf[0], 40, 24);
-    memory.raw_copy((?buf[56])::ptr, install_name::ptr, name_len);
-    ret O.is_none[str](fs.write_bytes(path_, ?buf[0], 128, 420));
+    bin.write_u32_le(buf, off, 0xFEEDFACF); # MH_MAGIC_64
+    bin.write_u32_le(buf, off + 4, cpu_type);
+    bin.write_u32_le(buf, off + 8, 3);
+    bin.write_u32_le(buf, off + 12, 6);     # MH_DYLIB
+    bin.write_u32_le(buf, off + 16, 1);
+    bin.write_u32_le(buf, off + 20, 96);
+    bin.write_u32_le(buf, off + 32, 0xD);   # LC_ID_DYLIB
+    bin.write_u32_le(buf, off + 36, 96);
+    bin.write_u32_le(buf, off + 40, 24);
+    memory.raw_copy((buf::usize + off + 56)::ptr, install_name::ptr, name_len);
+    ret true;
 }
 
 # create a unique temporary directory path
@@ -1527,8 +1553,10 @@ test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
     var reg: target.TargetRegistry = target.registry_init();
     if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
     val tr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "darwin", "sysv64");
-    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    val ar: R.Result[target.Target, str] = target.select(?reg, "aarch64", "darwin", "aapcs64");
+    if (R.is_err[target.Target, str](tr) || R.is_err[target.Target, str](ar)) { ret 1; }
     var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+    var arm: target.Target = R.unwrap_ok[target.Target, str](ar);
 
     val root_r: R.Result[str, str] = ut_temp_dir(?alloc);
     if (R.is_err[str, str](root_r)) { ret 1; }
@@ -1541,7 +1569,7 @@ test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
     }
     val dylib: str = R.unwrap_ok[str, str](dylib_r);
     val elf: str = R.unwrap_ok[str, str](elf_r);
-    if (!ut_write_dylib(dylib, "@rpath/libglfw.3.dylib")
+    if (!ut_write_dylib(dylib, "@rpath/libglfw.3.dylib", 0x01000007)
         || O.is_some[str](fs.write_bytes(elf, "ELF", 3, 420))) {
         fs.remove_all(?alloc, root);
         ret 1;
@@ -1565,11 +1593,63 @@ test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
         ret 1;
     }
 
+    # the same thin x86_64 dylib cannot satisfy an aarch64 plan.
+    val wrong_arch: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(?alloc, ?arm, ?dirs, "", "glfw"::*u8);
+    if (R.is_ok[LinkInput, outcome.Fail](wrong_arch)) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+
+    # an explicit ELF shared object cannot become a Mach-O loader dependency.
+    val wrong_format: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(?alloc, ?tgt, ?dirs, "", elf::*u8);
+    if (R.is_ok[LinkInput, outcome.Fail](wrong_format)) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+
     # no libhostonly.dylib exists; the Darwin target must not consume the `.so`.
     val host_only: R.Result[LinkInput, outcome.Fail] =
         resolve_token(?alloc, ?tgt, ?dirs, "", "hostonly"::*u8);
     fs.remove_all(?alloc, root);
     if (R.is_ok[LinkInput, outcome.Fail](host_only)) { ret 1; }
+    ret 0;
+}
+
+# a universal dylib selects the slice matching the target cputype
+test "mach.lang.build.plan.extract_fat_dylib_id:selects_target_slice" {
+    var buf: [320]u8;
+    var i: usize = 0;
+    for (i < 320) { buf[i] = 0; i = i + 1; }
+    bin.write_u32_be(?buf[0], 0, 0xCAFEBABE);
+    bin.write_u32_be(?buf[0], 4, 2);
+
+    bin.write_u32_be(?buf[0], 8, 0x01000007);
+    bin.write_u32_be(?buf[0], 12, 3);
+    bin.write_u32_be(?buf[0], 16, 64);
+    bin.write_u32_be(?buf[0], 20, 128);
+    bin.write_u32_be(?buf[0], 24, 6);
+
+    bin.write_u32_be(?buf[0], 28, 0x0100000C);
+    bin.write_u32_be(?buf[0], 32, 0);
+    bin.write_u32_be(?buf[0], 36, 192);
+    bin.write_u32_be(?buf[0], 40, 128);
+    bin.write_u32_be(?buf[0], 44, 6);
+
+    if (!ut_fill_dylib(?buf[0], 64, "@rpath/libx.dylib", 0x01000007)
+        || !ut_fill_dylib(?buf[0], 192, "@rpath/liba.dylib", 0x0100000C)) {
+        ret 1;
+    }
+    var name: [64]u8;
+    if (!extract_fat_dylib_id(?buf[0], 320, false, 0x0100000C, ?name[0], 64)
+        || !str_equals((?name[0])::str, "@rpath/liba.dylib")) {
+        ret 1;
+    }
+    if (!extract_fat_dylib_id(?buf[0], 320, false, 0x01000007, ?name[0], 64)
+        || !str_equals((?name[0])::str, "@rpath/libx.dylib")) {
+        ret 1;
+    }
     ret 0;
 }
 
@@ -1628,7 +1708,7 @@ test "mach.lang.build.plan.resolve_requirement:darwin_framework" {
     val xi: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](x);
     val ai: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](a);
     if (!str_equals(xi.text, want) || !str_equals(ai.text, want)) { ret 1; }
-    if (xi.library != req.library || ai.library != req.library) { ret 1; }
+    if (!str_equals(xi.library, "appkit") || !str_equals(ai.library, "appkit")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -25,6 +25,7 @@ use std.data.toml;
 use fs: std.filesystem;
 use std.memory;
 use std.print;
+use std.process.env;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -39,6 +40,7 @@ use std.types.string.str_equals;
 use std.types.string.str_join;
 use std.types.string.str_len;
 use std.types.string.str_replace;
+use std.types.string.str_starts_with;
 use std.types.path;
 
 use A: std.allocator;
@@ -98,10 +100,12 @@ pub val LINK_DYNAMIC: LinkInputKind = 1;
 #          the plan allocator
 # library: stable logical `#[library]` attribution name; STR_NIL for an explicit
 #          path without a portable identity
+# rpath:   resolved root for a Mach-O `@rpath/` dependency; empty otherwise
 pub rec LinkInput {
     kind:    LinkInputKind;
     text:    str;
     library: intern.StrId;
+    rpath:   str;
 }
 
 # one build unit: a (target, profile, artifact) cell, everything concrete
@@ -663,10 +667,14 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
         if (exists) {
             var install_name: [4096]u8;
             if (read_dylib_install_name(a, actual, ?install_name[0], 4096)) {
-                ret dyn_copy(a, ?install_name[0]);
+                ret dylib_copy(a, actual, ?install_name[0]);
             }
             ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", actual::str,
                 "' is not a loadable Mach-O dylib (missing a valid LC_ID_DYLIB)")));
+        }
+        if (str_starts_with(tok::str, "@rpath/")) {
+            ret R.err[LinkInput, outcome.Fail](outcome.user(
+                "an @rpath dylib input must resolve to an existing file so its runtime search path can be retained"));
         }
         ret dyn_copy(a, tok);
     }
@@ -703,8 +711,11 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
     # `resolve_shared_into` writes the library's own canonical loader name.
     if (!found && !request.is_object_path(tok) && !is_shared_path(tok)) {
         var sname: [4096]u8;
-        if (resolve_shared_into(a, tgt, dirs, tok, ?sname[0], 4096)) {
-            ret dyn_copy(a, ?sname[0]);
+        var rpath: [4096]u8;
+        rpath[0] = 0;
+        if (resolve_shared_into(a, tgt, dirs, tok, ?sname[0], 4096,
+                                ?rpath[0], 4096)) {
+            ret dyn_copy_with_rpath(a, ?sname[0], ?rpath[0]);
         }
     }
 
@@ -718,6 +729,7 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
     li.kind = LINK_STATIC;
     li.text = R.unwrap_ok[str, str](dup_r);
     li.library = intern.STR_NIL;
+    li.rpath = "";
     ret R.ok[LinkInput, outcome.Fail](li);
 }
 
@@ -773,18 +785,45 @@ fun resolve_framework(a: *A.Allocator, tgt: *target.Target,
     li.kind    = LINK_DYNAMIC;
     li.text    = install_name;
     li.library = intern.STR_NIL;
+    li.rpath   = "";
     ret R.ok[LinkInput, outcome.Fail](li);
 }
 
 # a DYNAMIC fact carrying an owned copy of `name`
 fun dyn_copy(a: *A.Allocator, name: *u8) R.Result[LinkInput, outcome.Fail] {
+    ret dyn_copy_with_rpath(a, name, ""::*u8);
+}
+
+# a DYNAMIC fact carrying owned copies of its loader name and optional run path
+fun dyn_copy_with_rpath(a: *A.Allocator, name: *u8,
+                        rpath: *u8) R.Result[LinkInput, outcome.Fail] {
     val dup_r: R.Result[str, str] = str_copy(a, name);
     if (R.is_err[str, str](dup_r)) { ret R.err[LinkInput, outcome.Fail](outcome.internal("out of memory")); }
+    var run_path: str = "";
+    if (rpath != nil && !str_empty(rpath::str)) {
+        val rp_r: R.Result[str, str] = str_copy(a, rpath);
+        if (R.is_err[str, str](rp_r)) { ret R.err[LinkInput, outcome.Fail](outcome.internal("out of memory")); }
+        run_path = R.unwrap_ok[str, str](rp_r);
+    }
     var li: LinkInput;
-    li.kind = LINK_DYNAMIC;
-    li.text = R.unwrap_ok[str, str](dup_r);
+    li.kind    = LINK_DYNAMIC;
+    li.text    = R.unwrap_ok[str, str](dup_r);
     li.library = intern.STR_NIL;
+    li.rpath   = run_path;
     ret R.ok[LinkInput, outcome.Fail](li);
+}
+
+# retain an existing dylib's resolved directory when its install name uses @rpath
+fun dylib_copy(a: *A.Allocator, actual: *u8,
+               install_name: *u8) R.Result[LinkInput, outcome.Fail] {
+    if (!str_starts_with(install_name::str, "@rpath/")) {
+        ret dyn_copy(a, install_name);
+    }
+    val rp_r: R.Result[str, str] = dylib_rpath(a, actual, install_name);
+    if (R.is_err[str, str](rp_r)) {
+        ret R.err[LinkInput, outcome.Fail](outcome.user(R.unwrap_err[str, str](rp_r)));
+    }
+    ret dyn_copy_with_rpath(a, install_name, R.unwrap_ok[str, str](rp_r)::*u8);
 }
 
 # concatenate `va` into one owned message string on `al`, for a Fail's message
@@ -1105,9 +1144,10 @@ fun dll_basename(path: *u8) *u8 {
 # dynamic fallback here. Target format gating prevents a Darwin cross-plan from
 # probing or consuming a host ELF shared library.
 fun resolve_shared_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
-                        name: *u8, buf: *u8, cap: usize) bool {
+                        name: *u8, buf: *u8, cap: usize,
+                        rpath: *u8, rpath_cap: usize) bool {
     if (str_equals(tgt.of.shared_input_ext, ".dylib")) {
-        ret resolve_dylib_into(a, tgt, dirs, name, buf, cap);
+        ret resolve_dylib_into(a, tgt, dirs, name, buf, cap, rpath, rpath_cap);
     }
     if (!str_equals(tgt.of.shared_input_ext, ".so")) { ret false; }
     ret resolve_elf_shared_into(a, tgt, dirs, name, buf, cap);
@@ -1134,17 +1174,20 @@ fun resolve_elf_shared_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[
 
 # resolve a bare Mach-O library name through -L and target system directories
 fun resolve_dylib_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
-                       name: *u8, buf: *u8, cap: usize) bool {
+                       name: *u8, buf: *u8, cap: usize,
+                       rpath: *u8, rpath_cap: usize) bool {
     var i: usize = 0;
     for (i < dirs.len) {
-        if (try_dylib_in_dir(a, dirs.data[i]::*u8, name, buf, cap)) { ret true; }
+        if (try_dylib_in_dir(a, dirs.data[i]::*u8, name, buf, cap,
+                             rpath, rpath_cap)) { ret true; }
         i = i + 1;
     }
     if (tgt.os != nil) {
         var li: u32 = 0;
         for (li < tgt.os.libdir_len) {
             val ld: str = tgt.os.libdirs[li];
-            if (!str_empty(ld) && try_dylib_in_dir(a, ld::*u8, name, buf, cap)) { ret true; }
+            if (!str_empty(ld) && try_dylib_in_dir(a, ld::*u8, name, buf, cap,
+                                                   rpath, rpath_cap)) { ret true; }
             li = li + 1;
         }
     }
@@ -1153,17 +1196,69 @@ fun resolve_dylib_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
 
 # probe `<dir>/lib<name>.dylib`, then `lib<name>.<N>.dylib` for N in 6..0
 fun try_dylib_in_dir(a: *A.Allocator, dir: *u8, name: *u8,
-                     buf: *u8, cap: usize) bool {
+                     buf: *u8, cap: usize, rpath: *u8, rpath_cap: usize) bool {
     var cand: [4096]u8;
     if (write_named_candidate(dir, "lib", name, "dylib", ?cand[0], 4096)
-        && accept_dylib(a, ?cand[0], buf, cap)) { ret true; }
+        && accept_dylib(a, ?cand[0], buf, cap)) {
+        ret dylib_rpath_into(a, ?cand[0], buf, rpath, rpath_cap);
+    }
     var v: i64 = 6;
     for (v >= 0) {
         if (write_named_dylib_version(dir, name, v::u32, ?cand[0], 4096)
-            && accept_dylib(a, ?cand[0], buf, cap)) { ret true; }
+            && accept_dylib(a, ?cand[0], buf, cap)) {
+            ret dylib_rpath_into(a, ?cand[0], buf, rpath, rpath_cap);
+        }
         v = v - 1;
     }
     ret false;
+}
+
+# write the selected file's resolved directory for an @rpath install name
+fun dylib_rpath_into(a: *A.Allocator, candidate: *u8, install_name: *u8,
+                     out: *u8, cap: usize) bool {
+    if (out == nil || cap == 0) { ret false; }
+    out[0] = 0;
+    if (!str_starts_with(install_name::str, "@rpath/")) { ret true; }
+    val rp_r: R.Result[str, str] = dylib_rpath(a, candidate, install_name);
+    if (R.is_err[str, str](rp_r)) { ret false; }
+    val rp: str = R.unwrap_ok[str, str](rp_r);
+    val n: usize = str_len(rp);
+    if (n + 1 > cap) { ret false; }
+    memory.raw_copy(out::ptr, rp::ptr, n + 1);
+    ret true;
+}
+
+# derive the runtime root whose appended @rpath suffix reaches `candidate`
+fun dylib_rpath(a: *A.Allocator, candidate: *u8,
+                install_name: *u8) R.Result[str, str] {
+    val abs_r: R.Result[str, str] = resolve_from_cwd(a, candidate::str);
+    if (R.is_err[str, str](abs_r)) { ret abs_r; }
+    val abs: str = R.unwrap_ok[str, str](abs_r);
+    val suffix: str = (install_name::usize + 7)::str;
+    if (!str_contains(suffix, "/")) { ret path.parent(a, abs); }
+    val abs_len: usize = str_len(abs);
+    val suffix_len: usize = str_len(suffix);
+    if (suffix_len == 0 || suffix[0] == '/' || abs_len <= suffix_len
+        || !str_ends_with(abs, suffix)) {
+        ret R.err[str, str](
+            "the selected dylib path does not match its @rpath install-name suffix");
+    }
+    var cut: usize = abs_len - suffix_len;
+    if (abs[cut - 1] != '/') {
+        ret R.err[str, str](
+            "the selected dylib path does not match its @rpath install-name suffix");
+    }
+    if (cut > 1) { cut = cut - 1; }
+    (abs::*u8)[cut] = 0;
+    ret R.ok[str, str](abs);
+}
+
+# resolve a relative selected path against the directory the probe used
+fun resolve_from_cwd(a: *A.Allocator, p: str) R.Result[str, str] {
+    if (path.is_abs(p)) { ret path.clone(a, p); }
+    val cwd_r: R.Result[str, str] = env.current_dir(a);
+    if (R.is_err[str, str](cwd_r)) { ret R.err[str, str](R.unwrap_err[str, str](cwd_r)); }
+    ret path.resolve(a, R.unwrap_ok[str, str](cwd_r), p);
 }
 
 # accept an existing Mach-O dylib and retain its canonical install name
@@ -1263,7 +1358,10 @@ pub fun explain(p: *BuildPlan, itn: *intern.Interner) {
         for (li < u.link_inputs.len) {
             val inp: *LinkInput = ?u.link_inputs.data[li];
             if (inp.kind == LINK_STATIC) { print.printf("  link    static  {}\n", inp.text); }
-            or                           { print.printf("  link    dynamic {}\n", inp.text); }
+            or {
+                print.printf("  link    dynamic {}\n", inp.text);
+                if (!str_empty(inp.rpath)) { print.printf("  rpath   {}\n", inp.rpath); }
+            }
             li = li + 1;
         }
 
@@ -1461,7 +1559,8 @@ test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
         ret 1;
     }
     val li: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](rr);
-    if (li.kind != LINK_DYNAMIC || !str_equals(li.text, "@rpath/libglfw.3.dylib")) {
+    if (li.kind != LINK_DYNAMIC || !str_equals(li.text, "@rpath/libglfw.3.dylib")
+        || !str_equals(li.rpath, root)) {
         fs.remove_all(?alloc, root);
         ret 1;
     }
@@ -1471,6 +1570,26 @@ test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
         resolve_token(?alloc, ?tgt, ?dirs, "", "hostonly"::*u8);
     fs.remove_all(?alloc, root);
     if (R.is_ok[LinkInput, outcome.Fail](host_only)) { ret 1; }
+    ret 0;
+}
+
+# @rpath roots preserve basename symlinks and strip nested install-name suffixes
+test "mach.lang.build.plan.dylib_rpath:matches_install_name_suffix" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val base: R.Result[str, str] =
+        dylib_rpath(?alloc, "/opt/lib/libfoo.dylib"::*u8,
+                    "@rpath/libfoo.3.dylib"::*u8);
+    val nested: R.Result[str, str] =
+        dylib_rpath(?alloc, "/opt/lib/sub/libfoo.dylib"::*u8,
+                    "@rpath/sub/libfoo.dylib"::*u8);
+    val mismatch: R.Result[str, str] =
+        dylib_rpath(?alloc, "/opt/lib/libfoo.dylib"::*u8,
+                    "@rpath/sub/libfoo.dylib"::*u8);
+    if (R.is_err[str, str](base) || R.is_err[str, str](nested)
+        || R.is_ok[str, str](mismatch)) { ret 1; }
+    if (!str_equals(R.unwrap_ok[str, str](base), "/opt/lib")
+        || !str_equals(R.unwrap_ok[str, str](nested), "/opt/lib")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -7,8 +7,8 @@
 # the same `manifest.resolve_build_unit` the driver and compose share (one
 # rule, one home); output templates expand to final absolute paths; link
 # tokens resolve against the unit's composed target to `LinkInput` facts - an
-# absolute object/archive path, or the soname a shared library is loaded by -
-# discovered by the exact filesystem probing the link performs. A link input
+# absolute object/archive path, or the canonical loader name of a shared library
+# or framework - discovered by target-aware resolution. A link input
 # that does not exist fails the plan with the same error text the link would
 # have produced: same visible behavior, earlier and honest.
 #
@@ -606,15 +606,17 @@ fun steps_demanded(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest
 # The single home of link-token resolution, shared by the planner (the
 # request's tokens, at plan time) and the link path (the manifest's merged
 # overlay and the cascading dep libs, discovered during the build). A
-# `.dll`/`.dylib` is a loader dependency named by string alone, recorded by
-# basename with no on-disk probe and gated to its object format. Anything
-# else probes the filesystem: an explicit `.o`/`.a` path verbatim (then
+# `.dll` is a PE loader dependency recorded by basename without an on-disk
+# probe; a `.dylib` is a Mach-O dependency whose LC_ID_DYLIB is retained when
+# the file exists and whose explicit spelling is retained on a cross host.
+# Both are gated to their object format. Anything else probes the filesystem:
+# an explicit `.o`/`.a` path verbatim (then
 # retried against the project root), a bare name through the `-L` dirs and
 # working directory as `lib<name>.o`/`<name>.o`/`lib<name>.a`/`<name>.a`, a
-# shared object by reading its DT_SONAME, and a bare name lastly as
-# `lib<name>.so` through the `-L` dirs and the target OS's library
-# directories. An input that resolves to no existing file is a hard error so
-# a typo never silently drops a dependency.
+# shared object by reading its DT_SONAME, and a bare name lastly as the
+# target format's `.so` or `.dylib` through the `-L` dirs and the target OS's
+# library directories. An input that resolves to no existing file is a hard
+# error so a typo never silently drops a dependency.
 # ---
 # a:    allocator owning the returned fact's text
 # tgt:  the unit's composed target (object-format gating, os library dirs)
@@ -636,16 +638,37 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
         ret dyn_copy(a, dll_basename(tok));
     }
 
-    # a Darwin `.dylib` is a Mach-O LC_LOAD_DYLIB dependency named by its install
-    # name, resolved by dyld at run time; recorded by basename with no on-disk
-    # probe (a system dylib is absent on a cross host).
+    # a Darwin `.dylib` is a Mach-O LC_LOAD_DYLIB dependency named by its canonical
+    # install name. an existing file contributes its LC_ID_DYLIB; a path absent on
+    # a cross host is retained verbatim rather than incorrectly reduced to basename.
     if (is_dylib_path(tok)) {
         # likewise only the format declaring `.dylib` as its shared-library input
         # extension (Mach-O) consumes a `.dylib`.
         if (!str_equals(tgt.of.shared_input_ext, ".dylib")) {
             ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", tok::str, "' is a Mach-O dylib; .dylib inputs require a Mach-O target")));
         }
-        ret dyn_copy(a, dll_basename(tok));
+        var actual: *u8 = tok;
+        var rooted: str = "";
+        var exists: bool = fs.is_file(tok);
+        if (!exists && tok[0] != '/') {
+            val cand_r: R.Result[str, str] = path.join(a, root, tok::str);
+            if (R.is_ok[str, str](cand_r)) {
+                rooted = R.unwrap_ok[str, str](cand_r);
+                if (fs.is_file(rooted)) {
+                    actual = rooted::*u8;
+                    exists = true;
+                }
+            }
+        }
+        if (exists) {
+            var install_name: [4096]u8;
+            if (read_dylib_install_name(a, actual, ?install_name[0], 4096)) {
+                ret dyn_copy(a, ?install_name[0]);
+            }
+            ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", actual::str,
+                "' is not a loadable Mach-O dylib (missing a valid LC_ID_DYLIB)")));
+        }
+        ret dyn_copy(a, tok);
     }
 
     var buf: [4096]u8;
@@ -687,9 +710,9 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
         }
     }
 
-    # a bare `-l` name with no static `.o`/`.a` falls back to a shared
-    # `lib<name>.so` in the `-L` dirs and the system library directories;
-    # `resolve_shared_into` writes the library's own soname.
+    # a bare `-l` name with no static `.o`/`.a` falls back to the selected
+    # format's shared library in the `-L` dirs and target system directories;
+    # `resolve_shared_into` writes the library's own canonical loader name.
     if (!found && !request.is_object_path(tok) && !is_shared_path(tok)) {
         var sname: [4096]u8;
         if (resolve_shared_into(a, tgt, dirs, tok, ?sname[0], 4096)) {
@@ -726,11 +749,16 @@ pub fun resolve_requirement(a: *A.Allocator, itn: *intern.Interner, tgt: *target
         ret R.err[LinkInput, outcome.Fail](outcome.internal("link requirement text not interned"));
     }
     val text: str = O.unwrap[str](text_opt);
+    if (req.source == manifest.LINK_FRAMEWORK) {
+        val fr: R.Result[LinkInput, outcome.Fail] =
+            resolve_framework(a, tgt, text::*u8);
+        if (R.is_err[LinkInput, outcome.Fail](fr)) { ret fr; }
+        var fi: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](fr);
+        fi.library = req.library;
+        ret R.ok[LinkInput, outcome.Fail](fi);
+    }
     var r: R.Result[LinkInput, outcome.Fail] =
         resolve_token(a, tgt, dirs, root, text::*u8);
-    if (req.source == manifest.LINK_FRAMEWORK) {
-        r = resolve_framework(a, tgt, text::*u8);
-    }
     if (R.is_err[LinkInput, outcome.Fail](r)) { ret r; }
     var li: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](r);
     li.library = req.library;
@@ -941,6 +969,98 @@ fun extract_soname(buf: *u8, len: usize, out: *u8, cap: usize) bool {
     ret false;
 }
 
+# read a Mach-O dylib's LC_ID_DYLIB install name into `out`
+#
+# Accepts a thin 64-bit Mach-O dylib or a 32/64-bit universal wrapper containing
+# one. Every supported Darwin target is 64-bit; universal slices are scanned in
+# declaration order and must carry a valid LC_ID_DYLIB command.
+fun read_dylib_install_name(a: *A.Allocator, dylib_path: *u8,
+                            out: *u8, cap: usize) bool {
+    val res_read: R.Result[Vector[u8], str] = fs.read_bytes(a, dylib_path);
+    if (R.is_err[Vector[u8], str](res_read)) { ret false; }
+    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](res_read);
+    var ok: bool = false;
+    if (b.len >= 4 && bin.read_u32_le(b.data, 0) == 0xFEEDFACF) {
+        ok = extract_dylib_id(b.data, b.len, 0, b.len, out, cap);
+    }
+    or (b.len >= 8 && bin.read_u32_be(b.data, 0) == 0xCAFEBABE) {
+        ok = extract_fat_dylib_id(b.data, b.len, false, out, cap);
+    }
+    or (b.len >= 8 && bin.read_u32_be(b.data, 0) == 0xCAFEBABF) {
+        ok = extract_fat_dylib_id(b.data, b.len, true, out, cap);
+    }
+    vector.dnit[u8](?b);
+    ret ok;
+}
+
+# extract LC_ID_DYLIB from one thin 64-bit Mach-O slice
+fun extract_dylib_id(buf: *u8, len: usize, base: usize, slice_len: usize,
+                     out: *u8, cap: usize) bool {
+    if (base > len || slice_len > len - base || slice_len < 32) { ret false; }
+    val end: usize = base + slice_len;
+    if (bin.read_u32_le(buf, base) != 0xFEEDFACF) { ret false; }
+    if (bin.read_u32_le(buf, base + 12) != 6)     { ret false; } # MH_DYLIB
+    val ncmds: u32 = bin.read_u32_le(buf, base + 16);
+    val sizeofcmds: usize = bin.read_u32_le(buf, base + 20)::usize;
+    if (sizeofcmds > end - (base + 32)) { ret false; }
+    val cmds_end: usize = base + 32 + sizeofcmds;
+
+    var off: usize = base + 32;
+    var i: u32 = 0;
+    for (i < ncmds) {
+        if (off + 8 > cmds_end) { ret false; }
+        val cmd: u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmdsize < 8 || cmdsize > cmds_end - off) { ret false; }
+        if (cmd == 0xD) { # LC_ID_DYLIB
+            if (cmdsize < 24) { ret false; }
+            val name_off: usize = bin.read_u32_le(buf, off + 8)::usize;
+            if (name_off < 24 || name_off >= cmdsize) { ret false; }
+            val at: usize = off + name_off;
+            var k: usize = 0;
+            for (at + k < off + cmdsize && buf[at + k] != 0 && k + 1 < cap) {
+                out[k] = buf[at + k];
+                k = k + 1;
+            }
+            if (at + k >= off + cmdsize || buf[at + k] != 0 || k == 0) { ret false; }
+            out[k] = 0;
+            ret true;
+        }
+        off = off + cmdsize;
+        i = i + 1;
+    }
+    ret false;
+}
+
+# extract LC_ID_DYLIB from the first valid slice of a universal Mach-O
+fun extract_fat_dylib_id(buf: *u8, len: usize, wide: bool,
+                         out: *u8, cap: usize) bool {
+    val nfat: usize = bin.read_u32_be(buf, 4)::usize;
+    var ent_size: usize = 20;
+    if (wide) { ent_size = 32; }
+    if (nfat > (len - 8) / ent_size) { ret false; }
+
+    var i: usize = 0;
+    for (i < nfat) {
+        val ent: usize = 8 + i * ent_size;
+        var off: usize = bin.read_u32_be(buf, ent + 8)::usize;
+        var size: usize = bin.read_u32_be(buf, ent + 12)::usize;
+        if (wide) {
+            off  = read_u64_be(buf, ent + 8)::usize;
+            size = read_u64_be(buf, ent + 16)::usize;
+        }
+        if (extract_dylib_id(buf, len, off, size, out, cap)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# read a big-endian u64 through the format-neutral binary helpers
+fun read_u64_be(buf: *u8, off: usize) u64 {
+    ret (bin.read_u32_be(buf, off)::u64 << 32)
+        | bin.read_u32_be(buf, off + 4)::u64;
+}
+
 # whether a path/token names a shared library: it contains a `.so` segment
 # followed by end-of-string or a `.<version>` suffix
 fun is_shared_path(tok: *u8) bool {
@@ -989,16 +1109,24 @@ fun dll_basename(path: *u8) *u8 {
     ret (path::usize + last)::*u8;
 }
 
-# resolve a bare `-l` name to a shared library `lib<name>.so` (or a
-# `.so.<version>`)
+# resolve a bare `-l` name to the selected format's shared-library spelling
 #
-# Searches each `-L <dir>`, then the target OS's ordered library directories
-# (per-OS, so a cross-OS link probes the right directories rather than the
-# host's). Writes the soname to record for DT_NEEDED (the library's own
-# DT_SONAME) into `buf`. A non-ELF match (a GNU ld linker script at
-# `lib<name>.so`) is skipped so a versioned `lib<name>.so.N` is preferred.
+# ELF targets probe `.so[.N]` and retain DT_SONAME; Mach-O targets probe
+# `.dylib`/`.<N>.dylib` and retain LC_ID_DYLIB. Other formats have no bare-name
+# dynamic fallback here. Target format gating prevents a Darwin cross-plan from
+# probing or consuming a host ELF shared library.
 fun resolve_shared_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
                         name: *u8, buf: *u8, cap: usize) bool {
+    if (str_equals(tgt.of.shared_input_ext, ".dylib")) {
+        ret resolve_dylib_into(a, tgt, dirs, name, buf, cap);
+    }
+    if (!str_equals(tgt.of.shared_input_ext, ".so")) { ret false; }
+    ret resolve_elf_shared_into(a, tgt, dirs, name, buf, cap);
+}
+
+# resolve a bare ELF library name through -L and target system directories
+fun resolve_elf_shared_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
+                            name: *u8, buf: *u8, cap: usize) bool {
     var i: usize = 0;
     for (i < dirs.len) {
         if (try_shared_in_dir(a, dirs.data[i]::*u8, name, buf, cap)) { ret true; }
@@ -1013,6 +1141,69 @@ fun resolve_shared_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str]
         }
     }
     ret false;
+}
+
+# resolve a bare Mach-O library name through -L and target system directories
+fun resolve_dylib_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
+                       name: *u8, buf: *u8, cap: usize) bool {
+    var i: usize = 0;
+    for (i < dirs.len) {
+        if (try_dylib_in_dir(a, dirs.data[i]::*u8, name, buf, cap)) { ret true; }
+        i = i + 1;
+    }
+    if (tgt.os != nil) {
+        var li: u32 = 0;
+        for (li < tgt.os.libdir_len) {
+            val ld: str = tgt.os.libdirs[li];
+            if (!str_empty(ld) && try_dylib_in_dir(a, ld::*u8, name, buf, cap)) { ret true; }
+            li = li + 1;
+        }
+    }
+    ret false;
+}
+
+# probe `<dir>/lib<name>.dylib`, then `lib<name>.<N>.dylib` for N in 6..0
+fun try_dylib_in_dir(a: *A.Allocator, dir: *u8, name: *u8,
+                     buf: *u8, cap: usize) bool {
+    var cand: [4096]u8;
+    if (write_named_candidate(dir, "lib", name, "dylib", ?cand[0], 4096)
+        && accept_dylib(a, ?cand[0], buf, cap)) { ret true; }
+    var v: i64 = 6;
+    for (v >= 0) {
+        if (write_named_dylib_version(dir, name, v::u32, ?cand[0], 4096)
+            && accept_dylib(a, ?cand[0], buf, cap)) { ret true; }
+        v = v - 1;
+    }
+    ret false;
+}
+
+# accept an existing Mach-O dylib and retain its canonical install name
+fun accept_dylib(a: *A.Allocator, cand: *u8, buf: *u8, cap: usize) bool {
+    if (!fs.is_file(cand)) { ret false; }
+    ret read_dylib_install_name(a, cand, buf, cap);
+}
+
+# compose `<dir>/lib<name>.<v>.dylib` into `buf`
+fun write_named_dylib_version(dir: *u8, name: *u8, v: u32,
+                              buf: *u8, cap: usize) bool {
+    if (v > 9) { ret false; }
+    val dl: usize = str_len(dir);
+    val nl: usize = str_len(name::str);
+    val need: usize = dl + 1 + 3 + nl + 1 + 1 + 6 + 1;
+    if (need > cap) { ret false; }
+    var k: usize = 0;
+    var i: usize = 0;
+    for (i < dl) { buf[k] = dir[i]; k = k + 1; i = i + 1; }
+    if (k > 0 && buf[k - 1] != '/') { buf[k] = '/'; k = k + 1; }
+    buf[k] = 'l'; buf[k + 1] = 'i'; buf[k + 2] = 'b'; k = k + 3;
+    i = 0;
+    for (i < nl) { buf[k] = name[i]; k = k + 1; i = i + 1; }
+    buf[k] = '.'; buf[k + 1] = ('0'::u32 + v)::u8; buf[k + 2] = '.'; k = k + 3;
+    val ext: str = "dylib";
+    i = 0;
+    for (i < 5) { buf[k] = ext[i]; k = k + 1; i = i + 1; }
+    buf[k] = 0;
+    ret true;
 }
 
 # probe `<dir>/lib<name>.so` then the common SONAME-bearing `lib<name>.so.<N>`
@@ -1204,6 +1395,133 @@ fun ut_path_eq(a: str, b: str) bool {
     }
 
     ret a[i] == b[i];
+}
+
+# write a minimal thin 64-bit Mach-O dylib carrying `install_name`
+fun ut_write_dylib(path_: str, install_name: str) bool {
+    var buf: [160]u8;
+    var i: usize = 0;
+    for (i < 160) { buf[i] = 0; i = i + 1; }
+    val name_len: usize = str_len(install_name);
+    if (name_len + 1 > 72) { ret false; }
+
+    bin.write_u32_le(?buf[0], 0, 0xFEEDFACF); # MH_MAGIC_64
+    bin.write_u32_le(?buf[0], 4, 0x01000007); # CPU_TYPE_X86_64
+    bin.write_u32_le(?buf[0], 8, 3);
+    bin.write_u32_le(?buf[0], 12, 6);         # MH_DYLIB
+    bin.write_u32_le(?buf[0], 16, 1);
+    bin.write_u32_le(?buf[0], 20, 96);
+    bin.write_u32_le(?buf[0], 32, 0xD);       # LC_ID_DYLIB
+    bin.write_u32_le(?buf[0], 36, 96);
+    bin.write_u32_le(?buf[0], 40, 24);
+    memory.raw_copy((?buf[56])::ptr, install_name::ptr, name_len);
+    ret O.is_none[str](fs.write_bytes(path_, ?buf[0], 128, 420));
+}
+
+# create a unique temporary directory path
+fun ut_temp_dir(a: *A.Allocator) R.Result[str, str] {
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(a, "mach_plan_dylib");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[str, str](R.unwrap_err[fs.TempFile, str](tf_r)); }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val root_r: R.Result[str, str] = str_copy(a, fs.temp_path(?tf)::*u8);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[str, str](root_r)) { ret root_r; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val mk: O.Option[str] = fs.create_dir_all(a, root, 493);
+    if (O.is_some[str](mk)) { ret R.err[str, str](O.unwrap[str](mk)); }
+    ret R.ok[str, str](root);
+}
+
+# a named Darwin system requirement probes `.dylib`, reads LC_ID_DYLIB, and
+# never falls through to a host ELF `.so`
+test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "darwin", "sysv64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    val root_r: R.Result[str, str] = ut_temp_dir(?alloc);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val dylib_r: R.Result[str, str] = path.join(?alloc, root, "libglfw.dylib");
+    val elf_r: R.Result[str, str] = path.join(?alloc, root, "libhostonly.so");
+    if (R.is_err[str, str](dylib_r) || R.is_err[str, str](elf_r)) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+    val dylib: str = R.unwrap_ok[str, str](dylib_r);
+    val elf: str = R.unwrap_ok[str, str](elf_r);
+    if (!ut_write_dylib(dylib, "@rpath/libglfw.3.dylib")
+        || O.is_some[str](fs.write_bytes(elf, "ELF", 3, 420))) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+
+    var dirs: Vector[str] = vector.init[str](?alloc);
+    if (R.is_err[usize, str](vector.push[str](?dirs, root))) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+    val rr: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(?alloc, ?tgt, ?dirs, "", "glfw"::*u8);
+    if (R.is_err[LinkInput, outcome.Fail](rr)) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+    val li: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](rr);
+    if (li.kind != LINK_DYNAMIC || !str_equals(li.text, "@rpath/libglfw.3.dylib")) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+
+    # no libhostonly.dylib exists; the Darwin target must not consume the `.so`.
+    val host_only: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(?alloc, ?tgt, ?dirs, "", "hostonly"::*u8);
+    fs.remove_all(?alloc, root);
+    if (R.is_ok[LinkInput, outcome.Fail](host_only)) { ret 1; }
+    ret 0;
+}
+
+# frameworks resolve identically for both supported Darwin architectures without
+# probing the host, and reject a non-Darwin target
+test "mach.lang.build.plan.resolve_requirement:darwin_framework" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var itn: intern.Interner = intern.init(?alloc);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val xr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "darwin", "sysv64");
+    val ar: R.Result[target.Target, str] = target.select(?reg, "aarch64", "darwin", "aapcs64");
+    val lr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[target.Target, str](xr) || R.is_err[target.Target, str](ar)
+        || R.is_err[target.Target, str](lr)) { ret 1; }
+    var xt: target.Target = R.unwrap_ok[target.Target, str](xr);
+    var at: target.Target = R.unwrap_ok[target.Target, str](ar);
+    var lt: target.Target = R.unwrap_ok[target.Target, str](lr);
+
+    var req: manifest.LinkRequirement;
+    req.source = manifest.LINK_FRAMEWORK;
+    req.text = R.unwrap_ok[intern.StrId, str](intern.intern(?itn, "Cocoa"));
+    req.library = R.unwrap_ok[intern.StrId, str](intern.intern(?itn, "cocoa"));
+    var dirs: Vector[str] = vector.init[str](?alloc);
+
+    val x: R.Result[LinkInput, outcome.Fail] =
+        resolve_requirement(?alloc, ?itn, ?xt, ?dirs, "", ?req);
+    val a: R.Result[LinkInput, outcome.Fail] =
+        resolve_requirement(?alloc, ?itn, ?at, ?dirs, "", ?req);
+    val l: R.Result[LinkInput, outcome.Fail] =
+        resolve_requirement(?alloc, ?itn, ?lt, ?dirs, "", ?req);
+    if (R.is_err[LinkInput, outcome.Fail](x) || R.is_err[LinkInput, outcome.Fail](a)
+        || R.is_ok[LinkInput, outcome.Fail](l)) { ret 1; }
+    val want: str = "/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa";
+    val xi: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](x);
+    val ai: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](a);
+    if (!str_equals(xi.text, want) || !str_equals(ai.text, want)) { ret 1; }
+    if (xi.library != req.library || ai.library != req.library) { ret 1; }
+    ret 0;
 }
 
 # all_targets expands targets-outer, artifacts-inner in declaration order, and

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -698,18 +698,6 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
         ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", (?buf[0])::str, "' is not a loadable ELF shared object (an ld script or unsupported '.so')")));
     }
 
-    # an explicit `.so` token taken verbatim (it has no '/' so `is_object_path`
-    # skipped it) - resolve it as a file and record its soname.
-    if (!found && is_shared_path(tok)) {
-        if (fs.is_file(tok)) {
-            var sname: [4096]u8;
-            if (read_so_soname(a, tok, ?sname[0], 4096)) {
-                ret dyn_copy(a, ?sname[0]);
-            }
-            ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", tok::str, "' is not a loadable ELF shared object (an ld script or unsupported '.so')")));
-        }
-    }
-
     # a bare `-l` name with no static `.o`/`.a` falls back to the selected
     # format's shared library in the `-L` dirs and target system directories;
     # `resolve_shared_into` writes the library's own canonical loader name.
@@ -813,12 +801,11 @@ fun join_msg(al: *A.Allocator, va: ...) str {
 # resolve one link-input token to an existing input file, writing the
 # absolute-or-relative path into `buf`
 #
-# An explicit object/archive path (`is_object_path`, i.e. a `.o` or `.a`) is
-# taken verbatim. A bare `-l`-style name is searched in each `-L <dir>` as
+# An explicit link-file path (`is_object_path`) is taken verbatim. A bare
+# `-l`-style name is searched in each `-L <dir>` as
 # `<dir>/lib<name>.o`, `<dir>/<name>.o`, `<dir>/lib<name>.a`, `<dir>/<name>.a`,
-# then the same four candidates relative to the working directory. `.so` shared
-# libraries are not handled here - only loose `.o` objects and static `.a`
-# archives.
+# then the same four candidates relative to the working directory. A shared
+# library path is returned verbatim for the caller's format-specific handling.
 fun resolve_input_into(tok: *u8, dirs: *Vector[str], buf: *u8, cap: usize) bool {
     if (tok == nil || str_empty(tok::str)) { ret false; }
 

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -93,11 +93,15 @@ pub val LINK_DYNAMIC: LinkInputKind = 1;
 
 # one fully resolved link input
 # ---
-# kind: static (an on-disk object/archive) or dynamic (a loader dependency)
-# text: absolute path (STATIC) or soname (DYNAMIC), owned by the plan allocator
+# kind:    static (an on-disk object/archive) or dynamic (a loader dependency)
+# text:    absolute path (STATIC) or canonical loader name (DYNAMIC), owned by
+#          the plan allocator
+# library: stable logical `#[library]` attribution name; STR_NIL for an explicit
+#          path without a portable identity
 pub rec LinkInput {
-    kind: LinkInputKind;
-    text: str;
+    kind:    LinkInputKind;
+    text:    str;
+    library: intern.StrId;
 }
 
 # one build unit: a (target, profile, artifact) cell, everything concrete
@@ -357,11 +361,23 @@ fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
     u.link_inputs = vector.init[LinkInput](a);
     var ti: usize = 0;
     for (ti < req.link_tokens.len) {
-        val lr: R.Result[LinkInput, outcome.Fail] = resolve_token(a, ?tgt, ?req.lib_dirs, root, req.link_tokens.data[ti].text::*u8);
+        val token: str = req.link_tokens.data[ti].text;
+        val lr: R.Result[LinkInput, outcome.Fail] =
+            resolve_token(a, ?tgt, ?req.lib_dirs, root, token::*u8);
         if (R.is_err[LinkInput, outcome.Fail](lr)) {
             ret R.err[BuildUnit, outcome.Fail](R.unwrap_err[LinkInput, outcome.Fail](lr));
         }
-        val pr: R.Result[usize, str] = vector.push[LinkInput](?u.link_inputs, R.unwrap_ok[LinkInput, outcome.Fail](lr));
+        var input: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](lr);
+        # a bare `-l` token is itself a stable logical library name. explicit paths
+        # retain only their canonical runtime name for backwards-compatible exact
+        # `#[library]` attribution.
+        if (!request.is_object_path(token::*u8) && !is_shared_path(token::*u8)
+            && !is_dll_path(token::*u8) && !is_dylib_path(token::*u8)) {
+            val name_r: R.Result[intern.StrId, str] = intern.intern(itn, token);
+            if (R.is_err[intern.StrId, str](name_r)) { ret oom_unit(); }
+            input.library = R.unwrap_ok[intern.StrId, str](name_r);
+        }
+        val pr: R.Result[usize, str] = vector.push[LinkInput](?u.link_inputs, input);
         if (R.is_err[usize, str](pr)) { ret oom_unit(); }
         ti = ti + 1;
     }
@@ -690,6 +706,55 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
     var li: LinkInput;
     li.kind = LINK_STATIC;
     li.text = R.unwrap_ok[str, str](dup_r);
+    li.library = intern.STR_NIL;
+    ret R.ok[LinkInput, outcome.Fail](li);
+}
+
+# resolve one typed manifest requirement to a concrete link fact
+# ---
+# a:    allocator owning the returned fact's text
+# tgt:  selected target
+# dirs: `-L` search directories
+# root: project root for relative local paths
+# req:  typed manifest requirement
+# ret:  resolved static path or dynamic loader dependency
+pub fun resolve_requirement(a: *A.Allocator, itn: *intern.Interner, tgt: *target.Target,
+                            dirs: *Vector[str], root: str,
+                            req: *manifest.LinkRequirement) R.Result[LinkInput, outcome.Fail] {
+    val text_opt: O.Option[str] = intern.lookup(itn, req.text);
+    if (O.is_none[str](text_opt)) {
+        ret R.err[LinkInput, outcome.Fail](outcome.internal("link requirement text not interned"));
+    }
+    val text: str = O.unwrap[str](text_opt);
+    var r: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(a, tgt, dirs, root, text::*u8);
+    if (req.source == manifest.LINK_FRAMEWORK) {
+        r = resolve_framework(a, tgt, text::*u8);
+    }
+    if (R.is_err[LinkInput, outcome.Fail](r)) { ret r; }
+    var li: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](r);
+    li.library = req.library;
+    ret R.ok[LinkInput, outcome.Fail](li);
+}
+
+# resolve a named Darwin framework to its canonical system install name
+#
+# Framework resolution is target planning: it derives the dependency name from
+# the Darwin framework convention without probing the build host, so a Linux host
+# cross-planning either Darwin architecture cannot consume a host ELF library.
+fun resolve_framework(a: *A.Allocator, tgt: *target.Target,
+                      name: *u8) R.Result[LinkInput, outcome.Fail] {
+    if (tgt.os == nil || !str_equals(tgt.os.name, "darwin")
+        || !str_equals(tgt.of.shared_input_ext, ".dylib")) {
+        ret R.err[LinkInput, outcome.Fail](outcome.user(
+            join_msg(a, "framework link input '", name::str, "' requires a Darwin Mach-O target")));
+    }
+    val install_name: str = join_msg(a, "/System/Library/Frameworks/", name::str,
+        ".framework/Versions/A/", name::str);
+    var li: LinkInput;
+    li.kind    = LINK_DYNAMIC;
+    li.text    = install_name;
+    li.library = intern.STR_NIL;
     ret R.ok[LinkInput, outcome.Fail](li);
 }
 
@@ -700,6 +765,7 @@ fun dyn_copy(a: *A.Allocator, name: *u8) R.Result[LinkInput, outcome.Fail] {
     var li: LinkInput;
     li.kind = LINK_DYNAMIC;
     li.text = R.unwrap_ok[str, str](dup_r);
+    li.library = intern.STR_NIL;
     ret R.ok[LinkInput, outcome.Fail](li);
 }
 

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -765,11 +765,13 @@ pub fun resolve_requirement(a: *A.Allocator, itn: *intern.Interner, tgt: *target
     ret R.ok[LinkInput, outcome.Fail](li);
 }
 
-# resolve a named Darwin framework to its canonical system install name
+# resolve a named Darwin framework to its version-independent system path
 #
 # Framework resolution is target planning: it derives the dependency name from
 # the Darwin framework convention without probing the build host, so a Linux host
 # cross-planning either Darwin architecture cannot consume a host ELF library.
+# the top-level framework binary is the stable symlink across frameworks whose
+# canonical install names use different bundle versions (notably A versus C).
 fun resolve_framework(a: *A.Allocator, tgt: *target.Target,
                       name: *u8) R.Result[LinkInput, outcome.Fail] {
     if (tgt.os == nil || !str_equals(tgt.os.name, "darwin")
@@ -778,7 +780,7 @@ fun resolve_framework(a: *A.Allocator, tgt: *target.Target,
             join_msg(a, "framework link input '", name::str, "' requires a Darwin Mach-O target")));
     }
     val install_name: str = join_msg(a, "/System/Library/Frameworks/", name::str,
-        ".framework/Versions/A/", name::str);
+        ".framework/", name::str);
     var li: LinkInput;
     li.kind    = LINK_DYNAMIC;
     li.text    = install_name;
@@ -1485,8 +1487,8 @@ test "mach.lang.build.plan.resolve_token:darwin_dylib_install_name" {
     ret 0;
 }
 
-# frameworks resolve identically for both supported Darwin architectures without
-# probing the host, and reject a non-Darwin target
+# frameworks use a version-independent path for both supported Darwin
+# architectures without probing the host, and reject a non-Darwin target
 test "mach.lang.build.plan.resolve_requirement:darwin_framework" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -1504,8 +1506,8 @@ test "mach.lang.build.plan.resolve_requirement:darwin_framework" {
 
     var req: manifest.LinkRequirement;
     req.source = manifest.LINK_FRAMEWORK;
-    req.text = R.unwrap_ok[intern.StrId, str](intern.intern(?itn, "Cocoa"));
-    req.library = R.unwrap_ok[intern.StrId, str](intern.intern(?itn, "cocoa"));
+    req.text = R.unwrap_ok[intern.StrId, str](intern.intern(?itn, "AppKit"));
+    req.library = R.unwrap_ok[intern.StrId, str](intern.intern(?itn, "appkit"));
     var dirs: Vector[str] = vector.init[str](?alloc);
 
     val x: R.Result[LinkInput, outcome.Fail] =
@@ -1516,7 +1518,7 @@ test "mach.lang.build.plan.resolve_requirement:darwin_framework" {
         resolve_requirement(?alloc, ?itn, ?lt, ?dirs, "", ?req);
     if (R.is_err[LinkInput, outcome.Fail](x) || R.is_err[LinkInput, outcome.Fail](a)
         || R.is_ok[LinkInput, outcome.Fail](l)) { ret 1; }
-    val want: str = "/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa";
+    val want: str = "/System/Library/Frameworks/AppKit.framework/AppKit";
     val xi: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](x);
     val ai: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](a);
     if (!str_equals(xi.text, want) || !str_equals(ai.text, want)) { ret 1; }

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -26,6 +26,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_empty;
 use std.types.string.str_ends_with;
 use std.types.string.str_equals;
@@ -75,7 +76,7 @@ use mach.lang.me.pipeline;
 # jobs:        raw `--jobs` value (nil when not given); compose validates it
 # include_deps: --include-deps was passed; widen test collection to dependency
 #              modules
-# link_tokens: link-input tokens (`-l` values and bare object/archive path
+# link_tokens: link-input tokens (`-l` values and bare link-file path
 #              positionals) in invocation order
 # lib_dirs:    `-L` link search directories in invocation order
 pub rec CliArgs {
@@ -104,14 +105,16 @@ pub rec CliArgs {
 # `-l`-style library name
 #
 # A token is treated as a path when it contains a '/' (any directory component)
-# or ends in `.o` (a loose object) or `.a` (a static archive).
+# or names an object, archive, or target-format shared library.
 # ---
 # tok: the token to classify
-# ret: true when `tok` is an explicit object/archive path
+# ret: true when `tok` is an explicit link-file path
 pub fun is_object_path(tok: *u8) bool {
     if (tok == nil || str_empty(tok::str)) { ret false; }
     if (path.has_separator(tok::str))      { ret true; }
-    ret str_ends_with(tok::str, ".o") || str_ends_with(tok::str, ".a");
+    ret str_ends_with(tok::str, ".o") || str_ends_with(tok::str, ".a")
+        || str_ends_with(tok::str, ".dll") || str_ends_with(tok::str, ".dylib")
+        || str_ends_with(tok::str, ".so") || str_contains(tok::str, ".so.");
 }
 
 # what the build produces
@@ -164,8 +167,8 @@ pub rec LinkToken {
 # emit_ir:      emit per-module `.ir` SSA text (flag or profile default)
 # emit_asm:     emit per-module `.s` assembly text (flag or profile default)
 # out:          requested artifact path (`-o`); empty selects the manifest template
-# link_tokens:  link inputs in invocation order (`-l` values and bare
-#               object/archive path positionals)
+# link_tokens:  link inputs in invocation order (`-l` values and bare link-file
+#               path positionals)
 # lib_dirs:     `-L` link search directories in invocation order
 # include_deps: widen test collection to dependency modules
 # verbosity:    readout detail level: 0 plain, 1 (`-v`), 2 (`-vv`)
@@ -573,6 +576,19 @@ fun hb(e: *binary.Encoder, v: bool) bool {
     var b: u8 = 0;
     if (v) { b = 1; }
     ret R.is_ok[usize, str](binary.write_u8(e, b));
+}
+
+# bare shared-library filenames are explicit CLI inputs, while a plain library
+# name remains a `-l`-style token
+test "mach.lang.build.request.is_object_path:shared_library_suffixes" {
+    if (!is_object_path("libfoo.so"::*u8))    { ret 1; }
+    if (!is_object_path("libfoo.so.3"::*u8))  { ret 1; }
+    if (!is_object_path("libfoo.dylib"::*u8)) { ret 1; }
+    if (!is_object_path("foo.dll"::*u8))      { ret 1; }
+    if (!is_object_path("foo.o"::*u8))        { ret 1; }
+    if (!is_object_path("foo.a"::*u8))        { ret 1; }
+    if (is_object_path("foo"::*u8))           { ret 1; }
+    ret 0;
 }
 
 # a cell derivation swaps exactly the selection; every other settled decision

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -113,8 +113,28 @@ pub fun is_object_path(tok: *u8) bool {
     if (tok == nil || str_empty(tok::str)) { ret false; }
     if (path.has_separator(tok::str))      { ret true; }
     ret str_ends_with(tok::str, ".o") || str_ends_with(tok::str, ".a")
-        || str_ends_with(tok::str, ".dll") || str_ends_with(tok::str, ".dylib")
+        || ascii_suffix_equals(tok, ".dll"::*u8)
+        || ascii_suffix_equals(tok, ".dylib"::*u8)
         || str_ends_with(tok::str, ".so") || str_contains(tok::str, ".so.");
+}
+
+# whether `text` ends in `suffix`, folding ASCII letter case
+fun ascii_suffix_equals(text: *u8, suffix: *u8) bool {
+    val text_len: usize = str_len(text::str);
+    val suffix_len: usize = str_len(suffix::str);
+    if (text_len < suffix_len) { ret false; }
+
+    val start: usize = text_len - suffix_len;
+    var i: usize = 0;
+    for (i < suffix_len) {
+        var lhs: u8 = text[start + i];
+        var rhs: u8 = suffix[i];
+        if (lhs >= 'A' && lhs <= 'Z') { lhs = lhs + ('a' - 'A'); }
+        if (rhs >= 'A' && rhs <= 'Z') { rhs = rhs + ('a' - 'A'); }
+        if (lhs != rhs) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # what the build produces
@@ -134,7 +154,7 @@ pub val GOAL_TEST_LIST: BuildGoal = 3;
 
 # one link input as the invoker spelled it; the planner resolves it
 # ---
-# text: the token verbatim (`-l` value, or a bare object/archive path)
+# text: the token verbatim (`-l` value, or a bare link-file path)
 pub rec LinkToken {
     text: str;
 }
@@ -584,7 +604,9 @@ test "mach.lang.build.request.is_object_path:shared_library_suffixes" {
     if (!is_object_path("libfoo.so"::*u8))    { ret 1; }
     if (!is_object_path("libfoo.so.3"::*u8))  { ret 1; }
     if (!is_object_path("libfoo.dylib"::*u8)) { ret 1; }
+    if (!is_object_path("libfoo.DYLIB"::*u8)) { ret 1; }
     if (!is_object_path("foo.dll"::*u8))      { ret 1; }
+    if (!is_object_path("foo.DLL"::*u8))      { ret 1; }
     if (!is_object_path("foo.o"::*u8))        { ret 1; }
     if (!is_object_path("foo.a"::*u8))        { ret 1; }
     if (is_object_path("foo"::*u8))           { ret 1; }

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -216,32 +216,32 @@ pub fun link_dispatcher(p: *driver.Project, unit: *plan.BuildUnit, sc: *TestScop
     var shared_len: u32 = len0;
 
     # the external link inputs (libc, manifest/CLI libs), resolved once and shared.
-    var sonames:    *intern.StrId = nil;
-    var soname_len: u32           = 0;
-    val ec: R.Result[bool, outcome.Fail] = emit.append_external_inputs(p, unit, ?shared, ?shared_len, ?sonames, ?soname_len);
+    var dynlibs:    *of.DynLib = nil;
+    var dynlib_len: u32        = 0;
+    val ec: R.Result[bool, outcome.Fail] = emit.append_external_inputs(p, unit, ?shared, ?shared_len, ?dynlibs, ?dynlib_len);
     if (R.is_err[bool, outcome.Fail](ec)) {
         free_shared(p, shared, shared_len, len0);
-        emit.free_sonames(p.alloc, sonames, soname_len);
+        emit.free_dynlibs(p.alloc, dynlibs, dynlib_len);
         ret ec;
     }
 
     var scratch_backing: A.Allocator;
     if (O.is_some[str](page.make(?scratch_backing))) {
         free_shared(p, shared, shared_len, len0);
-        emit.free_sonames(p.alloc, sonames, soname_len);
+        emit.free_dynlibs(p.alloc, dynlibs, dynlib_len);
         ret R.err[bool, outcome.Fail](outcome.internal("failed to initialise test allocator"));
     }
     var scratch_ar: arena.Arena;
     if (O.is_some[str](arena.init(?scratch_ar, ?scratch_backing, 0))) {
         free_shared(p, shared, shared_len, len0);
-        emit.free_sonames(p.alloc, sonames, soname_len);
+        emit.free_dynlibs(p.alloc, dynlibs, dynlib_len);
         ret R.err[bool, outcome.Fail](outcome.internal("failed to initialise test allocator"));
     }
     var scratch_alloc: A.Allocator;
     if (O.is_some[str](arena.make(?scratch_alloc, ?scratch_ar))) {
         arena.dnit(?scratch_ar);
         free_shared(p, shared, shared_len, len0);
-        emit.free_sonames(p.alloc, sonames, soname_len);
+        emit.free_dynlibs(p.alloc, dynlibs, dynlib_len);
         ret R.err[bool, outcome.Fail](outcome.internal("failed to initialise test allocator"));
     }
 
@@ -252,12 +252,12 @@ pub fun link_dispatcher(p: *driver.Project, unit: *plan.BuildUnit, sc: *TestScop
     p.s.alloc = ?scratch_alloc;
     val result: R.Result[bool, outcome.Fail] = build_dispatch_executable(p, unit, unit.obj_dir::*u8,
                                               sc.sel, sc.sel_len, shared, shared_len,
-                                              sonames, soname_len);
+                                              dynlibs, dynlib_len);
     p.s.alloc = persistent;
     arena.dnit(?scratch_ar);
 
     free_shared(p, shared, shared_len, len0);
-    emit.free_sonames(p.alloc, sonames, soname_len);
+    emit.free_dynlibs(p.alloc, dynlibs, dynlib_len);
     ret result;
 }
 
@@ -293,13 +293,13 @@ fun free_shared(p: *driver.Project, shared: **u8, shared_len: u32, borrowed: u32
 # sel_len:    number of tests in `sel`
 # shared:     the shared per-module object path set
 # shared_len: number of shared object paths
-# sonames:    the shared dynamic-dependency soname list
-# soname_len: number of sonames
+# dynlibs:    the shared dynamic-dependency logical and loader names
+# dynlib_len: number of dynamic dependencies
 # ret:        ok(true) on success, or the failure as a Fail
 fun build_dispatch_executable(p: *driver.Project, unit: *plan.BuildUnit, obj_base: *u8,
                               sel: *testrunner.Test, sel_len: u32,
                               shared: **u8, shared_len: u32,
-                              sonames: *intern.StrId, soname_len: u32) R.Result[bool, outcome.Fail] {
+                              dynlibs: *of.DynLib, dynlib_len: u32) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_synth: R.Result[ir.Module, str] = testrunner.synthesize_dispatcher(p.s, sel, sel_len);
     if (R.is_err[ir.Module, str](res_synth)) {
@@ -351,7 +351,7 @@ fun build_dispatch_executable(p: *driver.Project, unit: *plan.BuildUnit, obj_bas
         ret R.err[bool, outcome.Fail](outcome.internal("failed to resolve the test executable path; check the `tests` template in mach.toml"));
     }
 
-    ret link_one_test(p, shared, shared_len, sonames, soname_len, entry_path, unit.out_path::*u8);
+    ret link_one_test(p, shared, shared_len, dynlibs, dynlib_len, entry_path, unit.out_path::*u8);
 }
 
 # link the shared object set plus the dispatcher entry object into the test
@@ -363,13 +363,13 @@ fun build_dispatch_executable(p: *driver.Project, unit: *plan.BuildUnit, obj_bas
 # p:          the project carrying the session and target
 # shared:     the shared per-module object path set
 # shared_len: number of shared object paths
-# sonames:    the shared dynamic-dependency soname list
-# soname_len: number of sonames
+# dynlibs:    the shared dynamic-dependency logical and loader names
+# dynlib_len: number of dynamic dependencies
 # entry_path: the test's entry-object path
 # exe_path:   the executable path to link into
 # ret:        ok(true) on success, or the failure as a Fail
 fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
-                  sonames: *intern.StrId, soname_len: u32,
+                  dynlibs: *of.DynLib, dynlib_len: u32,
                   entry_path: *u8, exe_path: *u8) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val total: u32 = shared_len + 1;
@@ -382,7 +382,7 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
     paths[shared_len] = entry_path;
 
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, total, sonames, soname_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, total, dynlibs, dynlib_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
     A.deallocate[*u8](p.alloc, paths, total::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -248,7 +248,7 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
         # target), not just the primary's, plus the exported dep entries the cascade
         # pass adds below (#1964). replaces the single-artifact libs synthesized above.
         if (is_test) {
-            var test_items: *intern.StrId = nil;
+            var test_items: *manifest.LinkRequirement = nil;
             var test_count: u32 = 0;
             val tlr: R.Result[bool, str] = manifest.resolve_test_libs(p.alloc, ?p.s.interner, m, bu.target, project_out_str, ?cell_v, ?test_items, ?test_count);
             if (R.is_err[bool, str](tlr)) { str_free(p.alloc, project_out_str); ret R.err[bool, str](R.unwrap_err[bool, str](tlr)); }
@@ -398,17 +398,13 @@ fun compute_step_plan(p: *project.Project, m: *manifest.Manifest, bu: *manifest.
 # the entry here rather than failing at link time. paths expand against the build
 # cell; the disk check resolves relative to the project root.
 fun validate_local_links(p: *project.Project, project_root: str, m: *manifest.Manifest, t: *manifest.TargetDef, proj_out: str, v: *manifest.TmplVars) R.Result[bool, str] {
-    val local_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "local");
-    if (R.is_err[intern.StrId, str](local_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](local_r)); }
-    val local_id: intern.StrId = R.unwrap_ok[intern.StrId, str](local_r);
-
     var li: u32 = 0;
     for (li < m.link_count) {
         val l: *manifest.LinkDef = ?m.links[li];
         # only entries selected for this build cell are validated: a cross-target
         # prebuilt (e.g. os=["windows"]) filters out of a linux build and is skipped,
         # never expanded against the wrong cell.
-        if (l.source == local_id && manifest.link_matches_target(?p.s.interner, l, t)) {
+        if (l.source == manifest.LINK_LOCAL && manifest.link_matches_target(?p.s.interner, l, t)) {
             val path_opt: O.Option[str] = intern.lookup(?p.s.interner, l.path);
             val name_opt: O.Option[str] = intern.lookup(?p.s.interner, l.name);
             if (O.is_none[str](path_opt) || O.is_none[str](name_opt)) { ret R.err[bool, str]("internal: link entry metadata not interned"); }

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -300,11 +300,12 @@ fun free_cascade_scratch(alloc: *A.Allocator, manifests: *manifest.Manifest, tab
 # build it is producing - so a platform link requirement (e.g. `kernel32.dll`)
 # lives once in the providing dependency's manifest. order is topological (a dep's
 # own deps first); within each dep the matching os overlays precede the matching
-# target libs. libs are deduplicated by name and the consumer's own `own_libs` are
-# excluded, so a shared requirement is never linked twice. an empty result leaves
-# the cascade nil/0, so a build with no inheriting deps is unaffected
+# target libs. requirements are deduplicated by source, text, and stable library
+# identity; the consumer's own `own_libs` are excluded, so a shared requirement is
+# never linked twice. an empty result leaves the cascade nil/0, so a build with no
+# inheriting deps is unaffected
 pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, os: str, abi: str,
-                         own_libs: *intern.StrId, own_count: u32) R.Result[bool, str] {
+                         own_libs: *manifest.LinkRequirement, own_count: u32) R.Result[bool, str] {
     p.config.cascade_libs      = nil;
     p.config.cascade_lib_count = 0;
     val n: u32 = p.config.dep_count;
@@ -385,25 +386,18 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
         ret R.ok[bool, str](true);
     }
 
-    val br: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](p.alloc, max::usize);
-    if (R.is_err[*intern.StrId, str](br)) {
+    val br: R.Result[*manifest.LinkRequirement, str] = A.allocate[manifest.LinkRequirement](p.alloc, max::usize);
+    if (R.is_err[*manifest.LinkRequirement, str](br)) {
         free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
-        ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](br));
+        ret R.err[bool, str](R.unwrap_err[*manifest.LinkRequirement, str](br));
     }
-    val buf: *intern.StrId = R.unwrap_ok[*intern.StrId, str](br);
+    val buf: *manifest.LinkRequirement = R.unwrap_ok[*manifest.LinkRequirement, str](br);
     var w: u32 = 0;
 
     var oi: u32 = 0;
     for (oi < order_len) {
         val di: u32 = order[oi];
         val mfd: *manifest.Manifest = ?manifests[di];
-        val vr_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.deps[di].vendor_root);
-        if (O.is_none[str](vr_opt)) {
-            free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
-            A.deallocate[intern.StrId](p.alloc, buf, max::usize);
-            ret R.err[bool, str]("internal: dep metadata not interned");
-        }
-        val dep_vr: str = O.unwrap[str](vr_opt);
 
         var li: u32 = 0;
         for (li < mfd.link_count) {
@@ -411,28 +405,25 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
             if (l.export && manifest.link_matches_target(?p.s.interner, l, ?tgt)) {
                 # a `local` entry's path homes against the ROOT project out (#1970): the
                 # exported object lands in the consumer out tree, where the demanding dep
-                # step (run beforehand by execute_dep_steps) writes it. system/framework
-                # entries contribute their lib name.
-                var lib_id: intern.StrId = intern.STR_NIL;
-                if (l.source == R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, "local"))) {
-                    val p_opt: O.Option[str] = intern.lookup(?p.s.interner, l.path);
-                    if (O.is_some[str](p_opt)) {
-                        val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
-                        var cv: manifest.TmplVars = cell_tmpl_vars(p);
-                        val exp_r: R.Result[str, str] = manifest.expand(p.alloc, O.unwrap[str](p_opt), root_out, ?cv);
-                        if (R.is_ok[str, str](exp_r)) {
-                            val exp: str = R.unwrap_ok[str, str](exp_r);
-                            lib_id = R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, exp));
-                            str_free(p.alloc, exp);
-                        }
-                    }
+                # step (run beforehand by execute_dep_steps) writes it. every source
+                # kind keeps its declared semantics and stable attribution identity.
+                val root_out_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.project_out);
+                if (O.is_none[str](root_out_opt)) {
+                    free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
+                    A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
+                    ret R.err[bool, str]("internal: project output not interned");
                 }
-                or {
-                    lib_id = l.lib_name;
+                var cv: manifest.TmplVars = cell_tmpl_vars(p);
+                val req_r: R.Result[manifest.LinkRequirement, str] =
+                    manifest.link_requirement(p.alloc, ?p.s.interner, l, O.unwrap[str](root_out_opt), ?cv);
+                if (R.is_err[manifest.LinkRequirement, str](req_r)) {
+                    free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
+                    A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
+                    ret R.err[bool, str](R.unwrap_err[manifest.LinkRequirement, str](req_r));
                 }
-
-                if (lib_id != intern.STR_NIL && !strid_in(buf, w, lib_id) && !strid_in(own_libs, own_count, lib_id)) {
-                    buf[w] = lib_id;
+                val req: manifest.LinkRequirement = R.unwrap_ok[manifest.LinkRequirement, str](req_r);
+                if (!requirement_in(buf, w, ?req) && !requirement_in(own_libs, own_count, ?req)) {
+                    buf[w] = req;
                     w = w + 1;
                 }
             }
@@ -444,13 +435,14 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
     free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
 
     if (w == 0) {
-        A.deallocate[intern.StrId](p.alloc, buf, max::usize);
+        A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
         ret R.ok[bool, str](true);
     }
     if (w < max) {
-        val sr: R.Result[*intern.StrId, str] = A.reallocate[intern.StrId](p.alloc, buf, max::usize, w::usize);
-        if (R.is_ok[*intern.StrId, str](sr)) {
-            p.config.cascade_libs      = R.unwrap_ok[*intern.StrId, str](sr);
+        val sr: R.Result[*manifest.LinkRequirement, str] =
+            A.reallocate[manifest.LinkRequirement](p.alloc, buf, max::usize, w::usize);
+        if (R.is_ok[*manifest.LinkRequirement, str](sr)) {
+            p.config.cascade_libs      = R.unwrap_ok[*manifest.LinkRequirement, str](sr);
             p.config.cascade_lib_count = w;
             ret R.ok[bool, str](true);
         }
@@ -493,12 +485,14 @@ fun dep_declares(t: *toml.Table, alias: str) bool {
     ret false;
 }
 
-# whether `id` already appears in the first `count` entries of `arr`
-fun strid_in(arr: *intern.StrId, count: u32, id: intern.StrId) bool {
+# whether a typed link requirement appears in the first `count` entries of `arr`
+fun requirement_in(arr: *manifest.LinkRequirement, count: u32,
+                   req: *manifest.LinkRequirement) bool {
     if (arr == nil) { ret false; }
     var k: u32 = 0;
     for (k < count) {
-        if (arr[k] == id) { ret true; }
+        if (arr[k].source == req.source && arr[k].text == req.text
+            && arr[k].library == req.library) { ret true; }
         k = k + 1;
     }
     ret false;

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -73,10 +73,9 @@ pub val TARGET_OPT_RELEASE: TargetOpt = 2;
 # opt:        resolved optimization level from the selected profile; TARGET_OPT_DEFAULT
 #             when none. the CLI maps it to a pipeline level, with an explicit
 #             `-O*` flag taking precedence
-# libs:       interned project-level link inputs (the merged target+artifact+cell
-#             link overlay) - each entry is either an explicit `.o` object / `.a`
-#             archive path (relative to the project root, or absolute) or a bare
-#             `-l`-style name resolved against the link search dirs; nil when none
+# libs:       typed project-level link requirements (the merged
+#             target+artifact+cell link overlay), preserving local/system/framework
+#             semantics and stable `#[library]` attribution names; nil when none
 # lib_count:  number of entries in `libs`
 # lib_kind:   for a library build (mode == MODE_LIBRARY), whether the artifact is
 #             static or shared; meaningless for an executable (#1980)
@@ -89,7 +88,7 @@ pub rec TargetEntry {
     entrypoint: intern.StrId;
     mode:       BuildMode;
     opt:        TargetOpt;
-    libs:       *intern.StrId;
+    libs:       *manifest.LinkRequirement;
     lib_count:  u32;
     lib_kind:   manifest.LibKind;
 }
@@ -147,7 +146,7 @@ pub rec DepEntry {
 #               < cell), each `NAME` or `NAME=VALUE`; bound into every module's
 #               comptime ctx during load (#1191); nil when none
 # define_count: number of entries in defines
-# cascade_libs:      transitive dependency link inputs whose declared target tuple
+# cascade_libs:      typed transitive dependency link requirements whose target tuple
 #                    (isa, os, abi) matches the selected target's, in topological
 #                    dep then declaration order, deduplicated by name and excluding
 #                    the consumer's own libs (#1218); nil when none
@@ -168,7 +167,7 @@ pub rec ProjectConfig {
     dep_count:    u32;
     defines:      *intern.StrId;
     define_count: u32;
-    cascade_libs:      *intern.StrId;
+    cascade_libs:      *manifest.LinkRequirement;
     cascade_lib_count: u32;
     profile:      intern.StrId;
     project_out:  intern.StrId;
@@ -491,7 +490,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
         for (i < c.target_count) {
             val te: *TargetEntry = ?c.targets[i];
             if (te.libs != nil && te.lib_count > 0) {
-                A.deallocate[intern.StrId](alloc, te.libs, te.lib_count::usize);
+                A.deallocate[manifest.LinkRequirement](alloc, te.libs, te.lib_count::usize);
             }
             i = i + 1;
         }
@@ -504,7 +503,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
         A.deallocate[intern.StrId](alloc, c.defines, c.define_count::usize);
     }
     if (c.cascade_libs != nil && c.cascade_lib_count > 0) {
-        A.deallocate[intern.StrId](alloc, c.cascade_libs, c.cascade_lib_count::usize);
+        A.deallocate[manifest.LinkRequirement](alloc, c.cascade_libs, c.cascade_lib_count::usize);
     }
     if (c.steps != nil && c.step_count > 0) {
         var si: u32 = 0;

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -148,8 +148,8 @@ pub rec DepEntry {
 # define_count: number of entries in defines
 # cascade_libs:      typed transitive dependency link requirements whose target tuple
 #                    (isa, os, abi) matches the selected target's, in topological
-#                    dep then declaration order, deduplicated by name and excluding
-#                    the consumer's own libs (#1218); nil when none
+#                    dep then declaration order, deduplicated by typed identity and
+#                    excluding the consumer's own libs (#1218); nil when none
 # cascade_lib_count: number of entries in cascade_libs
 pub rec ProjectConfig {
     id:           intern.StrId;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4820,14 +4820,16 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (lkD == lkC)                   { bad = 1; }
     project.dnit_project(?pD);
 
-    # build E: add a dynamic dependency (soname) -> re-link.
+    # build E: add a logical and canonical dynamic dependency -> re-link.
     val sn_r: R.Result[intern.StrId, str] = intern.intern(?sA.interner, "libfoo");
     if (R.is_err[intern.StrId, str](sn_r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    var sn: [1]intern.StrId; sn[0] = R.unwrap_ok[intern.StrId, str](sn_r);
+    var libs: [1]of.DynLib;
+    libs[0].name = R.unwrap_ok[intern.StrId, str](sn_r);
+    libs[0].soname = libs[0].name;
     val pEr: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pEr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pE: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pEr);
-    if (R.is_err[bool, outcome.Fail](bengine.set_link_config_input(?pE, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, ?sn[0], 1))) { project.dnit_project(?pE); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, outcome.Fail](bengine.set_link_config_input(?pE, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, ?libs[0], 1))) { project.dnit_project(?pE); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val rlE: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pE);
     if (R.is_err[bool, outcome.Fail](rlE)) { project.dnit_project(?pE); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlE)) { bad = 1; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4742,8 +4742,8 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
 
 # driver incremental: Q_LINK re-links when an external static input's CONTENT changes
 # at the same path (not just its path), when its path changes, and when a dynamic
-# dependency (soname) is added - the external-axis completeness of the link
-# fingerprint (#1618)
+# dependency (soname) is added, or its runtime search path changes - the
+# external-axis completeness of the link fingerprint (#1618)
 test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -4826,6 +4826,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     var libs: [1]of.DynLib;
     libs[0].name = R.unwrap_ok[intern.StrId, str](sn_r);
     libs[0].soname = libs[0].name;
+    libs[0].rpath = intern.STR_NIL;
     val pEr: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pEr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pE: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pEr);
@@ -4833,8 +4834,23 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     val rlE: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pE);
     if (R.is_err[bool, outcome.Fail](rlE)) { project.dnit_project(?pE); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlE)) { bad = 1; }
-    if (ut_link_lc(?sA) == lkD)       { bad = 1; }
+    val lkE: query.Revision = ut_link_lc(?sA);
+    if (lkE == lkD)                   { bad = 1; }
     project.dnit_project(?pE);
+
+    # build F: only the runtime search path changes -> re-link.
+    val rp_r: R.Result[intern.StrId, str] = intern.intern(?sA.interner, "/opt/lib");
+    if (R.is_err[intern.StrId, str](rp_r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    libs[0].rpath = R.unwrap_ok[intern.StrId, str](rp_r);
+    val pFr: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
+    if (R.is_err[project.Project, outcome.Fail](pFr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var pF: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pFr);
+    if (R.is_err[bool, outcome.Fail](bengine.set_link_config_input(?pF, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, ?libs[0], 1))) { project.dnit_project(?pF); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val rlF: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pF);
+    if (R.is_err[bool, outcome.Fail](rlF)) { project.dnit_project(?pF); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, outcome.Fail](rlF)) { bad = 1; }
+    if (ut_link_lc(?sA) == lkE)       { bad = 1; }
+    project.dnit_project(?pF);
 
     fs.remove_all(?alloc, root);
     session.dnit(?sA);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -114,6 +114,23 @@ pub val LINK_SYSTEM:    LinkSource = 1;
 # a Darwin framework dependency resolved by framework name
 pub val LINK_FRAMEWORK: LinkSource = 2;
 
+# one declared `[link.X]` requirement before target filtering and path expansion
+# ---
+# name:        table name and default logical attribution identity
+# source:      local file, system library, or Darwin framework semantics
+# library:     stable logical `#[library]` identity
+# lib_name:    system library or framework name; STR_NIL for local sources
+# path:        local path template; STR_NIL for non-local sources
+# os:          OS filter values
+# os_count:    number of OS filter values
+# os_present:  whether the OS filter was declared
+# isa:         instruction-set filter values
+# isa_count:   number of instruction-set filter values
+# isa_present: whether the instruction-set filter was declared
+# abi:         ABI filter values
+# abi_count:   number of ABI filter values
+# abi_present: whether the ABI filter was declared
+# export:      whether matching consumers inherit the requirement
 pub rec LinkDef {
     name:        intern.StrId;
     source:      LinkSource;
@@ -926,9 +943,18 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         d.source = LINK_LOCAL;
         if (str_equals(source_s, "system"))    { d.source = LINK_SYSTEM; }
         if (str_equals(source_s, "framework")) { d.source = LINK_FRAMEWORK; }
-        val library_s: str = toml.get_str(sub, "library");
         d.library = d.name;
-        if (!str_empty(library_s)) { d.library = intern_unwrap(itn, library_s); }
+        val library_v: *toml.Value = toml.get(sub, "library");
+        if (library_v != nil) {
+            if (library_v.tag != toml.TYPE_STRING) {
+                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
+            }
+            val library_s: str = library_v.data.string;
+            if (str_empty(library_s)) {
+                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
+            }
+            d.library = intern_unwrap(itn, library_s);
+        }
 
         val name_val: str = toml.get_str(sub, "name");
         val path_val: str = toml.get_str(sub, "path");
@@ -1846,7 +1872,7 @@ fun requirement_in_buf(buf: *LinkRequirement, count: u32, req: *LinkRequirement)
 
 # resolve the `mach test` link surface (#1964): the union of every artifact's
 # referenced link entries whose filters match target `t` (the native target for a
-# test build), deduplicated, each resolved to its link token. exported dep entries
+# test build), deduplicated, each retained as a typed link requirement. exported dep entries
 # are added separately by the driver's cascade pass. on success `out_items` and
 # `out_count` receive the union (nil/0 when empty).
 pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, t: *TargetDef,
@@ -3001,6 +3027,23 @@ test "mach.lang.manifest.parse:link_filter_bad_type" {
     # a non-string, non-array filter axis is a strict error
     val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[link.bad]\nsource=\"system\"\nname=\"a\"\nos=1\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [link.bad].os must be a string or array of strings")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:link_library_requires_nonempty_string" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val prefix: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[link.bad]\nsource=\"system\"\nname=\"a\"\nlibrary=";
+    val empty_src: str = sfmt(?alloc, "{}\"\"\n", prefix);
+    val typed_src: str = sfmt(?alloc, "{}1\n", prefix);
+    val empty: R.Result[Manifest, str] = tparse(?alloc, ?itn, empty_src);
+    val typed: R.Result[Manifest, str] = tparse(?alloc, ?itn, typed_src);
+    val want: str = "mach.toml: [link.bad].library must be a non-empty string";
+    if (R.is_ok[Manifest, str](empty) || !str_equals(R.unwrap_err[Manifest, str](empty), want)) { code = 1; }
+    if (R.is_ok[Manifest, str](typed) || !str_equals(R.unwrap_err[Manifest, str](typed), want)) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -102,9 +102,22 @@ pub rec DepDef {
     ref:  intern.StrId;
 }
 
+# the source semantics of a manifest link requirement
+pub def LinkSource: u8;
+
+# a project-relative file produced locally or already present on disk
+pub val LINK_LOCAL:     LinkSource = 0;
+
+# a system library resolved by name for the selected target
+pub val LINK_SYSTEM:    LinkSource = 1;
+
+# a Darwin framework dependency resolved by framework name
+pub val LINK_FRAMEWORK: LinkSource = 2;
+
 pub rec LinkDef {
     name:        intern.StrId;
-    source:      intern.StrId;
+    source:      LinkSource;
+    library:     intern.StrId;
     lib_name:    intern.StrId;
     path:        intern.StrId;
     os:          *intern.StrId;
@@ -117,6 +130,17 @@ pub rec LinkDef {
     abi_count:   u32;
     abi_present: bool;
     export:      bool;
+}
+
+# one target-matched link requirement carried into a build
+# ---
+# source:  the declared local, system, or framework semantics
+# text:    expanded local path or concrete system/framework name
+# library: stable logical name used by `#[library]` attribution
+pub rec LinkRequirement {
+    source:  LinkSource;
+    text:    intern.StrId;
+    library: intern.StrId;
 }
 
 pub rec StepDef {
@@ -180,7 +204,7 @@ pub rec BuildUnit {
     float_reassoc: bool;
     is_lib:       bool;
     kind:         LibKind;
-    libs:         *intern.StrId;
+    libs:         *LinkRequirement;
     lib_count:    u32;
     defines:      *intern.StrId;
     define_count: u32;
@@ -512,7 +536,7 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
         ret str_equals(k, "git") || str_equals(k, "path") || str_equals(k, "ref");
     }
     if (kind == TK_LINK) {
-        ret str_equals(k, "source") || str_equals(k, "name") || str_equals(k, "path")
+        ret str_equals(k, "source") || str_equals(k, "name") || str_equals(k, "path") || str_equals(k, "library")
             || str_equals(k, "os") || str_equals(k, "isa") || str_equals(k, "abi") || str_equals(k, "export");
     }
     if (kind == TK_STEP) {
@@ -899,7 +923,12 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         if (!str_equals(source_s, "system") && !str_equals(source_s, "framework") && !str_equals(source_s, "local")) {
             ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.source must be \"system\", \"framework\", or \"local\"", label));
         }
-        d.source = intern_unwrap(itn, source_s);
+        d.source = LINK_LOCAL;
+        if (str_equals(source_s, "system"))    { d.source = LINK_SYSTEM; }
+        if (str_equals(source_s, "framework")) { d.source = LINK_FRAMEWORK; }
+        val library_s: str = toml.get_str(sub, "library");
+        d.library = d.name;
+        if (!str_empty(library_s)) { d.library = intern_unwrap(itn, library_s); }
 
         val name_val: str = toml.get_str(sub, "name");
         val path_val: str = toml.get_str(sub, "path");
@@ -1420,21 +1449,34 @@ fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
     ret sfmt(alloc, "{}/{}", a_sub, b_sub);
 }
 
-# resolve a matched link entry to its interned link token: the expanded path for a
-# `local` source, or the library name for system/framework. filters are assumed
-# already matched; `{project.out}` and the target/profile templates in a local path
-# resolve against the given build cell.
-fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out: str, v: *TmplVars) R.Result[intern.StrId, str] {
-    if (l.source == intern_unwrap(itn, "local")) {
+# resolve a matched link entry without discarding its declared source semantics
+# ---
+# alloc:    allocator used while expanding a local path
+# itn:      interner owning the requirement text and stable library name
+# l:        target-matched manifest entry
+# proj_out: expanded project output root for a local path
+# v:        selected build-cell template variables
+# ret:      the typed requirement, or a template/interner error
+pub fun link_requirement(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef,
+                         proj_out: str, v: *TmplVars) R.Result[LinkRequirement, str] {
+    var req: LinkRequirement;
+    req.source  = l.source;
+    req.library = l.library;
+    if (l.source == LINK_LOCAL) {
         val raw_path: str = idstr(itn, l.path);
         val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, v);
-        if (R.is_err[str, str](expanded_r)) { ret R.err[intern.StrId, str](R.unwrap_err[str, str](expanded_r)); }
+        if (R.is_err[str, str](expanded_r)) { ret R.err[LinkRequirement, str](R.unwrap_err[str, str](expanded_r)); }
         val expanded: str = R.unwrap_ok[str, str](expanded_r);
         val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded);
         str_free(alloc, expanded);
-        ret res_int;
+        if (R.is_err[intern.StrId, str](res_int)) {
+            ret R.err[LinkRequirement, str](R.unwrap_err[intern.StrId, str](res_int));
+        }
+        req.text = R.unwrap_ok[intern.StrId, str](res_int);
+        ret R.ok[LinkRequirement, str](req);
     }
-    ret R.ok[intern.StrId, str](l.lib_name);
+    req.text = l.lib_name;
+    ret R.ok[LinkRequirement, str](req);
 }
 
 # the index of the declared step that produces `expanded_path` as one of its `out`
@@ -1559,7 +1601,6 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
     val order: *u32 = R.unwrap_ok[*u32, str](or_);
     var order_len: u32 = 0;
 
-    val local_id: intern.StrId = intern_unwrap(itn, "local");
     var ai: u32 = 0;
     for (ai < art_count) {
         val a: *ArtifactDef = find_artifact_by_name(m, art_names[ai]);
@@ -1567,7 +1608,7 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
             var li: u32 = 0;
             for (li < a.link_count) {
                 val l: *LinkDef = find_link_by_name(m, a.link[li]);
-                if (l != nil && l.source == local_id && link_matches_target(itn, l, t)) {
+                if (l != nil && l.source == LINK_LOCAL && link_matches_target(itn, l, t)) {
                     val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, v);
                     if (R.is_ok[str, str](exp_r)) {
                         val exp: str = R.unwrap_ok[str, str](exp_r);
@@ -1637,11 +1678,10 @@ pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     val order: *u32 = R.unwrap_ok[*u32, str](or_);
     var order_len: u32 = 0;
 
-    val local_id: intern.StrId = intern_unwrap(itn, "local");
     var li: u32 = 0;
     for (li < m.link_count) {
         val l: *LinkDef = ?m.links[li];
-        if (l.export && l.source == local_id && link_matches_target(itn, l, t)) {
+        if (l.export && l.source == LINK_LOCAL && link_matches_target(itn, l, t)) {
             val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, v);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
@@ -1727,11 +1767,11 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     # Link resolution in V2: look up the link entries requested in the artifact's `link` array.
     # Filter them against target compatibility.
     var match_count: u32 = 0;
-    var matched_items: *intern.StrId = nil;
+    var matched_items: *LinkRequirement = nil;
     if (a.link_count > 0) {
-        val res_match_arr: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](alloc, a.link_count::usize);
-        if (R.is_err[*intern.StrId, str](res_match_arr)) { ret R.err[BuildUnit, str](R.unwrap_err[*intern.StrId, str](res_match_arr)); }
-        matched_items = R.unwrap_ok[*intern.StrId, str](res_match_arr);
+        val res_match_arr: R.Result[*LinkRequirement, str] = A.allocate[LinkRequirement](alloc, a.link_count::usize);
+        if (R.is_err[*LinkRequirement, str](res_match_arr)) { ret R.err[BuildUnit, str](R.unwrap_err[*LinkRequirement, str](res_match_arr)); }
+        matched_items = R.unwrap_ok[*LinkRequirement, str](res_match_arr);
 
         var li: u32 = 0;
         for (li < a.link_count) {
@@ -1746,9 +1786,9 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
             }
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, rt.target)) {
-                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, ?v);
-                    if (R.is_err[intern.StrId, str](tok_r)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](tok_r)); }
-                    matched_items[match_count] = R.unwrap_ok[intern.StrId, str](tok_r);
+                    val req_r: R.Result[LinkRequirement, str] = link_requirement(alloc, itn, found_l, proj_out, ?v);
+                    if (R.is_err[LinkRequirement, str](req_r)) { ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r)); }
+                    matched_items[match_count] = R.unwrap_ok[LinkRequirement, str](req_r);
                     match_count = match_count + 1;
                 }
             }
@@ -1794,10 +1834,11 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     ret R.ok[BuildUnit, str](u);
 }
 
-fun strid_in_buf(buf: *intern.StrId, count: u32, id: intern.StrId) bool {
+fun requirement_in_buf(buf: *LinkRequirement, count: u32, req: *LinkRequirement) bool {
     var i: u32 = 0;
     for (i < count) {
-        if (buf[i] == id) { ret true; }
+        if (buf[i].source == req.source && buf[i].text == req.text
+            && buf[i].library == req.library) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -1810,7 +1851,7 @@ fun strid_in_buf(buf: *intern.StrId, count: u32, id: intern.StrId) bool {
 # `out_count` receive the union (nil/0 when empty).
 pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, t: *TargetDef,
                           proj_out: str, v: *TmplVars,
-                          out_items: **intern.StrId, out_count: *u32) R.Result[bool, str] {
+                          out_items: **LinkRequirement, out_count: *u32) R.Result[bool, str] {
     @out_items = nil;
     @out_count = 0;
 
@@ -1819,9 +1860,9 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     for (ai < m.artifact_count) { max = max + m.artifacts[ai].link_count; ai = ai + 1; }
     if (max == 0) { ret R.ok[bool, str](true); }
 
-    val br: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](alloc, max::usize);
-    if (R.is_err[*intern.StrId, str](br)) { ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](br)); }
-    val buf: *intern.StrId = R.unwrap_ok[*intern.StrId, str](br);
+    val br: R.Result[*LinkRequirement, str] = A.allocate[LinkRequirement](alloc, max::usize);
+    if (R.is_err[*LinkRequirement, str](br)) { ret R.err[bool, str](R.unwrap_err[*LinkRequirement, str](br)); }
+    val buf: *LinkRequirement = R.unwrap_ok[*LinkRequirement, str](br);
     var w: u32 = 0;
 
     ai = 0;
@@ -1838,13 +1879,13 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
             }
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, t)) {
-                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, v);
-                    if (R.is_err[intern.StrId, str](tok_r)) {
-                        A.deallocate[intern.StrId](alloc, buf, max::usize);
-                        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](tok_r));
+                    val req_r: R.Result[LinkRequirement, str] = link_requirement(alloc, itn, found_l, proj_out, v);
+                    if (R.is_err[LinkRequirement, str](req_r)) {
+                        A.deallocate[LinkRequirement](alloc, buf, max::usize);
+                        ret R.err[bool, str](R.unwrap_err[LinkRequirement, str](req_r));
                     }
-                    val tok: intern.StrId = R.unwrap_ok[intern.StrId, str](tok_r);
-                    if (!strid_in_buf(buf, w, tok)) { buf[w] = tok; w = w + 1; }
+                    val req: LinkRequirement = R.unwrap_ok[LinkRequirement, str](req_r);
+                    if (!requirement_in_buf(buf, w, ?req)) { buf[w] = req; w = w + 1; }
                 }
             }
             li = li + 1;
@@ -1852,11 +1893,11 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
         ai = ai + 1;
     }
 
-    if (w == 0) { A.deallocate[intern.StrId](alloc, buf, max::usize); ret R.ok[bool, str](true); }
+    if (w == 0) { A.deallocate[LinkRequirement](alloc, buf, max::usize); ret R.ok[bool, str](true); }
     if (w < max) {
-        val sr: R.Result[*intern.StrId, str] = A.reallocate[intern.StrId](alloc, buf, max::usize, w::usize);
-        if (R.is_ok[*intern.StrId, str](sr)) {
-            @out_items = R.unwrap_ok[*intern.StrId, str](sr);
+        val sr: R.Result[*LinkRequirement, str] = A.reallocate[LinkRequirement](alloc, buf, max::usize, w::usize);
+        if (R.is_ok[*LinkRequirement, str](sr)) {
+            @out_items = R.unwrap_ok[*LinkRequirement, str](sr);
             @out_count = w;
             ret R.ok[bool, str](true);
         }
@@ -1948,10 +1989,10 @@ fun host_target_stanza(alloc: *A.Allocator, name: str) str {
     ret sfmt(alloc, "[target.{}]\nisa = \"{}\"\nos = \"{}\"\nabi = \"sysv64\"\n", name, host_isa_name(), host_os_name());
 }
 
-fun strarr_has(itn: *intern.Interner, items: *intern.StrId, count: u32, lit: str) bool {
+fun requirement_has(itn: *intern.Interner, items: *LinkRequirement, count: u32, lit: str) bool {
     var i: u32 = 0;
     for (i < count) {
-        if (str_equals(idstr(itn, items[i]), lit)) { ret true; }
+        if (str_equals(idstr(itn, items[i].text), lit)) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -2498,7 +2539,7 @@ test "mach.lang.manifest.resolve_build_unit:links" {
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
 
-    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[link.sys]\nsource=\"system\"\nname=\"c\"\nos=[\"linux\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.local_lib]\nsource=\"local\"\npath=\"lib/mylib.a\"\nos=[\"*\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"sys\", \"local_lib\"]\nneed = []\n";
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[link.sys]\nsource=\"system\"\nname=\"c\"\nlibrary=\"c-runtime\"\nos=[\"linux\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[link.local_lib]\nsource=\"local\"\npath=\"lib/mylib.a\"\nos=[\"*\"]\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets = [\"*\"]\nlink = [\"sys\", \"local_lib\"]\nneed = []\n";
     val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
@@ -2510,8 +2551,11 @@ test "mach.lang.manifest.resolve_build_unit:links" {
         or {
             val bu: BuildUnit = R.unwrap_ok[BuildUnit, str](ul);
             if (bu.lib_count != 2) { code = 1; }
-            if (!strarr_has(?itn, bu.libs, bu.lib_count, "c")) { code = 1; }
-            if (!strarr_has(?itn, bu.libs, bu.lib_count, "lib/mylib.a")) { code = 1; }
+            if (!requirement_has(?itn, bu.libs, bu.lib_count, "c")) { code = 1; }
+            if (!requirement_has(?itn, bu.libs, bu.lib_count, "lib/mylib.a")) { code = 1; }
+            if (bu.libs[0].source != LINK_SYSTEM || bu.libs[1].source != LINK_LOCAL) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.libs[0].library), "c-runtime")) { code = 1; }
+            if (!str_equals(idstr(?itn, bu.libs[1].library), "local_lib")) { code = 1; }
         }
 
         val uw: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
@@ -2520,7 +2564,7 @@ test "mach.lang.manifest.resolve_build_unit:links" {
             val bu: BuildUnit = R.unwrap_ok[BuildUnit, str](uw);
             # matches only local_lib (no os constraint) since sys specifies os = ["linux"]
             if (bu.lib_count != 1) { code = 1; }
-            if (!strarr_has(?itn, bu.libs, bu.lib_count, "lib/mylib.a")) { code = 1; }
+            if (!requirement_has(?itn, bu.libs, bu.lib_count, "lib/mylib.a")) { code = 1; }
         }
     }
     arena.dnit(?ar);
@@ -2609,7 +2653,7 @@ test "mach.lang.manifest.resolve_build_unit:local_project_out" {
         or {
             val bu: BuildUnit = R.unwrap_ok[BuildUnit, str](ul);
             if (bu.lib_count != 1) { code = 1; }
-            if (!strarr_has(?itn, bu.libs, bu.lib_count, "out/linux/obj/shim.o")) { code = 1; }
+            if (!requirement_has(?itn, bu.libs, bu.lib_count, "out/linux/obj/shim.o")) { code = 1; }
         }
     }
     arena.dnit(?ar);
@@ -2931,17 +2975,17 @@ test "mach.lang.manifest.resolve_test_libs:union" {
         val tl: *TargetDef = find_target_by_name(?itn, ?m, "linux");
         if (tl == nil) { code = 1; }
         or {
-            var items: *intern.StrId = nil;
+            var items: *LinkRequirement = nil;
             var count: u32 = 0;
             var v: TmplVars = tmpl_vars_of(?itn, tl, "debug");
             val r: R.Result[bool, str] = resolve_test_libs(?alloc, ?itn, ?m, tl, "out/linux", ?v, ?items, ?count);
             if (R.is_err[bool, str](r)) { code = 1; }
             or {
                 if (count != 3) { code = 1; }
-                if (!strarr_has(?itn, items, count, "liba")) { code = 1; }
-                if (!strarr_has(?itn, items, count, "libb")) { code = 1; }
-                if (!strarr_has(?itn, items, count, "libshared")) { code = 1; }
-                if ( strarr_has(?itn, items, count, "libc")) { code = 1; }
+                if (!requirement_has(?itn, items, count, "liba")) { code = 1; }
+                if (!requirement_has(?itn, items, count, "libb")) { code = 1; }
+                if (!requirement_has(?itn, items, count, "libshared")) { code = 1; }
+                if ( requirement_has(?itn, items, count, "libc")) { code = 1; }
             }
         }
     }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -140,8 +140,8 @@ pub val Q_MODULE_NUMBER: QueryKind = 14;
 # output path and product name, the output kind, the pie flag, and the external
 # link inputs. static external inputs (`.o` / `.a` baked into the output) are folded
 # by path AND by content hash, so a same-path rebuild of a vendored archive
-# invalidates; dynamic dependencies (sonames, loaded at run time) are folded by
-# identity. Q_LINK depends on it so a change to any of them re-links even when every
+# invalidates; dynamic dependencies are folded by logical and loader identity.
+# Q_LINK depends on it so a change to any of them re-links even when every
 # module's object is unchanged; set_input's early-cutoff keeps the link reused when
 # the config is byte-identical (#1618).
 pub val Q_LINK_CONFIG: QueryKind = 15;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -248,8 +248,10 @@ pub rec ObjectImage {
 # The linker collects one per shared-library link input; the format writer emits
 # it into the format's dependency list. format-neutral so PE/Mach-O reuse it.
 # ---
-# soname: interned shared-object name the loader resolves (e.g. "libc.so.6")
+# name:   stable logical dependency name used by `#[library]` attribution
+# soname: canonical shared-object name the loader resolves (e.g. "libc.so.6")
 pub rec DynLib {
+    name:   intern.StrId;
     soname: intern.StrId;
 }
 

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -250,9 +250,11 @@ pub rec ObjectImage {
 # ---
 # name:   stable logical dependency name used by `#[library]` attribution
 # soname: canonical shared-object name the loader resolves (e.g. "libc.so.6")
+# rpath:  Mach-O runtime search root for an `@rpath/` soname, or STR_NIL
 pub rec DynLib {
     name:   intern.StrId;
     soname: intern.StrId;
+    rpath:  intern.StrId;
 }
 
 # one dynamic import: an undefined symbol satisfied at run time by a shared

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -5190,6 +5190,7 @@ fun t_iat_slots_exact(i: *intern.Interner, counts: *u32, nlib: u32) bool {
     var l: u32 = 0;
     for (l < nlib) {
         libs[l].soname = t_intern(i, "lib.dll");
+        libs[l].rpath = intern.STR_NIL;
         var j: u32 = 0;
         for (j < counts[l]) {
             imports[total].symbol = t_intern(i, "fn");

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -85,6 +85,8 @@ val LC_DYSYMTAB:      u32 = 0xB;
 val LC_UNIXTHREAD:    u32 = 0x5;
 val LC_LOAD_DYLIB:    u32 = 0xC;
 val LC_LOAD_DYLINKER: u32 = 0xE;
+# LC_REQ_DYLD marks LC_RPATH as required for correct loading semantics
+val LC_RPATH:         u32 = 0x8000001C;
 # the LC_REQ_DYLD bit is set on LC_DYLD_INFO_ONLY so a loader that cannot read
 # the compressed dyld-info stream refuses the image rather than mis-loading it
 val LC_DYLD_INFO_ONLY: u32 = 0x80000022;
@@ -171,6 +173,7 @@ val DYSYMTAB_CMD_SIZE:   usize = 80;
 val DYLD_INFO_CMD_SIZE:  usize = 48;   # cmd + cmdsize + 5 (off,size) pairs
 val DYLINKER_CMD_BASE:   usize = 12;   # cmd + cmdsize + name lc_str offset
 val DYLIB_CMD_BASE:      usize = 24;   # the dylib lc_str, then 3 version words
+val RPATH_CMD_BASE:      usize = 12;   # cmd + cmdsize + path lc_str offset
 val NLIST_64_SIZE:       usize = 16;
 val RELOC_INFO_SIZE:     usize = 8;
 
@@ -2110,6 +2113,13 @@ fun dylib_cmd_size(name: str) usize {
     ret bin.align_up(DYLIB_CMD_BASE + n + 1, 8);
 }
 
+# the byte size of an LC_RPATH command for one runtime search directory
+fun rpath_cmd_size(name: str) usize {
+    var n: usize = 0;
+    if (name != nil) { n = str_len(name); }
+    ret bin.align_up(RPATH_CMD_BASE + n + 1, 8);
+}
+
 # write the LC_LOAD_DYLINKER command naming the dynamic loader
 # ---
 # buf: the output buffer
@@ -2143,6 +2153,26 @@ fun write_load_dylib(buf: *u8, off: usize, name: str) usize {
     bin.write_u32_le(buf, off + 20, 0x10000);
     bin.write_str(buf, off + DYLIB_CMD_BASE, name);
     ret off + sz;
+}
+
+# write one LC_RPATH command naming a runtime search directory
+fun write_rpath(buf: *u8, off: usize, name: str) usize {
+    val sz: usize = rpath_cmd_size(name);
+    bin.write_u32_le(buf, off, LC_RPATH);
+    bin.write_u32_le(buf, off + 4, sz::u32);
+    bin.write_u32_le(buf, off + 8, RPATH_CMD_BASE::u32);
+    bin.write_str(buf, off + RPATH_CMD_BASE, name);
+    ret off + sz;
+}
+
+# whether a dependency's run path already appeared in the preceding prefix
+fun rpath_seen_before(libs: *of.DynLib, end: u32, rpath: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < end) {
+        if (libs[i].rpath == rpath) { ret true; }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # write the LC_UNIXTHREAD command carrying the entry point in the arch's thread
@@ -2864,9 +2894,20 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
                           + dylinker_cmd_size() + entry_cmd_size + LINKEDIT_DATA_CMD_SIZE;   # + LC_CODE_SIGNATURE
     if (pie) { sizeofcmds = sizeofcmds + BUILD_VERSION_CMD_SIZE + UUID_CMD_SIZE; }
     var di: u32 = 0;
-    for (di < dyn.lib_count) { sizeofcmds = sizeofcmds + dylib_cmd_size(bin.resolve_name(itn, dyn.libs[di].soname)); di = di + 1; }
+    var rpath_count: u32 = 0;
+    for (di < dyn.lib_count) {
+        sizeofcmds = sizeofcmds + dylib_cmd_size(bin.resolve_name(itn, dyn.libs[di].soname));
+        if (dyn.libs[di].rpath != intern.STR_NIL
+            && !rpath_seen_before(dyn.libs, di, dyn.libs[di].rpath)) {
+            sizeofcmds = sizeofcmds
+                + rpath_cmd_size(bin.resolve_name(itn, dyn.libs[di].rpath));
+            rpath_count = rpath_count + 1;
+        }
+        di = di + 1;
+    }
 
-    var ncmds: u32 = seg_cmds + 6 + dyn.lib_count;   # dyld_info,symtab,dysymtab,dylinker,entry,code_signature
+    var ncmds: u32 = seg_cmds + 6 + dyn.lib_count + rpath_count;
+    # dyld_info,symtab,dysymtab,dylinker,entry,code_signature + dylibs + rpaths
     if (pie) { ncmds = ncmds + 2; }                  # LC_BUILD_VERSION + LC_UUID
 
     # a non-mapped __DWARF segment (debug sections) is placed below the code
@@ -3151,8 +3192,17 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     bin.write_u32_le(buf, lc + 28, nimp);                   # nundefsym
     lc = lc + DYSYMTAB_CMD_SIZE;
 
-    # LC_LOAD_DYLINKER, then one LC_LOAD_DYLIB per dependency.
+    # LC_LOAD_DYLINKER, each distinct required LC_RPATH, then one LC_LOAD_DYLIB
+    # per dependency.
     lc = write_load_dylinker(buf, lc);
+    di = 0;
+    for (di < dyn.lib_count) {
+        if (dyn.libs[di].rpath != intern.STR_NIL
+            && !rpath_seen_before(dyn.libs, di, dyn.libs[di].rpath)) {
+            lc = write_rpath(buf, lc, bin.resolve_name(itn, dyn.libs[di].rpath));
+        }
+        di = di + 1;
+    }
     di = 0;
     for (di < dyn.lib_count) {
         lc = write_load_dylib(buf, lc, bin.resolve_name(itn, dyn.libs[di].soname));
@@ -4411,7 +4461,9 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     var libs: [1]of.DynLib;
-    libs[0].soname = t_intern(?itn, "libprobe.dylib");
+    libs[0].name = t_intern(?itn, "probe");
+    libs[0].soname = t_intern(?itn, "@rpath/libprobe.dylib");
+    libs[0].rpath = t_intern(?itn, "/opt/probe/lib");
     var imps: [1]of.DynImport;
     imps[0].symbol = t_intern(?itn, "probe_add");
     imps[0].lib_index = 0;
@@ -4464,6 +4516,9 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     val ld: usize = t_find_lc(buf.data, LC_LOAD_DYLIB);
     if (ld == 0)                                                           { ret 1; }
     if (!t_bytes_contain(buf.data, ld, bin.read_u32_le(buf.data, ld + 4)::usize, "libprobe.dylib")) { ret 1; }
+    val rp: usize = t_find_lc(buf.data, LC_RPATH);
+    if (rp == 0)                                                           { ret 1; }
+    if (!t_bytes_contain(buf.data, rp, bin.read_u32_le(buf.data, rp + 4)::usize, "/opt/probe/lib")) { ret 1; }
 
     val info: usize = t_find_lc(buf.data, LC_DYLD_INFO_ONLY);
     if (info == 0)                                                         { ret 1; }


### PR DESCRIPTION
Closes #2424

## Summary

- preserve typed `local`, `system`, and `framework` requirements through direct and cascading links
- resolve Darwin dylibs by target-architecture `LC_ID_DYLIB` selection and frameworks through version-independent system paths for x86_64 and aarch64 targets
- retain the selected runtime search root for `@rpath` install names and emit stable, deduplicated `LC_RPATH` commands
- collect bare `.so`, `.dylib`, and `.dll` path positionals as documented link inputs while rejecting inputs incompatible with the selected object format or architecture
- map stable logical `#[library]` identities to platform-specific loader names across planning and execution sessions while retaining exact-name compatibility
- deduplicate shared loader dependencies and static inputs, and reject logical/loader identity collisions—including Darwin's implicit libSystem—that would make attribution order-dependent
- document manifest, CLI, decorator, and repository-skill behavior

## Verification

- `mach test .` — 996 passed, 0 failed
- complete Linux integration suite — all debug/release cases passed
- focused manifest, planner, CLI link-input, linker-attribution, interner-boundary, universal/thin Mach-O architecture, implicit libSystem, and runtime-path checks
- incompatible ELF-on-Mach-O and wrong-architecture dylib fixtures are rejected
- Linux release self-host reached a byte-identical b/c fixpoint (`sha256:24a87f1f24d02dc3a837d5ddfdc55500d5ac85028a6f5c0cd244854215fe6add`)
- incremental determinism checks pass for warm no-op and post-edit builds
- downstream `briar-systems/mach-glfw#30` builds from fresh archives with one unconditional `#[library("glfw")]`: Linux attributes all 117 imports and records `libglfw.so.3`; Windows attributes all 117 imports to `glfw3.dll`; Darwin attributes all 117 imports, preserves version-independent framework paths, emits no `LC_RPATH` for an absolute install name, and emits exactly one supplying-directory `LC_RPATH` for an `@rpath` install name
- `git diff --check`

No CI configuration changes.
