### PR TITLE
test(int): surface each case's resolved mach-std commit for CI forensics

### DIFF
--- a/int/.gitignore
+++ b/int/.gitignore
@@ -1,4 +1,11 @@
 # per-case build state, realized by the harness (`mach dep pull` + build)
 dep/
 out/
+# never committed, deliberately: a case's `ref = "branch/main"` tracks mach-std's
+# latest release (see doc/cli.md's Lockfile section), so this lock's resolved
+# commit is meant to move on every run, not be pinned - committing it would
+# freeze the case to whichever commit last happened to be recorded. `run.sh`
+# prints the resolved commit into every PASS/FAIL/BLESS line instead, which
+# durably records what a run compiled against without pinning what the next one
+# will (#2387).
 mach.lock

--- a/int/run.sh
+++ b/int/run.sh
@@ -109,6 +109,33 @@ in_list() {
     return 1
 }
 
+# dep_commits <case-dir> — print "name@shortsha ..." for every [dep.<name>] a
+# case's mach.lock records, or nothing when no lock exists.
+#
+# A case's `ref = "branch/main"` deliberately tracks mach-std's latest RELEASE
+# (moving `main` is the reviewed release event, not drift - see doc/cli.md's
+# Lockfile section), so int/.gitignore excludes `mach.lock`: committing it here
+# would freeze every case to whatever commit happened to be resolved when someone
+# last regenerated it, contradicting that intent. But an ephemeral lock means
+# nothing durable records which commit a given run actually compiled against -
+# `mach dep pull`'s own lock write vanishes with the rest of the case's gitignored
+# state (#2387). Printing it into every PASS/FAIL/BLESS line is that record: it
+# survives exactly as long as the CI log does, which is exactly as long as anyone
+# would want to ask "what did this run compile against".
+dep_commits() {
+    dir=$1
+    [ -f "$dir/mach.lock" ] || return 0
+    awk '
+        /^\[dep\./ { name = $0; sub(/^\[dep\./, "", name); sub(/\]$/, "", name); next }
+        /^commit = / && name != "" {
+            sha = $0
+            sub(/^commit = "/, "", sha); sub(/"$/, "", sha)
+            printf "%s@%s ", name, substr(sha, 1, 7)
+            name = ""
+        }
+    ' "$dir/mach.lock"
+}
+
 runmode=$(conf_runmode "$target") || {
     echo "run.sh: target '$target' is not in targets.conf" >&2
     exit 2
@@ -216,20 +243,26 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
             build_ok=0
         fi
 
+        # a label suffix naming what mach-std commit `dep pull` resolved (#2387),
+        # once one exists to report; every PASS/FAIL line from here on carries it.
+        deps=$(dep_commits "$dir")
+        flabel=$label
+        [ -n "$deps" ] && flabel="$label (${deps% })"
+
         # a build-fails case asserts the compile is rejected and takes the compiler's
         # 'error:' diagnostic as its observable (deterministic: no paths, just the
         # message text). every other mode requires a clean build and runs a producer
         # on the artifact.
         if [ "$case_run" = build-fails ]; then
             if [ "$build_ok" -eq 1 ]; then
-                echo "FAIL $label (build succeeded; expected a link error)"
+                echo "FAIL $flabel (build succeeded; expected a link error)"
                 fails=$((fails + 1))
                 rm -rf "$tmp" "$dir/out/int"
                 continue
             fi
             grep '^error:' "$tmp/build.log" >"$tmp/out.txt" || true
             if [ ! -s "$tmp/out.txt" ]; then
-                echo "FAIL $label (build failed without an 'error:' diagnostic)"
+                echo "FAIL $flabel (build failed without an 'error:' diagnostic)"
                 sed 's/^/    /' "$tmp/build.log" >&2
                 fails=$((fails + 1))
                 rm -rf "$tmp" "$dir/out/int"
@@ -237,7 +270,7 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
             fi
         else
             if [ "$build_ok" -eq 0 ]; then
-                echo "FAIL $label (build)"
+                echo "FAIL $flabel (build)"
                 sed 's/^/    /' "$tmp/build.log" >&2
                 fails=$((fails + 1))
                 rm -rf "$tmp" "$dir/out/int"
@@ -252,7 +285,7 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
             if [ "$case_run" = debuginfo ]; then
                 gbin="$dir/out/int/prog-g$exe"
                 if ! (cd "$dir" && $buildcc build . --target "$build_target" --profile "$profile" $case_build_flags -g -o "out/int/prog-g$exe") >"$tmp/build-g.log" 2>&1; then
-                    echo "FAIL $label (build -g)"
+                    echo "FAIL $flabel (build -g)"
                     sed 's/^/    /' "$tmp/build-g.log" >&2
                     fails=$((fails + 1))
                     rm -rf "$tmp" "$dir/out/int"
@@ -266,7 +299,7 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
                 prc=$?
             fi
             if [ "$prc" -ne 0 ]; then
-                echo "FAIL $label (producer exit $prc)"
+                echo "FAIL $flabel (producer exit $prc)"
                 sed 's/^/    /' "$tmp/err.txt" >&2
                 fails=$((fails + 1))
                 rm -rf "$tmp" "$dir/out/int"
@@ -276,22 +309,22 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
 
         if [ "$bless" -eq 1 ]; then
             cp "$tmp/out.txt" "$golden"
-            echo "BLESS $label -> ${golden#"$here"/}"
+            echo "BLESS $flabel -> ${golden#"$here"/}"
             rm -rf "$tmp" "$dir/out/int"
             continue
         fi
 
         if [ ! -f "$golden" ]; then
-            echo "FAIL $label (no golden ${golden#"$here"/}; run with --bless)"
+            echo "FAIL $flabel (no golden ${golden#"$here"/}; run with --bless)"
             fails=$((fails + 1))
             rm -rf "$tmp" "$dir/out/int"
             continue
         fi
 
         if diff -u "$golden" "$tmp/out.txt" >"$tmp/diff.txt" 2>&1; then
-            echo "PASS $label"
+            echo "PASS $flabel"
         else
-            echo "FAIL $label (diff)"
+            echo "FAIL $flabel (diff)"
             sed 's/^/    /' "$tmp/diff.txt" >&2
             fails=$((fails + 1))
         fi

--- a/int/run.sh
+++ b/int/run.sh
@@ -109,8 +109,44 @@ in_list() {
     return 1
 }
 
-# dep_commits <case-dir> — print "name@shortsha ..." for every [dep.<name>] a
-# case's mach.lock records, or nothing when no lock exists.
+# lock_commit <mach.lock> <name> — the commit mach.lock records for [dep.<name>],
+# or empty when the file or the entry is absent.
+lock_commit() {
+    lockfile=$1
+    want=$2
+    [ -f "$lockfile" ] || return 0
+    awk -v want="$want" '
+        /^\[dep\./ { name = $0; sub(/^\[dep\./, "", name); sub(/\]$/, "", name); next }
+        /^commit = / && name == want {
+            sha = $0
+            sub(/^commit = "/, "", sha); sub(/"$/, "", sha)
+            print sha
+            exit
+        }
+    ' "$lockfile"
+}
+
+# dep_commits <case-dir> — print "name@shortsha ..." for every git dep checked
+# out under a case's dep/, or nothing when none exist.
+#
+# Ground-truthed from the CHECKOUT (`git rev-parse --short HEAD`), not from
+# mach.lock: the lock is the RECORD of a resolution, the checkout is the
+# ENTITY that was actually compiled against, and #2387's own observation was a
+# case where those disagreed - lock said one commit, dep/mach-std's HEAD was on
+# another (reproduced locally: a manual `git checkout` inside dep/mach-std,
+# bypassing `mach dep`, leaves mach.lock exactly where it was). Reading the
+# lock here would print the record, not the entity, and inherit that gap one
+# level up. When the checkout and the lock disagree, this prints
+# "name@<checkout>!lock=<locked>" instead of silently trusting either one.
+#
+# Traced (process_git_node in src/cli/cmd/dep.mach) and reproduced: `dep pull`
+# itself repairs a drifted checkout LOUDLY every time it runs, restoring it to
+# the lock and printing `repaired <name> (checkout drift: ...)`. Since run.sh
+# always calls `dep pull` immediately before build in the same command, a case
+# actually BUILT under this harness cannot disagree with its own lock by the
+# time this function reads it - the mismatch marker exists as a tripwire for a
+# future path that reads dep/ without first pulling (or a `dep pull` that
+# somehow stopped repairing), not because the current flow produces one.
 #
 # A case's `ref = "branch/main"` deliberately tracks mach-std's latest RELEASE
 # (moving `main` is the reviewed release event, not drift - see doc/cli.md's
@@ -119,21 +155,26 @@ in_list() {
 # last regenerated it, contradicting that intent. But an ephemeral lock means
 # nothing durable records which commit a given run actually compiled against -
 # `mach dep pull`'s own lock write vanishes with the rest of the case's gitignored
-# state (#2387). Printing it into every PASS/FAIL/BLESS line is that record: it
+# state. Printing the checkout into every PASS/FAIL/BLESS line is that record: it
 # survives exactly as long as the CI log does, which is exactly as long as anyone
 # would want to ask "what did this run compile against".
 dep_commits() {
     dir=$1
-    [ -f "$dir/mach.lock" ] || return 0
-    awk '
-        /^\[dep\./ { name = $0; sub(/^\[dep\./, "", name); sub(/\]$/, "", name); next }
-        /^commit = / && name != "" {
-            sha = $0
-            sub(/^commit = "/, "", sha); sub(/"$/, "", sha)
-            printf "%s@%s ", name, substr(sha, 1, 7)
-            name = ""
-        }
-    ' "$dir/mach.lock"
+    [ -d "$dir/dep" ] || return 0
+    for depdir in "$dir"/dep/*/; do
+        [ -d "${depdir}.git" ] || [ -f "${depdir}.git" ] || continue
+        name=$(basename "$depdir")
+        head=$(git -C "$depdir" rev-parse --short HEAD 2>/dev/null) || continue
+        locked=$(lock_commit "$dir/mach.lock" "$name")
+        if [ -n "$locked" ]; then
+            case "$locked" in
+                "$head"*) printf '%s@%s ' "$name" "$head" ;;
+                *)        printf '%s@%s!lock=%s ' "$name" "$head" "$(printf '%s' "$locked" | cut -c1-7)" ;;
+            esac
+        else
+            printf '%s@%s ' "$name" "$head"
+        fi
+    done
 }
 
 runmode=$(conf_runmode "$target") || {


### PR DESCRIPTION
## Summary

Investigation first, per the issue's own retitled scope. The original filing assumed `ref = "branch/main"` on int fixtures was a mistake ("fixtures track a moving branch"); the owner corrected that in a comment — the `main`/`dev` split is intentional, `main` carries tagged releases, and tracking the *latest* one is the point. What survives, narrower: **the lock records a commit nothing durable can later consult**, because `int/.gitignore` excludes `mach.lock` from every case.

**Traced the actual mechanism** (`src/cli/cmd/dep.mach`'s `process_git_node`) and reproduced the owner's exact divergence: a fresh `mach dep pull`, then a manual `git checkout` directly inside `dep/mach-std` (bypassing `mach dep` entirely), leaves `mach.lock` exactly where it was while the checkout moves — matching "lock said 7fd2a30, checkout was on eff1e8e" precisely.

Then traced what happens next: running `mach dep pull` again detects the drift and **repairs it loudly, every time** — `repaired mach-std (checkout drift: <old> -> <new>)`, restoring the checkout to the lock. Verified this directly against the reproduced divergence above. Since `int/run.sh` always calls `dep pull` immediately before `build` in the same command, **a case actually built by this harness cannot disagree with its own lock by the time anything reads it afterward.** The divergence the owner observed could only have come from inspecting `dep/mach-std` directly — most plausibly during the #2369 investigation this issue was filed from — not from anything the harness itself built against or printed. There is no honoring bug in `mach dep pull`, and the harness's own flow cannot produce this gap.

**Committing the fixtures' locks was considered and rejected.** It would freeze every one of the (now 53, not the original 26 — the suite has grown) fixtures to whichever commit last happened to be recorded, directly contradicting the corrected intent. Unilaterally changing what every int fixture resolves its dependency against is a testing-infrastructure *policy* decision — owner-reserved design space per prior ruling on the `int/` framework. The 2026-07-19 veto on "dep re-pull/diagnostic work on stale cached dep manifests" is adjacent but distinct: this touches neither `dep pull`'s resolution logic nor adds any staleness auto-repair; it only changes what `run.sh` *prints* about a resolution `dep pull` already performs.

**What shipped**: a `dep_commits` helper in `int/run.sh`, revised after review to source the printed sha from the **checkout** (`git rev-parse --short HEAD`), not from the lock — ground truth over claim, since reading the lock alone would have silently reproduced the record-vs-entity gap one level up. It separately reads the lock only to compare against the checkout, printing `name@<checkout>!lock=<locked>` when they disagree instead of trusting either one silently. Given the trace above, that marker is not expected to ever fire from a normal harness run — it exists as a tripwire for a future code path that reads `dep/` without a preceding pull, or a `dep pull` that stops repairing. Every `PASS`/`FAIL`/`BLESS` line for a case with a git dependency carries the result, durable for as long as the CI log survives, without pinning what the *next* run resolves. `int/.gitignore` gains a comment explaining why `mach.lock` is excluded on purpose, cross-referencing `doc/cli.md`'s existing (accurate) Lockfile documentation, which already says "commit `mach.lock` to pin builds" — `int/` deliberately doesn't, and now says why in the one place someone investigating the ignore rule would look.

Closes #2387

## Verification

- Empirically traced `dep pull`'s resolution: fresh checkout → resolves `branch/main`'s current tip; idempotent re-run untouched; a corrupted-golden `FAIL` correctly shows the commit.
- **Reproduced the owner's exact divergence** (manual checkout inside `dep/mach-std`, bypassing `mach dep`) and confirmed `dep pull`'s repair path fixes it loudly every time — the harness's own flow cannot build against a lock≠checkout state.
- Confirmed the mismatch marker (`name@<checkout>!lock=<locked>`) fires correctly when called directly against the reproduced divergence.
- `mach test .`: 1019 passed, 0 failed.
- Full `int/` suite (not filtered) on `linux` (121 cases) and `linux-riscv64` (88 cases): all green, commit suffix present/absent correctly per case.
- No `src/lang` changes; compiler binary byte-identical to the `dev` baseline it was built against.

## Test plan

- [x] `dep pull` resolution mechanism traced and empirically confirmed correct
- [x] Owner's divergence reproduced directly; `dep pull`'s repair path confirmed to fix it every time, so the harness's own flow cannot produce it
- [x] Mismatch marker confirmed to fire correctly against the reproduced divergence
- [x] `mach test .`: 1019/0/1019
- [x] Full `int/` suite green on `linux` (121) and `linux-riscv64` (88), commit suffix correct per case
- [x] Compiler binary byte-identical to `dev` baseline
- [x] CI green before marking ready