### PR TITLE
feat(ct): the inline-asm constant-time classification tables

### DIFF
--- a/src/lang/ct.mach
+++ b/src/lang/ct.mach
@@ -136,3 +136,69 @@ test "mach.lang.ct.ct_cap:table" {
     if (ct_op_gates_count_only(CT_OP_INT_MUL))    { ret 1; }
     ret 0;
 }
+
+# how an inline-asm mnemonic behaves under the constant-time leakage checks
+#
+# The per-instruction half of `#[oblivious]`'s asm validation (#2230). A block is
+# walked instruction by instruction; this is what the walk needs to know about each
+# one that the register-effect model does not already carry.
+#
+# FAIL-CLOSED BY CONSTRUCTION: `known` is false in the zero value, so a mnemonic an
+# ISA has not classified refuses the moment a secret reaches it. Adding a grammar row
+# without classifying it cannot silently widen what validates.
+#
+# THE BRANCH SHAPE IS SEPARATE FROM THE OP CLASS because the two checks differ. A
+# conditional branch whose condition is a REGISTER operand (`cbz`/`cbnz` on aarch64,
+# `beq`/`bne`/... on riscv64) is checkable from register taint. One whose condition
+# rides the FLAGS register (every x86-64 `jcc`) is not: `isa.asm` models no flags -
+# "condition flags are not modeled", since the allocator holds no value in them - so
+# `cmp {secret}, rbx ; je 1f` would walk as two instructions that read and write
+# nothing and pass as leak-free. That is a secret-dependent branch carrying a
+# constant-time guarantee, so a flags-conditioned branch is REFUSED outright rather
+# than analyzed. Lifting that needs flags in the effect model, tracked as #2460.
+# ---
+# op:         the constant-time class of the operation
+# known:      false when the ISA has not classified this mnemonic (refuse on secret)
+# cond_flags: a conditional branch whose condition rides the flags register
+# cond_reg:   a conditional branch whose condition is a register operand
+pub rec AsmClass {
+    op:         CtOp;
+    known:      bool;
+    cond_flags: bool;
+    cond_reg:   bool;
+}
+
+# an unclassified mnemonic: refuses the moment a secret reaches it
+pub fun asm_unknown() AsmClass {
+    var a: AsmClass;
+    a.op         = CT_OP_NONE;
+    a.known      = false;
+    a.cond_flags = false;
+    a.cond_reg   = false;
+    ret a;
+}
+
+# a classified straight-line mnemonic of constant-time class `op`
+# ---
+# op:  the operation's constant-time class
+# ret: the classification
+pub fun asm_op(op: CtOp) AsmClass {
+    var a: AsmClass = asm_unknown();
+    a.op    = op;
+    a.known = true;
+    ret a;
+}
+
+# a conditional branch whose condition rides the flags register: always refused
+pub fun asm_branch_flags() AsmClass {
+    var a: AsmClass = asm_op(CT_OP_NONE);
+    a.cond_flags = true;
+    ret a;
+}
+
+# a conditional branch whose condition is a register operand: checked against taint
+pub fun asm_branch_reg() AsmClass {
+    var a: AsmClass = asm_op(CT_OP_NONE);
+    a.cond_reg = true;
+    ret a;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9827,3 +9827,28 @@ test "mach.lang.driver:secret_store_taint_survives_lower" {
     if (vmarked == 0)                 { ret 7; }   # a secret VALUE store carries no taint
     ret 0;
 }
+
+# with the constant-time classification tables landed but no scanner wired, an
+# inline-asm block inside `#[oblivious]` is still refused, verbatim
+#
+# The neutrality claim of #2230's first half, pinned as BEHAVIOUR rather than as a
+# comment. The tables classify every mnemonic all three grammars admit, and the
+# `asm_ct_scan` vtable slot exists - but every ISA leaves it nil, and a nil scanner
+# means `ctvalidate` keeps refusing. That is the fail-closed default being
+# STRUCTURAL: the analysis can land, and be reviewed, without widening by a single
+# program what `#[oblivious]` accepts. When the walk is wired this test is the one
+# that must be deliberately changed, which is exactly the review checkpoint wanted.
+test "mach.lang.driver:oblivious_asm_still_refused_without_a_scanner" {
+    var bad: i32 = 0;
+
+    # a block that leaks nothing on any axis - a bare `nop` - is refused, so the
+    # refusal is unconditional rather than a leak finding.
+    if (ut_codegen_rejects("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "contains inline assembly, which cannot be verified constant-time") != 0) { bad = 1; }
+
+    # and the guidance the message offers is unchanged.
+    if (ut_codegen_rejects("#[oblivious]\nfun g(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "move it to a non-oblivious function and `:^`-declassify at the boundary") != 0) { bad = 1; }
+
+    ret bad;
+}

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -345,6 +345,27 @@ pub rec MachineModel {
 # fp_out: receives the vector-register clobber bitmask (index n -> bit n)
 pub def AsmClobbersFn: fun(str, *u32, *u32);
 
+# the concrete signature the erased `RegMachine.asm_ct_scan` pointer is cast back to
+#
+# Walks an inline-asm body for the constant-time leakage checks `#[oblivious]`
+# enforces everywhere else, so a block can be VALIDATED rather than refused (#2230).
+# `secret_names` names the `{name}` bindings whose storage is secret; taint enters
+# the walk through those and propagates by the effect model.s register-write facts.
+#
+# Returns the FIRST leak found, so a diagnostic can name the offending instruction,
+# or ok(true) when the body leaks nothing. FAILS CLOSED in every unmodeled case: a
+# body that does not parse, an instruction whose constant-time class is unclassified,
+# and (on x86-64 only) any conditional branch, whose condition rides FLAGS - which
+# the effect model does not represent (#2460).
+# ---
+# body:         raw inline-asm body text
+# secret_names: the `{name}` binding names whose storage is secret, as text - the
+#               scan compares them against the names it reads out of the body, so
+#               the ISA contract needs no interner
+# n_secret:     number of entries in `secret_names`
+# alloc:        allocator for the returned diagnostic
+pub def AsmCtScanFn: fun(str, *str, u32, *A.Allocator) R.Result[bool, str];
+
 # the concrete signature the erased `RegMachine.is_reg_move` pointer is cast back to
 #
 # Given a post-selection concrete opcode, returns true when it is one of this
@@ -502,6 +523,11 @@ pub def CvRegFn: fun(i32) i32;
 #                       preserves any callee-saved register a body writes. nil when
 #                       the ISA supplies no analyzer, which regalloc treats
 #                       conservatively (every register potentially clobbered)
+# asm_ct_scan:          OPTIONAL capability - walk an inline-asm body for the
+#                       constant-time leakage checks, so `#[oblivious]` can validate
+#                       a block instead of refusing it (#2230). nil when the ISA
+#                       supplies no scanner, which `ctvalidate` treats as the old
+#                       blanket refusal - the fail-closed default
 # dwarf_reg:            OPTIONAL capability - map a physical register id to its
 #                       DWARF register number, the ISA-specific numbering the
 #                       `DW_OP_reg*` / `DW_OP_breg*` variable locations use; the
@@ -531,6 +557,7 @@ pub rec RegMachine {
 
     emit_asm:     *u8;
     asm_clobbers: AsmClobbersFn;
+    asm_ct_scan:  AsmCtScanFn;
     dwarf_reg:    DwarfRegFn;
     cv_reg:       CvRegFn;
 }
@@ -718,6 +745,17 @@ pub fun with_asm_printer(m: *RegMachine, emit_asm: *u8) {
 # f: the clobber analyzer
 pub fun with_asm_clobbers(m: *RegMachine, f: AsmClobbersFn) {
     m.asm_clobbers = f;
+}
+
+# declare the optional inline-asm constant-time scanner
+#
+# Without it `#[oblivious]` refuses every inline-asm block outright, which is the
+# fail-closed default this capability relaxes (#2230).
+# ---
+# m: the register-machine contract to extend
+# f: the constant-time scanner
+pub fun with_asm_ct_scan(m: *RegMachine, f: AsmCtScanFn) {
+    m.asm_ct_scan = f;
 }
 
 # declare the optional DWARF register numbering
@@ -1444,6 +1482,7 @@ test "mach.lang.target.isa.reg_machine:optionals_cleared_then_declared" {
     var m: RegMachine = t_machine();
     if (m.emit_asm != nil)     { ret 1; }
     if (m.asm_clobbers != nil) { ret 1; }
+    if (m.asm_ct_scan != nil)  { ret 1; }
     if (m.dwarf_reg != nil)    { ret 1; }
     if (m.cv_reg != nil)       { ret 1; }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -59,6 +59,7 @@ use R: std.types.result;
 use mach.lang.be.codegen.encode;
 use codegen_frame: mach.lang.be.codegen.frame;
 use mach.lang.be.codegen.mir;
+use mach.lang.ct;
 use mach.lang.intern;
 use mach.lang.target.isa;
 use iasm: mach.lang.target.isa.asm;
@@ -7229,5 +7230,135 @@ test "mach.lang.target.isa.arm64.encode:unnamed_forms_are_refused" {
     if (!R.is_err[u32, str](scale_shift(3)))  { bad = 1; }
     if (!R.is_err[u32, str](scale_shift(16))) { bad = 1; }
 
+    ret bad;
+}
+
+# the constant-time classification of every aarch64 inline-asm mnemonic (#2230)
+#
+# Read by the `#[oblivious]` asm walk. Every row the grammar admits is classified
+# here; anything unclassified returns `ct.asm_unknown()` and refuses the moment a
+# secret reaches it.
+#
+# CONDITIONAL BRANCHES ARE CHECKED HERE, NOT REFUSED. This grammar carries no `b.cc`
+# row at all - its only conditional forms are `cbz` / `cbnz`, whose condition is a
+# REGISTER operand and therefore visible to the taint walk. x86-64 must refuse its
+# `jcc` family because the condition rides FLAGS, which the effect model does not
+# represent (#2460); aarch64 has no such gap and gets the full three checks.
+#
+# That is what makes the LL/SC atomic loop CHECKED rather than asserted: `stlxr Ws,
+# Xt, [Xn]` writes its status register and the retry `cbnz Ws` reads it, both plain
+# register operands, so the walk sees mechanically that the retry conditions on the
+# CONTENTION status and not on a taint. A `cbnz` on a secret-bound register in the
+# same block still refuses.
+#
+# ATOMICS AND FENCES ARE CONSTANT-TIME HERE, CONDITIONALLY. An LL/SC pair's retry
+# count varies with CONTENTION, not with the value carried, and contention at a
+# PUBLIC address is other threads' public behaviour - the class the leakage model
+# already accepts for cache state on a public-address load. This holds ONLY BECAUSE
+# check (b) refuses a secret address. DELETING OR WEAKENING THE SECRET-ADDRESS CHECK
+# INVALIDATES EVERY ATOMIC AND FENCE ROW BELOW.
+#
+# VARIABLE-LATENCY OPS ARE NEARLY ABSENT ON THIS TARGET: the aarch64 grammar carries
+# no divide, no multiply and no floating-point row, so check (c) reaches only the
+# register-count shifts (`lslv` / `lsrv` / `asrv`). riscv64 is the target where check
+# (c) is substantive.
+# ---
+# code: the mnemonic's aarch64 code
+# ret:  its classification, or `ct.asm_unknown()` when unclassified
+pub fun asm_ct_class(code: u32) ct.AsmClass {
+    # data movement, address formation, loads and stores: constant-time.
+    if (code == A64M_MOV  || code == A64M_MOVZ || code == A64M_MOVK ||
+        code == A64M_ADRP || code == A64M_LDR  || code == A64M_STR  ||
+        code == A64M_LDRB || code == A64M_STRB || code == A64M_LDRH ||
+        code == A64M_STRH || code == A64M_LDP  || code == A64M_STP) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # integer add / sub / bitwise / compare, and the CSET boolean materializer.
+    if (code == A64M_ADD || code == A64M_SUB || code == A64M_AND ||
+        code == A64M_ORR || code == A64M_EOR || code == A64M_CMP ||
+        code == A64M_CSET) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # the IMMEDIATE-count shifts are constant-time; the REGISTER-count forms are the
+    # only variable-latency shape this grammar can express, and the shared gate reads
+    # the count operand alone.
+    if (code == A64M_LSL || code == A64M_LSR || code == A64M_ASR) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    if (code == A64M_LSLV || code == A64M_LSRV || code == A64M_ASRV) {
+        ret ct.asm_op(ct.CT_OP_VAR_SHIFT);
+    }
+    # atomics and fences: see the conditional row above.
+    if (code == A64M_LDAXR || code == A64M_LDAR || code == A64M_STLXR ||
+        code == A64M_STLR  || code == A64M_DMB  || code == A64M_YIELD) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # unconditional control transfer, system registers, and the traps: the target of
+    # each is public by construction.
+    if (code == A64M_B   || code == A64M_BL  || code == A64M_BLR || code == A64M_BR ||
+        code == A64M_RET || code == A64M_SVC || code == A64M_BRK ||
+        code == A64M_NOP || code == A64M_MSR || code == A64M_MRS) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # the register-conditioned branches: checked against taint, not refused.
+    if (code == A64M_CBZ || code == A64M_CBNZ) {
+        ret ct.asm_branch_reg();
+    }
+    ret ct.asm_unknown();
+}
+
+# every mnemonic the aarch64 grammar admits carries a constant-time classification
+#
+# Walks the shipping grammar table, so adding a mnemonic without classifying it fails
+# here rather than becoming a row `#[oblivious]` silently cannot use (#2230).
+test "mach.lang.target.isa.arm64.encode.asm_ct_class:every_grammar_row_is_classified" {
+    var bad: i32 = 0;
+    var i: usize = 0;
+    for (i < A64_MNEMONIC_COUNT) {
+        if (!asm_ct_class(A64_MNEMONICS[i].code).known) { bad = 1; }
+        i = i + 1;
+    }
+    ret bad;
+}
+
+# aarch64's conditional branches are CHECKED, not refused - the property that makes
+# the LL/SC atomic loop analyzable rather than merely asserted
+#
+# `stlxr Ws, Xt, [Xn]` writes its status register and the retry `cbnz Ws` reads it,
+# both plain register operands, so the walk sees mechanically that the retry
+# conditions on CONTENTION status rather than on a taint. x86-64 cannot do this: its
+# `jcc` family conditions on FLAGS, which the effect model does not represent (#2460).
+test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_conditioned" {
+    var bad: i32 = 0;
+
+    # the only conditional forms this grammar has, and both are register-conditioned.
+    if (!asm_ct_class(A64M_CBZ).cond_reg)   { bad = 1; }
+    if (!asm_ct_class(A64M_CBNZ).cond_reg)  { bad = 1; }
+    # no aarch64 row is flags-conditioned: there is no `b.cc` in the grammar at all,
+    # which is exactly why this target needs no refusal.
+    var i: usize = 0;
+    for (i < A64_MNEMONIC_COUNT) {
+        if (asm_ct_class(A64_MNEMONICS[i].code).cond_flags) { bad = 1; }
+        i = i + 1;
+    }
+    # the unconditional transfers are not conditional branches.
+    if (asm_ct_class(A64M_B).cond_reg)  { bad = 1; }
+    if (asm_ct_class(A64M_BL).cond_reg) { bad = 1; }
+
+    # check (c) is near-vacuous HERE: no divide, multiply or float row exists, and the
+    # register-count shifts are the only variable-latency shape.
+    if (asm_ct_class(A64M_LSLV).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(A64M_LSRV).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(A64M_ASRV).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    # the immediate-count forms are not.
+    if (asm_ct_class(A64M_LSL).op != ct.CT_OP_NONE) { bad = 1; }
+    i = 0;
+    for (i < A64_MNEMONIC_COUNT) {
+        val op: ct.CtOp = asm_ct_class(A64_MNEMONICS[i].code).op;
+        if (op == ct.CT_OP_INT_DIVMOD) { bad = 1; }
+        if (op == ct.CT_OP_INT_MUL)    { bad = 1; }
+        if (op == ct.CT_OP_FLOAT)      { bad = 1; }
+        i = i + 1;
+    }
     ret bad;
 }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -69,6 +69,7 @@ use R: std.types.result;
 use mach.lang.be.codegen.encode;
 use codegen_frame: mach.lang.be.codegen.frame;
 use mach.lang.be.codegen.mir;
+use mach.lang.ct;
 use mach.lang.intern;
 use mach.lang.target.isa;
 use iasm: mach.lang.target.isa.asm;
@@ -5861,5 +5862,159 @@ test "mach.lang.target.isa.riscv64.encode:unnamed_forms_are_refused" {
     if (!R.is_err[u32, str](scale_shift(3)))  { bad = 1; }
     if (!R.is_err[u32, str](scale_shift(16))) { bad = 1; }
 
+    ret bad;
+}
+
+# the constant-time classification of every riscv64 inline-asm mnemonic (#2230)
+#
+# Read by the `#[oblivious]` asm walk. Every row the grammar admits is classified
+# here; anything unclassified returns `ct.asm_unknown()` and refuses the moment a
+# secret reaches it.
+#
+# THIS IS THE TARGET WHERE CHECK (c) IS SUBSTANTIVE, and it is why the honest note
+# has to be per-target. x86-64's and aarch64's grammars carry no divide, multiply or
+# float row at all, so on those two the variable-latency check reaches only a
+# register-count shift. This grammar admits the WHOLE M-EXTENSION - thirteen rows:
+# `mul mulh mulhsu mulhu mulw` (CT_OP_INT_MUL, constant-time only under a documented
+# data-independent multiply) and `div divu divw divuw rem remu remw remuw`
+# (CT_OP_INT_DIVMOD, variable-latency on every target, so a secret operand is always
+# refused). A reader told "check (c) is nearly vacuous" would be reading a claim that
+# is false precisely where the check bites.
+#
+# CONDITIONAL BRANCHES ARE CHECKED HERE, NOT REFUSED. RISC-V has no flags register:
+# every branch (`beq` / `bne` / `blt` / `bge` / `bltu` / `bgeu` and their pseudo
+# forms) compares two REGISTER operands, so the condition is visible to the taint
+# walk. x86-64 must refuse its `jcc` family because the condition rides FLAGS, which
+# the effect model does not represent (#2460).
+#
+# FENCES ARE CONSTANT-TIME HERE, CONDITIONALLY. A fence's cost varies with other
+# threads' memory traffic, not with any value it carries, and traffic at PUBLIC
+# addresses is public behaviour - the class the leakage model already accepts for
+# cache state on a public-address load. This holds ONLY BECAUSE check (b) refuses a
+# secret address. DELETING OR WEAKENING THE SECRET-ADDRESS CHECK INVALIDATES THE
+# FENCE ROW BELOW.
+# ---
+# code: the mnemonic's riscv64 code
+# ret:  its classification, or `ct.asm_unknown()` when unclassified
+pub fun asm_ct_class(code: u32) ct.AsmClass {
+    # integer divide and remainder: variable-latency on every target, so a secret
+    # operand is refused regardless of target capability.
+    if (code == inst.DIV::u32   || code == inst.DIVU::u32 || code == inst.DIVW::u32 ||
+        code == inst.DIVUW::u32 || code == inst.REM::u32  || code == inst.REMU::u32 ||
+        code == inst.REMW::u32  || code == inst.REMUW::u32) {
+        ret ct.asm_op(ct.CT_OP_INT_DIVMOD);
+    }
+    # integer multiply: constant-time only where the target documents a
+    # data-independent multiply.
+    if (code == inst.MUL::u32   || code == inst.MULH::u32 || code == inst.MULHSU::u32 ||
+        code == inst.MULHU::u32 || code == inst.MULW::u32) {
+        ret ct.asm_op(ct.CT_OP_INT_MUL);
+    }
+    # register-count shifts: variable-latency without a barrel shifter. the shared
+    # gate reads the COUNT operand alone.
+    if (code == inst.SLL::u32  || code == inst.SRL::u32  || code == inst.SRA::u32 ||
+        code == inst.SLLW::u32 || code == inst.SRLW::u32 || code == inst.SRAW::u32) {
+        ret ct.asm_op(ct.CT_OP_VAR_SHIFT);
+    }
+    # immediate-count shifts are constant-time: the count is a literal.
+    if (code == inst.SLLI::u32  || code == inst.SRLI::u32  || code == inst.SRAI::u32 ||
+        code == inst.SLLIW::u32 || code == inst.SRLIW::u32 || code == inst.SRAIW::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # integer add / sub / bitwise / set-less-than, and the address / constant formers.
+    if (code == inst.ADD::u32   || code == inst.ADDI::u32 || code == inst.ADDW::u32 ||
+        code == inst.ADDIW::u32 || code == inst.SUB::u32  || code == inst.SUBW::u32 ||
+        code == inst.AND::u32   || code == inst.ANDI::u32 || code == inst.OR::u32 ||
+        code == inst.ORI::u32   || code == inst.XOR::u32  || code == inst.XORI::u32 ||
+        code == inst.SLT::u32   || code == inst.SLTU::u32 || code == inst.SLTI::u32 ||
+        code == inst.SLTIU::u32 || code == inst.LUI::u32  || code == inst.AUIPC::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # loads and stores: constant-time given a public address, which check (b) enforces.
+    if (code == inst.LB::u32  || code == inst.LBU::u32 || code == inst.LH::u32 ||
+        code == inst.LHU::u32 || code == inst.LW::u32  || code == inst.LWU::u32 ||
+        code == inst.LD::u32  || code == inst.SB::u32  || code == inst.SH::u32 ||
+        code == inst.SW::u32  || code == inst.SD::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # fences and the hint: see the conditional row above.
+    if (code == inst.FENCE::u32 || code == inst.PAUSE::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # unconditional control transfer and the environment traps.
+    if (code == inst.JAL::u32   || code == inst.JALR::u32 ||
+        code == inst.ECALL::u32 || code == inst.EBREAK::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # the register-comparing branches: checked against taint, not refused.
+    if (code == inst.BEQ::u32 || code == inst.BNE::u32  || code == inst.BLT::u32 ||
+        code == inst.BGE::u32 || code == inst.BLTU::u32 || code == inst.BGEU::u32) {
+        ret ct.asm_branch_reg();
+    }
+    ret ct.asm_unknown();
+}
+
+# every mnemonic the riscv64 grammar admits carries a constant-time classification
+#
+# Walks the shipping grammar table, so adding a mnemonic without classifying it fails
+# here rather than becoming a row `#[oblivious]` silently cannot use (#2230).
+test "mach.lang.target.isa.riscv64.encode.asm_ct_class:every_grammar_row_is_classified" {
+    var bad: i32 = 0;
+    var i: usize = 0;
+    for (i < RV_MNEMONIC_COUNT) {
+        if (!asm_ct_class(RV_MNEMONICS[i].code).known) { bad = 1; }
+        i = i + 1;
+    }
+    ret bad;
+}
+
+# riscv64 is the target where the variable-latency check is SUBSTANTIVE - the claim
+# "check (c) is nearly vacuous" is false precisely here
+#
+# x86-64's and aarch64's grammars carry no divide, multiply or float row, so on those
+# two the check reaches only a register-count shift. This grammar admits the whole
+# M-extension, and this test names all thirteen rows so the per-target honesty note
+# cannot drift from what the grammar actually contains (#2230).
+test "mach.lang.target.isa.riscv64.encode.asm_ct_class:m_extension_is_variable_latency" {
+    var bad: i32 = 0;
+
+    # the eight divide / remainder rows: variable-latency on EVERY target, so a
+    # secret operand is refused whatever the target's capability flags say.
+    if (asm_ct_class(inst.DIV::u32).op   != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIVU::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIVW::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIVUW::u32).op != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REM::u32).op   != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REMU::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REMW::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REMUW::u32).op != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (ct.ct_cap(ct.CT_OP_INT_DIVMOD)   != ct.CT_CAP_ALWAYS)    { bad = 1; }
+
+    # the five multiply rows: constant-time only under a documented
+    # data-independent multiply.
+    if (asm_ct_class(inst.MUL::u32).op    != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULH::u32).op   != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULHSU::u32).op != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULHU::u32).op  != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULW::u32).op   != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (ct.ct_cap(ct.CT_OP_INT_MUL)       != ct.CT_CAP_MUL)    { bad = 1; }
+
+    # register-count shifts gate on the count operand alone; immediate-count ones
+    # are constant-time outright.
+    if (asm_ct_class(inst.SLL::u32).op  != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(inst.SRA::u32).op  != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(inst.SLLI::u32).op != ct.CT_OP_NONE)      { bad = 1; }
+    if (asm_ct_class(inst.SRAI::u32).op != ct.CT_OP_NONE)      { bad = 1; }
+
+    # every branch is register-comparing: RISC-V has no flags register, so none is
+    # refused the way x86-64's `jcc` family must be.
+    if (!asm_ct_class(inst.BEQ::u32).cond_reg)  { bad = 1; }
+    if (!asm_ct_class(inst.BNE::u32).cond_reg)  { bad = 1; }
+    if (!asm_ct_class(inst.BLTU::u32).cond_reg) { bad = 1; }
+    var i: usize = 0;
+    for (i < RV_MNEMONIC_COUNT) {
+        if (asm_ct_class(RV_MNEMONICS[i].code).cond_flags) { bad = 1; }
+        i = i + 1;
+    }
     ret bad;
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -54,6 +54,7 @@ use R: std.types.result;
 use enc: mach.lang.be.codegen.encode;
 use codegen_frame: mach.lang.be.codegen.frame;
 use mach.lang.be.codegen.mir;
+use mach.lang.ct;
 use mach.lang.intern;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
@@ -6908,5 +6909,138 @@ test "mach.lang.target.isa.x64.encode.encode_fp_mov:single_instruction_shapes" {
     or (buf.data[4] != 0xF0)  { bad = 1; }
 
     enc.buf_dnit(?buf);
+    ret bad;
+}
+
+# the constant-time classification of every x86-64 inline-asm mnemonic (#2230)
+#
+# Read by the `#[oblivious]` asm walk. Every row the grammar admits is classified
+# here; anything unclassified returns `ct.asm_unknown()` and refuses the moment a
+# secret reaches it, so adding a grammar row without adding a row here cannot widen
+# what validates.
+#
+# CONDITIONAL BRANCHES ARE REFUSED ON THIS TARGET. Every x86-64 `jcc` conditions on
+# the flags register, and the shared asm effect model does not represent flags, so
+# `cmp {secret}, rbx ; je 1f` would walk as two instructions that read and write
+# nothing. Refusing is the only sound answer until flags are modeled (#2460);
+# `jmp` is unconditional and validates normally.
+#
+# ATOMICS AND FENCES ARE CONSTANT-TIME HERE, AND THAT ROW IS CONDITIONAL. A LOCK-
+# prefixed read-modify-write's latency varies with CONTENTION, not with the value it
+# carries, and contention at a PUBLIC address is a function of other threads' public
+# behaviour - the same class as cache-state variation on an ordinary public-address
+# load, which the leakage model already accepts. This holds ONLY BECAUSE check (b)
+# refuses a secret address: at a secret address, contention would be a function of
+# the secret. DELETING OR WEAKENING THE SECRET-ADDRESS CHECK INVALIDATES EVERY
+# ATOMIC AND FENCE ROW BELOW.
+#
+# VARIABLE-LATENCY OPS ARE NEARLY ABSENT ON THIS TARGET, and saying so is the honest
+# framing: the x86-64 grammar carries no `div`, no `mul` and no floating-point row at
+# all, so check (c) reaches only the register-count shifts (`shl`/`shr`/`sar` by
+# `cl`). riscv64's grammar is the one where check (c) is substantive - it admits the
+# whole M-extension. A validator that looks stronger than it is would be a security
+# gate repeating #2288's failure.
+# ---
+# code: the mnemonic's x86-64 opcode
+# ret:  its classification, or `ct.asm_unknown()` when unclassified
+pub fun asm_ct_class(code: u32) ct.AsmClass {
+    # data movement, address formation, and the extends: constant-time everywhere.
+    if (code == x64.MOV::u32 || code == x64.MOVZX::u32 || code == x64.MOVSX::u32 ||
+        code == x64.LEA::u32 || code == x64.PUSH::u32  || code == x64.POP::u32 ||
+        code == x64.XCHG::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # integer add / sub / bitwise / compare / test / neg / not / inc / dec, and the
+    # SETcc byte materializers: fixed-latency on every x86-64 part.
+    if (code == x64.ADD::u32 || code == x64.SUB::u32 || code == x64.AND::u32 ||
+        code == x64.OR::u32  || code == x64.XOR::u32 || code == x64.CMP::u32 ||
+        code == x64.TEST::u32 || code == x64.NEG::u32 || code == x64.NOT::u32 ||
+        code == x64.INC::u32 || code == x64.DEC::u32 ||
+        code == x64.SETB::u32 || code == x64.SETAE::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # the shifts: variable-latency ONLY through a register (`cl`) count, which is the
+    # single variable-latency form this grammar can express. the shared gate reads the
+    # COUNT operand alone (`ct.ct_op_gates_count_only`), so a constant-count shift of a
+    # secret value stays constant-time.
+    if (code == x64.SHL::u32 || code == x64.SHR::u32 || code == x64.SAR::u32) {
+        ret ct.asm_op(ct.CT_OP_VAR_SHIFT);
+    }
+    # atomics and fences: see the conditional row above.
+    if (code == x64.CMPXCHG::u32 || code == x64.XADD::u32 ||
+        code == x64.MFENCE::u32  || code == x64.PAUSE::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # control transfer with no condition: the target is public by construction (a
+    # symbol or a numeric local label), so it reveals nothing about a secret.
+    if (code == x64.JMP::u32 || code == x64.CALL::u32 || code == x64.RET::u32 ||
+        code == x64.SYSCALL::u32 || code == x64.NOP::u32 || code == x64.HLT::u32 ||
+        code == x64.UD2::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+    # every conditional jump: refused, per the flags note above.
+    if (code == x64.JE::u32  || code == x64.JNE::u32 || code == x64.JB::u32 ||
+        code == x64.JAE::u32) {
+        ret ct.asm_branch_flags();
+    }
+    ret ct.asm_unknown();
+}
+
+# every mnemonic the x86-64 grammar admits carries a constant-time classification
+#
+# The structural half of fail-closed: `asm_ct_class` defaults to `ct.asm_unknown()`,
+# so an unclassified row refuses rather than validates - but a row nobody classified
+# is a row `#[oblivious]` silently cannot use, which is a papercut rather than a
+# leak. This walks the shipping grammar table, so adding a mnemonic without adding a
+# classification fails here rather than being discovered by a user (#2230).
+test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_is_classified" {
+    var bad: i32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val m: *iasm.Mnemonic = ?X64_MNEMONICS[i];
+        # `.byte` is a directive, not an instruction: its payload is opaque bytes the
+        # walk refuses on kind, so it carries no classification.
+        if (!str_equals(m.name, ".byte")) {
+            val cls: ct.AsmClass = asm_ct_class(m.code);
+            if (!cls.known) { bad = 1; }
+        }
+        i = i + 1;
+    }
+    ret bad;
+}
+
+# the classification says what the x86-64 grammar actually contains, not what a
+# reader might assume - the #2288 honesty bar applied to a security gate
+test "mach.lang.target.isa.x64.encode.asm_ct_class:variable_latency_surface" {
+    var bad: i32 = 0;
+
+    # the register-count shifts are the ONLY variable-latency form this grammar can
+    # express, and they gate on the count operand alone.
+    if (asm_ct_class(x64.SHL::u32).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(x64.SHR::u32).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(x64.SAR::u32).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (!ct.ct_op_gates_count_only(ct.CT_OP_VAR_SHIFT))      { bad = 1; }
+
+    # there is no divide, multiply or float row to reach: check (c) is otherwise
+    # vacuous HERE, which is why the honest note is per-target.
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code);
+        if (cls.op == ct.CT_OP_INT_DIVMOD) { bad = 1; }
+        if (cls.op == ct.CT_OP_INT_MUL)    { bad = 1; }
+        if (cls.op == ct.CT_OP_FLOAT)      { bad = 1; }
+        i = i + 1;
+    }
+
+    # every conditional jump is refused; the unconditional one is not.
+    if (!asm_ct_class(x64.JE::u32).cond_flags)  { bad = 1; }
+    if (!asm_ct_class(x64.JNE::u32).cond_flags) { bad = 1; }
+    if (!asm_ct_class(x64.JB::u32).cond_flags)  { bad = 1; }
+    if (!asm_ct_class(x64.JAE::u32).cond_flags) { bad = 1; }
+    if (asm_ct_class(x64.JMP::u32).cond_flags)  { bad = 1; }
+    # and no x86-64 branch is register-conditioned, which is the whole reason the
+    # flags refusal exists on this target.
+    if (asm_ct_class(x64.JE::u32).cond_reg)     { bad = 1; }
+
     ret bad;
 }


### PR DESCRIPTION
Part of #2230. Closes nothing.

The analysis substrate for validating inline asm inside `#[oblivious]`, landed **without** the walk that consumes it. **No behaviour change: every asm block is still refused**, and that is proven rather than asserted.

## Why this is a separate PR

The tables are the reviewable security content — thirteen riscv64 M-extension rows, the conditional atomics classification, the x86-64 flags refusal — and they are mergeable before anything consumes them. Landing them first shrinks the second PR's diff to exactly the surface the full review gate is for: the walk, the rewiring, and the checks.

## The model

`ct.AsmClass` carries what the register-effect model does not: an instruction's constant-time class, and its **branch shape**. It is fail-closed **by construction** — `known` is false in the zero value, so a mnemonic no ISA classified refuses the moment a secret reaches it.

Branch shape is held separately from op class because the two checks genuinely differ, and the difference is per-target:

| target | conditional forms | checkable? |
|---|---|---|
| x86-64 | `je jne jb jae` (and aliases) | **No** — condition rides FLAGS |
| aarch64 | `cbz` `cbnz` only | Yes — condition is a register operand |
| riscv64 | `beq bne blt bge bltu bgeu` | Yes — compares two register operands |

`isa/asm.mach` states plainly that **"condition flags are not modeled"** — the model was built for register allocation, where flags hold no value. So on x86-64, `cmp {secret}, rbx ; je 1f` would walk as two instructions that read and write nothing and pass as leak-free: a secret-dependent branch carrying a constant-time guarantee. Flags-conditioned branches are therefore refused outright there, tracked for lifting as #2460. aarch64 and riscv64 have no such gap and get the full checks.

## Three sharpenings recorded at the tables

**Atomics and fences are `CT_OP_NONE`, conditionally.** A LOCK-prefixed RMW's (or an LL/SC pair's) latency varies with **contention**, not with the value carried, and contention at a **public** address is other threads' public behaviour — the same class as cache-state variation on an ordinary public-address load, which the leakage model already accepts. The tables say, in these words, that this holds **only because check (b) refuses a secret address**, and that weakening that check invalidates every atomic and fence row below it. That coupling is the invariant a future editor needs.

**The aarch64 LL/SC loop is now checkable, not merely asserted.** `stlxr Ws, Xt, [Xn]` writes its status register and the retry `cbnz Ws` reads it — both plain register operands — so the walk will see mechanically that the retry conditions on contention status rather than on a taint. A test pins that aarch64 has no flags-conditioned row at all.

**The variable-latency note is per-target, because the global version is false.** x86-64 and aarch64 carry no divide, multiply or float row, so check (c) reaches only their register-count shifts. riscv64 admits the **entire M-extension** — eight divide/remainder rows (`CT_OP_INT_DIVMOD`, refused on a secret operand whatever the target claims) and five multiply rows (`CT_OP_INT_MUL`, constant-time only under a documented data-independent multiply). A test names all thirteen, so the note cannot drift from the grammar. A validator that looks stronger than it is would be #2288's failure mode on a security gate.

## Tests

Per target, a coverage test walking the **shipping** mnemonic table: a row added later without a classification fails there rather than becoming one `#[oblivious]` silently cannot use. Plus the per-target honesty tests above.

And `mach.lang.driver:oblivious_asm_still_refused_without_a_scanner` — **the neutrality claim pinned as behaviour**. Every ISA leaves the `asm_ct_scan` slot nil, and a nil scanner means `ctvalidate` keeps refusing. The test uses a bare `nop`, which leaks nothing on any axis, so it pins the refusal as *unconditional* rather than as a leak finding, and pins the guidance the message offers. When the walk is wired, this is the test that must be deliberately changed — the review checkpoint that change deserves.

## Verification

- **Byte-identical on all three targets** — `linux-x86_64`, `linux-arm64`, `linux-riscv64` — against the `dev` baseline, with a self-vs-self control run first. That is the neutrality claim.
- Three-generation fixpoint `b == c`, branch and baseline.
- `mach test` **1029 / 0** (baseline 1022; +7 for the classification, honesty and neutrality tests).

## Next

PR 2 carries the walk (already written), the per-ISA wrappers, the `ctvalidate` rewiring, the docs, the specified accept/reject tests, the mutation matrix per capability row, and the full bar set. It closes #2230.