### PR TITLE
fix(target,codegen): correct the "var does not zero" claim and drop the redundant clears it justified

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -597,27 +597,29 @@ pub rec MirInstr {
 
 # build a fresh MIR instruction, every caller-owned field supplied
 #
-# THIS IS THE ONLY PLACE A `MirInstr` IS CLEARED. `var` does not zero, so a site
-# that builds one field by field leaves whatever it does not name holding the
-# frame's residue - and a field added later is named by no site at all. That is not
-# hypothetical here: `vec_lane` was added and `regalloc.rewrite_instr` did not learn
-# about it, so every rewritten vector op read as the `.16b` byte arrangement and the
-# NEON encoder collapsed every arrangement after register assignment (#2032, #2321).
+# THIS IS THE ONLY PLACE A `MirInstr` IS BUILT. `var` zero-fills a bare declaration,
+# so every metadata field below already comes back at its zero default without being
+# named - but that is exactly the hazard, not the absence of one: a field whose
+# meaningful default is not zero would be silently wrong here with nothing to catch
+# it, the way `vec_lane` read as element 0 - a plausible arrangement, not a crash -
+# after `regalloc.rewrite_instr` rebuilt a `MirInstr` without it (#2032, #2321).
+# Naming this as the one construction site means a field added later is a decision
+# made once, here, rather than a silent zero at every caller.
 #
 # The five fields a caller genuinely chooses are positional parameters, so omitting
 # one is an arity error at build time rather than a garbage operation width reaching
 # the encoder. Everything else is METADATA the caller does not author: `asm_block`
 # belongs to MIR_ASM alone, `loc` / `inline_site` / `vec_lane` / `writes_secret` are
 # stamped from the lowering context at `mir.context.push_instr`, and the dbg-binding
-# list is attached there too. Cleared here, so an instruction built outside that
-# chokepoint carries defined metadata rather than the stack's.
+# list is attached there too - all zero-valued by default, which is what an
+# instruction built outside that chokepoint would otherwise leave undefined.
 # ---
 # opcode:        the MIR opcode
 # operands:      the operand array (borrowed or owned per the caller's convention)
 # operand_count: number of operands
 # width:         operation width in bytes
 # src_width:     source width in bytes, for a widening / narrowing op
-# ret:           the instruction, with every metadata field cleared
+# ret:           the instruction, with every metadata field at its zero default
 pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
               width: u8, src_width: u8) MirInstr {
     var mi: MirInstr;
@@ -626,14 +628,6 @@ pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
     mi.operand_count = operand_count;
     mi.width         = width;
     mi.src_width     = src_width;
-
-    mi.asm_block         = nil;
-    mi.loc               = source.loc_nil();
-    mi.dbg_bindings      = nil;
-    mi.dbg_binding_count = 0;
-    mi.inline_site       = 0;
-    mi.vec_lane          = VEC_LANE_NONE;
-    mi.writes_secret     = false;
     ret mi;
 }
 

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -669,9 +669,9 @@ pub rec IsaVTable {
 # built results in XMM14 - the declared and the real primary had drifted apart with
 # no way to observe it. A slot belongs here only once something reads it.
 #
-# The four optional capabilities are cleared here and added afterwards through the
-# `with_*` setters, so an ISA that wires none of them still leaves no field reading
-# stack garbage (`var` does not zero).
+# The four optional capabilities are left at their zero default here and added
+# afterwards through the `with_*` setters: nil is the zero value for a function
+# pointer, so a bare `var` already leaves each one absent before any setter runs.
 # ---
 # select:               instruction selector, erased (the arch's `SelectFn`)
 # encode:               byte encoder, erased (the arch's `EncodeFn`)
@@ -711,11 +711,6 @@ pub fun reg_machine(select: *u8, encode: *u8, is_reg_move: IsRegMoveFn,
     m.div_reg              = div_reg;
     m.div_hi_reg           = div_hi_reg;
     m.shift_count_reg      = shift_count_reg;
-
-    m.emit_asm     = nil;
-    m.asm_clobbers = nil;
-    m.dwarf_reg    = nil;
-    m.cv_reg       = nil;
     ret m;
 }
 
@@ -781,9 +776,9 @@ pub fun module_emitter(emit_module: *u8) ModuleEmitter {
 # relocatable objects are not ELF may still pass a deliberate nil for
 # `elf_reloc_type`.
 #
-# The one optional capability is cleared here and added afterwards through
-# `with_elf_attributes`, so an arch that declares none still leaves no field
-# reading stack garbage (`var` does not zero).
+# The one optional capability is left at its zero default here and added afterwards
+# through `with_elf_attributes`: nil is the zero value for this erased fn ptr, so a
+# bare `var` already leaves it absent before the setter runs.
 # ---
 # apply_reloc:    the relocation applier, erased (`of.reloc.ApplyRelocFn`)
 # reloc_traits:   the relocation-traits source, erased
@@ -797,8 +792,6 @@ pub fun reloc_seam(apply_reloc: *u8, reloc_traits: *u8,
     s.apply_reloc    = apply_reloc;
     s.reloc_traits   = reloc_traits;
     s.elf_reloc_type = elf_reloc_type;
-
-    s.elf_attributes = nil;
     ret s;
 }
 
@@ -864,11 +857,12 @@ pub fun emitter_isa(id: u32, name: str, pointer_width: u32,
     ret vt;
 }
 
-# the family-agnostic half of a composed vtable: identity, description, and a
-# cleared relocatable-object seam
+# the family-agnostic half of a composed vtable: identity, description, and both
+# family payloads at their zero default
 #
-# Shared by `machine_isa` and `emitter_isa` so neither can forget to clear a slot
-# the other fills - `var` does not zero, so an unwritten field reads stack garbage.
+# Shared by `machine_isa` and `emitter_isa` so neither can forget to leave the
+# slot the other fills at nil, its zero value - a bare `var` already leaves both
+# family-payload pointers there before either caller names the one it owns.
 # ---
 # id:              architecture id
 # name:            interned architecture name
@@ -884,10 +878,6 @@ fun isa_common(id: u32, name: str, elf_machine: u32, pointer_width: u32,
     vt.elf_machine     = elf_machine;
     vt.pointer_width   = pointer_width;
     vt.model           = model;
-
-    vt.reloc   = nil;
-    vt.machine = nil;
-    vt.emitter = nil;
     ret vt;
 }
 
@@ -1436,8 +1426,8 @@ test "mach.lang.target.isa.family:payloads_are_exclusive" {
 
 # `reloc_seam` takes each required member positionally, so an arch that omits one
 # is an arity error rather than a hook discovered missing at link time, and it
-# clears the optional descriptor so a declaring arch leaves no field reading stack
-# garbage (`var` does not zero)
+# leaves the optional descriptor at its zero default (nil), which a declaring
+# arch never named, before `with_elf_attributes` turns it on
 test "mach.lang.target.isa.reloc_seam:required_then_optional" {
     var s: RelocSeam = t_reloc();
     if (s.apply_reloc == nil)    { ret 1; }
@@ -1458,9 +1448,9 @@ test "mach.lang.target.isa.reloc_seam:required_then_optional" {
     ret 0;
 }
 
-# `reg_machine` clears every optional capability, so an ISA that declares none
-# leaves no field reading stack garbage (`var` does not zero). each `with_*` setter
-# then turns exactly one on
+# `reg_machine` leaves every optional capability at its zero default (nil), which
+# an ISA that declares none never named. each `with_*` setter then turns exactly
+# one on
 test "mach.lang.target.isa.reg_machine:optionals_cleared_then_declared" {
     var m: RegMachine = t_machine();
     if (m.emit_asm != nil)     { ret 1; }


### PR DESCRIPTION
## Summary

`var` zero-fills every uninitialized binding (`lower_decl_stmt`), but eight sites justified defensive field-by-field clearing with the claim that it doesn't. This corrects the claim and removes the clears that turn out to be genuinely redundant.

- **Converted (comment corrected, redundant code removed)**: `mir.instr` (`src/lang/be/codegen/mir.mach`), `isa.reg_machine`, `isa.reloc_seam`, `isa.isa_common` (`src/lang/target/isa.mach`). Every field each one cleared writes its type's exact zero value — `nil` for a function/erased pointer, `0` for an integer, `VEC_LANE_NONE` (0), `source.loc_nil()`'s all-zero `SrcLoc`, `false` — so a bare `var` already leaves it there; removing the explicit clear is behavior-neutral.
- **Comment-only corrections**: two `isa.mach` test doc-comments (`reloc_seam:required_then_optional`, `reg_machine:optionals_cleared_then_declared`) that echoed the false claim with no adjacent init code to remove.
- **Excluded, left untouched**: `isa.inst_blank`. `mi.dst` / `mi.src1` / `mi.src2` are set via `make_none()`, which threads through `operand_blank()` and writes `reg`/`base`/`index` as `-1` sentinels — not zero. Removing that clear would change behavior, so per the task's bar this site stays out of the cleanup.
- **Deferred, left untouched**: `isa/tests.mach:7`. The issue explicitly calls this out as owned by #2335's census documentation — coordinating rather than duplicating.

Refs #2394 (partial — the two sites above are intentionally out of scope for this PR)

## Verification

- `mach test .` through a from-source generation-B compiler (built by the installed seed): **1000 passed, 0 failed, 1000 total**, including the `mach.lang.target.isa.tests` census test, confirming the construction-site invariant these edits touch still holds.
- Self-hosting fixpoint: built generation C with generation B at `--jobs 1` (parallel `mach build` is independently non-deterministic at the object level, tracked separately as #2433 — not this PR's concern). All 215 object files and the final linked binary are byte-identical between B and C.
- Byte-identity against a `dev` baseline was not required for this change (removing explicit stores may legitimately shift codegen) and wasn't checked.

## Test plan

- [x] `mach test .` via from-source compiler: 1000/0/1000, including the census test
- [x] B == C self-hosting fixpoint at `--jobs 1` (objects + binary, byte-identical)
- [x] CI green before marking ready