### PR TITLE
feat(legalize): implement wide sign-extension on mos6502

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -575,6 +575,16 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
         # one move per destination lane (low lanes copy the source, high lanes zero).
         ret R.ok[u32, str](dst_lane_count(plan, mi));
     }
+    if (op == mir.MIR_SEXT) {
+        # one move per destination lane, plus one piece for the sign fill itself when
+        # any high lane exists (an arithmetic shift of the source's top lane, reused
+        # by every high lane exactly as a shift's own sign fill is - see emit_sign_fill).
+        val dl: u32 = dst_lane_count(plan, mi);
+        val sl: u32 = src_lane_count(plan, mi);
+        var n: u32 = dl;
+        if (dl > sl) { n = n + 1; }
+        ret R.ok[u32, str](n);
+    }
     if (op == mir.MIR_TRUNC) {
         # one move per (narrower) destination lane, copying the low source lanes.
         ret R.ok[u32, str](dst_lane_count(plan, mi));
@@ -782,6 +792,9 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     }
     if (op == mir.MIR_ZEXT) {
         ret expand_zext(alloc, plan, mi, dst, cursor);
+    }
+    if (op == mir.MIR_SEXT) {
+        ret expand_sext(alloc, plan, f, mi, dst, cursor);
     }
     if (op == mir.MIR_TRUNC) {
         ret expand_trunc(alloc, plan, mi, dst, cursor);
@@ -1640,6 +1653,49 @@ fun expand_zext(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
     ret R.ok[bool, str](true);
 }
 
+# expand a sign-extension into per-lane moves: the low lanes copy the source, the
+# high lanes take the SIGN FILL - `emit_sign_fill`'s arithmetic shift of the
+# source's own top lane, computed once and reused by every high lane exactly as a
+# wide arithmetic shift reuses it (#2217: an arithmetic shift never changes the
+# sign of what it shifts).
+#
+# ASSUMES A LANE-ALIGNED SOURCE: the source's top lane (`sl - 1`) is read whole and
+# its bit 7 taken as the sign bit, which is only correct when the source's actual
+# width fills that lane completely - true for every source width this pass ever
+# sees, because mach's narrowest scalar (one byte) is exactly one mos6502 lane. A
+# future narrow-ALU target whose lane is wider than its narrowest scalar (a
+# "sub-lane source") would need the sign taken from within the lane instead - a
+# different shape than this one handles, not merely a wider version of it.
+fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
+                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
+    if (mi.operand_count != 2 ||
+        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
+        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+    }
+    val dl: u32 = dst_lane_count(plan, mi);
+    val sl: u32 = src_lane_count(plan, mi);
+    val lw: u8  = plan.lane_width;
+
+    var fill: mir.MirOperand = mir.op_imm(0);
+    if (dl > sl) {
+        val top: mir.MirOperand = lane_operand(plan, ?mi.operands[1], sl - 1);
+        val rf: R.Result[bool, str] = emit_sign_fill(alloc, f, mi, dst, cursor, top, lw, ?fill);
+        if (R.is_err[bool, str](rf)) { ret rf; }
+    }
+
+    var i: u32 = 0;
+    for (i < dl) {
+        var ops: [2]mir.MirOperand;
+        ops[0] = lane_operand(plan, ?mi.operands[0], i);
+        if (i < sl) { ops[1] = lane_operand(plan, ?mi.operands[1], i); }
+        or          { ops[1] = fill; }
+        val r: R.Result[bool, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        if (R.is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
 # expand a truncation into per-lane moves of the low destination lanes; the high
 # source lanes are dropped
 fun expand_trunc(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
@@ -1692,13 +1748,6 @@ fun unsupported_message(op: mir.MirOpcode, width: u8) str {
     }
     if (op == mir.MIR_GEP || op == mir.MIR_ALLOCA) {
         ret "legalize: materializing an address wider than one register is not yet legalized on this target";
-    }
-    # a wide SIGN-extension became reachable only once an 8-byte scalar reported its
-    # real width (#2323); until then no wide value of any kind got this far on the one
-    # target that legalizes. It is named rather than left to the generic message, so the
-    # frontier reads as the specific unimplemented expansion it is.
-    if (op == mir.MIR_SEXT) {
-        ret "legalize: wide sign-extension is not yet legalized on this target";
     }
     ret "legalize: operation wider than the target ALU is unsupported";
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9652,6 +9652,40 @@ fun ut_mos_u64_ref(k: u32, v: u64) u64 {
     ret v + 4294967297;                 # $100000001, a carry across the lane-4 boundary
 }
 
+# the sign-extension probe module: one function per source width, each truncating
+# an `i64` down to that width and sign-extending it back (test helper)
+#
+# Every function takes and returns a single 8-byte scalar, the same ABI shape
+# `ut_mos_u64_src` uses, so the runner needs no per-function knowledge.
+fun ut_mos_sext_src() str {
+    ret "fun f0(v: i64) i64 { ret (v::i8)::i64; }\nfun f1(v: i64) i64 { ret (v::i16)::i64; }\nfun f2(v: i64) i64 { ret (v::i32)::i64; }\nfun main() i32 { ret 0; }\n";
+}
+
+# the number of probe functions `ut_mos_sext_src` declares
+val UT_MOS_SEXT_OPS: u32 = 3;
+
+# the reference answer for sign-extension probe function `k`, computed
+# independently of the emitted bytes (test helper)
+# ---
+# k: 0 selects an i8 source, 1 an i16 source, 2 an i32 source
+# v: the i64 argument, reduced to the source width's bit pattern and
+#    sign-extended back out of it
+fun ut_mos_sext_ref(k: u32, v: u64) u64 {
+    if (k == 0) {
+        val b: u64 = v & 0xFF;
+        if ((b & 0x80) != 0) { ret b | 0xFFFFFFFFFFFFFF00; }
+        ret b;
+    }
+    if (k == 1) {
+        val b: u64 = v & 0xFFFF;
+        if ((b & 0x8000) != 0) { ret b | 0xFFFFFFFFFFFF0000; }
+        ret b;
+    }
+    val b: u64 = v & 0xFFFFFFFF;
+    if ((b & 0x80000000) != 0) { ret b | 0xFFFFFFFF00000000; }
+    ret b;
+}
+
 # mos6502 (#2323): a `u64` COMPUTATION builds and runs, executed on a reference 6502 core
 #
 # The issue's own reproducers - `v + 1`, `v & mask`, and a widening cast - none of which
@@ -9664,6 +9698,10 @@ fun ut_mos_u64_ref(k: u32, v: u64) u64 {
 # Eight lanes is also the widest the carry chain has ever run - `+`, `-` and the borrow
 # through every lane - and the values sweep the patterns a carry-propagation bug hides
 # behind: all-ones (carry out of every lane), the lane boundaries, and a spread.
+#
+# The same widening cast also frontiered a wide SIGN-extension (#2345), swept below
+# across every source width the cast can name (i8 / i16 / i32) against the same value
+# patterns, over the same reference core.
 test "mach.lang.driver:u64_computation_executes_on_a_6502_core_mos6502" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -9711,21 +9749,52 @@ test "mach.lang.driver:u64_computation_executes_on_a_6502_core_mos6502" {
     }
 
     project.dnit_project(?p);
-    A.deallocate[u8](?alloc, mem, UT_MOS_MEM);
 
-    # THE FRONTIER THAT MOVED, PINNED POSITIVELY. A wide SIGN-extension is reachable
-    # only now that an 8-byte scalar reports its real width - before, every `u64` was a
-    # byte and nothing wide got this far - and it is not legalized. It must say so
-    # specifically rather than fall back to the generic "wider than the target ALU",
-    # which is what an unimplemented expansion looks like when nobody named it.
-    val pe: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
-        "fun f(v: i64) i64 { ret (v::i8)::i64; }\nfun main() i32 { ret 0; }\n", "mos");
+    # THE FRONTIER THAT MOVED, PINNED POSITIVELY (#2345). A wide SIGN-extension is
+    # reachable only now that an 8-byte scalar reports its real width, and it is now
+    # legalized - proven by execution across every source width the cast can name,
+    # the same discipline every other wide op on this target is held to, rather than
+    # by the absence of the rejection this block used to assert.
+    val pe: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, ut_mos_sext_src(), "mos");
     if (R.is_err[project.Project, outcome.Fail](pe)) { bad = 1; }
     or {
         var pf: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pe);
-        if (ut_run_codegen_err(?pf, "wide sign-extension is not yet legalized") != 0) { bad = 1; }
+        if (ut_run_codegen_ok(?pf) != 0) { bad = 1; }
+        or {
+            var stext: *u8 = nil;
+            var stlen: u32 = 0;
+            var soffs: [4]u32;
+            if (!ut_mos_text(?pf, ?stext, ?stlen, ?soffs[0], UT_MOS_SEXT_OPS)) { bad = 1; }
+            or (UT_MOS_CODE + stlen >= UT_MOS_ARGS)                           { bad = 1; }
+            or {
+                ut_mos_load(stext, stlen, mem);
+                var sk: u32 = 0;
+                for (sk < UT_MOS_SEXT_OPS) {
+                    var sfixed: u32 = 0;
+                    var svi: u32 = 0;
+                    for (svi < UT_SHIFT_VALUES) {
+                        val sv: u64 = ut_shift_value(svi);
+                        var sgot: u64 = 0;
+                        var scy:  u32 = 0;
+                        if (!ut_mos_run(mem, soffs[sk], 8, sv, 0, ?sgot, ?scy)) { bad = 1; }
+                        or {
+                            if (sgot != ut_mos_sext_ref(sk, sv)) { bad = 1; }
+                            # a per-lane move sequence, straight-line like every other
+                            # width conversion on this target: one cycle count for
+                            # every value, positive or negative.
+                            if (svi == 0)      { sfixed = scy; }
+                            or (scy != sfixed) { bad = 1; }
+                        }
+                        svi = svi + 1;
+                    }
+                    sk = sk + 1;
+                }
+            }
+        }
         project.dnit_project(?pf);
     }
+
+    A.deallocate[u8](?alloc, mem, UT_MOS_MEM);
 
     session.dnit(?s);
     ret bad;


### PR DESCRIPTION
## Reachability

Confirmed mos6502-only, as the issue anticipated. `instr_needs_legalize`
(`legalize.mach`) triggers legalization whenever `mi.width > mach.lane_width ||
mi.src_width > mach.lane_width`; every wide-native target (x86-64/aarch64/riscv64)
declares `max_alu_width = 8`, so no scalar operation in the language (widest is
64-bit) is ever wider than the native ALU on those targets and the pass returns
inert without touching anything (the file's own documented inertness contract).
mos6502 is the only target that declares a narrow ALU (1 byte), so it is the only
target where a wide `MIR_SEXT` was ever reachable, and the only target this
change has any effect on.

The failure was a loud, specific REFUSAL (`"legalize: wide sign-extension is not
yet legalized on this target"`, added by #2323 precisely so this frontier read as
a named unimplemented expansion rather than the generic width-unsupported
message) - never a crash or a silent wrong-code path. Nothing to flag before
implementing.

## Implementation

`expand_sext` follows the `expand_zext` template exactly: `dst_lane_count`
destination lanes, the low `src_lane_count` of them copy the source lane, the
rest take a fill. The only difference from ZEXT is the fill's value - ZEXT's is
always `0`; SEXT's is the SIGN FILL `emit_sign_fill` already builds for the
shift work (#2217): one arithmetic right-shift of the source's own top lane by
`lane_width*8 - 1` bits, computed once and reused by every high lane, because an
arithmetic shift never changes the sign of what it shifts. `expansion_count`
gets the matching arm: `dst_lane_count` pieces, plus one for the fill itself
when any high lane exists (`dl > sl`) - mirroring the shift piece count's own
`needs_sign_fill` gate.

**Shared, not mos6502-specific.** `expand_sext` reads only the four `Machine`
facts every expansion in this pass reads (`lane_width` via `lw`, nothing else)
- no mos6502-specific register, no target-specific fact. Matches #2216/#2217/
#2323's pattern of finding "shared" more often than the issue expected.

**The sub-lane source case, addressed by precondition rather than by code.**
`emit_sign_fill`'s arithmetic shift reads bit 7 of the source's top LANE as the
sign bit, which is only correct when the source's actual width fills that lane
completely. On mos6502 (`lane_width = 1` byte) this is always true: mach's
narrowest scalar type is exactly one byte, so `src_width` is never smaller than
`lane_width` and `src_lane_count` is never rounded up from a fractional lane.
Documented explicitly on `expand_sext` rather than guarded in code, since no
reachable input violates it today; a future narrow-ALU target whose lane is
wider than its narrowest scalar (a "sub-lane source") would need the sign taken
from within the lane instead - named as a different shape, not a wider version
of this one, so the next person implementing such a target knows not to assume
this expansion already covers it.

`unsupported_message`'s `MIR_SEXT` special case (and its explaining comment) is
removed along with the pinned rejection - the frontier that moved is now
legalized, not merely no longer rejected.

## Verification

- `mach test .` via a from-source `--jobs 1` compiler: **1022 passed, 0 failed**
  - identical to the `dev` baseline at the branch point (`35f1f929`), confirmed
  by measuring both with the same from-source methodology. No test count drift:
  this change extends one existing pinned test's body rather than adding new
  `test` blocks.
- **Mutation test on the fill logic** (the one guard genuinely new to this
  change - the piece count and dispatch shape are template copies already
  proven by ZEXT/TRUNC): forced the computed sign fill to be discarded and
  replaced with a constant `0` after `emit_sign_fill` runs (preserving the
  exact piece count, so this isolates the VALUE bug from a shape bug). Result:
  **1021 passed, 1 failed** - the new sweep in
  `u64_computation_executes_on_a_6502_core_mos6502` catches it immediately.
  Reverted; confirmed clean **1022/0** afterward.
- **Object-level byte-identity** (one target `linux-x86_64`, one profile
  `release`, per the bar - no divergence found, so no widening needed): held
  the `dev`-baseline project source fixed, built its 215 objects once with the
  unmodified baseline compiler and once with this branch's from-source
  compiler. `diff -rq`: **zero differences** - confirms the inertness contract
  holds for this change exactly as documented (the new `MIR_SEXT` arm is
  unreached code on any wide-native target).
- **Three-generation self-host fixpoint**: gen3 == gen4 byte-identical
  (`57129a3bc2fef1740237d94281032f59096b7294965f6c13d42b55e6f2d63f32`),
  `--jobs 1` throughout.
- mos6502 has no `int/` leg (per #2435 precedent), so its coverage is the unit
  suite above: the executed sweep in `driver:u64_computation_executes_on_a_6502_core_mos6502`
  now covers all three source widths the cast can name (i8/i16/i32) against a
  reference computed independently of the emitted bytes
  (`ut_mos_sext_ref`), sweeping both signs and the lane boundaries via the
  existing `ut_shift_value` value set, and asserting a fixed cycle count per
  width (straight-line, no branch on the sign) - the same constant-time
  discipline every other wide op on this target is held to.

Closes #2345