### PR TITLE
docs: correct the last two "var does not zero" comments to their true rationale

### DIFF
--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -615,14 +615,15 @@ pub fun mem_operand_of(ctx: *LowerCtx, v: value.Value) mir.MirOperand {
 # append a MIR instruction to a block, growing its instruction list on demand
 #
 # Enforces the asm_block invariant: a mir.MirInstr carries an inline-asm payload
-# only for a mir.MIR_ASM instruction, and nil otherwise. Instructions are built
-# field-by-field and only the mir.MIR_ASM emitter ever sets asm_block; since
-# struct locals are not guaranteed zero-initialized, an otherwise-indeterminate
-# asm_block would reach the back end -- `regalloc.flatten` reads `asm_block !=
-# nil` as the inline-asm clobber-barrier discriminant and would wrongly fence
-# almost every instruction, collapsing the argument-register reservation
-# windows. Nil it here, at the single store chokepoint, so the field's
-# documented contract holds.
+# only for a mir.MIR_ASM instruction, and nil otherwise. The hazard here is not an
+# uninitialized field - `mir.instr` already zero-fills it - but inheritance:
+# `mir.instr_like` carries EVERY field from its source, including asm_block, so an
+# instruction derived from an ASM one and then repurposed to a different opcode can
+# still arrive here holding its source's payload. `regalloc.flatten` reads
+# `asm_block != nil` as the inline-asm clobber-barrier discriminant and would
+# wrongly fence almost every instruction, collapsing the argument-register
+# reservation windows. Nil it here, at the single store chokepoint, so the field's
+# documented contract holds regardless of how `mi` was derived.
 # ---
 # ctx: the lowering context
 # mb:  the block to append to
@@ -637,15 +638,17 @@ pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result
     # the real loc is what the line table wants.)
     ni.loc = ctx.cur_loc;
     # the inline instance rides beside loc, stamped at the same chokepoint for the same
-    # non-zero-init reason, so every lowered instruction carries its inlined-from origin.
+    # inheritance reason: an instr_like-derived `mi` would otherwise carry its source's
+    # inline_site rather than the instruction actually being lowered now.
     ni.inline_site = ctx.cur_inline_site;
-    # the vector lane descriptor rides beside loc for the same non-zero-init reason,
-    # so every lowered instruction carries the lane shape of the IR op it came from
-    # (VEC_LANE_NONE for non-vector code, leaving those instructions unaffected).
+    # the vector lane descriptor rides beside loc for the same inheritance reason, so
+    # every lowered instruction carries the lane shape of the IR op it came from rather
+    # than a derived source's (VEC_LANE_NONE for non-vector code, leaving those
+    # instructions unaffected).
     ni.vec_lane = ctx.cur_vec_lane;
     # the store-secret seed rides beside vec_lane, stamped at the same chokepoint for the
-    # same non-zero-init reason; read only on a store / memzero opcode, so a stray value
-    # on any other instruction is inert (#1646).
+    # same inheritance reason; read only on a store / memzero opcode, so a stray value on
+    # any other instruction is inert (#1646).
     ni.writes_secret = ctx.cur_writes_secret;
     # the dbg-binding list defaults empty here for the same reason (callers build
     # instructions field-by-field and never set it); any pending -g binding then

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -1272,11 +1272,15 @@ pub fun make_sym_mod(sym_id: u32, size: u8, mod: SymModifier) Operand {
 # its form uses, so an unset field never reads as a live operand.
 #
 # EVERY `Inst` IN THE BACK END STARTS HERE, and that is what makes adding a field
-# additive: `var` does not zero, so a construction site that cleared its fields by
-# hand would leave any later field holding whatever the frame held. That is not
-# hypothetical - `Operand.sym_mod` was added and three hand-written clears did not
-# learn about it. One constructor means a new field is neutral at every site by
-# construction, and a target that wants a value sets it deliberately.
+# additive: a hand-written clear, built directly rather than through this
+# constructor, would not learn about a field added later - not hypothetical,
+# `Operand.sym_mod` was added and three hand-written clears did not learn about it.
+# It also matters HOW `dst` / `src1` / `src2` clear: `make_none()` sets `reg` /
+# `base` / `index` to their `-1` ABSENT sentinels, not to 0 - and 0 is a live
+# register / base / index id, so a bare declaration's zero-fill would read as
+# "operand 0", a plausible wrong value, not as "no operand". One constructor means
+# a new field is neutral at every site by construction, and a target that wants a
+# value sets it deliberately.
 # ---
 # ret: an Inst with opcode 0 and three absent operands
 pub fun inst_blank() Inst {


### PR DESCRIPTION
## Summary

Closes out the "`var` does not zero" claim family started by #2394 and continued by #2438. Both remaining sites' code is already correct — this is comment-only, no code changes.

- **`src/lang/be/codegen/mir/context.mach` `push_instr`**: the `asm_block` clear is load-bearing, but not for the stated reason. `mir.instr` already zero-fills `asm_block`, so the real hazard is *inheritance* — `mir.instr_like` carries every field from its source, so an instruction derived from a `MIR_ASM` one and repurposed to a different opcode can still arrive here holding its source's payload, which `regalloc.flatten` would misread as an inline-asm clobber barrier. The three neighboring "same reason" comments (`inline_site`/`vec_lane`/`writes_secret`) are updated to the same inheritance framing for coherence, since they explicitly refer back to this paragraph.
- **`src/lang/target/isa.mach` `inst_blank`**: the code is correct as-is (#2394 kept it) — `make_none()` sets `dst`/`src1`/`src2`'s `reg`/`base`/`index` to `-1` absent sentinels, not to `0`, and `0` is a live register/base/index id. A bare declaration's zero-fill would read as "operand 0", a plausible wrong value, not "no operand" — that sentinel is why this site must build through the constructor, not "var doesn't zero".

Closes #2440

## Verification

- `git grep -niE "not zero-init|does not zero|not guaranteed zero-initialized" -- 'src/*'`: **no hits** tree-wide, matching the issue's acceptance criteria exactly.
- `mach test .` through a from-source compiler: **1012 passed, 0 failed**, unchanged from the pre-change baseline.
- Byte-identical to a `dev` baseline: self-checked the comparison apparatus first (built the same `dev` tree twice, 0/215 object differences), then built this branch and compared — **0/215 objects differ, final binary hash identical**. Confirms the comment-only change is genuinely inert.

## Test plan

- [x] Acceptance grep: no site tree-wide asserts the false claim
- [x] `mach test .` via from-source compiler: 1012/0/1012
- [x] Byte-identical to `dev` baseline (self-checked apparatus first, then 0/215 objects differ + identical binary hash)
- [x] CI green before marking ready