### PR TITLE
fix(build): build every declared artifact for the selected target

### DIFF
--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -530,6 +530,36 @@ A build cell is one artifact × one target × one profile.
   only). If two artifacts' objects collide on symbols in that union, that is an
   honest link error — restructure the entries.
 
+### Enumerated cells are filtered; named ones are not
+
+A cell whose artifact does not list the cell's target is a cell the manifest never
+declared, so enumerating skips it. Naming that pair is a different act: `--bin
+kernel --target host` is refused by name, because you asked for a cell that does not
+exist. `--bin kernel --all-targets` re-enumerates the target axis and so filters
+back to the targets `kernel` declares.
+
+If a selection is well-formed but enumerates nothing — a `--target` no artifact
+lists — the build fails naming that target and the declared artifacts, rather than
+succeeding with an empty plan.
+
+### `-o` names one output
+
+`-o` is accepted exactly when the selection resolves to a single build cell, and
+refused otherwise, naming the cells it resolved to. Two artifacts collide on one
+output path the same way two targets do: each would link over the previous, leaving
+only the last with no warning. Narrow with `--bin`/`--lib` and `--target`.
+
+### When one cell fails
+
+Every cell is attempted; a failure does not abandon the ones after it. Each cell's
+diagnostics are reported under its own heading as it happens, and every cell that
+succeeded leaves its artifact on disk at its own path — nothing is rolled back. The
+exit code is `0` when all cells succeeded, `2` if the first failure was an internal
+error, and `1` otherwise.
+
+Artifacts cannot share an output path: a manifest whose expanded `out` templates
+collide is rejected before the build starts.
+
 ### `native` target resolution
 
 `native` resolves the host's `(isa, os)` against the **declared** targets only —

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -102,40 +102,6 @@ pub fun plan_invocation(a: *A.Allocator, root: str, cli: *args.CliArgs, goal: re
     ret plan_r;
 }
 
-# reject a `mach build` flag combination that cannot produce correct output
-#
-# `-o` names a single artifact path; `--all-targets` builds every declared
-# target. Combined, each target would link to that one path and overwrite the
-# previous, leaving only the last target's binary with no warning. A per-target
-# `-o` template could be considered later; an explicit error is the floor.
-# ---
-# config: the parsed CLI config
-# ret:    ok(true) when the combination is valid, err naming the conflict
-fun reject_output_all_targets(config: *args.CliArgs) R.Result[bool, str] {
-    if (config.output != nil && config.all_targets) {
-        ret R.err[bool, str]("-o cannot be combined with --all-targets (it names a single output)");
-    }
-    ret R.ok[bool, str](true);
-}
-
-# `-o` and `--all-targets` are rejected together; either alone is accepted
-test "mach.cli.cmd.build.reject_output_all_targets:rejects_the_pair" {
-    var config: args.CliArgs;
-
-    config.output      = "bin/app";
-    config.all_targets = true;
-    if (R.is_ok[bool, str](reject_output_all_targets(?config)))  { ret 1; }
-
-    config.all_targets = false;
-    if (R.is_err[bool, str](reject_output_all_targets(?config))) { ret 1; }
-
-    config.output      = nil;
-    config.all_targets = true;
-    if (R.is_err[bool, str](reject_output_all_targets(?config))) { ret 1; }
-
-    ret 0;
-}
-
 # `mach build` subcommand entry point
 #
 # parse -> compose -> plan -> execute -> render: the flags settle into a
@@ -179,12 +145,6 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         val f: outcome.Fail = outcome.user("--bin and --lib cannot be combined");
         ret cli_diag.render_fail(?f);
     }
-    val oc: R.Result[bool, str] = reject_output_all_targets(?config);
-    if (R.is_err[bool, str](oc)) {
-        val f: outcome.Fail = outcome.user(R.unwrap_err[bool, str](oc));
-        ret cli_diag.render_fail(?f);
-    }
-
     # mark the flags `mach build` accepts from their tables - the cross-cutting
     # set (`parse` read their values), the `-O` override, the build-flow inputs,
     # and `--explain` (prints the resolved plan and builds nothing) - then reject
@@ -245,14 +205,9 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         arena.dnit(?menu_ar);
         ret c;
     }
+    # a successful plan always holds at least one unit - an empty matrix is the
+    # planner's own error, naming the target nothing was declared for.
     val bp: plan.BuildPlan = R.unwrap_ok[plan.BuildPlan, outcome.Fail](plan_r);
-    if (bp.units.len == 0) {
-        val f: outcome.Fail = outcome.user("nothing to build");
-        val c: i64 = cli_diag.render_fail(?f);
-        session.dnit(?ps);
-        arena.dnit(?menu_ar);
-        ret c;
-    }
 
     # `--explain`: render the resolved plan and exit without building.
     if (explain_only) {

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -145,6 +145,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         val f: outcome.Fail = outcome.user("--bin and --lib cannot be combined");
         ret cli_diag.render_fail(?f);
     }
+
     # mark the flags `mach build` accepts from their tables - the cross-cutting
     # set (`parse` read their values), the `-O` override, the build-flow inputs,
     # and `--explain` (prints the resolved plan and builds nothing) - then reject

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -1839,6 +1839,143 @@ test "mach.lang.build.plan.plan:matrix_expands_targets_outer_artifacts_inner" {
     ret 0;
 }
 
+# the multi-artifact project (#2474): a hosted tool and a freestanding kernel
+# from one manifest, plus a target neither declares. the shape the fix exists
+# for - one invocation per artifact was the only way to build it.
+fun ut_split_src() str {
+    ret "[project]\nid = \"p\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n[target.host]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n[target.kern]\nisa = \"x86_64\"\nos = \"freestanding\"\nabi = \"sysv64\"\n[target.other]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n[artifact.tool]\nkind = \"bin\"\nentry = \"tool.mach\"\nout = \"bin/tool\"\ntargets = [\"host\"]\nlink = []\nneed = []\n[artifact.kernel]\nkind = \"bin\"\nentry = \"kernel.mach\"\nout = \"bin/kernel\"\ntargets = [\"kern\"]\nlink = []\nneed = []\n";
+}
+
+# a plain build enumerates every artifact and keeps only those declaring the
+# selected target: the freestanding kernel is absent from a host build, rather
+# than the whole invocation refusing to choose between the two (#2474)
+test "mach.lang.build.plan.plan:artifacts_expand_filtered_by_target" {
+    var alloc: A.Allocator;
+    var itn:   intern.Interner;
+    var reg:   target.TargetRegistry;
+    var m:     manifest.Manifest;
+    if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, ut_split_src())) { ret 1; }
+
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = "/r";
+
+    val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
+    val bp: BuildPlan = R.unwrap_ok[BuildPlan, outcome.Fail](pr);
+
+    if (bp.units.len != 1)                                  { ret 1; }
+    if (!str_equals(bp.units.data[0].sel_artifact, "tool")) { ret 1; }
+    if (!ut_path_eq(bp.units.data[0].out_path, "/r/out/host/debug/bin/tool")) { ret 1; }
+    ret 0;
+}
+
+# `--all-targets` crosses both axes and keeps every declared cell: 3 targets x
+# 2 artifacts enumerates 6, of which the manifest declares 2. `other` is
+# declared by neither artifact and contributes nothing.
+test "mach.lang.build.plan.plan:all_targets_keeps_declared_cells" {
+    var alloc: A.Allocator;
+    var itn:   intern.Interner;
+    var reg:   target.TargetRegistry;
+    var m:     manifest.Manifest;
+    if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, ut_split_src())) { ret 1; }
+
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = "/r";
+    rq.all_targets  = true;
+
+    val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
+    val bp: BuildPlan = R.unwrap_ok[BuildPlan, outcome.Fail](pr);
+
+    if (bp.units.len != 2)                                    { ret 1; }
+    if (!str_equals(bp.units.data[0].sel_target, "host"))     { ret 1; }
+    if (!str_equals(bp.units.data[0].sel_artifact, "tool"))   { ret 1; }
+    if (!str_equals(bp.units.data[1].sel_target, "kern"))     { ret 1; }
+    if (!str_equals(bp.units.data[1].sel_artifact, "kernel")) { ret 1; }
+    if (!ut_path_eq(bp.units.data[1].out_path, "/r/out/kern/debug/bin/kernel")) { ret 1; }
+    ret 0;
+}
+
+# a named artifact whose `targets` excludes the selected target is refused by
+# name: the filter applies to enumerated cells only, never to a cell the
+# invoker asked for. `--all-targets` re-enumerates the target axis, so the same
+# artifact then filters to the targets it declares (#2484).
+test "mach.lang.build.plan.plan:explicit_selection_errors_enumerated_filters" {
+    var alloc: A.Allocator;
+    var itn:   intern.Interner;
+    var reg:   target.TargetRegistry;
+    var m:     manifest.Manifest;
+    if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, ut_split_src())) { ret 1; }
+
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = "/r";
+    rq.artifact     = "kernel";
+
+    val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (!R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
+    var f: outcome.Fail = R.unwrap_err[BuildPlan, outcome.Fail](pr);
+    if (!str_contains(f.message, "does not support target")) { ret 1; }
+
+    rq.all_targets = true;
+    val pa: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (R.is_err[BuildPlan, outcome.Fail](pa)) { ret 1; }
+    val bp: BuildPlan = R.unwrap_ok[BuildPlan, outcome.Fail](pa);
+    if (bp.units.len != 1)                                { ret 1; }
+    if (!str_equals(bp.units.data[0].sel_target, "kern")) { ret 1; }
+    ret 0;
+}
+
+# a well-formed selection that enumerates no declared cell is an error naming
+# the target, not an empty plan the caller has to interpret
+test "mach.lang.build.plan.plan:no_declared_cell_names_the_target" {
+    var alloc: A.Allocator;
+    var itn:   intern.Interner;
+    var reg:   target.TargetRegistry;
+    var m:     manifest.Manifest;
+    if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, ut_split_src())) { ret 1; }
+
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = "/r";
+    rq.target       = "other";
+
+    val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (!R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
+    var f: outcome.Fail = R.unwrap_err[BuildPlan, outcome.Fail](pr);
+    if (!str_contains(f.message, "no artifact declares target 'other'")) { ret 1; }
+    if (!str_contains(f.message, "tool"))                                { ret 1; }
+    ret 0;
+}
+
+# `-o` names one path, so it is legal exactly when the selection resolved to
+# one unit. two artifacts collide on it just as two targets do - the plan's
+# shape decides, not the flag combination.
+test "mach.lang.build.plan.plan:out_override_requires_a_single_unit" {
+    var alloc: A.Allocator;
+    var itn:   intern.Interner;
+    var reg:   target.TargetRegistry;
+    var m:     manifest.Manifest;
+    if (!ut_scaffold(?alloc, ?itn, ?reg, ?m)) { ret 1; }
+
+    # both artifacts declare `*`, so a plain build resolves two units
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = "/r";
+    rq.out          = "bin/custom";
+
+    val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (!R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
+    var f: outcome.Fail = R.unwrap_err[BuildPlan, outcome.Fail](pr);
+    if (!str_contains(f.message, "-o names a single output")) { ret 1; }
+
+    # narrowing the artifact axis leaves one unit, and `-o` applies
+    rq.artifact = "appa";
+    val pa: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (R.is_err[BuildPlan, outcome.Fail](pa)) { ret 1; }
+    val bp: BuildPlan = R.unwrap_ok[BuildPlan, outcome.Fail](pa);
+    if (bp.units.len != 1)                                  { ret 1; }
+    if (!ut_path_eq(bp.units.data[0].out_path, "/r/bin/custom")) { ret 1; }
+    ret 0;
+}
+
 # the phase list follows the goal: an execute goal emits and links, an objects
 # goal stops at emit, a test-list goal compiles only, a tests goal links the
 # dispatcher at the resolved `tests` template path

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -1856,8 +1856,11 @@ test "mach.lang.build.plan.plan:artifacts_expand_filtered_by_target" {
     var m:     manifest.Manifest;
     if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, ut_split_src())) { ret 1; }
 
+    # the target is named rather than defaulted: `native` resolution is
+    # host-dependent, and this pins the artifact filter, not target selection.
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = "/r";
+    rq.target       = "host";
 
     val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
     if (R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
@@ -1907,15 +1910,19 @@ test "mach.lang.build.plan.plan:explicit_selection_errors_enumerated_filters" {
     var m:     manifest.Manifest;
     if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, ut_split_src())) { ret 1; }
 
+    # both axes named: neither is enumerated, so the pair is refused by name
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = "/r";
     rq.artifact     = "kernel";
+    rq.target       = "host";
 
     val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
     if (!R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
     var f: outcome.Fail = R.unwrap_err[BuildPlan, outcome.Fail](pr);
-    if (!str_contains(f.message, "does not support target")) { ret 1; }
+    if (!str_contains(f.message, "artifact 'kernel' does not support target 'host'")) { ret 1; }
 
+    # the target axis enumerates again, so the same artifact filters to its own
+    rq.target      = "";
     rq.all_targets = true;
     val pa: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
     if (R.is_err[BuildPlan, outcome.Fail](pa)) { ret 1; }

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -236,6 +236,20 @@ pub fun plan(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry
                 aname    = O.unwrap[str](ao);
                 want_lib = m.artifacts[ai].is_lib;
             }
+
+            # an enumerated cell the manifest never declared is absent, not an
+            # error: the artifact's `targets` list decides which cells exist. A
+            # fully explicit selection is enumerated by neither axis and so
+            # reaches `resolve_build_unit`, which rejects the incompatible pair
+            # by name - the user asked for that cell and deserves to be told.
+            if (expand_targets || expand_artifacts) {
+                val sup_r: R.Result[bool, str] = cell_declared(a, itn, m, tname, aname, want_lib);
+                if (R.is_err[bool, str](sup_r)) {
+                    ret R.err[BuildPlan, outcome.Fail](outcome.user(R.unwrap_err[bool, str](sup_r)));
+                }
+                if (!R.unwrap_ok[bool, str](sup_r)) { ai = ai + 1; cnt; }
+            }
+
             val ur: R.Result[BuildUnit, outcome.Fail] = plan_unit(a, itn, reg, m, req, tname, aname, want_lib, true);
             if (R.is_err[BuildUnit, outcome.Fail](ur)) {
                 ret R.err[BuildPlan, outcome.Fail](R.unwrap_err[BuildUnit, outcome.Fail](ur));
@@ -246,12 +260,88 @@ pub fun plan(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry
         }
         ti = ti + 1;
     }
+
+    # every enumerated cell filtered out: the selection is well-formed but names
+    # nothing this manifest declares. Naming the target and the artifacts that
+    # skipped it is the difference between a usable message and "nothing to build".
+    if (bp.units.len == 0) {
+        ret R.err[BuildPlan, outcome.Fail](outcome.user(no_cells_msg(a, itn, m, req.target)));
+    }
+
+    # `-o` names ONE output path. Every unit would link to it in turn, leaving
+    # only the last with no warning, so it is legal exactly when the selection
+    # resolved to a single unit - a plan-shape rule, not a flag-shape one: two
+    # artifacts collide on `-o` just as two targets do.
+    if (!str_empty(req.out) && bp.units.len > 1) {
+        ret R.err[BuildPlan, outcome.Fail](outcome.user(out_conflict_msg(a, ?bp)));
+    }
     ret R.ok[BuildPlan, outcome.Fail](bp);
+}
+
+# the failure text for a selection that enumerated no declared cell
+#
+# Names the target that was selected and every artifact that does not declare
+# it, so the fix (a `--target`, or the artifact's `targets` list) is visible
+# without reading mach.toml.
+# ---
+# tsel: the invocation's target selector (empty selects the manifest default)
+fun no_cells_msg(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest, tsel: str) str {
+    var tname: str = "the default target";
+    if (!str_empty(tsel)) { tname = join_msg(a, "target '", tsel, "'"); }
+
+    var names: str = "";
+    var i: u32 = 0;
+    for (i < m.artifact_count) {
+        val ao: O.Option[str] = intern.lookup(itn, m.artifacts[i].name);
+        if (O.is_some[str](ao)) {
+            if (!str_empty(names)) { names = join_msg(a, names, ", "); }
+            names = join_msg(a, names, O.unwrap[str](ao));
+        }
+        i = i + 1;
+    }
+    ret join_msg(a, "mach.toml: no artifact declares ", tname, "; declared artifacts: ", names);
+}
+
+# the failure text for `-o` against a multi-unit plan
+#
+# Reports how many units the selection resolved to and how to narrow it, since
+# the conflict is invisible from the flags alone.
+fun out_conflict_msg(a: *A.Allocator, bp: *BuildPlan) str {
+    var cells: str = "";
+    var i: usize = 0;
+    for (i < bp.units.len) {
+        if (!str_empty(cells)) { cells = join_msg(a, cells, ", "); }
+        var tlabel: str = "the default target";
+        if (!str_empty(bp.units.data[i].sel_target)) { tlabel = bp.units.data[i].sel_target; }
+        cells = join_msg(a, cells, bp.units.data[i].sel_artifact, " for ", tlabel);
+        i = i + 1;
+    }
+    ret join_msg(a, "-o names a single output but the selection resolves to several build units (",
+        cells, "); narrow it with --bin/--lib and --target");
 }
 
 # the shared out-of-memory plan failure
 fun oom_plan() R.Result[BuildPlan, outcome.Fail] {
     ret R.err[BuildPlan, outcome.Fail](outcome.internal("out of memory"));
+}
+
+# whether the manifest declares one enumerated matrix cell
+#
+# The selection wrapper over `manifest.cell_supported`, which owns the rule.
+# ---
+# tname:    the cell's target selector (empty selects the manifest default)
+# aname:    the cell's artifact selector
+# want_lib: the artifact selector names a `[lib.*]`
+# ret:      whether the cell exists, or the failure that made it unresolvable
+fun cell_declared(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
+                  tname: str, aname: str, want_lib: bool) R.Result[bool, str] {
+    var sel: manifest.Selection;
+    sel.target       = tname;
+    sel.profile      = "";
+    sel.artifact     = aname;
+    sel.want_lib     = want_lib;
+    sel.has_artifact = true;
+    ret manifest.cell_supported(a, itn, m, sel);
 }
 
 # resolve one (target, artifact) cell into its concrete unit

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -281,15 +281,16 @@ pub fun release(r: *BuildRequest) bool {
 #
 # Applies ALL precedence: an explicit `-O*` wins over the profile's `opt`,
 # `-g` over the profile's `debug`, an explicit `--jobs` over the host CPU
-# count; emissions are the flag OR the profile default. The selection is
-# validated against the manifest through the same `resolve_build_unit` the
-# driver runs, so selection errors surface here with identical text and
-# precedence; for a test goal with no named artifact, a multi-artifact
-# manifest settles on the first declared artifact (the whole-source test
-# build links them all).
+# count; emissions are the flag OR the profile default. Only the profile is
+# resolved here - it is invocation-wide, shared by every cell. The artifact and
+# target selection stays unresolved: an invocation can name a whole matrix, so
+# binding it to one build unit here would be a category error (#2474). The
+# planner resolves each cell and raises selection errors with the same text.
+# For a test goal with no named artifact, a multi-artifact manifest settles on
+# the first declared artifact (the whole-source test build links them all).
 # ---
 # a:    allocator backing the request's link-input vectors and the transient
-#       unit resolution
+#       profile resolution
 # itn:  the interner the manifest was parsed into
 # m:    the parsed root manifest, loaded once and handed forward
 # cli:  the parsed command line
@@ -323,14 +324,17 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
     r.artifact = esel.artifact;
     r.want_lib = esel.want_lib;
 
-    # the selection and profile resolution: the same resolver the driver runs
-    # over the same manifest, so an invalid selection fails here first with
-    # the exact message the build would have produced.
-    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(a, itn, m, esel);
-    if (R.is_err[manifest.BuildUnit, str](ur)) {
-        ret R.err[BuildRequest, outcome.Fail](outcome.user(R.unwrap_err[manifest.BuildUnit, str](ur)));
+    # the profile resolution: every decision below is profile-derived, and the
+    # profile is invocation-wide - the same for every cell the planner
+    # enumerates. Resolving the *selection* here would bind the invocation to one
+    # artifact before the matrix exists, which is what made a multi-artifact
+    # `mach build` unreachable (#2474); the planner owns selection resolution and
+    # raises the identical text per cell.
+    val pr_r: R.Result[manifest.ResolvedProfile, str] = manifest.resolve_profile(a, itn, m, esel.profile);
+    if (R.is_err[manifest.ResolvedProfile, str](pr_r)) {
+        ret R.err[BuildRequest, outcome.Fail](outcome.user(R.unwrap_err[manifest.ResolvedProfile, str](pr_r)));
     }
-    val bu: manifest.BuildUnit = R.unwrap_ok[manifest.BuildUnit, str](ur);
+    val pf: manifest.ResolvedProfile = R.unwrap_ok[manifest.ResolvedProfile, str](pr_r);
 
     # optimization: an explicit CLI `-O*` is a per-invocation override that wins
     # outright; absent one the profile's `opt` decides, else the debug pipeline
@@ -338,15 +342,15 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
     if (cli.opt_set) {
         if (cli.opt_release) { r.opt = pipeline.OPT_RELEASE; }
     }
-    or (bu.opt == manifest.MOPT_RELEASE) {
+    or (pf.opt == manifest.MOPT_RELEASE) {
         r.opt = pipeline.OPT_RELEASE;
     }
 
-    r.debug     = cli.g || bu.debug;
+    r.debug     = cli.g || pf.debug;
     r.pie       = cli.pie;
-    r.simd          = bu.simd;
-    r.vectorize     = bu.vectorize;
-    r.float_reassoc = bu.float_reassoc;
+    r.simd          = pf.simd;
+    r.vectorize     = pf.vectorize;
+    r.float_reassoc = pf.float_reassoc;
     r.verify_ir = cli.verify_ir;
 
     # worker count: an explicit `--jobs` wins (a positive integer); absent it
@@ -365,8 +369,8 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
         if (nc > 1) { r.jobs = nc::u32; }
     }
 
-    r.emit_ir  = cli.emit_ir  || bu.emit_ir;
-    r.emit_asm = cli.emit_asm || bu.emit_asm;
+    r.emit_ir  = cli.emit_ir  || pf.emit_ir;
+    r.emit_asm = cli.emit_asm || pf.emit_asm;
     if (cli.output != nil) { r.out = cli.output::str; }
 
     r.link_tokens = vector.init[LinkToken](a);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7779,6 +7779,70 @@ fun ut_cap_fail(ctx: ptr, f: *outcome.Fail) {
     }
 }
 
+# the six-target host-matching manifest of ut_manifest, declaring TWO bins.
+# an end-to-end multi-artifact build needs the default target to match the host
+# (it links natively), which ut_manifest_multi's linux/windows pair does not give.
+fun ut_manifest_two_bins() str {
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64\"\n\n[target.darwin-x86_64]\nisa = \"x86_64\"\nos = \"darwin\"\nabi = \"sysv64\"\n\n[target.darwin-arm64]\nisa = \"aarch64\"\nos = \"darwin\"\nabi = \"aapcs64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# a plain build of a two-artifact manifest produces BOTH binaries in one
+# invocation (#2474). the end-to-end proof behind the planner's matrix tests:
+# two units plan, both link, and each lands at its own `out` path - the shape
+# that previously refused to build at all without --bin.
+test "mach.lang.build.engine.execute_warm_all:two_artifacts_both_link" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    # each artifact is its own link unit, so each entry carries the host's
+    # entry symbol; the scaffold vendors no std.
+    var names: [2]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach";
+    var texts: [2]str;
+    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun sa() i32 { ret 1; }\n");
+    texts[1] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun sb() i32 { ret 2; }\n");
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_two_bins(), ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+
+    # no artifact named: the selection every multi-artifact project wants
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    if (bp.units.len != 2) { bad = 1; }
+
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm_all(?bp, ?s, ?alloc, nil, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r);
+
+    if (!bo.ok)                { bad = 1; }
+    if (bo.artifacts.len != 2) { bad = 1; }
+    or {
+        # both on disk, each under the name its `out` template gave it
+        if (!fs.is_file(bo.artifacts.data[0].path)) { bad = 1; }
+        if (!fs.is_file(bo.artifacts.data[1].path)) { bad = 1; }
+        if (!ut_str_contains(bo.artifacts.data[0].path, "alpha")) { bad = 1; }
+        if (!ut_str_contains(bo.artifacts.data[1].path, "beta"))  { bad = 1; }
+        if (ut_str_contains(bo.artifacts.data[0].path, "beta"))   { bad = 1; }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
 # warm engine failure path: the fail event must carry the intact error text.
 # plan against a valid manifest, break the manifest on disk, execute_warm with
 # a render seam installed - the engine's per-call manifest load fails with a

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1743,6 +1743,51 @@ pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     ret R.ok[bool, str](true);
 }
 
+# whether an artifact's `targets` list admits a target
+#
+# The single owner of the `"*"`/by-name match. `resolve_build_unit` rejects an
+# explicitly named selection that fails it and `cell_supported` filters an
+# enumerated matrix cell by it, so the error path and the filter path can never
+# disagree about which cells an artifact declares.
+# ---
+# itn:   the interner the manifest was parsed into
+# a:     the artifact whose `targets` list is consulted
+# tname: the interned name of the resolved target
+# ret:   true when `targets` lists `"*"` or names the target
+pub fun artifact_supports_target(itn: *intern.Interner, a: *ArtifactDef, tname: intern.StrId) bool {
+    val star: intern.StrId = intern_unwrap(itn, "*");
+    var i: u32 = 0;
+    for (i < a.target_count) {
+        if (a.targets[i] == star || a.targets[i] == tname) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# whether a matrix cell exists: does the cell's artifact declare the cell's target
+#
+# The planner's filter for an enumerated axis. A cell the manifest never
+# declared is an absent cell, not a failure - only an explicit selection that
+# names an incompatible pair is an error, and `resolve_build_unit` owns that.
+# Resolution runs the same target and artifact resolvers that back the explicit
+# path, so the two agree by construction.
+# ---
+# alloc: allocator for the transient resolution
+# itn:   the interner the manifest was parsed into
+# m:     the parsed manifest
+# sel:   the cell's selection
+# ret:   whether the cell exists, or the failure that made it unresolvable
+pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[bool, str] {
+    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
+    if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[bool, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
+    val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](res_target);
+
+    val a: *ArtifactDef = resolve_artifact(itn, m, sel);
+    if (a == nil) { ret R.err[bool, str](artifact_err(alloc, itn, m, sel)); }
+
+    ret R.ok[bool, str](artifact_supports_target(itn, a, rt.target.name));
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
@@ -1755,17 +1800,9 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     val a: *ArtifactDef = resolve_artifact(itn, m, sel);
     if (a == nil) { ret R.err[BuildUnit, str](artifact_err(alloc, itn, m, sel)); }
 
-    # Check if target is supported
-    var target_ok: bool = false;
-    val star: intern.StrId = intern_unwrap(itn, "*");
-    var ti: u32 = 0;
-    for (ti < a.target_count) {
-        if (a.targets[ti] == star || a.targets[ti] == rt.target.name) {
-            target_ok = true;
-        }
-        ti = ti + 1;
-    }
-    if (!target_ok) {
+    # an explicitly named selection that names an incompatible pair is an error;
+    # the planner filters enumerated cells through the same predicate instead.
+    if (!artifact_supports_target(itn, a, rt.target.name)) {
         val art_name: str = idstr(itn, a.name);
         val tgt_name: str = idstr(itn, rt.target.name);
         ret R.err[BuildUnit, str](sfmt(alloc, "mach.toml: artifact '{}' does not support target '{}'", art_name, tgt_name));


### PR DESCRIPTION
Makes `mach build` match `doc/manifest.md`: every declared artifact whose `targets` includes the selected target, and every compatible (artifact, target) cell under `--all-targets`.

The planner (`plan.mach`) and engine were already fully multi-unit — the planner has expanded both axes since it was written, and the test at `plan.mach:matrix_expands_targets_outer_artifacts_inner` already asserted a 2x2 matrix. Two things sat in front of them.

**The pre-flight.** `request.compose` resolved the whole *selection* through `resolve_build_unit` as validation, which returns the `multiple artifacts declared` error and killed the invocation before `plan()` ran. Every decision compose takes from that resolution is profile-derived, so it now resolves the profile alone. Selection resolution belongs to the planner, which raises the identical text per cell.

**The target check.** `resolve_build_unit` hard-errored when an artifact’s `targets` excluded the cell’s target. Correct for an explicitly named selection, wrong for an enumerated cell — the manifest simply never declared that cell. The star/name match now lives in `manifest.artifact_supports_target`, called by both the error path and the planner’s filter, so they cannot drift apart.

This second half is #2484, a distinct user-visible bug that predates multi-artifact: `mach build . --all-targets --bin b` with **one** explicitly named, target-restricted artifact failed the same way.

### The rule

An enumerated cell is **filtered**; a fully explicit selection is an **error**. So `--bin b --target host` still says `artifact 'b' does not support target 'host'`, while `--bin b --all-targets` filters to the targets `b` declares.

### `-o`

Now a plan-shape rule — legal when the selection resolves to exactly one unit, rejected otherwise. It replaces `reject_output_all_targets`, a flag-shape check that caught `-o --all-targets` but would have sailed past `-o` on a two-artifact plain build: the same silent last-writer-wins overwrite it existed to prevent. Accepted consequence: `-o --all-targets` is legal when filtering leaves exactly one cell. That is not ambiguous, so it is not wrong.

### Failure semantics

Ratified as-is and now documented rather than emergent: continue-on-error. Every unit is attempted, the first failure classes the exit code (0 ok / 1 user / 2 internal), and each successful artifact is on disk at its own path — output collisions between artifacts are already rejected by `check_collisions`.

### Verified

Against a from-source compiler on a bmos-shaped manifest (host artifact + freestanding kernel artifact):

- plain `mach build .` → 1 unit, the host artifact only (kernel cell filtered)
- `--all-targets` → 2 units, `a@host` and `b@kernel`, incompatible cells skipped
- `--bin b` and `--bin b --target host` → error unchanged
- `--bin b --all-targets` → filters to kernel (#2484)
- `-o` with 2 units → new error naming the cells; with 1 unit → accepted
- no artifact declares the target → `no artifact declares target 'other'; declared artifacts: a, b`

Closes #2474
Closes #2484