### PR TITLE
cleanup(mir): correct the disproven zero-init claim at the phi-move splice

### DIFF
--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -688,20 +688,18 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
         mi.width     = 16;
         mi.src_width = 16;
     }
-    # this splice bypasses lctx.push_instr, so enforce its invariants here: asm_block
-    # is nil'd (struct locals are not zero-initialized, and regalloc.flatten reads a
-    # non-nil asm_block as an inline-asm clobber barrier), and loc is stamped from the
-    # cursor so the move carries the real source line (an unstamped loc would be a
-    # zeroed {FILE_NIL, 0} == loc_nil, correctly no row, since FILE_NIL is 0).
-    mi.asm_block         = nil;
+    # this splice bypasses lctx.push_instr, so the metadata that chokepoint would stamp
+    # has to be settled here. `mir.instr` hands back every metadata field at its zero
+    # default, and for a phi-elimination move each of those defaults is already the
+    # value this site wants: asm_block stays nil (regalloc.flatten reads a non-nil
+    # asm_block as an inline-asm clobber barrier), the dbg-binding list stays empty, and
+    # vec_lane stays VEC_LANE_NONE because the move is a full-width register copy,
+    # lane-agnostic even for a vector phi. loc and inline_site are the two genuine
+    # overrides: the zero default is loc_nil ({FILE_NIL, 0}, and FILE_NIL is 0), which
+    # would mean "no row" rather than the move's real source line, so both are stamped
+    # from the cursor.
     mi.loc               = ctx.cur_loc;
     mi.inline_site       = ctx.cur_inline_site;
-    mi.dbg_bindings      = nil;
-    mi.dbg_binding_count = 0;
-    # a phi-elimination move is a full-width register copy, lane-agnostic even for a
-    # vector phi, so it carries no lane descriptor (and struct locals are not
-    # zero-initialized, so it is set explicitly like the other push_instr invariants).
-    mi.vec_lane          = mir.VEC_LANE_NONE;
     mi.writes_secret     = false;   # a phi-elimination move never writes secret storage (#1646)
 
     # grow by one, shift the terminator right, and drop the move into its place.


### PR DESCRIPTION
Closes #2438.

The ninth "var does not zero" site, correctly excluded from #2394 because it rides
a different construction shape: `mi` is a whole-record copy from `mir.instr()` and
then amended, which is already the safe pattern the other eight were argued into.

`var` zero-fills every uninitialized binding (`lower_decl_stmt`), so the claim the
site made twice is false. Post-#2394 `mir.instr()` leaves `asm_block`,
`dbg_bindings`, `dbg_binding_count` and `vec_lane` at their zero defaults, and for a
phi-elimination move each of those defaults is exactly the value this site wants —
so the four re-clears were dead code justified by a false comment. Both phrasings
are replaced by one comment saying *why the defaults are correct* rather than why
they cannot be trusted.

Kept, deliberately:

- `loc` / `inline_site` — genuine overrides. The zero default is `loc_nil`, which
  would mean "no row" instead of the move's real source line.
- `writes_secret = false` — also redundant against the zero default, but its comment
  records a security decision (#1646) rather than echoing the disproven claim, so it
  is an explicit assertion rather than defensive residue. Flagging it since it is a
  redundant store either way; happy to drop it if you'd rather the site carry no
  dead assignments at all.

## Verification

One pinned process. Object comparisons carry both controls in the same run — a
self-check (tree vs itself, must be 0) and a positive control (one byte flipped in
a copy, must be caught as exactly 1).

**Emission neutrality (the #2434 bar).** A dev-baseline compiler and this branch's
compiler, each built generation-2 by the same recipe, then each compiling the *same
fixed unmodified tree*:

| | objects differing | linked binary |
|---|---|---|
| debug | 0/215 | identical |
| release | 0/215 | identical |

with self-check 0/215 and positive control 1/215 alongside. The two compiler
binaries themselves differ, as expected — the removed stores are real instructions —
but what they *emit* is byte-for-byte the same.

**Other bars.** `mach test` through the from-source compiler: 1005 passed, 0 failed.
Dev baseline measured with the same compiler is also 1005, so the delta is 0, which
is correct for a change that adds no tests. `B == C` self-host fixpoint: passes.
All 16 CI checks green.

## Out of scope, for follow-up

Grepping the disproven claim across `src/` turns up two further sites this issue
does not cover, both of which keep their code and need only the comment corrected:

- `src/lang/be/codegen/mir/context.mach:625` — `push_instr` justifies its
  `asm_block` nil-ing with "struct locals are not guaranteed zero-initialized". The
  clear itself must stay, but for a different reason than the one given:
  `mir.instr_like` carries *every* field, so a derived non-`MIR_ASM` instruction can
  inherit an `asm_block` from its source. Left alone here because #2335 is in flight
  on this file.
- `src/lang/target/isa.mach:1275` — `inst_blank` repeats "`var` does not zero".
  #2394 deliberately left the *code* (the `make_none()` writes are -1 sentinels, not
  zeros) but the false justification is still there.

`src/lang/target/isa/tests.mach:7` also echoes it and is already assigned to #2335.
