### PR TITLE
docs(ct): the zeroize guarantee is secret-storage scoped, not decorator scoped

### DIFF
--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -184,10 +184,17 @@ ordinary relocations.
 
 Marks a function as a constant-time boundary. Applies to functions only; takes
 no arguments. Inside it the backend must not introduce a secret-dependent
-branch, select a variable-latency instruction on a secret operand, or eliminate
-a zeroizing write to secret storage; a translation validator re-derives the
-secret taint over the lowered MIR and rejects any such leak. Inline `asm` is
-rejected inside an `#[oblivious]` function, since a type system cannot check it.
+branch or select a variable-latency instruction on a secret operand; a
+translation validator re-derives the secret taint over the lowered MIR and
+rejects any such leak. Inline `asm` is rejected inside an `#[oblivious]`
+function, since a type system cannot check it.
+
+The **zeroizing-write** guarantee is *not* one of the decorator's obligations,
+and describing it as one understates it. A write into secret storage carries a
+taint applied at lowering, keyed on the storage's secrecy rather than on any
+decorator, so a zeroizing wipe is protected in a function carrying no
+`#[oblivious]` at all. See [secrecy.md](secrecy.md#the-zeroizing-write-guarantee)
+for what that covers and what it does not.
 
 ```mach
 #[oblivious]

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -168,9 +168,10 @@ determine a layout it declines, which rejects.
 
 The flow typing constrains the *source*; `#[oblivious]` carries the obligation
 through *codegen*. Inside a function carrying it, the backend must not introduce
-a secret-dependent branch, select a variable-latency instruction on a secret
-operand, or dead-store-eliminate a zeroizing write to secret storage. Inline
-`asm` is rejected inside such a function.
+a secret-dependent branch or select a variable-latency instruction on a secret
+operand. Inline `asm` is rejected inside such a function.
+
+The zeroizing-write guarantee is separate and broader; it is described below.
 
 A secret-taint bit is threaded from sema's flow typing through IR and MIR to the
 emitted instruction stream, preserved across every value replacement, inline
@@ -194,6 +195,50 @@ re-checks the leakage conditions, so a secret reaching a branch condition, a
 memory address, or a forbidden variable-latency op is a compile error naming the
 function and the offending operation. It is a backstop behind the compile-time
 gates, not a replacement for them.
+
+## The zeroizing-write guarantee
+
+Wiping a secret is only useful if the wipe survives to run. That guarantee exists,
+but it is **not** provided by `#[oblivious]`, and it is scoped more broadly than the
+decorator is.
+
+A store into secret storage is tainted at lowering, from two composing sources: the
+stored **value**'s secrecy, and — for a public value written into secret storage, the
+shape a wipe takes — the **destination**'s secrecy, read from the lvalue's semantic
+type. Either one marks the store. That taint is the thing an optimization must
+consult, and it is keyed on the storage, not on any decorator, so:
+
+```mach
+# no decorator: the wipe is protected anyway
+fun clear(p: *^u8, n: usize) {
+    var i: usize = 0;
+    for (i < n) { p[i] = 0; i = i + 1; }
+}
+```
+
+**What it covers.** Memory, reached through a pointer that escapes the function — the
+shape `crypto.ct.zeroize` has. Such a store cannot be promoted out of memory, and the
+taint is present for any future pass to read.
+
+**What it does not cover.** A value the compiler keeps in a **register**. Writing to a
+promoted local is not a memory write, so wiping one is not preserved:
+
+```mach
+var x: ^u8 = k;
+x = 0;          # NOT guaranteed: `x` may never have been in memory
+```
+
+Adding `#[oblivious]` does not change this — the wipe is outside the memory-address
+leakage model rather than an exception within it. To wipe reliably, write through a
+pointer whose target is memory the compiler cannot promote away, which is what the
+standard library's `zeroize` does. Whether the language should instead *enforce* the
+register boundary — by refusing to promote a wiped secret local, or by other means —
+is open in RFC #2456 and deliberately undecided here.
+
+**Today the guarantee is not yet load-bearing**, because no dead-store elimination
+exists to remove anything: an entirely dead fill of a *public* local also survives at
+release. The taint is what makes the requirement enforceable *before* such a pass
+lands, and `mach.lang.driver:secret_store_taint_survives_lower` pins it.
 
 The contract is only offered where mach emits the instructions that execute.
 A target whose back half hands a module to a downstream compiler instead — the

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9722,3 +9722,108 @@ test "mach.lang.driver:setup_registry_refuses_an_unwired_debug_identity" {
     session.dnit(?s2);
     ret 0;
 }
+
+# tally the lowered stores and how many carry the secret-storage taint
+#
+# Walks post-lower IR because that is what a dead-store-elimination sweep would
+# walk. The counts are separated so a test can assert both that the taint is present
+# where it must be and ABSENT where it must not - a marker that is always set carries
+# no information and would satisfy a presence-only assertion.
+# ---
+# p:      the lowered project
+# stores: out - every OP_STORE / OP_MEMZERO across the project's modules
+# marked: out - how many of those carry `Instruction.secret`
+fun ut_tally_secret_stores(p: *project.Project, stores: *u32, marked: *u32) {
+    @stores = 0;
+    @marked = 0;
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var fi: u32 = 0;
+            for (fi < m.function_len) {
+                val fn: *ir.Function = ?m.functions[fi];
+                var bi: u32 = 0;
+                for (bi < fn.block_count) {
+                    val blk: *ir.Block = ?fn.blocks[bi];
+                    var ix: u32 = 0;
+                    for (ix < blk.instr_count) {
+                        val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
+                        if (ins.kind == instruction.OP_STORE || ins.kind == instruction.OP_MEMZERO) {
+                            @stores = @stores + 1;
+                            if (ins.secret) { @marked = @marked + 1; }
+                        }
+                        ix = ix + 1;
+                    }
+                    bi = bi + 1;
+                }
+                fi = fi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+}
+
+# a zeroizing write into secret storage carries the taint a future dead-store
+# elimination must consult - and an identical write into PUBLIC storage does not
+#
+# This is the #2364 guard, and it deliberately does NOT assert that the stores
+# survive. They survive today because no dead-store elimination exists, so a
+# survival assertion passes for the wrong reason and would keep passing right up
+# until a sweep lands that reads the wrong thing. What must hold before that sweep
+# is written is that the TAINT is there to read, on the shape that needs it.
+#
+# The shape under test is `crypto.ct.zeroize`'s exact one: `q[i] = 0` through a
+# `*^u8`. That is a PUBLIC zero written into SECRET storage, so it is invisible to
+# the value-keyed marking in `me.ir.builder.emit_store` and is caught only by the
+# destination-keyed marking in `me.lower.expr.assign_epilogue`. Removing either half
+# must fail this test.
+#
+# The `^`-stripped control is what makes the assertion mean something: the identical
+# source with the secrecy qualifier removed must produce the same stores with NONE
+# of them tainted. Without it, a marking that tainted every store would pass.
+test "mach.lang.driver:secret_store_taint_survives_lower" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # SECRET storage: a public zero written through a pointer to `^` storage. no
+    # `#[oblivious]` anywhere - the guarantee is secret-storage scoped, not decorator
+    # scoped, and this pins that.
+    val ssrc: str = "fun wipe(q: *^u8, n: u64) { var i: u64 = 0; for (i < n) { q[i] = 0; i = i + 1; } }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+    val spr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, ssrc, "linux");
+    if (R.is_err[project.Project, outcome.Fail](spr)) { ret 1; }
+    var sp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](spr);
+    var sstores: u32 = 0;
+    var smarked: u32 = 0;
+    ut_tally_secret_stores(?sp, ?sstores, ?smarked);
+
+    # PUBLIC storage: byte-identical source with the `^` removed.
+    val psrc: str = "fun wipe(q: *u8, n: u64) { var i: u64 = 0; for (i < n) { q[i] = 0; i = i + 1; } }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+    val ppr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, psrc, "linux");
+    if (R.is_err[project.Project, outcome.Fail](ppr)) { ret 4; }
+    var pp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](ppr);
+    var pstores: u32 = 0;
+    var pmarked: u32 = 0;
+    ut_tally_secret_stores(?pp, ?pstores, ?pmarked);
+
+    # a secret VALUE stored by an aggregate literal. the element stores go through
+    # `emit_store` directly - they are neither an assignment nor a decl statement - so
+    # ONLY the value-keyed half marks them. without this the value-keyed half is
+    # entirely untested: removing it fails nothing else in the suite (#2364).
+    val vsrc: str = "fun mk(k: ^u8) [2]^u8 { var a: [2]^u8 = [2]^u8{k, k}; ret a; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+    val vpr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, vsrc, "linux");
+    if (R.is_err[project.Project, outcome.Fail](vpr)) { ret 6; }
+    var vp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](vpr);
+    var vstores: u32 = 0;
+    var vmarked: u32 = 0;
+    ut_tally_secret_stores(?vp, ?vstores, ?vmarked);
+
+    if (sstores == 0 || pstores == 0) { ret 3; }   # nothing lowered: the probe is broken
+    if (smarked == 0)                 { ret 2; }   # the secret wipe carries NO taint
+    if (pmarked != 0)                 { ret 5; }   # a public store is tainted: no discrimination
+    if (vmarked == 0)                 { ret 7; }   # a secret VALUE store carries no taint
+    ret 0;
+}

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -528,12 +528,18 @@ pub fun emit_store(b: *Builder, value_arg: value.Value, ptr: value.Value) R.Resu
     if (R.is_err[id.InstructionId, str](res_iid)) {
         ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](res_iid));
     }
-    # a store of a secret value writes secret storage; mark the store so a future
+    # a store of a secret VALUE writes secret storage; mark the store so a future
     # dead-store-elimination pass and the #1648 validator can identify it and keep a
-    # zeroizing write to secret storage alive (#1646). a zeroizing store of a public
-    # zero into secret storage is not caught here (its destination pointee, not its
-    # value, is secret) - that refinement needs the lvalue's semantic type at the
-    # store site and rides with the validator work.
+    # zeroizing write to secret storage alive (#1646).
+    #
+    # This is one of TWO marking sites, and it is the value-keyed half. A zeroizing
+    # store of a PUBLIC zero into secret storage is not caught here - its destination
+    # pointee is secret, not its value - and is marked by the destination-keyed half
+    # instead: `me.lower.expr.assign_epilogue` and the decl-statement sites in
+    # `me.lower.stmt`, which read the lvalue's semantic type and call
+    # `mark_last_secret`. The two compose to cover the whole of `Instruction.secret`;
+    # neither alone does, and reading only this one is how #2364 concluded the
+    # `ct.zeroize` shape was unprotected when it is not.
     if (value_arg.secret) {
         val siid: id.InstructionId = R.unwrap_ok[id.InstructionId, str](res_iid);
         if (siid::u32 < b.fn.instr_len) { b.fn.instrs[siid::u32].secret = true; }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2841,6 +2841,12 @@ fun assign_epilogue(ctx: *context.LowerContext, e: *expr.Expr, rhs: value.Value)
     # public - a zeroizing wipe `k = 0` of a `^` local (#1646). emit_store marks a
     # secret-VALUE store; this marks by DESTINATION secrecy (the lvalue's semantic type),
     # so a future dead-store-elimination and the #1648 validator keep the wipe.
+    #
+    # This is the DESTINATION-keyed half of `Instruction.secret`, and it is the half
+    # that covers `crypto.ct.zeroize` - `p[i] = 0` through a `*^u8`, a public zero into
+    # secret storage, which the value-keyed half in `me.ir.builder.emit_store` cannot
+    # see. The guarantee is therefore SECRET-STORAGE scoped, not `#[oblivious]` scoped:
+    # it holds in a function carrying no decorator at all (#2364).
     if (context.type_is_secret(ctx, context.expr_type_of(ctx, e.data.binary.lhs))) {
         builder.mark_last_secret(?ctx.builder);
     }

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -28,6 +28,21 @@
 # it MUST consult the secret taint (`Instruction.secret`) and never remove a store /
 # memzero to secret storage; eliminating a zeroization would leave a secret in memory
 # past its intended lifetime, the leak the #1648 validator checks on emitted code.
+#
+# THERE IS ONE TAINT, NOT TWO (#2364). The MIR-side `MirInstr.writes_secret` seed is
+# DERIVED from this field - `be.codegen.mir.lower` stamps it as `(OP_STORE ||
+# OP_MEMZERO) && inst.secret` - so a sweep may consult whichever side it runs on and
+# get the same answer. `Instruction.secret` itself is written by two composing sites,
+# and a sweep depends on BOTH: `me.ir.builder.emit_store` marks a secret-VALUE store,
+# and `me.lower.expr.assign_epilogue` (with the decl-statement sites in
+# `me.lower.stmt`) marks by DESTINATION secrecy, which is the half that covers a
+# public zero written into secret storage - `crypto.ct.zeroize`'s exact shape.
+#
+# The guarantee this protects is SECRET-STORAGE scoped, not `#[oblivious]` scoped: it
+# holds in a function carrying no decorator. A sweep must therefore key on the taint,
+# never on the decorator - keying on the decorator would silently drop every wipe
+# outside an annotated function. `mach.lang.driver:secret_store_taint_survives_lower`
+# pins the taint so this requirement is enforceable before such a sweep exists.
 
 use std.allocator.page;
 use std.types.bool.bool;


### PR DESCRIPTION
Closes #2364.

Docs, one test, and comment corrections. **No codegen change** — objects byte-identical on all three targets.

## Current truth, measured from emitted code

Three probes, disassembled per symbol. **Debug and release are identical**, which is part of the finding:

| probe | emitted |
|---|---|
| wipe through a pointer to `^` storage (`ct.zeroize`'s shape) | 10 insns, **1 store — survives** |
| entirely dead fill of a **public** local | 20 insns, **5 stores — also survives** |
| promoted secret scalar `var x: ^u8 = k; x = 0;` | 2 insns, **0 stores — wipe gone** |

Both of the issue's claims confirmed: there is **no dead-store elimination** for `#[oblivious]` to forbid, and the one store that *is* removed is removed with or without the decorator.

## The correction runs upward

`decorators.md` and `secrecy.md` both listed "dead-store-eliminate a zeroizing write" among the decorator's obligations. The real mechanism is **stronger**: a taint applied at lowering, keyed on the **storage's** secrecy rather than on any decorator, so a wipe is protected in a function carrying no `#[oblivious]` at all. Documenting less than the mechanism delivers would be the same falsehood in the other direction, so the docs now say what it actually does — and what it does **not** (a promoted register), citing RFC #2456 for whether that boundary should be *enforced* rather than deciding it here.

## The recorded finding was derivation, not disagreement

The #2364 comment held that there are two markings that don't cover the same thing, and that a future DSE reading the IR-level `Instruction.secret` would not see `zeroize` as protected. Not reproduced:

- `MirInstr.writes_secret` is **derived** from the IR marking — `mir/lower.mach` stamps it `(OP_STORE || OP_MEMZERO) && inst.secret`. They cannot disagree about which stores are marked.
- `Instruction.secret` **does** cover public-zero-into-secret-storage, via a second site the finding missed: `assign_epilogue` marks by the lvalue's secrecy.

Verified by walking lowered IR, not by reading: the secret-storage wipe's store carries the taint; the byte-identical source with `^` removed does not.

The stale comment in `me/ir/builder.mach` claiming that refinement was still pending is corrected, and both marking sites now say they compose — that comment is what the finding read.

## Tests

One test, `mach.lang.driver:secret_store_taint_survives_lower`. It deliberately does **not** assert that stores survive: they survive today because no DSE exists, so a survival assertion passes for the wrong reason and would keep passing right up until a sweep lands reading the wrong thing. It asserts the **taint a future sweep must consult** is present on the shape that needs it, absent on the public control, and present on a secret-value store.

**Mutation-checked 4/4**, each with a distinct exit code naming the broken property:

| mutation | result |
|---|---|
| destination-keyed marking off (`assign_epilogue`) | FAILS, exit 2 — secret wipe untainted |
| destination-keyed off (assign + decl sites) | FAILS, exit 2 |
| marking made indiscriminate (taint every store) | FAILS, exit 5 — no discrimination |
| value-keyed marking off (`emit_store`) | FAILS, exit 7 |

**The fourth found a real gap.** Before this test, removing the value-keyed marking entirely failed **zero** tests in the whole suite — that half of `Instruction.secret` was untested. Covering it needed a shape that reaches `emit_store` without being an assignment or a decl: an aggregate literal's element stores. That case is now in the test.

## Verification

- Three-generation fixpoint `b == c`, branch and baseline.
- `mach test` **1020 / 0** (baseline 1019 — the one added test).
- `int/run.sh` green on **`linux` and `linux-riscv64`**, both profiles. `linux-arm64` is `native` in `targets.conf` and cannot run on this x86_64 host; it fails 78/78 identically on the unmodified baseline, so that is apparatus. CI's arm64 runner is the authority.
- **Byte-identical, all three targets**, binary and object tree, with both controls: self-vs-self identical first, then base-vs-mine 0 differing across 221 / 436 / 651 objects. No behaviour change, as the issue predicted.

## Not decided here

Whether the language should *enforce* the register/memory boundary is RFC #2456, parked for the owner. This PR documents the boundary and cites it.