### PR TITLE
fix(regalloc): drop a same-vreg copy at every width, on every target

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -530,6 +530,25 @@ pub rec MirAsm {
 #                the encoder treats as the machine-word width so a pseudo with no
 #                natural width (call / ret / branch / asm) still encodes its
 #                address-sized fields correctly.
+#
+#                BITS ABOVE `width` ARE UNDEFINED. Width is a property of the
+#                OPERATION, not of the value - a `MirVReg` carries no width at
+#                all - so an instruction states how many bytes it operates on and
+#                says nothing about the rest of the register. A consumer that
+#                wants a value at a wider width must go through an explicit
+#                conversion op (TRUNC / SEXT / ZEXT); none may read above the
+#                width its producer declared.
+#
+#                This is settled, not assumed (#2395). The three register targets
+#                already disagree about those bits and all three are correct:
+#                x86-64's 4-byte move zero-extends into the 64-bit register,
+#                aarch64's every sub-word move does, and riscv64's is `addi
+#                rd,rs,0` at the machine width and extends nothing. riscv64
+#                self-hosts and passes CI on the same MIR, which is the witness -
+#                if a width-4 move were specified to define bits 32..63, riscv64
+#                would be miscompiling every one of them. Regalloc relied on the
+#                opposite reading to keep same-register copies alive on x86-64 and
+#                aarch64; that premise was false and the copies are now dropped.
 # src_width:     source operand width in bytes for the width-changing conversions
 #                (TRUNC / SEXT / ZEXT and the integer-side CVT forms), where the
 #                source is narrower or wider than the destination. for every other

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1452,28 +1452,23 @@ fun rename_vregs(ctx: *AllocCtx, parent: *u32, nv: u32) {
     }
 }
 
-# true when a register-to-register move at `width` is a no-op when its source and
-# destination are the same register
-#
-# A move is observable only if it writes bits it does not read - a sub-word move that
-# extends into the rest of the register. Whether one does is a per-ISA register-file
-# fact, not a universal: x86-64 extends at 4 bytes only, aarch64 at every sub-word
-# width, riscv64 at none (`isa.MachineModel.move_extends_from`). A width at or above
-# the spill width is full-width, so there is nothing above it to write (#2275).
-# ---
-# tgt:   the active target, supplying the machine model
-# width: the move's operation width in bytes
-# ret:   true when a same-register move at this width writes nothing
-fun self_move_is_inert(tgt: *target.Target, width: u8) bool {
-    if (width::u32 >= tgt.model.spill_width) { ret true; }
-    if (tgt.model.move_extends_from == 0)    { ret true; }
-    ret width::u32 < tgt.model.move_extends_from;
-}
-
 # delete every register copy both of whose operands name the same vreg - the
-# coalesced copies `rename_vregs` collapsed - whenever a same-register move at that
-# width writes nothing (`self_move_is_inert`). mirrors the compaction of
+# coalesced copies `rename_vregs` collapsed. mirrors the compaction of
 # `sweep_dead_movs`, and a block always ends in a terminator so it never empties
+#
+# A same-vreg copy is dropped at EVERY width, on every target. This used to be
+# gated on whether the ISA's move writes the bits above its own width - x86-64's
+# 4-byte move zero-extends into the 64-bit register, aarch64's every sub-word move
+# does - on the reading that such a move performs an extension something relies on.
+# That premise was false (#2395): `MirInstr.width` sizes the OPERATION and leaves
+# the bits above it undefined, a `MirVReg` carries no width at all, and a consumer
+# wanting a wider value must go through an explicit conversion op. The witness is
+# riscv64, whose move is `addi rd,rs,0` at the machine width and extends nothing -
+# it self-hosts and passes CI on the same MIR, which it could not if a width-4 move
+# were specified to define bits 32..63.
+#
+# So the ISA's extension behaviour is real and decides nothing here, and the
+# `move_extends_from` model field it was read from is gone with this gate.
 fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
     val f: *mir.MirFunction = ctx.f;
     var bi: u32 = 0;
@@ -1484,7 +1479,7 @@ fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
         for (read < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[read];
             var drop: bool = false;
-            if (instr_is_reg_copy(tgt, mi) && self_move_is_inert(tgt, mi.width)) {
+            if (instr_is_reg_copy(tgt, mi)) {
                 val a: *mir.MirOperand = ?mi.operands[0];
                 val b: *mir.MirOperand = ?mi.operands[1];
                 drop = a.kind == mir.MIR_OP_VREG && b.kind == mir.MIR_OP_VREG && a.vreg == b.vreg;
@@ -3299,11 +3294,13 @@ fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
 # into the register the copy hints point at, and until #2275 nothing looked at them
 # again: 37,662 on riscv64, 168 on x86-64.
 #
-# Deletes only what `self_move_is_inert` clears, so a sub-word move that zero-extends
-# is kept on the ISAs where one does. Compacts in place like `drop_self_copies`; a
-# block always ends in a terminator, which is never a copy, so no block empties.
+# Deletes a same-register copy at EVERY width, for the reason `drop_self_copies`
+# records: MIR leaves the bits above an instruction`s width undefined, so no move is
+# kept for an extension nothing relies on (#2395). Compacts in place like
+# `drop_self_copies`; a block always ends in a terminator, which is never a copy, so
+# no block empties.
 # ---
-# tgt: the active target, supplying the move-extension fact
+# tgt: the active target, supplying the register-copy classifier
 # ctx: the allocation context whose function is compacted
 fun drop_self_copies_physical(tgt: *target.Target, ctx: *AllocCtx) {
     val f: *mir.MirFunction = ctx.f;
@@ -3315,7 +3312,7 @@ fun drop_self_copies_physical(tgt: *target.Target, ctx: *AllocCtx) {
         for (read < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[read];
             var drop: bool = false;
-            if (instr_is_reg_copy(tgt, mi) && self_move_is_inert(tgt, mi.width)) {
+            if (instr_is_reg_copy(tgt, mi)) {
                 val a: *mir.MirOperand = ?mi.operands[0];
                 val b: *mir.MirOperand = ?mi.operands[1];
                 drop = a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_PREG && a.preg == b.preg;
@@ -4465,47 +4462,84 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:forwarded_values_survive" {
     ret 0;
 }
 
-# a same-register copy is deleted only where the machine says the move writes
-# nothing, and the answer is per-ISA rather than universal
+# test-only: true when `drop_self_copies` removes a same-vreg copy at `width` on
+# `t`, keeping a real copy beside it
 #
-# `self_move_is_inert` is the whole of #2275: a move from a register to itself is
-# observable exactly when it extends into the bits above its own width, which is a
-# register-file property no two of the three ISAs share. Pinning it against the
-# three real targets rather than a synthetic model, so the values under test are the
-# ones the ISAs actually declare
-test "mach.lang.be.codegen.regalloc.self_move_is_inert:per_isa_extension_rules" {
+# Drives the real sweep rather than a predicate, so the test cannot pass against a
+# gate that was merely renamed. The second copy is the control: a sweep that emptied
+# the block indiscriminately would also delete it.
+# ---
+# t:     the target whose register-copy classifier the sweep reads
+# width: the copy's operation width in bytes
+# ret:   true when exactly the self-copy was removed
+fun t_self_copy_is_dropped(t: *target.Target, width: u8) bool {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 3);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 2);
+    t_mov(?alloc, ?b, 0, mir.op_vreg(1), mir.op_vreg(1));   # the self-copy: dropped
+    t_mov(?alloc, ?b, 1, mir.op_vreg(2), mir.op_vreg(0));   # a real copy: kept
+    b.instrs[0].width = width; b.instrs[0].src_width = width;
+    b.instrs[1].width = width; b.instrs[1].src_width = width;
+    f.blocks      = ?b;
+    f.block_count = 1;
+    f.block_cap   = 1;
+
+    var slots: [3]bool;
+    slots[0] = false; slots[1] = false; slots[2] = false;
+    var ctx: AllocCtx;
+    t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
+
+    drop_self_copies(t, ?ctx);
+
+    if (b.instr_count != 1) { ret false; }
+    val kept: *mir.MirOperand = b.instrs[0].operands;
+    ret kept[0].kind == mir.MIR_OP_VREG && kept[0].vreg == 2 &&
+        kept[1].kind == mir.MIR_OP_VREG && kept[1].vreg == 0;
+}
+
+# a same-vreg copy is dropped at every width, on every target - the MIR contract
+# decides this, not the ISA's register file
+#
+# This replaces the per-ISA extension table #2275 shipped. That table was correct
+# about the ISAs and wrong about what governs: it kept a same-register copy wherever
+# the machine's move writes the bits above its own width, on the reading that the
+# move performs an extension something relies on. `MirInstr.width` sizes the
+# OPERATION and leaves those bits undefined (#2395), so nothing may rely on it, and
+# the three targets are pinned here at the same answer rather than three.
+test "mach.lang.be.codegen.regalloc.drop_self_copies:width_is_not_a_gate" {
     var reg: target.TargetRegistry = target.registry_init();
     if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
 
-    # x86-64: a 4-byte write zero-extends into the 64-bit register, so that self-move
-    # is load-bearing; 1- and 2-byte writes preserve the bits above them.
-    val tx: R.Result[target.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
-    if (R.is_err[target.Target, str](tx)) { ret 1; }
-    var x: target.Target = R.unwrap_ok[target.Target, str](tx);
-    if (!self_move_is_inert(?x, 1)) { ret 1; }
-    if (!self_move_is_inert(?x, 2)) { ret 1; }
-    if (self_move_is_inert(?x, 4))  { ret 1; }
-    if (!self_move_is_inert(?x, 8)) { ret 1; }
+    # the three register targets disagree about the bits above a move's width -
+    # x86-64 zero-extends at 4, aarch64 at every sub-word width, riscv64 never - and
+    # all three drop the copy anyway. riscv64 is the witness the other two follow:
+    # it has always extended nothing and has always self-hosted.
+    var isa: [3]str;
+    var abi: [3]str;
+    isa[0] = "x86_64";  abi[0] = "sysv64";
+    isa[1] = "aarch64"; abi[1] = "aapcs64";
+    isa[2] = "riscv64"; abi[2] = "lp64";
 
-    # aarch64: every non-64-bit move encodes as ORR_W and zero-extends into X, so no
-    # sub-word self-move is inert.
-    val ta: R.Result[target.Target, str] = target.select(?reg, "aarch64", "linux", "aapcs64");
-    if (R.is_err[target.Target, str](ta)) { ret 1; }
-    var a: target.Target = R.unwrap_ok[target.Target, str](ta);
-    if (self_move_is_inert(?a, 1)) { ret 1; }
-    if (self_move_is_inert(?a, 2)) { ret 1; }
-    if (self_move_is_inert(?a, 4)) { ret 1; }
-    if (!self_move_is_inert(?a, 8)) { ret 1; }
+    var i: usize = 0;
+    for (i < 3) {
+        val tr: R.Result[target.Target, str] = target.select(?reg, isa[i], "linux", abi[i]);
+        if (R.is_err[target.Target, str](tr)) { ret 1; }
+        var t: target.Target = R.unwrap_ok[target.Target, str](tr);
 
-    # riscv64: a move is `addi rd,rs,0` at XLEN whatever the width, extending
-    # nothing, so a self-move is inert at every width.
-    val tr: R.Result[target.Target, str] = target.select(?reg, "riscv64", "linux", "lp64");
-    if (R.is_err[target.Target, str](tr)) { ret 1; }
-    var r: target.Target = R.unwrap_ok[target.Target, str](tr);
-    if (!self_move_is_inert(?r, 1)) { ret 1; }
-    if (!self_move_is_inert(?r, 2)) { ret 1; }
-    if (!self_move_is_inert(?r, 4)) { ret 1; }
-    if (!self_move_is_inert(?r, 8)) { ret 1; }
+        # a same-vreg copy at each width, which `drop_self_copies` must remove.
+        var w: usize = 0;
+        var widths: [4]u8;
+        widths[0] = 1; widths[1] = 2; widths[2] = 4; widths[3] = 8;
+        for (w < 4) {
+            if (!t_self_copy_is_dropped(?t, widths[w])) { ret 1; }
+            w = w + 1;
+        }
+        i = i + 1;
+    }
     ret 0;
 }
 

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -230,20 +230,6 @@ pub rec RegClass {
 # pointer_width:     pointer width in bytes
 # gpr_width:         general-purpose / machine-word width in bytes
 # spill_width:       spill / reload move width in bytes
-# move_extends_from: the narrowest byte width at which a register-to-register move
-#                    WRITES THE WHOLE destination register, clearing the bits above
-#                    its own width, or 0 on an ISA where no move does. this is the
-#                    fact that decides whether a move from a register to itself is
-#                    observable: one that extends is a zero-extension and must be
-#                    kept, one that does not is a no-op and can be deleted. x86-64
-#                    is 4 (a 32-bit write zero-extends into the 64-bit register; a
-#                    1- or 2-byte write preserves the bits above it), aarch64 is 1
-#                    (every non-64-bit move encodes as `ORR_W` and so zero-extends
-#                    into X), riscv64 and mos6502 are 0 (a move is `addi rd,rs,0` /
-#                    a byte transfer at the machine width, extending nothing).
-#                    read by `regalloc.drop_self_copies` (#2275); a width at or
-#                    above `spill_width` is full-width and extends nothing by
-#                    definition, so this only ever governs the sub-word case
 # endianness:        byte order of scalar storage (ENDIAN_*)
 # reg_classes:       borrowed array of the ISA's register classes
 # reg_class_len:     number of register classes
@@ -299,7 +285,6 @@ pub rec MachineModel {
     gpr_width:     u32;
     max_alu_width: u32;
     spill_width:   u32;
-    move_extends_from: u32;
     endianness:    Endian;
 
     reg_classes:    *RegClass;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -234,7 +234,6 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # every non-64-bit register move encodes as `ORR_W` (encode.mach), and a W-form
     # write zero-extends into the 64-bit X register, so a self-move at ANY sub-word
     # width is a real zero-extension rather than a no-op.
-    arm64_model.move_extends_from = 1;
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
     # NEON 128-bit vector unit is baseline on aarch64 (#1965).
     arm64_model.has_v128        = true;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -106,7 +106,6 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_model.max_alu_width   = 1;
     mos6502_model.spill_width     = 1;
     # the machine word IS one byte, so every move is full-width and extends nothing.
-    mos6502_model.move_extends_from = 0;
     mos6502_model.endianness      = isa.ENDIAN_LITTLE;
     mos6502_model.has_v128        = false;
     mos6502_model.vector_compute_generic = false;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -281,7 +281,6 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # never consults it on that path): RV64 has no sub-word register write, and
     # narrowing is explicit (sext.w / a shift pair). so no move extends anything and
     # a self-move is inert at every width.
-    riscv64_model.move_extends_from = 0;
     riscv64_model.endianness      = isa.ENDIAN_LITTLE;
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
     # vector ops scalarize before MIR lowering and none reaches the vector path.

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -60,7 +60,6 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     spirv_model.spill_width   = 8;
     # a whole-module emitter runs no register allocation, so nothing reads this; 0 is
     # the honest value rather than a borrowed one.
-    spirv_model.move_extends_from = 0;
     spirv_model.endianness    = isa.ENDIAN_LITTLE;
     # the general-purpose bank is declared first (class index 0, the shared
     # REG_CLASS_GP convention) and the float bank second; the lowering finds each

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -282,7 +282,6 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # a 32-bit `mov` (89 /r with no REX.W) zero-extends into the full 64-bit
     # register, so `mov %eax,%eax` is a real zero-extension; the 16- and 8-bit forms
     # (66 89 /r, 88 /r) preserve the bits above them, so those self-moves are inert.
-    x64_model.move_extends_from = 4;
     x64_model.endianness      = isa.ENDIAN_LITTLE;
     # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
     x64_model.has_v128        = true;


### PR DESCRIPTION
Closes #2395.

The issue asked for the premise to be **settled from the MIR contract**, not re-tested against a corpus. It is settled, and it is **false**.

## What MIR guarantees about bits above a width

Nothing. Three pieces of evidence, in increasing strength:

1. **`MirVReg` carries no width.** Its fields are `id`, `class`, `spill_slot`, `assigned`, `vector`, `secret`. Width is a property of the **operation**, not of the value — so "the bits above a value's width" is not a MIR-level concept, and there is nothing for a move to extend *to*.
2. **`MirInstr.width`'s contract is a sizing directive** — "the byte width the encoder uses to size MOV / ALU / CMP / LOAD / STORE / conversion ops". It says nothing about the rest of the register.
3. **riscv64 is the witness.** Its `encode_mov` reg-reg path is `emit_i(OPC_OP_IMM, F3_ADD, rd, rs, 0)` — a full machine-width `mv` with **no width involvement at all**. A width-4 move there copies bits 32..63 verbatim and does not zero-extend; `move_extends_from = 0` recorded exactly that. riscv64 self-hosts and passes CI on the same MIR. **If a width-4 move were specified to define bits 32..63, riscv64 would be miscompiling every one of them today.**

Point 3 is the falsification the issue wanted, and it is a *different kind* of evidence from #2391's. That was "no failing case could be constructed on x86-64" — absence of a counterexample from one corpus, exactly the weak evidence #2395 exists to replace. This is a second, known-good implementation shipping the **opposite** upper-bit behaviour on the same input.

So the gate asked an **ISA** question (`move_extends_from`: does this ISA's move extend?) where a **MIR-contract** question governs (may anything rely on it?). The ISA fact is true, and it decided nothing.

## What changed

`drop_self_copies` and `drop_self_copies_physical` now drop a same-vreg copy at every width, on every target. That leaves `isa.MachineModel.move_extends_from` with no consumer, so it is deleted along with `self_move_is_inert` — per the rule stated in that field's own doc block, which warns against a description without a consumer.

**The contract is now documented on `MirInstr.width` itself**, where someone asking this question will look, rather than only at the consumer's decision site.

## Two counting corrections

- The issue's **4,704** is an object-file count; the linked binary has 2,678.
- A disassembly count of `movl %eN,%eN` is **not the gate's population** — it also catches genuine `MIR_TRUNC`s (width 4, src_width 8), which `drop_self_copies` never touches because `instr_is_reg_copy` requires `width == src_width`. The trustworthy number comes from flipping the gate and diffing, which is what the table below does.

## Numbers (linked compiler, dev → this branch)

| target | instructions | TEXT | |
|---|---|---|---|
| x86_64 | 1,000,691 → 997,950 (**−2,741**) | **−6,144 bytes** | |
| arm64 | 1,025,577 → 1,021,994 (**−3,583**) | **−14,032 bytes** | |
| **riscv64** | 1,100,577 → 1,100,577 (0) | 0 | **BYTE-IDENTICAL** |

Emission changes on **two** targets, because the gate was answering the wrong question on both. arm64 gains more than x86-64 does.

**riscv64 byte-identity is the built-in control**: its gate value was already `0`, so nothing there may move. It doesn't. A self-vs-self control ran first and was byte-identical, so the harness was proven sound before any delta was believed.

## Tests

`self_move_is_inert:per_isa_extension_rules` pinned the deleted per-ISA constants; it is replaced by `drop_self_copies:width_is_not_a_gate`, which drives the **real sweep** (not a predicate, so it cannot pass against a gate that was merely renamed) across all three register targets at widths 1/2/4/8, asserting the copy is dropped and a real copy beside it is kept.

**Mutation-checked 4/4**, covering boundary-minus-one in both directions:

| mutation | result |
|---|---|
| gate restored, `width >= 8` only | FAILS |
| gate restored, `width >= 4` | FAILS |
| gate restored, `width < 4` only | FAILS |
| `drop = true` (delete every copy, not just self-copies) | FAILS — the kept-copy control catches over-deletion |

The fourth initially reported "no test failed"; that was a mutation whose pattern silently did not apply. I verified it applied before trusting the result, and it then failed 1,019 tests.

## Verification

- Three-generation fixpoint `b == c`, on the branch and on the `dev` baseline.
- `mach test` **1019 / 0** (baseline 1019 — one test replaced by one test).
- `int/run.sh` green on **`linux` and `linux-riscv64`**, both profiles.
- arm64 has no local lane (`native` in `targets.conf`, x86_64 host), so as an early signal I ran every int case for `linux-arm64` under `qemu-aarch64` with both compilers and compared stdout and exit status: **87 case×profile combinations, all identical.** CI's arm64 runner is the authority.