### PR TITLE
fix(ct): classify on code AND flags — aarch64 b.<cond> was passing as unconditional

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -183,14 +183,18 @@ declared type. What the walk cannot model, it refuses:
 | a body that does not parse | nothing to analyze |
 | a `.byte` directive | its payload can encode any instruction |
 | a mnemonic the target has not classified | its timing behaviour is unknown |
-| **a conditional branch, on x86-64 only** | its condition rides FLAGS, which the inline-asm effect model does not represent (#2460) |
+| **a flags-conditioned branch** (x86-64 `jcc`, aarch64 `b.<cond>`) | its condition rides the flags register, which the inline-asm effect model does not represent (#2460) |
 
-That last row is a per-target asymmetry worth stating plainly. aarch64's only
-conditional forms are `cbz`/`cbnz` and riscv64's branches compare two registers, so
-on both the condition is a register operand the walk can see, and both get the full
-three checks. x86-64's `jcc` family conditions on flags the model does not carry, so
-a `cmp` of a secret before it would be invisible — the branch is refused there until
-flags are modeled.
+That last row is a per-target asymmetry worth stating precisely, because getting it
+wrong was a real hole (#2477). A branch whose condition is a **register operand** is
+visible to the walk and is checked: aarch64's `cbz`/`cbnz`, and every riscv64 branch,
+which compares two registers — RISC-V has no flags register at all. A branch whose
+condition rides the **flags register** cannot be checked, because the effect model
+carries no flags, so a `cmp` of a secret before it would be invisible: those are
+refused. x86-64's `jcc` family is flags-conditioned, and so is **aarch64's
+`b.<cond>`** — which is easy to miss, because `b.<cond>` does not appear in aarch64's
+mnemonic table at all. It is admitted by the grammar's *decode hook*, carrying the
+unconditional branch's own opcode with the condition in its flags.
 
 The variable-latency check also bites unevenly: x86-64's and aarch64's asm grammars
 carry no divide, multiply or float instruction at all, so it reaches only their

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -10049,6 +10049,11 @@ test "mach.lang.driver:oblivious_asm_validated_not_refused" {
 
     # aarch64 and riscv64 get the full three checks, including their branches.
     if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm aarch64 { nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-arm64") != 0) { bad = 1; }
+
+    # an LL/SC retry conditions on the STATUS register, a plain register operand, so
+    # it stays accepted - the property #2477's fix must not break while closing the
+    # flags-conditioned hole beside it.
+    if (ut_codegen_target_ok("#[oblivious]\nfun ll(p: *i64) i64 { var v: i64 = 0; asm aarch64 { ldr x12, {p}\n ldaxr x9, [x12]\n stlxr w10, x9, [x12]\n cbnz w10, 1f\n1:\n nop } ret v; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-arm64") != 0) { bad = 1; }
     if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm riscv64 { nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-riscv64") != 0) { bad = 1; }
 
     ret bad;
@@ -10073,6 +10078,14 @@ test "mach.lang.driver:oblivious_asm_leaks_refused" {
     # branch. there is nothing to analyze, so it is refused on KIND.
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { .byte 0x90 } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "linux", "its payload can encode any instruction") != 0) { bad = 1; }
+
+    # #2477 REGRESSION. aarch64 DOES have flags-conditioned branches - `b.<cond>`,
+    # admitted by the grammar's decode hook rather than its static table, and given
+    # the UNCONDITIONAL branch's own code with the condition in flags. Classifying on
+    # code alone read it as unconditional, and this exact block compiled clean: a
+    # secret-dependent branch with a constant-time guarantee attached.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun bc(k: ^u64) ^u64 { var r: ^u64 = k; asm aarch64 { ldr x9, {r}\n cmp x9, x1\n b.eq 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux-arm64", "its condition rides the flags register") != 0) { bad = 1; }
 
     # (a) a REGISTER-conditioned branch on a secret, on a target where the condition
     # is visible: aarch64's `cbnz` reads a register, so this one is caught rather

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -7266,7 +7266,7 @@ test "mach.lang.target.isa.arm64.encode:unnamed_forms_are_refused" {
 # ---
 # code: the mnemonic's aarch64 code
 # ret:  its classification, or `ct.asm_unknown()` when unclassified
-pub fun asm_ct_class(code: u32) ct.AsmClass {
+pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     # data movement, address formation, loads and stores: constant-time.
     if (code == A64M_MOV  || code == A64M_MOVZ || code == A64M_MOVK ||
         code == A64M_ADRP || code == A64M_LDR  || code == A64M_STR  ||
@@ -7294,6 +7294,16 @@ pub fun asm_ct_class(code: u32) ct.AsmClass {
         code == A64M_STLR  || code == A64M_DMB  || code == A64M_YIELD) {
         ret ct.asm_op(ct.CT_OP_NONE);
     }
+    # A FLAGS-CONDITIONED BRANCH IS REFUSED, and it must be tested BEFORE the code
+    # groups below. `a64_decode_bcond` admits `b.<cond>` with `A64M_B` - the
+    # unconditional branch's own code - and carries the condition in flags alone, so a
+    # code-keyed test reads it as unconditional and lets a secret-dependent branch
+    # through (#2477). Same reasoning as x86-64's `jcc` family: the condition rides
+    # NZCV, which the inline-asm effect model does not represent (#2460).
+    # NOTE the equality: A64P_* are ENUMERATED pattern values in the low byte, not bit
+    # flags, so a bitwise test here would match every pattern sharing a set bit.
+    if (a64_pattern(flags) == A64P_BCOND) { ret ct.asm_branch_flags(); }
+
     # unconditional control transfer, system registers, and the traps: the target of
     # each is public by construction.
     if (code == A64M_B   || code == A64M_BL  || code == A64M_BLR || code == A64M_BR ||
@@ -7316,14 +7326,21 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:every_grammar_row_is_classi
     var bad: i32 = 0;
     var i: usize = 0;
     for (i < A64_MNEMONIC_COUNT) {
-        if (!asm_ct_class(A64_MNEMONICS[i].code).known) { bad = 1; }
+        if (!asm_ct_class(A64_MNEMONICS[i].code, A64_MNEMONICS[i].flags).known) { bad = 1; }
         i = i + 1;
     }
     ret bad;
 }
 
-# aarch64's conditional branches are CHECKED, not refused - the property that makes
-# the LL/SC atomic loop analyzable rather than merely asserted
+# aarch64's REGISTER-conditioned branches are checked, not refused - the property
+# that makes the LL/SC atomic loop analyzable rather than merely asserted
+#
+# SCOPE, corrected by #2477: this walks the STATIC mnemonic table, and what it proves
+# is a fact about that table only. aarch64 also admits `b.<cond>` through the
+# grammar's DECODE hook, which is flags-conditioned and refused; the sibling
+# `decode_channel_is_classified` covers that channel. Read alone this test once
+# looked like proof that aarch64 has no flags-conditioned branch at all, which is
+# what let one through.
 #
 # `stlxr Ws, Xt, [Xn]` writes its status register and the retry `cbnz Ws` reads it,
 # both plain register operands, so the walk sees mechanically that the retry
@@ -7333,29 +7350,29 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_condi
     var bad: i32 = 0;
 
     # the only conditional forms this grammar has, and both are register-conditioned.
-    if (!asm_ct_class(A64M_CBZ).cond_reg)   { bad = 1; }
-    if (!asm_ct_class(A64M_CBNZ).cond_reg)  { bad = 1; }
-    # no aarch64 row is flags-conditioned: there is no `b.cc` in the grammar at all,
-    # which is exactly why this target needs no refusal.
+    if (!asm_ct_class(A64M_CBZ, 0).cond_reg)   { bad = 1; }
+    if (!asm_ct_class(A64M_CBNZ, 0).cond_reg)  { bad = 1; }
+    # no STATIC row is flags-conditioned. that is a fact about the table, not about
+    # the grammar: `b.<cond>` arrives through the decode hook (#2477).
     var i: usize = 0;
     for (i < A64_MNEMONIC_COUNT) {
-        if (asm_ct_class(A64_MNEMONICS[i].code).cond_flags) { bad = 1; }
+        if (asm_ct_class(A64_MNEMONICS[i].code, A64_MNEMONICS[i].flags).cond_flags) { bad = 1; }
         i = i + 1;
     }
     # the unconditional transfers are not conditional branches.
-    if (asm_ct_class(A64M_B).cond_reg)  { bad = 1; }
-    if (asm_ct_class(A64M_BL).cond_reg) { bad = 1; }
+    if (asm_ct_class(A64M_B, 0).cond_reg)  { bad = 1; }
+    if (asm_ct_class(A64M_BL, 0).cond_reg) { bad = 1; }
 
     # check (c) is near-vacuous HERE: no divide, multiply or float row exists, and the
     # register-count shifts are the only variable-latency shape.
-    if (asm_ct_class(A64M_LSLV).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(A64M_LSRV).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(A64M_ASRV).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(A64M_LSLV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(A64M_LSRV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(A64M_ASRV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
     # the immediate-count forms are not.
-    if (asm_ct_class(A64M_LSL).op != ct.CT_OP_NONE) { bad = 1; }
+    if (asm_ct_class(A64M_LSL, 0).op != ct.CT_OP_NONE) { bad = 1; }
     i = 0;
     for (i < A64_MNEMONIC_COUNT) {
-        val op: ct.CtOp = asm_ct_class(A64_MNEMONICS[i].code).op;
+        val op: ct.CtOp = asm_ct_class(A64_MNEMONICS[i].code, A64_MNEMONICS[i].flags).op;
         if (op == ct.CT_OP_INT_DIVMOD) { bad = 1; }
         if (op == ct.CT_OP_INT_MUL)    { bad = 1; }
         if (op == ct.CT_OP_FLOAT)      { bad = 1; }
@@ -7373,4 +7390,56 @@ pub fun asm_ct_scan(body: str, secret_names: *str, n_secret: u32,
                     trust_mul: bool, trust_shift: bool, alloc: *A.Allocator) R.Result[bool, str] {
     var g: iasm.Grammar = a64_grammar();
     ret iasm.ct_scan(?g, body, secret_names, n_secret, trust_mul, trust_shift);
+}
+
+# every form the DECODE channel admits is classified - probed against the decoder
+# itself, not against a copy of its accepted list
+#
+# This is the test #2477 needed and #2230 lacked. The old coverage test walked
+# `A64_MNEMONICS` and asserted no row is flags-conditioned. That is TRUE of the static
+# table and false of the grammar: a grammar admits forms through TWO channels, and
+# `a64_decode_bcond` synthesizes `b.<cond>` rows that never appear in the table. So
+# the assertion held while `cmp {secret}, x1 ; b.eq` walked as leak-free.
+#
+# The fix is to probe the DECODER over a generated alphabet rather than enumerate what
+# it is believed to accept: every two-letter suffix is offered, and whatever the
+# decoder ACCEPTS must classify as a flags-conditioned branch. A condition added to
+# `asm_parse_cond` later is picked up automatically, because the test asks the decoder
+# rather than a list beside it.
+test "mach.lang.target.isa.arm64.encode.asm_ct_class:decode_channel_is_classified" {
+    var bad: i32 = 0;
+    var accepted: u32 = 0;
+
+    var a: u32 = 0;
+    for (a < 26) {
+        var b: u32 = 0;
+        for (b < 26) {
+            var buf: [8]u8;
+            buf[0] = 98;                      # 'b'
+            buf[1] = 46;                      # '.'
+            buf[2] = (97 + a)::u8;
+            buf[3] = (97 + b)::u8;
+            buf[4] = 0;
+            val body: str = (?buf[0])::str;
+
+            var m: iasm.Mnemonic;
+            var n: usize = 0;
+            if (a64_decode_bcond(body, 0, 4, ?m, ?n)) {
+                accepted = accepted + 1;
+                # whatever the decoder admits must be refused as flags-conditioned.
+                val cls: ct.AsmClass = asm_ct_class(m.code, m.flags);
+                if (!cls.cond_flags) { bad = 1; }
+                # and it must NOT read as the unconditional branch it shares a code
+                # with - the exact confusion that opened the hole.
+                if (m.code != A64M_B) { bad = 1; }
+            }
+            b = b + 1;
+        }
+        a = a + 1;
+    }
+
+    # the probe must actually have exercised the channel: a decoder that accepted
+    # nothing would satisfy every assertion above vacuously.
+    if (accepted == 0) { bad = 1; }
+    ret bad;
 }

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -364,8 +364,17 @@ pub def SlotFn: fun(*mir.MirFunction, u32) O.Option[i64];
 # `Mnemonic` row already carries. An unclassified code returns `ct.asm_unknown()`,
 # which refuses the moment a secret reaches it.
 # ---
-# code: the mnemonic's code, in the ISA's own space
-pub def CtClassFn: fun(u32) ct.AsmClass;
+# A form's classification is a function of BOTH its code and its encoding flags,
+# not the code alone. A grammar admits forms through TWO channels - its static
+# `Mnemonic` table and its `decode` hook - and a decoded form may share a code with
+# a statically-declared one while differing in flags. aarch64's `b.<cond>` is exactly
+# that: `a64_decode_bcond` gives it `A64M_B`, the UNCONDITIONAL branch's code, and
+# carries the condition in flags. Classifying on code alone read every `b.eq` as an
+# unconditional branch and passed secret-dependent branches as leak-free (#2477).
+# ---
+# code:  the mnemonic's code, in the ISA's own space
+# flags: the mnemonic's encoding flags, in the ISA's own space
+pub def CtClassFn: fun(u32, u16) ct.AsmClass;
 
 # one target's inline-assembly grammar
 #
@@ -1581,7 +1590,7 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
         ret R.err[bool, str]("contains a `.byte` directive inside an #[oblivious] function; its payload can encode any instruction, so it cannot be verified constant-time");
     }
 
-    val cls: ct.AsmClass = g.ct_class(item.code);
+    val cls: ct.AsmClass = g.ct_class(item.code, item.flags);
     val reads_secret: bool = item_reads_secret(body, item, @taint, secret_names, n_secret);
 
     # a conditional branch whose condition rides the flags register cannot be checked

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -5897,7 +5897,7 @@ test "mach.lang.target.isa.riscv64.encode:unnamed_forms_are_refused" {
 # ---
 # code: the mnemonic's riscv64 code
 # ret:  its classification, or `ct.asm_unknown()` when unclassified
-pub fun asm_ct_class(code: u32) ct.AsmClass {
+pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     # integer divide and remainder: variable-latency on every target, so a secret
     # operand is refused regardless of target capability.
     if (code == inst.DIV::u32   || code == inst.DIVU::u32 || code == inst.DIVW::u32 ||
@@ -5938,6 +5938,28 @@ pub fun asm_ct_class(code: u32) ct.AsmClass {
         code == inst.SW::u32  || code == inst.SD::u32) {
         ret ct.asm_op(ct.CT_OP_NONE);
     }
+    # the A extension: reservations (`lr` / `sc`) and the read-modify-write atomics.
+    # These reach the walk through the grammar's DECODE hook, not its static mnemonic
+    # table - `rv_decode_amo` strips the `.aq` / `.rl` / `.aqrl` ordering and the
+    # `.w` / `.d` width and synthesizes the row - so they are absent from the table a
+    # coverage test walks, and were unclassified until #2477. Their timing varies with
+    # CONTENTION, not with the value carried, which at a PUBLIC address is other
+    # threads' public behaviour - the same conditional row as every other atomic here,
+    # and it holds ONLY BECAUSE check (b) refuses a secret address.
+    if (code == inst.LR_W::u32      || code == inst.LR_D::u32      ||
+        code == inst.SC_W::u32      || code == inst.SC_D::u32      ||
+        code == inst.AMOSWAP_W::u32 || code == inst.AMOSWAP_D::u32 ||
+        code == inst.AMOADD_W::u32  || code == inst.AMOADD_D::u32  ||
+        code == inst.AMOXOR_W::u32  || code == inst.AMOXOR_D::u32  ||
+        code == inst.AMOAND_W::u32  || code == inst.AMOAND_D::u32  ||
+        code == inst.AMOOR_W::u32   || code == inst.AMOOR_D::u32   ||
+        code == inst.AMOMIN_W::u32  || code == inst.AMOMIN_D::u32  ||
+        code == inst.AMOMAX_W::u32  || code == inst.AMOMAX_D::u32  ||
+        code == inst.AMOMINU_W::u32 || code == inst.AMOMINU_D::u32 ||
+        code == inst.AMOMAXU_W::u32 || code == inst.AMOMAXU_D::u32) {
+        ret ct.asm_op(ct.CT_OP_NONE);
+    }
+
     # fences and the hint: see the conditional row above.
     if (code == inst.FENCE::u32 || code == inst.PAUSE::u32) {
         ret ct.asm_op(ct.CT_OP_NONE);
@@ -5963,7 +5985,7 @@ test "mach.lang.target.isa.riscv64.encode.asm_ct_class:every_grammar_row_is_clas
     var bad: i32 = 0;
     var i: usize = 0;
     for (i < RV_MNEMONIC_COUNT) {
-        if (!asm_ct_class(RV_MNEMONICS[i].code).known) { bad = 1; }
+        if (!asm_ct_class(RV_MNEMONICS[i].code, RV_MNEMONICS[i].flags).known) { bad = 1; }
         i = i + 1;
     }
     ret bad;
@@ -5981,40 +6003,40 @@ test "mach.lang.target.isa.riscv64.encode.asm_ct_class:m_extension_is_variable_l
 
     # the eight divide / remainder rows: variable-latency on EVERY target, so a
     # secret operand is refused whatever the target's capability flags say.
-    if (asm_ct_class(inst.DIV::u32).op   != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.DIVU::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.DIVW::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.DIVUW::u32).op != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.REM::u32).op   != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.REMU::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.REMW::u32).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
-    if (asm_ct_class(inst.REMUW::u32).op != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIV::u32, 0).op   != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIVU::u32, 0).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIVW::u32, 0).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.DIVUW::u32, 0).op != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REM::u32, 0).op   != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REMU::u32, 0).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REMW::u32, 0).op  != ct.CT_OP_INT_DIVMOD) { bad = 1; }
+    if (asm_ct_class(inst.REMUW::u32, 0).op != ct.CT_OP_INT_DIVMOD) { bad = 1; }
     if (ct.ct_cap(ct.CT_OP_INT_DIVMOD)   != ct.CT_CAP_ALWAYS)    { bad = 1; }
 
     # the five multiply rows: constant-time only under a documented
     # data-independent multiply.
-    if (asm_ct_class(inst.MUL::u32).op    != ct.CT_OP_INT_MUL) { bad = 1; }
-    if (asm_ct_class(inst.MULH::u32).op   != ct.CT_OP_INT_MUL) { bad = 1; }
-    if (asm_ct_class(inst.MULHSU::u32).op != ct.CT_OP_INT_MUL) { bad = 1; }
-    if (asm_ct_class(inst.MULHU::u32).op  != ct.CT_OP_INT_MUL) { bad = 1; }
-    if (asm_ct_class(inst.MULW::u32).op   != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MUL::u32, 0).op    != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULH::u32, 0).op   != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULHSU::u32, 0).op != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULHU::u32, 0).op  != ct.CT_OP_INT_MUL) { bad = 1; }
+    if (asm_ct_class(inst.MULW::u32, 0).op   != ct.CT_OP_INT_MUL) { bad = 1; }
     if (ct.ct_cap(ct.CT_OP_INT_MUL)       != ct.CT_CAP_MUL)    { bad = 1; }
 
     # register-count shifts gate on the count operand alone; immediate-count ones
     # are constant-time outright.
-    if (asm_ct_class(inst.SLL::u32).op  != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(inst.SRA::u32).op  != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(inst.SLLI::u32).op != ct.CT_OP_NONE)      { bad = 1; }
-    if (asm_ct_class(inst.SRAI::u32).op != ct.CT_OP_NONE)      { bad = 1; }
+    if (asm_ct_class(inst.SLL::u32, 0).op  != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(inst.SRA::u32, 0).op  != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(inst.SLLI::u32, 0).op != ct.CT_OP_NONE)      { bad = 1; }
+    if (asm_ct_class(inst.SRAI::u32, 0).op != ct.CT_OP_NONE)      { bad = 1; }
 
     # every branch is register-comparing: RISC-V has no flags register, so none is
     # refused the way x86-64's `jcc` family must be.
-    if (!asm_ct_class(inst.BEQ::u32).cond_reg)  { bad = 1; }
-    if (!asm_ct_class(inst.BNE::u32).cond_reg)  { bad = 1; }
-    if (!asm_ct_class(inst.BLTU::u32).cond_reg) { bad = 1; }
+    if (!asm_ct_class(inst.BEQ::u32, 0).cond_reg)  { bad = 1; }
+    if (!asm_ct_class(inst.BNE::u32, 0).cond_reg)  { bad = 1; }
+    if (!asm_ct_class(inst.BLTU::u32, 0).cond_reg) { bad = 1; }
     var i: usize = 0;
     for (i < RV_MNEMONIC_COUNT) {
-        if (asm_ct_class(RV_MNEMONICS[i].code).cond_flags) { bad = 1; }
+        if (asm_ct_class(RV_MNEMONICS[i].code, RV_MNEMONICS[i].flags).cond_flags) { bad = 1; }
         i = i + 1;
     }
     ret bad;
@@ -6029,4 +6051,71 @@ pub fun asm_ct_scan(body: str, secret_names: *str, n_secret: u32,
                     trust_mul: bool, trust_shift: bool, alloc: *A.Allocator) R.Result[bool, str] {
     var g: iasm.Grammar = rv_grammar();
     ret iasm.ct_scan(?g, body, secret_names, n_secret, trust_mul, trust_shift);
+}
+
+# every form the DECODE channel admits is classified - probed against the decoder,
+# with the base-name list pinned to the decoder's own accepted set
+#
+# The riscv64 half of #2477. `rv_decode_amo` admits the A extension through the
+# grammar's decode hook, not its static table, so the table-walking coverage test
+# beside this one cannot see a single atomic - and every one of them was unclassified
+# until #2477, which would have refused `std.sync.atomic` inside `#[oblivious]` the
+# moment those bodies were inlined.
+#
+# Unlike aarch64's, this channel cannot be probed over a generated alphabet: the
+# accepted spellings are multi-character base names, so the space is not enumerable.
+# The base list below is therefore a COPY of `rv_decode_amo`'s own accepted set, and
+# the count assertion is what keeps the two from drifting: a base name added to the
+# decoder without being added here changes the number the probe accepts, and this
+# test fails rather than silently covering less than it claims.
+test "mach.lang.target.isa.riscv64.encode.asm_ct_class:decode_channel_is_classified" {
+    var bad: i32 = 0;
+
+    # `rv_decode_amo`'s accepted base names, in its own order.
+    var bases: [11]str;
+    bases[0] = "lr";      bases[1] = "sc";       bases[2] = "amoswap";
+    bases[3] = "amoadd";  bases[4] = "amoxor";   bases[5] = "amoand";
+    bases[6] = "amoor";   bases[7] = "amominu";  bases[8] = "amomaxu";
+    bases[9] = "amomin";  bases[10] = "amomax";
+
+    # every width x ordering combination the decoder strips.
+    var sfx: [8]str;
+    sfx[0] = ".w";       sfx[1] = ".d";
+    sfx[2] = ".w.aq";    sfx[3] = ".d.aq";
+    sfx[4] = ".w.rl";    sfx[5] = ".d.rl";
+    sfx[6] = ".w.aqrl";  sfx[7] = ".d.aqrl";
+
+    var accepted: u32 = 0;
+    var i: usize = 0;
+    for (i < 11) {
+        var j: usize = 0;
+        for (j < 8) {
+            var buf: [32]u8;
+            val n1: usize = t_copy_str(?buf[0], 0, bases[i]);
+            val n2: usize = t_copy_str(?buf[0], n1, sfx[j]);
+            buf[n2] = 0;
+            val body: str = (?buf[0])::str;
+
+            var m: iasm.Mnemonic;
+            var used: usize = 0;
+            if (rv_decode_amo(body, 0, n2, ?m, ?used)) {
+                accepted = accepted + 1;
+                if (!asm_ct_class(m.code, m.flags).known) { bad = 1; }
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+
+    # 11 bases x 8 suffixes, all accepted. a base added to the decoder and not here
+    # moves this number, which is the drift guard.
+    if (accepted != 88) { bad = 1; }
+    ret bad;
+}
+
+# append `s` into `dst` at `at`, returning the new end (test helper)
+fun t_copy_str(dst: *u8, at: usize, s: str) usize {
+    var i: usize = 0;
+    for (s[i] != 0) { dst[at + i] = s[i]; i = i + 1; }
+    ret at + i;
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -6944,7 +6944,7 @@ test "mach.lang.target.isa.x64.encode.encode_fp_mov:single_instruction_shapes" {
 # ---
 # code: the mnemonic's x86-64 opcode
 # ret:  its classification, or `ct.asm_unknown()` when unclassified
-pub fun asm_ct_class(code: u32) ct.AsmClass {
+pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     # data movement, address formation, and the extends: constant-time everywhere.
     if (code == x64.MOV::u32 || code == x64.MOVZX::u32 || code == x64.MOVSX::u32 ||
         code == x64.LEA::u32 || code == x64.PUSH::u32  || code == x64.POP::u32 ||
@@ -7002,7 +7002,7 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_is_classifi
         # `.byte` is a directive, not an instruction: its payload is opaque bytes the
         # walk refuses on kind, so it carries no classification.
         if (!str_equals(m.name, ".byte")) {
-            val cls: ct.AsmClass = asm_ct_class(m.code);
+            val cls: ct.AsmClass = asm_ct_class(m.code, m.flags);
             if (!cls.known) { bad = 1; }
         }
         i = i + 1;
@@ -7017,16 +7017,16 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:variable_latency_surface" {
 
     # the register-count shifts are the ONLY variable-latency form this grammar can
     # express, and they gate on the count operand alone.
-    if (asm_ct_class(x64.SHL::u32).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(x64.SHR::u32).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(x64.SAR::u32).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(x64.SHL::u32, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(x64.SHR::u32, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(x64.SAR::u32, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
     if (!ct.ct_op_gates_count_only(ct.CT_OP_VAR_SHIFT))      { bad = 1; }
 
     # there is no divide, multiply or float row to reach: check (c) is otherwise
     # vacuous HERE, which is why the honest note is per-target.
     var i: usize = 0;
     for (i < X64_MNEMONIC_COUNT) {
-        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code);
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
         if (cls.op == ct.CT_OP_INT_DIVMOD) { bad = 1; }
         if (cls.op == ct.CT_OP_INT_MUL)    { bad = 1; }
         if (cls.op == ct.CT_OP_FLOAT)      { bad = 1; }
@@ -7034,14 +7034,14 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:variable_latency_surface" {
     }
 
     # every conditional jump is refused; the unconditional one is not.
-    if (!asm_ct_class(x64.JE::u32).cond_flags)  { bad = 1; }
-    if (!asm_ct_class(x64.JNE::u32).cond_flags) { bad = 1; }
-    if (!asm_ct_class(x64.JB::u32).cond_flags)  { bad = 1; }
-    if (!asm_ct_class(x64.JAE::u32).cond_flags) { bad = 1; }
-    if (asm_ct_class(x64.JMP::u32).cond_flags)  { bad = 1; }
+    if (!asm_ct_class(x64.JE::u32, 0).cond_flags)  { bad = 1; }
+    if (!asm_ct_class(x64.JNE::u32, 0).cond_flags) { bad = 1; }
+    if (!asm_ct_class(x64.JB::u32, 0).cond_flags)  { bad = 1; }
+    if (!asm_ct_class(x64.JAE::u32, 0).cond_flags) { bad = 1; }
+    if (asm_ct_class(x64.JMP::u32, 0).cond_flags)  { bad = 1; }
     # and no x86-64 branch is register-conditioned, which is the whole reason the
     # flags refusal exists on this target.
-    if (asm_ct_class(x64.JE::u32).cond_reg)     { bad = 1; }
+    if (asm_ct_class(x64.JE::u32, 0).cond_reg)     { bad = 1; }
 
     ret bad;
 }


### PR DESCRIPTION
Closes #2477. Fail-open defect in the `#[oblivious]` inline-asm gate, introduced by #2230 (mine), found while re-verifying #2231's framing.

## The hole

```mach
#[oblivious]
fun a64_secret_branch(k: ^u64) ^u64 {
    var r: ^u64 = k;
    asm aarch64 {
        ldr x9, {r}     # the secret into x9
        cmp x9, x1      # compare the secret
        b.eq 1f         # BRANCH ON IT
1:
        nop
    }
    ret r;
}
```

Compiled **clean** on dev @ `292f879f`. A secret-dependent branch with a compiler-issued constant-time guarantee attached — exactly what the gate exists to prevent. Verified by execution, before and after.

## Root cause: a grammar has two admission channels

Besides the static `Mnemonic` table, each grammar has a `decode` hook. **`a64_decode_bcond` admits `b.<cond>` with `m.code = A64M_B`** — the *unconditional* branch's own code — carrying the condition in `m.flags`. Classifying on `code` alone therefore read every `b.eq` as an unconditional branch: `CT_OP_NONE`, `known`, not conditional. It walked as leak-free.

The classifier now takes `(code, flags)` and refuses a flags-conditioned branch on aarch64 as it already did on x86-64.

> One detail worth a reviewer's eye: the test is **pattern equality**, not a bitwise AND. `A64P_*` are *enumerated values* in the low byte, so `flags & A64P_BCOND` matches every pattern sharing a set bit — my first attempt did exactly that and refused half the grammar. The suite caught it.

## riscv64: the same channel, failing closed

`rv_decode_amo` admits the entire A extension — `lr`/`sc` and the AMOs, after stripping `.w`/`.d` and `.aq`/`.rl`/`.aqrl` — with codes absent from the static table. **All twenty-two were unclassified.** That is fail-*closed*, so not a leak, but it would have refused `std.sync.atomic` inside `#[oblivious]` the moment **#2231** inlined those bodies — the "strictly worse" outcome the sequencing comment predicted, arriving through the channel nobody was watching. Now classified under the same conditional atomics row, which still holds only because check (b) refuses a secret address.

## Why the old test missed it, and what replaces it

The #2230 coverage test walked `A64_MNEMONICS` and asserted no row is flags-conditioned. That is **true of the table and false of the grammar** — it tested the wrong entity, in the one place where that is a leak rather than a wrong number.

The replacement **probes the decoder** rather than a copy of its accepted list: every two-letter suffix is offered to `a64_decode_bcond`, and whatever it *accepts* must classify as flags-conditioned. A condition added to `asm_parse_cond` later is picked up without touching the test, and the probe asserts it accepted something so it cannot pass vacuously.

riscv64's channel cannot be probed that way — its spellings are multi-character base names, so the space is not enumerable. That test enumerates the decoder's own base list (11 bases × 8 suffixes) with a **count assertion as the drift guard**: a base added to the decoder without being added here moves the number and fails the test. Stated plainly in the test's own comment, per the ruling's fallback.

## Tests and mutations

Added: the `b.eq` repro must refuse; the aarch64 **LL/SC** loop (`ldaxr` / `stlxr` / `cbnz` on the status register) must still be **accepted**, since the fix must close the flags hole without breaking the register-conditioned path beside it; and both decode-channel coverage tests.

Mutations, all caught:

| mutation | result |
|---|---|
| remove the aarch64 `b.<cond>` guard (reopen the hole) | **the structural decode-channel test AND the leak regression both fail** |
| bitwise `&` instead of pattern equality | 3 tests fail |
| drop the riscv64 AMO classification | the riscv64 decode-channel test fails |

The first is the important one: the *structural* test catches the reopened hole, which is precisely what the enumerative one could not do.

## Docs

`secrecy.md` shipped the claim that aarch64 has no flags-conditioned branch. It is corrected here — a false statement in merged documentation is worse than one in a PR body — and now says that `b.<cond>` exists, is refused, and is easy to miss *because it does not appear in the mnemonic table at all*.

## Verification

Three-generation fixpoint `b == c`; `mach test` **1034 / 0**; `int` green on `linux` and `linux-riscv64`. Dev delta check: **0 files**, so no re-merge. No byte-identity bar — this change is emission-altering by design on the refusal path.