### PR TITLE
feat(target): freestanding platform tag + base override (#2426 PR A)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3739,14 +3739,16 @@ fun image_name(modules: *of.ObjectImage, module_count: u32) intern.StrId {
     ret modules[0].name;
 }
 
-# the base virtual address for the active OS's executables, read
-# from the OS vtable (`tgt.os.base_addr`). the loader parameters belong to the OS
-# layer, so the linker never branches on the numeric os id. `link` validates
-# `tgt.os != nil` before any vaddr assignment, so the vtable is always present
+# the base virtual address for the active target's executables. a per-target
+# manifest `base` override (nonzero `tgt.base`) wins; otherwise the OS vtable's
+# `base_addr` applies. the loader parameters belong to the OS layer, so the linker
+# never branches on the numeric os id. `link` validates `tgt.os != nil` before any
+# vaddr assignment, so the vtable is always present
 # ---
-# tgt: active target - supplies the OS base address
-# ret: the base virtual address for the OS's executables
+# tgt: active target - supplies the base override and the OS base address
+# ret: the base virtual address for the target's executables
 fun os_base_addr(tgt: *target.Target) u64 {
+    if (tgt.base != 0) { ret tgt.base; }
     ret tgt.os.base_addr;
 }
 
@@ -4308,6 +4310,27 @@ test "mach.lang.be.linker.build_dynamic_info:implicit_platform_identity" {
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
     session.dnit(?s);
+    ret 0;
+}
+
+# a per-target manifest base overrides the OS vtable base; an unset (0) base defers
+# to the vtable value - the mechanism a freestanding bmos image places itself (#2426)
+test "mach.lang.be.linker.os_base_addr:manifest_base_override" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "freestanding", "sysv64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    # select installs no override; freestanding's vtable base is 0, so os_base_addr
+    # reports the vtable value.
+    if (tgt.base != 0)                            { ret 1; }
+    if (os_base_addr(?tgt) != tgt.os.base_addr)   { ret 1; }
+    if (os_base_addr(?tgt) != 0)                  { ret 1; }
+
+    # a nonzero manifest base wins over the vtable value (the bmos high-half placement).
+    tgt.base = 0xFFFF800000000000;
+    if (os_base_addr(?tgt) != 0xFFFF800000000000) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -192,18 +192,20 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     if (R.is_err[*project.TargetEntry, str](ter)) { ret R.err[bool, str](R.unwrap_err[*project.TargetEntry, str](ter)); }
     val targets: *project.TargetEntry = R.unwrap_ok[*project.TargetEntry, str](ter);
     var entry: project.TargetEntry;
-    entry.name       = bu.target_name;
-    entry.os_name    = bu.target.os;
-    entry.isa_name   = bu.target.isa;
-    entry.abi_name   = bu.target.abi;
-    entry.of_name    = bu.target.of;
-    entry.entrypoint = bu.entry;
-    entry.mode       = project.MODE_EXECUTABLE;
+    entry.name          = bu.target_name;
+    entry.os_name       = bu.target.os;
+    entry.isa_name      = bu.target.isa;
+    entry.abi_name      = bu.target.abi;
+    entry.of_name       = bu.target.of;
+    entry.platform_name = bu.target.platform;
+    entry.base          = bu.target.base;
+    entry.entrypoint    = bu.entry;
+    entry.mode          = project.MODE_EXECUTABLE;
     if (bu.is_lib) { entry.mode = project.MODE_LIBRARY; }
-    entry.lib_kind   = bu.kind;
-    entry.opt        = project.map_opt(bu.opt);
-    entry.libs       = bu.libs;
-    entry.lib_count  = bu.lib_count;
+    entry.lib_kind      = bu.kind;
+    entry.opt           = project.map_opt(bu.opt);
+    entry.libs          = bu.libs;
+    entry.lib_count     = bu.lib_count;
     targets[0] = entry;
 
     p.config.id           = m.id;
@@ -468,6 +470,9 @@ pub fun select_target(p: *project.Project, t: *project.TargetEntry) R.Result[boo
     val tr: R.Result[target.Target, str] = target.select_of(?p.s.registry, isa_name, os_name, abi_name, of_name);
     if (R.is_err[target.Target, str](tr)) { ret R.err[bool, str](R.unwrap_err[target.Target, str](tr)); }
     p.target = R.unwrap_ok[target.Target, str](tr);
+    # the manifest base override rides on the resolved target; the linker's
+    # os_base_addr prefers it over the os vtable's base_addr when nonzero.
+    p.target.base = t.base;
 
     val rcn: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "mach");
     if (R.is_err[intern.StrId, str](rcn)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rcn)); }

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -383,6 +383,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     comptime.set_build_context(?m.ctx,
         p.config.id, p.config.version, p.config.name, p.config.description,
         p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
+        p.target_entry.platform_name,
         p.config.bin_name);
     m.pub_consts        = nil;
     m.pub_const_count   = 0;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1518,6 +1518,10 @@ fun write_build_config(fb: *dq.FpBuf, p: *project.Project) R.Result[bool, str] {
     val a5: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.os_name::u32);  if (R.is_err[bool, str](a5)) { ret a5; }
     val a6: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.isa_name::u32); if (R.is_err[bool, str](a6)) { ret a6; }
     val a7: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.abi_name::u32); if (R.is_err[bool, str](a7)) { ret a7; }
+    # platform tag folds comptime output and base overrides the linked image base;
+    # both must key the cache so two builds differing only in these don't alias.
+    val apl: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.platform_name::u32); if (R.is_err[bool, str](apl)) { ret apl; }
+    val abz: R.Result[bool, str] = dq.fp_u64(fb, p.target.base);        if (R.is_err[bool, str](abz)) { ret abz; }
     val a8: R.Result[bool, str] = dq.fp_u32(fb, p.config.id::u32);      if (R.is_err[bool, str](a8)) { ret a8; }
     val a9: R.Result[bool, str] = dq.fp_u32(fb, p.config.version::u32); if (R.is_err[bool, str](a9)) { ret a9; }
     val aa: R.Result[bool, str] = dq.fp_u32(fb, p.config.name::u32);    if (R.is_err[bool, str](aa)) { ret aa; }

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -63,34 +63,40 @@ pub val TARGET_OPT_RELEASE: TargetOpt = 2;
 # the selected target a build resolves to - synthesized by the
 # manifest reader from the chosen `[target.<name>]` stanza and build unit
 # ---
-# name:       interned target selector (e.g. "linux")
-# os_name:    interned os name (e.g. "linux"); read by `$project.target.os`
-# isa_name:   interned isa name (e.g. "x86_64"); read by `$project.target.arch`
-# abi_name:   interned abi name (e.g. "sysv64"); read by `$project.target.abi`
-# of_name:    interned object-format override, "" to derive from the os default
-# entrypoint: interned entry-source path, relative to the project src dir (e.g. "main.mach")
-# mode:       whether the build links an executable or stops at the objects
-# opt:        resolved optimization level from the selected profile; TARGET_OPT_DEFAULT
-#             when none. the CLI maps it to a pipeline level, with an explicit
-#             `-O*` flag taking precedence
-# libs:       typed project-level link requirements (the merged
-#             target+artifact+cell link overlay), preserving local/system/framework
-#             semantics and stable `#[library]` attribution names; nil when none
-# lib_count:  number of entries in `libs`
-# lib_kind:   for a library build (mode == MODE_LIBRARY), whether the artifact is
-#             static or shared; meaningless for an executable (#1980)
+# name:          interned target selector (e.g. "linux")
+# os_name:       interned os name (e.g. "linux"); read by `$project.target.os`
+# isa_name:      interned isa name (e.g. "x86_64"); read by `$project.target.arch`
+# abi_name:      interned abi name (e.g. "sysv64"); read by `$project.target.abi`
+# of_name:       interned object-format override, "" to derive from the os default
+# platform_name: interned platform tag surfaced as `$mach.build.platform`; STR_NIL when
+#                unset. an open string libraries key on, not a compiler os/enum
+# base:          first-segment load-address override threaded to the resolved target;
+#                0 (unset) defers to the OS vtable's base_addr at link time
+# entrypoint:    interned entry-source path, relative to the project src dir (e.g. "main.mach")
+# mode:          whether the build links an executable or stops at the objects
+# opt:           resolved optimization level from the selected profile; TARGET_OPT_DEFAULT
+#                when none. the CLI maps it to a pipeline level, with an explicit
+#                `-O*` flag taking precedence
+# libs:          typed project-level link requirements (the merged
+#                target+artifact+cell link overlay), preserving local/system/framework
+#                semantics and stable `#[library]` attribution names; nil when none
+# lib_count:     number of entries in `libs`
+# lib_kind:      for a library build (mode == MODE_LIBRARY), whether the artifact is
+#                static or shared; meaningless for an executable (#1980)
 pub rec TargetEntry {
-    name:       intern.StrId;
-    os_name:    intern.StrId;
-    isa_name:   intern.StrId;
-    abi_name:   intern.StrId;
-    of_name:    intern.StrId;
-    entrypoint: intern.StrId;
-    mode:       BuildMode;
-    opt:        TargetOpt;
-    libs:       *manifest.LinkRequirement;
-    lib_count:  u32;
-    lib_kind:   manifest.LibKind;
+    name:          intern.StrId;
+    os_name:       intern.StrId;
+    isa_name:      intern.StrId;
+    abi_name:      intern.StrId;
+    of_name:       intern.StrId;
+    platform_name: intern.StrId;
+    base:          u64;
+    entrypoint:    intern.StrId;
+    mode:          BuildMode;
+    opt:           TargetOpt;
+    libs:          *manifest.LinkRequirement;
+    lib_count:     u32;
+    lib_kind:      manifest.LibKind;
 }
 
 # one entry under `[deps.<alias>]` in mach.toml plus the dep's

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -286,6 +286,8 @@ pub def FrameMark: u32;
 #                 (the declared tuple's string, distinct from `$mach.build.os`'s tag)
 # target_isa:     interned selected-target isa name, read by `$project.target.arch`
 # target_abi:     interned selected-target abi name, read by `$project.target.abi`
+# target_platform: interned selected-target platform tag, read by `$mach.build.platform`;
+#                 STR_NIL when unset, which the read folds to the empty string
 # bin_name:       interned name of the artifact being built, read by `$bin.name`;
 #                 STR_NIL when no single artifact is selected (v1 manifests)
 # member_fn:      erased ModuleMemberFn resolving `alias.CONST` member paths, or
@@ -318,6 +320,7 @@ pub rec ComptimeCtx {
     target_os:      intern.StrId;
     target_isa:     intern.StrId;
     target_abi:     intern.StrId;
+    target_platform: intern.StrId;
     bin_name:       intern.StrId;
     member_fn:      *u8;
     member_data:    ptr;
@@ -386,6 +389,7 @@ pub fun init(
     c.target_os      = intern.STR_NIL;
     c.target_isa     = intern.STR_NIL;
     c.target_abi     = intern.STR_NIL;
+    c.target_platform = intern.STR_NIL;
     c.bin_name       = intern.STR_NIL;
     c.member_fn      = nil;
     c.member_data    = nil;
@@ -454,6 +458,7 @@ pub fun set_field_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 # target_os:    interned selected-target os name
 # target_isa:   interned selected-target isa name
 # target_abi:   interned selected-target abi name, or STR_NIL
+# target_platform: interned selected-target platform tag, or STR_NIL
 # bin_name:     interned artifact name, or STR_NIL
 pub fun set_build_context(
     c:            *ComptimeCtx,
@@ -464,6 +469,7 @@ pub fun set_build_context(
     target_os:    intern.StrId,
     target_isa:   intern.StrId,
     target_abi:   intern.StrId,
+    target_platform: intern.StrId,
     bin_name:     intern.StrId
 ) {
     c.project_id   = project_id;
@@ -473,6 +479,7 @@ pub fun set_build_context(
     c.target_os    = target_os;
     c.target_isa   = target_isa;
     c.target_abi   = target_abi;
+    c.target_platform = target_platform;
     c.bin_name     = bin_name;
 }
 
@@ -2194,6 +2201,17 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "pie")) {
         ret int_value(c.build_pie::i64);
     }
+    # $mach.build.platform - the resolved target's platform tag (an OPEN string a
+    # library keys its backend on, not a compiler enum), or "" when the manifest
+    # declared none. the unset read interns "" so `== ""` folds true and `== "x"`
+    # false. checked before the `$mach.build.<name>` define lookup so a manifest
+    # define never shadows this reserved build fact.
+    if (depth == 3 && seg_is(source, stack, 1, "build") && seg_is(source, stack, 0, "platform")) {
+        if (c.target_platform != intern.STR_NIL) { ret str_value(c.target_platform); }
+        val pr: R.Result[intern.StrId, str] = intern.intern(interner, "");
+        if (R.is_err[intern.StrId, str](pr)) { ret R.err[CTValue, str](R.unwrap_err[intern.StrId, str](pr)); }
+        ret str_value(R.unwrap_ok[intern.StrId, str](pr));
+    }
 
     # $mach.build.{timestamp,host} - build metadata stubs. checked before the
     # dynamic define lookup so a manifest define can never shadow a reserved name.
@@ -2802,6 +2820,34 @@ test "mach.lang.fe.comptime.resolve_project_path:target_tuple" {
     if (t_str_id(resolve_project_path(?c, sisa, ?stack[0], t_dotted(sisa, ?stack[0]), ?itab)) != 21) { ret 1; }
     val sabi: str = "project.target.abi";
     if (t_str_id(resolve_project_path(?c, sabi, ?stack[0], t_dotted(sabi, ?stack[0]), ?itab)) != 22) { ret 1; }
+    ret 0;
+}
+
+# $mach.build.platform folds the resolved platform tag verbatim; an unset tag
+# (STR_NIL) folds to the interned empty string so `== ""` holds (#2426)
+test "mach.lang.fe.comptime.resolve_mach_path:build_platform" {
+    var c: ComptimeCtx = t_build_ctx();
+    var stack: [8]token.Span;
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itab: intern.Interner = intern.init(?alloc);
+
+    val sp: str = "mach.build.platform";
+
+    # a declared tag folds to its interned StrId unchanged (an open string, no enum).
+    val pid_r: R.Result[intern.StrId, str] = intern.intern(?itab, "bmos");
+    if (R.is_err[intern.StrId, str](pid_r)) { ret 1; }
+    val pid: intern.StrId = R.unwrap_ok[intern.StrId, str](pid_r);
+    c.target_platform = pid;
+    if (t_str_id(resolve_mach_path(?c, sp, ?stack[0], t_dotted(sp, ?stack[0]), ?itab)) != pid) { ret 1; }
+
+    # unset folds to the interned "" - not STR_NIL - so a `== ""` comptime compare is true.
+    c.target_platform = intern.STR_NIL;
+    val empty_r: R.Result[intern.StrId, str] = intern.intern(?itab, "");
+    if (R.is_err[intern.StrId, str](empty_r)) { ret 1; }
+    val empty_id: intern.StrId = R.unwrap_ok[intern.StrId, str](empty_r);
+    if (empty_id == intern.STR_NIL) { ret 1; }
+    if (t_str_id(resolve_mach_path(?c, sp, ?stack[0], t_dotted(sp, ?stack[0]), ?itab)) != empty_id) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -63,11 +63,13 @@ val TK_LINK:     TableKind = 5;
 val TK_STEP:     TableKind = 6;
 
 pub rec TargetDef {
-    name: intern.StrId;
-    isa:  intern.StrId;
-    os:   intern.StrId;
-    abi:  intern.StrId;
-    of:   intern.StrId;
+    name:     intern.StrId;
+    isa:      intern.StrId;
+    os:       intern.StrId;
+    abi:      intern.StrId;
+    of:       intern.StrId;
+    platform: intern.StrId;   # user-defined tag surfaced as `$mach.build.platform`; STR_NIL when unset
+    base:     u64;            # first-segment load-address override; 0 (unset) defers to the os base_addr
 }
 
 pub rec ArtifactDef {
@@ -532,7 +534,8 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
         ret false;
     }
     if (kind == TK_TARGET) {
-        ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi") || str_equals(k, "of");
+        ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi") || str_equals(k, "of")
+            || str_equals(k, "platform") || str_equals(k, "base");
     }
     if (kind == TK_ARTIFACT) {
         ret str_equals(k, "kind") || str_equals(k, "entry") || str_equals(k, "out")
@@ -696,6 +699,15 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         d.os  = intern_unwrap(itn, os_s);
         d.abi = intern_unwrap(itn, abi_s);
         d.of  = intern_opt_unwrap(itn, toml.get_str(sub, "of"));
+
+        # optional platform tag (open string) and load-address override. an absent
+        # `base` leaves 0, deferring to the os vtable's base_addr at link time. the
+        # toml integer is stored as an i64 bit pattern; reinterpret it as the u64
+        # address (a high-half kernel base like 0xFFFF800000000000 round-trips clean).
+        d.platform = intern_opt_unwrap(itn, toml.get_str(sub, "platform"));
+        d.base     = 0;
+        val base_opt: O.Option[i64] = toml.get_int(sub, "base");
+        if (O.is_some[i64](base_opt)) { d.base = O.unwrap[i64](base_opt)::u64; }
 
         m.targets[i] = d;
         i = i + 1;
@@ -1355,11 +1367,13 @@ fun resolve_target(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel
         val res_host: R.Result[*TargetDef, str] = A.allocate[TargetDef](alloc, 1);
         if (R.is_err[*TargetDef, str](res_host)) { ret R.err[ResolvedTarget, str](R.unwrap_err[*TargetDef, str](res_host)); }
         val host: *TargetDef = R.unwrap_ok[*TargetDef, str](res_host);
-        host.name = intern_unwrap(itn, "native");
-        host.isa  = intern_unwrap(itn, host_isa_name());
-        host.os   = intern_unwrap(itn, host_os_name());
-        host.abi  = intern_unwrap(itn, abi.abi_name_for(tgt.host_abi_id()));
-        host.of   = intern.STR_NIL;
+        host.name     = intern_unwrap(itn, "native");
+        host.isa      = intern_unwrap(itn, host_isa_name());
+        host.os       = intern_unwrap(itn, host_os_name());
+        host.abi      = intern_unwrap(itn, abi.abi_name_for(tgt.host_abi_id()));
+        host.of       = intern.STR_NIL;
+        host.platform = intern.STR_NIL;
+        host.base     = 0;
         rt.target = host;
         rt.warned = false;
         ret R.ok[ResolvedTarget, str](rt);
@@ -2295,6 +2309,34 @@ test "mach.lang.manifest.parse:backslash_rejected" {
 
     val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"a\\\\b\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n");
     if (R.is_ok[Manifest, str](a) || !str_equals(R.unwrap_err[Manifest, str](a), "mach.toml: [project].src contains a '\\\\'; manifest paths use '/'")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# the optional [target.X] platform tag and base override parse and thread onto the
+# TargetDef; omitting them leaves platform STR_NIL and base 0 (defer to os) (#2426)
+test "mach.lang.manifest.parse:platform_and_base" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.bmos]\nisa=\"x86_64\"\nos=\"freestanding\"\nabi=\"sysv64\"\nplatform=\"bmos\"\nbase=0xFFFF800000000000\n[target.plain]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n";
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        val tb: *TargetDef = find_target_by_name(?itn, ?m, "bmos");
+        val tp: *TargetDef = find_target_by_name(?itn, ?m, "plain");
+        if (tb == nil || tp == nil) { code = 1; }
+        or {
+            # the bmos target carries the tag verbatim and the high-half base override.
+            if (!str_equals(idstr(?itn, tb.platform), "bmos")) { code = 1; }
+            if (tb.base != 0xFFFF800000000000)                 { code = 1; }
+            # the plain target declared neither: platform STR_NIL, base defers to 0.
+            if (tp.platform != intern.STR_NIL)                 { code = 1; }
+            if (tp.base != 0)                                  { code = 1; }
+        }
+    }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -306,6 +306,9 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
 
     var t: resolved.Target;
     t.os      = os_vt;
+    # no manifest base override by default; the driver overwrites this from the
+    # selected target's `base`, and the linker falls back to os_vt.base_addr when 0.
+    t.base    = 0;
     t.isa     = arch_vt;
     # the register-machine contract, or nil for a whole-module emitter. every stage
     # that reads it runs after `codegen_module` forks on `isa.emits_whole_module`.

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -46,6 +46,10 @@ use mach.lang.target.os;
 #           by `target.select` from the isa's model template overlaid with the abi's
 #           stack scalars; held by value because those scalars vary by abi, so a
 #           shared per-arch template cannot bake them in
+# base:     per-target first-segment load-address override threaded from the manifest
+#           `base`; 0 means "no override" and the linker falls back to the os vtable's
+#           base_addr. lets a freestanding image place itself (e.g. a high-half kernel
+#           base) without modeling a bespoke OS in the compiler
 pub rec Target {
     os_id:    u32;
     arch_id:  u32;
@@ -58,4 +62,5 @@ pub rec Target {
     of:       *of.OfVTable;
     debug:    *of.DebugVTable;
     model:    isa.MachineModel;
+    base:     u64;
 }


### PR DESCRIPTION
Part of #2426.

## Scope

The **additive, seed-safe** half of #2426: it lets a bespoke platform (bmos) be expressed as `os = freestanding` + a manifest platform tag + a base override, **without removing the existing bmos OS yet**. `OS_BMOS`, `src/lang/target/os/bmos.mach`, and the `$mach.os.bmos` comptime selector are all untouched, so mach-std keeps composing (its dead `$if` bmos arm still resolves `$mach.os.bmos`). The bmos-OS removal + the mach-std re-gate to `$mach.build.platform == "bmos"` are follow-up PRs.

## Three additive changes

1. **Manifest schema.** `[target.X]` gains two optional keys: `platform = "<tag>"` (an open string, STR_NIL when unset) and `base = <addr>` (u64 load-address override, 0/unset defers to the OS default). Both parse, validate as known keys, and thread onto `TargetDef`; the native host-synthesis path initializes them too.
2. **`$mach.build.platform`.** A new comptime selector returning the resolved platform string, folding an unset tag to `""` (interned, so `== ""` holds). It is an OPEN string — no enum, no `PLATFORM_*` ids. Checked before the `$mach.build.<name>` define lookup so a manifest define cannot shadow it.
3. **Base override → linker.** The resolved `Target` gains a per-target `base`; `target.select_of` initializes it to 0, the driver overwrites it from the selected target, and the linker's `os_base_addr` prefers a nonzero override over the OS vtable's `base_addr`. This is exactly the mechanism a bmos project will use (`os=freestanding, base=0xFFFF800000000000, platform=bmos`).

The build fingerprint keys on both new fields so two builds differing only in `platform`/`base` do not alias in the incremental cache.

## Design notes

- **`resolved.Target` holds a *borrowed* OS vtable pointer** (`os: *OsVTable`), it does not copy `base_addr`. So the override cannot mutate the shared vtable — it is a new per-target `base: u64` field on the resolved target, read by the linker with the vtable as fallback.
- **`base` is a single `u64` where 0 == "unset / use OS default"**, matching the issue wording. Freestanding's vtable base is already 0, so an unset base on freestanding links at 0; a nonzero manifest base wins. No separate "is-set" bool.
- The x86_64-only test path (`target.mach` `select:x86_64_freestanding_raw`) reads `t.os.base_addr` directly; it constructs its own segments and is not the production image-base path, so it is left as-is. The authoritative image base is `os_base_addr` in the linker.

## Tests

- `manifest.parse:platform_and_base` — a `[target.X] platform="bmos" base=0xFFFF800000000000` surfaces both; a plain target leaves platform STR_NIL and base 0.
- `comptime.resolve_mach_path:build_platform` — a set tag folds verbatim; unset folds to interned `""`.
- `linker.os_base_addr:manifest_base_override` — freestanding base 0 defers to the vtable; a nonzero override wins.

## Verification

- Clean self-host build (seed → HEAD): exit 0.
- `mach test` through the freshly-built HEAD compiler: **996 → 999 passed, 0 failed** (+1 each in manifest / comptime / linker).
- Self-host fixpoint: HEAD-built-HEAD (B) == B-built-HEAD (C), byte-identical; B passes 999/0. Change does not perturb the compiler's own output (its manifest sets no platform/base).
