### PR TITLE
docs,fe: say why a layout intrinsic is rejected, and document where it works

### DIFF
--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -36,6 +36,26 @@ fun probe[T]() u64 {
 `$offset_of`'s **second** argument is the exception: a bare field name, resolved
 against the record's layout, never a type or a value.
 
+### Where a layout intrinsic is constant
+
+These three measure a type's storage, so they have a value only once that type's
+layout is resolved. That happens after the front end has settled every type, which
+puts two positions out of reach — both of them decided *while* layout is still
+being worked out:
+
+| position | layout intrinsic |
+|---|---|
+| `val` / `var` initializer | yes |
+| global `align` | yes |
+| record / union type `align` | **no** |
+| array length `[N]T` | **no** |
+| `$if` / `$or` condition | **no** |
+
+A literal is accepted in all of them. Binding the intrinsic to a `val` and using
+the name does not work around a rejection — the binding's own value is folded
+after the point that needs it. Every rejected position reports the reason at the
+point of failure. Lifting the restriction is tracked as #2442.
+
 ## Type intrinsic
 
 `$type_of(expr)` produces a comptime type value — the resolved type of its
@@ -260,7 +280,10 @@ $or { $error("no writer for this argument type"); }    # compile error on an unh
 > **`$assert` not yet implemented.** `$assert` parses as a comptime directive
 > but the compiler does not yet evaluate it. It is intended as sugar over `$if`
 > plus `$error` — `$assert(cond, "msg")` ≡ `$if (!cond) { $error("msg"); }`,
-> e.g. `$assert($size_of(i64) == 8, "expected 64-bit i64");`.
+> e.g. `$assert($mach.build.arch == $mach.arch.x86_64, "expected x86_64");`. Being `$if`
+> sugar, it will inherit `$if`'s restrictions: a layout intrinsic in `cond` is
+> rejected for the reason above, so `$assert($size_of(i64) == 8, ...)` is not a
+> spelling to plan on until #2442 lands.
 
 ## Not provided as intrinsics
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -135,17 +135,29 @@ caller's instruction cache, or to hold code size down on a constrained target.
 ### `align(expr)` — alignment override
 
 Sets the alignment of a global variable or a record/union type. `expr` must
-be a comptime integer — either a literal or a comptime expression such as
-`$size_of(T)` or `$align_of(T)`.
+be a comptime integer.
+
+Which spellings are accepted depends on the target, because the two are decided
+at different points in the compile:
+
+| target | literal | `$size_of(T)` / `$align_of(T)` |
+|---|---|---|
+| global variable | yes | yes |
+| record / union type | yes | **no** |
+
+A type's alignment is settled while the layouts it would measure are themselves
+still being resolved, so a layout intrinsic has no value yet at that point; a
+global's alignment is decided later, once layout is known. Binding the intrinsic
+to a `val` first does not help — the same ordering applies. Tracked as #2442.
 
 ```mach
 #[align(64)]
 pub var cache_line: u8 = 0;
 
-#[align($size_of(Pair))]
+#[align($size_of(Pair))]   # ok: layout is known by the time a global is aligned
 pub var g_cmp: u8 = 0;
 
-#[align(32)]
+#[align(32)]               # ok: a literal needs no layout
 rec Over { a: u8; }
 ```
 

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -221,7 +221,9 @@ decorated-decl ::= { decorator } decl
 - Clauses may appear on the same line (space-separated) or one per line.
 - The argument list is optional; a bare `#[inline]` carries no arguments.
 - Arguments are comptime expressions (not types): `$size_of(T)` is a valid
-  argument; `T` as a raw type name is not.
+  argument; `T` as a raw type name is not. A layout intrinsic argument is
+  further restricted by position — accepted on a global's `align`, rejected on a
+  record/union type's, see [decorators.md](decorators.md).
 - The closed directive set is `symbol`, `section`, `inline`, `align`,
   `library`, `oblivious`, `scalar`. See [decorators.md](decorators.md).
 - A backtick form (`` `name(args)` ``) existed through v2.3.0 and was removed in
@@ -415,7 +417,9 @@ Notes:
 - `*T` is a pointer; the untyped pointer type is the primitive name `ptr`
   (an ordinary `named-type`, not its own syntax).
 - `[N]T` is a fixed-length array; `N` is a full expression (a comptime
-  constant). Nesting (`[N][M]T`) falls out of the recursion.
+  constant). Nesting (`[N][M]T`) falls out of the recursion. A layout intrinsic
+  is not a usable `N` — the length is needed before layout is resolved — see
+  [comptime-intrinsics.md](comptime-intrinsics.md).
 - `named-type` covers both plain names (`i64`, `Point`) and generic
   instantiations (`Pair[i64, u8]`, `Map[str, u32]`). The dotted path allows
   module-qualified names (`core.Thing`).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1303,6 +1303,35 @@ test "mach.lang.driver:aggregate_eq_positive_control" {
     ret bad;
 }
 
+# a layout intrinsic is syntactically a call, so the comptime evaluator rejects it
+# wherever a call is rejected - but the operand IS constant, and it is the position
+# that cannot see layout yet. each rejecting position must say so rather than call
+# `$size_of(Pair)` non-constant (#2316); a genuinely variable operand must keep the
+# original wording, which is what stops the correction from becoming a blanket
+# reword that hides the real non-constant case
+test "mach.lang.driver:layout_intrinsic_position_diagnostics" {
+    var bad: i32 = 0;
+
+    # a record/union type's `align` is settled while layout is still resolving
+    if (ut_vec_diag("rec Pair { a: u64; b: u64; }\n#[align($align_of(Pair))]\nrec Over { x: u8; }\nfun main() i32 { ret 0; }\n",
+                    "a layout intrinsic is not available in an `align` on a type") != 0) { bad = 1; }
+
+    # an array length is needed before layout is resolved
+    if (ut_vec_diag("rec Pair { a: u64; b: u64; }\nfun main() i32 { var a: [$size_of(Pair)]u8; ret a[0]::i32; }\n",
+                    "a layout intrinsic is not available as an array length") != 0) { bad = 1; }
+
+    # every other position reports from the evaluator itself - a `$if` condition here
+    if (ut_vec_diag("rec Pair { a: u64; b: u64; }\n$if ($size_of(Pair) == 16) {\n    fun helper() i32 { ret 1; }\n}\nfun main() i32 { ret 0; }\n",
+                    "a layout intrinsic has no value in this position") != 0) { bad = 1; }
+
+    # the distinctness that matters: a real call is still reported as a call, so the
+    # layout-intrinsic wording never absorbs the genuinely non-comptime operand
+    if (ut_vec_diag("fun sz() u64 { ret 16; }\nfun main() i32 { var a: [sz()]u8; ret a[0]::i32; }\n",
+                    "array length is not a comptime constant") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # build a two-module project (main.mach + a.mach) from source, run resolve + sema,
 # and return the project so a test can inspect p.s.diags. the caller tears down the
 # project and session

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -711,7 +711,19 @@ pub fun eval(
         ret eval_module_member(c, e);
     }
 
-    if (k == expr.EXPR_KIND_CALL)       { ret R.err[CTValue, str]("function calls are not comptime-evaluable"); }
+    # a layout intrinsic is a call syntactically but a constant semantically, so the
+    # generic call rejection describes it wrongly and sends the reader hunting for a
+    # non-constant operand that is not there. it is the POSITION that cannot see
+    # layout yet, not the operand that is variable (#2316). callers with position
+    # advice to add (a type `align`, an array length) test
+    # `is_layout_intrinsic_call` and replace this; every other position - a `$if`
+    # condition, a `$assert` - reports it from here.
+    if (k == expr.EXPR_KIND_CALL) {
+        if (is_layout_intrinsic_call(a, source, e)) {
+            ret R.err[CTValue, str]("a layout intrinsic has no value in this position: layout is not resolved until after the front end, and this is decided before then (#2442)");
+        }
+        ret R.err[CTValue, str]("function calls are not comptime-evaluable");
+    }
     if (k == expr.EXPR_KIND_INDEX)      { ret R.err[CTValue, str]("index expressions are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_CAST)       { ret R.err[CTValue, str]("type casts are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_ARRAY_LIT)  { ret R.err[CTValue, str]("array literals are not comptime-evaluable"); }
@@ -1351,6 +1363,26 @@ pub fun type_of_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
 # ret:    true when `eid` is a `$fields(...)` call
 pub fun is_fields_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
     ret is_comptime_call(a, source, eid, "fields");
+}
+
+# whether `eid` is a LAYOUT intrinsic call - `$size_of(T)`, `$align_of(T)`, or
+# `$offset_of(T, f)` - recognized structurally like the other intrinsic predicates
+#
+# These three are the intrinsics whose value is a measurement of a type's storage,
+# so they are constant only where that type's layout is already settled. `eval`
+# rejects every call uniformly ("function calls are not comptime-evaluable"), which
+# is true of a runtime call but misleading for these: the operand IS constant, it is
+# the position that cannot see layout yet (#2316). A caller that reports a
+# non-constant operand asks this first, so the two causes get different diagnostics.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the callee span)
+# eid:    expression id to test
+# ret:    true when `eid` is a layout intrinsic call
+pub fun is_layout_intrinsic_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (is_comptime_call(a, source, eid, "size_of"))   { ret true; }
+    if (is_comptime_call(a, source, eid, "align_of"))  { ret true; }
+    ret is_comptime_call(a, source, eid, "offset_of");
 }
 
 # the single type-naming argument of a `$fields(T)` call, or

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -506,6 +506,10 @@ fun record_type_align(sc: *context.SemaContext, did: id.DeclId, ty: type.TypeId)
             val arg: id.ExprId = sc.a.expr_ids[dec.args_start];
             val ev: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arg, ?sc.s.interner);
             if (R.is_err[comptime.CTValue, str](ev)) {
+                if (comptime.is_layout_intrinsic_call(sc.a, sc.source, arg)) {
+                    context.report(sc, dec.name, "a layout intrinsic is not available in an `align` on a type: this alignment is decided while the layout it would measure is still being resolved. use a literal, or `#[align(...)]` on a global, where layout is known (#2442)");
+                    ret;
+                }
                 context.report(sc, dec.name, "`align` on a type must be a compile-time constant");
                 ret;
             }
@@ -2746,6 +2750,10 @@ fun resolve_type_array(sc: *context.SemaContext, ar: *atype.TypeArray, span: tok
 
     val len_r: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, ar.length, ?sc.s.interner);
     if (R.is_err[comptime.CTValue, str](len_r)) {
+        if (comptime.is_layout_intrinsic_call(sc.a, sc.source, ar.length)) {
+            context.report(sc, span, "a layout intrinsic is not available as an array length: the length is needed while the layout it would measure is still being resolved. use a literal length (binding the intrinsic to a `val` first does not help - its value is folded after this point) (#2442)");
+            ret type.TYPE_ERROR;
+        }
         context.report(sc, span, "cannot infer type: array length is not a comptime constant");
         ret type.TYPE_ERROR;
     }


### PR DESCRIPTION
Closes #2316. The fold gap itself is #2442 (parked).

Option 2 from the issue: make the documentation true and the diagnostics honest,
without wiring the fold.

## The diagnostics

A layout intrinsic is syntactically a call, so `comptime.eval` rejected it with
"function calls are not comptime-evaluable" and the two position-specific callers
reported the operand as non-constant. All three describe `$size_of(Pair)` as not
compile-time-constant — the most constant thing in the language — and send the
reader hunting for a variable operand that is not there. **The operand is constant;
the position cannot see layout yet.**

`comptime.is_layout_intrinsic_call` is now the one structural predicate for the
three layout intrinsics, mirroring the existing `is_fields_call` / `is_error_call`.
`eval` reports the real cause for *every* position; the type-`align` and
array-length callers add position-specific advice on top.

A genuinely non-comptime operand keeps the original wording. That distinction is
pinned by a test, because a blanket reword would have hidden the real
non-constant case — which is the failure mode worth guarding here.

## Slightly beyond the two sites the issue names

The issue asked for a check of the `$assert` note, and it turned out to be a third
instance: `$assert` is documented as sugar over `$if`, illustrated with
`$assert($size_of(i64) == 8, ...)`, and `$if` rejects layout intrinsics too. Rather
than special-case a third caller I put the correction in `eval` itself, so every
present and future position gets the real cause for free. The illustration is
replaced with one that works (`$mach.build.arch == $mach.arch.x86_64`) and the note
now says the intrinsic form waits on #2442.

## The docs

`decorators.md` offered `$size_of(T)` for a type `align`, `grammar.md` called it a
valid decorator argument without qualification, and `comptime-intrinsics.md` had no
statement of scope at all. Each now says which positions work, with the table living
in `comptime-intrinsics.md` as the intrinsics' own page.

**The `val` workaround is documented as NOT working, verified rather than assumed.**
My first draft of the array-length diagnostic suggested it; I tested it before
shipping and it is rejected — `val N: u64 = $size_of(Pair)` is accepted but
`[N]u8` is not, because the binding's value folds after the point that needs it.
A literal is the only workaround, and that is what both the message and the docs say.## Verification

One pinned process, dev merged (`5c6c8845`, which brought #2335). Object comparisons
carry both controls in the same run — self-check (tree vs itself, must be 0) and
positive control (one byte flipped in a copy, must be caught as exactly 1).

**Emission neutrality.** A dev-baseline compiler and this branch's compiler, each
built generation-2 by the same recipe, each compiling the same fixed tree — one that
triggers none of the changed diagnostics, so only the neutral path is measured:

| | objects differing | linked binary |
|---|---|---|
| debug | 0/215 | identical |
| release | 0/215 | identical |

with self-check 0/215 and positive control 1/215 alongside. The change is comments,
diagnostic strings, docs and one test, so emitted code is untouched.

**Other bars.** `mach test` through the from-source compiler: 1013 passed, 0 failed;
dev measured with the same compiler is 1012, so the delta is exactly the one test
added here. `B == C` self-host fixpoint: passes. `int` suite on linux: all cases
passed. All 16 CI checks green.

**Diagnostics, as a user now sees them:**

```
error: a layout intrinsic is not available in an `align` on a type: this alignment
is decided while the layout it would measure is still being resolved. use a literal,
or `#[align(...)]` on a global, where layout is known (#2442)

error: a layout intrinsic is not available as an array length: the length is needed
while the layout it would measure is still being resolved. use a literal length
(binding the intrinsic to a `val` first does not help - its value is folded after
this point) (#2442)

error: a layout intrinsic has no value in this position: layout is not resolved
until after the front end, and this is decided before then (#2442)
```

The accepted positions are unchanged and re-confirmed: global `align` with an
intrinsic, `val` initializer with an intrinsic, and literals in every position.