### PR TITLE
docs(vector): state the real reason integer lane multiply is refused

### DIFF
--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -147,7 +147,13 @@ test "mach.lang.be.codegen.vector_runtime.arith:u64x2_add_sub" {
     ret 0;
 }
 
-# integer multiply is 16-bit lanes only (32-bit pmulld is SSE4.1, off-baseline).
+# integer multiply is covered at 16-bit lanes only because that is the width mach's
+# x86-64 baseline provides: SSE2 has PMULLW and no 32-bit lane multiply (PMULLD is
+# SSE4.1, off-baseline), and the language rule is uniform for that reason rather
+# than because wider integer lane multiply is universally unsupported - NEON has it.
+# Whether that uniformity should hold is RFC #2488; this coverage follows the rule
+# in `fe.sema` and moves only when it does.
+#
 # 256 * 2 = 512 crosses the byte boundary; a byte multiply gives 0.
 test "mach.lang.be.codegen.vector_runtime.arith:i16x8_mul" {
     var a: i16x8 = i16x8{ 256, 3, -4, 100, 5, 6, 7, 8 };

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1440,7 +1440,23 @@ fun infer_vector_binary(sc: *context.SemaContext, op: expr.BinOp, lt: type.TypeI
         ret join_secret(sc, lbase, either_secret);
     }
 
-    # `*` is float lanes, or 16-bit integer lanes only (pmulld is out of baseline).
+    # `*` is float lanes, or 16-bit integer lanes only - and the reason is a BASELINE
+    # fact about one target, not a property of the operation (#2349).
+    #
+    # mach's x86-64 baseline is SSE2, which multiplies 16-bit lanes (PMULLW) and has
+    # no 32-bit lane multiply; PMULLD arrives with SSE4.1, off-baseline. NEON has an
+    # integer lane multiply outright. The rule is uniform anyway, deliberately: this
+    # is the LANGUAGE surface, so admitting `i32x4 * i32x4` here would make a
+    # source-level operation compile on aarch64 and fail on x86-64.
+    #
+    # Whether mach's vector surface should stay uniform, scalarize the absent op, or
+    # become per-target is an open language question - RFC #2488. Until it is
+    # answered this stays uniform, and the same reasoning governs the two other homes
+    # of this rule (`me.transform.vectorize.supported_vector_op` and the
+    # `vector_runtime` multiply coverage), which must not drift from it.
+    #
+    # One hardware fact for whichever direction wins: AArch64 has NO integer multiply
+    # on `.2d`, so 64-bit integer lanes stay refused on that target regardless.
     if (op == expr.BIN_MUL) {
         if (float_lane || (int_lane && d.bits == 16)) {
             ret join_secret(sc, lbase, either_secret);

--- a/src/lang/me/transform/vectorize.mach
+++ b/src/lang/me/transform/vectorize.mach
@@ -618,6 +618,21 @@ fun admits(k: instruction.InstrKind, iid: id.InstructionId, is_float: bool, mask
     ret supported_vector_op(k, is_float);
 }
 
+# the ops this pass may put in a vector set
+#
+# INTEGER MULTIPLY IS ABSENT ON PURPOSE, and the reason is a baseline fact about one
+# target rather than a property of the operation (#2349). mach's x86-64 baseline is
+# SSE2: 16-bit lane multiply (PMULLW) and no 32-bit one, since PMULLD is SSE4.1 and
+# off-baseline. NEON has an integer lane multiply outright.
+#
+# It is refused uniformly rather than per-target because the language surface refuses
+# it uniformly (`fe.sema.infer`, same reason) - a vectorizer that admitted what the
+# source language rejects would make the auto-vectorized form of a loop legal where
+# the hand-written form is not. The two must move together, and whether they should
+# move at all is the open question in RFC #2488.
+#
+# This takes no target parameter for the same reason: consulting one here would
+# imply a per-target answer the rest of the surface does not have.
 fun supported_vector_op(k: instruction.InstrKind, is_float: bool) bool {
     if (k == instruction.OP_ADD) { ret true; }
     if (k == instruction.OP_SUB) { ret true; }


### PR DESCRIPTION
Closes #2349.

Per the ruling: the comment-truth fix, **not** the three-site capability change — that decision (whether mach's vector surface stays uniform, scalarizes, or goes per-target) is the language question in RFC #2488.

## What was wrong

The refusal was written three times as a property of the *operation*. It is a baseline fact about *one target*: mach's x86-64 baseline is SSE2 — PMULLW at 16-bit lanes, no 32-bit lane multiply, since PMULLD is SSE4.1. NEON has an integer lane multiply outright. So `integer multiply is 16-bit lanes only` was true of the rule and false about the world.

## What changed

All three sites now state the real reason and that they are **one rule**:

- `fe/sema/infer.mach` — the language surface, and why uniformity is deliberate: admitting `i32x4 * i32x4` would make a source-level operation compile on aarch64 and fail on x86-64.
- `me/transform/vectorize.mach` — refused uniformly *because the language refuses it uniformly*; a vectorizer admitting what the source rejects would make the auto-vectorized form of a loop legal where the hand-written form is not. Records why it takes no target parameter.
- `be/codegen/vector_runtime.mach` — the coverage follows the sema rule and moves with it.

Each points at #2488. The AArch64 `.2d` fact (no integer multiply on 64-bit lanes) is recorded where it belongs, since it constrains every candidate direction.

## Verification

Comment-only, asserted rather than claimed: the diff has **zero** non-comment changed lines (`git diff | grep -v '^[+-]\s*#'` is empty), and the emission bar is the load-bearing one —

| bar | result |
|---|---|
| objects vs dev-baseline compiler | 0/215 (self-check 0/215, positive control 1/215) |
| linked binary | identical |
| `mach test` | 1035 / 0, same as dev |

No fixpoint run: nothing executable moved, and byte-identity against dev is the stronger statement.