### PR TITLE
feat(legalize): implement wide multiply on mos6502

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -2,28 +2,30 @@
 # sequences
 #
 # A shared backend pass that runs between MIR lowering (`mir.lower_ir`) and
-# instruction selection (`isel.run`). It reads two declared machine facts - the
+# instruction selection (`isel.run`). It reads three declared machine facts - the
 # target's `MachineModel.max_alu_width` (the widest integer operation the ISA
-# computes in one native step, in bytes) and `MachineModel.has_var_shift` (whether
-# the ISA shifts by a runtime count at all) - and rewrites every scalar MIR
+# computes in one native step, in bytes), `MachineModel.has_var_shift` (whether the
+# ISA shifts by a runtime count at all), and `MachineModel.has_mul` (whether the
+# ISA has a hardware integer multiply at all, #2344) - and rewrites every scalar MIR
 # instruction they say the ISA cannot realize into a sequence of native ones, so
 # selection and the encoder never see such an operation. It is the wide-integer
 # analogue of the middle end's `scalarize` pass (which legalizes vectors before
 # codegen): scalarize splits a 128-bit vector into lane scalars, this splits a wide
 # scalar into native-width byte lanes.
 #
-# THE INERTNESS CONTRACT. Every 64-bit target declares `max_alu_width = 8` and
-# `has_var_shift = true`, and the language's widest scalar is 64-bit (pointers
-# included), so on x86-64 / aarch64 / riscv64 no scalar instruction is ever wider
-# than the native ALU and no shift is ever one the ISA lacks. The pass proves this
+# THE INERTNESS CONTRACT. Every 64-bit target declares `max_alu_width = 8`,
+# `has_var_shift = true`, and `has_mul = true`, and the language's widest scalar is
+# 64-bit (pointers included), so on x86-64 / aarch64 / riscv64 no scalar
+# instruction is ever wider than the native ALU, no shift is ever one the ISA
+# lacks, and no multiply is ever one the ISA lacks either. The pass proves this
 # per function with a single pre-scan (`function_needs_legalize`) and, when nothing
 # needs legalizing, RETURNS HAVING TOUCHED NOTHING - no
 # allocation, no vreg added, no block rebuilt. The output is therefore byte-
 # identical to a build without this pass on every wide-native target; only a
-# target that declares a narrow ALU (the 8-bit mos6502 declares 1) drives the
-# rewrite. A 128-bit vector instruction (`vec_lane != 0`) is never legalized here:
-# it is the vector path's responsibility and was already legalized (or rejected)
-# in the middle end.
+# target that declares a narrow ALU or no multiply (the 8-bit mos6502 declares
+# both: `max_alu_width = 1`, `has_mul = false`) drives the rewrite. A 128-bit
+# vector instruction (`vec_lane != 0`) is never legalized here: it is the vector
+# path's responsibility and was already legalized (or rejected) in the middle end.
 #
 # THE MODEL. A wide value is one vreg; the pass splits it into
 # `width / max_alu_width` native-width LANE vregs (lane 0 the least significant),
@@ -54,6 +56,22 @@
 # normalizing an out-of-range count to the operation width, so the backend below it
 # only ever sees a native shift at a constant in-range count.
 #
+# THE MULTIPLY IS AN ALGORITHM TOO, AND NOT WIDTH-DRIVEN (#2344). A machine
+# declaring `has_mul = false` has no hardware multiply at ANY width, so this pass
+# owns every `MIR_MUL` there - native-width included, unlike every other clause
+# above, which only ever admits a WIDE instruction. The expansion is classic
+# shift-and-add ("Russian peasant" multiplication): per bit of the multiplier, the
+# running multiplicand joins an accumulator through the same carry chain add
+# already drives, branchlessly selected by that bit exactly as the shift barrel
+# selects its own stages, then the multiplicand doubles and the multiplier gives up
+# the bit just tested - both a one-bit constant shift, so this expansion is built
+# entirely from the two algorithms already above it, not a third one from scratch.
+# Straight-line for the same structural reason the shift barrel is (this pass
+# cannot build the control flow a data-dependent branch would need), never for
+# secrecy: `ct_trust_mul = false` on every target this compiler has, so a secret
+# multiply operand is already refused upstream, in `mir.lower`, before this pass
+# ever sees one.
+#
 # THE ADDRESS IS A VALUE TOO. A target whose registers are narrower than an address
 # (mos6502: 8-bit registers, 16-bit pointers) cannot hold a runtime pointer in one
 # register either, so a memory access through one is legalized as well - at ANY
@@ -67,11 +85,10 @@
 # base would name a vreg nothing defines.
 #
 # UNSUPPORTED WIDE OPERATIONS fail loudly and specifically (never silently), the
-# same discipline the vector path uses for an unimplemented lane op: a wide
-# multiply by a non-constant, any wide divide / remainder, a wide floating-point op,
-# a shift at a width that is not a power of two, and any other operation carrying a
-# runtime-pointer memory operand are rejected with a diagnostic naming the
-# operation and width.
+# same discipline the vector path uses for an unimplemented lane op: any wide
+# divide / remainder, a wide floating-point op, a shift at a width that is not a
+# power of two, and any other operation carrying a runtime-pointer memory operand
+# are rejected with a diagnostic naming the operation and width.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -91,13 +108,16 @@ use target: mach.lang.target.resolved;
 # the machine facts the pass reads, lifted off the resolved target once
 #
 # Keeping them in a record rather than threading the whole `target.Target` is what
-# lets the pass be exercised directly by its own tests, and it names the exact four
+# lets the pass be exercised directly by its own tests, and it names the exact five
 # facts legalization depends on.
 # ---
 # lane_width: the native ALU width in bytes (`model.max_alu_width`); one lane
 # ptr_width:  an address's byte width (`model.pointer_width`)
 # var_shift:  whether the ISA shifts by a RUNTIME count at all
 #             (`model.has_var_shift`); false hands this pass every shift
+# has_mul:    whether the ISA has a hardware integer multiply at all
+#             (`model.has_mul`); false hands this pass every MIR_MUL, native width
+#             included - unlike every other gate here, this one is not width-driven
 # stage_lo:   low half of the backend's reserved address-staging register pair
 #             (`RegMachine.scratch_reg`), the fixed base a runtime-pointer access
 #             is decomposed at
@@ -106,6 +126,7 @@ rec Machine {
     lane_width: u8;
     ptr_width:  u8;
     var_shift:  bool;
+    has_mul:    bool;
     stage_lo:   i32;
     stage_hi:   i32;
 }
@@ -159,6 +180,7 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
     mach.lane_width = maw::u8;
     mach.ptr_width  = tgt.model.pointer_width::u8;
     mach.var_shift  = tgt.model.has_var_shift;
+    mach.has_mul    = tgt.model.has_mul;
     mach.stage_lo   = -1;
     mach.stage_hi   = -1;
     # a register machine declares the reserved scratch pair; a whole-module emitter
@@ -222,15 +244,23 @@ fun function_needs_legalize(f: *mir.MirFunction, mach: *Machine) bool {
 # the encoder needing the same rule anyway. A native shift at an in-range constant
 # count rewrites to itself, so the clause costs nothing where nothing is needed. On an
 # ISA with a variable shift the clause is dead and the gate is the width test alone.
+#
+# The MUL clause is the same shape for the opposite reason (#2344): a machine
+# declaring `has_mul = false` has no hardware multiply at ANY width, not just a wide
+# one, so this pass owns every MIR_MUL there - native-width included - rather than
+# leaving a native-width multiply to reach an encoder with nothing to encode it into.
+# On an ISA with a hardware multiply the clause is dead and the gate is the width
+# test alone, same as every other clause here.
 # ---
 # f:    the MIR function (for vreg classes / the vector flag)
 # mi:   the instruction to test
-# mach: the machine facts (native lane width, pointer width, shift capability)
+# mach: the machine facts (native lane width, pointer width, shift/multiply capability)
 # ret:  true when the instruction needs legalization
 fun instr_needs_legalize(f: *mir.MirFunction, mi: *mir.MirInstr, mach: *Machine) bool {
     if (instr_is_vector(f, mi)) { ret false; }
     if (mi.width > mach.lane_width || mi.src_width > mach.lane_width) { ret true; }
     if (!mach.var_shift && is_shift(mi.opcode)) { ret true; }
+    if (!mach.has_mul && mi.opcode == mir.MIR_MUL) { ret true; }
     ret mach.ptr_width > mach.lane_width && instr_has_value_base(mi);
 }
 
@@ -567,9 +597,7 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
         ret R.ok[u32, str](nl);
     }
     if (op == mir.MIR_ADD || op == mir.MIR_SUB || op == mir.MIR_NEG) {
-        # carry / borrow chain: 2 for the low lane, 5 per middle lane, 2 for the
-        # top lane (its carry-out is discarded) = 4 + 5*(nl - 2) for nl >= 2.
-        ret R.ok[u32, str](4 + 5 * (nl - 2));
+        ret R.ok[u32, str](addsub_chain_piece_count(nl));
     }
     if (op == mir.MIR_ZEXT) {
         # one move per destination lane (low lanes copy the source, high lanes zero).
@@ -579,6 +607,7 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
         # one move per (narrower) destination lane, copying the low source lanes.
         ret R.ok[u32, str](dst_lane_count(plan, mi));
     }
+    if (op == mir.MIR_MUL) { ret mul_piece_count(plan, mi); }
     ret R.err[u32, str](unsupported_message(op, mi.width));
 }
 
@@ -780,6 +809,9 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     if (op == mir.MIR_NEG) {
         ret expand_neg(alloc, plan, f, mi, dst, cursor);
     }
+    if (op == mir.MIR_MUL) {
+        ret expand_mul(alloc, plan, f, mi, dst, cursor);
+    }
     if (op == mir.MIR_ZEXT) {
         ret expand_zext(alloc, plan, mi, dst, cursor);
     }
@@ -979,11 +1011,11 @@ fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 
 # expand a wide add or subtract into an explicit native-width carry / borrow chain
 #
-# Each lane computes its native sum / difference and the carry / borrow out of it
-# as an ordinary value (an unsigned compare), threading that into the next lane -
-# this IR has no hardware carry flag, so the carry is materialized. The low lane
-# needs no carry-in and the top lane's carry-out is discarded (wrapping
-# arithmetic), so the shape is: low lane 2 pieces, each middle lane 5, top lane 2.
+# A thin shape-validating wrapper: builds the per-lane destination / operand arrays
+# through `lane_operand` and hands them to `emit_addsub_chain`, the reusable
+# primitive `expand_mul`'s double-and-add also drives (#2344) - the wide multiply
+# accumulates through the identical chain, just fed fresh temporaries instead of
+# the instruction's own operands.
 # ---
 # is_sub: true for subtraction (borrow chain), false for addition (carry chain)
 fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
@@ -994,6 +1026,49 @@ fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
+
+    var d_ops: [MAX_SHIFT_LANES]mir.MirOperand;
+    var a_ops: [MAX_SHIFT_LANES]mir.MirOperand;
+    var b_ops: [MAX_SHIFT_LANES]mir.MirOperand;
+    var i: u32 = 0;
+    for (i < nl) {
+        d_ops[i] = lane_operand(plan, ?mi.operands[0], i);
+        a_ops[i] = lane_operand(plan, ?mi.operands[1], i);
+        b_ops[i] = lane_operand(plan, ?mi.operands[2], i);
+        i = i + 1;
+    }
+    ret emit_addsub_chain(alloc, f, mi, dst, cursor, ?d_ops[0], ?a_ops[0], ?b_ops[0], nl, lw, is_sub);
+}
+
+# emit `d[] = a[] (+/-) b[]` as an explicit native-width carry / borrow chain
+#
+# Each lane computes its native sum / difference and the carry / borrow out of it
+# as an ordinary value (an unsigned compare), threading that into the next lane -
+# this IR has no hardware carry flag, so the carry is materialized. The low lane
+# needs no carry-in and the top lane's carry-out is discarded (wrapping
+# arithmetic), so the shape is: low lane 2 pieces, each middle lane 5, top lane 2
+# (`addsub_chain_piece_count`). A single lane (`nl == 1`) takes the low-lane path
+# alone: 2 pieces, the second (the carry-out compare) computed and discarded, since
+# nothing beyond one lane ever reads it - correct, if one instruction more than a
+# dedicated single-lane path would spend.
+# ---
+# alloc:  backing allocator for piece operand arrays and lane temporaries
+# f:      the MIR function (for appending carry / temp vregs)
+# src:    the instruction the chain replaces (source of loc / inline_site)
+# dst:    the rebuilt instruction array
+# cursor: next write index into `dst`; advanced past the emitted pieces
+# d_ops:  the `nl` destination lane operands
+# a_ops:  the `nl` left-hand lane operands
+# b_ops:  the `nl` right-hand lane operands
+# nl:     the lane count
+# lw:     the native lane width in bytes
+# is_sub: true for subtraction (borrow chain), false for addition (carry chain)
+# ret:    ok(true) on success, or an allocation error
+fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
+                      dst: *mir.MirInstr, cursor: *u32,
+                      d_ops: *mir.MirOperand, a_ops: *mir.MirOperand, b_ops: *mir.MirOperand,
+                      nl: u32, lw: u8, is_sub: bool) R.Result[bool, str] {
+    val mi: *mir.MirInstr = src;
     val cmp:  mir.MirOpcode = mir.MIR_CMP_LT_U;
     var op0:  mir.MirOpcode = mir.MIR_ADD;
     if (is_sub) { op0 = mir.MIR_SUB; }
@@ -1001,9 +1076,9 @@ fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
     var carry: u32 = mir.MIR_VREG_NIL;  # the carry / borrow vreg out of the last lane
     var i: u32 = 0;
     for (i < nl) {
-        val d: mir.MirOperand = lane_operand(plan, ?mi.operands[0], i);
-        val a: mir.MirOperand = lane_operand(plan, ?mi.operands[1], i);
-        val b: mir.MirOperand = lane_operand(plan, ?mi.operands[2], i);
+        val d: mir.MirOperand = d_ops[i];
+        val a: mir.MirOperand = a_ops[i];
+        val b: mir.MirOperand = b_ops[i];
         val is_low: bool = i == 0;
         val is_top: bool = i == nl - 1;
 
@@ -1070,6 +1145,16 @@ fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# the exact piece count of `emit_addsub_chain` over `nl` lanes
+# ---
+# nl:  the lane count
+# ret: 2 for a single lane (the low-lane path alone, its carry-out discarded),
+#      else 4 + 5*(nl - 2): 2 for the low lane, 5 per middle lane, 2 for the top
+fun addsub_chain_piece_count(nl: u32) u32 {
+    if (nl <= 1) { ret 2; }
+    ret 4 + 5 * (nl - 2);
 }
 
 # expand a wide negate as `0 - value` through the subtract carry chain
@@ -1600,6 +1685,200 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
     ret R.ok[bool, str](true);
 }
 
+# the exact piece count of a wide multiply's double-and-add expansion, or a loud
+# error
+#
+# Rejects the shapes the expansion cannot realize before any block is rebuilt: an
+# operand that is neither lane-ready, a lane count past what a scalar can span, and
+# a destination that is not a plain vreg - the same shapes `expand_mul` itself
+# checks, so the two cannot disagree.
+# ---
+# plan: the function's lane assignment
+# mi:   the multiply instruction
+# ret:  the exact piece count, or an error naming the unsupported shape
+fun mul_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+    val nl: u32 = wide_lane_count(plan, mi);
+    if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES ||
+        mi.operands[0].kind != mir.MIR_OP_VREG || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
+        !operand_is_lane_ready(plan, ?mi.operands[1], nl) || !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
+        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+    }
+    val lw:   u8  = plan.lane_width;
+    val bits: u32 = nl * lw::u32 * 8;
+    # per stage: extract the running multiplier's low bit, turn it into a select
+    # mask, accumulate the running multiplicand into the result through the carry
+    # chain, and branchlessly select the accumulated-or-unchanged result.
+    val per_stage: u32 = 2 + addsub_chain_piece_count(nl) + 3 * nl;
+    # every stage but the last also advances both running values by one bit: the
+    # multiplicand left (doubling it), the multiplier right (consuming the bit
+    # just tested) - both a shift-by-one template, one lane classification each.
+    val shl1: u32 = const_shift_pieces(nl, 0, 1, true, false);
+    val shr1: u32 = const_shift_pieces(nl, 0, 1, false, false);
+    ret R.ok[u32, str](bits * per_stage + (bits - 1) * (shl1 + shr1));
+}
+
+# expand a wide multiply into a double-and-add sequence over the operation's own
+# width
+#
+# THE ALGORITHM (#2344). Classic shift-and-add, "Russian peasant" multiplication:
+# for every bit of the multiplier, from the low bit up, the running multiplicand
+# joins an accumulator when that bit is set, then the multiplicand doubles (shifts
+# left one) and the multiplier is consumed one bit (shifts right one) so the NEXT
+# bit tested is always the running value's own low bit - no per-stage lane/bit
+# indexing into the original operand is needed, only two per-stage constant
+# shifts-by-one, which is why this reuses the shift template so directly.
+#
+# BRANCHLESS, NOT CONSTANT-TIME - and that distinction is deliberate, not an
+# oversight. This pass emits straight-line code into ONE block; it cannot build the
+# new control-flow edges a data-dependent branch would need, so the per-stage
+# "add or don't" decision is a mask-and-select exactly like the shift barrel's own
+# per-stage decision (#2217), for the same structural reason. It is NOT for secrecy:
+# `ct_trust_mul = false` on every target this compiler has (mos6502 included), so
+# `mir.lower`'s GATE (#1646) already refuses a secret multiply operand before this
+# pass ever runs - nothing here needs to be data-independent, and the full
+# `bits`-stage cost (linear in width, no early exit) is paid by every multiply,
+# public values included, purely because this pass cannot express "stop early."
+#
+# THE COST IS HONEST RATHER THAN CHEAP, the same call the shift barrel already
+# made: `bits` stages of an add-chain plus two shifts-by-one is asymptotically
+# BETTER than a lane-wise schoolbook of partial products would be (O(width) stages
+# against O(lanes^2) partial products, each itself a smaller multiply), not merely
+# simpler to write.
+#
+# SHARED, NOT MOS6502-SPECIFIC: nothing here reads a mos6502 fact: only
+# `plan.lane_width`, the shift template, and the carry chain, all already
+# target-blind. It also serves the native-width case (`u8 * u8`) the same way as
+# the wide one - `nl == 1` runs the identical loop with a single-lane accumulator,
+# the same shape `emit_addsub_chain` already handles for a single-lane add.
+# ---
+# alloc:  backing allocator for piece operand arrays and lane temporaries
+# plan:   the function's lane assignment
+# f:      the MIR function (for appending temporaries)
+# mi:     the multiply instruction to expand
+# dst:    the rebuilt instruction array
+# cursor: next write index into `dst`; advanced past the emitted pieces
+# ret:    ok(true) on success, or an error naming the unsupported shape
+fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
+               dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
+    val rc: R.Result[u32, str] = mul_piece_count(plan, mi);
+    if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
+
+    val nl: u32 = wide_lane_count(plan, mi);
+    val lw: u8  = plan.lane_width;
+    val lb: u32 = lw::u32 * 8;
+    val bits: u32 = nl * lb;
+
+    var dst_ops: [MAX_SHIFT_LANES]mir.MirOperand;
+    var mcand:   [MAX_SHIFT_LANES]mir.MirOperand;  # the running multiplicand, doubles each stage
+    var mplier:  [MAX_SHIFT_LANES]mir.MirOperand;  # the running multiplier, halves each stage
+    var result:  [MAX_SHIFT_LANES]mir.MirOperand;  # the accumulator, zero initially
+    var i: u32 = 0;
+    for (i < nl) {
+        dst_ops[i] = lane_operand(plan, ?mi.operands[0], i);
+        mcand[i]   = lane_operand(plan, ?mi.operands[1], i);
+        mplier[i]  = lane_operand(plan, ?mi.operands[2], i);
+        result[i]  = mir.op_imm(0);
+        i = i + 1;
+    }
+
+    var j: u32 = 0;
+    for (j < bits) {
+        # the running multiplier's own low bit - always the next bit to test,
+        # because the multiplier itself shifts right one lower each stage.
+        val rb: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (R.is_err[u32, str](rb)) { ret R.err[bool, str](R.unwrap_err[u32, str](rb)); }
+        val bit: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rb));
+        val r1: R.Result[bool, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit, mplier[0], mir.op_imm(1), lw);
+        if (R.is_err[bool, str](r1)) { ret r1; }
+
+        # `0 - bit` is all-ones exactly when the bit is set: the select's mask.
+        val rm: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (R.is_err[u32, str](rm)) { ret R.err[bool, str](R.unwrap_err[u32, str](rm)); }
+        val mask: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rm));
+        val r2: R.Result[bool, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), bit, lw);
+        if (R.is_err[bool, str](r2)) { ret r2; }
+
+        # cand = result + mcand, through the same carry chain a wide ADD drives.
+        var cand: [MAX_SHIFT_LANES]mir.MirOperand;
+        i = 0;
+        for (i < nl) {
+            val rc2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (R.is_err[u32, str](rc2)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc2)); }
+            cand[i] = mir.op_vreg(R.unwrap_ok[u32, str](rc2));
+            i = i + 1;
+        }
+        val r3: R.Result[bool, str] = emit_addsub_chain(alloc, f, mi, dst, cursor, ?cand[0], ?result[0], ?mcand[0], nl, lw, false);
+        if (R.is_err[bool, str](r3)) { ret r3; }
+
+        # select: result = result ^ ((result ^ cand) & mask), per lane - the last
+        # stage lands in the destination lanes, every earlier one in fresh temps.
+        val is_last: bool = j == bits - 1;
+        var nxt: [MAX_SHIFT_LANES]mir.MirOperand;
+        i = 0;
+        for (i < nl) {
+            if (is_last) { nxt[i] = dst_ops[i]; }
+            or {
+                val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (R.is_err[u32, str](rn)) { ret R.err[bool, str](R.unwrap_err[u32, str](rn)); }
+                nxt[i] = mir.op_vreg(R.unwrap_ok[u32, str](rn));
+            }
+            i = i + 1;
+        }
+        i = 0;
+        for (i < nl) {
+            val rx: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (R.is_err[u32, str](rx)) { ret R.err[bool, str](R.unwrap_err[u32, str](rx)); }
+            val x: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rx));
+            val r4: R.Result[bool, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, result[i], cand[i], lw);
+            if (R.is_err[bool, str](r4)) { ret r4; }
+
+            val ry: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (R.is_err[u32, str](ry)) { ret R.err[bool, str](R.unwrap_err[u32, str](ry)); }
+            val y: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ry));
+            val r5: R.Result[bool, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
+            if (R.is_err[bool, str](r5)) { ret r5; }
+
+            val r6: R.Result[bool, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, nxt[i], result[i], y, lw);
+            if (R.is_err[bool, str](r6)) { ret r6; }
+            i = i + 1;
+        }
+        i = 0;
+        for (i < nl) { result[i] = nxt[i]; i = i + 1; }
+
+        if (!is_last) {
+            # advance: the multiplicand doubles, the multiplier gives up the bit
+            # just tested - both a one-bit constant-shift template.
+            var nmc: [MAX_SHIFT_LANES]mir.MirOperand;
+            i = 0;
+            for (i < nl) {
+                val rmc: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (R.is_err[u32, str](rmc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rmc)); }
+                nmc[i] = mir.op_vreg(R.unwrap_ok[u32, str](rmc));
+                i = i + 1;
+            }
+            val r7: R.Result[bool, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?mcand[0], ?nmc[0], nl, lw, 0, 1, true, false, mir.op_imm(0));
+            if (R.is_err[bool, str](r7)) { ret r7; }
+            i = 0;
+            for (i < nl) { mcand[i] = nmc[i]; i = i + 1; }
+
+            var nmp: [MAX_SHIFT_LANES]mir.MirOperand;
+            i = 0;
+            for (i < nl) {
+                val rmp: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (R.is_err[u32, str](rmp)) { ret R.err[bool, str](R.unwrap_err[u32, str](rmp)); }
+                nmp[i] = mir.op_vreg(R.unwrap_ok[u32, str](rmp));
+                i = i + 1;
+            }
+            val r8: R.Result[bool, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?mplier[0], ?nmp[0], nl, lw, 0, 1, false, false, mir.op_imm(0));
+            if (R.is_err[bool, str](r8)) { ret r8; }
+            i = 0;
+            for (i < nl) { mplier[i] = nmp[i]; i = i + 1; }
+        }
+        j = j + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
 # the destination lane count of a width-changing op (its operation width in native
 # lanes, at least one)
 fun dst_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
@@ -1681,7 +1960,6 @@ fun emit_bin(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.Mi
 # width: the operation width in bytes
 # ret:   the diagnostic string
 fun unsupported_message(op: mir.MirOpcode, width: u8) str {
-    if (op == mir.MIR_MUL)     { ret "legalize: wide multiply by a non-constant is unsupported on this target"; }
     if (op == mir.MIR_DIV_S || op == mir.MIR_DIV_U) { ret "legalize: wide divide is unsupported on this target"; }
     if (op == mir.MIR_REM_S || op == mir.MIR_REM_U) { ret "legalize: wide remainder is unsupported on this target"; }
     if (is_shift(op)) {
@@ -1711,6 +1989,9 @@ fun t_mach(maw: u8, ptr: u8) Machine {
     m.ptr_width  = ptr;
     # the 6502 shape: no variable-count shift, so the pass owns every shift
     m.var_shift  = false;
+    # a hardware multiply by default: only the multiply-specific tests flip this,
+    # so every existing shift / add / memory test keeps its established shape
+    m.has_mul    = true;
     m.stage_lo   = 6;
     m.stage_hi   = 7;
     ret m;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9778,6 +9778,177 @@ test "mach.lang.driver:shift_executes_on_a_6502_core_mos6502" {
     ret bad;
 }
 
+# build the source of a two-operand multiply probe module at width `bits`: both
+# operands arrive and the result leaves as `u64` (the ABI shape every mos6502 probe
+# in this file already uses). For a narrower `ty`, both operands are truncated to
+# it and multiplied at THAT width, then widened back, so the multiply itself
+# happens at `bits` wide while the function's own calling convention stays the one
+# this harness already exercises. `ty == "u64"` skips the cast pair entirely - a
+# same-width cast is its own untested legalize frontier (a bare BITCAST reaches no
+# arm in `expand_instr`), unrelated to #2344 and not this issue's to fix; `v * w`
+# directly exercises the identical multiply at the same width without it (test
+# helper)
+# ---
+# buf: the source buffer to write
+# ty:  the multiply's own operand type (`u8` / `u16` / `u32` / `u64`)
+fun ut_mos_mul_src(buf: *u8, ty: str) usize {
+    var w: usize = 0;
+    if (str_equals(ty, "u64")) {
+        w = ut_app(buf, w, "fun f(v: u64, w: u64) u64 { ret v * w; }\n");
+    }
+    or {
+        w = ut_app(buf, w, "fun f(v: u64, w: u64) u64 { ret ((v::");
+        w = ut_app(buf, w, ty);
+        w = ut_app(buf, w, ") * (w::");
+        w = ut_app(buf, w, ty);
+        w = ut_app(buf, w, "))::u64; }\n");
+    }
+    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
+    buf[w] = 0;
+    ret w;
+}
+
+# the reference answer for a multiply at `bits` wide, computed independently of the
+# emitted bytes (test helper)
+fun ut_mul_ref(bits: u32, v: u64, w: u64) u64 {
+    var mask: u64 = 0xFFFFFFFFFFFFFFFF;
+    if (bits < 64) { mask = (1::u64 << bits::u64) - 1; }
+    ret ((v & mask) * (w & mask)) & mask;
+}
+
+# sweep one width of the mos6502 wide-multiply work over a real build (test helper)
+#
+# `w` is paired with `v` at a fixed offset into the same `ut_shift_value` sweep
+# (rather than the full 16x16 cross product), so both operands range over every
+# value pattern the set names - zero, all-ones, alternating, lane boundaries, a
+# spread - at a sixteenth of the cost.
+# ---
+# s:     the session to build in
+# alloc: allocator for the source buffer and the memory image
+# bits:  the scalar width in bits
+# ty:    the scalar type name
+# ret:   0 when every pair answered correctly at a fixed cycle count
+fun ut_mos_mul_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: str) i32 {
+    val sr: R.Result[*u8, str] = A.allocate[u8](alloc, 8192);
+    if (R.is_err[*u8, str](sr)) { ret 1; }
+    val srcbuf: *u8 = R.unwrap_ok[*u8, str](sr);
+    ut_mos_mul_src(srcbuf, ty);
+
+    val mr: R.Result[*u8, str] = A.zallocate[u8](alloc, UT_MOS_MEM);
+    if (R.is_err[*u8, str](mr)) { A.deallocate[u8](alloc, srcbuf, 8192); ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(s, alloc, srcbuf::str, "mos");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
+        or {
+            var text: *u8 = nil;
+            var tlen: u32 = 0;
+            var offs: [1]u32;
+            if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], 1))    { bad = 1; }
+            or (UT_MOS_CODE + tlen >= UT_MOS_ARGS)              { bad = 1; }
+            or {
+                ut_mos_load(text, tlen, mem);
+                var fixed: u32 = 0;
+                var vi: u32 = 0;
+                for (vi < UT_SHIFT_VALUES) {
+                    val v: u64 = ut_shift_value(vi);
+                    val ww: u64 = ut_shift_value((vi + 5) % UT_SHIFT_VALUES);
+                    var got: u64 = 0;
+                    var cy:  u32 = 0;
+                    if (!ut_mos_run(mem, offs[0], 8, v, ww, ?got, ?cy)) { bad = 1; }
+                    or {
+                        if (got != ut_mul_ref(bits, v, ww)) { bad = 1; }
+                        # branchless double-and-add (#2344): one cycle count for
+                        # every value pair, the same discipline the shift barrel
+                        # and the carry chain are already held to.
+                        if (vi == 0)     { fixed = cy; }
+                        or (cy != fixed) { bad = 1; }
+                    }
+                    vi = vi + 1;
+                }
+            }
+        }
+        project.dnit_project(?p);
+    }
+
+    A.deallocate[u8](alloc, mem, UT_MOS_MEM);
+    A.deallocate[u8](alloc, srcbuf, 8192);
+    ret bad;
+}
+
+# mos6502 (#2344): a wide multiply BUILDS AND RUNS, executed on a reference 6502 core
+#
+# The 6502 has no hardware multiply at any width, so `be.codegen.legalize` owns
+# every `MIR_MUL` here - the native-width case (`u8 * u8`) alongside the wide one,
+# unlike every other expansion in this file, which only ever admits a wide
+# instruction. Swept at the width boundary (`u8`, the narrowest and the only
+# native-width case), a middle width (`u16`), and the widest (`u64`, `u32` also
+# covered), each a genuine two-operand runtime multiply - neither operand a
+# compile-time constant, so the general double-and-add algorithm is exercised with
+# no shortcut available.
+#
+# THE CONSTANT-MULTIPLIER CASE, PROVEN SEPARATELY. The issue's own reproducer,
+# `v * 2`, is a constant multiplier only because no algebraic pass runs at `opt =
+# 0`; this expansion draws no distinction between a constant and a runtime operand
+# - both are ordinary lane operands to the same algorithm (an immediate's lane is
+# read through `imm_lane`, exactly like any other immediate operand elsewhere in
+# this pass) - so there is no separate "strength reduction" code path to exercise
+# here. The message the old refusal used to give ("wide multiply by a
+# non-constant") is retired along with it: the new expansion does not distinguish.
+test "mach.lang.driver:mul_executes_on_a_6502_core_mos6502" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    if (ut_mos_mul_sweep(?s, ?alloc, 8,  "u8")  != 0) { bad = 1; }
+    if (ut_mos_mul_sweep(?s, ?alloc, 16, "u16") != 0) { bad = 1; }
+    if (ut_mos_mul_sweep(?s, ?alloc, 32, "u32") != 0) { bad = 1; }
+    if (ut_mos_mul_sweep(?s, ?alloc, 64, "u64") != 0) { bad = 1; }
+
+    val mr: R.Result[*u8, str] = A.zallocate[u8](?alloc, UT_MOS_MEM);
+    if (R.is_err[*u8, str](mr)) { bad = 1; }
+    or {
+        val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+        val pe: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
+            "fun f(v: u64) u64 { ret v * 2; }\nfun main() i32 { ret 0; }\n", "mos");
+        if (R.is_err[project.Project, outcome.Fail](pe)) { bad = 1; }
+        or {
+            var pf: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pe);
+            if (ut_run_codegen_ok(?pf) != 0) { bad = 1; }
+            or {
+                var text: *u8 = nil;
+                var tlen: u32 = 0;
+                var offs: [1]u32;
+                if (!ut_mos_text(?pf, ?text, ?tlen, ?offs[0], 1)) { bad = 1; }
+                or {
+                    ut_mos_load(text, tlen, mem);
+                    var vi: u32 = 0;
+                    for (vi < UT_SHIFT_VALUES) {
+                        val v: u64 = ut_shift_value(vi);
+                        var got: u64 = 0;
+                        var cy:  u32 = 0;
+                        if (!ut_mos_run(mem, offs[0], 8, v, 0, ?got, ?cy)) { bad = 1; }
+                        or (got != v * 2) { bad = 1; }
+                        vi = vi + 1;
+                    }
+                }
+            }
+            project.dnit_project(?pf);
+        }
+        A.deallocate[u8](?alloc, mem, UT_MOS_MEM);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 
 # `setup_registry` refuses a debug identity whose producer no registrar wired
 #

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -321,6 +321,15 @@ pub rec MachineModel {
     # register (aarch64) and on one with no variable shift at all
     has_var_shift:     bool;
 
+    # whether the ISA has a hardware integer multiply instruction at all (#2344).
+    # false on a machine with no multiply of any width (mos6502), where
+    # `be.codegen.legalize` owns every `MIR_MUL` - native-width included, unlike the
+    # width-driven gates above - and rewrites it into a straight-line double-and-add
+    # sequence over the operation's own width, so no multiply ever reaches selection.
+    # true on every ISA this compiler otherwise targets (x86-64 IMUL, aarch64 MUL,
+    # rv64 MUL, and SPIR-V's OpIMul), so the gate is dead everywhere but mos6502.
+    has_mul: bool;
+
     # the second constant-time capability fact (#1646): true when the ISA shifts by a
     # variable count in constant time (a barrel shifter), so a secret shift COUNT is
     # permitted; false gates a shift by a secret count as a variable-latency leak (an

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -247,6 +247,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # PSTATE.DIT, which the static contract does not assume until the mode is wired.
     arm64_model.ct_trust_mul  = false;
     arm64_model.has_var_shift = true;        # LSLV / LSRV / ASRV read the count from a register (#2217)
+    arm64_model.has_mul = true;              # MUL (#2344)
     arm64_model.ct_trust_var_shift = true;   # aarch64 variable shift is constant-time (#1646)
 
     arm64_model.reg_classes     = ?arm64_classes[0];

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -789,6 +789,16 @@ pub rec Core {
 # Runs from `core.pc` until `RTS`, accumulating cycles. Any opcode outside the pinned set,
 # any access outside the image, and any run that does not terminate is a failure rather
 # than a silently truncated answer.
+#
+# THE STEP CAP IS A RUNAWAY BACKSTOP, NOT A WORKLOAD CEILING - raised from 4096 to 65536
+# (#2344) once a legitimate, terminating sequence exceeded it: the width legalizer's
+# double-and-add wide multiply is honest-cost by design (bits stages of a carry chain
+# plus two shifts, #2344's own doc comment), and a u64 runtime multiply's ~48KB of
+# emitted bytes needs on the close order of 16-19K real 6502 instructions to finish - a
+# real, executed answer, not a hang. 65536 keeps the backstop's actual job (catching a
+# genuinely non-terminating sequence, the #2158-shaped failure this core exists to
+# catch) while giving the largest expansion this pass has ever produced room to run to
+# completion.
 # ---
 # mem:  the flat memory image (zero page at 0, code wherever `core.pc` points)
 # size: the image size in bytes
@@ -796,7 +806,7 @@ pub rec Core {
 # ret:  true when the run reached RTS inside the pinned opcode set
 pub fun exec_reference(mem: *u8, size: usize, core: *Core) bool {
     var steps: u32 = 0;
-    for (steps < 4096) {
+    for (steps < 65536) {
         steps = steps + 1;
         if (core.pc::usize >= size) { ret false; }
         val op:  u8    = mem[core.pc::usize];

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -117,6 +117,9 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # whether the hardware's variable shift is data-independent, and there is none (#1646).
     mos6502_model.has_var_shift = false;
     mos6502_model.ct_trust_var_shift = false;
+    # no hardware multiply at any width (#2344): be.codegen.legalize owns every
+    # MIR_MUL, native-width included, and expands it into a double-and-add sequence.
+    mos6502_model.has_mul = false;
 
     mos6502_model.reg_classes     = ?mos6502_classes[0];
     mos6502_model.reg_class_len   = 1;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -290,6 +290,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # timing mode, so a secret multiply is always a variable-latency leak here.
     riscv64_model.ct_trust_mul = false;
     riscv64_model.has_var_shift = true;        # SLL / SRL / SRA read the count from a register (#2217)
+    riscv64_model.has_mul = true;              # MUL, the M extension (#2344)
     riscv64_model.ct_trust_var_shift = true;   # rv64 SLL/SRL variable shift is constant-time (#1646)
 
     riscv64_model.reg_classes     = ?riscv64_classes[0];

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -90,6 +90,7 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     spirv_model.ct_trust_mul           = false;
     spirv_model.has_var_shift          = true;
+    spirv_model.has_mul                = true;   # OpIMul (#2344)
     spirv_model.ct_trust_var_shift     = false;
 
     # the whole-module contract is the entire SPIR-V back half, and it is the whole

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -293,6 +293,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # conservative until the mode is wired.
     x64_model.ct_trust_mul    = false;
     x64_model.has_var_shift = true;        # SHL/SHR/SAR by CL is a single instruction (#2217)
+    x64_model.has_mul = true;              # IMUL (#2344)
     x64_model.ct_trust_var_shift = true;   # SHL/SHR by CL is single-instruction constant-time (#1646)
 
     x64_model.reg_classes     = ?x64_classes[0];


### PR DESCRIPTION
## Reachability

Both pieces the issue named are now reachable and implemented; neither was a
silent wrong-code path - both were loud, specific refusals (the wide case's
"legalize: wide multiply by a non-constant is unsupported on this target", the
native case's "mos6502: the 6502 has no hardware multiply" from `encode.mach`).

## The two pieces, resolved as one

**Checked the constant-multiplier question before writing code, per the issue's
own instruction.** `mul_piece_count`/`expand_mul` draw no distinction between a
constant and a runtime multiplier operand: an immediate is just another lane
operand (`lane_operand`'s existing `imm_lane` path), read exactly like any other
immediate elsewhere in this pass. So the diagnostic's implication - that a
constant multiplier already had a path - was not true before this change either;
now there is exactly one algorithm, and it serves `v * 2` and a genuine runtime
`v * w` identically. The old message is retired along with the frontier it named.

**The native-width case (`u8 * u8`) needed a design decision beyond "implement
the expansion".** `be.codegen.legalize`'s existing gates are all width-driven:
they only ever admit a WIDE instruction (`mi.width > mach.lane_width`). But
mos6502 has no hardware multiply at ANY width, so a *native* 1-byte multiply was
separately dead-ending at the encoder (`mos6502.encode`'s own message). Rather
than build a second implementation in the ISA's rules/encode layer, `MachineModel`
gained a `has_mul: bool` fact (mirroring `has_var_shift`'s existing precedent
exactly) - `true` on every wide-native target (x86-64 IMUL, aarch64 MUL, rv64 MUL,
SPIR-V OpIMul) and `false` on mos6502. `instr_needs_legalize` admits `MIR_MUL`
whenever `!has_mul`, native width included - the one clause in this pass that
isn't purely width-driven, documented as such both at the top of the file and at
the call site. This means `be.codegen.legalize` now owns 100% of MUL on mos6502;
the encoder's own rejection (and its direct-call unit test) stays as legitimate
defense-in-depth for `encode_alu` called out of the normal pipeline, unchanged.

## Implementation

`expand_mul` is classic shift-and-add ("Russian peasant" multiplication): per bit
of the multiplier, from the low bit up, the running multiplicand joins an
accumulator when that bit is set, then the multiplicand doubles (shift left one)
and the multiplier gives up the bit just tested (shift right one) - so the NEXT
bit tested is always the running multiplier's own low bit, needing no per-stage
indexing into the original operand. This reuses two things this pass already has
rather than inventing new machinery: the wide carry-chain add (extracted from
`expand_addsub` into a reusable `emit_addsub_chain` both now call, since neither
ADD nor MUL had ever driven its `nl == 1` degenerate path before - a real,
previously-untested edge this PR's mutation testing exercises) and the constant
shift-by-one template (`emit_const_shift`, already parameterized generically).

**Branchless, not constant-time - and that distinction is deliberate.** This pass
emits straight-line code into one block; it cannot build new control-flow edges,
so the per-stage "add or don't" decision is a mask-and-select exactly like the
shift barrel's own per-stage decision, for the same structural reason. It is not
for secrecy: `ct_trust_mul = false` on every target this compiler has (mos6502
included - checked `target/isa/*/register.mach` for all four), so a secret
multiply operand is already refused upstream in `mir.lower`'s GATE (#1646) before
this pass ever runs. The full linear-in-width cost (no early exit, since this pass
can't express "stop early" either) is paid by every multiply, public values
included, purely as a consequence of the pass's own architecture - not a security
requirement.

**The cost is honest, and asymptotically the right choice, not just simpler to
write.** `bits` stages of an add-chain-plus-two-shifts is O(width) - strictly
better than a lane-wise schoolbook of partial products would have been
(O(lanes²), each partial product itself a smaller multiply) for the widths this
language actually has (≤8 lanes).

**Shared, not mos6502-specific**, confirmed the same way #2216/#2217/#2323 found:
`expand_mul` reads only `plan.lane_width`, nothing target-specific.

## A found-but-out-of-scope frontier, sidestepped rather than fixed

A same-width cast on an already-wide value (`v::u64` where `v: u64`) reaches
`be.codegen.legalize` and hits the generic "operation wider than the target ALU is
unsupported" - some pass-through opcode (likely a bare `MIR_BITCAST`, which has no
arm in `expand_instr`) that nothing has ever exercised, since no existing mos6502
test performs a same-width cast on a wide value. Found while iterating on this
PR's own multiply test harness (an early draft generated `((v::u64)*(w::u64))::u64`
uniformly across all four widths); not `#2344`'s to fix, and the test now skips
the redundant cast pair for `ty == "u64"`, calling `v * w` directly instead -
proven equivalent by executing both forms during debugging. Flagging here per the
standing escalation rule rather than filing separately, since it's adjacent to
this exact code but orthogonal to what this issue asks for.

## Also touched: the reference core's step cap

`mos6502.encode.exec_reference`'s step cap was a runaway backstop (`for (steps <
4096)`, "any run that does not terminate is a failure"), not an intentional
workload ceiling - and a `u64` runtime multiply's honestly-costed expansion
(~48KB of emitted bytes, on the order of 16-19K real 6502 instructions) needs more
steps than 4096 to reach `RTS`. Raised to 65536, generous headroom over the
largest expansion this pass has ever produced, while still catching an actually
non-terminating sequence (the `#2158`-shaped failure this core exists to catch).

## Verification

- `mach test .` via a from-source `--jobs 1` compiler: **1033 passed, 0 failed** -
  exactly the `dev` baseline at the branch's post-merge base (`292f879f`, 1032/0,
  measured with the same from-source methodology) plus the one new test block.
- **Mutation test on the one new non-width-driven guard** (the native-width MUL
  admission in `instr_needs_legalize` - the piece genuinely new to this pass's
  architecture, not a template copy): disabled the clause, rebuilt. Result:
  **1032 passed, 1 failed** - the new executed test catches it immediately
  (the `u8` sweep specifically, since `u16`/`u32`/`u64` stay admitted via the
  pre-existing width-driven clause regardless). Reverted; confirmed clean
  **1033/0** afterward.
- **Object-level byte-identity** (one target `linux-x86_64`, one profile
  `release`, per the bar - no divergence found, so no widening needed): held the
  `dev`-baseline project source fixed, built its 215 objects once with the
  unmodified baseline compiler and once with this branch's from-source compiler.
  `diff -rq`: **zero differences** - confirms the inertness contract: `has_mul =
  true` on every wide-native target means the new clause is provably dead there.
- **Three-generation self-host fixpoint**: gen3 == gen4 byte-identical
  (`82ce1992f46671fb8c5eb76c2ed52a0bb5c98cc8f0f1e7b80462349e5e3c96b7`), `--jobs 1`
  throughout.
- **Boundary coverage across widths**: the executed sweep covers `u8` (the
  boundary case - the only native-width multiply, `nl == 1`, exercising
  `emit_addsub_chain`'s never-before-reached single-lane path), `u16` (the
  smallest wide case), `u32`, and `u64` (widest, most lanes), each against a
  reference computed independently of the emitted bytes, over 16 value pairs
  drawn from the existing `ut_shift_value` set (zero, all-ones, alternating, lane
  boundaries, a spread) paired at a fixed offset so both operands range over every
  pattern. Each width also asserts a fixed cycle count - the branchless-not-secret
  distinction above, demonstrated by execution: the sequence really is
  data-independent in its instruction count, whether or not that is a security
  requirement here. mos6502 has no `int/` leg (#2435 precedent), so this executed
  unit-test sweep is its coverage.

Closes #2344