### PR TITLE
fix(build): delete BuildRequest.verbosity/.quiet, dead since dd267534

### DIFF
--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -191,8 +191,6 @@ pub rec LinkToken {
 #               path positionals)
 # lib_dirs:     `-L` link search directories in invocation order
 # include_deps: widen test collection to dependency modules
-# verbosity:    readout detail level: 0 plain, 1 (`-v`), 2 (`-vv`)
-# quiet:        suppress non-error output
 pub rec BuildRequest {
     project_root: str;
 
@@ -221,9 +219,6 @@ pub rec BuildRequest {
     lib_dirs:     Vector[str];
 
     include_deps: bool;
-
-    verbosity:    u8;
-    quiet:        bool;
 }
 
 # a zeroed request: manifest-default selection, execute goal, debug pipeline,
@@ -263,8 +258,6 @@ pub fun defaults() BuildRequest {
     r.lib_dirs.len  = 0;
     r.lib_dirs.cap  = 0;
     r.include_deps = false;
-    r.verbosity    = 0;
-    r.quiet        = false;
     ret r;
 }
 
@@ -398,8 +391,6 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
     }
 
     r.include_deps = cli.include_deps;
-    r.verbosity    = cli.verbosity;
-    r.quiet        = cli.quiet;
     ret R.ok[BuildRequest, outcome.Fail](r);
 }
 
@@ -469,7 +460,7 @@ pub val HASH_SIZE: usize = 32;
 # compute); `emit_ir` / `emit_asm` (per-module `.ir` / `.s` side artifacts dumped
 # from the already-computed IR, a plan-level concern); `out` and the link inputs
 # `link_tokens` / `lib_dirs` (they reach the build through Q_LINK_CONFIG, never a
-# per-module compute). `verbosity` / `quiet` are presentation and are in neither.
+# per-module compute).
 #
 # request_hash writes these first, then the OUT fields; semantic_hash writes only
 # these. A new request field MUST be placed deliberately: here when it changes a
@@ -532,9 +523,10 @@ fun write_request_extra(e: *binary.Encoder, r: *BuildRequest) bool {
 # build-identity-only fields (write_request_extra) - and hashes the bytes with
 # sha256. Because fields are settled values, the key reflects effective
 # configuration: any change from either the manifest or the command line that
-# changes the build changes the key. The presentation fields (`verbosity`,
-# `quiet`) are excluded - they change the readout, never the artifacts. This is
-# the build's whole identity; the Q_TARGET cache fold keys on semantic_hash, the
+# changes the build changes the key. Presentation (readout verbosity, quiet) is
+# not a request field at all - it reaches the engine through the `readout.Progress`
+# sink `execute` takes directly, so it never enters this identity. This is the
+# build's whole identity; the Q_TARGET cache fold keys on semantic_hash, the
 # semantic subset.
 # ---
 # a:      allocator for the transient serialization buffer
@@ -632,41 +624,6 @@ test "mach.lang.build.request.for_cell:swaps_selection_only" {
     if (!c.debug)                          { ret 1; }
     if (c.jobs != 7)                       { ret 1; }
     if (!str_equals(c.project_root, "/r")) { ret 1; }
-    ret 0;
-}
-
-# two identical requests hash identically; a settled-field change (opt) diverges
-# and a presentation-field change (verbosity) does not, exactly as documented
-test "mach.lang.build.request.request_hash:settled_fields_key_the_identity" {
-    var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
-
-    var ra: BuildRequest = defaults();
-    ra.project_root = "/tmp/p";
-    ra.opt          = pipeline.OPT_DEBUG;
-    var rb: BuildRequest = ra;
-
-    var da: [32]u8;
-    var db: [32]u8;
-    if (R.is_err[bool, str](request_hash(?alloc, ?ra, ?da[0]))) { ret 1; }
-    if (R.is_err[bool, str](request_hash(?alloc, ?rb, ?db[0]))) { ret 1; }
-    var i: usize = 0;
-    for (i < 32) { if (da[i] != db[i]) { ret 1; } i = i + 1; }
-
-    # a settled decision changes the identity.
-    rb.opt = pipeline.OPT_RELEASE;
-    if (R.is_err[bool, str](request_hash(?alloc, ?rb, ?db[0]))) { ret 1; }
-    var same: bool = true;
-    i = 0;
-    for (i < 32) { if (da[i] != db[i]) { same = false; } i = i + 1; }
-    if (same) { ret 1; }
-
-    # a presentation field does not.
-    rb.opt       = pipeline.OPT_DEBUG;
-    rb.verbosity = 2;
-    if (R.is_err[bool, str](request_hash(?alloc, ?rb, ?db[0]))) { ret 1; }
-    i = 0;
-    for (i < 32) { if (da[i] != db[i]) { ret 1; } i = i + 1; }
     ret 0;
 }
 


### PR DESCRIPTION
## Disposition: DELETE, with the real channel identified

`BuildRequest.verbosity`/`.quiet` are set by `compose()` from `CliArgs` and
read by nothing. Evidence, traced through every actual and hypothetical
consumer:

- **`mach build`** (`src/cli/cmd/build.mach:270-271`) reads `config.verbosity`
  (`config` is `args.CliArgs`, `request.CliArgs` under a re-export)
  **directly**, before/alongside composing `req` (the `BuildRequest`), to
  decide whether to construct a `readout.Readout` at all. It never reads
  `req.verbosity`.
- **`mach test`** (`src/cli/cmd/testing.mach:175`) reads `config.verbosity`
  the same way.
- **`mach doc`** (`src/cli/cmd/doc.mach:590`) reads `config.quiet` the same
  way (`build`/`test` don't read `.quiet` at all - see note below).
- **The narration channel itself is not `BuildRequest`.** `engine.execute` /
  `engine.execute_warm_all` take `ev: *readout.Progress` as an explicit
  parameter ("the progress-event sink (`-v` narration), or nil for
  silence" - `src/lang/build/engine.mach:121`). The CLI builds that sink
  from `config.verbosity` and passes it in; `BuildRequest` never enters the
  picture.
- **The one embedding consumer that composes a bare `BuildRequest` with no
  `CliArgs`** is `src/lang/editor.mach`'s `EditorSession.build` - exactly the
  case the issue flags as the likely reason to wire instead of delete. It
  documents itself explicitly: *"The build is silent - no progress
  narration, no rendering"* (`editor.mach:439`), and calls
  `engine.execute_warm_all(?bp, s, es.alloc, nil, nil)` - passing `nil` for
  the progress sink by design. So even the one caller that could have used
  `req.verbosity` deliberately opts out at the same call site, rather than
  merely lacking a wire-up.

So: not "wire it for embedders" - the embedder that exists does not want it.
Presentation reaches the engine through `readout.Progress`, an independent
side-channel, not through the request's settled fields.

## The hash-exclusion test's fate

`request_hash:settled_fields_key_the_identity` asserted two things: (a) a
settled-field change (`opt`) diverges `request_hash`, and (b) a
presentation-field change (`verbosity`) does not, because `verbosity`/`quiet`
are serialized by neither `write_semantic_fields` nor `write_request_extra`.

Deleting the fields makes (b) inexpressible - there's no more presentation
field on `BuildRequest` to demonstrate the "excluded from the whole hash"
claim with. (a) survives as a testable behavior, but it's already covered:
`semantic_hash:omits_nonsemantic_fields` independently asserts `request_hash`
diverges on `opt` and on `pie`. So the test isn't just still-passing with a
stale name, it has no distinguishing content left - deleted rather than
trimmed to a redundant husk.

## Sweep

Checked every remaining `BuildRequest` field (`project_root`, `target`,
`profile`, `artifact`, `want_lib`, `all_targets`, `goal`, `opt`, `debug`,
`pie`, `simd`, `vectorize`, `float_reassoc`, `verify_ir`, `jobs`, `emit_ir`,
`emit_asm`, `out`, `link_tokens`, `lib_dirs`, `include_deps`) and every
`CliArgs`-only field (`bin`, `lib`, `output`, `g`, `opt_set`, `opt_release`)
for the same write-and-never-read shape. All have live readers outside
`request.mach` (e.g. `ctx.req.jobs` in `engine.mach`/`passes.mach`,
`ctx.req.verify_ir` in `testing.mach`/`passes.mach`, `req.all_targets` in
`plan.mach`, `cli.g`/`cli.opt_set` consumed inside `compose()` itself).
`verbosity`/`quiet` are the only dead pair.

**Related but out of scope, flagging rather than fixing here:** `CliArgs.quiet`
is parsed and validated (mutually exclusive with `-v`/`-vv`) for `build`,
`test`, and `dep`, but is only actually read by `doc.mach`. `--quiet`/`-q`
currently suppresses nothing for `mach build` or `mach test` - there's no
narration to suppress at verbosity 0 already, so the flag is a silent no-op
rather than a dead field, a different (milder) shape than this issue's. Not
touched here since it's not the write-and-never-read pattern and would be
scope creep on this fix.

## Verification

- `mach test .` via a from-source `--jobs 1` compiler: **1019 passed, 0
  failed** - exactly baseline `dev` (1020/0, verified pre-merge at the same
  commit) minus the one deleted test.
- `mach test .` in `dep/mach-std` at the current lock
  (`a35a0c4645785596929ae62700f4bd9c74ddb609`): **680 passed, 0 failed**.
- Three-generation self-host fixpoint: gen3 == gen4 byte-identical
  (`e6d63253e07f9119ff6d98b9f5bca83cf6991367b670ffd72a6c26be52517780`),
  `--jobs 1`. The seed-built gen2 differs from gen2-built gen3 - confirmed
  **pre-existing and branch-independent** by reproducing the identical gap on
  an unmodified `dev` baseline compiler chain (seed→gen2→gen3 also differs,
  gen3==gen4 also holds there).
- **Object-level byte-identity** (one target `linux-x86_64`, one profile
  `release`): built the unmodified `dev`-baseline project source
  (`--emit obj --all-targets` scope not needed for the bar; single target/
  profile per the ask) once with the unmodified baseline compiler and once
  with this branch's from-source compiler, holding the input source tree
  fixed and varying only the compiler. `diff -rq` over all 215 `.o` files:
  **zero differences**.
- **The two compiler *binaries* are NOT byte-identical** (expected, not
  hand-waved): `verbosity`/`quiet` were the two trailing fields of
  `BuildRequest`, so removing them shrinks `sizeof(BuildRequest)` without
  shifting any of its own remaining field offsets - but every function
  anywhere in the compiler's own source that sizes, copies, or arrays a
  `BuildRequest` by value recompiles against the new width, so the linked
  binary differs throughout (not merely at one displacement). This is
  self-compilation struct-layout noise from the same mechanism PR #2304
  documented for the analogous `ProjectConfig` field removals - not a
  behavior change, which the object-level check above isolates and confirms.

Closes #2307