### PR TITLE
test(int): remove qemu_bin()'s three structurally-dead entries

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -64,14 +64,27 @@ _flat_loader_bin=
 # qemu_bin <target> — the qemu-user interpreter for a harness target, keyed by ISA
 # rather than sliced from the name. linux-riscv64's name suffix happens to match its
 # qemu-user binary (qemu-riscv64), but linux-arm64's does not (qemu-aarch64, never
-# qemu-arm64), and the bare `linux` / `windows` legs carry no ISA suffix at all. keep
-# in sync with the ISA each int/*/mach.toml's `[target.<leg>]` declares when a
-# targets.conf row is added.
+# qemu-arm64), and the bare `linux` leg carries no ISA suffix at all. keep in sync
+# with the ISA each int/*/mach.toml's `[target.<leg>]` declares when a targets.conf
+# row is added.
+#
+# ELF ONLY. qemu-user's loader understands the Linux ELF ABI and nothing else - a
+# PE or Mach-O artifact can never load under it, on any host, no matter which
+# qemu-<arch> binary is named. A target whose `[target.<leg>].os` is not `linux`
+# has no qemu interpreter and never will (#2453, found by executing qemu-x86_64
+# against a real windows PE artifact and qemu-aarch64 against a real darwin-aarch64
+# Mach-O one: both fail `Exec format error` unconditionally). Naming that here
+# explicitly is what keeps the next target addition from reintroducing a mapping
+# that looks alive and cannot work - the same shape #2314 found for linux-arm64,
+# except that one was dead-but-workable and these are dead-permanently.
 qemu_bin() {
     case "$1" in
-        linux|windows|darwin-x86_64) echo qemu-x86_64 ;;
-        linux-arm64|darwin-aarch64)  echo qemu-aarch64 ;;
-        linux-riscv64)               echo qemu-riscv64 ;;
+        linux)         echo qemu-x86_64 ;;
+        linux-arm64)   echo qemu-aarch64 ;;
+        linux-riscv64) echo qemu-riscv64 ;;
+        windows|darwin-x86_64|darwin-aarch64)
+            echo "int: '$1' is not linux - qemu-user loads ELF only, so a PE or Mach-O target has no qemu interpreter (#2453)" >&2
+            return 1 ;;
         *) echo "int: no qemu interpreter mapping for target '$1'" >&2; return 1 ;;
     esac
 }

--- a/int/run.sh
+++ b/int/run.sh
@@ -43,6 +43,11 @@
 # whether qemu-user runs because targets.conf says so or because `--runmode`
 # said so. Use it to iterate locally; CI never passes it, so the authoritative
 # lane - native on the real runner targets.conf names - is unaffected.
+#
+# `--runmode qemu` only reaches a leg qemu-user can actually load: qemu_bin() in
+# lib/produce.sh names the ELF-only rule and the three targets that can never
+# work under it (#2453) - passing `qemu` for one of those fails loudly with that
+# reason once the case's producer runs, not silently as an `Exec format error`.
 set -eu
 
 usage() {


### PR DESCRIPTION
## Summary

Found during #2314 (PR #2452) by execution, not inference: `windows`, `darwin-x86_64`, and `darwin-aarch64` build PE / Mach-O artifacts, and qemu-user's loader understands the Linux ELF ABI only. Built each target's artifact and ran its mapped `qemu-<arch>` interpreter directly against it — all three fail `Exec format error` unconditionally, on any host, regardless of which interpreter is named. Unlike `linux-arm64` (dead but *workable*, closed by #2314's `--runmode`), these three cannot ever work: the mapping implies a capability the harness cannot deliver — the exact "dead code that looks alive" shape #2314 itself named.

Removed the three entries from `qemu_bin()` and replaced them with an explicit refusal naming the reason, rather than falling through to the generic "no mapping" message. Added an **ELF ONLY** rule comment at the function so the next target addition doesn't reintroduce one of these by pattern-matching the surviving three rows.

Closes #2453

## Verification

- `--runmode qemu` against `windows`/`darwin-x86_64`/`darwin-aarch64` now reports `'<target>' is not linux - qemu-user loads ELF only, so a PE or Mach-O target has no qemu interpreter (#2453)` instead of `Exec format error`.
- `linux-arm64` unaffected: 87/0, matching #2314 exactly.
- `mach test .`: 1019 passed, 0 failed.
- Full `int/` suite unchanged on `linux` (121 cases) and `linux-riscv64` (88 cases).
- No `src/lang` changes; compiler binary byte-identical to the `dev` baseline it was built against.

## Test plan

- [x] `--runmode qemu` on all three dead targets reports the stated reason, not `Exec format error`
- [x] `linux-arm64` via `--runmode qemu` unaffected: 87/0
- [x] `mach test .`: 1019/0/1019
- [x] Full `int/` suite green on `linux` (121) and `linux-riscv64` (88)
- [x] Compiler binary byte-identical to `dev` baseline
- [x] CI green before marking ready