### PR TITLE
fix(sema): resolve type layout on demand so layout intrinsics fold in type positions

### DIFF
--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -38,23 +38,40 @@ against the record's layout, never a type or a value.
 
 ### Where a layout intrinsic is constant
 
-These three measure a type's storage, so they have a value only once that type's
-layout is resolved. That happens after the front end has settled every type, which
-puts two positions out of reach — both of them decided *while* layout is still
-being worked out:
+`$size_of` and `$align_of` fold in every **type** position, including ones resolved
+before layout would otherwise be known — the measured type's layout is established
+on demand when the measurement asks for it, so where the type is *declared* relative
+to where it is measured makes no difference:
 
-| position | layout intrinsic |
+| position | `$size_of` / `$align_of` |
 |---|---|
 | `val` / `var` initializer | yes |
 | global `align` | yes |
-| record / union type `align` | **no** |
-| array length `[N]T` | **no** |
+| record / union type `align` | yes |
+| array length `[N]T` | yes |
 | `$if` / `$or` condition | **no** |
 
-A literal is accepted in all of them. Binding the intrinsic to a `val` and using
-the name does not work around a rejection — the binding's own value is folded
-after the point that needs it. Every rejected position reports the reason at the
-point of failure. Lifting the restriction is tracked as #2442.
+```mach
+rec Pair { a: u64; b: u64; }
+
+#[align($align_of(Pair))]        # a type's alignment
+rec Over { x: u8; }
+
+rec Holder { buf: [$size_of(Pair)]u8; }   # an array length, inside a field type
+```
+
+`$offset_of` is the exception among the three: it folds in a value position but not
+in a type one, because a field offset is settled during lowering rather than by the
+front end.
+
+A `$if` / `$or` condition is not a type position and does not get the on-demand
+layout, so a layout intrinsic there is still rejected, and reports why.
+
+**Cycles are refused, not resolved.** A measurement whose answer is one of its own
+inputs — `#[align($size_of(Self))]`, or two types each aligned to the other's size —
+is reported as a layout cycle naming the type that closes it. A pointer field does
+not create one: it stores an address of fixed width, so `rec Node { next: *Node; }`
+measures normally.
 
 ## Type intrinsic
 
@@ -283,7 +300,7 @@ $or { $error("no writer for this argument type"); }    # compile error on an unh
 > e.g. `$assert($mach.build.arch == $mach.arch.x86_64, "expected x86_64");`. Being `$if`
 > sugar, it will inherit `$if`'s restrictions: a layout intrinsic in `cond` is
 > rejected for the reason above, so `$assert($size_of(i64) == 8, ...)` is not a
-> spelling to plan on until #2442 lands.
+> spelling to plan on.
 
 ## Not provided as intrinsics
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -135,31 +135,27 @@ caller's instruction cache, or to hold code size down on a constrained target.
 ### `align(expr)` — alignment override
 
 Sets the alignment of a global variable or a record/union type. `expr` must
-be a comptime integer.
+be a comptime integer — either a literal or a comptime expression such as
+`$size_of(T)` or `$align_of(T)`, in both positions.
 
-Which spellings are accepted depends on the target, because the two are decided
-at different points in the compile:
-
-| target | literal | `$size_of(T)` / `$align_of(T)` |
-|---|---|---|
-| global variable | yes | yes |
-| record / union type | yes | **no** |
-
-A type's alignment is settled while the layouts it would measure are themselves
-still being resolved, so a layout intrinsic has no value yet at that point; a
-global's alignment is decided later, once layout is known. Binding the intrinsic
-to a `val` first does not help — the same ordering applies. Tracked as #2442.
+A type's alignment is settled during type resolution, before layouts are otherwise
+known; the measured type's layout is established on demand when the intrinsic asks
+for it, so the answer does not depend on whether `T` is declared above or below.
 
 ```mach
 #[align(64)]
 pub var cache_line: u8 = 0;
 
-#[align($size_of(Pair))]   # ok: layout is known by the time a global is aligned
+#[align($size_of(Pair))]
 pub var g_cmp: u8 = 0;
 
-#[align(32)]               # ok: a literal needs no layout
+#[align($align_of(Pair))]
 rec Over { a: u8; }
 ```
+
+A type aligned to a measurement of itself — `#[align($size_of(Self))]`, or two
+types each aligned to the other's size — is a layout cycle and is reported as one,
+naming the type that closes it.
 
 - On a `var` / `val`, sets the global's section alignment and address
   alignment.

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -221,9 +221,8 @@ decorated-decl ::= { decorator } decl
 - Clauses may appear on the same line (space-separated) or one per line.
 - The argument list is optional; a bare `#[inline]` carries no arguments.
 - Arguments are comptime expressions (not types): `$size_of(T)` is a valid
-  argument; `T` as a raw type name is not. A layout intrinsic argument is
-  further restricted by position — accepted on a global's `align`, rejected on a
-  record/union type's, see [decorators.md](decorators.md).
+  argument; `T` as a raw type name is not. A layout intrinsic is accepted on both
+  a global's `align` and a record/union type's, see [decorators.md](decorators.md).
 - The closed directive set is `symbol`, `section`, `inline`, `align`,
   `library`, `oblivious`, `scalar`. See [decorators.md](decorators.md).
 - A backtick form (`` `name(args)` ``) existed through v2.3.0 and was removed in
@@ -417,9 +416,9 @@ Notes:
 - `*T` is a pointer; the untyped pointer type is the primitive name `ptr`
   (an ordinary `named-type`, not its own syntax).
 - `[N]T` is a fixed-length array; `N` is a full expression (a comptime
-  constant). Nesting (`[N][M]T`) falls out of the recursion. A layout intrinsic
-  is not a usable `N` — the length is needed before layout is resolved — see
-  [comptime-intrinsics.md](comptime-intrinsics.md).
+  constant), including `$size_of(T)` / `$align_of(T)` — see
+  [comptime-intrinsics.md](comptime-intrinsics.md). Nesting (`[N][M]T`) falls out
+  of the recursion.
 - `named-type` covers both plain names (`i64`, `Point`) and generic
   instantiations (`Pair[i64, u8]`, `Map[str, u32]`). The dotted path allows
   module-qualified names (`core.Thing`).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1303,31 +1303,144 @@ test "mach.lang.driver:aggregate_eq_positive_control" {
     ret bad;
 }
 
-# a layout intrinsic is syntactically a call, so the comptime evaluator rejects it
-# wherever a call is rejected - but the operand IS constant, and it is the position
-# that cannot see layout yet. each rejecting position must say so rather than call
-# `$size_of(Pair)` non-constant (#2316); a genuinely variable operand must keep the
-# original wording, which is what stops the correction from becoming a blanket
-# reword that hides the real non-constant case
-test "mach.lang.driver:layout_intrinsic_position_diagnostics" {
+# 0 when a two-module project compiles through sema with no error diagnostic
+fun ut_layout_ok2(main: str, lib: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach";
+    names[1] = "lib.mach";
+    var texts: [2]str;
+    texts[0] = main;
+    texts[1] = lib;
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val n: u32 = ut_count_errors(?p.s.diags);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    if (n == 0) { ret 0; }
+    ret 1;
+}
+
+# 0 when `src` compiles through sema with no error diagnostic, 1 otherwise
+fun ut_layout_ok(src: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val n: u32 = ut_count_errors(?p.s.diags);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    if (n == 0) { ret 0; }
+    ret 1;
+}
+
+# a layout intrinsic folds in a type `align` and an array length, and the answer does
+# not depend on where the measured type is declared (#2442)
+#
+# The forcing is what is being pinned. Before it, the same program compiled or failed
+# on whether the measured type was written above or below the measuring one, because
+# the decl pass reaches declarations in source order - so EVERY case here is paired
+# with its reversed-order twin, and a regression that reintroduces the ordering
+# dependence fails exactly half of them rather than all of them.
+test "mach.lang.driver:layout_intrinsic_folds_order_independent" {
     var bad: i32 = 0;
 
-    # a record/union type's `align` is settled while layout is still resolving
-    if (ut_vec_diag("rec Pair { a: u64; b: u64; }\n#[align($align_of(Pair))]\nrec Over { x: u8; }\nfun main() i32 { ret 0; }\n",
-                    "a layout intrinsic is not available in an `align` on a type") != 0) { bad = 1; }
+    # type `align`, measured type declared BEFORE and AFTER
+    if (ut_layout_ok("rec Pair { a: u64; b: u64; }\n#[align($align_of(Pair))]\nrec Over { x: u8; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n") != 0) { bad = 1; }
+    if (ut_layout_ok("#[align($align_of(Pair))]\nrec Over { x: u8; }\nrec Pair { a: u64; b: u64; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n") != 0) { bad = 1; }
 
-    # an array length is needed before layout is resolved
-    if (ut_vec_diag("rec Pair { a: u64; b: u64; }\nfun main() i32 { var a: [$size_of(Pair)]u8; ret a[0]::i32; }\n",
-                    "a layout intrinsic is not available as an array length") != 0) { bad = 1; }
+    # array length, measured type declared BEFORE and AFTER. the `[16]u8` literal
+    # type-checks only when the length folded to exactly 16, so these pin the VALUE
+    # and not merely that something constant came back.
+    if (ut_layout_ok("rec Pair { a: u64; b: u64; }\nfun main() i32 { var a: [$size_of(Pair)]u8 = [16]u8{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; ret a[15]::i32; }\n") != 0) { bad = 1; }
+    if (ut_layout_ok("fun main() i32 { var a: [$size_of(Pair)]u8 = [16]u8{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; ret a[15]::i32; }\nrec Pair { a: u64; b: u64; }\n") != 0) { bad = 1; }
 
-    # every other position reports from the evaluator itself - a `$if` condition here
+    # a wrong fold is caught: the same length against an [8]u8 literal must mismatch
+    if (ut_vec_diag("rec Pair { a: u64; b: u64; }\nfun main() i32 { var a: [$size_of(Pair)]u8 = [8]u8{0,0,0,0,0,0,0,0}; ret a[0]::i32; }\n",
+                    "type mismatch") != 0) { bad = 1; }
+
+    # array length INSIDE a field type - the mutual dependency, since the length is
+    # needed while field tables are still being built - both orders
+    if (ut_layout_ok("rec Pair { a: u64; b: u64; }\nrec Holder { buf: [$size_of(Pair)]u8; }\nfun main() i32 { var h: Holder; h.buf[15] = 0; ret h.buf[15]::i32; }\n") != 0) { bad = 1; }
+    if (ut_layout_ok("rec Holder { buf: [$size_of(Pair)]u8; }\nrec Pair { a: u64; b: u64; }\nfun main() i32 { var h: Holder; h.buf[15] = 0; ret h.buf[15]::i32; }\n") != 0) { bad = 1; }
+
+    # the override feeds back into layout: Over's natural alignment is 1, so an
+    # `$align_of(Over)` of 8 is only right if the `align` fold was applied first
+    if (ut_layout_ok("rec Pair { a: u64; b: u64; }\n#[align($align_of(Pair))]\nrec Over { x: u8; }\nfun main() i32 { var a: [$align_of(Over)]u8 = [8]u8{0,0,0,0,0,0,0,0}; ret a[7]::i32; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# a layout query whose answer is one of its own inputs is refused by name, and the
+# by-value walk that finds it stops at pointers so an ordinary self-referential
+# record stays measurable (#2442)
+test "mach.lang.driver:layout_intrinsic_cycles" {
+    var bad: i32 = 0;
+
+    # a type aligned to its own size
+    if (ut_vec_diag("#[align($size_of(Over))]\nrec Over { x: u8; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n",
+                    "layout cycle: measuring `Over`") != 0) { bad = 1; }
+
+    # a mutual pair, each aligned to the other's size
+    if (ut_vec_diag("#[align($size_of(B))]\nrec A { x: u8; }\n#[align($size_of(A))]\nrec B { y: u8; }\nfun main() i32 { var a: A; a.x = 0; ret a.x::i32; }\n",
+                    "layout cycle") != 0) { bad = 1; }
+
+    # a record whose field length measures itself
+    if (ut_vec_diag("rec Loop { buf: [$size_of(Loop)]u8; }\nfun main() i32 { ret 0; }\n",
+                    "layout cycle") != 0) { bad = 1; }
+
+    # NOT a cycle: a pointer stores an address of fixed width, so the walk stops and
+    # the ordinary linked-list shape is still measurable
+    if (ut_layout_ok("rec Node { next: *Node; v: u64; }\n#[align($align_of(Node))]\nrec Aligned { x: u8; }\nfun main() i32 { var a: Aligned; a.x = 0; ret a.x::i32; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# positions the fold does NOT cover keep reporting the real cause, and a genuinely
+# non-comptime operand keeps the original wording - so neither correction absorbs the
+# other (#2316, #2442)
+test "mach.lang.driver:layout_intrinsic_remaining_positions" {
+    var bad: i32 = 0;
+
+    # a `$if` condition is not a type position and has no layout to force
     if (ut_vec_diag("rec Pair { a: u64; b: u64; }\n$if ($size_of(Pair) == 16) {\n    fun helper() i32 { ret 1; }\n}\nfun main() i32 { ret 0; }\n",
                     "a layout intrinsic has no value in this position") != 0) { bad = 1; }
 
-    # the distinctness that matters: a real call is still reported as a call, so the
-    # layout-intrinsic wording never absorbs the genuinely non-comptime operand
+    # a real call in array-length position is still reported as a call
     if (ut_vec_diag("fun sz() u64 { ret 16; }\nfun main() i32 { var a: [sz()]u8; ret a[0]::i32; }\n",
                     "array length is not a comptime constant") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# an IMPORTED nominal measures in both folding positions (#2442)
+#
+# The premise the same-module-only forcing rests on: dependencies are type-checked
+# first, in topo order, so another module's nominal is already elaborated and needs
+# no forcing here. If that ever stopped holding, these would fail with an
+# undetermined layout rather than silently measuring something wrong - the extent
+# fails closed - which is why the premise is pinned rather than assumed.
+test "mach.lang.driver:layout_intrinsic_cross_module" {
+    var bad: i32 = 0;
+
+    # imported type in a type `align`
+    if (ut_layout_ok2("use lib: uniontest.lib;\n#[align($align_of(lib.Pair))]\nrec Over { x: u8; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n",
+                      "pub rec Pair { a: u64; b: u64; }\n") != 0) { bad = 1; }
+
+    # imported type as an array length, pinned to the value 16 by the literal
+    if (ut_layout_ok2("use lib: uniontest.lib;\nfun main() i32 { var b: [$size_of(lib.Pair)]u8 = [16]u8{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; ret b[15]::i32; }\n",
+                      "pub rec Pair { a: u64; b: u64; }\n") != 0) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1379,6 +1379,33 @@ test "mach.lang.driver:layout_intrinsic_folds_order_independent" {
     # `$align_of(Over)` of 8 is only right if the `align` fold was applied first
     if (ut_layout_ok("rec Pair { a: u64; b: u64; }\n#[align($align_of(Pair))]\nrec Over { x: u8; }\nfun main() i32 { var a: [$align_of(Over)]u8 = [8]u8{0,0,0,0,0,0,0,0}; ret a[7]::i32; }\n") != 0) { bad = 1; }
 
+    # a UNION measures the same way, both orders (the walk treats rec and uni alike;
+    # only `nominal_overlays` distinguishes them, and that is the measurement's job)
+    if (ut_layout_ok("uni Choice { a: u64; b: u32; }\n#[align($align_of(Choice))]\nrec Over { x: u8; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n") != 0) { bad = 1; }
+    if (ut_layout_ok("#[align($align_of(Choice))]\nrec Over { x: u8; }\nuni Choice { a: u64; b: u32; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# a GENERIC INSTANCE measures in a folding position, in either declaration order
+# (#2442)
+#
+# The TYPE_INSTANCE arm of the forcing walk, which is the one path that does not
+# build a table itself: an instance's fields are materialized from its generic's by
+# `generics.ensure_fields`, so the walk has to reach the GENERIC's declaration first
+# and elaborate that. With the generic declared after the measurement, nothing else
+# would have elaborated it - so a regression here shows up only in the second of
+# each pair, exactly as with the plain-nominal cases.
+test "mach.lang.driver:layout_intrinsic_generic_instance" {
+    var bad: i32 = 0;
+
+    # `Pair[i64]` is two i64s: the [16]u8 literal pins the value, not just acceptance
+    if (ut_layout_ok("rec Pair[T] { a: T; b: T; }\nfun main() i32 { var a: [$size_of(Pair[i64])]u8 = [16]u8{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; ret a[15]::i32; }\n") != 0) { bad = 1; }
+    if (ut_layout_ok("fun main() i32 { var a: [$size_of(Pair[i64])]u8 = [16]u8{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; ret a[15]::i32; }\nrec Pair[T] { a: T; b: T; }\n") != 0) { bad = 1; }
+
+    # the same instance in a type `align`, generic declared after
+    if (ut_layout_ok("#[align($align_of(Pair[i64]))]\nrec Over { x: u8; }\nrec Pair[T] { a: T; b: T; }\nfun main() i32 { var o: Over; o.x = 0; ret o.x::i32; }\n") != 0) { bad = 1; }
+
     ret bad;
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1380,9 +1380,25 @@ pub fun is_fields_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
 # eid:    expression id to test
 # ret:    true when `eid` is a layout intrinsic call
 pub fun is_layout_intrinsic_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
-    if (is_comptime_call(a, source, eid, "size_of"))   { ret true; }
-    if (is_comptime_call(a, source, eid, "align_of"))  { ret true; }
+    if (is_size_of_call(a, source, eid))  { ret true; }
+    if (is_align_of_call(a, source, eid)) { ret true; }
     ret is_comptime_call(a, source, eid, "offset_of");
+}
+
+# whether `eid` is a `$size_of(T)` call
+pub fun is_size_of_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    ret is_comptime_call(a, source, eid, "size_of");
+}
+
+# whether `eid` is an `$align_of(T)` call
+pub fun is_align_of_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    ret is_comptime_call(a, source, eid, "align_of");
+}
+
+# the single type-naming argument of a `$size_of(T)` / `$align_of(T)` call, or
+# EXPR_NIL when `eid` is not such a call or carries no argument
+pub fun layout_intrinsic_type_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
+    ret first_call_arg(a, eid);
 }
 
 # the single type-naming argument of a `$fields(T)` call, or

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -713,14 +713,13 @@ pub fun eval(
 
     # a layout intrinsic is a call syntactically but a constant semantically, so the
     # generic call rejection describes it wrongly and sends the reader hunting for a
-    # non-constant operand that is not there. it is the POSITION that cannot see
-    # layout yet, not the operand that is variable (#2316). callers with position
-    # advice to add (a type `align`, an array length) test
-    # `is_layout_intrinsic_call` and replace this; every other position - a `$if`
-    # condition, a `$assert` - reports it from here.
+    # non-constant operand that is not there (#2316). TYPE positions do not arrive
+    # here at all - they fold the intrinsic against forced layout material before
+    # asking the evaluator (#2442) - so what reaches this arm is a position with no
+    # layout to force: a `$if` / `$or` condition, or a `$assert` once it evaluates.
     if (k == expr.EXPR_KIND_CALL) {
         if (is_layout_intrinsic_call(a, source, e)) {
-            ret R.err[CTValue, str]("a layout intrinsic has no value in this position: layout is not resolved until after the front end, and this is decided before then (#2442)");
+            ret R.err[CTValue, str]("a layout intrinsic has no value in this position: it measures a type's storage, which only a type position resolves");
         }
         ret R.err[CTValue, str]("function calls are not comptime-evaluable");
     }
@@ -1368,12 +1367,15 @@ pub fun is_fields_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
 # whether `eid` is a LAYOUT intrinsic call - `$size_of(T)`, `$align_of(T)`, or
 # `$offset_of(T, f)` - recognized structurally like the other intrinsic predicates
 #
-# These three are the intrinsics whose value is a measurement of a type's storage,
-# so they are constant only where that type's layout is already settled. `eval`
-# rejects every call uniformly ("function calls are not comptime-evaluable"), which
-# is true of a runtime call but misleading for these: the operand IS constant, it is
-# the position that cannot see layout yet (#2316). A caller that reports a
-# non-constant operand asks this first, so the two causes get different diagnostics.
+# These three are the intrinsics whose value is a measurement of a type's storage.
+# `eval` rejects every call uniformly ("function calls are not comptime-evaluable"),
+# which is true of a runtime call but misleading for these: the operand IS constant
+# (#2316). Asking this first is what keeps the two causes apart, so a genuinely
+# non-comptime operand keeps the wording that is right for it.
+#
+# Used by `eval` for the positions that cannot resolve a type - a `$if` condition.
+# A type position never consults this: it folds through sema's layout forcing
+# instead (#2442), where the measurement has an answer rather than a reason.
 # ---
 # a:      the ast that owns `eid`
 # source: source text (for the callee span)

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -844,11 +844,6 @@ fun typeid_array_alloc(a: *A.Allocator, len: usize) R.Result[*type.TypeId, str] 
     ret R.ok[*type.TypeId, str](arr);
 }
 
-# allocate a `len`-slot memo-state array, each slot TYPE_MEMO_NONE
-# ---
-# a:   allocator
-# len: number of state slots
-# ret: the allocated array, or an allocation error
 # allocate the per-declaration layout state array, every slot LAYOUT_PENDING (#2442)
 # ---
 # a:   allocator
@@ -867,6 +862,11 @@ fun layout_state_alloc(a: *A.Allocator, len: usize) R.Result[*u8, str] {
     ret R.ok[*u8, str](arr);
 }
 
+# allocate a `len`-slot memo-state array, each slot TYPE_MEMO_NONE
+# ---
+# a:   allocator
+# len: number of state slots
+# ret: the allocated array, or an allocation error
 fun memo_array_alloc(a: *A.Allocator, len: usize) R.Result[*u8, str] {
     val res_arr: R.Result[*u8, str] = A.allocate[u8](a, len);
     if (R.is_err[*u8, str](res_arr)) { ret res_arr; }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -270,6 +270,7 @@ pub fun reinfer_pack_each_body(
     # no memo: an episode resolves under its instance's substitution, where the same
     # node asks a different question per instantiation (#2334).
     sc.type_resolved_memo = nil;
+    sc.layout_state       = nil;
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
@@ -376,6 +377,7 @@ pub fun reinfer_instance_body(
     sc.type_resolved_ty = sema_result.type_resolved_ty;
     sc.decl_type        = sema_result.decl_type;
     sc.type_resolved_memo = nil;
+    sc.layout_state       = nil;
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
@@ -575,6 +577,7 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.expr_type        = scratch_expr;
     tsc.type_resolved_ty = o_type_resolved;
     tsc.type_resolved_memo = nil;
+    tsc.layout_state       = nil;
     tsc.decl_type        = scratch_decl;
     tsc.callee_eid       = id.EXPR_NIL;
     tsc.in_comptime_gate = false;
@@ -749,6 +752,7 @@ fun init_context(
     sc.expr_type        = nil;
     sc.type_resolved_ty = nil;
     sc.type_resolved_memo = nil;
+    sc.layout_state       = nil;
     sc.decl_type        = nil;
 
     sc.callee_eid       = id.EXPR_NIL;
@@ -800,6 +804,17 @@ fun init_context(
             ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](res_decl));
         }
         sc.decl_type = R.unwrap_ok[*type.TypeId, str](res_decl);
+
+        # the layout-forcing state is the main pass's alone (#2442), for the same reason
+        # the memo is: an episode reads tables the producer pass already elaborated, so
+        # it has nothing to force and must not re-enter a declaration under a
+        # substitution the original elaboration did not have.
+        val res_lay: R.Result[*u8, str] = layout_state_alloc(s.alloc, a.decl_len);
+        if (R.is_err[*u8, str](res_lay)) {
+            dnit_context(sc);
+            ret R.err[bool, str](R.unwrap_err[*u8, str](res_lay));
+        }
+        sc.layout_state = R.unwrap_ok[*u8, str](res_lay);
     }
 
     val res_seed: R.Result[bool, str] = infer.seed_builtins(sc);
@@ -834,6 +849,24 @@ fun typeid_array_alloc(a: *A.Allocator, len: usize) R.Result[*type.TypeId, str] 
 # a:   allocator
 # len: number of state slots
 # ret: the allocated array, or an allocation error
+# allocate the per-declaration layout state array, every slot LAYOUT_PENDING (#2442)
+# ---
+# a:   allocator
+# len: number of declarations in the module
+# ret: the cleared array, or an allocation error
+fun layout_state_alloc(a: *A.Allocator, len: usize) R.Result[*u8, str] {
+    val res_arr: R.Result[*u8, str] = A.allocate[u8](a, len);
+    if (R.is_err[*u8, str](res_arr)) { ret res_arr; }
+    val arr: *u8 = R.unwrap_ok[*u8, str](res_arr);
+
+    var i: u32 = 0;
+    for (i < len::u32) {
+        arr[i] = context.LAYOUT_PENDING;
+        i = i + 1;
+    }
+    ret R.ok[*u8, str](arr);
+}
+
 fun memo_array_alloc(a: *A.Allocator, len: usize) R.Result[*u8, str] {
     val res_arr: R.Result[*u8, str] = A.allocate[u8](a, len);
     if (R.is_err[*u8, str](res_arr)) { ret res_arr; }
@@ -886,9 +919,14 @@ fun dnit_context(sc: *context.SemaContext) {
     if (sc.type_resolved_memo != nil && sc.a.type_len > 0) {
         A.deallocate[u8](sc.s.alloc, sc.type_resolved_memo, sc.a.type_len);
     }
+    # same ownership as the memo: main-pass only, never transferred (#2442).
+    if (sc.layout_state != nil && sc.a.decl_len > 0) {
+        A.deallocate[u8](sc.s.alloc, sc.layout_state, sc.a.decl_len);
+    }
     sc.expr_type          = nil;
     sc.type_resolved_ty   = nil;
     sc.type_resolved_memo = nil;
+    sc.layout_state       = nil;
     sc.decl_type          = nil;
     context.inst_worklist_dnit(sc);
 }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -192,6 +192,19 @@ pub val TYPE_MEMO_NONE:     u8 = 0;
 pub val TYPE_MEMO_QUIET:    u8 = 1;
 pub val TYPE_MEMO_REPORTED: u8 = 2;
 
+# `layout_state` values (#2442): how far a declaration's own layout material has been
+# elaborated, so a layout query can force it on demand instead of depending on where
+# the decl pass has reached.
+#
+# ACTIVE is the cycle detector. It is set for exactly as long as a declaration's field
+# table and `align` are being established, so a layout query that reaches the same
+# declaration again is asking for an answer whose inputs include itself -
+# `#[align($size_of(Self))]`, or a mutual pair - and is refused by name rather than
+# recursing until the stack ends.
+pub val LAYOUT_PENDING: u8 = 0;
+pub val LAYOUT_ACTIVE:  u8 = 1;
+pub val LAYOUT_READY:   u8 = 2;
+
 # the number of distinct mixed-secrecy generic union instances one analysis remembers
 # having reported (#2225)
 val UNI_REPORT_CAP: u32 = 256;
@@ -327,6 +340,22 @@ pub rec SemaContext {
     # sink across its own call. That question survives memoization only if the answer is
     # remembered with the node.
     type_resolved_memo: *u8;
+
+    # per-declaration layout elaboration state (#2442): parallel to `ast.decls`, one
+    # `LAYOUT_*` value each.
+    #
+    # A layout intrinsic in a type `align` or an array length needs the measured type's
+    # field table, and the decl pass reaches declarations in source order - so without
+    # this the same program folded or failed depending on whether the measured type was
+    # written above or below. `ensure_nominal_laid_out` forces the material instead, and
+    # this array is what makes the forcing idempotent (READY is not rebuilt) and finite
+    # (ACTIVE is a cycle, not a deeper recursion).
+    #
+    # Same-module declarations only. A nominal from another module was elaborated by
+    # that module's own completed sema pass - dependencies are type-checked first, in
+    # topo order - so an imported type is always READY by construction and never needs
+    # forcing here.
+    layout_state: *u8;
 
     # set transiently by infer_call so infer_ident permits a comptime-parameter
     # function in callee position (a template, callable but not a value) and

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -23,6 +23,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_join;
 use std.types.string.str_region_equals;
 
 use A: std.allocator;
@@ -41,6 +42,7 @@ use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.generics;
+use mach.lang.layout;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.session;
@@ -149,8 +151,7 @@ fun infer_nominal(sc: *context.SemaContext, did: id.DeclId, name_span: token.Spa
     if (R.is_err[type.TypeId, str](tr)) { ret type.TYPE_ERROR; }
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
-    build_field_table(sc, ty, r.fields_start, r.fields_len);
-    record_type_align(sc, did, ty);
+    elaborate_nominal(sc, did, ty, r.fields_start, r.fields_len);
     ret ty;
 }
 
@@ -168,10 +169,218 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
     if (R.is_err[type.TypeId, str](tr)) { ret type.TYPE_ERROR; }
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
-    build_field_table(sc, ty, u.fields_start, u.fields_len);
-    record_type_align(sc, did, ty);
+    elaborate_nominal(sc, did, ty, u.fields_start, u.fields_len);
     ret ty;
 }
+
+# establish declaration `did`'s layout material - its field table and its `align`
+# override - exactly once, whoever asks first (#2442)
+#
+# The decl pass reaches declarations in source order, but a layout intrinsic can ask
+# for a type's size from a declaration written above it. Routing both the pass and
+# the on-demand forcer through here makes "has this been elaborated" a property of
+# the declaration rather than of how far the walk has got, which is what removes the
+# declaration-order dependence.
+#
+# LAYOUT_ACTIVE for the duration is the cycle detector: re-entering a declaration
+# that is still being elaborated means its layout is an input to itself, so the
+# caller is told which declaration closed the loop instead of recursing until the
+# stack ends. The state is left ACTIVE on that path - the elaboration genuinely did
+# not complete - and the query that started it fails, so no half-built table is ever
+# published as READY.
+# ---
+# sc:           sema context
+# did:          the record / union declaration
+# ty:           its interned nominal TypeId
+# fields_start: index of its first field
+# fields_len:   number of fields
+# ret:          none once elaborated, or the name of the declaration closing a cycle
+fun elaborate_nominal(sc: *context.SemaContext, did: id.DeclId, ty: type.TypeId,
+                      fields_start: u32, fields_len: u32) O.Option[intern.StrId] {
+    val st: u8 = layout_state_of(sc, did);
+    if (st == context.LAYOUT_READY)  { ret O.none[intern.StrId](); }
+    if (st == context.LAYOUT_ACTIVE) { ret O.some[intern.StrId](nominal_name_id(sc, did)); }
+
+    layout_state_set(sc, did, context.LAYOUT_ACTIVE);
+    build_field_table(sc, ty, fields_start, fields_len);
+    record_type_align(sc, did, ty);
+    layout_state_set(sc, did, context.LAYOUT_READY);
+    ret O.none[intern.StrId]();
+}
+
+# `did`'s layout state, LAYOUT_READY when this context keeps no state array
+#
+# An episode (a per-instance re-validation) has no array: it reads tables the
+# producing pass already elaborated, so every declaration it sees is finished and
+# nothing it does may re-enter one.
+fun layout_state_of(sc: *context.SemaContext, did: id.DeclId) u8 {
+    if (sc.layout_state == nil)     { ret context.LAYOUT_READY; }
+    if (did >= sc.a.decl_len::u32)  { ret context.LAYOUT_READY; }
+    ret sc.layout_state[did];
+}
+
+fun layout_state_set(sc: *context.SemaContext, did: id.DeclId, st: u8) {
+    if (sc.layout_state == nil)    { ret; }
+    if (did >= sc.a.decl_len::u32) { ret; }
+    sc.layout_state[did] = st;
+}
+
+# a record / union declaration's interned name, for the diagnostic that has to point
+# at the declaration closing a cycle
+fun nominal_name_id(sc: *context.SemaContext, did: id.DeclId) intern.StrId {
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(sc.a, did);
+    if (O.is_none[*decl.Decl](d_opt)) { ret intern.STR_NIL; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    if (d.kind == decl.DECL_KIND_UNI) { ret intern_span_or_nil(sc, d.data.uni_.name); }
+    if (d.kind == decl.DECL_KIND_REC) { ret intern_span_or_nil(sc, d.data.rec_.name); }
+    ret intern.STR_NIL;
+}
+
+# force every declaration whose layout `tid` depends on to be elaborated (#2442)
+#
+# BY-VALUE CONTAINMENT ONLY, the same relation the occurs-check walks (#2355): a
+# record, a union, a generic instance and an array all store the contained bytes
+# inline, so measuring the outer type needs the inner one's table. A pointer or a
+# function value stores an address of fixed width, so the walk stops there - which
+# is what keeps `rec Node { next: *Node; }` measurable rather than cyclic.
+#
+# This FORCES tables; it does not measure anything. `generics.type_extent` remains
+# the only thing in sema that turns a type into a size or an alignment, so there is
+# no second layout policy to drift from `me.ir.type` (#2289).
+#
+# Only same-module declarations are forced. Another module's nominal was elaborated
+# by that module's completed sema pass - dependencies are type-checked first, in topo
+# order - so it is already finished and its DeclId does not even index this context.
+# ---
+# sc:  sema context
+# tid: the type about to be measured
+# ret: none when every dependency is elaborated, or the name closing a layout cycle
+fun ensure_layout_ready(sc: *context.SemaContext, tid: type.TypeId) O.Option[intern.StrId] {
+    ret ensure_layout_walk(sc, tid, 0);
+}
+
+# `ensure_layout_ready`'s recursion. `depth` bounds a by-value nest the same way
+# SEMA_LAYOUT_MAX_DEPTH bounds the measuring walk: the cycle marker catches a
+# declaration reached twice, but a semantic universe can hold a legal nest deeper
+# than any walk should follow, and an over-deep one is left to the measurement to
+# refuse with its own cause.
+fun ensure_layout_walk(sc: *context.SemaContext, tid: type.TypeId, depth: u32) O.Option[intern.StrId] {
+    if (depth > LAYOUT_FORCE_MAX_DEPTH) { ret O.none[intern.StrId](); }
+    if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret O.none[intern.StrId](); }
+
+    val base: type.TypeId = type.strip_secret(?sc.s.types, tid);
+    val t_opt: O.Option[*type.Type] = type.get(?sc.s.types, base);
+    if (O.is_none[*type.Type](t_opt)) { ret O.none[intern.StrId](); }
+    val t: *type.Type = O.unwrap[*type.Type](t_opt);
+
+    if (t.kind == type.TYPE_ARRAY) { ret ensure_layout_walk(sc, t.data.array.base, depth + 1); }
+
+    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
+        if (t.data.nominal.origin != sc.own_module) { ret O.none[intern.StrId](); }
+        val did: id.DeclId = t.data.nominal.decl;
+        val d_opt: O.Option[*decl.Decl] = ast.get_decl(sc.a, did);
+        if (O.is_none[*decl.Decl](d_opt)) { ret O.none[intern.StrId](); }
+        val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+
+        var fstart: u32 = d.data.rec_.fields_start;
+        var flen:   u32 = d.data.rec_.fields_len;
+        if (d.kind == decl.DECL_KIND_UNI) {
+            fstart = d.data.uni_.fields_start;
+            flen   = d.data.uni_.fields_len;
+        }
+        or (d.kind != decl.DECL_KIND_REC) { ret O.none[intern.StrId](); }
+
+        val cyc: O.Option[intern.StrId] = elaborate_nominal(sc, did, base, fstart, flen);
+        if (O.is_some[intern.StrId](cyc)) { ret cyc; }
+        ret ensure_layout_fields(sc, base, depth);
+    }
+
+    if (t.kind == type.TYPE_INSTANCE) {
+        # an instance's table is materialized from its generic's, which the walk
+        # above elaborates when the generic is declared in this module.
+        val cyc: O.Option[intern.StrId] = ensure_layout_walk(sc, t.data.instance.nominal, depth + 1);
+        if (O.is_some[intern.StrId](cyc)) { ret cyc; }
+        generics.ensure_fields(sc.s, base);
+        ret ensure_layout_fields(sc, base, depth);
+    }
+
+    ret O.none[intern.StrId]();
+}
+
+# force each field type of an already-elaborated aggregate
+fun ensure_layout_fields(sc: *context.SemaContext, ty: type.TypeId, depth: u32) O.Option[intern.StrId] {
+    val n: u32 = type.field_count(?sc.s.types, ty);
+    var i: u32 = 0;
+    for (i < n) {
+        val fe: O.Option[*type.FieldEntry] = type.field_at(?sc.s.types, ty, i);
+        if (O.is_some[*type.FieldEntry](fe)) {
+            val cyc: O.Option[intern.StrId] = ensure_layout_walk(sc, O.unwrap[*type.FieldEntry](fe).ty, depth + 1);
+            if (O.is_some[intern.StrId](cyc)) { ret cyc; }
+        }
+        i = i + 1;
+    }
+    ret O.none[intern.StrId]();
+}
+
+# fold `$size_of(T)` / `$align_of(T)` to its measured constant, forcing `T`'s layout
+# material first (#2442)
+#
+# The two positions that need this - a type's `align` and an array length - are
+# decided during type resolution, where the measured type may not have been reached
+# yet. Forcing is what makes the answer independent of declaration order; the
+# measurement itself is `generics.type_extent`, the same policy `me.ir.type` uses
+# (#2289), so a length folded here and the same intrinsic folded in the middle end
+# cannot disagree.
+#
+# `$offset_of` is deliberately NOT folded here: sema's field-descriptor contract
+# answers `.offset` with none and leaves offsets to lowering, and moving that line
+# is a separate decision from this one. It keeps reporting through the evaluator.
+# ---
+# sc:   sema context
+# eid:  the expression in constant position
+# span: the span to report against
+# ret:  none when `eid` is not a layout intrinsic; some(none) when one was reported
+#       on; some(some(v)) with the measured constant
+fun fold_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) O.Option[O.Option[comptime.CTValue]] {
+    val is_size:  bool = comptime.is_size_of_call(sc.a, sc.source, eid);
+    val is_align: bool = comptime.is_align_of_call(sc.a, sc.source, eid);
+    if (!is_size && !is_align) { ret O.none[O.Option[comptime.CTValue]](); }
+
+    val arg: id.ExprId = comptime.layout_intrinsic_type_arg(sc.a, eid);
+    if (arg == id.EXPR_NIL) {
+        context.report(sc, span, "a layout intrinsic takes one type argument");
+        ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
+    }
+
+    # `intrinsic_operand_type` reports its own failure, so a TYPE_ERROR here is
+    # already on the sink and must not be doubled.
+    val tid: type.TypeId = intrinsic_operand_type(sc, arg, span);
+    if (tid == type.TYPE_ERROR) { ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]()); }
+
+    val cyc: O.Option[intern.StrId] = ensure_layout_ready(sc, tid);
+    if (O.is_some[intern.StrId](cyc)) {
+        check.report_named(sc, span, "layout cycle: measuring `", O.unwrap[intern.StrId](cyc),
+                           "` here needs a layout this measurement is itself deciding. break the cycle with a literal alignment or length",
+                           "layout cycle: this measurement's answer is one of its own inputs");
+        ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
+    }
+
+    val ext: layout.Extent = generics.type_extent(sc.s, context.ptr_width_of(sc), tid);
+    if (!ext.ok) {
+        context.report(sc, span, "the layout of the type named by this intrinsic could not be determined");
+        ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
+    }
+
+    var n: u32 = ext.size;
+    if (is_align) { n = ext.align; }
+    ret O.some[O.Option[comptime.CTValue]](O.some[comptime.CTValue](comptime.ct_uint(n::u64)));
+}
+
+# the by-value nesting depth the forcing walk follows before leaving the rest to the
+# measurement. cycle protection is the ACTIVE marker, not this; the bound only stops
+# a pathological nest from running the stack out ahead of `SEMA_LAYOUT_MAX_DEPTH`,
+# which refuses the same shape with a cause the caller reports.
+val LAYOUT_FORCE_MAX_DEPTH: u32 = 64;
 
 # whether `ty` reaches nominal `target` BY VALUE (#2355)
 #
@@ -504,16 +713,24 @@ fun record_type_align(sc: *context.SemaContext, did: id.DeclId, ty: type.TypeId)
         if (str_region_equals(sc.source, dec.name.offset, dec.name.len, "align")) {
             if (dec.args_len != 1) { ret; }
             val arg: id.ExprId = sc.a.expr_ids[dec.args_start];
-            val ev: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arg, ?sc.s.interner);
-            if (R.is_err[comptime.CTValue, str](ev)) {
-                if (comptime.is_layout_intrinsic_call(sc.a, sc.source, arg)) {
-                    context.report(sc, dec.name, "a layout intrinsic is not available in an `align` on a type: this alignment is decided while the layout it would measure is still being resolved. use a literal, or `#[align(...)]` on a global, where layout is known (#2442)");
+            # a layout intrinsic is folded against forced layout material rather than
+            # by the evaluator, which has no layout of its own (#2442). it reports its
+            # own failures, so a none payload is already on the sink.
+            var cv: comptime.CTValue;
+            val lay: O.Option[O.Option[comptime.CTValue]] = fold_layout_intrinsic(sc, arg, dec.name);
+            if (O.is_some[O.Option[comptime.CTValue]](lay)) {
+                val got: O.Option[comptime.CTValue] = O.unwrap[O.Option[comptime.CTValue]](lay);
+                if (O.is_none[comptime.CTValue](got)) { ret; }
+                cv = O.unwrap[comptime.CTValue](got);
+            }
+            or {
+                val ev: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arg, ?sc.s.interner);
+                if (R.is_err[comptime.CTValue, str](ev)) {
+                    context.report(sc, dec.name, "`align` on a type must be a compile-time constant");
                     ret;
                 }
-                context.report(sc, dec.name, "`align` on a type must be a compile-time constant");
-                ret;
+                cv = R.unwrap_ok[comptime.CTValue, str](ev);
             }
-            val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](ev);
             # the body-pass validator skips the type-arg checks for rec/uni (it
             # would double-report against this fold), so every invalid case is
             # reported here -- a non-integer, a negative, a non-power-of-two, or
@@ -576,7 +793,18 @@ fun build_field_table(sc: *context.SemaContext, ty: type.TypeId, fields_start: u
     for (i < fields_len) {
         val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
         val fname: intern.StrId = intern_span_or_nil(sc, tn.name);
-        val fty: type.TypeId = context.resolved_type_of(sc, tn.ty);
+        var fty: type.TypeId = context.resolved_type_of(sc, tn.ty);
+        # `resolved_type_of` READS the resolution table. A layout query can force this
+        # declaration before `resolve_all_types` has indexed its annotations (#2442),
+        # and an unresolved slot read as nil would give the table nil field types -
+        # measuring as an unknown extent rather than the real one. Resolving on demand
+        # here fills the same memo the index walk would have, so the walk later finds
+        # it done and the answer does not depend on which arrived first. Main pass
+        # only: under a substitution the annotation's answer comes from the producer's
+        # table through `apply_subst`, and re-resolving would apply it twice (#2168).
+        if (fty == type.TYPE_NIL && sc.subst == nil && tn.ty != id.TYPE_NIL) {
+            fty = resolve_type_ref(sc, tn.ty);
+        }
         context.field_table_push(sc, tbl, fname, fty);
         i = i + 1;
     }
@@ -2748,16 +2976,23 @@ fun resolve_type_array(sc: *context.SemaContext, ar: *atype.TypeArray, span: tok
     val elem: type.TypeId = resolve_type_ref(sc, ar.element);
     if (elem == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
-    val len_r: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, ar.length, ?sc.s.interner);
-    if (R.is_err[comptime.CTValue, str](len_r)) {
-        if (comptime.is_layout_intrinsic_call(sc.a, sc.source, ar.length)) {
-            context.report(sc, span, "a layout intrinsic is not available as an array length: the length is needed while the layout it would measure is still being resolved. use a literal length (binding the intrinsic to a `val` first does not help - its value is folded after this point) (#2442)");
+    # a layout intrinsic length is measured against forced layout material; the
+    # evaluator has no layout of its own (#2442). it reports its own failures.
+    var cv: comptime.CTValue;
+    val lay: O.Option[O.Option[comptime.CTValue]] = fold_layout_intrinsic(sc, ar.length, span);
+    if (O.is_some[O.Option[comptime.CTValue]](lay)) {
+        val got: O.Option[comptime.CTValue] = O.unwrap[O.Option[comptime.CTValue]](lay);
+        if (O.is_none[comptime.CTValue](got)) { ret type.TYPE_ERROR; }
+        cv = O.unwrap[comptime.CTValue](got);
+    }
+    or {
+        val len_r: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, ar.length, ?sc.s.interner);
+        if (R.is_err[comptime.CTValue, str](len_r)) {
+            context.report(sc, span, "cannot infer type: array length is not a comptime constant");
             ret type.TYPE_ERROR;
         }
-        context.report(sc, span, "cannot infer type: array length is not a comptime constant");
-        ret type.TYPE_ERROR;
+        cv = R.unwrap_ok[comptime.CTValue, str](len_r);
     }
-    val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](len_r);
     if (cv.kind != comptime.CT_KIND_INT) {
         context.report(sc, span, "type mismatch: array length must be an integer");
         ret type.TYPE_ERROR;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -23,7 +23,6 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_join;
 use std.types.string.str_region_equals;
 
 use A: std.allocator;
@@ -185,9 +184,17 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
 # LAYOUT_ACTIVE for the duration is the cycle detector: re-entering a declaration
 # that is still being elaborated means its layout is an input to itself, so the
 # caller is told which declaration closed the loop instead of recursing until the
-# stack ends. The state is left ACTIVE on that path - the elaboration genuinely did
-# not complete - and the query that started it fails, so no half-built table is ever
-# published as READY.
+# stack ends.
+#
+# The frame that DETECTS a cycle returns without touching the state - it is not the
+# owner of that elaboration. The frame that OWNS it finishes normally and marks
+# READY even when the align fold inside it was the query that failed: the field
+# table is built either way, and the failed `align` has already been reported
+# against its own decorator. READY therefore means "elaboration was carried out",
+# not "every part of it succeeded" - which is what stops a later measurement of the
+# same type from re-entering and reporting the same cycle a second time. Such a
+# declaration keeps its natural alignment, the same outcome as any other rejected
+# `align`.
 # ---
 # sc:           sema context
 # did:          the record / union declaration


### PR DESCRIPTION
Closes #2442.

`$size_of` / `$align_of` folded in a global's `align` but were rejected in a type's
`align` and in an array length. The blocker this issue records — that layout is
unavailable where `comptime.eval` runs — stopped being true at #2167/#2289:
`generics.type_extent` measures a semantic type through `mach.lang.layout`, the same
policy `me.ir.type` uses. **The real blocker was ordering**, and that is what this
fixes.

## The change

`elaborate_nominal` becomes the single entry for establishing a declaration's layout
material — its field table and its `align` — guarded by a per-declaration
`LAYOUT_PENDING/ACTIVE/READY` state. `ensure_layout_ready` forces everything a
measurement depends on before `type_extent` runs. The decl pass and the on-demand
forcer go through the same entry, so "elaborated" is a property of the declaration
rather than of how far the walk has got. That is what removes the order dependence.

The forcing walk follows **by-value containment only** — the relation the #2355
occurs-check already walks. Records, unions, instances and arrays store their bytes
inline; a pointer or function value stores an address of fixed width, so the walk
stops there and `rec Node { next: *Node; }` stays measurable. `LAYOUT_ACTIVE` turns a
genuine by-value cycle into a diagnostic naming the type that closes it:

```
error: layout cycle: measuring `Over` here needs a layout this measurement is
itself deciding. break the cycle with a literal alignment or length
 --> ./src/main.mach:1:3
  |
1 | #[align($size_of(Over))]
```

One supporting fix: `build_field_table` resolves an unresolved field annotation
rather than reading nil out of the resolution table. A forced elaboration can reach a
declaration before `resolve_all_types` has indexed it, and a nil field type measures
as an *unknown extent* rather than the real one — which is exactly how the
array-length half failed in my first working draft. Main pass only, since under a
substitution the answer comes through `apply_subst` and re-resolving would apply it
twice (#2168).

## Scope notes

- **`$offset_of` is deliberately not folded here.** Sema's field-descriptor contract
  answers `.offset` with none and leaves offsets to lowering; `layout.field_offset_of`
  exists and would work, but moving that line is a separate decision from this one.
  It keeps reporting through the evaluator. This is the one place I do not meet
  #2442's acceptance text literally ("the same layout intrinsics the global position
  accepts") — flagging rather than quietly satisfying it.
- A `$if` / `$or` condition is not a type position and gets no on-demand layout, so
  it still reports the real cause from the evaluator.
- Docs updated: the tables #2444 narrowed now say these positions work, with the
  cycle rule and the two remaining exceptions stated.

## Verification

One pinned process, dev merged (`ae4065ea`). Object comparisons carry both controls
in the same run — self-check (tree vs itself, must be 0) and positive control (one
byte flipped in a copy, must be caught as exactly 1).

**Acceptance bars from #2442:**

| bar | result |
|---|---|
| both positions fold, with the measured value | yes — pinned by `[16]u8` / `[8]u8` literals that only type-check on the right number |
| declaration order irrelevant | yes — every case paired with its reversed-order twin |
| `#[align($size_of(Self))]` and mutual cycles refused **by name** | yes |
| array length inside a field type | yes, both orders |
| one layout policy | `layout.*` calls in `fe/sema` outside `generics.mach`: **0** |
| `mach test` + fixpoint | 1017 passed / 0 failed; `B == C` passes |

**Emission neutrality**, asserted as required: a dev-baseline compiler and this
branch's compiler each compiling the same fixed dev tree —

| | objects differing | linked binary |
|---|---|---|
| debug | 0/215 | identical |
| release | 0/215 | identical |

Expected: seed lag means compiler source cannot use the new positions in this PR, so
the fold changes what the compiler *accepts*, not what it emits.

Suite delta accounted exactly: dev is 1014, branch is 1017 — four tests added
(order-independence, cycles, remaining positions, cross-module) and #2444's
now-obsolete rejection test removed. Also green: the 13-case functional matrix
through the fixpoint compiler, and the `int` suite on linux.

**Cross-module** is pinned in both positions, per the request: it is the premise the
same-module-only forcing rests on (dependencies are type-checked first, in topo
order), and if it ever stopped holding these fail with an undetermined layout rather
than measuring something wrong — the extent fails closed.
