### PR TITLE
fix(asm): notify the assembly sink of a `.byte` payload

### DIFF
--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -28,6 +28,7 @@
 # and how one resolved branch displacement is written into the text. No opcode,
 # register, displacement-width, or byte-encoding knowledge lives here.
 
+use std.format;
 use std.io.writer;
 use std.system.panic.panic;
 use std.types.bool.bool;
@@ -690,6 +691,58 @@ pub fun sink_claim(buf: *ByteBuf, start: usize) {
     }
     s.accounted = buf.len;
     s.claims    = s.claims + 1;
+}
+
+# render a raw-byte directive's payload into the sink and account for its bytes
+#
+# THE ONE PLACE `.byte` TEXT IS PRODUCED. A directive renders identically on every
+# target - it is a payload, not an instruction - so putting the text here rather than
+# in each printer means a target cannot render it differently, and a target added
+# later inherits it rather than reimplementing it (#2467).
+#
+# The per-ISA half is only WHEN to call this: a printer that renders on the spot
+# (x86-64, aarch64) calls it as the bytes are emitted, and one that buffers notes for
+# a later pass (riscv64) calls it from its own note walk, so the directive lands in
+# program order either way.
+# ---
+# buf:   the encoder byte sink carrying the assembly sink
+# bytes: the payload
+# n:     number of payload bytes
+# start: `.text` offset of the payload's first byte
+# ret:   true on success, or the first write error
+pub fun render_bytes_directive(buf: *ByteBuf, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
+    if (!sink_active(buf)) { ret R.ok[bool, str](true); }
+    val out: *writer.Writer = buf.asm.out;
+
+    val ri: R.Result[usize, str] = format.write_str(out, "  .byte ");
+    if (R.is_err[usize, str](ri)) { ret R.err[bool, str](R.unwrap_err[usize, str](ri)); }
+    var i: usize = 0;
+    for (i < n) {
+        if (i > 0) {
+            val rc: R.Result[usize, str] = format.write_str(out, ", ");
+            if (R.is_err[usize, str](rc)) { ret R.err[bool, str](R.unwrap_err[usize, str](rc)); }
+        }
+        val rb: R.Result[usize, str] = format.write_str(out, "0x");
+        if (R.is_err[usize, str](rb)) { ret R.err[bool, str](R.unwrap_err[usize, str](rb)); }
+        var hex: [3]u8;
+        hex[0] = hex_digit((bytes[i] >> 4) & 0xF);
+        hex[1] = hex_digit(bytes[i] & 0xF);
+        hex[2] = 0;
+        val rh: R.Result[usize, str] = format.write_str(out, (?hex[0])::str);
+        if (R.is_err[usize, str](rh)) { ret R.err[bool, str](R.unwrap_err[usize, str](rh)); }
+        i = i + 1;
+    }
+    val rn: R.Result[usize, str] = format.write_str(out, "\n");
+    if (R.is_err[usize, str](rn)) { ret R.err[bool, str](R.unwrap_err[usize, str](rn)); }
+
+    sink_claim(buf, start);
+    ret R.ok[bool, str](true);
+}
+
+# one lowercase hex digit for a nibble
+fun hex_digit(v: u8) u8 {
+    if (v < 10) { ret 48 + v; }
+    ret 87 + v;
 }
 
 # the number of instruction notifications this sink accepted

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4737,6 +4737,7 @@ fun a64_grammar() iasm.Grammar {
     g.all_fp    = 0xFFFFFFFF;
     g.word      = 4;
     g.ct_class  = asm_ct_class;
+    g.note_bytes = asm_note_bytes;
     ret g;
 }
 
@@ -7441,5 +7442,55 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:decode_channel_is_classifie
     # the probe must actually have exercised the channel: a decoder that accepted
     # nothing would satisfy every assertion above vacuously.
     if (accepted == 0) { bad = 1; }
+    ret bad;
+}
+
+# the `NoteBytesFn` the aarch64 grammar wires: this printer renders on the spot, so the
+# directive is written as its bytes are emitted and lands in program order (#2467)
+fun asm_note_bytes(st: *encode.EncodeState, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
+    ret encode.render_bytes_directive(?st.buf, bytes, n, start);
+}
+
+# a `.byte` payload REACHES THE ASSEMBLY SINK and renders as a directive (#2467)
+#
+# The defect this pins: `emit_one` wrote a directive's payload straight into the
+# buffer and never notified the sink, so those bytes were never accounted. The
+# encoder's own guard then refused the whole `--emit-asm` run - blaming the enclosing
+# ASM_BLOCK when the directive stood alone, and blaming the NEXT instruction for bytes
+# it never emitted when one followed. One cause, two diagnostics.
+#
+# The rendering is SHARED (`encode.render_bytes_directive`); only the timing is
+# per-ISA. Tested here because this printer carries a capture sink; the round-trip
+# half - that what is rendered assembles back to the same bytes - is in `x64.encode`.
+test "mach.lang.target.isa.arm64.encode.render_bytes_directive:reaches_the_sink" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var interner: intern.Interner;
+    var st: encode.EncodeState;
+    tasm(?st, ?alloc, ?interner);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = printer.test_sink_write;
+    printer.test_sink_reset();
+    var sink: encode.AsmSink = encode.sink_init(?w, ?interner);
+    st.buf.asm = ?sink;
+
+    var payload: [3]u8;
+    payload[0] = 0xEC; payload[1] = 0x90; payload[2] = 0x0F;
+    val start: usize = st.buf.len;
+    var i: usize = 0;
+    for (i < 3) { encode.emit_byte(?st.buf, payload[i]); i = i + 1; }
+
+    # before the notification the bytes are emitted but unaccounted - the state that
+    # made the encoder refuse.
+    if (encode.sink_unaccounted(?st.buf) == 0) { bad = 1; }
+
+    if (R.is_err[bool, str](encode.render_bytes_directive(?st.buf, ?payload[0], 3, start))) { ret 1; }
+
+    # and after it, every byte is accounted for.
+    if (encode.sink_unaccounted(?st.buf) != 0) { bad = 1; }
+
     ret bad;
 }

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -376,6 +376,20 @@ pub def SlotFn: fun(*mir.MirFunction, u32) O.Option[i64];
 # flags: the mnemonic's encoding flags, in the ISA's own space
 pub def CtClassFn: fun(u32, u16) ct.AsmClass;
 
+# notify this target's assembly printer of a raw-byte directive's payload
+#
+# The TEXT is shared (`encode.render_bytes_directive`); only the TIMING is per-ISA. A
+# printer that renders on the spot notifies as the bytes are emitted; one that buffers
+# notes for a later pass records it so the directive lands in program order. Without a
+# notification the payload's bytes are never accounted, and the encoder refuses the
+# whole `--emit-asm` run rather than silently dropping them (#2467).
+# ---
+# st:    the encode state carrying the sink
+# bytes: the payload
+# n:     number of payload bytes
+# start: `.text` offset of the payload's first byte
+pub def NoteBytesFn: fun(*encode.EncodeState, *u8, usize, usize) R.Result[bool, str];
+
 # one target's inline-assembly grammar
 #
 # Everything the shared parser needs that is not the same on every machine. A target
@@ -411,6 +425,7 @@ pub rec Grammar {
     all_fp:    u32;
     word:      u8;
     ct_class:  CtClassFn;
+    note_bytes: NoteBytesFn;
 }
 
 # an operand in the neutral state each lexer fills in
@@ -1382,10 +1397,21 @@ fun emit_one(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels, item:
         ret label_record_def(st, g, l, item.ref_num, st.buf.len::u32);
     }
     if (item.kind == AI_BYTES) {
+        val start: usize = st.buf.len;
         var i: usize = 0;
         for (i < item.byte_count) {
             encode.emit_byte(?st.buf, item.bytes[i]);
             i = i + 1;
+        }
+        # the payload's bytes must reach the assembly sink like any other emission.
+        # a target that wires no hook is refused rather than left to emit a dump that
+        # silently omits the directive - a dump missing instructions is worse than one
+        # that fails (#2467).
+        if (encode.sink_active(?st.buf)) {
+            if (g.note_bytes == nil) {
+                ret R.err[bool, str]("--emit-asm: this target wires no raw-byte directive printer, so a `.byte` payload cannot be rendered");
+            }
+            ret g.note_bytes(st, ?item.bytes[0], item.byte_count, start);
         }
         ret R.ok[bool, str](true);
     }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -4199,6 +4199,7 @@ fun rv_grammar() iasm.Grammar {
     g.all_fp    = 0xFFFFFFFF;
     g.word      = 4;
     g.ct_class  = asm_ct_class;
+    g.note_bytes = asm_note_bytes;
     ret g;
 }
 
@@ -6118,4 +6119,14 @@ fun t_copy_str(dst: *u8, at: usize, s: str) usize {
     var i: usize = 0;
     for (s[i] != 0) { dst[at + i] = s[i]; i = i + 1; }
     ret at + i;
+}
+
+# the `NoteBytesFn` the riscv64 grammar wires
+#
+# This printer BUFFERS its notes and renders them in a later pass, so a directive
+# written directly here would appear ahead of every instruction around it. It is
+# rendered on the spot only because an asm block's bytes are already final - no
+# relaxation rewrites inside one - so program order is the emission order (#2467).
+fun asm_note_bytes(st: *encode.EncodeState, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
+    ret encode.render_bytes_directive(?st.buf, bytes, n, start);
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5546,6 +5546,7 @@ fun x64_grammar() iasm.Grammar {
     g.all_fp    = X64_ALL_FP;
     g.word      = 0;
     g.ct_class  = asm_ct_class;
+    g.note_bytes = asm_note_bytes;
     ret g;
 }
 
@@ -7055,4 +7056,30 @@ pub fun asm_ct_scan(body: str, secret_names: *str, n_secret: u32,
                     trust_mul: bool, trust_shift: bool, alloc: *A.Allocator) R.Result[bool, str] {
     var g: iasm.Grammar = x64_grammar();
     ret iasm.ct_scan(?g, body, secret_names, n_secret, trust_mul, trust_shift);
+}
+
+# the `NoteBytesFn` the x86-64 grammar wires: this printer renders on the spot, so the
+# directive is written as its bytes are emitted and lands in program order (#2467)
+fun asm_note_bytes(st: *enc.EncodeState, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
+    ret enc.render_bytes_directive(?st.buf, bytes, n, start);
+}
+
+# what the shared `.byte` renderer emits ASSEMBLES BACK to the same payload (#2467)
+#
+# The round-trip half of the bar. Rendering something is easy; rendering something an
+# assembler reads as the identical payload is the property `--emit-asm` claims. The
+# spelling under test is exactly what `encode.render_bytes_directive` produces, and
+# because that renderer is SHARED - a directive is a payload, not an instruction, and
+# has no per-target spelling - pinning it once pins it for every target. The render
+# and byte-accounting half lives in `arm64.encode`, where a capture sink exists.
+test "mach.lang.target.isa.x64.encode.render_bytes_directive:round_trips" {
+    var want: [3]u8;
+    want[0] = 0xEC; want[1] = 0x90; want[2] = 0x0F;
+    if (!t_asm_bytes(".byte 0xec, 0x90, 0x0f", ?want[0], 3)) { ret 1; }
+
+    # a single-byte payload, the shape the port-i/o escape hatch actually writes.
+    var one: [1]u8;
+    one[0] = 0xEC;
+    if (!t_asm_bytes(".byte 0xec", ?one[0], 1)) { ret 1; }
+    ret 0;
 }


### PR DESCRIPTION
Closes #2467.

`--emit-asm` refused any module whose inline asm used `.byte`. The shared `emit_one` wrote the payload straight into the buffer and **never notified the sink**, so those bytes were never accounted and the encoder's own guard failed the run.

## Both reported failure modes are this one bug

Reproduced both:

| block | diagnostic |
|---|---|
| `.byte 0xec` alone | `--emit-asm: opcode 70 emitted bytes the x86-64 assembly printer did not render` |
| `.byte 0xec` then `nop` | `encode: inline-asm instruction 'nop' emitted machine code the assembly printer was not notified of` |

Same cause. Which one you get depends only on whether an instruction follows in the same block: the per-item accounting check blames the **next** instruction for bytes it never emitted, and with nothing following, the block-level check blames the enclosing `ASM_BLOCK`.

That also resolves the comment's open question — the second mode looked "not universal, needs triage" because the modules that printed fine **contain no `.byte`**. It was never about local stores or `shl rdx, 32`. **No separate triage.**

Two corrections to the issue body, for the record: **there is no raw-bytes opcode** — 70 is `x64.ASM_BLOCK`, the enclosing block — and the fix is **not x64-local**; the printer was not missing a case, the shared emitter was missing a notification.

## Why the fix is shared, and where each piece lives

The bug is in `isa/asm.mach`, which serves all three ISAs, so the same failure exists on arm64 and riscv64 the moment a `.byte` is written there — which is exactly what #2479 is adding. Fixing it shared means those directives arrive on a working emitter instead of two more targets inheriting the bug.

**The text lives in one place** (`encode.render_bytes_directive`). A directive is a *payload*, not an instruction, and has no per-target spelling — so a target cannot render it differently, and one added later inherits it rather than reimplementing it. **Only the timing is per-ISA**: a printer that renders on the spot (x86-64, aarch64) notifies as the bytes are emitted; one that buffers notes for a later pass (riscv64) records it so the directive lands in program order. Each grammar wires a one-line `note_bytes` hook.

That is the reasoning behind choosing a hook over a pseudo-opcode, per the criterion of *fewer places for a future target to forget*: a pseudo-opcode would need a case in each of the three printers, and the two rendering styles mean even a shared note kind would. This way the only per-target obligation is one line saying *when*, and the thing most likely to be got wrong — the text itself — cannot vary.

**A target that wires no hook is refused**, not silently degraded. `sink_claim` would have silenced the error by marking the bytes accounted without rendering them; a dump that quietly omits instructions is worse than one that fails.

## Tests

Split by capability, because the two halves need different helpers:

- **`x64.encode…:round_trips`** — what the renderer emits **assembles back to the same payload**, for a three-byte payload and the single-byte shape port i/o actually writes. This is the real bar: rendering something is easy, rendering something an assembler reads as the identical payload is what `--emit-asm` claims.
- **`arm64.encode…:reaches_the_sink`** — the bytes are unaccounted before the notification (the exact state that made the encoder refuse) and fully accounted after.

The renderer is shared, so together they pin it for every target.

Verified end to end: both original repros now build clean under `--emit-asm`, and the dump contains `.byte 0xec`.

## Verification

Fixpoint `b == c`; `mach test` **1037 / 0**; `int` green on `linux` and `linux-riscv64`. Dev moved 5 files during the work; checked disjoint from mine, so no re-verification.

Sequencing: this should land before #2479's directive registrations.