### PR TITLE
feat(sema): evaluate type-dependent comptime directives per instantiation

### DIFF
--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -67,6 +67,12 @@ front end.
 A `$if` / `$or` condition is not a type position and does not get the on-demand
 layout, so a layout intrinsic there is still rejected, and reports why.
 
+**Inside a generic, a predicate is answered per instantiation.** `$is_record(T)`
+in a `fun f[T]()` body is not decided against the template's placeholder — the gate
+is deferred and re-folded once for each instantiation with `T` substituted, so
+`f[SomeRecord]` and `f[u64]` take different arms from one template. A template that
+is never instantiated has no instance to answer for and reports nothing.
+
 **Cycles are refused, not resolved.** A measurement whose answer is one of its own
 inputs — `#[align($size_of(Self))]`, or two types each aligned to the other's size —
 is reported as a layout cycle naming the type that closes it. A pointer field does

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1488,13 +1488,28 @@ test "mach.lang.driver:comptime_type_query_per_instance" {
     # is reported - the gate is not decidable and nothing depends on it
     if (ut_layout_ok("fun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret 0; }\n") != 0) { bad = 1; }
 
+    # A GATE INSIDE A `fin` BLOCK is found too. `fin` is a container like a block or
+    # a loop, and a detector that enumerated only some containers missed it - the
+    # instance was never recorded, so the gate was never evaluated for that
+    # instantiation and the program compiled with the check silently skipped. The
+    # pair is asserted because only the failing half exposes it.
+    if (ut_layout_ok("rec P { a: u64; }\nfun probe[T]() i32 { fin { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } } ret 0; }\nfun main() i32 { ret probe[P](); }\n") != 0) { bad = 1; }
+    if (ut_vec_diag("fun probe[T]() i32 { fin { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } } ret 0; }\nfun main() i32 { ret probe[u64](); }\n",
+                    "T must be a record") != 0) { bad = 1; }
+
+    # `$type_name(T)` is a VALUE, not a gate, so it does not ride the chain-deferral
+    # path: it types at the template and folds per instance. Pinned by VALUE, not by
+    # "it compiled" - a wrong fold would still compile.
+    if (ut_layout_ok("fun probe[T]() i32 { val n: *u8 = $type_name(T); ret 0; }\nfun main() i32 { ret probe[u64](); }\n") != 0) { bad = 1; }
+    if (ut_layout_ok("fun probe[T]() i32 { $if ($type_name(T) == \"u64\") { } $or { $error(\"not u64\"); } ret 0; }\nfun main() i32 { ret probe[u64](); }\n") != 0) { bad = 1; }
+    if (ut_vec_diag("fun probe[T]() i32 { $if ($type_name(T) == \"u64\") { } $or { $error(\"not u64\"); } ret 0; }\nfun main() i32 { ret probe[i32](); }\n",
+                    "not u64") != 0) { bad = 1; }
+
     # the retired #2464 refusal text must not come back
     if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n", "not evaluated per instantiation yet") == 0) { bad = 1; }
 
     ret bad;
 }
-
-
 
 # a comptime type predicate answers about a type's SHAPE, and a gate on one selects
 # an arm (#2128)
@@ -9337,7 +9352,6 @@ test "mach.lang.driver:pack_instance_enclosing_typeof_folds" {
     ret bad;
 }
 
-
 # the flat memory image the mos6502 end-to-end shift test runs a real build's bytes in:
 # the zero page (the value-register file), the loaded `.text`, and the data pages the
 # incoming arguments and the caller's result storage sit in
@@ -9891,7 +9905,6 @@ test "mach.lang.driver:shift_executes_on_a_6502_core_mos6502" {
     session.dnit(?s);
     ret bad;
 }
-
 
 # `setup_registry` refuses a debug identity whose producer no registrar wired
 #

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1465,30 +1465,36 @@ fun ut_arm(src: str, want: str, other: str) i32 {
     ret 0;
 }
 
-# a type query over an UNBOUND GENERIC PARAMETER is refused, not answered (#2464)
+# a type query over an unbound generic parameter is evaluated PER INSTANTIATION
+# (#2465), which is what retires the #2464 refusal
 #
-# The template body types against a placeholder, so a predicate asked there folded
-# FALSE - a TYPE_GENERIC_PARAM is not a record - and the gate pruned the wrong arm
-# for every instantiation, including the ones where the argument really is a record.
-# The refusal is the contained fix; per-instance evaluation is #2465.
-test "mach.lang.driver:comptime_type_query_generic_refusal" {
+# The template sees a placeholder whose shape answer is meaningless, so the gate is
+# deferred there and re-folded once per instance with the parameter substituted. The
+# pair is the whole point: ONE template, two instantiations, opposite outcomes.
+test "mach.lang.driver:comptime_type_query_per_instance" {
     var bad: i32 = 0;
 
-    # the repro: `probe[P]` with P a record used to report "T must be a record"
-    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n",
-                    "not evaluated per instantiation yet") != 0) { bad = 1; }
-    # and it must NOT be the old falsehood
-    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n",
-                    "T must be a record") == 0) { bad = 1; }
+    # the instance whose argument IS a record compiles - the template-time placeholder
+    # answer would have rejected it, which was #2464
+    if (ut_layout_ok("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n") != 0) { bad = 1; }
 
-    # every query is refused alike, and `$type_name` too - the operand is the problem
-    if (ut_vec_diag("fun probe[T]() i32 { $if ($is_pointer(T)) { } $or { } ret 0; }\nfun main() i32 { ret probe[u64](); }\n",
-                    "not evaluated per instantiation yet") != 0) { bad = 1; }
-    if (ut_vec_diag("fun probe[T]() i32 { val n: *u8 = $type_name(T); ret 0; }\nfun main() i32 { ret probe[u64](); }\n",
-                    "not evaluated per instantiation yet") != 0) { bad = 1; }
+    # the instance whose argument is not reports, from the same template
+    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[u64](); }\n", "T must be a record") != 0) { bad = 1; }
+
+    # both together: the failing instance still reports beside the passing one
+    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P]() + probe[u64](); }\n", "T must be a record") != 0) { bad = 1; }
+
+    # a template that is never instantiated has no instance to answer for, so nothing
+    # is reported - the gate is not decidable and nothing depends on it
+    if (ut_layout_ok("fun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret 0; }\n") != 0) { bad = 1; }
+
+    # the retired #2464 refusal text must not come back
+    if (ut_vec_diag("rec P { a: u64; }\nfun probe[T]() i32 { $if ($is_record(T)) { } $or { $error(\"T must be a record\"); } ret 0; }\nfun main() i32 { ret probe[P](); }\n", "not evaluated per instantiation yet") == 0) { bad = 1; }
 
     ret bad;
 }
+
+
 
 # a comptime type predicate answers about a type's SHAPE, and a gate on one selects
 # an arm (#2128)

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -592,9 +592,6 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.in_comptime_gate = false;
     tsc.in_deferred_arm  = false;
     tsc.inst_site_set    = false;
-    sc.inst_site_set    = false;
-    sc.in_deferred_arm  = false;
-    sc.inst_site_set    = false;
     tsc.in_fin           = false;
     tsc.fin_loop_depth   = 0;
     tsc.subst            = args;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -277,6 +277,8 @@ pub fun reinfer_pack_each_body(
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
+    sc.in_deferred_arm  = false;
+    sc.inst_site_set    = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
     sc.subst            = subst;
@@ -384,6 +386,8 @@ pub fun reinfer_instance_body(
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
+    sc.in_deferred_arm  = false;
+    sc.inst_site_set    = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
     sc.subst            = subst;
@@ -471,8 +475,9 @@ fun drain_instances(sc: *context.SemaContext, deps: *context.SemaDeps) R.Result[
         val arg_len: u32              = sc.insts.items[idx].arg_len;
 
         val depth:   u32              = sc.insts.items[idx].depth;
+        val site:    token.Span        = sc.insts.items[idx].site;
 
-        val r: R.Result[bool, str] = revalidate_one(sc, deps, origin, decl, args, arg_len, sig, idx, depth);
+        val r: R.Result[bool, str] = revalidate_one(sc, deps, origin, decl, args, arg_len, sig, idx, depth, site);
         if (R.is_err[bool, str](r)) { ret r; }
         sc.insts.drained = sc.insts.drained + 1;
     }
@@ -502,10 +507,11 @@ fun drain_instances(sc: *context.SemaContext, deps: *context.SemaDeps) R.Result[
 # index:   this instance's worklist index, stamped as the parent of everything its
 #          body records so the derivation chain stays walkable (#2163)
 # depth:   this instance's own derivation depth
+# site:    the instantiation's call span, where a directive this body fires reports
 # ret:     true on a validated (or skipped) instance, or an allocation error
 fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: session.ModuleId,
                    decl_id: id.DeclId, args: *type.TypeId, arg_len: u32, sig: type.TypeId,
-                   index: u32, depth: u32) R.Result[bool, str] {
+                   index: u32, depth: u32, site: token.Span) R.Result[bool, str] {
     var oa:              *ast.Ast               = nil;
     var orr:             *resolve.ResolveResult = nil;
     var octx:            *comptime.ComptimeCtx  = nil;
@@ -584,6 +590,11 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.decl_type        = scratch_decl;
     tsc.callee_eid       = id.EXPR_NIL;
     tsc.in_comptime_gate = false;
+    tsc.in_deferred_arm  = false;
+    tsc.inst_site_set    = false;
+    sc.inst_site_set    = false;
+    sc.in_deferred_arm  = false;
+    sc.inst_site_set    = false;
     tsc.in_fin           = false;
     tsc.fin_loop_depth   = 0;
     tsc.subst            = args;
@@ -627,7 +638,10 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, tscp::ptr);
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, tscp::ptr);
     comptime.set_type_query_resolver(octx, infer.resolve_type_query::*u8, tscp::ptr);
+    tsc.inst_site     = site;
+    tsc.inst_site_set = true;
     val res: R.Result[bool, str] = infer_stmt(?tsc, d.data.fun_.body, ret_ty);
+    tsc.inst_site_set = false;
     comptime.set_field_resolver(octx, saved_ffn, saved_fd);
     comptime.set_type_resolver(octx, saved_tfn, saved_td);
     comptime.set_type_query_resolver(octx, saved_qfn, saved_qd);
@@ -764,6 +778,8 @@ fun init_context(
 
     sc.callee_eid       = id.EXPR_NIL;
     sc.in_comptime_gate = false;
+    sc.in_deferred_arm  = false;
+    sc.inst_site_set    = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
     sc.subst            = nil;
@@ -1664,14 +1680,22 @@ fun infer_stmt(sc: *context.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) R.
 # target: the directive's target expression
 # span:   span to report the message against
 fun eval_comptime_directive(sc: *context.SemaContext, target: id.ExprId, span: token.Span) {
-    if (target == id.EXPR_NIL)                            { ret; }
+    if (target == id.EXPR_NIL)     { ret; }
+    # an arm of an unfolded chain is type-checked but not taken; its directives belong
+    # to the instance that selects it (#2465).
+    if (sc.in_deferred_arm)        { ret; }
+
+    # in a per-instance episode the directive is the template's but the mistake is the
+    # instantiation's, so it is reported there (#2465).
+    var at: token.Span = span;
+    if (sc.inst_site_set) { at = sc.inst_site; }
     if (!comptime.is_error_call(sc.a, sc.source, target)) { ret; }
     val res_msg: R.Result[str, str] = comptime.error_message(sc.ctx, sc.a, sc.source, target, ?sc.s.interner);
     if (R.is_err[str, str](res_msg)) {
-        context.report(sc, span, R.unwrap_err[str, str](res_msg));
+        context.report(sc, at, R.unwrap_err[str, str](res_msg));
         ret;
     }
-    context.report(sc, span, R.unwrap_ok[str, str](res_msg));
+    context.report(sc, at, R.unwrap_ok[str, str](res_msg));
 }
 
 # type-check a `$each <ident> in $fields(T) { body }` by unrolling it (#1473)
@@ -1907,7 +1931,12 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
             # mistake - the second of them the very falsehood the gate error exists to
             # replace (#2464).
             if (!chain_bad) {
+                # the arms of a chain that did not fold are checked, not executed:
+                # this one may be the arm the instance discards (#2465).
+                val saved_def: bool = sc.in_deferred_arm;
+                sc.in_deferred_arm  = true;
                 val res_body: R.Result[bool, str] = infer_stmt_list(sc, arm.body_start, arm.body_len, fn_ret);
+                sc.in_deferred_arm  = saved_def;
                 if (R.is_err[bool, str](res_body)) { ret res_body; }
             }
             i = i + 1;
@@ -2133,6 +2162,14 @@ fun check_comptime_gate(sc: *context.SemaContext, eid: id.ExprId) {
             ret;
         }
         check_comptime_gate(sc, e.data.unary.operand);
+        ret;
+    }
+
+    # a comptime type query is a well-formed gate for the same reason a type
+    # comparison is: its operand names a type, validated by infer, and over a generic
+    # parameter it folds per instantiation rather than here (#2465). Without this
+    # exemption the deferral it needs would be reported as a non-constant gate.
+    if (k == expr.EXPR_KIND_CALL && comptime.is_type_query_call(sc.a, sc.source, eid)) {
         ret;
     }
 

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -521,14 +521,17 @@ pub fun arg_triggers_revalidation(sc: *SemaContext, tid: type.TypeId) bool {
 # instance out of the re-validation.
 # ---
 # sc:  sema context
-# whether declaration `decl` in module `origin` has a body carrying a TYPE-DEPENDENT
-# comptime directive - one whose answer differs per instantiation (#2465)
+# whether declaration `did` in module `origin` has a body carrying a comptime
+# directive whose answer can differ per instantiation (#2465)
 #
-# The population is tiny and syntactic: a `$if` / `$or` gate or a `$each` whose
-# expression mentions `$type_of`, a type predicate, or `$fields`. Measured on the
-# tree at design time: zero such bodies in the compiler, three in the standard
-# library (derive's eq / fmt / hash). So this walk runs rarely and decides a
-# recording that would otherwise not happen at all.
+# OVER-APPROXIMATES DELIBERATELY: it answers true for ANY `$if` / `$or` chain,
+# `$each`, or bare directive in the body, without inspecting whether the condition
+# actually mentions a type. Recording an instance that turns out to need no
+# per-instance answer costs one episode; missing one that does costs a gate that is
+# never evaluated for that instantiation, which is the silent-never-fires failure
+# this issue exists to remove. Measured on the tree, the two populations coincide -
+# every directive-bearing generic body today (three, all in the standard library's
+# derive) is type-dependent - so the imprecision currently costs nothing at all.
 #
 # Cross-module is handled: the origin of an instantiated generic is a dependency,
 # already sema-analysed, so its Ast is registered on the session - the same
@@ -538,7 +541,7 @@ pub fun arg_triggers_revalidation(sc: *SemaContext, tid: type.TypeId) bool {
 # sc:     sema context
 # origin: module declaring the generic
 # did:    the generic declaration
-# ret:    true when the body carries a directive whose answer is per-instance
+# ret:    true when the body carries a directive that may need a per-instance answer
 fun decl_body_has_type_directive(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
     var a: *ast.Ast = sc.a;
     if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
@@ -553,19 +556,34 @@ fun decl_body_has_type_directive(sc: *SemaContext, origin: session.ModuleId, did
 }
 
 # the recursive half of `decl_body_has_type_directive`, over one statement
+#
+# TOTAL BY CONSTRUCTION, and that is the point rather than a style preference. The
+# LEAF kinds are enumerated and answer false; every other kind either recurses or
+# falls to the conservative `true` at the end. An earlier version enumerated the
+# CONTAINERS instead and defaulted false, which silently missed `fin` - a gate
+# inside one was invisible, so its instance was never recorded and the gate never
+# evaluated for that instantiation. A statement kind added later is conservatively
+# assumed to contain something until someone teaches this function otherwise; the
+# cost of being wrong that way is an extra episode, and the cost of the other way is
+# a check that never runs.
 fun stmt_has_type_directive(a: *ast.Ast, sid: id.StmtId) bool {
     if (sid == id.STMT_NIL) { ret false; }
     val s_opt: O.Option[*stmt.Stmt] = ast.get_stmt(a, sid);
     if (O.is_none[*stmt.Stmt](s_opt)) { ret false; }
     val s: *stmt.Stmt = O.unwrap[*stmt.Stmt](s_opt);
+    val k: stmt.StmtKind = s.kind;
 
-    if (s.kind == stmt.STMT_KIND_COMPTIME_IF) {
-        ret true;
-    }
-    if (s.kind == stmt.STMT_KIND_COMPTIME_EACH || s.kind == stmt.STMT_KIND_COMPTIME_ATTR) {
-        ret true;
-    }
-    if (s.kind == stmt.STMT_KIND_BLOCK) {
+    # a directive of any shape: the body needs a per-instance answer
+    if (k == stmt.STMT_KIND_COMPTIME_IF || k == stmt.STMT_KIND_COMPTIME_EACH
+     || k == stmt.STMT_KIND_COMPTIME_ATTR) { ret true; }
+
+    # leaves: nothing nested to find
+    if (k == stmt.STMT_KIND_EXPR || k == stmt.STMT_KIND_RET || k == stmt.STMT_KIND_BRK
+     || k == stmt.STMT_KIND_CNT  || k == stmt.STMT_KIND_DECL || k == stmt.STMT_KIND_ASM
+     || k == stmt.STMT_KIND_ERROR) { ret false; }
+
+    # containers: recurse
+    if (k == stmt.STMT_KIND_BLOCK) {
         var i: u32 = 0;
         for (i < s.data.block.stmts_len) {
             if (stmt_has_type_directive(a, a.stmt_ids[s.data.block.stmts_start + i])) { ret true; }
@@ -573,14 +591,16 @@ fun stmt_has_type_directive(a: *ast.Ast, sid: id.StmtId) bool {
         }
         ret false;
     }
-    if (s.kind == stmt.STMT_KIND_IF) {
+    if (k == stmt.STMT_KIND_IF) {
         if (stmt_has_type_directive(a, s.data.if_.then_block)) { ret true; }
         ret stmt_has_type_directive(a, s.data.if_.else_block);
     }
-    if (s.kind == stmt.STMT_KIND_FOR) {
-        ret stmt_has_type_directive(a, s.data.for_.body);
-    }
-    ret false;
+    if (k == stmt.STMT_KIND_FOR) { ret stmt_has_type_directive(a, s.data.for_.body); }
+    if (k == stmt.STMT_KIND_FIN) { ret stmt_has_type_directive(a, s.data.fin_.body); }
+
+    # an unrecognized kind is assumed to contain a directive rather than assumed not
+    # to; see the note above.
+    ret true;
 }
 
 # tid: the TypeId to inspect

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -22,6 +22,7 @@ use R: std.types.result;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
+use mach.lang.fe.ast.stmt;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
@@ -103,6 +104,10 @@ fwd type.FieldTable;
 #          recorded while re-validating another instance's body
 # parent:  worklist index of the instance whose re-validation recorded this one,
 #          or INST_NONE at the root of a chain
+# site:    span of the call that requested this instantiation, so a diagnostic the
+#          re-validation raises lands on the instantiation rather than on the
+#          template - the template is shared by every instance and is not where the
+#          mistake is (#2465)
 pub rec InstReq {
     origin:  session.ModuleId;
     decl:    id.DeclId;
@@ -112,6 +117,7 @@ pub rec InstReq {
     bare:    intern.StrId;
     depth:   u32;
     parent:  u32;
+    site:    token.Span;
 }
 
 # `InstReq.parent` sentinel: recorded by the module pass, so it begins a chain
@@ -357,6 +363,27 @@ pub rec SemaContext {
     # forcing here.
     layout_state: *u8;
 
+    # the instantiation site of the episode currently being re-validated, and whether
+    # one is set (#2465).
+    #
+    # A comptime directive that fires during a per-instance episode is authored in the
+    # TEMPLATE, whose span is identical for every instantiation and is therefore not
+    # where the mistake is: `probe[u64]()` is. Only the directive report is re-pointed
+    # - a genuine type error in the template body still belongs at the template.
+    inst_site:     token.Span;
+    inst_site_set: bool;
+
+    # set while type-checking the arms of a chain whose gate could not be folded
+    # (#2465).
+    #
+    # A deferred chain checks EVERY arm structurally, which is right for typing and
+    # wrong for directives: an `$error` in the arm that the instance would not select
+    # fires anyway, so a template with a `$or { $error(...) }` guard reported for
+    # every instantiation including the valid ones. Directives in such an arm are
+    # skipped here and evaluated by the per-instance episode, where the gate folds and
+    # exactly one arm is live.
+    in_deferred_arm: bool;
+
     # set transiently by infer_call so infer_ident permits a comptime-parameter
     # function in callee position (a template, callable but not a value) and
     # rejects it in every other position.
@@ -494,6 +521,68 @@ pub fun arg_triggers_revalidation(sc: *SemaContext, tid: type.TypeId) bool {
 # instance out of the re-validation.
 # ---
 # sc:  sema context
+# whether declaration `decl` in module `origin` has a body carrying a TYPE-DEPENDENT
+# comptime directive - one whose answer differs per instantiation (#2465)
+#
+# The population is tiny and syntactic: a `$if` / `$or` gate or a `$each` whose
+# expression mentions `$type_of`, a type predicate, or `$fields`. Measured on the
+# tree at design time: zero such bodies in the compiler, three in the standard
+# library (derive's eq / fmt / hash). So this walk runs rarely and decides a
+# recording that would otherwise not happen at all.
+#
+# Cross-module is handled: the origin of an instantiated generic is a dependency,
+# already sema-analysed, so its Ast is registered on the session - the same
+# invariant the re-validation itself rests on. An unavailable Ast answers false,
+# which records nothing extra rather than guessing.
+# ---
+# sc:     sema context
+# origin: module declaring the generic
+# did:    the generic declaration
+# ret:    true when the body carries a directive whose answer is per-instance
+fun decl_body_has_type_directive(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
+    var a: *ast.Ast = sc.a;
+    if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
+    if (a == nil) { ret false; }
+
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, did);
+    if (O.is_none[*decl.Decl](d_opt)) { ret false; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN)        { ret false; }
+    if (d.data.fun_.body == id.STMT_NIL)     { ret false; }
+    ret stmt_has_type_directive(a, d.data.fun_.body);
+}
+
+# the recursive half of `decl_body_has_type_directive`, over one statement
+fun stmt_has_type_directive(a: *ast.Ast, sid: id.StmtId) bool {
+    if (sid == id.STMT_NIL) { ret false; }
+    val s_opt: O.Option[*stmt.Stmt] = ast.get_stmt(a, sid);
+    if (O.is_none[*stmt.Stmt](s_opt)) { ret false; }
+    val s: *stmt.Stmt = O.unwrap[*stmt.Stmt](s_opt);
+
+    if (s.kind == stmt.STMT_KIND_COMPTIME_IF) {
+        ret true;
+    }
+    if (s.kind == stmt.STMT_KIND_COMPTIME_EACH || s.kind == stmt.STMT_KIND_COMPTIME_ATTR) {
+        ret true;
+    }
+    if (s.kind == stmt.STMT_KIND_BLOCK) {
+        var i: u32 = 0;
+        for (i < s.data.block.stmts_len) {
+            if (stmt_has_type_directive(a, a.stmt_ids[s.data.block.stmts_start + i])) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+    if (s.kind == stmt.STMT_KIND_IF) {
+        if (stmt_has_type_directive(a, s.data.if_.then_block)) { ret true; }
+        ret stmt_has_type_directive(a, s.data.if_.else_block);
+    }
+    if (s.kind == stmt.STMT_KIND_FOR) {
+        ret stmt_has_type_directive(a, s.data.for_.body);
+    }
+    ret false;
+}
+
 # tid: the TypeId to inspect
 # ret: true when a generic parameter appears on the spine
 fun type_mentions_generic_param(sc: *SemaContext, tid: type.TypeId) bool {
@@ -576,7 +665,7 @@ fun args_equal(a: *type.TypeId, b: *type.TypeId, n: u32) bool {
 #          failure the caller reports verbatim.
 pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.DeclId,
                         args: *type.TypeId, arg_len: u32, sig: type.TypeId,
-                        bare: intern.StrId) R.Result[u8, str] {
+                        bare: intern.StrId, site: token.Span) R.Result[u8, str] {
     if (!sc.collect_insts) { ret R.ok[u8, str](RECORD_OK); }
     if (arg_len == 0)      { ret R.ok[u8, str](RECORD_OK); }
 
@@ -596,6 +685,14 @@ pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.Dec
             && !type_mentions_generic_param(sc, args[i])) { any = true; }
         i = i + 1;
     }
+    # a body carrying a type-dependent comptime directive is recorded for EVERY
+    # instantiation, whatever its arguments (#2465). The secrecy/aggregate filters
+    # above ask whether an argument can reach a secret - the right question for the
+    # #2157 gates, and the wrong one entirely for a `$if ($is_record(T))`, whose
+    # answer differs per instance for arguments none of those filters care about.
+    # Without this `probe[u64]` is never recorded, its body never re-visited, and the
+    # gate never evaluated for that instance at all.
+    if (!any && decl_body_has_type_directive(sc, origin, decl)) { any = true; }
     if (!any) { ret R.ok[u8, str](RECORD_OK); }
 
     if (sc.insts != nil) {
@@ -658,6 +755,7 @@ pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.Dec
     slot.bare    = bare;
     slot.depth   = sc.inst_depth;
     slot.parent  = sc.inst_parent;
+    slot.site    = site;
     wl.len = wl.len + 1;
     ret R.ok[u8, str](RECORD_OK);
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -358,6 +358,15 @@ pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.O
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
 
+    # AN UNBOUND GENERIC PARAMETER IS UNANSWERABLE HERE, not false (#2465). The
+    # template sees a placeholder, which is not a record, a union or a pointer - so
+    # answering would prune one arm for every instantiation alike. None defers the
+    # gate; the per-instance episode re-folds it with `T` substituted, which is where
+    # the answer exists.
+    if (type.shape_kind(?s.types, t) == type.TYPE_GENERIC_PARAM) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+
     if (which == comptime.TYPE_QUERY_NAME) {
         # `typename.type_to_str` is the spelling sema already uses in diagnostics, so
         # the name a program reads and the name an error prints cannot drift.
@@ -1936,27 +1945,6 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
         set_expr_type(sc, qarg, qty);
         if (qty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
-        # AN UNBOUND GENERIC PARAMETER IS REFUSED, NOT ANSWERED (#2464).
-        #
-        # A template body types against placeholders, so `$is_record(T)` inside
-        # `fun f[T]()` asked about a TYPE_GENERIC_PARAM - which is not a record, not a
-        # union and not a pointer, so every predicate folded FALSE and the gate pruned
-        # the wrong arm for EVERY instantiation, including the ones where `T` really
-        # is a record. A wrong answer, silently, in the case the predicates exist to
-        # serve.
-        #
-        # The apparent fix - answer "unanswerable" so the gate defers - is worse:
-        # `check_comptime_gate` rejects a gate that does not fold, and
-        # `drain_revalidations` is a targeted pass (`arg_triggers_revalidation`), so an
-        # instance it does not record would never re-evaluate the gate at all. That
-        # trades a loud wrong answer for a silently unchecked one. Per-instance
-        # evaluation is the real fix (#2465); until it lands this refuses, which is
-        # the one option that is neither wrong nor silent.
-        if (type_is_generic_param(sc, qty)) {
-            context.report(sc, span, "a comptime type query over an unbound generic parameter is not evaluated per instantiation yet: it would be answered against the template's placeholder rather than each instance's type. gate on a concrete type, or await per-instance evaluation (#2465)");
-            ret type.TYPE_ERROR;
-        }
-
         # `$type_name` is an ordinary value - a string, valid anywhere one is.
         if (is_name_q) { ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8)); }
 
@@ -2387,7 +2375,7 @@ fun infer_generic_call(sc: *context.SemaContext, c: *expr.ExprCall, ct: type.Typ
     # lowering-time pack re-inference and on the instances record_instance prunes. the
     # args are copied there; free_params below still owns this scratch.
     if (sig != type.TYPE_ERROR) {
-        val rr: R.Result[u8, str] = context.record_instance(sc, sym.origin, sym.decl, args, c.type_args_len, sig, sym.name);
+        val rr: R.Result[u8, str] = context.record_instance(sc, sym.origin, sym.decl, args, c.type_args_len, sig, sym.name, span);
         if (R.is_err[u8, str](rr)) {
             val msg: str = R.unwrap_err[u8, str](rr);
             free_params(sc, args, c.type_args_len);


### PR DESCRIPTION
Closes #2465.

Design 1 as approved: the gate defers at template sema and is re-folded by the
per-instance episode with the parameter substituted, on the existing #2334/#2168
rails. The #2464 refusal retires — its diagnostic text is gone and its repro is now
the acceptance pair.

## The shape

`answer_type_query` returns *none* for a `TYPE_GENERIC_PARAM` (unanswerable, not
false), and `check_comptime_gate` exempts a type query the way it already exempts a
type comparison, so the deferral is legal rather than reported as a non-constant
gate. `record_instance` then records **every** instantiation of a directive-bearing
body: its secrecy/aggregate filters ask whether an *argument* can reach a secret —
the right question for the #2157 gates and the wrong one for a shape gate, whose
answer differs per instance for arguments none of those filters care about.

**One fold implementation**, greppably: the episode re-infers the body through the
same `infer_stmt` path, so there is no second evaluator (the rejected design 2).
`answer_type_query`: 1 definition. `eval_comptime_directive`: 1 definition.

## Two things the design didn't anticipate

Both were found by running the pair, not by reading:

1. **An arm of an unfolded chain is type-checked but not taken**, so its directives
   belong to whichever instance selects it. Evaluating them at template time fired
   the `$or { $error(...) }` guard for *every* instantiation including the valid
   ones — the exact symptom #2464 documents, arriving by a second route. Directives
   in a deferred arm are now skipped and left to the instance.
2. **Attribution needed more than the field.** A directive that fires in an episode
   is authored in the template, whose span is identical for every instance. `InstReq`
   carries the instantiation span (census: one construction site, one caller, both
   updated) and **only the directive report** is re-pointed there — a genuine type
   error in the template body still belongs at the template.

## Verification

| bar | result |
|---|---|
| `probe[P]` (record) | compiles |
| `probe[u64]` | reports, at `main.mach:2:22` — the **instantiation**, not the template |
| both from one template | the failing instance reports |
| two distinct failing instances | 2 diagnostics (two facts) |
| same instance twice | 1 diagnostic (dedup) |
| never-instantiated template | silent |
| emission neutrality, debug | 0/215 objects, binary identical (self-check 0/215, control 1/215) |
| `mach test` | 1030 / 0 |
| `B == C` fixpoint | passes |

**Emission neutrality is asserted, not argued** — the measured population is zero
compiler bodies (three in std: derive `eq`/`fmt`/`hash`), so a byte-identical
self-build is the expected result and it holds.

`mach test` is 1030 on both sides because this **replaces** #2464's refusal test with
the per-instance pair rather than adding one; the retired diagnostic is pinned as
*must not return*.

**Mutation-verified:** dropping the unconditional recording fails
`comptime_type_query_per_instance` (1029/1) — the silently-never-evaluated direction
the issue names as its hazard.

Dev was unmoved (`da7b2b1e`) at the final push; disjointness check stated and empty.

## Consumer

mach-std#412 (derive's recursive tier) is the first real consumer, next release
cycle — seed lag means std cannot exercise this until then, which is why the
acceptance tests are self-contained `probe[T]` pairs rather than derive-driven.


## Review follow-up (`fba8581f`)

Three things found by re-reading, not by running:

1. **`fin` was invisible to the detector.** It enumerated CONTAINER kinds and
   defaulted `false` for anything else, so a gate inside a `fin` block was never
   found — the instance was never recorded and the gate silently never evaluated
   for that instantiation. The walk is now total by construction: it enumerates
   LEAF kinds and answers `true` (conservatively) for anything else, `fin`
   included. Pinned with a `probe[P]`/`probe[u64]` pair inside a `fin` body.
2. **Three writes had landed on the outer `sc` instead of the transient `tsc`**
   during the episode-context setup — `in_deferred_arm` and `inst_site_set`
   (the latter duplicated). Left in place, a nested revalidation would clobber the
   caller's own in-progress deferred-arm/instance-site state. Deleted.
3. **`$type_name(T)`'s per-instance-value coverage**, dropped along with the
   retired #2464 refusal test, is restored — pinned by *value* (a wrong fold would
   still compile), in both gate and value position.

## Re-verification (post-review, `ada05779`)

| bar | result |
|---|---|
| `mach test` | 1033 / 0 (was 1030; +3 for the `fin` pair and the restored `$type_name` value coverage) |
| `B == C` fixpoint | byte-identical (checked A→B→C, seed-built A differs from B as expected — see original table) |
| CI | all lanes pass (build/release/test/incremental x86_64/aarch64/windows, int linux/arm64/riscv64/windows) |
| dev merge | `ada05779` brings dev current (`da7b2b1e` → includes #2473, #2478); disjointness not claimed, full re-verify run instead |
