### PR TITLE
fix(sema): refuse a type query over an unbound generic parameter

### DIFF
--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -44,7 +44,7 @@ neighboring links; start from the index below.
 - [comptime.md](comptime.md) — channel overview
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` compiler-owned namespace
 - [decorators.md](decorators.md) — codegen decorators, `#[name]` (replaces the removed `$sym.attr` setters)
-- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$each`, `$error`, `$assert`
+- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$is_record`, `$is_union`, `$is_pointer`, `$type_name`, `$each`, `$error`
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`
 
 ## Low-level

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -353,19 +353,27 @@ $or ($type_of(arg) == str) { write_str(w, arg); }
 $or { $error("no writer for this argument type"); }    # compile error on an unhandled type
 ```
 
-> **`$assert` not yet implemented.** `$assert` is rejected wherever it is written -
-> with any condition, a plain `1 == 1` included - not merely accepted and ignored.
-> It is intended as sugar over `$if` plus `$error` — `$assert(cond, "msg")` ≡ `$if (!cond) { $error("msg"); }`,
-> e.g. `$assert($mach.build.arch == $mach.arch.x86_64, "expected x86_64");`. Being `$if`
-> sugar, it will inherit `$if`'s restrictions: a layout intrinsic in `cond` is
-> rejected for the reason above, so `$assert($size_of(i64) == 8, ...)` is not a
-> spelling to plan on.
-
 ## Not provided as intrinsics
 
 Code intrinsics — runtime-instruction emitters like `trap`, `fence`,
 `pause` — are not in the compiler-shipped set. They belong in stdlib as
 functions with per-arch `asm` bodies. See [policy.md](policy.md).
+
+**`$assert` is not an intrinsic either**, and is not planned as one: `$if` and
+`$error` already compose to it exactly, so a dedicated directive would add spelling
+without adding capability. Write the composition directly.
+
+```mach
+# instead of $assert(cond, "msg")
+$if (!cond) { $error("msg"); }
+
+$if (!($mach.build.arch == $mach.arch.x86_64)) { $error("expected x86_64"); }
+```
+
+The composition inherits `$if`'s condition rules, which is the point: the same
+conditions fold there as in any other gate, and the ones that do not — a layout
+intrinsic, a type query over an unbound generic parameter — refuse with their own
+cause rather than through a second surface that could describe them differently.
 
 ## See also
 

--- a/doc/language/comptime.md
+++ b/doc/language/comptime.md
@@ -85,5 +85,5 @@ than each carrying their own.
 - [comptime-mach.md](comptime-mach.md) — the `$mach.*` namespace
 - [decorators.md](decorators.md) — `#[...]` codegen decorators
 - [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`,
-  `$assert`, …
+  `$is_record`, `$type_name`, …
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -672,8 +672,9 @@ mach-read      ::= comptime-ident { member }        (* $mach.build.os, $mach.arc
 ```
 
 - Intrinsic calls (`$size_of(T)`, `$align_of(T)`, `$offset_of(T, field)`,
-  `$type_of(e)`, `$fields(T)`, `$error("msg")`, `$assert(cond, "msg")`) are
-  syntactically a `comptime-ident` callee with `call-args`.
+  `$type_of(e)`, `$fields(T)`, `$is_record(T)`, `$is_union(T)`,
+  `$is_pointer(T)`, `$type_name(T)`, `$error("msg")`) are syntactically a
+  `comptime-ident` callee with `call-args`.
 - The **type-taking** intrinsics — `$size_of`, `$align_of`, `$offset_of`,
   `$fields` — parse their **first argument with the `type` production**, not the
   expression grammar, so the whole type language is spellable there:
@@ -749,8 +750,9 @@ Doc-only (intended surface, not a distinct parser production):
   sets are enforced later (see [asm.md](asm.md),
   [comptime-mach.md](comptime-mach.md)).
 - The closed intrinsic set (`$size_of`, `$align_of`, `$offset_of`,
-  `$type_of`, `$fields`, `$error`, `$assert`) — syntactically
-  indistinguishable from any other `comptime-ident` call.
+  `$type_of`, `$fields`, `$is_record`, `$is_union`, `$is_pointer`,
+  `$type_name`, `$error`) — syntactically indistinguishable from any other
+  `comptime-ident` call.
 - The closed decorator directive set (`symbol`, `library`, `inline`, `align`,
   `section`) — the parser accepts any `IDENT` after `#[`; sema enforces the
   closed set.

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1451,6 +1451,45 @@ test "mach.lang.driver:layout_intrinsic_remaining_positions" {
     ret bad;
 }
 
+# 0 when `src` selects the EXPECTED comptime arm: the expected marker fired and the
+# other one did NOT
+#
+# One-sided is not enough. A gate that fails to fold does not choose an arm - it
+# type-checks EVERY arm, so both markers fire and an "expected marker present"
+# assertion passes on a gate that stopped folding entirely. Requiring the other
+# marker's ABSENCE is what makes these cases catch a predicate that silently defers
+# as well as one that answers wrongly.
+fun ut_arm(src: str, want: str, other: str) i32 {
+    if (ut_vec_diag(src, want) != 0)  { ret 1; }
+    if (ut_vec_diag(src, other) == 0) { ret 1; }
+    ret 0;
+}
+
+# a type query over an UNBOUND GENERIC PARAMETER is refused, not answered (#2464)
+#
+# The template body types against a placeholder, so a predicate asked there folded
+# FALSE - a TYPE_GENERIC_PARAM is not a record - and the gate pruned the wrong arm
+# for every instantiation, including the ones where the argument really is a record.
+# The refusal is the contained fix; per-instance evaluation is #2465.
+test "mach.lang.driver:comptime_type_query_generic_refusal" {
+    var bad: i32 = 0;
+
+    # the repro: `probe[P]` with P a record used to report "T must be a record"
+    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n",
+                    "not evaluated per instantiation yet") != 0) { bad = 1; }
+    # and it must NOT be the old falsehood
+    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n",
+                    "T must be a record") == 0) { bad = 1; }
+
+    # every query is refused alike, and `$type_name` too - the operand is the problem
+    if (ut_vec_diag("fun probe[T]() i32 { $if ($is_pointer(T)) { } $or { } ret 0; }\nfun main() i32 { ret probe[u64](); }\n",
+                    "not evaluated per instantiation yet") != 0) { bad = 1; }
+    if (ut_vec_diag("fun probe[T]() i32 { val n: *u8 = $type_name(T); ret 0; }\nfun main() i32 { ret probe[u64](); }\n",
+                    "not evaluated per instantiation yet") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # a comptime type predicate answers about a type's SHAPE, and a gate on one selects
 # an arm (#2128)
 #
@@ -1466,26 +1505,26 @@ test "mach.lang.driver:comptime_type_predicates" {
     var bad: i32 = 0;
 
     # $is_record: a record yes, a union no, a scalar no, a pointer no
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_record(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
-    if (ut_vec_diag("fun main() i32 { $if ($is_record(u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_record(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_record(u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
     # an INSTANCE of a record answers as the record: post-#2168 that is the type a
     # reflection loop actually meets for `Box[i64]`
-    if (ut_vec_diag("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $is_union, mirrored
-    if (ut_vec_diag("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_union(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
-    if (ut_vec_diag("uni Box[T] { v: T; w: u32; }\nfun main() i32 { $if ($is_union(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_union(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("uni Box[T] { v: T; w: u32; }\nfun main() i32 { $if ($is_union(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $is_pointer covers BOTH spellings of a reference
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("fun main() i32 { $if ($is_pointer(ptr)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N") != 0) { bad = 1; }
-    if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_pointer(ptr)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # a predicate is comptime-only: there is no runtime boolean for one to become
     if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { val b: u8 = $is_record(P); ret 0; }\n",
@@ -1502,11 +1541,11 @@ test "mach.lang.driver:comptime_type_predicates" {
 test "mach.lang.driver:comptime_type_name" {
     var bad: i32 = 0;
 
-    if (ut_vec_diag("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # a composite spells compositely rather than degrading to the nominal
-    if (ut_vec_diag("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(*Pair) == \"*Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(*Pair) == \"*Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # the secret wrapper is stripped here too, so `^Pair` names `Pair`
-    if (ut_vec_diag("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # unlike the predicates it IS a value, usable outside a gate
     if (ut_layout_ok("rec Pair { a: u64; }\nfun main() i32 { val n: *u8 = $type_name(Pair); ret 0; }\n") != 0) { bad = 1; }
 
@@ -1520,19 +1559,19 @@ test "mach.lang.driver:comptime_reflection_descent" {
 
     # a record-typed field answers yes, a scalar field no - through the descriptor,
     # which is the operand a real derive walk actually holds
-    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
-    if (ut_vec_diag("rec Outer { n: u64; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N") != 0) { bad = 1; }
-    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { p: *Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_pointer(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec Outer { n: u64; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { p: *Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_pointer(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $type_name through the descriptor: the same operand path as the predicates, so
     # the spelling is pinned where a derive-style formatter would actually read it
-    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # a SECRET-typed field met through the loop: the #2297 / #2373 shape arriving via
     # the descriptor rather than as a literal `^T` spelling, which is how a real walk
     # would meet it. an unstripped query answers "not a record" and the derive walk
     # silently skips the field.
-    if (ut_vec_diag("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # and the whole shape together: gate, then descend, over a MIXED record - which
     # is the case that could not be written at all before, since the inner $fields

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -1878,6 +1878,10 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
     # once the resolver is installed at lowering. type-check EVERY arm
     # structurally; arm selection is deferred to per-value monomorphization.
     if (param_gated || has_type_cmp) {
+        # a chain-level flag, not a per-arm one: the final unconditional `$or` arm has
+        # no gate of its own, so an arm-local flag would still walk exactly the arm
+        # whose `$error` contradicts the gate's diagnostic.
+        var chain_bad: bool = false;
         var i: u32 = 0;
         for (i < len) {
             val arm: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + i];
@@ -1886,7 +1890,7 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
                 # here (and rejected as a value elsewhere).
                 val saved_gate: bool = sc.in_comptime_gate;
                 sc.in_comptime_gate = true;
-                infer.infer_expr(sc, arm.cond);
+                if (infer.infer_expr(sc, arm.cond) == type.TYPE_ERROR) { chain_bad = true; }
                 sc.in_comptime_gate = saved_gate;
                 # every arm gate of a param-gated chain must itself be comptime-
                 # foldable: its free identifiers must all be comptime (comptime
@@ -1896,8 +1900,16 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
                 # error. report it here, against the offending gate.
                 check_comptime_gate(sc, arm.cond);
             }
-            val res_body: R.Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
-            if (R.is_err[bool, str](res_body)) { ret res_body; }
+            # A GATE THAT DID NOT TYPE DECIDES NOTHING, so its arms are not checked.
+            # Checking them anyway cascades: the arms of an undecided chain are all
+            # walked, so a `$or { $error("...") }` fires its diagnostic beside the
+            # gate's own error and the user is told two contradictory things about one
+            # mistake - the second of them the very falsehood the gate error exists to
+            # replace (#2464).
+            if (!chain_bad) {
+                val res_body: R.Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
+                if (R.is_err[bool, str](res_body)) { ret res_body; }
+            }
             i = i + 1;
         }
         ret R.ok[bool, str](true);
@@ -1947,8 +1959,15 @@ fun prune_type_comparison_chain(sc: *context.SemaContext, start: u32, len: u32, 
         # fold it. a gate that does not fold to a bool defers the whole chain.
         val saved_gate: bool = sc.in_comptime_gate;
         sc.in_comptime_gate = true;
-        infer.infer_expr(sc, arm.cond);
+        val gate_ty: type.TypeId = infer.infer_expr(sc, arm.cond);
         sc.in_comptime_gate = saved_gate;
+
+        # A GATE THAT DID NOT TYPE DECIDES NOTHING. Reporting its own error and then
+        # ALSO walking every arm tells the user two contradictory things about one
+        # mistake - and the second is the falsehood the gate error exists to replace,
+        # since the `$or { $error(...) }` arm of a refused type query fires too
+        # (#2464). The chain is finished here: the error is already filed.
+        if (gate_ty == type.TYPE_ERROR) { ret R.ok[bool, str](true); }
 
         val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, arm.cond, ?sc.s.interner);
         if (R.is_err[comptime.CTValue, str](res_eval)) { ret R.ok[bool, str](false); }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1936,6 +1936,27 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
         set_expr_type(sc, qarg, qty);
         if (qty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+        # AN UNBOUND GENERIC PARAMETER IS REFUSED, NOT ANSWERED (#2464).
+        #
+        # A template body types against placeholders, so `$is_record(T)` inside
+        # `fun f[T]()` asked about a TYPE_GENERIC_PARAM - which is not a record, not a
+        # union and not a pointer, so every predicate folded FALSE and the gate pruned
+        # the wrong arm for EVERY instantiation, including the ones where `T` really
+        # is a record. A wrong answer, silently, in the case the predicates exist to
+        # serve.
+        #
+        # The apparent fix - answer "unanswerable" so the gate defers - is worse:
+        # `check_comptime_gate` rejects a gate that does not fold, and
+        # `drain_revalidations` is a targeted pass (`arg_triggers_revalidation`), so an
+        # instance it does not record would never re-evaluate the gate at all. That
+        # trades a loud wrong answer for a silently unchecked one. Per-instance
+        # evaluation is the real fix (#2465); until it lands this refuses, which is
+        # the one option that is neither wrong nor silent.
+        if (type_is_generic_param(sc, qty)) {
+            context.report(sc, span, "a comptime type query over an unbound generic parameter is not evaluated per instantiation yet: it would be answered against the template's placeholder rather than each instance's type. gate on a concrete type, or await per-instance evaluation (#2465)");
+            ret type.TYPE_ERROR;
+        }
+
         # `$type_name` is an ordinary value - a string, valid anywhere one is.
         if (is_name_q) { ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8)); }
 


### PR DESCRIPTION
Closes #2464.

Two commits: the fix, then the `$assert` docs salvage riding along per the ruling.

## The fix

A template body types against placeholders, so `$is_record(T)` inside `fun f[T]()`
asked about a `TYPE_GENERIC_PARAM` — not a record, not a union, not a pointer — and
every predicate folded **FALSE**. The gate then pruned the wrong arm for *every*
instantiation, including the ones where `T` really is a record. A wrong answer,
silently, in exactly the recursive-generic case the predicates exist to serve.

It now refuses, citing #2465. The apparent alternative — answer "unanswerable" so
the gate defers — is worse, and I measured that rather than assuming it:
`check_comptime_gate` rejects a gate that does not fold, and `drain_revalidations`
is targeted (`arg_triggers_revalidation`), so an instance it does not record would
never re-evaluate the gate at all. That trades a loud wrong answer for a silently
unchecked one.

**A chain whose gate did not type is no longer walked arm-by-arm.** Without this the
repro emitted *two* diagnostics — the refusal, and then `T must be a record` from the
`$or { $error(...) }` arm, which is the very falsehood the refusal replaces. One
mistake, one message.

## Verification

Full bars once, on this final pre-ready push (economy orders). Dev moved to
`347251ab` mid-work; the disjointness check was **not** clean — `--name-only` showed
`src/lang/driver/tests.mach` overlapping #2230's tests — so dev is merged and the
bars are run against the merge rather than skipped.

| bar | result |
|---|---|
| emission neutrality, debug | 0/215 objects, binary identical (self-check 0/215, positive control 1/215) |
| `mach test` | 1030 passed / 0 failed (dev 1029; +1 test) |
| `B == C` fixpoint | passes |
| repro | reports the refusal; `T must be a record` appears in **0** diagnostics |
| #2459 matrix | all five concrete cases still correct |

**Mutation-verified:** restoring the FALSE answer (`if (false)` at the refusal site)
fails `comptime_type_query_generic_refusal`, 1022/1.

Cross-ISA and the `int` suite are left to CI, which owns that matrix.

## A test-quality fix riding along, flagged for your call

The #2459 arm assertions were **one-sided** — they asserted the expected marker
fired, but not that the other one didn't. A gate that fails to fold doesn't choose an
arm; it type-checks *every* arm, so both markers fire and a one-sided assertion
passes on a gate that stopped working entirely. That is not hypothetical: it is how a
broken `$type_name` stayed green while I was breaking it during #2462. All 22 are now
two-sided via a `ut_arm` helper.

Strictly this is #2459 hardening rather than #2464, but #2464's own acceptance is
"the full #2459 matrix still green", and that bar means little while the matrix
cannot detect a predicate that silently stops folding. Easy to strip if you'd rather
it be separate.

## Docs commit

`$assert` moves to *Not provided as intrinsics* with the `$if` + `$error`
composition shown, per the not-planned ruling. Four other docs still listed it in the
closed intrinsic set (`README.md`, `comptime.md`, `grammar.md` ×2) and now list the
#2128 predicates instead — leaving them would have contradicted the change.
