### PR TITLE
fix(encode): refuse an unnamed relation instead of defaulting to one

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1410,13 +1410,21 @@ fun emit_add_imm(st: *encode.EncodeState, rd: u32, rn: u32, off: i64) {
 }
 
 # the LSL amount realizing an index scale (1/2/4/8 -> 0/1/2/3) for the
-# GEP scaled-index ADD. an unmodeled scale (never produced by the SIB-legal lowering)
-# takes 0
-fun scale_shift(scale: u8) u32 {
-    if (scale == 2) { ret 1; }
-    if (scale == 4) { ret 2; }
-    if (scale == 8) { ret 3; }
-    ret 0;
+# GEP scaled-index ADD
+#
+# Scale 1 is named rather than defaulted. The bound is `is_sib_scale` in the shared
+# GEP lowering, one module away, and an unmodeled scale used to take the same 0 as
+# scale 1 - so `base + index*3` computed `base + index`, a wrong address with no
+# diagnostic (#2435). x86-64 refuses the identical condition.
+# ---
+# scale: the index scale
+# ret:   the LSL amount, or an error naming the unrepresentable scale
+fun scale_shift(scale: u8) R.Result[u32, str] {
+    if (scale == 1) { ret R.ok[u32, str](0); }
+    if (scale == 2) { ret R.ok[u32, str](1); }
+    if (scale == 4) { ret R.ok[u32, str](2); }
+    if (scale == 8) { ret R.ok[u32, str](3); }
+    ret R.err[u32, str]("encode: a scaled-index address must have a scale of 1, 2, 4, or 8");
 }
 
 # emit `adrp Xd, sym` with a zero page-delta placeholder and record
@@ -1891,12 +1899,15 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         emit_add_imm(st, rd, m.base, m.off);
         ret R.ok[bool, str](true);
     }
+    val shr: R.Result[u32, str] = scale_shift(m.scale);
+    if (R.is_err[u32, str](shr)) { ret R.err[bool, str](R.unwrap_err[u32, str](shr)); }
+    val sh: u32 = R.unwrap_ok[u32, str](shr);
     if (m.off == 0) {
-        emit_alu3_sh(st, ADD_X, rd, m.base, m.index, scale_shift(m.scale));
+        emit_alu3_sh(st, ADD_X, rd, m.base, m.index, sh);
         ret R.ok[bool, str](true);
     }
     emit_add_imm(st, rd, m.base, m.off);
-    emit_alu3_sh(st, ADD_X, rd, rd, m.index, scale_shift(m.scale));
+    emit_alu3_sh(st, ADD_X, rd, rd, m.index, sh);
     ret R.ok[bool, str](true);
 }
 
@@ -2109,12 +2120,20 @@ fun resolve_fp_source(st: *encode.EncodeState, f: *mir.MirFunction, op: *mir.Mir
 
 # the A64 two-source base word for a float arithmetic MIR opcode and
 # precision (D when `dbl`, else S)
-fun fp_arith_base(op: mir.MirOpcode, dbl: bool) u32 {
-    if (op == mir.MIR_FADD) { if (dbl) { ret FADD_D; } ret FADD_S; }
-    if (op == mir.MIR_FSUB) { if (dbl) { ret FSUB_D; } ret FSUB_S; }
-    if (op == mir.MIR_FMUL) { if (dbl) { ret FMUL_D; } ret FMUL_S; }
-    if (dbl)                           { ret FDIV_D; }
-    ret FDIV_S;
+#
+# All four are named; an unmatched opcode is refused rather than taking the
+# trailing FDIV, which would silently turn some other operation into a division
+# (#2435).
+# ---
+# op:  the float arithmetic opcode
+# dbl: true for the double-precision form
+# ret: the A64 base word, or an error naming the unrealized opcode
+fun fp_arith_base(op: mir.MirOpcode, dbl: bool) R.Result[u32, str] {
+    if (op == mir.MIR_FADD) { if (dbl) { ret R.ok[u32, str](FADD_D); } ret R.ok[u32, str](FADD_S); }
+    if (op == mir.MIR_FSUB) { if (dbl) { ret R.ok[u32, str](FSUB_D); } ret R.ok[u32, str](FSUB_S); }
+    if (op == mir.MIR_FMUL) { if (dbl) { ret R.ok[u32, str](FMUL_D); } ret R.ok[u32, str](FMUL_S); }
+    if (op == mir.MIR_FDIV) { if (dbl) { ret R.ok[u32, str](FDIV_D); } ret R.ok[u32, str](FDIV_S); }
+    ret R.err[u32, str]("encode: aarch64 has no float arithmetic form for this opcode");
 }
 
 # the A64 condition a float comparison materializes through CSET. mirrors
@@ -2123,13 +2142,22 @@ fun fp_arith_base(op: mir.MirOpcode, dbl: bool) u32 {
 # unordered-aware conditions an FCMP's NZCV select - `<` is MI (N=1, set only for an
 # ordered less-than; an unordered compare leaves N=0), `<=` is LS, with GT / GE for
 # the swapped relations the lowerer never emits directly (canonicalized to LT/LE)
-fun fp_cond(cc: u8) u32 {
-    if (cc == mir.FCC_EQ) { ret CC_EQ; }
-    if (cc == mir.FCC_NE) { ret CC_NE; }
-    if (cc == mir.FCC_LT) { ret CC_MI; }
-    if (cc == mir.FCC_LE) { ret CC_LS; }
-    if (cc == mir.FCC_GT) { ret CC_GT; }
-    ret CC_GE;
+#
+# Every FCC code is named; a value that is not one is refused rather than taking
+# the trailing `CC_GE` and capturing the compare as a different relation (#2435).
+# The condition rides `mi.src_width`, a byte field the FCC codes share with the
+# operand widths, so nothing about its type bounds it to this alphabet.
+# ---
+# cc:  the FCC_* float condition code
+# ret: the A64 condition, or an error naming the unrealized code
+fun fp_cond(cc: u8) R.Result[u32, str] {
+    if (cc == mir.FCC_EQ) { ret R.ok[u32, str](CC_EQ); }
+    if (cc == mir.FCC_NE) { ret R.ok[u32, str](CC_NE); }
+    if (cc == mir.FCC_LT) { ret R.ok[u32, str](CC_MI); }
+    if (cc == mir.FCC_LE) { ret R.ok[u32, str](CC_LS); }
+    if (cc == mir.FCC_GT) { ret R.ok[u32, str](CC_GT); }
+    if (cc == mir.FCC_GE) { ret R.ok[u32, str](CC_GE); }
+    ret R.err[u32, str]("encode: aarch64 has no float comparison condition for this condition code");
 }
 
 # true when a surviving opcode is one of the scalar float
@@ -2167,7 +2195,9 @@ fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIn
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    val base: u32 = fp_arith_base(mi.opcode, dbl);
+    val baser: R.Result[u32, str] = fp_arith_base(mi.opcode, dbl);
+    if (R.is_err[u32, str](baser)) { ret R.err[bool, str](R.unwrap_err[u32, str](baser)); }
+    val base: u32 = R.unwrap_ok[u32, str](baser);
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
         emit_alu3(st, base, FP_SCRATCH0, rn, rm);
@@ -2462,7 +2492,9 @@ fun encode_fp_cmp(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     var base: u32 = FCMP_S;
     if (w == 8) { base = FCMP_D; }
     emit_alu3(st, base, 0, rn, rm);
-    emit_cset(st, CSINC_W, rd, fp_cond(cc));
+    val ccr: R.Result[u32, str] = fp_cond(cc);
+    if (R.is_err[u32, str](ccr)) { ret R.err[bool, str](R.unwrap_err[u32, str](ccr)); }
+    emit_cset(st, CSINC_W, rd, R.unwrap_ok[u32, str](ccr));
     ret R.ok[bool, str](true);
 }
 
@@ -2712,13 +2744,20 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
 # EQ / NE / LT / LE forms exist in the generic opcode space (the lowerer
 # canonicalizes GT/GE by swapping operands); signedness selects the signed
 # (LT/LE) versus unsigned (CC/LS) condition
-fun cmp_cond(op: mir.MirOpcode) u32 {
-    if (op == mir.MIR_SEL_CMP_EQ)   { ret CC_EQ; }
-    if (op == mir.MIR_SEL_CMP_NE)   { ret CC_NE; }
-    if (op == mir.MIR_SEL_CMP_LT_S) { ret CC_LT; }
-    if (op == mir.MIR_SEL_CMP_LT_U) { ret CC_CC; }
-    if (op == mir.MIR_SEL_CMP_LE_S) { ret CC_LE; }
-    ret CC_LS;
+# Every relation is named; an unmatched opcode is refused rather than taking the
+# trailing `CC_LS`, which would silently capture some other comparison as unsigned
+# less-or-equal (#2435).
+# ---
+# op:  the surviving comparison sentinel
+# ret: the A64 condition, or an error naming the unrealized relation
+fun cmp_cond(op: mir.MirOpcode) R.Result[u32, str] {
+    if (op == mir.MIR_SEL_CMP_EQ)   { ret R.ok[u32, str](CC_EQ); }
+    if (op == mir.MIR_SEL_CMP_NE)   { ret R.ok[u32, str](CC_NE); }
+    if (op == mir.MIR_SEL_CMP_LT_S) { ret R.ok[u32, str](CC_LT); }
+    if (op == mir.MIR_SEL_CMP_LT_U) { ret R.ok[u32, str](CC_CC); }
+    if (op == mir.MIR_SEL_CMP_LE_S) { ret R.ok[u32, str](CC_LE); }
+    if (op == mir.MIR_SEL_CMP_LE_U) { ret R.ok[u32, str](CC_LS); }
+    ret R.err[u32, str]("encode: aarch64 has no comparison condition for this relation");
 }
 
 # true when a post-isel opcode is a surviving generic comparison
@@ -2841,7 +2880,9 @@ fun encode_compare(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, st
     val rc: R.Result[bool, str] = emit_flag_cmp(st, ?mi.operands[1], ?mi.operands[2], mi.width, mir.is_signed_cmp(mi.opcode));
     if (R.is_err[bool, str](rc)) { ret rc; }
 
-    emit_cset(st, CSINC_W, rd, cmp_cond(mi.opcode));
+    val ccr: R.Result[u32, str] = cmp_cond(mi.opcode);
+    if (R.is_err[u32, str](ccr)) { ret R.err[bool, str](R.unwrap_err[u32, str](ccr)); }
+    emit_cset(st, CSINC_W, rd, R.unwrap_ok[u32, str](ccr));
     ret R.ok[bool, str](true);
 }
 
@@ -2899,13 +2940,22 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
 # EQ / NE / LT / LE forms exist in the fused opcode space (the lowerer
 # canonicalizes GT/GE by swapping operands); signedness selects the signed
 # (LT/LE) versus unsigned (CC/LS) condition, mirroring cmp_cond
-fun fused_cbr_cond(op: mir.MirOpcode) u32 {
-    if (op == mir.MIR_SEL_CBR_EQ)   { ret CC_EQ; }
-    if (op == mir.MIR_SEL_CBR_NE)   { ret CC_NE; }
-    if (op == mir.MIR_SEL_CBR_LT_S) { ret CC_LT; }
-    if (op == mir.MIR_SEL_CBR_LT_U) { ret CC_CC; }
-    if (op == mir.MIR_SEL_CBR_LE_S) { ret CC_LE; }
-    ret CC_LS;
+# Every relation is named; an unmatched opcode is refused rather than taking the
+# trailing `CC_LS` and branching on a different relation with no diagnostic
+# (#2435). The set is bounded by `mir.is_fused_cbr`, whose test is a RANGE over a
+# contiguous opcode block, so a relation added to that block would reach here
+# admitted and unnamed.
+# ---
+# op:  the fused terminator opcode
+# ret: the A64 branch condition, or an error naming the unrealized relation
+fun fused_cbr_cond(op: mir.MirOpcode) R.Result[u32, str] {
+    if (op == mir.MIR_SEL_CBR_EQ)   { ret R.ok[u32, str](CC_EQ); }
+    if (op == mir.MIR_SEL_CBR_NE)   { ret R.ok[u32, str](CC_NE); }
+    if (op == mir.MIR_SEL_CBR_LT_S) { ret R.ok[u32, str](CC_LT); }
+    if (op == mir.MIR_SEL_CBR_LT_U) { ret R.ok[u32, str](CC_CC); }
+    if (op == mir.MIR_SEL_CBR_LE_S) { ret R.ok[u32, str](CC_LE); }
+    if (op == mir.MIR_SEL_CBR_LE_U) { ret R.ok[u32, str](CC_LS); }
+    ret R.err[u32, str]("encode: aarch64 has no fused compare-and-branch condition for this relation");
 }
 
 # materialize a fused compare-and-branch terminator
@@ -2942,7 +2992,9 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R
 
     # B.cc then_block (a zero imm19 placeholder; pass 2 inserts the displacement).
     val bcc_pos: u32 = st.buf.len::u32;
-    emit_branch_block(st, BCOND | (fused_cbr_cond(mi.opcode) & 0xF), 0, false, then_block);
+    val ccr: R.Result[u32, str] = fused_cbr_cond(mi.opcode);
+    if (R.is_err[u32, str](ccr)) { ret R.err[bool, str](R.unwrap_err[u32, str](ccr)); }
+    emit_branch_block(st, BCOND | (R.unwrap_ok[u32, str](ccr) & 0xF), 0, false, then_block);
     val bcc_next: u32 = st.buf.len::u32;
     val f1: R.Result[bool, str] = encode.push_fixup(st, bcc_pos, bcc_next, then_block, fn_base);
     if (R.is_err[bool, str](f1)) { ret f1; }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -7131,3 +7131,103 @@ test "mach.lang.target.isa.arm64.encode:emitters_notify_once_per_word" {
     encode.buf_dnit(?st.buf);
     ret bad;
 }
+
+# a classifier's value, or a marker no encoding field can hold (test helper)
+#
+# An A64 condition is 4 bits and a base word is a fixed 32-bit pattern with no
+# all-ones form, so the marker cannot collide with a real answer: an accidentally
+# refused form fails the comparison rather than matching an expected value.
+# ---
+# r:   the classifier's result
+# ret: the value, or 0xFFFFFFFF when it refused
+fun t_cc(r: R.Result[u32, str]) u32 {
+    if (R.is_err[u32, str](r)) { ret 0xFFFFFFFF; }
+    ret R.unwrap_ok[u32, str](r);
+}
+
+# every relation, opcode and scale the classifiers model maps to the A64 value the
+# architecture names for it - the totality half of the #2435 audit
+#
+# The default arms these replaced returned a real encoding for an unmatched input,
+# so the claim being pinned is not "the named ones work" but "the named ones are
+# the ONLY ones", which the refusal test beside this closes. The unsigned relations
+# are the ones a wrong default is quietest about: CC (unsigned <) and LS (unsigned
+# <=) are perfectly ordinary conditions on a signed comparison's flags.
+test "mach.lang.target.isa.arm64.encode:classifiers_are_total_over_named_forms" {
+    var bad: i32 = 0;
+
+    # the six comparison relations, signed and unsigned.
+    if (t_cc(cmp_cond(mir.MIR_SEL_CMP_EQ))   != CC_EQ) { bad = 1; }
+    if (t_cc(cmp_cond(mir.MIR_SEL_CMP_NE))   != CC_NE) { bad = 1; }
+    if (t_cc(cmp_cond(mir.MIR_SEL_CMP_LT_S)) != CC_LT) { bad = 1; }
+    if (t_cc(cmp_cond(mir.MIR_SEL_CMP_LT_U)) != CC_CC) { bad = 1; }
+    if (t_cc(cmp_cond(mir.MIR_SEL_CMP_LE_S)) != CC_LE) { bad = 1; }
+    if (t_cc(cmp_cond(mir.MIR_SEL_CMP_LE_U)) != CC_LS) { bad = 1; }
+
+    # the six fused-branch relations, which must agree with the split pair above.
+    if (t_cc(fused_cbr_cond(mir.MIR_SEL_CBR_EQ))   != CC_EQ) { bad = 1; }
+    if (t_cc(fused_cbr_cond(mir.MIR_SEL_CBR_NE))   != CC_NE) { bad = 1; }
+    if (t_cc(fused_cbr_cond(mir.MIR_SEL_CBR_LT_S)) != CC_LT) { bad = 1; }
+    if (t_cc(fused_cbr_cond(mir.MIR_SEL_CBR_LT_U)) != CC_CC) { bad = 1; }
+    if (t_cc(fused_cbr_cond(mir.MIR_SEL_CBR_LE_S)) != CC_LE) { bad = 1; }
+    if (t_cc(fused_cbr_cond(mir.MIR_SEL_CBR_LE_U)) != CC_LS) { bad = 1; }
+
+    # the six float conditions. `<` is MI, not LT: an unordered FCMP leaves N=0, so
+    # MI is true only for an ordered less-than.
+    if (t_cc(fp_cond(mir.FCC_EQ)) != CC_EQ) { bad = 1; }
+    if (t_cc(fp_cond(mir.FCC_NE)) != CC_NE) { bad = 1; }
+    if (t_cc(fp_cond(mir.FCC_LT)) != CC_MI) { bad = 1; }
+    if (t_cc(fp_cond(mir.FCC_LE)) != CC_LS) { bad = 1; }
+    if (t_cc(fp_cond(mir.FCC_GT)) != CC_GT) { bad = 1; }
+    if (t_cc(fp_cond(mir.FCC_GE)) != CC_GE) { bad = 1; }
+
+    # the four float arithmetic base words, single and double.
+    if (t_cc(fp_arith_base(mir.MIR_FADD, false)) != FADD_S) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FADD, true))  != FADD_D) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FSUB, false)) != FSUB_S) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FSUB, true))  != FSUB_D) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FMUL, false)) != FMUL_S) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FMUL, true))  != FMUL_D) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FDIV, false)) != FDIV_S) { bad = 1; }
+    if (t_cc(fp_arith_base(mir.MIR_FDIV, true))  != FDIV_D) { bad = 1; }
+
+    # the four SIB-legal index scales.
+    if (t_cc(scale_shift(1)) != 0) { bad = 1; }
+    if (t_cc(scale_shift(2)) != 1) { bad = 1; }
+    if (t_cc(scale_shift(4)) != 2) { bad = 1; }
+    if (t_cc(scale_shift(8)) != 3) { bad = 1; }
+
+    ret bad;
+}
+
+# an input no classifier names is REFUSED, not defaulted - the half of the #2435
+# audit a trailing `ret <some real condition>` cannot satisfy
+#
+# Each of these used to return a valid encoding: an unnamed relation became an
+# unsigned less-or-equal branch, an unnamed float opcode an FDIV, an unnamed
+# condition code a GE, and an unrepresentable scale the same shift as scale 1 - so
+# `base + index*3` addressed `base + index`.
+test "mach.lang.target.isa.arm64.encode:unnamed_forms_are_refused" {
+    var bad: i32 = 0;
+
+    if (!R.is_err[u32, str](cmp_cond(mir.MIR_ADD)))                    { bad = 1; }
+    if (!R.is_err[u32, str](cmp_cond(mir.MIR_SEL_CBR_EQ)))             { bad = 1; }
+    if (!R.is_err[u32, str](fused_cbr_cond(mir.MIR_ADD)))              { bad = 1; }
+    # the relation one past the fused block: `is_fused_cbr` admits by RANGE, so
+    # this is the shape a seventh relation would arrive in.
+    if (!R.is_err[u32, str](fused_cbr_cond(mir.MIR_SEL_CBR_LE_U + 1))) { bad = 1; }
+    if (!R.is_err[u32, str](fp_arith_base(mir.MIR_ADD, false)))        { bad = 1; }
+    if (!R.is_err[u32, str](fp_arith_base(mir.MIR_FNEG, true)))        { bad = 1; }
+
+    # one past FCC_GE: the condition rides `mi.src_width`, a byte field nothing
+    # bounds to the FCC alphabet.
+    if (!R.is_err[u32, str](fp_cond(mir.FCC_GE + 1))) { bad = 1; }
+    if (!R.is_err[u32, str](fp_cond(200)))            { bad = 1; }
+
+    # a scale the SIB-legal lowering never produces.
+    if (!R.is_err[u32, str](scale_shift(0)))  { bad = 1; }
+    if (!R.is_err[u32, str](scale_shift(3)))  { bad = 1; }
+    if (!R.is_err[u32, str](scale_shift(16))) { bad = 1; }
+
+    ret bad;
+}

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -199,19 +199,24 @@ fun encode_alu(st: *enc.EncodeState, mi: *mir.MirInstr, op: mir.MirOpcode) R.Res
     val b:   *mir.MirOperand = ?mi.operands[2];
     if (dst.kind != mir.MIR_OP_PREG) { ret R.err[bool, str](unencodable_message(op)); }
 
-    val res_ld: R.Result[bool, str] = emit_load_a(st, a);
-    if (R.is_err[bool, str](res_ld)) { ret res_ld; }
-
-    if (op == mir.MIR_ADD) { enc.emit_byte(?st.buf, OP_CLC); }
-    if (op == mir.MIR_SUB) { enc.emit_byte(?st.buf, OP_SEC); }
-
+    # every operation is named, and the selection happens BEFORE any byte is
+    # emitted: an opcode this encoder does not realize is refused with nothing
+    # written, rather than riding the default into an EOR (#2435). the reachable set
+    # is bounded by `encode_instr`'s dispatch, one function away.
     var imm_op: u8 = 0;
     var zp_op:  u8 = 0;
     if (op == mir.MIR_ADD) { imm_op = OP_ADC_IMM; zp_op = OP_ADC_ZP; }
     or (op == mir.MIR_SUB) { imm_op = OP_SBC_IMM; zp_op = OP_SBC_ZP; }
     or (op == mir.MIR_AND) { imm_op = OP_AND_IMM; zp_op = OP_AND_ZP; }
     or (op == mir.MIR_OR)  { imm_op = OP_ORA_IMM; zp_op = OP_ORA_ZP; }
-    or                     { imm_op = OP_EOR_IMM; zp_op = OP_EOR_ZP; }
+    or (op == mir.MIR_XOR) { imm_op = OP_EOR_IMM; zp_op = OP_EOR_ZP; }
+    or                     { ret R.err[bool, str](unencodable_message(op)); }
+
+    val res_ld: R.Result[bool, str] = emit_load_a(st, a);
+    if (R.is_err[bool, str](res_ld)) { ret res_ld; }
+
+    if (op == mir.MIR_ADD) { enc.emit_byte(?st.buf, OP_CLC); }
+    if (op == mir.MIR_SUB) { enc.emit_byte(?st.buf, OP_SEC); }
 
     val res_op: R.Result[bool, str] = emit_operand(st, b, imm_op, zp_op, op);
     if (R.is_err[bool, str](res_op)) { ret res_op; }
@@ -347,6 +352,12 @@ fun encode_shift(st: *enc.EncodeState, mi: *mir.MirInstr, op: mir.MirOpcode) R.R
     if (cnt.imm < 0 || cnt.imm > 7) {
         ret R.err[bool, str]("mos6502: a byte shift count must be normalized to the 8-bit operation width by width legalization before encoding");
     }
+    # every direction is named, and the check precedes the first emitted byte: an
+    # opcode this encoder does not realize is refused with nothing written, rather
+    # than riding the default into the arithmetic-shift sequence (#2435).
+    if (op != mir.MIR_SHL && op != mir.MIR_SHR_U && op != mir.MIR_SHR_S) {
+        ret R.err[bool, str](unencodable_message(op));
+    }
 
     val res_ld: R.Result[bool, str] = emit_load_a(st, ?mi.operands[1]);
     if (R.is_err[bool, str](res_ld)) { ret res_ld; }
@@ -392,6 +403,13 @@ fun encode_cmp(st: *enc.EncodeState, mi: *mir.MirInstr, op: mir.MirOpcode) R.Res
     if (mi.operand_count != 3) { ret R.err[bool, str]("mos6502: malformed compare"); }
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind != mir.MIR_OP_PREG) { ret R.err[bool, str](unencodable_message(op)); }
+    # every relation is named, and the check precedes the first emitted byte: a
+    # relation this encoder does not realize is refused with nothing written, rather
+    # than riding the default into the difference-to-zero equality form (#2435).
+    # the signed and <= relations are the documented frontier this names.
+    if (op != mir.MIR_CMP_EQ && op != mir.MIR_CMP_NE && op != mir.MIR_CMP_LT_U) {
+        ret R.err[bool, str](unencodable_message(op));
+    }
 
     val res_ld: R.Result[bool, str] = emit_load_a(st, ?mi.operands[1]);
     if (R.is_err[bool, str](res_ld)) { ret res_ld; }

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -1413,3 +1413,63 @@ test "mach.lang.target.isa.mos6502.encode:page_crossing_costs_are_address_only" 
     A.deallocate[u8](?alloc, mem, T_MEM_SIZE);
     ret 0;
 }
+
+# an operation this encoder does not realize is REFUSED with nothing written, not
+# encoded as whichever one the default arm named - the #2435 audit
+#
+# The three dispatches here each ended in a bare `or { ... }` that named a real
+# instruction: an unmodeled binary op became an EOR, an unmodeled shift the
+# arithmetic-right sequence, and an unmodeled relation the difference-to-zero
+# equality form. The reachable set was bounded by `encode_instr`'s dispatch one
+# function away, so nothing mis-encoded - but nothing here said so either.
+#
+# The buffer length is asserted, not just the error: each dispatch used to sit
+# BELOW the `LDA` that starts the sequence, so refusing there would have left a
+# partial instruction in the text for the next one to run into.
+test "mach.lang.target.isa.mos6502.encode:unnamed_operations_are_refused" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var st: enc.EncodeState;
+    st.buf = enc.buf_init(?alloc);
+    var bad: i32 = 0;
+
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(10);
+    ops[1] = mir.op_preg(8);
+    ops[2] = mir.op_imm(1);
+
+    # a binary op with no 6502 form. MIR_MUL is the honest example: the 6502 has no
+    # hardware multiply, and it used to encode as an exclusive-or.
+    var alu: mir.MirInstr = mir.instr(mir.MIR_MUL, ?ops[0], 3, 1, 1);
+    if (!R.is_err[bool, str](encode_alu(?st, ?alu, mir.MIR_MUL)))     { bad = 1; }
+    if (st.buf.len != 0)                                             { bad = 1; }
+    if (!R.is_err[bool, str](encode_alu(?st, ?alu, mir.MIR_SHL)))     { bad = 1; }
+    if (st.buf.len != 0)                                             { bad = 1; }
+
+    # a shift direction with no 6502 form.
+    var sh: mir.MirInstr = mir.instr(mir.MIR_SHL, ?ops[0], 3, 1, 1);
+    if (!R.is_err[bool, str](encode_shift(?st, ?sh, mir.MIR_MUL)))   { bad = 1; }
+    if (st.buf.len != 0)                                             { bad = 1; }
+
+    # a relation outside the branchless trio. the SIGNED and <= relations are the
+    # documented frontier, and they used to encode as the EQUALITY sequence - a
+    # compare that answers a different question, not one that fails to build.
+    var cm: mir.MirInstr = mir.instr(mir.MIR_CMP_LT_S, ?ops[0], 3, 1, 1);
+    if (!R.is_err[bool, str](encode_cmp(?st, ?cm, mir.MIR_CMP_LT_S))) { bad = 1; }
+    if (st.buf.len != 0)                                             { bad = 1; }
+    if (!R.is_err[bool, str](encode_cmp(?st, ?cm, mir.MIR_CMP_LE_U))) { bad = 1; }
+    if (st.buf.len != 0)                                             { bad = 1; }
+
+    # the modeled forms still encode, so the guards did not close over real work.
+    if (R.is_err[bool, str](encode_alu(?st, ?alu, mir.MIR_XOR)))      { bad = 1; }
+    if (st.buf.len == 0)                                             { bad = 1; }
+    st.buf.len = 0;
+    if (R.is_err[bool, str](encode_shift(?st, ?sh, mir.MIR_SHR_S)))   { bad = 1; }
+    if (st.buf.len == 0)                                             { bad = 1; }
+    st.buf.len = 0;
+    if (R.is_err[bool, str](encode_cmp(?st, ?cm, mir.MIR_CMP_NE)))    { bad = 1; }
+    if (st.buf.len == 0)                                             { bad = 1; }
+
+    enc.buf_dnit(?st.buf);
+    ret bad;
+}

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1234,13 +1234,21 @@ fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) R.Result[RvMem, str] {
     ret R.ok[RvMem, str](m);
 }
 
-# the log2 of an index scale (1/2/4/8 -> 0/1/2/3) for a scaled-index `gep`. an
-# unmodeled scale takes 0 (a bare add)
-fun scale_shift(scale: u8) u32 {
-    if (scale == 2) { ret 1; }
-    if (scale == 4) { ret 2; }
-    if (scale == 8) { ret 3; }
-    ret 0;
+# the log2 of an index scale (1/2/4/8 -> 0/1/2/3) for a scaled-index `gep`
+#
+# Scale 1 is named rather than defaulted. The bound is `is_sib_scale` in the shared
+# GEP lowering, one module away, and an unmodeled scale used to take the same 0 as
+# scale 1 - so `base + index*3` computed `base + index`, a wrong address with no
+# diagnostic (#2435). x86-64 refuses the identical condition.
+# ---
+# scale: the index scale
+# ret:   the LSL amount, or an error naming the unrepresentable scale
+fun scale_shift(scale: u8) R.Result[u32, str] {
+    if (scale == 1) { ret R.ok[u32, str](0); }
+    if (scale == 2) { ret R.ok[u32, str](1); }
+    if (scale == 4) { ret R.ok[u32, str](2); }
+    if (scale == 8) { ret R.ok[u32, str](3); }
+    ret R.err[u32, str]("encode: a scaled-index address must have a scale of 1, 2, 4, or 8");
 }
 
 # a three-address integer ALU op `op rd, rs1, rs2`. the operands resolve to
@@ -1603,7 +1611,9 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
 
     if (m.has_index) {
         var idx: u32 = m.index;
-        val sh: u32 = scale_shift(m.scale);
+        val shr: R.Result[u32, str] = scale_shift(m.scale);
+        if (R.is_err[u32, str](shr)) { ret R.err[bool, str](R.unwrap_err[u32, str](shr)); }
+        val sh: u32 = R.unwrap_ok[u32, str](shr);
         if (sh != 0) {
             emit_i(st, OPC_OP_IMM, F3_SLL, SCRATCH, m.index, sh);  # slli t0, index, sh
             idx = SCRATCH;
@@ -1802,18 +1812,27 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
 # bge / bgeu with rs1 and rs2 exchanged), so `swap` tells the encoder to reverse
 # the register order
 # ---
+# Every relation is named. The unmatched case is refused rather than defaulted:
+# an unnamed opcode used to take the trailing `ret F3_BGEU` with `swap` ALREADY
+# set, so it encoded as an operand-reversed unsigned `bge` - a different branch, in
+# the other direction, with no diagnostic (#2435). The set is bounded by
+# `mir.is_fused_cbr`, whose test is a RANGE over a contiguous opcode block, so a
+# relation added to that block would reach here admitted and unnamed.
+# ---
 # op:   the fused terminator opcode
 # swap: out - true when rs1/rs2 must be exchanged (the LE-as-swapped-GE forms)
-# ret:  the branch funct3
-fun fused_cbr_funct3(op: mir.MirOpcode, swap: *bool) u32 {
+# ret:  the branch funct3, or an error naming the unrealized relation
+fun fused_cbr_funct3(op: mir.MirOpcode, swap: *bool) R.Result[u32, str] {
     @swap = false;
-    if (op == mir.MIR_SEL_CBR_EQ)   { ret F3_BEQ; }
-    if (op == mir.MIR_SEL_CBR_NE)   { ret F3_BNE; }
-    if (op == mir.MIR_SEL_CBR_LT_S) { ret F3_BLT; }
-    if (op == mir.MIR_SEL_CBR_LT_U) { ret F3_BLTU; }
+    if (op == mir.MIR_SEL_CBR_EQ)   { ret R.ok[u32, str](F3_BEQ); }
+    if (op == mir.MIR_SEL_CBR_NE)   { ret R.ok[u32, str](F3_BNE); }
+    if (op == mir.MIR_SEL_CBR_LT_S) { ret R.ok[u32, str](F3_BLT); }
+    if (op == mir.MIR_SEL_CBR_LT_U) { ret R.ok[u32, str](F3_BLTU); }
     @swap = true;
-    if (op == mir.MIR_SEL_CBR_LE_S) { ret F3_BGE; }
-    ret F3_BGEU;
+    if (op == mir.MIR_SEL_CBR_LE_S) { ret R.ok[u32, str](F3_BGE); }
+    if (op == mir.MIR_SEL_CBR_LE_U) { ret R.ok[u32, str](F3_BGEU); }
+    @swap = false;
+    ret R.err[u32, str]("encode: riscv64 has no fused compare-and-branch form for this relation");
 }
 
 # a fused compare-and-branch terminator `[lhs, rhs, then_block, else_block]`
@@ -1849,7 +1868,9 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R
     if (R.is_err[bool, str](rs)) { ret rs; }
 
     var swap: bool = false;
-    val funct3: u32 = fused_cbr_funct3(mi.opcode, ?swap);
+    val f3r: R.Result[u32, str] = fused_cbr_funct3(mi.opcode, ?swap);
+    if (R.is_err[u32, str](f3r)) { ret R.err[bool, str](R.unwrap_err[u32, str](f3r)); }
+    val funct3: u32 = R.unwrap_ok[u32, str](f3r);
     var rs1: u32 = lhs;
     var rs2: u32 = rhs;
     if (swap) {
@@ -1916,11 +1937,19 @@ fun is_mir_divide(op: mir.MirOpcode) bool {
 }
 
 # the M-extension funct3 for a surviving divide / remainder sentinel
-fun divide_funct3(op: mir.MirOpcode) u32 {
-    if (op == mir.MIR_SEL_DIV_S) { ret F3_DIV; }
-    if (op == mir.MIR_SEL_DIV_U) { ret F3_DIVU; }
-    if (op == mir.MIR_SEL_REM_S) { ret F3_REM; }
-    ret F3_REMU;
+#
+# All four are named; an unmatched opcode is refused rather than taking the
+# trailing `remu`, which would silently turn some other operation into an unsigned
+# remainder (#2435).
+# ---
+# op:  the surviving divide / remainder sentinel
+# ret: the M-extension funct3, or an error naming the unrealized opcode
+fun divide_funct3(op: mir.MirOpcode) R.Result[u32, str] {
+    if (op == mir.MIR_SEL_DIV_S) { ret R.ok[u32, str](F3_DIV); }
+    if (op == mir.MIR_SEL_DIV_U) { ret R.ok[u32, str](F3_DIVU); }
+    if (op == mir.MIR_SEL_REM_S) { ret R.ok[u32, str](F3_REM); }
+    if (op == mir.MIR_SEL_REM_U) { ret R.ok[u32, str](F3_REMU); }
+    ret R.err[u32, str]("encode: riscv64 has no M-extension form for this divide / remainder opcode");
 }
 
 # materialize a surviving divide / remainder `[dst, dividend, divisor]` into a single
@@ -1945,7 +1974,10 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rs2: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_r(st, alu_opcode(mi.width), divide_funct3(mi.opcode), F7_MULDIV, rd, rs1, rs2);
+    val f3r: R.Result[u32, str] = divide_funct3(mi.opcode);
+    if (R.is_err[u32, str](f3r)) { ret R.err[bool, str](R.unwrap_err[u32, str](f3r)); }
+
+    emit_r(st, alu_opcode(mi.width), R.unwrap_ok[u32, str](f3r), F7_MULDIV, rd, rs1, rs2);
     ret R.ok[bool, str](true);
 }
 
@@ -2135,13 +2167,25 @@ fun resolve_fp_source(st: *encode.EncodeState, f: *mir.MirFunction, op: *mir.Mir
 
 # the OPC_OP_FP funct7 for a binary float arithmetic MIR opcode and precision (the double
 # form is the single form set with bit 0)
-fun fp_arith_funct7(op: mir.MirOpcode, dbl: bool) u32 {
+#
+# All four are named; an unmatched opcode is refused rather than keeping the `fadd`
+# the accumulator was seeded with, which would silently turn some other operation
+# into an addition (#2435).
+# ---
+# op:  the float arithmetic opcode
+# dbl: true for the double-precision form
+# ret: the OPC_OP_FP funct7, or an error naming the unrealized opcode
+fun fp_arith_funct7(op: mir.MirOpcode, dbl: bool) R.Result[u32, str] {
     var base: u32 = F7_FADD;
-    if (op == mir.MIR_FSUB) { base = F7_FSUB; }
-    if (op == mir.MIR_FMUL) { base = F7_FMUL; }
-    if (op == mir.MIR_FDIV) { base = F7_FDIV; }
-    if (dbl) { ret base | 1; }
-    ret base;
+    if (op == mir.MIR_FADD)      { base = F7_FADD; }
+    or (op == mir.MIR_FSUB)      { base = F7_FSUB; }
+    or (op == mir.MIR_FMUL)      { base = F7_FMUL; }
+    or (op == mir.MIR_FDIV)      { base = F7_FDIV; }
+    or {
+        ret R.err[u32, str]("encode: riscv64 has no float arithmetic form for this opcode");
+    }
+    if (dbl) { ret R.ok[u32, str](base | 1); }
+    ret R.ok[u32, str](base);
 }
 
 # true when a surviving opcode is one of the scalar float arithmetic ops the encoder
@@ -2179,7 +2223,9 @@ fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIn
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    val f7: u32 = fp_arith_funct7(mi.opcode, dbl);
+    val f7r: R.Result[u32, str] = fp_arith_funct7(mi.opcode, dbl);
+    if (R.is_err[u32, str](f7r)) { ret R.err[bool, str](R.unwrap_err[u32, str](f7r)); }
+    val f7: u32 = R.unwrap_ok[u32, str](f7r);
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
         emit_r(st, OPC_OP_FP, RM_DYN, f7, FP_SCRATCH, rn, rm);
@@ -2223,17 +2269,18 @@ fun encode_fp_neg(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
 # captures, written into `out_funct3` / `out_swap`. mach canonicalizes a comparison to
 # the EQ / NE / LT / LE forms; `>` / `>=` are the swapped `<` / `<=`. NE has no direct
 # RISC-V form, so it rides feq and the caller inverts the boolean
-fun fp_cmp_relation(cc: u8, out_funct3: *u32, out_swap: *bool, out_invert: *bool) {
+fun fp_cmp_relation(cc: u8, out_funct3: *u32, out_swap: *bool, out_invert: *bool) R.Result[bool, str] {
     @out_swap   = false;
     @out_invert = false;
-    if (cc == mir.FCC_EQ) { @out_funct3 = F3_FEQ; ret; }
-    if (cc == mir.FCC_NE) { @out_funct3 = F3_FEQ; @out_invert = true; ret; }
-    if (cc == mir.FCC_LT) { @out_funct3 = F3_FLT; ret; }
-    if (cc == mir.FCC_LE) { @out_funct3 = F3_FLE; ret; }
-    if (cc == mir.FCC_GT) { @out_funct3 = F3_FLT; @out_swap = true; ret; }
+    @out_funct3 = F3_FEQ;
+    if (cc == mir.FCC_EQ) { @out_funct3 = F3_FEQ; ret R.ok[bool, str](true); }
+    if (cc == mir.FCC_NE) { @out_funct3 = F3_FEQ; @out_invert = true; ret R.ok[bool, str](true); }
+    if (cc == mir.FCC_LT) { @out_funct3 = F3_FLT; ret R.ok[bool, str](true); }
+    if (cc == mir.FCC_LE) { @out_funct3 = F3_FLE; ret R.ok[bool, str](true); }
+    if (cc == mir.FCC_GT) { @out_funct3 = F3_FLT; @out_swap = true; ret R.ok[bool, str](true); }
     # FCC_GE: the swapped fle.
-    @out_funct3 = F3_FLE;
-    @out_swap   = true;
+    if (cc == mir.FCC_GE) { @out_funct3 = F3_FLE; @out_swap = true; ret R.ok[bool, str](true); }
+    ret R.err[bool, str]("encode: riscv64 has no float comparison form for this condition code");
 }
 
 # materialize a surviving float comparison `[dst, lhs, rhs]` into `frel rd, fn, fm`
@@ -2267,7 +2314,8 @@ fun encode_fp_cmp(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     var funct3: u32 = F3_FEQ;
     var swap:   bool = false;
     var invert: bool = false;
-    fp_cmp_relation(mi.src_width, ?funct3, ?swap, ?invert);
+    val rel: R.Result[bool, str] = fp_cmp_relation(mi.src_width, ?funct3, ?swap, ?invert);
+    if (R.is_err[bool, str](rel)) { ret rel; }
 
     var a: u32 = rn;
     var b: u32 = rm;

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -5738,3 +5738,128 @@ test "mach.lang.target.isa.riscv64.encode:fmov_and_float_memory" {
     ret bad;
 }
 
+
+# a classifier's value, or a marker no encoding field can hold (test helper)
+#
+# Every field these classifiers produce is at most 7 bits, so the marker cannot
+# collide with a real answer and an accidentally-refused form fails the comparison
+# rather than matching one of the expected values.
+# ---
+# r:   the classifier's result
+# ret: the value, or 0xFFFFFFFF when it refused
+fun t_f3(r: R.Result[u32, str]) u32 {
+    if (R.is_err[u32, str](r)) { ret 0xFFFFFFFF; }
+    ret R.unwrap_ok[u32, str](r);
+}
+
+# true when `fp_cmp_relation` maps `cc` to exactly this relation, order and
+# inversion (test helper)
+# ---
+# cc:     the FCC_* float condition code
+# funct3: the expected feq / flt / fle funct3
+# swap:   the expected operand-order reversal
+# invert: the expected result inversion
+# ret:    true when all three match and the mapping was not refused
+fun t_fcmp(cc: u8, funct3: u32, swap: bool, invert: bool) bool {
+    var got_f3: u32  = 0xFFFFFFFF;
+    var got_sw: bool = false;
+    var got_iv: bool = false;
+    val r: R.Result[bool, str] = fp_cmp_relation(cc, ?got_f3, ?got_sw, ?got_iv);
+    if (R.is_err[bool, str](r)) { ret false; }
+    ret got_f3 == funct3 && got_sw == swap && got_iv == invert;
+}
+
+# every relation, opcode and scale the classifiers model maps to the value the
+# RISC-V spec names for it - the totality half of the #2435 audit
+#
+# The default arms these replaced returned a real encoding for an unmatched input,
+# so the byte-level claim is not "the named ones work" but "the named ones are the
+# ONLY ones", which the refusal test beside this closes. Asserting the classifier's
+# value rather than an emitted word is what makes the swapped-operand forms
+# visible: `swap` is invisible in a funct3 and decides which register is rs1.
+test "mach.lang.target.isa.riscv64.encode:classifiers_are_total_over_named_forms" {
+    var bad: i32 = 0;
+    var swap: bool = false;
+
+    # the six fused relations. LE has no B-type form and encodes as the SWAPPED GE,
+    # which is the pairing the trailing default used to hand every unnamed opcode.
+    if (t_f3(fused_cbr_funct3(mir.MIR_SEL_CBR_EQ,   ?swap)) != F3_BEQ)  { bad = 1; }
+    if (swap)                                                          { bad = 1; }
+    if (t_f3(fused_cbr_funct3(mir.MIR_SEL_CBR_NE,   ?swap)) != F3_BNE)  { bad = 1; }
+    if (swap)                                                          { bad = 1; }
+    if (t_f3(fused_cbr_funct3(mir.MIR_SEL_CBR_LT_S, ?swap)) != F3_BLT)  { bad = 1; }
+    if (swap)                                                          { bad = 1; }
+    if (t_f3(fused_cbr_funct3(mir.MIR_SEL_CBR_LT_U, ?swap)) != F3_BLTU) { bad = 1; }
+    if (swap)                                                          { bad = 1; }
+    if (t_f3(fused_cbr_funct3(mir.MIR_SEL_CBR_LE_S, ?swap)) != F3_BGE)  { bad = 1; }
+    if (!swap)                                                         { bad = 1; }
+    if (t_f3(fused_cbr_funct3(mir.MIR_SEL_CBR_LE_U, ?swap)) != F3_BGEU) { bad = 1; }
+    if (!swap)                                                         { bad = 1; }
+
+    # the four M-extension quotient / remainder forms.
+    if (t_f3(divide_funct3(mir.MIR_SEL_DIV_S)) != F3_DIV)  { bad = 1; }
+    if (t_f3(divide_funct3(mir.MIR_SEL_DIV_U)) != F3_DIVU) { bad = 1; }
+    if (t_f3(divide_funct3(mir.MIR_SEL_REM_S)) != F3_REM)  { bad = 1; }
+    if (t_f3(divide_funct3(mir.MIR_SEL_REM_U)) != F3_REMU) { bad = 1; }
+
+    # the four float arithmetic forms, single and double (the double is bit 0).
+    if (t_f3(fp_arith_funct7(mir.MIR_FADD, false)) != F7_FADD)     { bad = 1; }
+    if (t_f3(fp_arith_funct7(mir.MIR_FSUB, false)) != F7_FSUB)     { bad = 1; }
+    if (t_f3(fp_arith_funct7(mir.MIR_FMUL, false)) != F7_FMUL)     { bad = 1; }
+    if (t_f3(fp_arith_funct7(mir.MIR_FDIV, false)) != F7_FDIV)     { bad = 1; }
+    if (t_f3(fp_arith_funct7(mir.MIR_FADD, true))  != (F7_FADD | 1)) { bad = 1; }
+    if (t_f3(fp_arith_funct7(mir.MIR_FDIV, true))  != (F7_FDIV | 1)) { bad = 1; }
+
+    # the six float relations. RISC-V has feq / flt / fle only, so NE is the
+    # INVERTED feq and the > / >= forms are the swapped flt / fle.
+    if (!t_fcmp(mir.FCC_EQ, F3_FEQ, false, false)) { bad = 1; }
+    if (!t_fcmp(mir.FCC_NE, F3_FEQ, false, true))  { bad = 1; }
+    if (!t_fcmp(mir.FCC_LT, F3_FLT, false, false)) { bad = 1; }
+    if (!t_fcmp(mir.FCC_LE, F3_FLE, false, false)) { bad = 1; }
+    if (!t_fcmp(mir.FCC_GT, F3_FLT, true,  false)) { bad = 1; }
+    if (!t_fcmp(mir.FCC_GE, F3_FLE, true,  false)) { bad = 1; }
+
+    # the four SIB-legal index scales.
+    if (t_f3(scale_shift(1)) != 0) { bad = 1; }
+    if (t_f3(scale_shift(2)) != 1) { bad = 1; }
+    if (t_f3(scale_shift(4)) != 2) { bad = 1; }
+    if (t_f3(scale_shift(8)) != 3) { bad = 1; }
+
+    ret bad;
+}
+
+# an input no classifier names is REFUSED, not defaulted - the half of the #2435
+# audit a trailing `ret <some real encoding>` cannot satisfy
+#
+# Each of these used to return a valid encoding: an unnamed relation became an
+# operand-reversed `bgeu`, an unnamed arithmetic opcode a `remu` or an `fadd`, an
+# unnamed condition code a swapped `fle`, and an unrepresentable scale the same
+# shift as scale 1 - so `base + index*3` addressed `base + index`.
+test "mach.lang.target.isa.riscv64.encode:unnamed_forms_are_refused" {
+    var bad: i32 = 0;
+    var swap: bool = false;
+
+    if (!R.is_err[u32, str](fused_cbr_funct3(mir.MIR_ADD, ?swap)))     { bad = 1; }
+    # the relation one past the fused block: `is_fused_cbr` admits by RANGE, so
+    # this is the shape a seventh relation would arrive in.
+    if (!R.is_err[u32, str](fused_cbr_funct3(mir.MIR_SEL_CBR_LE_U + 1, ?swap))) { bad = 1; }
+    if (!R.is_err[u32, str](divide_funct3(mir.MIR_ADD)))               { bad = 1; }
+    if (!R.is_err[u32, str](divide_funct3(mir.MIR_MUL)))               { bad = 1; }
+    if (!R.is_err[u32, str](fp_arith_funct7(mir.MIR_ADD, false)))      { bad = 1; }
+    if (!R.is_err[u32, str](fp_arith_funct7(mir.MIR_FNEG, true)))      { bad = 1; }
+
+    var funct3: u32 = 0;
+    var sw: bool = false;
+    var inv: bool = false;
+    # one past FCC_GE: the condition rides `mi.src_width`, a byte field nothing
+    # bounds to the FCC alphabet.
+    if (!R.is_err[bool, str](fp_cmp_relation(mir.FCC_GE + 1, ?funct3, ?sw, ?inv))) { bad = 1; }
+    if (!R.is_err[bool, str](fp_cmp_relation(200, ?funct3, ?sw, ?inv)))            { bad = 1; }
+
+    # a scale the SIB-legal lowering never produces.
+    if (!R.is_err[u32, str](scale_shift(0)))  { bad = 1; }
+    if (!R.is_err[u32, str](scale_shift(3)))  { bad = 1; }
+    if (!R.is_err[u32, str](scale_shift(16))) { bad = 1; }
+
+    ret bad;
+}


### PR DESCRIPTION
Closes #2435.

Audit of arm64, riscv64 and mos6502 for the silent-fallthrough class proven on x86-64 in #2400.

**No reachable mis-encoding was found.** Every site is latent, so nothing needed its own bug issue and the emission-neutral bar applies throughout.

## The shape

The #2400 defect was an arm whose unmatched operand shape fell through to a *different instruction's* encoding. In the three remaining hand encoders the same class appears mostly as **classifiers**: an if-chain over relations, opcodes or scales whose last member rides a trailing default, so an input the encoder does not model silently becomes whichever one the default names. Twelve such sites, plus one arm, are now total — every member named, the unmatched case refused.

| encoder | site | what an unnamed input used to become |
|---|---|---|
| arm64 | `cmp_cond` | `CC_LS`, an unsigned less-or-equal |
| arm64 | `fused_cbr_cond` | `CC_LS` |
| arm64 | `fp_cond` | `CC_GE` |
| arm64 | `fp_arith_base` | an `FDIV` |
| arm64 | `scale_shift` | shift 0, the same as scale 1 |
| riscv64 | `fused_cbr_funct3` | `BGEU` **with `swap` already set** — an operand-reversed branch |
| riscv64 | `divide_funct3` | a `REMU` |
| riscv64 | `fp_arith_funct7` | an `FADD` |
| riscv64 | `fp_cmp_relation` | a swapped `FLE` |
| riscv64 | `scale_shift` | shift 0 |
| mos6502 | `encode_alu` | an `EOR` |
| mos6502 | `encode_shift` | the arithmetic-right sequence |
| mos6502 | `encode_cmp` | the difference-to-zero equality form |

The riscv64 fused-branch one is the worst of them: `@swap = true` is assigned *before* the last two relation tests, so an unnamed opcode got not merely the wrong condition but the wrong condition with its operands reversed.

## Proven safe, not converted

- **Width classifiers** (`alu_opcode`, `alu_imm_opcode`, `load_funct3`, `store_funct3`, `fmv_i2f_funct7`, `fmv_f2i_funct7`, `int_to_fp_rm`, `is64`, `sel`) key off an operation width, and every encode function that reaches them rejects a non-`{1,2,4,8}` width locally first (e.g. `encode_fp_cmp`'s `w != 4 && w != 8` guard). The default is the widest case and is documented as such.
- **`classify_*` / `invert_branch`** (riscv64) already return a `MOP_NONE` sentinel — the refusal idiom this audit generalizes.
- **`shaped_reg`, `branch_reg_operand`, `alu3_shape`, `ldst_shape`, `ldur_shape`** feed the `--emit-asm` printer, not the byte stream, and already carry a `255` unknown-marker.
- **mos6502 `encode_sel_cbr`** already refuses in its default, above its first emitted byte. It is the model the three converted mos6502 arms now follow.

## Refusal channel

The classifiers take `R.Result` and refuse with a **named** diagnostic rather than the anonymous zero-bytes channel #2434 established: a pure classifier emits nothing to withhold, and every call site is a single already-`R.Result`-returning function, so the ripple is one unwrap each. The three mos6502 sites *are* emitting arms, and their dispatch now precedes the first emitted byte — the tests assert `st.buf.len == 0`, because those dispatches used to sit below the `LDA` that starts the sequence.

## Two margins worth naming

- `mir.is_fused_cbr` admits by **range** over a contiguous opcode block, so a seventh relation added to that block would reach both fused-cbr classifiers admitted and unnamed. Both refusal tests exercise `MIR_SEL_CBR_LE_U + 1` for exactly that reason.
- Both `scale_shift` bounds live in `is_sib_scale`, in the shared GEP lowering — a different module. x86-64 refuses the identical condition locally.

## Tests

Two per encoder (+5 total, 1005 → 1010). The totality half pins every named mapping to the value its architecture specifies, `swap` included; the refusal half pins that nothing else is accepted — without it, "the named ones work" is satisfied by the old code too.

**Mutation-checked 13/13**: restoring any one converted fallthrough fails the matching refusal test. The totality tests were mutation-checked as well (unsigned `<` given the signed condition; the `LE_S` operand swap dropped) — both fail, the swap also failing the pre-existing `fused_cbr_sequences`.

## Verification

All at `--jobs 1` per #2433.

- Fixpoint `b == c` on the branch, and on the `dev` baseline.
- `mach test` through the from-source compiler: **1010 passed, 0 failed** (baseline 1005 — exactly the five added).
- `int/run.sh --target linux`: all cases passed, both profiles.
- **Emission-neutral across five targets.** The audited compiler recompiles unmodified `dev` to binaries byte-identical to the baseline's for `linux-x86_64`, `linux-arm64`, `linux-riscv64`, `windows-x86_64` and `darwin-aarch64`. The two cross-target rows are the load-bearing ones: an x86-64 self-build never executes a line of the arm64 or riscv64 encoder, so it could not have shown this.

mos6502 has no target in `mach.toml`, so its encoder is covered by its unit tests alone.

## Not touched

#2280 (mos6502 records an `RK_ABS64` relocation for a 2-byte `JSR` operand, against a target that registers no applier) is confirmed still present and still latent — `encode_call` is reached only after `encode_instr`, which refuses first. Out of scope here, as directed.