### PR TITLE
test(int): add --runmode to exercise a leg targets.conf marks native

### DIFF
--- a/int/run.sh
+++ b/int/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # run.sh — the integration-test harness.
 #
-# usage: run.sh --target <name> [--bless] [--filter <glob>] <compiler>
+# usage: run.sh --target <name> [--runmode native|qemu] [--bless] [--filter <glob>] <compiler>
 #
 # for each case directory under int/{surface,regression}/ that holds a mach.toml,
 # the harness loads its defaults (overridable by an optional line-based case.conf),
@@ -12,7 +12,7 @@
 #
 # the harness is the same on every OS (git-bash on windows, bash on linux/macOS);
 # the only target-specific knowledge it holds is the run-mode looked up per target
-# from targets.conf.
+# from targets.conf, `--runmode` overriding it for this invocation only.
 #
 # LEG vs BUILD-TARGET. --target names the LEG: the runner the harness runs on (and
 # the target an exec case builds + runs). a structural case (field / flat-loader)
@@ -33,23 +33,39 @@
 # where a 64K-aligned aarch64 image faulted ENOMEM on a native 4K-page kernel that every
 # qemu-aarch64 leg had reported green). keep the aarch64 int leg `native` for this
 # reason - do not move it to qemu.
+#
+# --runmode OVERRIDES targets.conf FOR THIS INVOCATION ONLY; the file itself, the
+# source of truth for CI's matrix, is never touched (#2314). It exists so a
+# developer on an x86-64 host can exercise a leg targets.conf marks `native` -
+# today, only `linux-arm64` - without hand-editing the SoT, which is exactly the
+# accidental-commit risk #2314 named. It does NOT make a qemu run CI-equivalent:
+# the RELRO/mprotect fidelity gap two paragraphs up applies exactly the same
+# whether qemu-user runs because targets.conf says so or because `--runmode`
+# said so. Use it to iterate locally; CI never passes it, so the authoritative
+# lane - native on the real runner targets.conf names - is unaffected.
 set -eu
 
 usage() {
-    echo "usage: run.sh --target <name> [--bless] [--filter <glob>] <compiler>" >&2
+    echo "usage: run.sh --target <name> [--runmode native|qemu] [--bless] [--filter <glob>] <compiler>" >&2
     exit 2
 }
 
 target=
+runmode_override=
 bless=0
 filter='*'
 compiler=
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --target) shift; [ $# -gt 0 ] || usage; target=$1 ;;
-        --filter) shift; [ $# -gt 0 ] || usage; filter=$1 ;;
-        --bless)  bless=1 ;;
+        --target)  shift; [ $# -gt 0 ] || usage; target=$1 ;;
+        --runmode) shift; [ $# -gt 0 ] || usage; runmode_override=$1
+                   case "$runmode_override" in
+                       native|qemu) : ;;
+                       *) echo "run.sh: --runmode must be 'native' or 'qemu', got '$runmode_override'" >&2; usage ;;
+                   esac ;;
+        --filter)  shift; [ $# -gt 0 ] || usage; filter=$1 ;;
+        --bless)   bless=1 ;;
         -h|--help) usage ;;
         -*) echo "run.sh: unknown flag '$1'" >&2; usage ;;
         *)  [ -z "$compiler" ] || { echo "run.sh: unexpected argument '$1'" >&2; usage; }
@@ -181,6 +197,10 @@ runmode=$(conf_runmode "$target") || {
     echo "run.sh: target '$target' is not in targets.conf" >&2
     exit 2
 }
+if [ -n "$runmode_override" ] && [ "$runmode_override" != "$runmode" ]; then
+    echo "run.sh: --runmode overrides '$target' to $runmode_override (targets.conf says $runmode; not CI-equivalent, see NATIVE vs QEMU FIDELITY above)" >&2
+    runmode=$runmode_override
+fi
 
 fails=0
 ran=0


### PR DESCRIPTION
## Summary

`qemu_bin()`'s `linux-arm64` mapping (`linux-arm64 -> qemu-aarch64`) was correct but never exercised: `targets.conf` marks that leg `native`, so on CI it runs on the real arm64 runner, and on any x86-64 host it fails every case with `Exec format error` — confirmed 78/78, per the groundwork recorded on the issue during #2443.

**Studied the model `linux-riscv64` already uses rather than inventing a second one.** `targets.conf` gives each leg exactly one run-mode, and the qemu execution machinery (`qemu_bin()`, `produce_exec`'s qemu branch) is already generic over ISA, not tied to any one leg name — `linux-riscv64` exercises that machinery by having its row say `qemu` unconditionally, since there's no native GH-hosted riscv64 runner at all. `linux-arm64` can't do the same without changing CI's own lane from native to emulated, which the existing `NATIVE vs QEMU FIDELITY` comment explicitly forbids (#1885: qemu-aarch64's page-size model missed a real aarch64 fault a native runner caught). So the gap wasn't in the execution machinery — it's that there was no way to *select* it for one invocation without editing the source of truth.

**What shipped**: `--runmode native|qemu` on `run.sh`, overriding `targets.conf`'s row for that invocation only. The file itself is never touched, so there's nothing to accidentally commit. CI never passes it, so `linux-arm64` stays native on the real runner exactly as today. The flag reuses the exact same `qemu_bin()` lookup and `produce_exec` dispatch `linux-riscv64` already exercises live — nothing new was built to run a binary under qemu, only a new way to select the existing path for a leg whose default is native.

**Investigated the other targets' `qemu_bin()` entries**, per the issue's own bar ("check... and report which are genuinely covered") — built each target's artifact and invoked its mapped `qemu-user` interpreter directly:

| Leg | Mapping | Status |
|---|---|---|
| `linux` | `qemu-x86_64` | **Functional** (same-arch self-emulation, verified) |
| `linux-arm64` | `qemu-aarch64` | **Functional** — 87/87 cases, this issue's subject |
| `linux-riscv64` | `qemu-riscv64` | **Functional, and the only one already live** (every PR) |
| `windows` | `qemu-x86_64` | **Non-functional** — qemu-user loads ELF only; a PE binary fails `Exec format error` unconditionally |
| `darwin-x86_64` | `qemu-x86_64` | **Non-functional** — same reason, Mach-O |
| `darwin-aarch64` | `qemu-aarch64` | **Non-functional** — same reason, Mach-O |

The windows/darwin entries aren't "unexercised but correct" the way `linux-arm64` was — they cannot work under *any* invocation, since qemu-user's loader only understands the Linux ELF ABI. Left as found: removing them is a defensible follow-up (dead code that looks alive, the issue's own standard), but it's a different, smaller finding than this issue's named scope, so it's reported rather than folded in here.

Closes #2314

## Verification

- Confirmed the baseline failure first: `linux-arm64` without the override fails every case with `Exec format error` on this x86-64 host, matching the issue exactly.
- `--runmode qemu` fixes it: full `int/` suite on `linux-arm64` — 87 cases, 0 failures, matching the #2443 groundwork's 87×0 exactly.
- Built each of `windows`/`darwin-x86_64`/`darwin-aarch64`'s artifacts and ran their mapped qemu interpreter directly against them, confirming `Exec format error` (PE/Mach-O incompatible with qemu-user's ELF-only loader) — not inferred, executed.
- `mach test .`: 1019 passed, 0 failed.
- Full `int/` suite clean on `linux` (121 cases), `linux-riscv64` (88 cases), and `linux-arm64` via `--runmode qemu` (87 cases).
- `targets.conf` untouched and `git status` clean throughout every run.
- No `src/lang` changes; compiler binary byte-identical to the `dev` baseline it was built against.

## Test plan

- [x] Baseline failure confirmed (78 cases × Exec format error, unmodified)
- [x] `--runmode qemu` on `linux-arm64`: 87/0, `targets.conf` unmodified, `git status` clean
- [x] Other legs' `qemu_bin()` mappings executed directly and reported (1 more functional-but-unexercised, 3 non-functional)
- [x] `mach test .`: 1019/0/1019
- [x] Full `int/` suite green on `linux` (121), `linux-riscv64` (88), `linux-arm64` (87)
- [x] Compiler binary byte-identical to `dev` baseline
- [x] CI green, including the real arm64 runner staying native, before marking ready