### PR TITLE
feat(comptime): type predicates + $type_name, over a field-descriptor type operand

### DIFF
--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -353,9 +353,9 @@ $or ($type_of(arg) == str) { write_str(w, arg); }
 $or { $error("no writer for this argument type"); }    # compile error on an unhandled type
 ```
 
-> **`$assert` not yet implemented.** `$assert` parses as a comptime directive
-> but the compiler does not yet evaluate it. It is intended as sugar over `$if`
-> plus `$error` — `$assert(cond, "msg")` ≡ `$if (!cond) { $error("msg"); }`,
+> **`$assert` not yet implemented.** `$assert` is rejected wherever it is written -
+> with any condition, a plain `1 == 1` included - not merely accepted and ignored.
+> It is intended as sugar over `$if` plus `$error` — `$assert(cond, "msg")` ≡ `$if (!cond) { $error("msg"); }`,
 > e.g. `$assert($mach.build.arch == $mach.arch.x86_64, "expected x86_64");`. Being `$if`
 > sugar, it will inherit `$if`'s restrictions: a layout intrinsic in `cond` is
 > rejected for the reason above, so `$assert($size_of(i64) == 8, ...)` is not a

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -73,6 +73,65 @@ is reported as a layout cycle naming the type that closes it. A pointer field do
 not create one: it stores an address of fixed width, so `rec Node { next: *Node; }`
 measures normally.
 
+## Type predicates
+
+Ask about a type's **shape** rather than its storage. Each takes one type operand
+and folds in a `$if` / `$or` gate:
+
+```mach
+$is_record(T)           # T is a record (or an instance of one)
+$is_union(T)            # T is a union  (or an instance of one)
+$is_pointer(T)          # T is a reference: the raw `ptr` or a typed `*U`
+```
+
+They are **comptime-only** — a gate condition selects an arm, and there is no
+runtime boolean for one to become, so using a predicate as a value is an error.
+
+A `^` secret wrapper is stripped before the question is answered: `^Pair` is a
+record, because `^T` is a wrapper over `T`'s storage. A generic instance answers as
+the declaration it instantiates, so `Box[i64]` is a record — which is the type a
+reflection loop actually meets.
+
+```mach
+rec Inner { x: u64; y: u64; }
+rec Outer { i: Inner; n: u64; }
+
+$each f in $fields(Outer) {
+    $if ($is_record(f.type)) {
+        $each g in $fields(f.type) { ... }   # descend
+    } $or { ... }                            # a scalar field
+}
+```
+
+## `$type_name(T)` — a type's spelling
+
+```mach
+$type_name(T)           # the type's spelling, as a NUL-terminated string
+```
+
+Unlike the predicates this **is** a value (`*u8`), usable anywhere one is. The
+spelling is the same one diagnostics print, so a name a program reads and a name an
+error reports cannot drift. Composites spell compositely (`$type_name(*Pair)` is
+`"*Pair"`), and a `^` wrapper is stripped as it is for the predicates.
+
+## The type operand
+
+`$size_of` / `$align_of` / `$offset_of` / `$fields` and the queries above all take a
+**type** in argument 0, written with the ordinary type grammar — plus one extra
+form: a field descriptor's `f.type` inside a `$each` body.
+
+```mach
+$each f in $fields(T) {
+    val n: u64 = $size_of(f.type);      # the field's own size
+    $each g in $fields(f.type) { ... }  # its own fields
+}
+```
+
+That form is what makes recursive reflection expressible: inside the loop a field's
+type has no spelling, only the descriptor. A path that is genuinely a qualified type
+name (`mod.Type`) still reads as one, and a wrong one still reports against the type
+grammar.
+
 ## Type intrinsic
 
 `$type_of(expr)` produces a comptime type value — the resolved type of its

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1451,6 +1451,87 @@ test "mach.lang.driver:layout_intrinsic_remaining_positions" {
     ret bad;
 }
 
+# a comptime type predicate answers about a type's SHAPE, and a gate on one selects
+# an arm (#2128)
+#
+# Each case drives the answer out through `$error`, so the assertion is on WHICH arm
+# the gate selected rather than on the program merely compiling - a predicate that
+# always answered false would still compile every one of these.
+#
+# The secret cases are the ones worth having: `^T` is a wrapper over `T`, so a shape
+# question asked through one must answer about `T`. An unstripped query silently
+# reports the wrapper's shape, which is this repo's recurring silent-wrong-answer
+# family (#2297, #2373) - so the strip is pinned here rather than assumed.
+test "mach.lang.driver:comptime_type_predicates" {
+    var bad: i32 = 0;
+
+    # $is_record: a record yes, a union no, a scalar no, a pointer no
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_record(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
+    if (ut_vec_diag("fun main() i32 { $if ($is_record(u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
+    # an INSTANCE of a record answers as the record: post-#2168 that is the type a
+    # reflection loop actually meets for `Box[i64]`
+    if (ut_vec_diag("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+
+    # $is_union, mirrored
+    if (ut_vec_diag("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_union(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
+    if (ut_vec_diag("uni Box[T] { v: T; w: u32; }\nfun main() i32 { $if ($is_union(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+
+    # $is_pointer covers BOTH spellings of a reference
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("fun main() i32 { $if ($is_pointer(ptr)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+
+    # a predicate is comptime-only: there is no runtime boolean for one to become
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { val b: u8 = $is_record(P); ret 0; }\n",
+                    "comptime type predicate is comptime-only") != 0) { bad = 1; }
+    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(P, P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n",
+                    "expected 1 argument") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# `$type_name(T)` yields the type's spelling, and it is the SAME spelling sema
+# prints in diagnostics - `typename.type_to_str` is the one authority, so a program
+# reading a name and an error reporting one cannot drift (#2128)
+test "mach.lang.driver:comptime_type_name" {
+    var bad: i32 = 0;
+
+    if (ut_vec_diag("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    # a composite spells compositely rather than degrading to the nominal
+    if (ut_vec_diag("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(*Pair) == \"*Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    # the secret wrapper is stripped here too, so `^Pair` names `Pair`
+    if (ut_vec_diag("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    # unlike the predicates it IS a value, usable outside a gate
+    if (ut_layout_ok("rec Pair { a: u64; }\nfun main() i32 { val n: *u8 = $type_name(Pair); ret 0; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# the reflection loop the two issues exist to enable: a predicate gates the descent
+# and `$fields(f.type)` performs it (#2128 over #2454)
+test "mach.lang.driver:comptime_reflection_descent" {
+    var bad: i32 = 0;
+
+    # a record-typed field answers yes, a scalar field no - through the descriptor,
+    # which is the operand a real derive walk actually holds
+    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_vec_diag("rec Outer { n: u64; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N") != 0) { bad = 1; }
+    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { p: *Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_pointer(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+
+    # and the whole shape together: gate, then descend, over a MIXED record - which
+    # is the case that could not be written at all before, since the inner $fields
+    # would have been reached with a scalar
+    if (ut_layout_ok("rec Inner { x: u64; y: u64; }\nrec Outer { i: Inner; n: u64; }\nfun main() i32 { var c: i32 = 0; $each f in $fields(Outer) { $if ($is_record(f.type)) { $each g in $fields(f.type) { c = c + 1; } } $or { c = c + 100; } } ret c; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # an IMPORTED nominal measures in both folding positions (#2442)
 #
 # The premise the same-module-only forcing rests on: dependencies are type-checked

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1524,6 +1524,16 @@ test "mach.lang.driver:comptime_reflection_descent" {
     if (ut_vec_diag("rec Outer { n: u64; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N") != 0) { bad = 1; }
     if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { p: *Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_pointer(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
 
+    # $type_name through the descriptor: the same operand path as the predicates, so
+    # the spelling is pinned where a derive-style formatter would actually read it
+    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+
+    # a SECRET-typed field met through the loop: the #2297 / #2373 shape arriving via
+    # the descriptor rather than as a literal `^T` spelling, which is how a real walk
+    # would meet it. an unstripped query answers "not a record" and the derive walk
+    # silently skips the field.
+    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+
     # and the whole shape together: gate, then descend, over a MIXED record - which
     # is the case that could not be written at all before, since the inner $fields
     # would have been reached with a scalar

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -217,6 +217,22 @@ pub val FIELD_SEL_OFFSET: u8 = 2;
 # installs this hook with `set_field_resolver`
 pub def FieldMemberFn: fun(ptr, u32, u32, u8) R.Result[O.Option[CTValue], str];
 
+# the questions a comptime type query answers about one already-resolved type
+# (#2128). `eval` holds no type universe, so the typed layer installs the answer
+# with `set_type_query_resolver`, the same shape as the field-member hook above.
+pub val TYPE_QUERY_IS_RECORD:  u8 = 0;  # a record, or an instance of one
+pub val TYPE_QUERY_IS_UNION:   u8 = 1;  # a union, or an instance of one
+pub val TYPE_QUERY_IS_POINTER: u8 = 2;  # the raw `ptr` or a typed `*T`
+pub val TYPE_QUERY_NAME:       u8 = 3;  # the type's spelling, as a string
+
+# answers one TYPE_QUERY_* about a TypeId: a bool for the predicates, a string for
+# the name, or none when this context cannot answer (no resolver installed)
+pub def TypeQueryFn: fun(ptr, u32, u8) R.Result[O.Option[CTValue], str];
+
+# surfaced when a type predicate is used where no type query resolver is installed
+pub val COMPTIME_TYPE_QUERY_NO_RESOLVER_MSG: str =
+    "a comptime type predicate is only evaluable after type checking";
+
 # surfaced when a field-descriptor member is read
 # in a context that installed no field resolver (every pass before sema)
 pub val COMPTIME_FIELD_NO_RESOLVER_MSG: str =
@@ -328,6 +344,8 @@ pub rec ComptimeCtx {
     type_data:      ptr;
     field_fn:       *u8;
     field_data:     ptr;
+    query_fn:       *u8;
+    query_data:     ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -439,6 +457,16 @@ pub fun set_type_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 pub fun set_field_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.field_fn   = fn;
     c.field_data = data;
+}
+
+# install the type-query resolver `eval` calls to answer a type predicate (#2128)
+# ---
+# c:    the comptime context
+# fn:   erased TypeQueryFn, or nil to clear
+# data: opaque context handed back to `fn`
+pub fun set_type_query_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.query_fn   = fn;
+    c.query_data = data;
 }
 
 # bind the manifest-derived project metadata, the selected
@@ -718,6 +746,11 @@ pub fun eval(
     # asking the evaluator (#2442) - so what reaches this arm is a position with no
     # layout to force: a `$if` / `$or` condition, or a `$assert` once it evaluates.
     if (k == expr.EXPR_KIND_CALL) {
+        # a type predicate answers about the SHAPE of its operand type rather than
+        # its storage, so it folds here in the comptime channel - which is where the
+        # `$if` gate that consumes it is decided (#2128).
+        val q: O.Option[R.Result[CTValue, str]] = eval_type_query(c, a, source, e, interner);
+        if (O.is_some[R.Result[CTValue, str]](q)) { ret O.unwrap[R.Result[CTValue, str]](q); }
         if (is_layout_intrinsic_call(a, source, e)) {
             ret R.err[CTValue, str]("a layout intrinsic has no value in this position: it measures a type's storage, which only a type position resolves");
         }
@@ -1328,7 +1361,11 @@ pub fun intrinsic_takes_type_operand(source: str, full: token.Span) bool {
     ret view_eq_str(text, "size_of")
      || view_eq_str(text, "align_of")
      || view_eq_str(text, "offset_of")
-     || view_eq_str(text, "fields");
+     || view_eq_str(text, "fields")
+     || view_eq_str(text, "is_record")
+     || view_eq_str(text, "is_union")
+     || view_eq_str(text, "is_pointer")
+     || view_eq_str(text, "type_name");
 }
 
 # whether `eid` is a `$type_of(arg)` intrinsic call, recognized
@@ -1607,6 +1644,76 @@ fun eval_type_comparison(
 # `$type_of(...)` or type-name operand resolves through the installed type
 # resolver (#1472). errors when no resolver is installed, or when the operand has
 # no resolvable type identity
+# fold `$is_record(T)` / `$is_union(T)` / `$is_pointer(T)` / `$type_name(T)` (#2128)
+#
+# These ask about the SHAPE of a type rather than its storage, which is what makes
+# them the missing half of reflection-driven generics: `$fields` can now descend
+# into a field's own type (#2454), but only a predicate can say whether descending
+# is meaningful. The operand is resolved through the same path a type comparison
+# uses, so a type spelling, an `f.type` field descriptor, and `$type_of(v)` are all
+# spellable here.
+#
+# eval holds no type universe, so the answer comes from the installed
+# TypeQueryFn; without one this is a context that cannot answer rather than a
+# false predicate, and says so.
+# ---
+# ret: none when `e` is not one of the four, else the folded answer or an error
+fun eval_type_query(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    e:        id.ExprId,
+    interner: *intern.Interner
+) O.Option[R.Result[CTValue, str]] {
+    var which: u8 = TYPE_QUERY_IS_RECORD;
+    if      (is_comptime_call(a, source, e, "is_record"))  { which = TYPE_QUERY_IS_RECORD; }
+    or      (is_comptime_call(a, source, e, "is_union"))   { which = TYPE_QUERY_IS_UNION; }
+    or      (is_comptime_call(a, source, e, "is_pointer")) { which = TYPE_QUERY_IS_POINTER; }
+    or      (is_comptime_call(a, source, e, "type_name"))  { which = TYPE_QUERY_NAME; }
+    or      { ret O.none[R.Result[CTValue, str]](); }
+
+    val arg: id.ExprId = first_call_arg(a, e);
+    if (arg == id.EXPR_NIL) {
+        ret O.some[R.Result[CTValue, str]](
+            R.err[CTValue, str]("a comptime type query takes one type argument"));
+    }
+
+    val tv: R.Result[CTValue, str] = eval_type_operand(c, a, source, arg, interner);
+    if (R.is_err[CTValue, str](tv)) { ret O.some[R.Result[CTValue, str]](tv); }
+    val t: CTValue = R.unwrap_ok[CTValue, str](tv);
+    if (t.kind != CT_KIND_TYPE) {
+        ret O.some[R.Result[CTValue, str]](
+            R.err[CTValue, str]("a comptime type query's argument must name a type"));
+    }
+
+    if (c.query_fn == nil) {
+        ret O.some[R.Result[CTValue, str]](R.err[CTValue, str](COMPTIME_TYPE_QUERY_NO_RESOLVER_MSG));
+    }
+    val fn: TypeQueryFn = c.query_fn::TypeQueryFn;
+    val r: R.Result[O.Option[CTValue], str] = fn(c.query_data, t.data.t, which);
+    if (R.is_err[O.Option[CTValue], str](r)) {
+        ret O.some[R.Result[CTValue, str]](R.err[CTValue, str](R.unwrap_err[O.Option[CTValue], str](r)));
+    }
+    val ans: O.Option[CTValue] = R.unwrap_ok[O.Option[CTValue], str](r);
+    if (O.is_none[CTValue](ans)) {
+        ret O.some[R.Result[CTValue, str]](R.err[CTValue, str](COMPTIME_TYPE_QUERY_NO_RESOLVER_MSG));
+    }
+    ret O.some[R.Result[CTValue, str]](R.ok[CTValue, str](O.unwrap[CTValue](ans)));
+}
+
+# whether `eid` is one of the four comptime type queries (#2128)
+pub fun is_type_query_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (is_comptime_call(a, source, eid, "is_record"))  { ret true; }
+    if (is_comptime_call(a, source, eid, "is_union"))   { ret true; }
+    if (is_comptime_call(a, source, eid, "is_pointer")) { ret true; }
+    ret is_comptime_call(a, source, eid, "type_name");
+}
+
+# whether `eid` is the string-valued `$type_name(T)` rather than a bool predicate
+pub fun is_type_name_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    ret is_comptime_call(a, source, eid, "type_name");
+}
+
 fun eval_type_operand(
     c:        *ComptimeCtx,
     a:        *ast.Ast,
@@ -2507,6 +2614,18 @@ pub fun ct_str(s: intern.StrId) CTValue {
     var v: CTValue;
     v.kind   = CT_KIND_STR;
     v.data.s = s;
+    ret v;
+}
+
+# a comptime bool value, for a caller outside this module building a predicate
+# answer (#2128)
+# ---
+# b:   the answer
+# ret: a CT_KIND_BOOL value
+pub fun ct_bool(b: bool) CTValue {
+    var v: CTValue;
+    v.kind   = CT_KIND_BOOL;
+    v.data.b = b;
     ret v;
 }
 

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -12,6 +12,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -605,6 +606,40 @@ fun callee_takes_type_operand(p: *state.Parser, callee: id.ExprId) bool {
     ret comptime.intrinsic_takes_type_operand(p.tokens.source, ce.span);
 }
 
+# whether the cursor sits on a field descriptor's `.type` member - `f.type`, the
+# operand a `$each f in $fields(T)` body has for the field's own type (#2454)
+#
+# A type-taking intrinsic reads argument 0 with the type grammar, where `f.type` is
+# indistinguishable from a qualified `module.Type` and fails on the root ("expected
+# a module alias before `.`"). So `$fields(f.type)` could not be spelled at all, and
+# recursive reflection was blocked by the operand grammar rather than by anything
+# semantic.
+#
+# ONE TOKEN OF LOOKAHEAD, matching only `IDENT . type` followed by `)` or `,`. It is
+# deliberately not a general "try the type grammar and back off": restoring the
+# cursor on failure would put backtracking into a single-pass parser AND would
+# absorb genuine type-operand errors, so a real mistake like `$size_of(nosuchmod.T)`
+# must still reach the type grammar and report against it. `type` is a contextual
+# spelling here, not a keyword - a module really named `type` would shadow this, and
+# that is the same trade `comptime.is_field_type_member` already makes on the value
+# side, whose shape this mirrors.
+# ---
+# p:   parser state, cursor on argument 0
+# ret: true when argument 0 should be read as an expression instead
+fun at_field_type_operand(p: *state.Parser) bool {
+    if (!state.at(p, token.KIND_IDENT)) { ret false; }
+    if (state.peek(p, 1::usize).kind != token.KIND_DOT) { ret false; }
+
+    val member: token.Token = state.peek(p, 2::usize);
+    if (member.kind != token.KIND_IDENT) { ret false; }
+    if (!str_region_equals(p.tokens.source, member.span.offset, member.span.len, "type")) { ret false; }
+
+    # a longer path (`a.type.b`, `mod.type.T`) is a type spelling again, so only the
+    # two-segment form is diverted.
+    val after: token.Kind = state.peek(p, 3::usize).kind;
+    ret after == token.KIND_RPAREN || after == token.KIND_COMMA;
+}
+
 # parses a type-taking intrinsic's first argument with the TYPE grammar, wrapped
 # in an EXPR_KIND_TYPE_REF node so it occupies an ordinary argument slot (#2178)
 #
@@ -664,8 +699,8 @@ fun parse_call(p: *state.Parser, callee: id.ExprId, type_args_start: u32, type_a
     # block after parsing keeps the slice intact.
     var buf: state.ListBuf[id.ExprId] = state.list_buf_init[id.ExprId]();
     if (!state.at(p, token.KIND_RPAREN)) {
-        if (type_operand) { state.list_buf_push[id.ExprId](p, ?buf, parse_type_operand(p)); }
-        or                { state.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p)); }
+        if (type_operand && !at_field_type_operand(p)) { state.list_buf_push[id.ExprId](p, ?buf, parse_type_operand(p)); }
+        or                                             { state.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p)); }
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RPAREN)) { brk; }
             state.list_buf_push[id.ExprId](p, ?buf, parse_call_arg(p));

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1896,6 +1896,13 @@ fun gate_has_type_comparison(rc: *ResolveContext, eid: id.ExprId) bool {
     if (e.kind == expr.EXPR_KIND_UNARY) {
         ret gate_has_type_comparison(rc, e.data.unary.operand);
     }
+    # a comptime type query (`$is_record(T)` and friends, #2128) asks about a type
+    # exactly as a type comparison does, and its answer needs the type universe just
+    # the same - so a chain gated on one defers here rather than folding against a
+    # resolver that does not exist until sema.
+    if (e.kind == expr.EXPR_KIND_CALL) {
+        ret comptime.is_type_query_call(rc.a, rc.source, eid);
+    }
     ret false;
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -163,10 +163,12 @@ pub fun sema(
     val scp: *context.SemaContext = ?sc;
     comptime.set_field_resolver(ctx, context.resolve_field_member::*u8, scp::ptr);
     comptime.set_type_resolver(ctx, context.resolve_type_comparison_operand::*u8, scp::ptr);
+    comptime.set_type_query_resolver(ctx, infer.resolve_type_query::*u8, scp::ptr);
     val res_bodies: R.Result[bool, str] = infer_all_bodies(?sc);
     if (R.is_err[bool, str](res_bodies)) {
         comptime.set_field_resolver(ctx, nil, nil);
         comptime.set_type_resolver(ctx, nil, nil);
+        comptime.set_type_query_resolver(ctx, nil, nil);
         dnit_context(?sc);
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_bodies));
     }
@@ -179,6 +181,7 @@ pub fun sema(
     val res_reval: R.Result[bool, str] = drain_revalidations(?sc);
     comptime.set_field_resolver(ctx, nil, nil);
     comptime.set_type_resolver(ctx, nil, nil);
+    comptime.set_type_query_resolver(ctx, nil, nil);
     context.inst_worklist_dnit(?sc);
     if (R.is_err[bool, str](res_reval)) {
         dnit_context(?sc);
@@ -619,11 +622,15 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     val saved_fd:  ptr                  = octx.field_data;
     val saved_tfn: *u8                  = octx.type_fn;
     val saved_td:  ptr                  = octx.type_data;
+    val saved_qfn: *u8                  = octx.query_fn;
+    val saved_qd:  ptr                  = octx.query_data;
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, tscp::ptr);
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, tscp::ptr);
+    comptime.set_type_query_resolver(octx, infer.resolve_type_query::*u8, tscp::ptr);
     val res: R.Result[bool, str] = infer_stmt(?tsc, d.data.fun_.body, ret_ty);
     comptime.set_field_resolver(octx, saved_ffn, saved_fd);
     comptime.set_type_resolver(octx, saved_tfn, saved_td);
+    comptime.set_type_query_resolver(octx, saved_qfn, saved_qd);
 
     free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);
     free_typeids(sc.s.alloc, scratch_decl, oa.decl_len);
@@ -2024,6 +2031,13 @@ fun gate_has_type_comparison(sc: *context.SemaContext, eid: id.ExprId) bool {
     }
     if (e.kind == expr.EXPR_KIND_UNARY) {
         ret gate_has_type_comparison(sc, e.data.unary.operand);
+    }
+    # a comptime type query (#2128) asks about a type just as a comparison does, so
+    # its chain is typed and folded here too. Typing it is what stamps the operand's
+    # expr_type, which is what both this fold and a deferred one at lowering read
+    # back - an untyped gate would silently select the `$or` arm.
+    if (e.kind == expr.EXPR_KIND_CALL) {
+        ret comptime.is_type_query_call(sc.a, sc.source, eid);
     }
     ret false;
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -21,8 +21,10 @@
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
+use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.string.str_region_equals;
 
 use A: std.allocator;
@@ -41,6 +43,7 @@ use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.generics;
+use mach.lang.fe.sema.typename;
 use mach.lang.layout;
 use mach.lang.fe.token;
 use mach.lang.intern;
@@ -327,6 +330,56 @@ fun ensure_layout_fields(sc: *context.SemaContext, ty: type.TypeId, depth: u32) 
         i = i + 1;
     }
     ret O.none[intern.StrId]();
+}
+
+# the type-query resolver (a comptime.TypeQueryFn) sema installs alongside the
+# others, so `comptime.eval` can answer a `$is_record` / `$is_union` /
+# `$is_pointer` / `$type_name` about an already-resolved type (#2128)
+#
+# The shape rule itself is `type.shape_kind` - shared with the lowering-side twin so
+# a gate folded at sema and the same gate deferred to monomorphization cannot
+# disagree. Here it only maps that kind onto the asked question.
+# ---
+# data:  the *SemaContext, erased to a ptr by the installer
+# tid:   the already-resolved TypeId to ask about
+# which: a comptime.TYPE_QUERY_* selector
+# ret:   some(bool) for a predicate, some(string) for the name, none when unanswerable
+pub fun resolve_type_query(data: ptr, tid: u32, which: u8) R.Result[O.Option[comptime.CTValue], str] {
+    val sc: *context.SemaContext = data::*context.SemaContext;
+    if (sc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    ret answer_type_query(sc.s, tid, which);
+}
+
+# the shared body of both type-query resolvers: everything either side needs is on
+# the session, so neither holds a rule of its own (#2128)
+pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.Option[comptime.CTValue], str] {
+    val t: type.TypeId = tid::type.TypeId;
+    if (t == type.TYPE_NIL || t == type.TYPE_ERROR) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+
+    if (which == comptime.TYPE_QUERY_NAME) {
+        # `typename.type_to_str` is the spelling sema already uses in diagnostics, so
+        # the name a program reads and the name an error prints cannot drift.
+        val r: R.Result[str, str] = typename.type_to_str(s, type.strip_secret(?s.types, t));
+        if (R.is_err[str, str](r)) { ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[str, str](r)); }
+        val text: str = R.unwrap_ok[str, str](r);
+        val ir_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, text);
+        A.deallocate[char](s.alloc, text, str_len(text) + 1);
+        if (R.is_err[intern.StrId, str](ir_r)) {
+            ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[intern.StrId, str](ir_r));
+        }
+        ret R.ok[O.Option[comptime.CTValue], str](
+            O.some[comptime.CTValue](comptime.ct_str(R.unwrap_ok[intern.StrId, str](ir_r))));
+    }
+
+    val k: type.TypeKind = type.shape_kind(?s.types, t);
+    var answer: bool = false;
+    if (which == comptime.TYPE_QUERY_IS_RECORD)  { answer = k == type.TYPE_REC; }
+    if (which == comptime.TYPE_QUERY_IS_UNION)   { answer = k == type.TYPE_UNI; }
+    # both spellings of a reference: the raw `ptr` primitive and a typed `*T`.
+    if (which == comptime.TYPE_QUERY_IS_POINTER) { answer = k == type.TYPE_POINTER || k == type.TYPE_PTR; }
+    ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_bool(answer)));
 }
 
 # fold `$size_of(T)` / `$align_of(T)` to its measured constant, forcing `T`'s layout
@@ -1863,6 +1916,39 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
     if (name == interned(sc, "type_of")) {
         context.report(sc, span, "`$type_of` yields a comptime type, not a value; use it as a type-comparison operand inside a `$if` gate");
         ret type.TYPE_ERROR;
+    }
+
+    # the type queries (#2128) take the same single type-naming argument and answer
+    # about its SHAPE rather than its storage: three bool predicates and the string
+    # `$type_name`. Typed here so the operand's expr_type is stamped for the
+    # resolver `comptime.eval` calls, exactly as the size/align path below does.
+    val is_rec_q:  bool = name == interned(sc, "is_record");
+    val is_uni_q:  bool = name == interned(sc, "is_union");
+    val is_ptr_q:  bool = name == interned(sc, "is_pointer");
+    val is_name_q: bool = name == interned(sc, "type_name");
+    if (is_rec_q || is_uni_q || is_ptr_q || is_name_q) {
+        if (c.args_len != 1) {
+            context.report_numbered(sc, span, "a comptime type query: expected ", 1::usize, " argument(s)", "comptime type query: wrong number of arguments");
+            ret type.TYPE_ERROR;
+        }
+        val qarg: id.ExprId   = sc.a.expr_ids[c.args_start];
+        val qty:  type.TypeId = intrinsic_operand_type(sc, qarg, span);
+        set_expr_type(sc, qarg, qty);
+        if (qty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+
+        # `$type_name` is an ordinary value - a string, valid anywhere one is.
+        if (is_name_q) { ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8)); }
+
+        # the three predicates answer a comptime question and are folded by arm
+        # selection, so like a `$type_of` comparison they are gate-only: there is no
+        # runtime boolean for one to become. Reported here rather than left to
+        # surface as an opaque bare-comptime-ident error at lowering.
+        if (!sc.in_comptime_gate) {
+            context.report(sc, span, "a comptime type predicate is comptime-only; it is valid only as a `$if` gate condition");
+            ret type.TYPE_ERROR;
+        }
+        # u8 stands in for the comptime boolean, the same as a type comparison's.
+        ret prim_or_error(sc, type.TYPE_U8);
     }
 
     val is_size:   bool = name == interned(sc, "size_of");

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1921,11 +1921,32 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
 # ret:  the named TypeId, substituted at an instance, or TYPE_ERROR
 fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    # the parser reads this slot with the type grammar for exactly these callees, so
-    # a node that is not a type spelling cannot be produced from source. NOTHING IN
-    # THE SUITE REACHES THIS ARM and deleting it changes no test - it asserts that
-    # parser guarantee, and without it a violation is back to dropping the `$each`
-    # body in silence. Do not remove it for being untested; see `report_unbound_ident`.
+
+    # `f.type` is the one operand the parser deliberately does NOT read with the type
+    # grammar (#2454): it names a field descriptor's type, which has no spelling, so
+    # it arrives as an ordinary member expression and folds to a TYPE value through
+    # the same field resolver the `==` type comparison uses. Taking the TypeId out of
+    # that value is what lets `$fields(f.type)` descend into a nested record.
+    if (O.is_some[*expr.Expr](e_opt) && comptime.is_field_type_member(sc.a, sc.source, eid)) {
+        val fv: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+        if (R.is_err[comptime.CTValue, str](fv)) {
+            context.report(sc, span, R.unwrap_err[comptime.CTValue, str](fv));
+            ret type.TYPE_ERROR;
+        }
+        val v: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](fv);
+        if (v.kind != comptime.CT_KIND_TYPE) {
+            context.report(sc, span, "a comptime intrinsic's type argument did not resolve to a type");
+            ret type.TYPE_ERROR;
+        }
+        ret v.data.t::type.TypeId;
+    }
+
+    # the parser reads this slot with the type grammar for every other spelling, so
+    # a node that is neither that nor the `f.type` form above cannot be produced from
+    # source. NOTHING IN THE SUITE REACHES THIS ARM and deleting it changes no test -
+    # it asserts that parser guarantee, and without it a violation is back to dropping
+    # the `$each` body in silence. Do not remove it for being untested; see
+    # `report_unbound_ident`.
     if (O.is_none[*expr.Expr](e_opt) || O.unwrap[*expr.Expr](e_opt).kind != expr.EXPR_KIND_TYPE_REF) {
         context.report(sc, span, "internal: a comptime intrinsic argument was not parsed as a type");
         ret type.TYPE_ERROR;

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -541,6 +541,7 @@ fun comptime_resolvers_install(octx: *comptime.ComptimeCtx, lc: *context.LowerCo
     comptime.set_member_resolver(octx, context.resolve_module_member_const::*u8, lc::ptr);
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, lc::ptr);
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, lc::ptr);
+    comptime.set_type_query_resolver(octx, context.resolve_type_query::*u8, lc::ptr);
 }
 
 # restores the home module's phase inputs after an instance drain (the body

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -26,6 +26,7 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
 use mach.lang.fe.sema.generics;
+use mach.lang.fe.sema.infer;
 use mach.lang.fe.sema.typename;
 use mach.lang.fe.token;
 use mach.lang.intern;
@@ -378,6 +379,8 @@ pub fun init_context(
     # install the field-descriptor member resolver so `f.name` / `f.type` /
     # `f.offset` fold inside `$each` bodies.
     comptime.set_field_resolver(ctx, resolve_field_member::*u8, lc::ptr);
+    # install the type-query resolver so a `$is_record` / `$type_name` gate folds here.
+    comptime.set_type_query_resolver(ctx, resolve_type_query::*u8, lc::ptr);
 
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, map.hash_u32, map.eq_u32);
     lc.local_names = map.init[intern.StrId, value.Value](s.alloc, map.hash_u32, map.eq_u32);
@@ -460,6 +463,7 @@ pub fun dnit_context(lc: *LowerContext) {
         comptime.set_member_resolver(lc.ctx, nil, nil);
         comptime.set_type_resolver(lc.ctx, nil, nil);
         comptime.set_field_resolver(lc.ctx, nil, nil);
+        comptime.set_type_query_resolver(lc.ctx, nil, nil);
     }
     map.dnit[intern.StrId, value.Value](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
@@ -619,6 +623,24 @@ pub fun resolve_type_comparison_operand(data: ptr, eid: id.ExprId) R.Result[O.Op
     val t: type.TypeId = expr_type_of(lc, eid);
     if (t == type.TYPE_NIL || t == type.TYPE_ERROR) { ret R.ok[O.Option[u32], str](O.none[u32]()); }
     ret R.ok[O.Option[u32], str](O.some[u32](t::u32));
+}
+
+# the type-query resolver lowering installs on every ComptimeCtx it evaluates
+# against (a comptime.TypeQueryFn), so a `$is_record` / `$is_union` / `$is_pointer`
+# / `$type_name` gate deferred past sema still folds here (#2128)
+#
+# Delegates to `infer.answer_type_query`, the one implementation, so a predicate
+# folded during arm selection and the same predicate folded at monomorphization
+# cannot answer differently.
+# ---
+# data:  the *LowerContext, erased to a ptr by the installer
+# tid:   the already-resolved TypeId to ask about
+# which: a comptime.TYPE_QUERY_* selector
+# ret:   some(bool) for a predicate, some(string) for the name, none when unanswerable
+pub fun resolve_type_query(data: ptr, tid: u32, which: u8) R.Result[O.Option[comptime.CTValue], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    ret infer.answer_type_query(lc.s, tid, which);
 }
 
 # the field-descriptor member resolver lowering installs on every ComptimeCtx it

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1438,6 +1438,20 @@ pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId,
         ret O.some[R.Result[value.Value, str]](R.err[value.Value, str](R.unwrap_err[intern.StrId, str](res_name)));
     }
     val name: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
+
+    # `$type_name(T)` is a string rather than a measurement, so it folds through the
+    # comptime channel (which owns the spelling) and materializes like any other
+    # folded CT_KIND_STR (#2128). The three type PREDICATES never reach here: they
+    # are gate-only and consumed by arm selection, so a value position is already a
+    # sema error.
+    if (name == interned_literal(ctx, "type_name")) {
+        val tv: R.Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner);
+        if (R.is_err[comptime.CTValue, str](tv)) {
+            ret O.some[R.Result[value.Value, str]](R.err[value.Value, str](R.unwrap_err[comptime.CTValue, str](tv)));
+        }
+        ret O.some[R.Result[value.Value, str]](const_value_of(ctx, eid, R.unwrap_ok[comptime.CTValue, str](tv)));
+    }
+
     val is_size:   bool = name == interned_literal(ctx, "size_of");
     val is_align:  bool = name == interned_literal(ctx, "align_of");
     val is_offset: bool = name == interned_literal(ctx, "offset_of");

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -754,7 +754,13 @@ pub fun strip_secret(ti: *TypeInterner, tid: TypeId) TypeId {
 # ---
 # ti:  the type interner
 # tid: the type to classify
-# ret: its shape kind, or TYPE_NIL's kind when `tid` is not a live type
+# ret: its shape kind; TYPE_U8 when `tid` names no live type
+#
+# TYPE_U8 is the deliberate answer for a dead id, not a placeholder: every predicate
+# built on this asks `kind == REC` / `== UNI` / `== POINTER`, so a scalar kind makes
+# all of them false. A type that does not exist is not a record, a union, or a
+# reference, and answering with a shape-bearing kind would make it one. There is no
+# "kind of TYPE_NIL" to return - TYPE_NIL is a TypeId sentinel, not a TypeKind.
 pub fun shape_kind(ti: *TypeInterner, tid: TypeId) TypeKind {
     if (tid == TYPE_NIL || tid == TYPE_ERROR) { ret TYPE_U8; }
     val base: TypeId = strip_secret(ti, tid);

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -739,6 +739,37 @@ pub fun strip_secret(ti: *TypeInterner, tid: TypeId) TypeId {
     ret t.data.secret.base;
 }
 
+# the SHAPE kind a comptime type predicate answers over: `tid` with any `^` secret
+# wrapper removed and a generic instance resolved to the kind of the declaration it
+# instantiates (#2128)
+#
+# ONE definition because two callers need the identical answer - sema folds these
+# predicates during arm selection, lowering folds them for a gate deferred to
+# monomorphization - and a shape rule enumerated twice is this codebase's recurring
+# drift bug. Secret is stripped because `^T` is a wrapper over `T`'s storage, so a
+# shape question asked through one is asking about `T` (#2297, #2373). An instance
+# resolves to its nominal because post-#2168 the type a reflection loop meets for
+# `Box[i64]` is a TYPE_INSTANCE, and answering "not a record" there would be useless
+# to exactly the generic code these predicates serve.
+# ---
+# ti:  the type interner
+# tid: the type to classify
+# ret: its shape kind, or TYPE_NIL's kind when `tid` is not a live type
+pub fun shape_kind(ti: *TypeInterner, tid: TypeId) TypeKind {
+    if (tid == TYPE_NIL || tid == TYPE_ERROR) { ret TYPE_U8; }
+    val base: TypeId = strip_secret(ti, tid);
+    val t_opt: O.Option[*Type] = get(ti, base);
+    if (O.is_none[*Type](t_opt)) { ret TYPE_U8; }
+    val t: *Type = O.unwrap[*Type](t_opt);
+    if (t.kind != TYPE_INSTANCE) { ret t.kind; }
+
+    val nom: TypeId = t.data.instance.nominal;
+    if (nom == TYPE_ERROR || nom == base) { ret t.kind; }
+    val n_opt: O.Option[*Type] = get(ti, nom);
+    if (O.is_none[*Type](n_opt)) { ret t.kind; }
+    ret O.unwrap[*Type](n_opt).kind;
+}
+
 # whether `tid` carries secret data anywhere along its pointer / array / secret
 # spine - the predicate the welded-storage rules use to keep secret memory off
 # the untyped `ptr`


### PR DESCRIPTION
Closes #2128
Closes #2454

Two commits, in dependency order: the operand grammar first (#2454), then the
predicates that need it (#2128). Shipped together because the predicates alone do
not unlock the use case — the reflection loop can ask "is this a record" but still
cannot descend.

## #2454 — the type operand

Argument 0 of `$size_of` / `$align_of` / `$offset_of` / `$fields` is read with the
type grammar (#2178), where `f.type` is indistinguishable from a qualified
`module.Type` and failed on the root. So the operand a `$each f in $fields(T)` body
actually holds for a field's type could not be passed to any of them:

```
$fields(f.type)  ->  error: expected a module alias before `.`
```

The call parser now diverts argument 0 to expression parsing on one token of
lookahead, matching only `IDENT . type` followed by `)` or `,`. Deliberately not
try-the-type-grammar-and-back-off: that puts backtracking into a single-pass parser
and would swallow real operand errors. **A genuinely wrong operand still reports
against the type grammar**, pinned by test.

## #2128 — the predicates

```mach
$is_record(T)   $is_union(T)   $is_pointer(T)   $type_name(T)
```

- **One shape rule.** `type.shape_kind` is the single definition; both the sema
  resolver (arm selection) and the lowering resolver (a gate deferred to
  monomorphization) delegate to one `answer_type_query`. A shape rule enumerated
  twice is this repo's recurring drift bug (#2373, #2335), so the bar is greppable:
  1 definition of each.
- **Secret is stripped**, pinned for every predicate. `^T` wraps `T`'s storage, so a
  shape question through one asks about `T`; an unstripped query is the
  silent-wrong-answer family of #2297/#2373.
- **An instance answers as its declaration** — `Box[i64]` is a record, because
  post-#2168 that is the type a reflection loop actually meets.
- **Predicates are comptime-only.** A gate selects an arm; there is no runtime
  boolean for one to become, so a value position reports rather than inventing a
  type. `$type_name` *is* a value (`*u8`), folded to a rodata string, spelled by
  `typename.type_to_str` — the same authority diagnostics use, so a name a program
  reads and a name an error prints cannot drift.

**Both gate-deferral detectors learned the new shape**, and this is the part worth
review: resolve must *defer* a chain gated on a type query (it has no type universe
to fold against), and sema must *type and fold* it. With only the resolve half, the
operand's `expr_type` was never stamped and every predicate silently selected the
`$or` arm — compiling fine, answering false. That failure is why the two rules are
paired.

## Verification

One pinned process, dev merged. Object comparisons carry both controls in the same
run (self-check must be 0, positive control must catch exactly 1).

| bar | result |
|---|---|
| one shape rule | `shape_kind`: 1 definition; `answer_type_query`: 1 |
| emission neutrality, debug | 0/215 objects, binary identical |
| emission neutrality, release | 0/215 objects, binary identical |
| `mach test` | 1022 passed / 0 failed (dev 1019; +3 tests added) |
| `B == C` fixpoint | passes |
| `int` suite, linux | all cases passed |

Emission neutrality is expected and asserted: seed lag means compiler source cannot
use the new spellings yet, so the change adds what the compiler *accepts*, not what
it emits.

**Behaviour matrix**, each answer driven out through `$error` so the assertion is on
which arm the gate selected, not on the program compiling — and read from the
`error:` message line only, never the echoed source:

| | `$is_record` | `$is_union` | `$is_pointer` |
|---|---|---|---|
| `rec P` | yes | no | no |
| `uni U` | no | yes | no |
| `Box[i64]` (rec) | yes | no | no |
| `Box[i64]` (uni) | no | yes | no |
| `*P` | no | no | yes |
| raw `ptr` | no | no | yes |
| `u64` | no | no | no |
| `^`-wrapped | strips | strips | strips |
| via `f.type` | yes/no correctly | — | yes |

`$type_name`: `Pair` → `"Pair"`, `*Pair` → `"*Pair"`, `^Pair` → `"Pair"`, and usable
as a value outside a gate.
