### PR TITLE
test(int): guard every case manifest declares its target blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,12 @@ jobs:
 
   # the integration matrix is data-driven from int/targets.conf: this setup job
   # turns the pr-cadence rows into the include list the integration job matrixes
-  # over, so adding a target is one targets.conf row and no workflow edit.
+  # over, so adding a target is one targets.conf row and no workflow edit. also
+  # runs the target-matrix consistency check (#2353): static, no compiler and no
+  # macOS runner needed, so it belongs in this already-lightweight job rather
+  # than its own - and failing here skips `integration` entirely via `needs`,
+  # catching a missing [target.<leg>] block before spending real build time on
+  # legs that would fail to compile anyway.
   int-matrix:
     name: int matrix
     runs-on: ubuntu-latest
@@ -322,6 +327,8 @@ jobs:
       include: ${{ steps.gen.outputs.include }}
     steps:
       - uses: actions/checkout@v6
+      - name: check every case declares its target blocks
+        run: bash int/lib/check-target-matrix.sh
       - id: gen
         run: echo "include=$(bash int/lib/ci-matrix.sh pr)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -6,8 +6,11 @@ name: int main
 # the release-integration gate catches a darwin codegen regression there while
 # paying the macOS cost only then. the leg set is still data-driven from
 # int/targets.conf (the main-cadence rows), so adding a darwin target needs no edit
-# here — but it is not free: every case manifest must declare the target too, and a
-# manifest that omits it only fails at that leg's cadence (#2353).
+# here — but it is not free: every case manifest must declare the target too, or the
+# leg fails to compile on the case that omitted it. ci.yml's int-matrix job runs
+# check-target-matrix.sh on every PR, which is where this actually has to be caught
+# (main-cadence-only enforcement is no enforcement, #2353); this job runs it again
+# as the second gate before the scarce runner time this workflow spends.
 
 on:
   push:
@@ -25,6 +28,8 @@ jobs:
       include: ${{ steps.gen.outputs.include }}
     steps:
       - uses: actions/checkout@v6
+      - name: check every case declares its target blocks
+        run: bash int/lib/check-target-matrix.sh
       - id: gen
         run: echo "include=$(bash int/lib/ci-matrix.sh main)" >> "$GITHUB_OUTPUT"
 

--- a/int/lib/case.sh
+++ b/int/lib/case.sh
@@ -1,0 +1,76 @@
+# case.sh — case-manifest loading, shared by run.sh and check-target-matrix.sh.
+#
+# the single reader for case.conf's key set and targets.conf's leg list (#2353):
+# a second implementation of either schema is exactly the kind of drifting
+# parallel enumeration this repo treats as a recurring defect family, and both
+# callers need the identical "which legs does this case run on" answer.
+
+_case_lib_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+_case_conf="$_case_lib_dir/../targets.conf"
+
+# all_targets — print every target name declared in targets.conf.
+all_targets() {
+    while read -r name runner runmode rowcadence rest; do
+        case "$name" in ''|\#*) continue ;; esac
+        echo "$name"
+    done < "$_case_conf"
+}
+
+# conf_runmode <target> — print the run-mode column for a target, or fail.
+conf_runmode() {
+    while read -r name runner runmode rowcadence rest; do
+        case "$name" in ''|\#*) continue ;; esac
+        if [ "$name" = "$1" ]; then echo "$runmode"; return 0; fi
+    done < "$_case_conf"
+    return 1
+}
+
+# in_list <item> <space-separated-list>
+in_list() {
+    case " $2 " in *" $1 "*) return 0 ;; esac
+    return 1
+}
+
+# read_case_conf <case-dir> — load a case's defaults, then override from
+# case.conf if present.
+#
+# Sets case_targets, case_exempt, case_profiles, case_run, case_build_target,
+# case_build_flags, case_self_host, and case_allow: the `targets:` resolution
+# (all targets.conf legs, or the explicit list) BEFORE the `exempt:`
+# subtraction a caller applies per leg with `in_list "$leg" "$case_exempt"` -
+# two separate checks, matching how a leg is included then excluded rather
+# than folding both into one filtered list here.
+read_case_conf() {
+    dir=$1
+    case_targets=all
+    case_exempt=
+    case_profiles="debug release"
+    case_run=exec
+    case_build_target=
+    case_build_flags=
+    case_self_host=false
+    if [ -f "$dir/case.conf" ]; then
+        while IFS= read -r line || [ -n "$line" ]; do
+            case "$line" in ''|\#*) continue ;; esac
+            key=${line%%:*}
+            value=${line#*:}
+            key=$(echo "$key" | tr -d '[:space:]')
+            value=$(echo "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+            case "$key" in
+                targets)      case_targets=$value ;;
+                exempt)       case_exempt=$value ;;
+                profiles)     case_profiles=$value ;;
+                run)          case_run=$value ;;
+                build-target) case_build_target=$value ;;
+                build-flags)  case_build_flags=$value ;;
+                self-host)    case_self_host=$value ;;
+                *) echo "run.sh: $dir/case.conf: unknown key '$key'" >&2; exit 2 ;;
+            esac
+        done < "$dir/case.conf"
+    fi
+    if [ "$case_targets" = all ]; then
+        case_allow=$(all_targets | tr '\n' ' ')
+    else
+        case_allow=$case_targets
+    fi
+}

--- a/int/lib/check-target-matrix.sh
+++ b/int/lib/check-target-matrix.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# check-target-matrix.sh — verify every case declares a [target.<build-target>]
+# block in its mach.toml for every leg it actually builds on.
+#
+# usage: check-target-matrix.sh
+#
+# targets.conf documents that adding a leg "is one row here and touches no
+# workflow" - true of the workflow, false of case manifests (#2353). A case
+# with no case.conf `targets:` restriction defaults to `targets: all` (see
+# case.sh's read_case_conf), so it is expected to build on every targets.conf
+# leg and needs a [target.<leg>] block for each - or, when case.conf names a
+# `build-target`, a single [target.<build-target>] block regardless of how
+# many legs cross-build that same format (a structural case that runs
+# `targets: linux` and cross-builds windows / darwin / freestanding / bmos /
+# spirv only ever needs the one block its build-target names, never a block
+# per leg it happens to run on).
+#
+# Five real cases were added while x86_64-darwin was dropped from
+# targets.conf, none declared its block, and they would have failed to
+# compile the moment the leg returned - caught only because someone was
+# actively restoring the platform at the time (#2327).
+#
+# STATIC AND FAST: no compiler, no build, no macOS runner - reads manifests
+# only. Wired into the int-matrix job, the same lightweight job that already
+# reads targets.conf to generate the CI matrix, so this runs on every
+# ordinary PR - not only at main cadence, the cadence the darwin gap this
+# guards against actually surfaces on.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$here/case.sh"
+
+fails=0
+checked=0
+
+for dir in "$here"/../surface/*/ "$here"/../regression/*/; do
+    dir=${dir%/}
+    [ -f "$dir/mach.toml" ] || continue
+    case_id=${dir#"$here"/../}
+
+    read_case_conf "$dir"
+
+    for leg in $case_allow; do
+        in_list "$leg" "$case_exempt" && continue
+        build_target=${case_build_target:-$leg}
+        checked=$((checked + 1))
+        if ! grep -q "^\[target\.$build_target\]" "$dir/mach.toml"; then
+            echo "FAIL $case_id: leg '$leg' needs [target.$build_target] in mach.toml" >&2
+            fails=$((fails + 1))
+        fi
+    done
+done
+
+if [ "$checked" -eq 0 ]; then
+    echo "check-target-matrix.sh: no case x leg pairs checked - broken harness, not a finding" >&2
+    exit 2
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "check-target-matrix: $fails missing target block(s)" >&2
+    exit 1
+fi
+echo "check-target-matrix: $checked case x leg pair(s) OK"

--- a/int/run.sh
+++ b/int/run.sh
@@ -83,7 +83,7 @@ done
 [ -n "$compiler" ] || { echo "run.sh: a compiler path is required" >&2; usage; }
 
 here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-conf="$here/targets.conf"
+. "$here/lib/case.sh"
 . "$here/lib/produce.sh"
 
 # resolve the compiler to an absolute path; cases are built from their own dirs.
@@ -106,29 +106,6 @@ esac
 if [ ! -f "$compiler" ] && [ -f "$compiler$exe" ]; then
     compiler=$compiler$exe
 fi
-
-# conf_runmode <target> — print the run-mode column for a target, or fail.
-conf_runmode() {
-    while read -r name runner runmode rowcadence rest; do
-        case "$name" in ''|\#*) continue ;; esac
-        if [ "$name" = "$1" ]; then echo "$runmode"; return 0; fi
-    done < "$conf"
-    return 1
-}
-
-# all_targets — print every target name declared in targets.conf.
-all_targets() {
-    while read -r name runner runmode rowcadence rest; do
-        case "$name" in ''|\#*) continue ;; esac
-        echo "$name"
-    done < "$conf"
-}
-
-# in_list <item> <space-separated-list>
-in_list() {
-    case " $2 " in *" $1 "*) return 0 ;; esac
-    return 1
-}
 
 # lock_commit <mach.lock> <name> — the commit mach.lock records for [dep.<name>],
 # or empty when the file or the entry is absent.
@@ -215,42 +192,11 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
     [ -f "$dir/mach.toml" ] || continue
     case_id=${dir#"$here"/}
 
-    # case defaults; case.conf overrides any of them (line-based `key: value`).
-    case_targets=all
-    case_exempt=
-    case_profiles="debug release"
-    case_run=exec
-    case_build_target=
-    case_build_flags=
-    case_self_host=false
-    if [ -f "$dir/case.conf" ]; then
-        while IFS= read -r line || [ -n "$line" ]; do
-            case "$line" in ''|\#*) continue ;; esac
-            key=${line%%:*}
-            value=${line#*:}
-            key=$(echo "$key" | tr -d '[:space:]')
-            value=$(echo "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-            case "$key" in
-                targets)        case_targets=$value ;;
-                exempt)         case_exempt=$value ;;
-                profiles)       case_profiles=$value ;;
-                run)            case_run=$value ;;
-                build-target)   case_build_target=$value ;;
-                build-flags)    case_build_flags=$value ;;
-                self-host)      case_self_host=$value ;;
-                *) echo "run.sh: $case_id/case.conf: unknown key '$key'" >&2; exit 2 ;;
-            esac
-        done < "$dir/case.conf"
-    fi
-
-    # resolve the applicable target set: the allowlist (all, or an explicit list)
-    # minus the exempt list.
-    if [ "$case_targets" = all ]; then
-        allow=$(all_targets | tr '\n' ' ')
-    else
-        allow=$case_targets
-    fi
-    if ! in_list "$target" "$allow"; then continue; fi
+    # case defaults, overridden by case.conf if present, and the resolved
+    # `targets: all`-or-explicit allowlist - shared with check-target-matrix.sh
+    # (#2353) so the two never disagree about what a case.conf line means.
+    read_case_conf "$dir"
+    if ! in_list "$target" "$case_allow"; then continue; fi
     if in_list "$target" "$case_exempt"; then continue; fi
 
     # the mach target to compile: the build-target if set, else the leg itself.


### PR DESCRIPTION
## Summary

`targets.conf` documents that adding a leg "is one row here and touches no workflow" — true of the workflow, false of case manifests. Five real cases were added while x86_64-darwin was dropped from `targets.conf`; none declared a `[target.darwin-x86_64]` block, and they would have failed to compile the moment the leg returned — caught only because someone was actively restoring the platform at the time (#2327). The gap only surfaces at main cadence, since the darwin legs run on merge to `main` rather than per-PR, so a case added on a green PR merges and the omission is discovered later on a lane nobody is watching at that moment.

**Answered the issue's own design question first, by inspection** of all ~64 case manifests (266 case×leg pairs) rather than assumption: every case that does *not* need every `targets.conf` leg already expresses that through case.conf's existing `targets:`/`exempt:` fields, each with an explanatory comment justifying the restriction (e.g. `debuginfo`: "windows (CodeView) and darwin (Mach-O) debug info have distinct validators and are out of scope here"; `syscall-inline-asm` exempts windows because "windows has no syscall ABI"). Structural cases (spirv/bmos/freestanding/macho/pe-*) run `targets: linux` and cross-build via `build-target:` to a format entirely outside the leg namespace — a different axis, not a target-matrix gap. **No case's declared blocks disagreed with its case.conf scope anywhere in the sweep**: the existing case.conf mechanism *is* the opt-out the issue asks for, visible at the case and self-explaining already. No new opt-out syntax needed, and no policy question to escalate — the inventory came back clean, not target-limited-by-default.

**What shipped**: `int/lib/check-target-matrix.sh` — a static, fast guard mirroring `run.sh`'s own resolution exactly: for every case, for every leg in its case.conf-resolved allowlist (minus exempt), the case must declare `[target.<build-target>]` in mach.toml. Extracted that resolution (case.conf parsing, the `targets.conf` leg list, the allow/exempt computation) into a new shared `int/lib/case.sh`, sourced by both `run.sh` and the new checker — a second implementation of case.conf's key set would have been exactly the kind of drifting parallel enumeration this repo already treats as a recurring defect family. `run.sh`'s own inline case.conf reader is gone in favor of one call to `read_case_conf`.

Wired into `ci.yml`'s `int-matrix` job, which already runs on every ordinary PR (not only main cadence) and already gates `integration` via `needs:`, so a missing block fails fast before any real build time is spent on a leg that would not have compiled anyway. Also wired into `int-main.yml`'s own `int-matrix` job as a second gate before the scarce darwin runner time that workflow spends.

Closes #2353

## Verification

- **Demonstrated firing, per the bar**: removed `[target.darwin-x86_64]` from `2368-deep-nest`'s mach.toml, ran the checker — `FAIL regression/2368-deep-nest: leg 'darwin-x86_64' needs [target.darwin-x86_64] in mach.toml` — restored, `git status` clean.
- Repeated against a build-target case (`pe-import-attribution`, `build-target: windows`): removing `[target.windows]` correctly reports `FAIL surface/pe-import-attribution: leg 'linux' needs [target.windows] in mach.toml`, naming the LEG the case actually runs on and the BUILD-TARGET block it's missing as two distinct facts.
- `check-target-matrix.sh` reports 266/266 case×leg pairs OK at HEAD.
- `mach test .`: 1019 passed, 0 failed.
- Full `int/` suite unchanged on `linux` (121 cases) and `linux-riscv64` (88 cases); `linux-arm64` via #2314's `--runmode` override also unchanged (87 cases) — confirming the `case.sh` extraction is fully behavior-preserving, not just the new check.
- No `src/lang` changes; compiler binary byte-identical to the `dev` baseline it was built against.

## Test plan

- [x] Design question answered by inspection: no case disagrees with its case.conf scope; existing mechanism is the opt-out
- [x] Removing a target block from a full-6-target case: check fails naming case + target, restored, `git status` clean
- [x] Removing a target block from a build-target case: check fails naming leg + build-target correctly, restored
- [x] `check-target-matrix.sh`: 266/266 OK
- [x] `mach test .`: 1019/0/1019
- [x] Full `int/` suite green on `linux` (121), `linux-riscv64` (88), `linux-arm64` via `--runmode` (87)
- [x] Compiler binary byte-identical to `dev` baseline
- [x] CI green (both `ci.yml` and, once relevant, `int-main.yml`) before marking ready