### PR TITLE
test(int): pin the panic exit contract, so exit 139 cannot silently regress

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -20,6 +20,11 @@
 #                 for a cross-built target with no host runner (a freestanding
 #                 aarch64/riscv64 image on the x86_64 leg). the observable is a
 #                 constant, so the golden is the fact "it emitted".
+#   panic-exit  — run a binary EXPECTED to call std.system.panic and report its
+#                 stderr message plus its exit status, distinguishing a deliberate
+#                 termination from a signal death (#2369). unlike relro-fault, the
+#                 message is part of the observable: printing it and then faulting
+#                 is exactly the regression this guards.
 #   debuginfo   — build the case with and without `-g` (run.sh builds both) and
 #                 assert over the artifacts: llvm-dwarfdump --verify accepts the `-g`
 #                 image and `-g` is loadable-byte additive (PT_LOAD segments identical).
@@ -109,6 +114,42 @@ produce_relro_fault() {
         echo "relro_write=faulted"
     else
         echo "relro_write=exit$ec"
+    fi
+}
+
+# produce_panic_exit <runmode> <target> <binary>
+# runs a binary EXPECTED to call std.system.panic and reports its stderr message
+# followed by its exit status, distinguishing a deliberate PANIC_EXIT from a signal
+# death (#2369): panic used to write its message and then execute a trap
+# instruction with no exit syscall, which faulted (SIGSEGV, exit 139 on x86_64;
+# SIGTRAP, exit 133, on aarch64 / riscv64) and made a correctly detected internal
+# error indistinguishable from memory corruption. stdout+stderr are captured to a
+# file rather than a command substitution, both to avoid stripping the message's
+# own trailing newline (`$()` strips all of them) and to keep the exit-status read
+# on the line directly after the command, matching produce_relro_fault - the
+# proven-safe shape under this harness's `set -e`.
+#
+# a signal death is 128 + N with N in 1..64 (POSIX real-time signals cap there); the
+# fact is reported as `signal(<n>)` rather than the raw number so a golden reviewer
+# does not have to recompute N to see what regressed.
+produce_panic_exit() {
+    runmode=$1
+    target=$2
+    bin=$3
+    out=$(mktemp)
+    if [ "$runmode" = "qemu" ]; then
+        interp=$(qemu_bin "$target") || { rm -f "$out"; return 1; }
+        "$interp" "$bin" >"$out" 2>&1
+    else
+        "$bin" >"$out" 2>&1
+    fi
+    ec=$?
+    cat "$out"
+    rm -f "$out"
+    if [ "$ec" -ge 129 ] && [ "$ec" -le 192 ]; then
+        echo "exit=signal($((ec - 128)))"
+    else
+        echo "exit=$ec"
     fi
 }
 
@@ -629,6 +670,7 @@ produce() {
     case "$run" in
         exec)        produce_exec "$@" ;;
         relro-fault) produce_relro_fault "$@" ;;
+        panic-exit)  produce_panic_exit "$@" ;;
         field)       produce_field "$@" ;;
         relro)       produce_relro "$@" ;;
         flat-loader) produce_flat_loader "$@" ;;

--- a/int/regression/2369-panic-exit/case.conf
+++ b/int/regression/2369-panic-exit/case.conf
@@ -1,0 +1,6 @@
+# the runtime half of #2369: a deliberate panic must print its message and then
+# terminate with PANIC_EXIT (255), not fault. panic_os has an arm on every leg
+# targets.conf declares (linux x86_64/aarch64/riscv64, windows, darwin
+# x86_64/aarch64), so this runs everywhere; the golden is target-independent since
+# the message and the exit fact do not vary by ISA.
+run: panic-exit

--- a/int/regression/2369-panic-exit/expect.txt
+++ b/int/regression/2369-panic-exit/expect.txt
@@ -1,0 +1,2 @@
+panic: case2369 deliberate test panic
+exit=255

--- a/int/regression/2369-panic-exit/mach.toml
+++ b/int/regression/2369-panic-exit/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2369"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2369-panic-exit/src/main.mach
+++ b/int/regression/2369-panic-exit/src/main.mach
@@ -1,0 +1,27 @@
+# regression pin for #2369: a deliberate panic must print and terminate cleanly,
+# not fault
+#
+# panic wrote its message and then executed a bare trap instruction with no exit
+# syscall. `hlt` is PRIVILEGED - executing it in user mode raises #GP, which the
+# kernel delivers as SIGSEGV - so every deliberate panic exited 139, the exact
+# status a wild pointer produces; aarch64 and riscv64 disagreed further, trapping
+# to SIGTRAP (133). The abort path itself was not unsound: the message write always
+# completed, and the fault came entirely from the terminator's choice of
+# instruction. Fixed in mach-std (panic.mach) to issue exit_group / exit with
+# PANIC_EXIT = 255, matching `std.system.os.abort()` - a status that cannot be
+# confused with a signal death (128 + N, N in 1..64).
+#
+# this pins the observable contract rather than the mechanism: the panic-exit
+# producer captures the message plus the exit status, so a regression that
+# reintroduces a bare trap terminator shows up as `exit=signal(N)` here instead of
+# silently passing.
+
+use std.runtime;
+use std.types.size.usize;
+use std.system.panic.panic;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    panic("panic: case2369 deliberate test panic\n");
+    ret 0;
+}

--- a/int/run.sh
+++ b/int/run.sh
@@ -163,13 +163,14 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
     # the mach target to compile: the build-target if set, else the leg itself.
     build_target=${case_build_target:-$target}
 
-    # the golden is shared across build-targets for target-independent observables (exec
-    # and the relro-fault guard, whose output is target-independent; debuginfo, whose
-    # two facts — validator-clean and additive — hold identically on every ELF ISA) and
-    # per-build-target for structural producers (their fact is format-specific).
+    # the golden is shared across build-targets for target-independent observables (exec,
+    # the relro-fault guard, and the panic-exit guard, whose outputs are all
+    # target-independent; debuginfo, whose two facts — validator-clean and additive —
+    # hold identically on every ELF ISA) and per-build-target for structural producers
+    # (their fact is format-specific).
     case "$case_run" in
-        exec|relro-fault|debuginfo) golden="$dir/expect.txt" ;;
-        *)                          golden="$dir/expect.$build_target.txt" ;;
+        exec|relro-fault|panic-exit|debuginfo) golden="$dir/expect.txt" ;;
+        *)                                     golden="$dir/expect.$build_target.txt" ;;
     esac
 
     for profile in $case_profiles; do


### PR DESCRIPTION
## Summary

Investigation-first, as scoped. Root cause: the fault was already found and fixed in **mach-std**, not this repo — nothing lands here on the code side.

`panic` wrote its message and then executed a bare trap instruction with no exit syscall. `hlt` is **privileged**; executing it in user mode raises `#GP`, which the kernel delivers as `SIGSEGV` — exit 139 on x86_64, and aarch64/riscv64 disagreed further, trapping to `SIGTRAP` (133). The abort path itself was never unsound (no bad handle, no freed state, no dead frame) — the message write always completed, and the fault came entirely from the terminator's choice of instruction.

mach-std's `panic.mach` already fixed this (commit `257771a`, `fix(panic): terminate deliberately instead of dying by signal`): it now issues `exit_group`/`exit` with `PANIC_EXIT = 255` — matching `std.system.os.abort()` — on every arm (linux x86_64/aarch64/riscv64, darwin x86_64/aarch64, windows). The **currently pinned** mach-std commit (`a35a0c4`) already carries the fix.

**Reproduced with a trivial panicking program through a from-source compiler on all three ISAs, both profiles**: message printed, exit 255, no fault, confirming the fix works as shipped. No mach-std change needed and no compiler-side code change needed.

What was still missing, per the issue's own bar: *"The distinction is checked in CI somewhere, so this cannot silently regress into looking like a crash again."* It wasn't. Adds a `panic-exit` `int/` producer (modeled on the existing `relro-fault` producer's proven-safe shape under this harness's `set -e`) that captures a panicking binary's stderr message plus its exit status, reporting a signal death as `signal(N)` rather than the raw code. `int/regression/2369-panic-exit` pins the observable contract on every leg `targets.conf` declares — the observable is target-independent, so one golden is shared across the matrix, matching `exec` and `relro-fault`.

Closes #2369

## Verification

- Reproduced the pre-fix defect's *absence*: a trivial `panic(...)` program through a from-source compiler prints its message and exits 255 (not 139/signal-death) across x86_64 (native), aarch64 (qemu), riscv64 (qemu), both debug and release — 6/6 combinations clean.
- `mach test .`: 1014 passed, 0 failed.
- New `int/regression/2369-panic-exit` case: `PASS` on `linux` and `linux-riscv64` (the two legs runnable in this sandbox); builds clean for `linux-arm64`, `windows`, `darwin-x86_64`, `darwin-aarch64` (execution on those legs is CI-only — `linux-arm64` runs `native` on a real arm64 runner per `targets.conf`, not qemu).
- Ran the full `int/` suite (not just the new case) on `linux` and `linux-riscv64` to confirm the `produce.sh`/`run.sh` changes don't regress anything else — all green.
- No `src/lang` changes; compiler binary is **byte-identical** to the `dev` baseline it was built against (confirmed by hash).

## Test plan

- [x] Trivial panic repro: message printed + exit 255, no fault, on all 3 ISAs × both profiles
- [x] `mach test .`: 1014/0/1014
- [x] New `int/regression/2369-panic-exit` case passes on `linux` and `linux-riscv64`; builds clean on the remaining 4 legs
- [x] Full `int/` suite unaffected on `linux` and `linux-riscv64`
- [x] Compiler binary byte-identical to `dev` baseline (no `src/lang` touched)
- [x] CI green before marking ready