### PR TITLE
fix(target,codegen): make AbiVTable / MirVReg construction visible to the census

### DIFF
--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -522,14 +522,7 @@ fun fn_name(interner: *intern.Interner, id: intern.StrId) str {
 
 # a virtual register with a given secret seed, other fields defaulted (test helper)
 fun t_vreg(id: u32, secret: bool) mir.MirVReg {
-    var v: mir.MirVReg;
-    v.id         = id;
-    v.class      = mir.REG_CLASS_GP;
-    v.spill_slot = -1;
-    v.assigned   = mir.MIR_VREG_NIL;
-    v.vector     = false;
-    v.secret     = secret;
-    ret v;
+    ret mir.vreg(id, mir.REG_CLASS_GP, false, secret);
 }
 
 # a MIR instruction over a borrowed operand array (test helper)

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -593,10 +593,19 @@ test "mach.lang.be.codegen.frame.run:stamps_the_omission_decision" {
     m.function_len = 2;
     m.function_cap = 2;
 
-    # only the two fields `run` reads are set: the ABI's stack alignment and the two
-    # register ids the frame-reference scan compares against.
-    var abi_vt: abi.AbiVTable;
-    abi_vt.stack_align = 16;
+    # only the field `run` reads is set to a real value, the ABI's stack alignment;
+    # the rest are placeholders `abi.abi_vtable` requires but this test does not
+    # exercise (the other read `run` makes is the frame- / stack-pointer register
+    # ids on `tgt.model`, set below).
+    var abi_vt: abi.AbiVTable = abi.abi_vtable(
+        0, "", 0,
+        nil, nil, nil,
+        nil, nil,
+        16, 0, 0,
+        -1, false,
+        false, false,
+        nil
+    );
 
     var tgt: target.Target;
     tgt.abi                = ?abi_vt;

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -413,15 +413,9 @@ fun new_vreg(alloc: *A.Allocator, f: *mir.MirFunction, cls: u32) R.Result[u32, s
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
-    f.vregs[vid].id         = vid;
-    f.vregs[vid].class      = cls;
-    f.vregs[vid].spill_slot = -1;
-    f.vregs[vid].assigned   = mir.MIR_VREG_NIL;
-    f.vregs[vid].vector     = false;
-    # the vreg table grows via a non-zeroing reallocate, so initialize the taint bit too
-    # (its twin mir.context.new_vreg does the same); the durable taint is re-derived over
-    # the final MIR, so false is the safe init here (#1646).
-    f.vregs[vid].secret     = false;
+    # the durable taint is re-derived over the final MIR, so false is the correct
+    # start state here, matching its twin mir.context.new_vreg (#1646).
+    f.vregs[vid] = mir.vreg(vid, cls, false, false);
     f.vreg_count = f.vreg_count + 1;
     ret R.ok[u32, str](vid);
 }
@@ -797,6 +791,14 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
 
 # emit one native-width piece into `dst[*cursor]`, copying the source's location
 # metadata and advancing the cursor
+#
+# Whole-record copy from `mir.instr` into the slot, not a field-by-field rebuild:
+# `dst[ci]` is a slot in the caller's rebuilt array, not a fresh declaration, so it
+# is invisible to the construction-site census and was the last remaining
+# field-by-field `MirInstr` rebuild in the tree (#2335) - the other two sites
+# converted to `mir.instr_like` under #2321. `mir.instr` already zero-fills
+# `asm_block` / `vec_lane` / `dbg_bindings` / `dbg_binding_count`, so only the three
+# fields a piece inherits from `src` need amending afterward.
 # ---
 # alloc:  allocator for the piece's operand array
 # dst:    the rebuilt array
@@ -818,21 +820,13 @@ fun emit_piece(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.
         for (j < nops) { arr[j] = ops[j]; j = j + 1; }
     }
     val ci: u32 = @cursor;
+    dst[ci] = mir.instr(opcode, arr, nops, width, width);
     val p: *mir.MirInstr = ?dst[ci];
-    p.opcode        = opcode;
-    p.operands      = arr;
-    p.operand_count = nops;
-    p.width         = width;
-    p.src_width     = width;
-    p.asm_block     = nil;
     p.loc           = src.loc;
     p.inline_site   = src.inline_site;
-    p.vec_lane      = mir.VEC_LANE_NONE;
     # a legalized store's narrow-store pieces all write the same secret storage; carry
-    # the seed onto each (a `var` is not zero-init) (#1646).
+    # the seed onto each (#1646).
     p.writes_secret = src.writes_secret;
-    p.dbg_bindings      = nil;
-    p.dbg_binding_count = 0;
     @cursor = ci + 1;
     ret R.ok[bool, str](true);
 }

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -618,15 +618,9 @@ fun add_vreg_like(alloc: *A.Allocator, f: *mir.MirFunction, like: u32) R.Result[
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
-    f.vregs[vid].id         = vid;
-    f.vregs[vid].class      = f.vregs[like].class;
-    f.vregs[vid].spill_slot = -1;
-    f.vregs[vid].assigned   = mir.MIR_VREG_NIL;
-    f.vregs[vid].vector     = f.vregs[like].vector;
-    # carry the constant-time seed marker from the template (the vreg table grows via a
-    # non-zeroing reallocate, so this must be set explicitly, like the other new_vreg
-    # twins) - a loop-rotated copy of a secret-source vreg stays a secret source (#1646).
-    f.vregs[vid].secret     = f.vregs[like].secret;
+    # carry the class / vector / constant-time seed marker from the template - a
+    # loop-rotated copy of a secret-source vreg stays a secret source (#1646).
+    f.vregs[vid] = mir.vreg(vid, f.vregs[like].class, f.vregs[like].vector, f.vregs[like].secret);
     f.vreg_count = f.vreg_count + 1;
     ret R.ok[u32, str](vid);
 }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -767,6 +767,64 @@ pub rec MirVReg {
     secret:     bool;
 }
 
+# build a fresh MIR virtual register, unspilled and unassigned
+#
+# THIS IS THE ONLY PLACE A `MirVReg` IS BUILT. Every caller grows `MirFunction.vregs`
+# with a non-zeroing `A.reallocate` before writing into the new slot, so an unnamed
+# field here would carry the previous allocation's residue rather than a defined
+# value - the same hazard `mir.instr` guards for `MirInstr` (#2032, #2335). `id` is
+# always the slot's own index and `spill_slot` / `assigned` always start at their
+# unspilled / unassigned sentinels at every call site, so those three are not
+# parameters: a caller cannot pass an inconsistent one, and a new caller cannot
+# forget to set them to anything but the one correct start state.
+# ---
+# id:     the vreg's own index into MirFunction.vregs (its slot, by construction)
+# class:  register-class index the new vreg belongs to
+# vector: whether the vreg holds a 128-bit SIMD vector (#2014)
+# secret: the constant-time SEED marker (#1646): true when defined by a secret source
+# ret:    the vreg, unspilled and unassigned
+pub fun vreg(id: u32, class: u32, vector: bool, secret: bool) MirVReg {
+    var v: MirVReg;
+    v.id         = id;
+    v.class      = class;
+    v.spill_slot = -1;
+    v.assigned   = MIR_VREG_NIL;
+    v.vector     = vector;
+    v.secret     = secret;
+    ret v;
+}
+
+# `mir.vreg` SETS EVERY FIELD OF A FRESH VIRTUAL REGISTER.
+#
+# The guard the three vreg-table growth sites need: each grows `MirFunction.vregs`
+# with a non-zeroing `A.reallocate` and then calls this constructor into the new
+# slot, so a field this left unset would read the previous allocation's residue
+# rather than a defined value (#2335, the same hazard #2032 shipped for `MirInstr`).
+#
+# Every field below is asserted against a value that DIFFERS from the field's own
+# zero default (`id` / `class` nonzero, `vector` / `secret` true), because `var`
+# zero-fills a forgotten field - so a check against the zero value itself would
+# pass whether or not the assignment that produces it is still there. `spill_slot`
+# / `assigned` are not parameters (every call site starts a vreg unspilled and
+# unassigned), so their fixed sentinels are checked directly.
+# ---
+# To see it fail, drop a field from `vreg`'s assignment list.
+test "mach.lang.be.codegen.mir.vreg:sets_every_field" {
+    val v: MirVReg = vreg(7, 3, true, true);
+    if (v.id != 7)                  { ret 1; }
+    if (v.class != 3)               { ret 1; }
+    if (v.spill_slot != -1)         { ret 1; }
+    if (v.assigned != MIR_VREG_NIL) { ret 1; }
+    if (!v.vector)                  { ret 1; }
+    if (!v.secret)                  { ret 1; }
+
+    # and the flags genuinely echo the parameter rather than being hard-coded true.
+    val v2: MirVReg = vreg(0, 0, false, false);
+    if (v2.vector) { ret 1; }
+    if (v2.secret) { ret 1; }
+    ret 0;
+}
+
 # discriminant distinguishing an addressed alloca slot from a by-value spill slot
 pub def MirSlotKind: u8;
 

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1866,11 +1866,16 @@ test "mach.lang.be.codegen.mir.abi.require_abi:variadic_facts_are_not_call_preco
     # a whole-module ISA: this is a convention with no register machine behind it,
     # which is exactly the shape the two variadic facts are absent from.
     var vt: isa.IsaVTable = isa.emitter_isa(isa.ARCH_SPIRV, "probe", 8, nil, nil);
-    var av: abi.AbiVTable;
-    av.arg_passing = probe_arg::*u8;
-    av.ret_passing = probe_ret::*u8;
-    av.gp_arg_regs = nil;
-    av.va_model    = nil;
+    # gp_arg_regs / va_model absent (nil): the two variadic-only facts under test.
+    var av: abi.AbiVTable = abi.abi_vtable(
+        0, "", 0,
+        nil, probe_arg::*u8, probe_ret::*u8,
+        nil, nil,
+        0, 0, 0,
+        -1, false,
+        false, false,
+        nil
+    );
 
     var t: target.Target;
     t.isa = ?vt;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -283,12 +283,7 @@ pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
-    f.vregs[vid].id         = vid;
-    f.vregs[vid].class      = reg_class;
-    f.vregs[vid].spill_slot = -1;
-    f.vregs[vid].assigned   = mir.MIR_VREG_NIL;
-    f.vregs[vid].vector     = false;
-    f.vregs[vid].secret     = false;   # public until ctx_setup marks a secret definition (#1646)
+    f.vregs[vid] = mir.vreg(vid, reg_class, false, false);   # public until ctx_setup marks a secret definition (#1646)
     f.vreg_count = f.vreg_count + 1;
     ret R.ok[u32, str](vid);
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -16,6 +16,8 @@
 # itself names no ISA or ABI value type.
 
 use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.string.str;
 use std.types.string.str_equals;
 
@@ -363,6 +365,114 @@ pub rec AbiVTable {
     va_model:                    *u8;
 }
 
+# build an ABI vtable, every field supplied
+#
+# THIS IS THE ONLY PLACE AN `AbiVTable` IS BUILT. Every convention module declares
+# a process-global storage var and hand-wrote all sixteen fields into it from
+# `register`, which was invisible to the construction-site census twice over:
+# `AbiVTable` was not one of the censused records, and a field written into an
+# already-declared global is not the declaration-with-no-initializer shape the
+# census's text scan matches at all (#2244 shipped exactly this shape for
+# `IsaVTable` before it joined the census; `AbiVTable` sat beside it, uncovered,
+# until #2335). Taking every field as a positional parameter makes an omission an
+# arity error at build time rather than a convention silently supplying zero for a
+# field added later.
+# ---
+# id:                          calling-convention id (one of ABI_*)
+# name:                        interned convention name
+# arch_id:                     the isa.ARCH_* id this convention targets
+# classify:                    erased fn ptr - classify a value's class
+# arg_passing:                 erased fn ptr - assign arg regs/stack slots
+# ret_passing:                 erased fn ptr - assign return regs/sret
+# gp_arg_regs:                 erased fn ptr - fill the GP argument bank
+# callee_saved:                erased fn ptr - fill the callee-saved bank
+# stack_align:                 required stack alignment in bytes at a call boundary
+# red_zone:                    leaf-function red-zone size in bytes (0 if none)
+# shadow_space:                caller-reserved home/shadow bytes below stack args
+# indirect_result_reg:         physical register carrying the hidden sret pointer
+# indirect_result_in_argfile:  true when that register consumes a GP argument slot
+# consumes_agg_layout:         true when the classifier reads the flattened-
+#                              aggregate descriptor
+# fp_callee_saved_full_vector: true when a callee-saved FP register preserves the
+#                              full 128-bit vector across a call
+# va_model:                    erased fn ptr - return the convention's VaModel
+# ret:                         the fully-populated vtable
+pub fun abi_vtable(id: u32, name: str, arch_id: u32, classify: *u8, arg_passing: *u8,
+                   ret_passing: *u8, gp_arg_regs: *u8, callee_saved: *u8,
+                   stack_align: u32, red_zone: u32, shadow_space: u32,
+                   indirect_result_reg: i32, indirect_result_in_argfile: bool,
+                   consumes_agg_layout: bool, fp_callee_saved_full_vector: bool,
+                   va_model: *u8) AbiVTable {
+    var v: AbiVTable;
+    v.id                          = id;
+    v.name                        = name;
+    v.arch_id                     = arch_id;
+    v.classify                    = classify;
+    v.arg_passing                 = arg_passing;
+    v.ret_passing                 = ret_passing;
+    v.gp_arg_regs                 = gp_arg_regs;
+    v.callee_saved                = callee_saved;
+    v.stack_align                 = stack_align;
+    v.red_zone                    = red_zone;
+    v.shadow_space                = shadow_space;
+    v.indirect_result_reg         = indirect_result_reg;
+    v.indirect_result_in_argfile  = indirect_result_in_argfile;
+    v.consumes_agg_layout         = consumes_agg_layout;
+    v.fp_callee_saved_full_vector = fp_callee_saved_full_vector;
+    v.va_model                    = va_model;
+    ret v;
+}
+
+# `abi_vtable` SETS EVERY FIELD OF A FRESH CALLING-CONVENTION VTABLE.
+#
+# The guard #2335 needs: `AbiVTable` was uncensused and every convention module
+# hand-wrote it field by field into a bare-declared global, so a field this
+# constructor forgot would leave every convention silently defaulting rather than
+# refusing to build - the `IsaVTable` shape #2244 shipped and #2294 closed.
+#
+# Every field below is asserted against a value that DIFFERS from the field's own
+# zero default (a real, non-nil function reference for each erased fn ptr; nonzero
+# numbers; `true` for every bool), because `var` zero-fills a forgotten field - so
+# a check against the zero value itself would pass whether or not the assignment
+# that produces it is still there.
+# ---
+# To see it fail, drop a field from `abi_vtable`'s assignment list.
+test "mach.lang.target.abi.abi_vtable:sets_every_field" {
+    val v: AbiVTable = abi_vtable(
+        ABI_SYSV, "probe", isa.ARCH_X86_64,
+        register::*u8, lookup::*u8, registered::*u8,
+        registered_count::*u8, covers_isa::*u8,
+        16, 128, 32,
+        3, true,
+        true, true,
+        abi_id_for::*u8
+    );
+
+    if (v.id != ABI_SYSV)                       { ret 1; }
+    if (!str_equals(v.name, "probe"))           { ret 1; }
+    if (v.arch_id != isa.ARCH_X86_64)           { ret 1; }
+    if (v.classify != register::*u8)            { ret 1; }
+    if (v.arg_passing != lookup::*u8)           { ret 1; }
+    if (v.ret_passing != registered::*u8)       { ret 1; }
+    if (v.gp_arg_regs != registered_count::*u8) { ret 1; }
+    if (v.callee_saved != covers_isa::*u8)      { ret 1; }
+    if (v.stack_align != 16)                    { ret 1; }
+    if (v.red_zone != 128)                      { ret 1; }
+    if (v.shadow_space != 32)                   { ret 1; }
+    if (v.indirect_result_reg != 3)             { ret 1; }
+    if (!v.indirect_result_in_argfile)          { ret 1; }
+    if (!v.consumes_agg_layout)                 { ret 1; }
+    if (!v.fp_callee_saved_full_vector)         { ret 1; }
+    if (v.va_model != abi_id_for::*u8)          { ret 1; }
+
+    # and the bools genuinely echo the parameter rather than being hard-coded true.
+    val v2: AbiVTable = abi_vtable(0, "", 0, nil, nil, nil, nil, nil, 0, 0, 0, 0, false, false, false, nil);
+    if (v2.indirect_result_in_argfile)  { ret 1; }
+    if (v2.consumes_agg_layout)         { ret 1; }
+    if (v2.fp_callee_saved_full_vector) { ret 1; }
+    ret 0;
+}
+
 # maximum number of ABI implementations an AbiRegistry holds
 val ABI_REGISTRY_CAP: u32 = 8;
 
@@ -637,8 +747,17 @@ pub fun make_slot_pieces(class: ParamClass, pieces: *ParamPiece, count: u32, siz
 # covers_isa matches only the convention's self-declared instruction set, since a
 # calling convention is per-ISA by construction
 test "mach.lang.target.abi.covers_isa:matches_declared_arch" {
-    var vt: AbiVTable;
-    vt.arch_id = isa.ARCH_AARCH64;
+    # only `arch_id` is under test; the rest are placeholders `abi_vtable` requires
+    # but `covers_isa` does not read.
+    var vt: AbiVTable = abi_vtable(
+        0, "", isa.ARCH_AARCH64,
+        nil, nil, nil,
+        nil, nil,
+        0, 0, 0,
+        -1, false,
+        false, false,
+        nil
+    );
     if (!covers_isa(?vt, isa.ARCH_AARCH64)) { ret 1; }
     if (covers_isa(?vt, isa.ARCH_X86_64))   { ret 1; }
     ret 0;

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -64,6 +64,12 @@ use R: std.types.result;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 
+# the AAPCS64 ABI vtable. populated by `register` on first call and handed out as a
+# borrowed pointer to the registry. its classify/arg/ret function pointers are
+# stored type-erased (`*u8`); consumers cast them back to
+# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`
+var aapcs64_vtable: abi.AbiVTable;
+
 # canonical AArch64 general-purpose register numbers used by the AAPCS64
 # convention. these are the same physical-register ids the aarch64 ISA exposes;
 # they are fixed by the architecture, so the ABI carries them directly rather than
@@ -394,12 +400,6 @@ pub fun va_model() abi.VaModel {
     ret m;
 }
 
-# the AAPCS64 ABI vtable. populated by `register` on first call and handed out as a
-# borrowed pointer to the registry. its classify/arg/ret function pointers are
-# stored type-erased (`*u8`); consumers cast them back to
-# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`
-var aapcs64_vtable: abi.AbiVTable;
-
 # build the AAPCS64 AbiVTable and install it into `reg`
 #
 # Sets the convention name ("aapcs64") as an immutable `str` constant, wires the
@@ -412,29 +412,27 @@ var aapcs64_vtable: abi.AbiVTable;
 # reg: the ABI registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
-    aapcs64_vtable.id           = abi.ABI_AAPCS64;
-    aapcs64_vtable.name         = "aapcs64";
-    aapcs64_vtable.arch_id      = isa.ARCH_AARCH64;
-    aapcs64_vtable.classify     = classify::*u8;
-    aapcs64_vtable.arg_passing  = classify_arg::*u8;
-    aapcs64_vtable.ret_passing  = classify_return::*u8;
-    aapcs64_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    aapcs64_vtable.callee_saved = callee_saved::*u8;
-    aapcs64_vtable.stack_align  = STACK_ALIGN;
-    aapcs64_vtable.red_zone     = RED_ZONE;
     # AAPCS64 reserves no caller shadow space -- stack arguments start at [sp+0].
-    aapcs64_vtable.shadow_space = 0;
+    val shadow_space: u32 = 0;
     # the hidden sret pointer rides the dedicated X8 indirect-result register,
     # OUTSIDE the X0-X7 argument file -- so `classify_signature` leaves gp_used = 0
     # and the real arguments still start at X0.
-    aapcs64_vtable.indirect_result_reg        = REG_X8;
-    aapcs64_vtable.indirect_result_in_argfile = false;
+    val indirect_result_reg: i32 = REG_X8;
     # AAPCS64 ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
-    aapcs64_vtable.consumes_agg_layout        = false;
+    val consumes_agg_layout: bool = false;
     # AAPCS64 preserves only the low 64 bits of the callee-saved V8-V15; a 128-bit
     # vector's upper half is caller-saved, so one live across a call must be spilled.
-    aapcs64_vtable.fp_callee_saved_full_vector = false;
-    aapcs64_vtable.va_model                   = va_model::*u8;
+    val fp_callee_saved_full_vector: bool = false;
+
+    aapcs64_vtable = abi.abi_vtable(
+        abi.ABI_AAPCS64, "aapcs64", isa.ARCH_AARCH64,
+        classify::*u8, classify_arg::*u8, classify_return::*u8,
+        gp_param_regs::*u8, callee_saved::*u8,
+        STACK_ALIGN, RED_ZONE, shadow_space,
+        indirect_result_reg, false,
+        consumes_agg_layout, fp_callee_saved_full_vector,
+        va_model::*u8
+    );
 
     abi.register(reg, ?aapcs64_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -55,6 +55,12 @@ use R: std.types.result;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 
+# the lp64d ABI vtable. populated by `register` on first call and handed out as a
+# borrowed pointer to the registry. its classify/arg/ret function pointers are
+# stored type-erased (`*u8`); consumers cast them back to
+# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`
+var lp64_vtable: abi.AbiVTable;
+
 # canonical RISC-V integer register numbers used by the lp64d convention. these are
 # the same physical-register ids the riscv64 ISA exposes; they are fixed by the
 # architecture, so the ABI carries them directly rather than depending on the ISA
@@ -465,12 +471,6 @@ pub fun va_model() abi.VaModel {
     ret m;
 }
 
-# the lp64d ABI vtable. populated by `register` on first call and handed out as a
-# borrowed pointer to the registry. its classify/arg/ret function pointers are
-# stored type-erased (`*u8`); consumers cast them back to
-# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`
-var lp64_vtable: abi.AbiVTable;
-
 # build the lp64d AbiVTable and install it into `reg`
 #
 # Sets the convention name ("lp64") as an immutable `str` constant, wires the
@@ -485,29 +485,27 @@ var lp64_vtable: abi.AbiVTable;
 # reg: the ABI registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
-    lp64_vtable.id           = abi.ABI_LP64;
-    lp64_vtable.name         = "lp64";
-    lp64_vtable.arch_id      = isa.ARCH_RISCV64;
-    lp64_vtable.classify     = classify::*u8;
-    lp64_vtable.arg_passing  = classify_arg::*u8;
-    lp64_vtable.ret_passing  = classify_return::*u8;
-    lp64_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    lp64_vtable.callee_saved = callee_saved::*u8;
-    lp64_vtable.stack_align  = STACK_ALIGN;
-    lp64_vtable.red_zone     = RED_ZONE;
     # lp64d reserves no caller shadow space -- stack arguments start at [sp+0].
-    lp64_vtable.shadow_space = 0;
+    val shadow_space: u32 = 0;
     # the hidden sret pointer rides a0, the first integer argument register, so
     # `classify_signature` seeds gp_used = 1 for an sret return.
-    lp64_vtable.indirect_result_reg        = gp_param_reg(0);
-    lp64_vtable.indirect_result_in_argfile = true;
+    val indirect_result_reg: i32 = gp_param_reg(0);
     # lp64d is the one convention whose classifier reads the flattened-aggregate
     # descriptor (the mixed float+int and different-width float-pair rules).
-    lp64_vtable.consumes_agg_layout        = true;
+    val consumes_agg_layout: bool = true;
     # riscv64 scalarizes 128-bit vectors before allocation, so none rides a callee-saved
     # FP register across a call; the flag is moot and set true.
-    lp64_vtable.fp_callee_saved_full_vector = true;
-    lp64_vtable.va_model                   = va_model::*u8;
+    val fp_callee_saved_full_vector: bool = true;
+
+    lp64_vtable = abi.abi_vtable(
+        abi.ABI_LP64, "lp64", isa.ARCH_RISCV64,
+        classify::*u8, classify_arg::*u8, classify_return::*u8,
+        gp_param_regs::*u8, callee_saved::*u8,
+        STACK_ALIGN, RED_ZONE, shadow_space,
+        indirect_result_reg, true,
+        consumes_agg_layout, fp_callee_saved_full_vector,
+        va_model::*u8
+    );
 
     abi.register(reg, ?lp64_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/mos6502.mach
+++ b/src/lang/target/abi/mos6502.mach
@@ -121,27 +121,21 @@ fun va_model() abi.VaModel {
 # reg: the ABI registry to install the vtable into
 # ret: true on success
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
-    mos6502_abi_vtable.id      = abi.ABI_UNKNOWN;
-    mos6502_abi_vtable.name    = "mos6502";
-    mos6502_abi_vtable.arch_id = isa.ARCH_MOS6502;
-
-    mos6502_abi_vtable.classify     = classify::*u8;
-    mos6502_abi_vtable.arg_passing  = arg_passing::*u8;
-    mos6502_abi_vtable.ret_passing  = ret_passing::*u8;
-    mos6502_abi_vtable.gp_arg_regs  = gp_arg_regs::*u8;
-    mos6502_abi_vtable.callee_saved = callee_saved::*u8;
-    mos6502_abi_vtable.va_model     = va_model::*u8;
-
-    mos6502_abi_vtable.stack_align  = 1;
-    mos6502_abi_vtable.red_zone     = 0;
-    mos6502_abi_vtable.shadow_space = 0;
     # the hidden sret pointer rides the encoder pointer pair; it is not part of the
     # byte-argument file, so the GP argument cursor starts at 0.
-    mos6502_abi_vtable.indirect_result_reg        = mos6502.PTR_LO;
-    mos6502_abi_vtable.indirect_result_in_argfile = false;
-    mos6502_abi_vtable.consumes_agg_layout        = false;
+    val indirect_result_reg: i32 = mos6502.PTR_LO;
     # no callee-saved FP register exists, so the full-vector-preservation fact is moot.
-    mos6502_abi_vtable.fp_callee_saved_full_vector = true;
+    val fp_callee_saved_full_vector: bool = true;
+
+    mos6502_abi_vtable = abi.abi_vtable(
+        abi.ABI_UNKNOWN, "mos6502", isa.ARCH_MOS6502,
+        classify::*u8, arg_passing::*u8, ret_passing::*u8,
+        gp_arg_regs::*u8, callee_saved::*u8,
+        1, 0, 0,
+        indirect_result_reg, false,
+        false, fp_callee_saved_full_vector,
+        va_model::*u8
+    );
 
     abi.register(reg, ?mos6502_abi_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/spirv.mach
+++ b/src/lang/target/abi/spirv.mach
@@ -104,22 +104,15 @@ fun callee_saved(out: *isa.Register) i32 {
 # reg: the ABI registry to install the vtable into
 # ret: true on success
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
-    spirv_abi_vtable.id           = abi.ABI_UNKNOWN;
-    spirv_abi_vtable.name         = "spirv";
-    spirv_abi_vtable.arch_id      = isa.ARCH_SPIRV;
-    spirv_abi_vtable.classify     = classify_value::*u8;
-    spirv_abi_vtable.arg_passing  = classify_arg::*u8;
-    spirv_abi_vtable.ret_passing  = classify_return::*u8;
-    spirv_abi_vtable.gp_arg_regs  = arg_regs::*u8;
-    spirv_abi_vtable.callee_saved = callee_saved::*u8;
-    spirv_abi_vtable.stack_align  = 0;
-    spirv_abi_vtable.red_zone     = 0;
-    spirv_abi_vtable.shadow_space = 0;
-    spirv_abi_vtable.indirect_result_reg         = 0;
-    spirv_abi_vtable.indirect_result_in_argfile  = false;
-    spirv_abi_vtable.consumes_agg_layout         = false;
-    spirv_abi_vtable.fp_callee_saved_full_vector = true;
-    spirv_abi_vtable.va_model                    = nil;
+    spirv_abi_vtable = abi.abi_vtable(
+        abi.ABI_UNKNOWN, "spirv", isa.ARCH_SPIRV,
+        classify_value::*u8, classify_arg::*u8, classify_return::*u8,
+        arg_regs::*u8, callee_saved::*u8,
+        0, 0, 0,
+        0, false,
+        false, true,
+        nil
+    );
 
     abi.register(reg, ?spirv_abi_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -20,6 +20,12 @@ use R: std.types.result;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 
+# the SysV AMD64 ABI vtable. populated by `register` on first call and handed out
+# as a borrowed pointer to the registry. its three classify / arg / ret function
+# pointers are stored type-erased (`*u8`); consumers cast them back to
+# `ClassifyFn` / `ArgPassingFn` / `RetPassingFn`
+var sysv_vtable: abi.AbiVTable;
+
 # canonical x86-64 register numbers (DWARF / encoding order) used by the SysV
 # AMD64 convention. these are the same physical-register ids the x86_64 ISA
 # exposes; they are fixed by the architecture, so the ABI carries them directly
@@ -376,12 +382,6 @@ pub fun va_model() abi.VaModel {
     ret m;
 }
 
-# the SysV AMD64 ABI vtable. populated by `register` on first call and handed out
-# as a borrowed pointer to the registry. its three classify / arg / ret function
-# pointers are stored type-erased (`*u8`); consumers cast them back to
-# `ClassifyFn` / `ArgPassingFn` / `RetPassingFn`
-var sysv_vtable: abi.AbiVTable;
-
 # build the SysV AMD64 AbiVTable and install it into `reg`
 #
 # Sets the convention name ("sysv64", matching the name the manifest spells),
@@ -395,28 +395,26 @@ var sysv_vtable: abi.AbiVTable;
 # reg: the ABI registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
-    sysv_vtable.id           = abi.ABI_SYSV;
-    sysv_vtable.name         = "sysv64";
-    sysv_vtable.arch_id      = isa.ARCH_X86_64;
-    sysv_vtable.classify     = classify::*u8;
-    sysv_vtable.arg_passing  = classify_arg::*u8;
-    sysv_vtable.ret_passing  = classify_return::*u8;
-    sysv_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    sysv_vtable.callee_saved = callee_saved::*u8;
-    sysv_vtable.stack_align  = STACK_ALIGN;
-    sysv_vtable.red_zone     = RED_ZONE;
-    sysv_vtable.va_model     = va_model::*u8;
     # SysV reserves no caller shadow space -- stack arguments start at [rsp+0].
-    sysv_vtable.shadow_space = 0;
+    val shadow_space: u32 = 0;
     # the hidden sret pointer rides the first GP argument register (RDI), consuming
     # a GP argument slot, so `classify_signature` seeds gp_used = 1 for an sret return.
-    sysv_vtable.indirect_result_reg        = gp_param_reg(0);
-    sysv_vtable.indirect_result_in_argfile = true;
+    val indirect_result_reg: i32 = gp_param_reg(0);
     # SysV ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
-    sysv_vtable.consumes_agg_layout        = false;
+    val consumes_agg_layout: bool = false;
     # SysV callee-saves no FP register, so no vector ever rides one across a call; the
     # flag is moot and set true (the general "callee-saved preserves the full value").
-    sysv_vtable.fp_callee_saved_full_vector = true;
+    val fp_callee_saved_full_vector: bool = true;
+
+    sysv_vtable = abi.abi_vtable(
+        abi.ABI_SYSV, "sysv64", isa.ARCH_X86_64,
+        classify::*u8, classify_arg::*u8, classify_return::*u8,
+        gp_param_regs::*u8, callee_saved::*u8,
+        STACK_ALIGN, RED_ZONE, shadow_space,
+        indirect_result_reg, true,
+        consumes_agg_layout, fp_callee_saved_full_vector,
+        va_model::*u8
+    );
 
     abi.register(reg, ?sysv_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -23,6 +23,12 @@ use mach.lang.target.abi;
 use mach.lang.target.isa;
 use mach.lang.target.isa.x64;
 
+# the win64 ABI vtable: populated by `register` on first call and handed out as a
+# borrowed pointer to the registry. its classify/arg/ret and register-file
+# function pointers are stored type-erased (`*u8`); consumers cast them back to the
+# shared `abi.ClassifyFn` / `abi.ArgPassingFn` / `abi.RetPassingFn` / `RegFileFn`
+var win64_vtable: abi.AbiVTable;
+
 # canonical x86-64 register numbers (DWARF / encoding order) used by the win64
 # convention. these are the same physical-register ids the x86_64 ISA exposes;
 # they are fixed by the architecture, so the ABI carries them directly rather than
@@ -405,12 +411,6 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
     ret gp_used + fp_used;
 }
 
-# the win64 ABI vtable: populated by `register` on first call and handed out as a
-# borrowed pointer to the registry. its classify/arg/ret and register-file
-# function pointers are stored type-erased (`*u8`); consumers cast them back to the
-# shared `abi.ClassifyFn` / `abi.ArgPassingFn` / `abi.RetPassingFn` / `RegFileFn`
-var win64_vtable: abi.AbiVTable;
-
 # build and install the win64 AbiVTable
 #
 # sets the convention name ("win64"), wires the type-erased classify/arg/ret
@@ -424,31 +424,28 @@ var win64_vtable: abi.AbiVTable;
 # reg: the ABI registry to install the vtable into
 # ret: true on success
 pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
-    win64_vtable.id           = abi.ABI_WIN64;
-    win64_vtable.name         = "win64";
-    win64_vtable.arch_id      = isa.ARCH_X86_64;
-    win64_vtable.classify     = classify::*u8;
-    win64_vtable.arg_passing  = classify_arg::*u8;
-    win64_vtable.ret_passing  = classify_return::*u8;
-    win64_vtable.gp_arg_regs  = gp_param_regs::*u8;
-    win64_vtable.callee_saved = callee_saved::*u8;
-    win64_vtable.stack_align  = STACK_ALIGN;
-    win64_vtable.red_zone     = RED_ZONE;
-    win64_vtable.va_model     = va_model::*u8;
-
     # win64 reserves 32 bytes of shadow space below the stack arguments for the
     # callee to home RCX/RDX/R8/R9; the outgoing stack args start above it.
-    win64_vtable.shadow_space = SHADOW_SPACE::u32;
+    val shadow_space: u32 = SHADOW_SPACE::u32;
     # the hidden sret pointer rides the first GP argument register (RCX), consuming
     # the first positional slot, so `classify_signature` seeds gp_used = 1 and the
     # real arguments shift one slot.
-    win64_vtable.indirect_result_reg        = slot_gp_reg(0);
-    win64_vtable.indirect_result_in_argfile = true;
+    val indirect_result_reg: i32 = slot_gp_reg(0);
     # win64 ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
-    win64_vtable.consumes_agg_layout        = false;
+    val consumes_agg_layout: bool = false;
     # win64 preserves the full 128 bits of the callee-saved XMM6-15, so a vector live
     # across a call survives in one without spilling.
-    win64_vtable.fp_callee_saved_full_vector = true;
+    val fp_callee_saved_full_vector: bool = true;
+
+    win64_vtable = abi.abi_vtable(
+        abi.ABI_WIN64, "win64", isa.ARCH_X86_64,
+        classify::*u8, classify_arg::*u8, classify_return::*u8,
+        gp_param_regs::*u8, callee_saved::*u8,
+        STACK_ALIGN, RED_ZONE, shadow_space,
+        indirect_result_reg, true,
+        consumes_agg_layout, fp_callee_saved_full_vector,
+        va_model::*u8
+    );
 
     abi.register(reg, ?win64_vtable);
     ret R.ok[bool, str](true);
@@ -687,8 +684,17 @@ test "mach.lang.target.abi.win64.register:indirect_result_in_argfile" {
 # SysV), so a callee that omits saving them corrupts it. this is the #1204
 # regression -- drive the list from a vtable whose callee-saved file is win64's
 test "mach.lang.target.abi.win64.callee_saved:includes_rdi_rsi" {
-    var vt: abi.AbiVTable;
-    vt.callee_saved = callee_saved::*u8;
+    # only `callee_saved` is under test; the rest are placeholders `abi.abi_vtable`
+    # requires but `x64.callee_saved_gp_list` does not read.
+    var vt: abi.AbiVTable = abi.abi_vtable(
+        0, "", 0,
+        nil, nil, nil,
+        nil, callee_saved::*u8,
+        0, 0, 0,
+        -1, false,
+        false, false,
+        nil
+    );
 
     var list: [16]i32;
     val n: i32 = x64.callee_saved_gp_list(?vt, ?list[0]);

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -1,25 +1,35 @@
 # the construction-site census for the target-layer records that own a constructor
 #
-# Seven records are cleared in exactly one place each - the machine-instruction
-# model (`Inst`, `Operand`), the four ISA contracts (`IsaVTable`, `RegMachine`,
-# `ModuleEmitter`, `RelocSeam`) and the MIR instruction (`MirInstr`) - and this
-# module proves it by reading the source
-# rather than by trusting review. `var` does not zero, so a site that builds one of
-# these records field by field leaves whatever field it does not name holding the
-# frame's residue - and a field added later is named by no site at all, on whichever
-# target happens to have written that stack.
+# Nine records are cleared in exactly one place each - the machine-instruction model
+# (`Inst`, `Operand`), the four ISA contracts (`IsaVTable`, `RegMachine`,
+# `ModuleEmitter`, `RelocSeam`), the MIR instruction and its virtual register
+# (`MirInstr`, `MirVReg`), and the calling-convention vtable (`AbiVTable`) - and this
+# module proves it by reading the source rather than by trusting review. Every
+# uninitialized binding is zero-filled (`var` DOES zero), so the fields a
+# field-by-field build does not name are not garbage - they are silently zero, which
+# is a plausible WRONG value rather than an obviously broken one, and a field added
+# later is zeroed the same way at every site that does not yet name it.
 #
 # That is not hypothetical, three times over. `Operand.sym_mod` was added and three
 # hand-written clears did not learn about it. `MirInstr` gained `vec_lane` and
-# `regalloc.rewrite_instr` did not, so every rewritten vector op read as element
-# bytes 0 and the NEON encoder collapsed each arrangement to `.16b` after register
-# assignment - a shipped miscompile (#2032, #2321). Then `IsaVTable` gained a
-# relocatable-object seam (#2244) and sixteen hand-built vtables in the ELF writer's
-# tests silently acquired it uninitialized - `attributes_for` runs on every exec
-# emit, so those tests were handing it a function pointer off the stack and
-# comparing it to nil. Whether the comparison said "nil" was a property of the
-# stack, not of the program. The ISA contracts were outside this census when that
-# happened; they are inside it now (#2294).
+# `regalloc.rewrite_instr` did not, so every rewritten vector op read as element 0 -
+# a plausible arrangement, not a crash - and the NEON encoder collapsed each one to
+# `.16b` after register assignment: a shipped miscompile (#2032, #2321). Then
+# `IsaVTable` gained a relocatable-object seam (#2244) and sixteen hand-built
+# vtables in the ELF writer's tests silently acquired it zeroed - `attributes_for`
+# runs on every exec emit, so those tests were handing it a nil function pointer and
+# comparing it to nil. Whether the comparison said "nil" was a property of every
+# field the test happened to name, not of the program. The ISA contracts were
+# outside this census when that happened; they are inside it now (#2294).
+#
+# `AbiVTable` shipped the identical shape independently (#2335): not one of the
+# censused records, so its six calling-convention modules each declared a
+# module-global vtable and hand-wrote all sixteen fields into it, unseen by any
+# scan. `MirVReg` shipped a related but DIFFERENT blind spot: its three growth
+# sites write every field into a slot from a non-zeroing reallocate, not into a
+# declaration - invisible to this census not because the type was uncensused but
+# because THE SHAPE ITSELF is outside what a declaration-scan can see at all. See
+# WHY A REBUILT SLOT IS A DIFFERENT PROPERTY below.
 #
 # WHY THE INVARIANT IS TEXTUAL. Runtime cannot see this. A test can assert that a
 # constructor returns cleared fields, but that is a property of the constructor, not
@@ -35,19 +45,36 @@
 # this same census. Forbidding the bare form outside the constructors therefore
 # forbids hand-building outright, and it does so for fields that do not exist yet.
 #
+# WHY A REBUILT SLOT IS A DIFFERENT PROPERTY, AND THIS SCAN DOES NOT COVER IT. A
+# slot from an existing array - `f.vregs[vid]`, a caller-owned out-parameter, a
+# reused local - is never a declaration, so nothing here can see one being written
+# field by field (#2335). Converting such a site means calling its record's
+# constructor and assigning the WHOLE result into the slot (`f.vregs[vid] =
+# mir.vreg(...)`), the same "whole-record copy, itself subject to the census"
+# argument above - but nothing textual distinguishes that assignment from an
+# ordinary field write, so this scan cannot verify the conversion happened, only
+# that the constructor it must go through is not hand-built either. The bar instead
+# is a mutation-tested whole-record guard per converted type (drop a field from the
+# constructor, show a unit test fails) - `instr_like`'s `carries_every_field` is the
+# model. This is stated plainly rather than left implicit: a green census here is
+# not evidence that every rebuild-through-a-slot in the tree has been found.
+#
 # WHY THE PERMITTED LIST CARRIES A COUNT. Two kinds of site legitimately declare one
 # of these records bare, and they are not the same kind of thing:
 #
 #   - the CONSTRUCTORS themselves, one per record, each the single place its record
 #     is cleared;
-#   - the PROCESS-GLOBAL STORAGE an arch's registration module declares for the
-#     vtable it installs. A module-level `var` cannot carry a call as its
-#     initializer, so the storage must be declared bare and whole-assigned from a
-#     constructor at startup (`x64_vtable = isa.machine_isa(...)`). That is a
-#     declaration of storage, not a construction site - but nothing in the text
-#     distinguishes the two, so each such file is permitted with the EXACT number of
-#     globals it declares. A fourth global in a file permitted for three fails the
-#     census and has to be argued for.
+#   - the PROCESS-GLOBAL STORAGE a registration module declares for the vtable it
+#     installs. A module-level `var` cannot carry a call as its initializer, so the
+#     storage must be declared bare and whole-assigned from a constructor at
+#     startup (`x64_vtable = isa.machine_isa(...)`). That is a declaration of
+#     storage, not a construction site - but nothing in the text distinguishes the
+#     two, so each such file is permitted with the EXACT number of globals it
+#     declares. A fourth global in a file permitted for three fails the census and
+#     has to be argued for. The declaration must precede every function in its file
+#     (module scope, `<top>`) - this scan attributes a bare declaration to the
+#     nearest PRECEDING `fun`/`pub fun` line, so one written after some unrelated
+#     function would be misattributed to it rather than read as `<top>`.
 #
 # The list below IS the census of clearing sites. It is short on purpose: adding to
 # it, or raising a count, is how the next place to forget a field gets introduced.
@@ -107,11 +134,15 @@ val CENSUS_COUNT:       i32 = 3;  # a permitted group holds a different number t
 
 # the number of permitted (file, function) groups
 #
-# Nine constructors - `Inst` and `Operand` have two apiece, the shared model's and
-# a target's own - plus the five arch registration modules whose process-global
-# vtable storage must be declared bare. Two kinds of entry, kept in one table so
-# neither is invisible.
-val ALLOWED_LEN: usize = 14;
+# Eleven constructors - `Inst` and `Operand` have two apiece, the shared model's
+# and a target's own; the four ISA contracts (`IsaVTable`, `RegMachine`,
+# `ModuleEmitter`, `RelocSeam`); the MIR instruction and its virtual register
+# (`MirInstr`, `MirVReg`); and the calling-convention vtable (`AbiVTable`) - plus
+# the eleven registration modules whose process-global storage must be declared
+# bare: five ISA arch modules install an `IsaVTable` (+ `RegMachine` / `RelocSeam`
+# where the arch has one), six ABI convention modules install an `AbiVTable`. Two
+# kinds of entry, kept in one table so neither is invisible.
+val ALLOWED_LEN: usize = 22;
 
 # the enclosing function name of each permitted group, positionally paired with
 # `allowed_file` and `allowed_count`. `<top>` is module scope
@@ -125,6 +156,8 @@ fun allowed_fun(i: usize) str {
     if (i == 6)  { ret "inst"; }
     if (i == 7)  { ret "op_none"; }
     if (i == 8)  { ret "instr"; }
+    if (i == 14) { ret "abi_vtable"; }
+    if (i == 15) { ret "vreg"; }
     ret "<top>";
 }
 
@@ -144,19 +177,30 @@ fun allowed_file(i: usize) str {
     if (i == 10) { ret "src/lang/target/isa/arm64/register.mach"; }
     if (i == 11) { ret "src/lang/target/isa/riscv64/register.mach"; }
     if (i == 12) { ret "src/lang/target/isa/mos6502/register.mach"; }
-    ret "src/lang/target/isa/spirv/register.mach";
+    if (i == 13) { ret "src/lang/target/isa/spirv/register.mach"; }
+    if (i == 14) { ret "src/lang/target/abi.mach"; }
+    if (i == 15) { ret "src/lang/be/codegen/mir.mach"; }
+    if (i == 16) { ret "src/lang/target/abi/sysv.mach"; }
+    if (i == 17) { ret "src/lang/target/abi/win64.mach"; }
+    if (i == 18) { ret "src/lang/target/abi/aapcs64.mach"; }
+    if (i == 19) { ret "src/lang/target/abi/lp64.mach"; }
+    if (i == 20) { ret "src/lang/target/abi/mos6502.mach"; }
+    ret "src/lang/target/abi/spirv.mach";
 }
 
 # the exact number of bare declarations each permitted group may hold
 #
-# One for each constructor. Three for an arch that installs a vtable, a register
-# machine and a relocation seam (x86-64, aarch64, riscv64); two for mos6502 (no
-# seam - a raw flat image carries no relocations) and for spirv (a whole-module
-# emitter payload instead of a register machine, and no seam by construction)
+# One for each constructor. Three for an ISA arch that installs a vtable, a
+# register machine and a relocation seam (x86-64, aarch64, riscv64); two for
+# mos6502 (no seam - a raw flat image carries no relocations) and for spirv (a
+# whole-module emitter payload instead of a register machine, and no seam by
+# construction). One for each ABI convention module's single `AbiVTable` global -
+# unlike `IsaVTable`, a calling convention bundles no sub-contracts alongside it.
 fun allowed_count(i: usize) usize {
     if (i <= 8)  { ret 1; }
     if (i <= 11) { ret 3; }
-    ret 2;
+    if (i <= 13) { ret 2; }
+    ret 1;
 }
 
 # the permitted group a site belongs to
@@ -243,6 +287,8 @@ fun is_model_type(text: str, at: usize, len: usize) bool {
     if (str_region_equals(text, at, len, "ModuleEmitter"))     { ret true; }
     if (str_region_equals(text, at, len, "RelocSeam"))         { ret true; }
     if (str_region_equals(text, at, len, "MirInstr"))          { ret true; }
+    if (str_region_equals(text, at, len, "MirVReg"))           { ret true; }
+    if (str_region_equals(text, at, len, "AbiVTable"))         { ret true; }
     if (str_region_equals(text, at, len, "isa.Inst"))          { ret true; }
     if (str_region_equals(text, at, len, "isa.Operand"))       { ret true; }
     if (str_region_equals(text, at, len, "isa.IsaVTable"))     { ret true; }
@@ -250,6 +296,8 @@ fun is_model_type(text: str, at: usize, len: usize) bool {
     if (str_region_equals(text, at, len, "isa.ModuleEmitter")) { ret true; }
     if (str_region_equals(text, at, len, "isa.RelocSeam"))     { ret true; }
     if (str_region_equals(text, at, len, "mir.MirInstr"))      { ret true; }
+    if (str_region_equals(text, at, len, "mir.MirVReg"))       { ret true; }
+    if (str_region_equals(text, at, len, "abi.AbiVTable"))     { ret true; }
     ret false;
 }
 


### PR DESCRIPTION
## Summary

The construction-site census only pattern-matches a bare `var x: Type;` declaration with no initializer — invisible to a record rebuilt field-by-field through a slot (an array element, a non-zeroing reallocated table entry). `AbiVTable` shipped that blind spot two ways at once: it was never a censused record at all, and its six calling-convention modules each hand-wrote all 16 fields into a process-global vtable. `MirVReg`'s three vreg-table growth sites write every field into a slot from a non-zeroing `A.reallocate` — the same shape #2032 shipped for `MirInstr` before #2321 closed it with `instr_like`.

- **`AbiVTable` × 6+4**: added `abi.abi_vtable(...)` (positional-arity constructor, mirrors `isa.reg_machine`). All six `register()`/`register_win64()` functions now do one whole-record assignment instead of 16 field writes. Also converted the 4 test-only bare `AbiVTable` declarations found across the tree (`abi.mach`, `win64.mach`, `mir/abi.mach`, `frame.mach`) — turning on the census for a type means *every* bare declaration of it must convert or be permitted, not just the ones originally scoped.
- **`MirInstr` × 1**: `legalize.emit_piece`, the one remaining field-by-field rebuild, converts to `dst[ci] = mir.instr(...)` plus the three fields it inherits from its source.
- **`MirVReg` × 3+1**: added `mir.vreg(id, class, vector, secret)`. All three growth sites plus one more test helper (`ctvalidate.t_vreg`, found by the census itself during verification) now assign the whole record into the slot.
- **`isa/tests.mach`**: extended `is_model_type`/`ALLOWED_LEN`/`allowed_fun`/`allowed_file`/`allowed_count` for the two new records and their groups; corrected the header's disproven "`var` does not zero, so a field-by-field build reads frame residue" claim; added a **WHY A REBUILT SLOT IS A DIFFERENT PROPERTY** section documenting, per the issue's own bar, that this scan cannot verify a rebuild-through-a-slot conversion happened — only that its constructor isn't itself hand-built.

**Excluded**: `isa.inst_blank` — its `dst`/`src1`/`src2` fields are set via `make_none()`, which writes `-1` sentinels, not zero, so it's not part of this cleanup. The 3 test-helper `MirVReg` table-fill sites (`legalize.mach`/`looprotate.mach`/`regalloc.mach` `t_vregs`/`t_fn`) are untouched too — the census's own lower-priority "test helper" bucket.

Closes #2335

## Verification

- `mach test .` through a from-source compiler: **1012 passed, 0 failed**, including the census test and both new guard tests.
- **Mutation-tested both new guards**: dropped a pointer field, a numeric field, and a boolean field from each of `abi_vtable` and `vreg` in turn, confirmed the corresponding guard test fails each time, then restored. (First attempt at the guards copied `instr_like`'s poison-then-copy pattern, which doesn't apply to a fresh-`var`-then-set-fields constructor — a dropped assignment there degrades to the type's own zero default regardless of poisoning, so the test only catches it if the test's own expected value differs from that zero default. Caught this via mutation-testing before it shipped and rewrote both guards accordingly.)
- Self-hosting fixpoint: built generation C with generation B at `--jobs 1`; all 215 object files and the final binary are byte-identical.

## Test plan

- [x] `mach test .` via from-source compiler: 1012/0/1012, including the census and both new guards
- [x] Mutation-tested `abi_vtable:sets_every_field` and `vreg:sets_every_field` against a pointer, numeric, and boolean field drop each
- [x] B == C self-hosting fixpoint at `--jobs 1` (objects + binary, byte-identical)
- [x] CI green before marking ready