### PR TITLE
perf(riscv64): select an identity conversion to a move so copies coalesce

### DIFF
--- a/src/lang/target/isa/riscv64/rules.mach
+++ b/src/lang/target/isa/riscv64/rules.mach
@@ -86,7 +86,7 @@ pub def SelectFn: fun(*A.Allocator, *target.Target, *mir.MirFunction) R.Result[b
 # the number of rules in the pack: every generic opcode that can reach RV64
 # selection plus the six fused compare-and-branch survivors. the coverage test
 # pins it so a rule added to the table and this count cannot drift apart
-pub val RULE_COUNT: usize = 61;
+pub val RULE_COUNT: usize = 63;
 
 # the number of post-selection plain register-copy opcodes: the concrete GP move
 # (`mv`), the concrete float move (`fmv`), and the generic `mir.MIR_MOV` the
@@ -240,6 +240,7 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # MIR_BITCAST, a plain register copy the integer conversion encoder handles.
     # the float-bank guard precedes its plain pass-through fallback.
     rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv64.FMV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: guard_identity_copy,        kind: rules.RULE_RETAG, to: riscv64.MOV::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: nil,                        kind: rules.RULE_PASS,  to: 0,               expand: nil, expansion_length: 0 },
 
     # the integer width conversions and the float conversions pass through
@@ -249,6 +250,7 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # fcvt.*.* / fmv for the float forms) and the allocator reads operand 0 as a
     # clean def.
     rules.Rule{ op: mir.MIR_TRUNC,    gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_SEXT,     gate: rules.GATE_ANY, guard: guard_identity_copy, kind: rules.RULE_RETAG, to: riscv64.MOV::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_SEXT,     gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_ZEXT,     gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_FP_TRUNC, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
@@ -324,6 +326,35 @@ pub fun is_reg_move(opcode: u32) bool {
     ret rules.is_reg_move(?PACK, opcode);
 }
 
+# guard admitting a conversion that is the IDENTITY on RV64, so selection can
+# retag it to the plain register move it already encodes as
+#
+# Two conversions do nothing at full register width: an 8-byte `BITCAST` between
+# GP registers reinterprets all 64 bits, and a `SEXT` whose SOURCE is already
+# 8 bytes has no sign bit left to propagate. `encode_convert` emitted `mv rd, rs`
+# for both - correct, but as a CONVERSION rather than a copy, so
+# `instr_is_reg_copy` rejected it (`is_reg_move` does not admit a conversion
+# opcode, rightly) and neither the coalescer nor the #2275 self-copy sweeps could
+# see it. When the allocator then gave source and destination the same register,
+# the result was `mv a0, a0` (#2392).
+#
+# The width test is the same one `encode_convert` used to select its `mv` arm - `dw
+# >= 8` for the reinterpret, `sw >= 8` for the sign-extension, and nothing narrower -
+# so the retag admits exactly the cases that already encoded as a move and no others:
+# a narrower `BITCAST` still canonicalizes through `sext.w` (an lp64 32-bit value
+# is held sign-extended, so that one is NOT a copy), and a narrowing `SEXT` still
+# takes the shift pair. x86-64 gets this for free by retagging every `MIR_BITCAST`
+# to `x64.MOV`; RV64 cannot retag unconditionally, because of that `sext.w`.
+# ---
+# f:   the MIR function owning the instruction (unused; the widths are self-contained)
+# mi:  the instruction under selection
+# ret: true when the conversion is a full-width register copy
+fun guard_identity_copy(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
+    if (mi.operand_count != 2) { ret false; }
+    if (mi.opcode == mir.MIR_BITCAST) { ret mi.width >= 8; }
+    ret mi.src_width >= 8;
+}
+
 # a float-bank physical register operand for register index `idx` (the composite
 # float id the allocator hands the float pre-coloring), so a test can drive the
 # float-vs-GP move classification without a vreg table
@@ -372,6 +403,10 @@ test "mach.lang.target.isa.riscv64.rules:opcode_rewrites" {
     # bitcast (instrs[10]) stays MIR_BITCAST.
     instrs[9].opcode  = mir.MIR_BITCAST;
     ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(11);
+    # a same-bank GP<->GP bitcast reaches the identity-copy guard only when it is
+    # well formed, and this fixture builds every instruction with THREE operands, so
+    # this one stays a bitcast on operand count alone. The two-operand shapes - the
+    # ones a real lowering produces - are covered by `identity_conversions` below.
     instrs[10].opcode = mir.MIR_BITCAST;
     instrs[13].opcode = mir.MIR_BITCAST;
     ops[13][0] = fp_preg(10); ops[13][1] = fp_preg(11);
@@ -426,7 +461,7 @@ test "mach.lang.target.isa.riscv64.rules:is_reg_move" {
 # length, so an appended rule and the storage size can never drift apart
 test "mach.lang.target.isa.riscv64.rules:generic_opcode_coverage" {
     val pack: *rules.RulePack = ?PACK;
-    if (pack.rule_count != 61) { ret 1; }
+    if (pack.rule_count != 63) { ret 1; }
 
     # the shared selection alphabet (a property of mir.lower_ir, one table for
     # every pack's coverage test): reachable opcodes must terminate in a rule.
@@ -472,4 +507,87 @@ test "mach.lang.target.isa.riscv64.rules:generic_opcode_coverage" {
     }
     if (pack.fused_cbr_cc_count != 6) { ret 1; }
     ret 0;
+}
+
+# a conversion that is the identity at full register width selects to the plain
+# register move it already encoded as, and a narrowing one does not
+#
+# `encode_convert` emitted `mv rd, rs` for an 8-byte BITCAST and for a SEXT whose
+# source is already 8 bytes, but as a CONVERSION - so `instr_is_reg_copy` rejected
+# it and neither the coalescer nor the #2275 self-copy sweeps could see it (#2392).
+# The retag is what puts them back in reach of the copy machinery.
+#
+# The narrow cases are the half that makes the guard non-trivial: a BITCAST below 8
+# bytes canonicalizes through `sext.w` (an lp64 32-bit value is HELD sign-extended,
+# so it is not a copy), and a narrowing SEXT takes `sext.w` or the shift pair. x64
+# retags every MIR_BITCAST unconditionally; RV64 cannot, and this pins that.
+test "mach.lang.target.isa.riscv64.rules:identity_conversions_select_to_a_move" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    var tgt:   target.Target;
+
+    var instrs: [7]mir.MirInstr;
+    var ops:    [7][2]mir.MirOperand;
+    var i:      u32 = 0;
+    for (i < 7) {
+        ops[i][0] = mir.op_preg(10);
+        ops[i][1] = mir.op_preg(11);
+        instrs[i].operands      = ?ops[i][0];
+        instrs[i].operand_count = 2;
+        instrs[i].width         = 8;
+        instrs[i].src_width     = 8;
+        i = i + 1;
+    }
+
+    # an 8-byte GP reinterpret is a full-width copy.
+    instrs[0].opcode = mir.MIR_BITCAST;
+    # a 4-byte reinterpret is NOT: it canonicalizes to the sign-extended form.
+    instrs[1].opcode = mir.MIR_BITCAST;
+    instrs[1].width  = 4;
+    # a sign-extension whose source already fills the register has nothing to do.
+    instrs[2].opcode = mir.MIR_SEXT;
+    # a real widening sign-extension does.
+    instrs[3].opcode = mir.MIR_SEXT;
+    instrs[3].src_width = 4;
+    instrs[4].opcode = mir.MIR_SEXT;
+    instrs[4].src_width = 1;
+    # the float-bank rule still precedes the identity guard at full width.
+    instrs[5].opcode = mir.MIR_BITCAST;
+    ops[5][0] = fp_preg(10);
+    # a 4-byte sign-extension whose source is ALSO 4 bytes. the widths match, so
+    # only the `src_width >= 8` half of the guard rejects it - and it must be
+    # rejected: `sext.w` canonicalizes a 32-bit value to the sign-extended form lp64
+    # holds it in, which a plain `mv` would not do.
+    instrs[6].opcode    = mir.MIR_SEXT;
+    instrs[6].width     = 4;
+    instrs[6].src_width = 4;
+
+    var blk: mir.MirBlock;
+    blk.id          = 0;
+    blk.instrs      = ?instrs[0];
+    blk.instr_count = 7;
+
+    var f: mir.MirFunction;
+    f.blocks      = ?blk;
+    f.block_count = 1;
+    f.vreg_count  = 0;
+
+    val r: R.Result[bool, str] = select(?alloc, ?tgt, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    if (instrs[0].opcode != riscv64.MOV::u32) { bad = 1; }
+    if (instrs[1].opcode != mir.MIR_BITCAST)  { bad = 1; }
+    if (instrs[2].opcode != riscv64.MOV::u32) { bad = 1; }
+    if (instrs[3].opcode != mir.MIR_SEXT)     { bad = 1; }
+    if (instrs[4].opcode != mir.MIR_SEXT)     { bad = 1; }
+    if (instrs[5].opcode != riscv64.FMV::u32) { bad = 1; }
+    if (instrs[6].opcode != mir.MIR_SEXT)     { bad = 1; }
+
+    # the retagged forms must now be what the copy machinery calls a move, which is
+    # the entire point of the retag - a MIR_BITCAST is not one.
+    if (!is_reg_move(riscv64.MOV::u32))  { bad = 1; }
+    if (is_reg_move(mir.MIR_BITCAST))    { bad = 1; }
+    if (is_reg_move(mir.MIR_SEXT))       { bad = 1; }
+
+    ret bad;
 }


### PR DESCRIPTION
Closes #2392.

> The issue's original figures (29,830 instances / ~119 KB) were a measurement artifact — they counted `%pcrel_lo` relocation placeholders in unlinked objects. Full correction with evidence in [this comment](https://github.com/briar-systems/mach/issues/2392#issuecomment-5172991727). Everything below is measured on the **linked** binary.

## What was wrong

`encode_convert` encodes two conversions as `mv rd, rs`, because on RV64 both are the identity at full register width: an 8-byte `BITCAST` between GP registers reinterprets all 64 bits, and a `SEXT` whose **source** is already 8 bytes has no sign bit left to propagate.

But they were emitted as *conversions*, so `instr_is_reg_copy` rejected them — `is_reg_move` does not admit a conversion opcode, and that rejection is correct as written, since a conversion generally is not a copy. The consequence is the one the issue's title now names: **the coalescer could not see them.** Neither could the #2275 self-copy sweeps.

## The fix, and why it is in selection

Selection retags both identity cases to `riscv64.MOV`, which is exactly where x86-64 already handles this — `x64/rules.mach:249` retags every `MIR_BITCAST` to `x64.MOV`, which is why x86-64 never had the problem.

RV64 **cannot** retag unconditionally the way x64 does. A narrower `BITCAST` must still canonicalize through `sext.w`, because lp64 holds a 32-bit value in sign-extended form; a plain `mv` would not produce that. So the retag is width-guarded:

```mach
fun guard_identity_copy(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
    if (mi.operand_count != 2) { ret false; }
    if (mi.opcode == mir.MIR_BITCAST) { ret mi.width >= 8; }
    ret mi.src_width >= 8;
}
```

Those width tests are the *same* ones `encode_convert` used to pick its `mv` arm, so the retag admits precisely the cases that already encoded as a move and no others. The change is behaviour-preserving per instruction; what changes is that the copy machinery can now act on them.

## Numbers (linked riscv64 compiler, dev → this branch)

| profile | instructions | .text | degenerate `mv rd,rd` |
|---|---|---|---|
| debug | 1,101,767 → 1,098,960 (**−2,807**) | 4,701,953 → 4,692,065 (**−9,888 bytes**, −0.21%) | 8 → 4 |
| release | 2,121,374 → 2,116,251 (**−5,123**) | 8,780,001 → 8,760,049 (**−19,952 bytes**, −0.23%) | 19 → 20 |

The win is **coalescing**, not dead-instruction removal — about 200x more instructions than eliminating the degenerate movs would have been. Note the release degenerate count goes *up* by one: that metric was never the real story, and different code layout after coalescing moves it around. Reported as measured.

Measurement used a self-check control first (same compiler twice → byte-identical) before any delta was believed.

## Tests

One new selection test, `riscv64.rules:identity_conversions_select_to_a_move`, pinning both directions: the 8-byte `BITCAST` and 8-byte-source `SEXT` retag to `riscv64.MOV`, while a 4-byte `BITCAST`, a widening `SEXT` (4→8, 1→8) and a **4-byte `SEXT` whose source is also 4 bytes** all stay generic. It also asserts the retagged opcode is what `is_reg_move` admits and the generic ones are not, which is the whole point of the retag.

**Guard mutation-checked 5/5** — widening either width test, narrowing either to admit nothing, and dropping the operand-count term each fail a test.

The mutation pass found a real hole in my first version. The guard originally carried a `width == src_width` term on the `SEXT` arm, and widening `src_width >= 8` to `>= 4` failed **no** test, because that term masked the mutation. The case that distinguishes them is a 4-byte `SEXT` whose source is also 4 bytes — which is exactly the shape that would **miscompile** if retagged, since it must keep its `sext.w`. I added that case and dropped the `width == src_width` term: it was narrower than `encode_convert`'s own condition, inert either way, and untestable.

I also commented a now-misleading assertion in the pre-existing `opcode_rewrites` test — its "same-bank GP bitcast survives" case only still holds because that fixture builds every instruction with three operands, so the guard rejects it on operand count.

## Verification

- Three-generation fixpoint `b == c`, on the branch and on the `dev` baseline.
- `mach test` **1014 / 0** (dev baseline 1013 — the one added test).
- `int/run.sh` green on **`linux` and `linux-riscv64`**, both profiles. The rv64 lane passed fully including the 1852 self-host case, with no qemu-11 flake this run, so no baseline comparison was needed.

Emission changes by construction, so there is no neutrality bar here.

## Follow-up

aarch64 has the same selection gap (`arm64/rules.mach` passes both opcodes through; x86-64 alone retags) and is filed as #2443. Not folded in — different target, different canonicalization contract, its own bar.