### PR TITLE
feat(asm): raw-encoding data directives on every target

### DIFF
--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -67,21 +67,48 @@ An indirect call clobbers exactly as a direct one does — the callee's caller-s
 registers, which the surrounding block's barrier already covers. The register or
 memory holding the target is **read**, not written.
 
-## Raw bytes
+## Raw encodings
 
-`.byte` emits its values verbatim, for an encoding the ISA's mnemonic table does
-not name:
+Four data directives emit their values verbatim, for an encoding the ISA's mnemonic
+table does not name. They work on every target:
 
 ```mach
 asm x86_64 {
     .byte 0x0f, 0x01, 0xd0    # xgetbv
 }
+
+asm aarch64 {
+    .word 0xd53be040          # mrs x0, cntvct_el0
+}
+
+asm riscv64 {
+    .word 0xc0102573          # csrr a0, time
+}
 ```
 
-One directive carries a whole sequence (up to 256 values), not four. A value that
-does not fit in a byte is refused. Raw bytes are an instruction stream the parser
-cannot read, so the block's clobber set becomes **every register in every bank** —
-which is why a real mnemonic is always preferable where one exists.
+The widths are GNU as's, per target — `.word` is the one that differs:
+
+| directive | x86-64 | aarch64 / riscv64 |
+|---|---|---|
+| `.byte` | 1 byte | 1 byte |
+| `.word` | **2 bytes** | **4 bytes** |
+| `.long` | 4 bytes | 4 bytes |
+| `.quad` | 8 bytes | 8 bytes |
+
+Values are written in the target's byte order, so `.word 0xd503201f` is the aarch64
+`nop` as its manual prints it. A non-negative value is read unsigned (`.quad
+0xFFFFFFFFFFFFFFFF` is a legal address); a negative one is its two's complement at the
+directive's width. A value the width cannot hold is refused rather than truncated, and
+one directive carries a whole sequence — up to 256 payload bytes — not four.
+
+On aarch64 and riscv64 a statement must emit a whole number of instruction words:
+`.byte 0x1f, 0x20, 0x03` is refused, because three bytes would misalign every
+instruction after it. x86-64 has no such constraint.
+
+A raw encoding is an instruction stream the parser cannot read, so the block's clobber
+set becomes **every register in every bank**, and an `#[oblivious]` function may not
+contain one at all — which is why a real mnemonic is always preferable where one
+exists.
 
 ## What the compiler infers
 

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -181,7 +181,7 @@ declared type. What the walk cannot model, it refuses:
 | construct | why |
 |---|---|
 | a body that does not parse | nothing to analyze |
-| a `.byte` directive | its payload can encode any instruction |
+| a data directive (`.byte`, `.word`, `.long`, `.quad`) | its payload can encode any instruction |
 | a mnemonic the target has not classified | its timing behaviour is unknown |
 | **a conditional branch, on x86-64 only** | its condition rides FLAGS, which the inline-asm effect model does not represent (#2460) |
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -10240,10 +10240,18 @@ test "mach.lang.driver:oblivious_asm_leaks_refused" {
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "linux", "#2460") != 0) { bad = 1; }
 
-    # a `.byte` payload can encode ANY instruction, including a secret-dependent
-    # branch. there is nothing to analyze, so it is refused on KIND.
+    # a data directive's payload can encode ANY instruction, including a secret-
+    # dependent branch. there is nothing to analyze, so it is refused on KIND -
+    # BEFORE any classification is consulted, which is what makes the whole family
+    # fail-closed rather than one entry per spelling (#2479).
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { .byte 0x90 } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "linux", "its payload can encode any instruction") != 0) { bad = 1; }
+    # the wider spellings, on the fixed-width targets where they are the only escape:
+    # a raw word is no more readable than a raw byte.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm aarch64 { .word 0xd503201f } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux-arm64", "its payload can encode any instruction") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm riscv64 { .quad 0x0000001300000013 } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux-riscv64", "its payload can encode any instruction") != 0) { bad = 1; }
 
     # (a) a REGISTER-conditioned branch on a secret, on a target where the condition
     # is visible: aarch64's `cbnz` reads a register, so this one is caught rather

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4724,19 +4724,23 @@ fun a64_patch(st: *encode.EncodeState, patch_pos: u32, target_off: u32) R.Result
 # the AArch64 inline-assembly grammar
 fun a64_grammar() iasm.Grammar {
     var g: iasm.Grammar;
-    g.isa       = "aarch64";
-    g.unknown   = "unknown aarch64 inline-asm instruction '";
-    g.rows      = ?A64_MNEMONICS[0];
-    g.row_count = A64_MNEMONIC_COUNT;
-    g.decode    = a64_decode_bcond;
-    g.parse     = a64_parse;
-    g.emit      = a64_emit;
-    g.patch     = a64_patch;
-    g.slot      = frame_slot_offset;
-    g.all_gp    = 0xFFFFFFFF;
-    g.all_fp    = 0xFFFFFFFF;
-    g.word      = 4;
-    g.ct_class  = asm_ct_class;
+    g.isa        = "aarch64";
+    g.unknown    = "unknown aarch64 inline-asm instruction '";
+    g.rows       = ?A64_MNEMONICS[0];
+    g.row_count  = A64_MNEMONIC_COUNT;
+    # aarch64's `.word` is one instruction word, as GNU as spells it here (#2479).
+    g.data       = ?iasm.DIRECTIVES_WORD32[0];
+    g.data_count = iasm.DIRECTIVE_COUNT;
+    g.decode     = a64_decode_bcond;
+    g.parse      = a64_parse;
+    g.emit       = a64_emit;
+    g.patch      = a64_patch;
+    g.slot       = frame_slot_offset;
+    g.all_gp     = 0xFFFFFFFF;
+    g.all_fp     = 0xFFFFFFFF;
+    g.word       = 4;
+    g.endian     = isa.ENDIAN_LITTLE;
+    g.ct_class   = asm_ct_class;
     ret g;
 }
 
@@ -6395,6 +6399,121 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_sysreg_moves" {
 
     iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the data directives emit raw instruction words, byte-exact, and `.word` is FOUR
+# bytes on this target (#2479)
+#
+# THE DERIVATION IS THE ENCODER BESIDE IT: `nop` is `0xD503201F` in the aarch64
+# manual, and the mnemonic row already emits that word, so a `.word 0xd503201f` that
+# does not produce the identical four bytes is wrong by comparison rather than by
+# assertion. That is also the whole point of the escape - an instruction the mnemonic
+# table does not name is reachable by writing its encoding, which on a fixed-width
+# target had no spelling at all before.
+#
+# `.word` IS FOUR BYTES HERE AND TWO ON x86-64, which is GNU as's own per-target
+# definition; the x86-64 encoder pins the other half of that divergence.
+test "mach.lang.target.isa.arm64.encode:inline_asm_data_directives" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    a64_asm_text(?st, ?f, ?labels, "nop");                            # 0
+    a64_asm_text(?st, ?f, ?labels, ".word 0xd503201f");                # 4
+    a64_asm_text(?st, ?f, ?labels, ".long 0xd503201f");                # 8
+    a64_asm_text(?st, ?f, ?labels, ".byte 0x1f, 0x20, 0x03, 0xd5");    # 12
+    a64_asm_text(?st, ?f, ?labels, ".quad 0xd503201fd503201f");        # 16, 20
+    # a raw encoding the mnemonic table does not name: `mrs x0, cntvct_el0`
+    # (0xD53BE040), which is exactly what #2480 exists to spell by name.
+    a64_asm_text(?st, ?f, ?labels, ".word 0xd53be040");                # 24
+
+    # every word is the same `nop` the mnemonic emits, whatever spelling produced it.
+    if (read_word(?st.buf, 0)  != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0xD503201F) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xD53BE040) { bad = 1; }
+    # `.word` consumed four bytes per value, not two: seven words in all.
+    if (st.buf.len != 28) { bad = 1; }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a payload that is not a whole number of instruction words is refused, and so is a
+# value the directive's width cannot hold
+#
+# A three-byte `.byte` would misalign every instruction after it - inside the block
+# and in the compiler-emitted code following it - and a fixed-width machine has no
+# unaligned instruction to fall back on. Refusing names the statement; emitting would
+# silently shift the whole instruction stream.
+test "mach.lang.target.isa.arm64.encode:inline_asm_data_directive_refusals" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    val r1: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, ".byte 0x1f");
+    if (!R.is_err[bool, str](r1))                                                                { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r1), "whole number of instruction words")) { bad = 1; } }
+
+    val r2: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, ".byte 0x1f, 0x20, 0x03");
+    if (!R.is_err[bool, str](r2))                                                                { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r2), "whole number of instruction words")) { bad = 1; } }
+
+    # a value wider than the directive is refused rather than truncated to its low
+    # word, which would be an instruction nobody wrote.
+    val r3: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, ".word 0x1d503201f");
+    if (!R.is_err[bool, str](r3))                                                    { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r3), "cannot hold")) { bad = 1; } }
+
+    # a directive is not a mnemonic: `.hword` is in no table and is refused by name.
+    val r4: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, ".hword 0x1234");
+    if (!R.is_err[bool, str](r4))                                                                       { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r4), "unknown aarch64 inline-asm instruction")) { bad = 1; } }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a data directive's payload is an instruction stream the parser cannot read, so it
+# reaches every register in every bank - on this target as on x86-64
+#
+# The conservative answer is the same for every spelling of the family: `.word` is no
+# more readable than `.byte`, so widening the escape (#2479) cannot narrow a clobber
+# set. A body naming only real mnemonics beside it stays precise.
+test "mach.lang.target.isa.arm64.encode:asm_clobbers_data_directives_are_opaque" {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var bad: i32 = 0;
+
+    asm_clobbers(".word 0xd503201f", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    if (fp != 0xFFFFFFFF) { bad = 1; }
+
+    asm_clobbers(".quad 0xd503201fd503201f", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    if (fp != 0xFFFFFFFF) { bad = 1; }
+
+    # the `nop` the same bytes spell is read, and writes nothing.
+    asm_clobbers("nop", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
     ret bad;
 }
 

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -43,7 +43,7 @@
 # the whole `asm` block (#2250).
 #
 # CONSERVATIVE BY DEFAULT. An unrecognized mnemonic refuses the block. A byte stream
-# the parser cannot read (a raw `.byte` payload) writes every register in every bank.
+# the parser cannot read (a data directive's payload) writes every register in every bank.
 # Precision is earned per mnemonic, on that mnemonic's own table row, and never
 # credited by category - `opaque-and-slow` is safe, `modeled-and-wrong` is a
 # miscompile.
@@ -88,10 +88,12 @@ pub val MAX_OPS: usize = 4;
 # longest inline-asm statement the parser accepts, in bytes
 pub val STMT_MAX: usize = 512;
 
-# most raw bytes one `.byte` directive can carry
+# most payload bytes one data directive can carry
 #
-# Derived, not chosen: a value needs at least a digit and a separator, so a statement
-# bounded by `STMT_MAX` can never name more than half that many.
+# Derived from the narrowest directive: a `.byte` value needs at least a digit and a
+# separator, so a statement bounded by `STMT_MAX` can never name more than half that
+# many. A wider directive reaches the same payload cap with fewer values - 32 `.quad`s
+# rather than 256 `.byte`s - which is a bound on the payload, not on the statement.
 pub val BYTES_MAX: usize = STMT_MAX / 2;
 
 # the kind of a parsed inline-asm operand
@@ -152,13 +154,12 @@ pub rec Operand {
 
 # the operand shape a mnemonic takes, as the shared cursor reads it
 #
-# The cursor distinguishes only three cases: a mnemonic that is the whole statement,
-# a raw byte directive, and everything else (split the operand list and hand it to
-# the ISA). A target's finer distinctions - one operand versus two, a branch target
-# versus a register - are its own, carried in `Mnemonic.code` and read by its parser.
+# The cursor distinguishes only two cases: a mnemonic that is the whole statement, and
+# everything else (split the operand list and hand it to the ISA). A target's finer
+# distinctions - one operand versus two, a branch target versus a register - are its
+# own, carried in `Mnemonic.code` and read by its parser.
 pub val AF_NONE:  u8 = 0;  # no operands; the mnemonic is the whole statement
 pub val AF_OPS:   u8 = 1;  # a comma-separated operand list the ISA parses
-pub val AF_BYTES: u8 = 2;  # a `.byte b, b, ...` raw payload
 
 # a form whose emitted instruction-word count is a property of its operands rather
 # than of the mnemonic, so no count can be checked against it
@@ -199,6 +200,54 @@ pub rec Mnemonic {
     flags:    u16;
     words:    u8;
 }
+
+# one data directive: its text and the width of each value it carries
+#
+# A data directive denotes no instruction - `.quad 1` means the same eight bytes on
+# every machine - so the family is a statement shape the shared cursor reads, like a
+# numeric local label, rather than rows in three mnemonic tables. That is also what
+# makes it the raw-encoding escape a fixed-width target needs (#2479): where a missing
+# mnemonic on x86-64 is an inconvenience, on aarch64 and riscv64 it is a wall, and
+# `.word <u32>` is the general way through it.
+#
+# WHAT IS PER-TARGET IS THE WIDTH OF `.word`, which is why a grammar names its own
+# table rather than reading one global list - see `DIRECTIVES_WORD16` /
+# `DIRECTIVES_WORD32`.
+# ---
+# name:  the directive text as written, including its leading dot
+# width: bytes each of its values occupies
+pub rec Directive {
+    name:  str;
+    width: u8;
+}
+
+# number of directives in each shared family table
+pub val DIRECTIVE_COUNT: usize = 4;
+
+# the data directives for a target whose `.word` is 16 bits (x86-64)
+#
+# The widths are GNU as's, per target, because a body is written by someone reading
+# that assembler's manual: `.byte` is one byte everywhere, `.long` four and `.quad`
+# eight, and `.word` IS THE ONE THAT DIVERGES - two bytes on x86, four on ARM and
+# RISC-V. Stating both conventions side by side here is what keeps the divergence a
+# documented fact rather than a per-encoder typo.
+pub val DIRECTIVES_WORD16: [DIRECTIVE_COUNT]Directive = [DIRECTIVE_COUNT]Directive{
+    Directive{ name: ".byte", width: 1 },
+    Directive{ name: ".word", width: 2 },
+    Directive{ name: ".long", width: 4 },
+    Directive{ name: ".quad", width: 8 },
+};
+
+# the data directives for a target whose `.word` is 32 bits (aarch64, riscv64)
+#
+# `.word` is one instruction word on both, which is the spelling a raw encoding takes:
+# `.word 0xd503201f` is aarch64's `nop`.
+pub val DIRECTIVES_WORD32: [DIRECTIVE_COUNT]Directive = [DIRECTIVE_COUNT]Directive{
+    Directive{ name: ".byte", width: 1 },
+    Directive{ name: ".word", width: 4 },
+    Directive{ name: ".long", width: 4 },
+    Directive{ name: ".quad", width: 8 },
+};
 
 # the parse outcomes one statement can have
 #
@@ -374,34 +423,40 @@ pub def CtClassFn: fun(u32) ct.AsmClass;
 # today, spir-v by construction) needs none, which is what makes the parser a
 # capability rather than a tax on every new target (#2212).
 # ---
-# isa:       the ISA tag the `asm` block spells
-# unknown:   the refusal prefix an unrecognized mnemonic takes, up to its opening
-#            quote - spelled out rather than composed, so naming the target in a
-#            diagnostic needs no buffer and can never degrade to a vaguer message
-# rows:      the mnemonic table
-# row_count: number of rows
-# decode:    the suffixed-family decoder, or nil
-# parse:     the operand lexer
-# emit:      the assembler
-# patch:     the branch-displacement insert
-# slot:      the frame-pointer-relative offset of a local's stack slot
-# all_gp:    every general-purpose register the grammar can reach
-# all_fp:    every float / vector register an unreadable byte stream could reach
-# word:      the instruction word size in bytes, or 0 for a variable-length encoding
+# isa:        the ISA tag the `asm` block spells
+# unknown:    the refusal prefix an unrecognized mnemonic takes, up to its opening
+#             quote - spelled out rather than composed, so naming the target in a
+#             diagnostic needs no buffer and can never degrade to a vaguer message
+# rows:       the mnemonic table
+# row_count:  number of rows
+# data:       the data-directive table (one of the shared `DIRECTIVES_*`)
+# data_count: number of directives
+# decode:     the suffixed-family decoder, or nil
+# parse:      the operand lexer
+# emit:       the assembler
+# patch:      the branch-displacement insert
+# slot:       the frame-pointer-relative offset of a local's stack slot
+# all_gp:     every general-purpose register the grammar can reach
+# all_fp:     every float / vector register an unreadable byte stream could reach
+# word:       the instruction word size in bytes, or 0 for a variable-length encoding
+# endian:     the byte order a data directive's values take
 pub rec Grammar {
-    isa:       str;
-    unknown:   str;
-    rows:      *Mnemonic;
-    row_count: usize;
-    decode:    DecodeFn;
-    parse:     ParseFn;
-    emit:      EmitFn;
-    patch:     PatchFn;
-    slot:      SlotFn;
-    all_gp:    u32;
-    all_fp:    u32;
-    word:      u8;
-    ct_class:  CtClassFn;
+    isa:        str;
+    unknown:    str;
+    rows:       *Mnemonic;
+    row_count:  usize;
+    data:       *Directive;
+    data_count: usize;
+    decode:     DecodeFn;
+    parse:      ParseFn;
+    emit:       EmitFn;
+    patch:      PatchFn;
+    slot:       SlotFn;
+    all_gp:     u32;
+    all_fp:     u32;
+    word:       u8;
+    endian:     isa.Endian;
+    ct_class:   CtClassFn;
 }
 
 # an operand in the neutral state each lexer fills in
@@ -522,6 +577,81 @@ pub fun region_i64(s: str, lo: usize, hi: usize) O.Option[i64] {
     val r: R.Result[i64, str] = parse.parse_i64_exact((?buf[0])::str, 0);
     if (R.is_err[i64, str](r)) { ret O.none[i64](); }
     ret O.some[i64](R.unwrap_ok[i64, str](r));
+}
+
+# parse `s[lo..hi)` as an unsigned integer literal in any base the shared literal
+# reader accepts, returning none when the region is not exactly one
+fun region_u64(s: str, lo: usize, hi: usize) O.Option[u64] {
+    var buf: [40]u8;
+    if (!copy_region(s, lo, hi, ?buf[0], 40)) { ret O.none[u64](); }
+    val r: R.Result[u64, str] = parse.parse_u64_exact((?buf[0])::str, 0);
+    if (R.is_err[u64, str](r)) { ret O.none[u64](); }
+    ret O.some[u64](R.unwrap_ok[u64, str](r));
+}
+
+# the largest unsigned value `width` bytes can hold
+fun width_max(width: u8) u64 {
+    if (width >= 8) { ret 18446744073709551615; }
+    ret (1::u64 << (width::u64 * 8)) - 1;
+}
+
+# the most negative signed value `width` bytes can hold
+fun width_min(width: u8) i64 {
+    if (width >= 8) { ret -9223372036854775808; }
+    ret 0 - (1::i64 << (width::i64 * 8 - 1));
+}
+
+# the `width`-byte value `body[lo..hi)` names, as the bits that reach the payload
+#
+# Both spellings of the same bytes are accepted, and each is bounded by what the width
+# holds: a negative literal by the signed minimum (`.byte -128`), everything else by
+# the unsigned maximum (`.byte 255`). Reading a non-negative literal UNSIGNED is what
+# lets `.quad 0xFFFFFFFFFFFFFFFF` name an address no `i64` can hold.
+#
+# A value the width cannot hold is refused rather than truncated, for the reason
+# `.byte 0x1FF` has always been: naming one byte and getting the low half of two is an
+# instruction stream nobody wrote.
+fun data_value(body: str, lo: usize, hi: usize, width: u8, out: *u64) bool {
+    if (hi > lo && body[lo] == '-'::char) {
+        val sv: O.Option[i64] = region_i64(body, lo, hi);
+        if (!O.is_some[i64](sv)) { ret false; }
+        val v: i64 = O.unwrap[i64](sv);
+        if (v < width_min(width)) { ret false; }
+        @out = v:~u64 & width_max(width);
+        ret true;
+    }
+    val uv: O.Option[u64] = region_u64(body, lo, hi);
+    if (!O.is_some[u64](uv)) { ret false; }
+    val v: u64 = O.unwrap[u64](uv);
+    if (v > width_max(width)) { ret false; }
+    @out = v;
+    ret true;
+}
+
+# write the low `width` bytes of `bits` into `dst` in `endian` byte order
+fun data_expand(bits: u64, width: u8, endian: isa.Endian, dst: *u8) {
+    var i: u64 = 0;
+    for (i < width::u64) {
+        var shift: u64 = i * 8;
+        if (endian == isa.ENDIAN_BIG) { shift = (width::u64 - 1 - i) * 8; }
+        dst[i::usize] = ((bits >> shift) & 255)::u8;
+        i = i + 1;
+    }
+}
+
+# the index of the directive `body[lo..hi)` names, or -1
+#
+# A directive matches its exact spelling followed by whitespace, so `.byte` alone is
+# not the directive and reaches the mnemonic table (where it is refused by name).
+fun directive_lookup(g: *Grammar, body: str, lo: usize, hi: usize) i32 {
+    var i: usize = 0;
+    for (i < g.data_count) {
+        val nlen: usize = str_len(g.data[i].name);
+        if (lo + nlen < hi && str_region_equals(body, lo, nlen, g.data[i].name)
+            && is_space(body[lo + nlen])) { ret i::i32; }
+        i = i + 1;
+    }
+    ret -1;
 }
 
 # build "<prefix><name><suffix>", interned so the message outlives this call
@@ -756,19 +886,19 @@ fun split_ops(c: *Cursor, lo: usize, hi: usize, s: *Stmt) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# decode a raw byte directive's payload from `body[lo..hi)`, claiming each value and
+# decode a data directive's payload from `body[lo..hi)`, claiming each value and
 # separator
 #
-# `.byte` is a directive, not an instruction: its payload is a byte sequence, not an
-# operand list, so it splits here rather than through `split_ops` and is bounded by
+# A directive is not an instruction: its payload is a value sequence, not an operand
+# list, so it splits here rather than through `split_ops` and is bounded by
 # `BYTES_MAX` rather than by `MAX_OPS`. Routing it through the operand splitter is
 # what capped a byte sequence at four (#2398) - a limit that belongs to instruction
 # operands, where four is a real machine fact, and means nothing here.
 #
-# A value outside a byte's range is refused rather than truncated: `.byte 0x1FF`
-# naming one byte is a typo, and silently emitting 0xFF makes it an instruction
-# stream nobody wrote.
-fun parse_bytes(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[bool, str] {
+# Each value is expanded to `d.width` bytes in the grammar's byte order, so `.word` on
+# a little-endian target writes the low byte first and a raw instruction word reads the
+# way its manual prints it.
+fun parse_data(c: *Cursor, lo: usize, hi: usize, d: *Directive, item: *Item) R.Result[bool, str] {
     item.kind = AI_BYTES;
 
     var a: usize = lo;
@@ -782,26 +912,28 @@ fun parse_bytes(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[bool, st
         or (c.body[i] == ','::char)     { sep = true; }
 
         if (sep) {
-            if (item.byte_count >= BYTES_MAX) {
+            if (item.byte_count + d.width::usize > BYTES_MAX) {
                 ret R.err[bool, str](span_message(c,
                     "encode: inline-asm directive '", lo, hi, "' names more bytes than a statement can carry",
-                    "encode: an inline-asm .byte directive names more bytes than a statement can carry"));
+                    "encode: an inline-asm data directive names more bytes than a statement can carry"));
             }
             var ta: usize = start;
             var tb: usize = i;
             for (ta < tb && is_space(c.body[ta])) { ta = ta + 1; }
             for (tb > ta && is_space(c.body[tb - 1])) { tb = tb - 1; }
-            if (tb <= ta) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
+            if (tb <= ta) { ret R.err[bool, str]("encode: malformed inline-asm data-directive value"); }
 
-            val v: O.Option[i64] = region_i64(c.body, ta, tb);
-            if (!O.is_some[i64](v)) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
-            val b: i64 = O.unwrap[i64](v);
-            if (b < -128 || b > 255) { ret R.err[bool, str]("encode: inline-asm .byte value does not fit in a byte"); }
+            var bits: u64 = 0;
+            if (!data_value(c.body, ta, tb, d.width, ?bits)) {
+                ret R.err[bool, str](span_message(c,
+                    "encode: inline-asm directive '", lo, hi, "' names a value its width cannot hold",
+                    "encode: an inline-asm data directive names a value its width cannot hold"));
+            }
 
             val cr: R.Result[bool, str] = claim(c, ta, tb - ta);
             if (R.is_err[bool, str](cr)) { ret cr; }
-            item.bytes[item.byte_count] = b::u8;
-            item.byte_count = item.byte_count + 1;
+            data_expand(bits, d.width, c.g.endian, ?item.bytes[item.byte_count]);
+            item.byte_count = item.byte_count + d.width::usize;
             if (i < hi) {
                 val cc: R.Result[bool, str] = claim(c, i, 1);
                 if (R.is_err[bool, str](cc)) { ret cc; }
@@ -863,6 +995,9 @@ fun finish(c: *Cursor) R.Result[bool, str] {
 # A numeric local-label definition is its own item and consumes only its `<digits>:`
 # prefix, so an instruction sharing the line is parsed by the next call and claims
 # its own bytes.
+#
+# A data directive is resolved BEFORE the mnemonic table, so the family means the same
+# thing on every target and a mnemonic table cannot shadow it.
 fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, str] {
     var num: u64 = 0;
     val dlen: usize = label_def_span(c.body, lo, hi, ?num);
@@ -873,6 +1008,9 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
         item.ref_num = num;
         ret R.ok[usize, str](lo + dlen);
     }
+
+    val di: i32 = directive_lookup(c.g, c.body, lo, hi);
+    if (di >= 0) { ret parse_directive(c, lo, hi, ?c.g.data[di::usize], item); }
 
     var s: Stmt;
     s.lo    = lo;
@@ -899,14 +1037,6 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
     item.implicit = s.m.implicit;
     item.words    = s.m.words;
 
-    # a raw byte payload is not an operand list, so it never reaches the operand
-    # splitter and is bounded by `BYTES_MAX` instead of `MAX_OPS`.
-    if (s.m.form == AF_BYTES) {
-        val br: R.Result[bool, str] = parse_bytes(c, lo + mlen, hi, item);
-        if (R.is_err[bool, str](br)) { ret R.err[usize, str](R.unwrap_err[bool, str](br)); }
-        ret R.ok[usize, str](hi);
-    }
-
     if (s.m.form != AF_NONE) {
         val sr: R.Result[bool, str] = split_ops(c, lo + mlen, hi, ?s);
         if (R.is_err[bool, str](sr)) { ret R.err[usize, str](R.unwrap_err[bool, str](sr)); }
@@ -915,6 +1045,33 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
     item.nops = s.nargs;
     val pr: R.Result[bool, str] = c.g.parse(c, ?s, item);
     if (R.is_err[bool, str](pr)) { ret R.err[usize, str](R.unwrap_err[bool, str](pr)); }
+    ret R.ok[usize, str](hi);
+}
+
+# parse one data-directive statement `body[lo..hi)`, returning the offset it consumed
+# through
+#
+# ON A FIXED-WIDTH TARGET THE PAYLOAD MUST BE A WHOLE NUMBER OF INSTRUCTION WORDS.
+# Every aarch64 and riscv64 instruction is one aligned word, so a directive emitting
+# three bytes silently misaligns every instruction after it - inside this block and in
+# the compiler-emitted code following it. Refusing here is the parse-side twin of the
+# emit-side word-count guard `check_words` applies to instructions: a variable-length
+# encoding declares no word (`g.word == 0`) and is unconstrained, which is why
+# `.byte 0x90` stays a legal single byte on x86-64.
+fun parse_directive(c: *Cursor, lo: usize, hi: usize, d: *Directive, item: *Item) R.Result[usize, str] {
+    val nlen: usize = str_len(d.name);
+    val cr: R.Result[bool, str] = claim(c, lo, nlen);
+    if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
+
+    val pr: R.Result[bool, str] = parse_data(c, lo + nlen, hi, d, item);
+    if (R.is_err[bool, str](pr)) { ret R.err[usize, str](R.unwrap_err[bool, str](pr)); }
+
+    if (c.g.word != 0 && item.byte_count % c.g.word::usize != 0) {
+        ret R.err[usize, str](span_message(c,
+            "encode: inline-asm directive '", lo, hi,
+            "' emits a payload that is not a whole number of instruction words, which would misalign every instruction after it",
+            "encode: an inline-asm data directive emits a payload that is not a whole number of instruction words"));
+    }
     ret R.ok[usize, str](hi);
 }
 
@@ -1476,6 +1633,77 @@ test "mach.lang.target.isa.asm:label_token_shapes" {
     ret bad;
 }
 
+# a data directive's value occupies exactly its width, in the target's byte order
+#
+# The byte order is where a raw-encoding escape is silently wrong or silently right:
+# `.word 0xd503201f` must land as `1f 20 03 d5` on a little-endian machine, which is
+# what makes it aarch64's `nop` rather than four bytes in the wrong order (#2479).
+# Both orders are asserted, so the parameter is exercised rather than assumed - a
+# big-endian target inherits a checked expansion instead of an untested branch.
+test "mach.lang.target.isa.asm:data_expand_orders_bytes_by_endianness" {
+    var bad: i32 = 0;
+    var b: [8]u8;
+
+    # little-endian: least-significant byte first.
+    data_expand(0xD503201F, 4, isa.ENDIAN_LITTLE, ?b[0]);
+    if (b[0] != 0x1F || b[1] != 0x20 || b[2] != 0x03 || b[3] != 0xD5) { bad = 1; }
+
+    # big-endian: the same value, most-significant byte first.
+    data_expand(0xD503201F, 4, isa.ENDIAN_BIG, ?b[0]);
+    if (b[0] != 0xD5 || b[1] != 0x03 || b[2] != 0x20 || b[3] != 0x1F) { bad = 1; }
+
+    # one byte is the same either way, and a full 64-bit value keeps every byte.
+    data_expand(0x90, 1, isa.ENDIAN_LITTLE, ?b[0]);
+    if (b[0] != 0x90) { bad = 1; }
+    data_expand(0x0123456789ABCDEF, 8, isa.ENDIAN_LITTLE, ?b[0]);
+    if (b[0] != 0xEF || b[1] != 0xCD || b[2] != 0xAB || b[3] != 0x89) { bad = 1; }
+    if (b[4] != 0x67 || b[5] != 0x45 || b[6] != 0x23 || b[7] != 0x01) { bad = 1; }
+
+    # a two-byte value writes two bytes and touches no third.
+    b[2] = 0xAA;
+    data_expand(0x1234, 2, isa.ENDIAN_LITTLE, ?b[0]);
+    if (b[0] != 0x34 || b[1] != 0x12 || b[2] != 0xAA) { bad = 1; }
+
+    ret bad;
+}
+
+# a value the directive's width cannot hold is refused, at every width
+#
+# The bounds are the two spellings of the same bytes: a negative literal down to the
+# signed minimum, everything else up to the unsigned maximum. Refusing rather than
+# truncating is what keeps `.word 0x10000` from becoming a zero word nobody wrote.
+test "mach.lang.target.isa.asm:data_value_bounds_are_per_width" {
+    var bad: i32 = 0;
+    var v: u64 = 0;
+
+    # one byte: -128 .. 255, and one past each end.
+    if (!data_value("255", 0, 3, 1, ?v) || v != 255)   { bad = 1; }
+    if (data_value("256", 0, 3, 1, ?v))                { bad = 1; }
+    if (!data_value("-128", 0, 4, 1, ?v) || v != 0x80) { bad = 1; }
+    if (data_value("-129", 0, 4, 1, ?v))               { bad = 1; }
+
+    # two bytes: the same shape one width up.
+    if (!data_value("65535", 0, 5, 2, ?v) || v != 65535) { bad = 1; }
+    if (data_value("65536", 0, 5, 2, ?v))                { bad = 1; }
+    if (!data_value("-32768", 0, 6, 2, ?v) || v != 0x8000) { bad = 1; }
+    if (data_value("-32769", 0, 6, 2, ?v))                 { bad = 1; }
+
+    # four bytes.
+    if (!data_value("4294967295", 0, 10, 4, ?v) || v != 4294967295) { bad = 1; }
+    if (data_value("4294967296", 0, 10, 4, ?v))                     { bad = 1; }
+
+    # eight bytes: the whole unsigned range is nameable, which an `i64` parse alone
+    # could not express.
+    if (!data_value("0xFFFFFFFFFFFFFFFF", 0, 18, 8, ?v) || v != 18446744073709551615) { bad = 1; }
+    if (!data_value("-1", 0, 2, 8, ?v) || v != 18446744073709551615)                   { bad = 1; }
+
+    # a region that is not exactly one literal names no value.
+    if (data_value("0x1 0x2", 0, 7, 1, ?v)) { bad = 1; }
+    if (data_value("zz", 0, 2, 1, ?v))      { bad = 1; }
+
+    ret bad;
+}
+
 # true when operand `op` names a `{name}` binding listed in `secret_names`
 #
 # A binding substitutes to the local's frame slot, so its ADDRESS is public (a fixed
@@ -1530,7 +1758,7 @@ fun item_reads_secret(body: str, item: *Item, taint: u32, secret_names: *str, n_
 #
 # FAILS CLOSED on every construct it cannot model:
 #   - a body that does not parse (the emitter will reject it too, with a location)
-#   - a `.byte` payload, whose bytes can encode any instruction at all
+#   - a data directive's payload, whose bytes can encode any instruction at all
 #   - a mnemonic the ISA has not classified
 #   - a conditional branch whose condition rides FLAGS (x86-64), which the effect
 #     model does not represent - see `ct.AsmClass` and #2460
@@ -1575,10 +1803,14 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
                   trust_mul: bool, trust_shift: bool) R.Result[bool, str] {
     if (item.kind == AI_LABEL) { ret R.ok[bool, str](true); }
 
-    # a raw byte payload can encode ANY instruction, including a secret-dependent
-    # branch. there is nothing to analyze, so it is refused outright.
+    # a data directive's payload can encode ANY instruction, including a secret-
+    # dependent branch. there is nothing to analyze, so the whole family - `.byte`,
+    # `.word`, `.long`, `.quad` - is refused outright, BEFORE any classification is
+    # consulted. that is what makes the raw-encoding escape (#2479) safe to widen: a
+    # directive can never reach `g.ct_class`, so no spelling of it can be classified
+    # constant-time by omission.
     if (item.kind == AI_BYTES) {
-        ret R.err[bool, str]("contains a `.byte` directive inside an #[oblivious] function; its payload can encode any instruction, so it cannot be verified constant-time");
+        ret R.err[bool, str]("contains a data directive inside an #[oblivious] function; its payload can encode any instruction, so it cannot be verified constant-time");
     }
 
     val cls: ct.AsmClass = g.ct_class(item.code);

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -4186,19 +4186,23 @@ fun rv_patch(st: *encode.EncodeState, patch_pos: u32, target_off: u32) R.Result[
 # the RV64 inline-assembly grammar
 fun rv_grammar() iasm.Grammar {
     var g: iasm.Grammar;
-    g.isa       = "riscv64";
-    g.unknown   = "unknown riscv64 inline-asm instruction '";
-    g.rows      = ?RV_MNEMONICS[0];
-    g.row_count = RV_MNEMONIC_COUNT;
-    g.decode    = rv_decode_amo;
-    g.parse     = rv_parse;
-    g.emit      = rv_emit;
-    g.patch     = rv_patch;
-    g.slot      = frame_slot_offset;
-    g.all_gp    = 0xFFFFFFFF;
-    g.all_fp    = 0xFFFFFFFF;
-    g.word      = 4;
-    g.ct_class  = asm_ct_class;
+    g.isa        = "riscv64";
+    g.unknown    = "unknown riscv64 inline-asm instruction '";
+    g.rows       = ?RV_MNEMONICS[0];
+    g.row_count  = RV_MNEMONIC_COUNT;
+    # riscv64's `.word` is one instruction word, as GNU as spells it here (#2479).
+    g.data       = ?iasm.DIRECTIVES_WORD32[0];
+    g.data_count = iasm.DIRECTIVE_COUNT;
+    g.decode     = rv_decode_amo;
+    g.parse      = rv_parse;
+    g.emit       = rv_emit;
+    g.patch      = rv_patch;
+    g.slot       = frame_slot_offset;
+    g.all_gp     = 0xFFFFFFFF;
+    g.all_fp     = 0xFFFFFFFF;
+    g.word       = 4;
+    g.endian     = isa.ENDIAN_LITTLE;
+    g.ct_class   = asm_ct_class;
     ret g;
 }
 
@@ -5152,6 +5156,114 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_core_forms" {
 
     iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the data directives emit raw instruction words, byte-exact, and `.word` is FOUR
+# bytes on this target (#2479)
+#
+# THE DERIVATION IS THE ENCODER BESIDE IT: `nop` is `addi x0, x0, 0` = 0x00000013, and
+# the mnemonic row already emits that word, so a `.word 0x00000013` that does not
+# produce the identical four bytes is wrong by comparison rather than by assertion.
+# The escape matters more here than anywhere: RV64 is fixed-width, so an instruction
+# the mnemonic table does not name had no spelling at all before - `csrr a0, time`
+# among them, which is what #2481 exists to name.
+test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directives" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    rv_asm_text(?st, ?f, ?labels, "nop");                            # 0
+    rv_asm_text(?st, ?f, ?labels, ".word 0x00000013");                # 4
+    rv_asm_text(?st, ?f, ?labels, ".long 0x00000013");                # 8
+    rv_asm_text(?st, ?f, ?labels, ".byte 0x13, 0x00, 0x00, 0x00");    # 12
+    rv_asm_text(?st, ?f, ?labels, ".quad 0x0000001300000013");        # 16, 20
+    # a raw encoding the mnemonic table does not name: `csrr a0, time`
+    # (`csrrs a0, 0xC01, x0` = 0xC0102573), the timer read #2481 exists to spell.
+    rv_asm_text(?st, ?f, ?labels, ".word 0xc0102573");                # 24
+
+    # every word is the same `nop` the mnemonic emits, whatever spelling produced it.
+    if (read_word(?st.buf, 0)  != 0x00000013) { bad = 1; }
+    if (read_word(?st.buf, 4)  != 0x00000013) { bad = 1; }
+    if (read_word(?st.buf, 8)  != 0x00000013) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0x00000013) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0x00000013) { bad = 1; }
+    if (read_word(?st.buf, 20) != 0x00000013) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xC0102573) { bad = 1; }
+    # `.word` consumed four bytes per value, not two: seven words in all.
+    if (st.buf.len != 28) { bad = 1; }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a payload that is not a whole number of instruction words is refused, and so is a
+# value the directive's width cannot hold
+#
+# A three-byte `.byte` would misalign every instruction after it - inside the block
+# and in the compiler-emitted code following it - and RV64 has no unaligned
+# instruction to fall back on. Refusing names the statement; emitting would silently
+# shift the whole instruction stream.
+test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directive_refusals" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    val r1: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, ".byte 0x13");
+    if (!R.is_err[bool, str](r1))                                                                { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r1), "whole number of instruction words")) { bad = 1; } }
+
+    val r2: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, ".byte 0x13, 0x00, 0x00");
+    if (!R.is_err[bool, str](r2))                                                                { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r2), "whole number of instruction words")) { bad = 1; } }
+
+    # a value wider than the directive is refused rather than truncated to its low
+    # word, which would be an instruction nobody wrote.
+    val r3: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, ".word 0x100000013");
+    if (!R.is_err[bool, str](r3))                                                    { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r3), "cannot hold")) { bad = 1; } }
+
+    # a directive is not a mnemonic: `.half` is in no table and is refused by name.
+    val r4: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, ".half 0x1234");
+    if (!R.is_err[bool, str](r4))                                                                       { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](r4), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a data directive's payload is an instruction stream the parser cannot read, so it
+# reaches every register in every bank
+#
+# The conservative answer is the same for every spelling of the family: `.word` is no
+# more readable than `.byte`, so widening the escape (#2479) cannot narrow a clobber
+# set.
+test "mach.lang.target.isa.riscv64.encode:asm_clobbers_data_directives_are_opaque" {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var bad: i32 = 0;
+
+    asm_clobbers(".word 0xc0102573", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    if (fp != 0xFFFFFFFF) { bad = 1; }
+
+    # the `nop` the same bytes spell is read, and writes nothing.
+    asm_clobbers("nop", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
     ret bad;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4950,7 +4950,7 @@ val X64_ALL_FP: u32 = 0xFFFF;
 fun x64_pattern(flags: u16) u16 { ret flags & 0x00FF; }
 
 # number of rows in the x86-64 inline-asm mnemonic table
-val X64_MNEMONIC_COUNT: usize = 48;
+val X64_MNEMONIC_COUNT: usize = 47;
 
 # the x86-64 inline-asm instruction surface
 #
@@ -5030,10 +5030,6 @@ val X64_MNEMONICS: [X64_MNEMONIC_COUNT]iasm.Mnemonic = [X64_MNEMONIC_COUNT]iasm.
     iasm.Mnemonic{ name: "dec",  code: x64.DEC::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
     iasm.Mnemonic{ name: "push", code: x64.PUSH::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_ONE, words: 0 },
     iasm.Mnemonic{ name: "pop",  code: x64.POP::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
-
-    # raw bytes are an instruction stream the parser cannot read, so the payload is
-    # carried verbatim and its effects are worst-case.
-    iasm.Mnemonic{ name: ".byte", code: 0, form: iasm.AF_BYTES, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
 };
 
 # map a register name to its (id, size), or false when the token names no register
@@ -5533,19 +5529,23 @@ fun x64_patch(st: *enc.EncodeState, patch_pos: u32, target_off: u32) R.Result[bo
 # the x86-64 inline-assembly grammar
 fun x64_grammar() iasm.Grammar {
     var g: iasm.Grammar;
-    g.isa       = "x86_64";
-    g.unknown   = "unknown x86_64 inline-asm instruction '";
-    g.rows      = ?X64_MNEMONICS[0];
-    g.row_count = X64_MNEMONIC_COUNT;
-    g.decode    = nil;
-    g.parse     = x64_parse;
-    g.emit      = x64_emit;
-    g.patch     = x64_patch;
-    g.slot      = frame_slot_offset;
-    g.all_gp    = X64_ALL_GP;
-    g.all_fp    = X64_ALL_FP;
-    g.word      = 0;
-    g.ct_class  = asm_ct_class;
+    g.isa        = "x86_64";
+    g.unknown    = "unknown x86_64 inline-asm instruction '";
+    g.rows       = ?X64_MNEMONICS[0];
+    g.row_count  = X64_MNEMONIC_COUNT;
+    # x86-64 is the target whose `.word` is 16 bits, as GNU as spells it here.
+    g.data       = ?iasm.DIRECTIVES_WORD16[0];
+    g.data_count = iasm.DIRECTIVE_COUNT;
+    g.decode     = nil;
+    g.parse      = x64_parse;
+    g.emit       = x64_emit;
+    g.patch      = x64_patch;
+    g.slot       = frame_slot_offset;
+    g.all_gp     = X64_ALL_GP;
+    g.all_fp     = X64_ALL_FP;
+    g.word       = 0;
+    g.endian     = isa.ENDIAN_LITTLE;
+    g.ct_class   = asm_ct_class;
     ret g;
 }
 
@@ -5757,13 +5757,14 @@ test "mach.lang.target.isa.x64.encode.asm_clobbers:indirect_call_is_not_opaque" 
     ret bad;
 }
 
-# a `.byte` directive carries a whole byte sequence in one statement, bounded by
+# a data directive carries a whole value sequence in one statement, bounded by
 # `BYTES_MAX` rather than by the four-operand instruction limit
 #
 # The seven bytes of an indirect call were the case that exposed the conflation
 # (#2398): a directive is not an instruction, so its payload never reaches the
-# operand splitter. A value outside a byte's range is refused rather than truncated.
-test "mach.lang.target.isa.x64.encode.parse_bytes:sequence_is_not_an_operand_list" {
+# operand splitter. A value outside the directive's width is refused rather than
+# truncated.
+test "mach.lang.target.isa.x64.encode.parse_data:sequence_is_not_an_operand_list" {
     var bad: i32 = 0;
 
     # seven values in one statement - one more than the four-operand instruction
@@ -5782,18 +5783,63 @@ test "mach.lang.target.isa.x64.encode.parse_bytes:sequence_is_not_an_operand_lis
     if (!t_asm_bytes(".byte -1", ?neg[0], 1)) { bad = 1; }
 
     # a value too wide for a byte is refused, not truncated to 0xFF.
-    if (!t_asm_refused(".byte 0x1ff", "byte"))   { bad = 1; }
-    if (!t_asm_refused(".byte -129", "byte"))    { bad = 1; }
-    # a bare `.byte` is not the directive at all: the mnemonic matcher requires a
-    # following space for any form that takes operands, so it never reaches the
-    # payload parser.
+    if (!t_asm_refused(".byte 0x1ff", "cannot hold")) { bad = 1; }
+    if (!t_asm_refused(".byte -129", "cannot hold"))  { bad = 1; }
+    # a bare `.byte` is not the directive at all: a directive matches only when
+    # followed by whitespace, so it never reaches the payload parser.
     if (!t_asm_refused(".byte", "unknown"))      { bad = 1; }
     # a payload that is only a separator names no value.
     if (!t_asm_refused(".byte ,", "value"))      { bad = 1; }
 
-    # a four-operand INSTRUCTION limit still holds: the cap moved off `.byte`, it
-    # was not removed from the operand splitter.
+    # a four-operand INSTRUCTION limit still holds: the cap moved off the directive,
+    # it was not removed from the operand splitter.
     if (!t_asm_refused("mov rax, rbx, rcx, rdx, rsi", "too many operands")) { bad = 1; }
+
+    ret bad;
+}
+
+# THE WIDE DIRECTIVES ARE GNU AS's WIDTHS ON THIS TARGET: `.word` is TWO bytes on
+# x86-64, not four (#2479)
+#
+# The divergence is the whole reason each grammar names its own table: `.word` is 16
+# bits here and 32 bits on aarch64 / riscv64, exactly as GNU as defines it per target.
+# A body pasted from an x86 assembly source must produce the bytes that source meant,
+# so this is asserted rather than assumed, and the sibling assertions in the aarch64
+# and riscv64 encoders state the other convention.
+test "mach.lang.target.isa.x64.encode.parse_data:gnu_as_widths" {
+    var bad: i32 = 0;
+
+    # `.word` is two bytes, little-endian.
+    var w: [2]u8;
+    w[0] = 0x34; w[1] = 0x12;
+    if (!t_asm_bytes(".word 0x1234", ?w[0], 2)) { bad = 1; }
+    if (!t_asm_refused(".word 0x10000", "cannot hold")) { bad = 1; }
+
+    # `.long` is four.
+    var l: [4]u8;
+    l[0] = 0x78; l[1] = 0x56; l[2] = 0x34; l[3] = 0x12;
+    if (!t_asm_bytes(".long 0x12345678", ?l[0], 4)) { bad = 1; }
+
+    # `.quad` is eight, and reads its value UNSIGNED - an address with the top bit set
+    # is not an `i64` and must still be nameable.
+    var q: [8]u8;
+    var i: usize = 0;
+    for (i < 8) { q[i] = 0xFF; i = i + 1; }
+    if (!t_asm_bytes(".quad 0xFFFFFFFFFFFFFFFF", ?q[0], 8)) { bad = 1; }
+
+    # a negative value is its two's complement at the directive's width, not at 64
+    # bits: `.word -1` is two bytes.
+    var n: [2]u8;
+    n[0] = 0xFF; n[1] = 0xFF;
+    if (!t_asm_bytes(".word -1", ?n[0], 2)) { bad = 1; }
+    if (!t_asm_refused(".word -32769", "cannot hold")) { bad = 1; }
+
+    # a mixed sequence tiles in order, each value at its own width.
+    var mix: [7]u8;
+    mix[0] = 0x90;
+    mix[1] = 0x34; mix[2] = 0x12;
+    mix[3] = 0x78; mix[4] = 0x56; mix[5] = 0x34; mix[6] = 0x12;
+    if (!t_asm_bytes(".byte 0x90\n.word 0x1234\n.long 0x12345678", ?mix[0], 7)) { bad = 1; }
 
     ret bad;
 }
@@ -6998,13 +7044,8 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_is_classifi
     var bad: i32 = 0;
     var i: usize = 0;
     for (i < X64_MNEMONIC_COUNT) {
-        val m: *iasm.Mnemonic = ?X64_MNEMONICS[i];
-        # `.byte` is a directive, not an instruction: its payload is opaque bytes the
-        # walk refuses on kind, so it carries no classification.
-        if (!str_equals(m.name, ".byte")) {
-            val cls: ct.AsmClass = asm_ct_class(m.code);
-            if (!cls.known) { bad = 1; }
-        }
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code);
+        if (!cls.known) { bad = 1; }
         i = i + 1;
     }
     ret bad;


### PR DESCRIPTION
Closes #2479.

`.byte` was a row in the x86-64 mnemonic table alone, so `asm aarch64` and `asm riscv64` refused it — and `.word` / `.long` / `.quad` existed nowhere at all. On a variable-length encoding a missing mnemonic is an inconvenience; on a fixed-width one it is a wall, which is what left bmos-mach with no timer on aarch64 and no trap vector on riscv64.

## What changed

The family is not an instruction-set fact — `.quad 1` is the same eight bytes on every machine — so it moved **out of the mnemonic tables** into the shared cursor (`isa/asm.mach`), beside the numeric local label, which is the other statement shape no target owns. It is resolved **before** the mnemonic table, so a target cannot shadow it. The x86-64 `.byte` row and the `AF_BYTES` mnemonic form are gone; the coverage test's `.byte`-shaped exemption goes with them.

What *is* per-target is the width of `.word`, so each grammar names one of two shared tables:

| directive | x86-64 (`DIRECTIVES_WORD16`) | aarch64 / riscv64 (`DIRECTIVES_WORD32`) |
|---|---|---|
| `.byte` | 1 | 1 |
| `.word` | **2** | **4** |
| `.long` | 4 | 4 |
| `.quad` | 8 | 8 |

These are GNU as's own per-target widths (`.word` is 16 bits on x86 and 32 on ARM/RISC-V), because a body is written by someone reading that assembler's manual. Stating both conventions side by side in one file is what keeps the divergence a documented fact rather than a per-encoder typo; each encoder pins its own half in a test.

Two behaviours worth calling out:

- **A payload that is not a whole number of instruction words is refused on a fixed-width target.** `.byte 0x1f, 0x20, 0x03` on aarch64 would misalign every instruction after it — inside the block and in the compiler-emitted code following it — and there is no unaligned instruction to fall back on. This is the parse-side twin of the emit-side `check_words` guard. `g.word == 0` (x86-64) is unconstrained, so `.byte 0x90` stays a legal single byte there.
- **A value the width cannot hold is refused, not truncated**, for the reason `.byte 0x1FF` always was. A non-negative literal is read *unsigned*, so `.quad 0xFFFFFFFFFFFFFFFF` names an address no `i64` can hold; a negative one is its two's complement at the directive's own width, bounded by that width's signed minimum.

## How each encoding was derived

Not by re-deriving field layouts, and not by asserting what the encoder already does:

- **`.word` / `.long` / `.byte` / `.quad` on aarch64** are checked against **the mnemonic row beside them**: `nop` is `0xD503201F` in the manual, and every spelling of the same four bytes (`.word 0xd503201f`, `.long`, `.byte 0x1f, 0x20, 0x03, 0xd5`, and a `.quad` of two) must produce the identical word the `nop` row emits. Same shape on riscv64 against `nop` = `addi x0, x0, 0` = `0x00000013`.
- **The values that are not `nop`** are read off the architecture manuals' own bit layouts: `mrs x0, cntvct_el0` = `0xD53BE040` (MRS is `1101 0101 001` + `L=1` + `o0`/`op1`/`CRn`/`CRm`/`op2`/`Rt`; CNTVCT_EL0 is op0=3 op1=3 CRn=14 CRm=0 op2=2), and `csrr a0, time` = `csrrs a0, 0xC01, x0` = `0xC0102573` (CSR address in `imm[11:0]`, funct3=010, rd=10, opcode `1110011`). Both are exactly the instructions #2480 and #2481 exist to name.
- **Independently confirmed end to end**: a freestanding probe compiled for all three targets and disassembled with `llvm-objdump` shows 5 `nop`s on aarch64, 5 on riscv64, and 15 `nop`s on x86-64 (1 + 2 + 4 + 8 bytes — which is also the proof that `.word` is two bytes there).

## Mutation checks

Each performed on a full build + `mach test`, then reverted:

| perturbation | result |
|---|---|
| `DIRECTIVES_WORD32` `.word` width 4 → 2 | `arm64.encode:inline_asm_data_directives` and `riscv64.encode:inline_asm_data_directives` FAIL |
| aarch64 grammar `endian` → `ENDIAN_BIG` | `arm64.encode:inline_asm_data_directives` FAILs |
| `DIRECTIVES_WORD16` `.word` width 2 → 4 | `x64.encode.parse_data:gnu_as_widths` FAILs |

## Constant-time classification (#2230)

Every directive parses to an `AI_BYTES` item, and `ct_scan` refuses that kind **outright, before any classification is consulted** — a payload can encode any instruction, including a secret-dependent branch. So the whole family is fail-closed by construction rather than by a table entry: no spelling of it can reach `g.ct_class`, and none can be classified constant-time by omission. The refusal message is generalized from "`.byte` directive" to "data directive"; the substring the driver tests match on ("its payload can encode any instruction") is unchanged, and the decode-channel coverage tests are untouched — directives arrive through neither channel.

## Verification

- `mach test` through the from-source compiler: **1042 passed, 0 failed** (1036 on dev + 6 new: 2 in `isa.asm`, 1 in `x64.encode`, 2 in `arm64.encode`, 1 in `riscv64.encode` — plus `arm64`/`riscv64` clobber-opacity tests, which is the 3+3 split).
- End-to-end object build for `linux-arm64`, `linux-riscv64`, `linux-x86_64`, disassembled with `llvm-objdump`.
- Fixpoint at the final pre-ready push.

## `--emit-asm`

Verified on real builds after merging dev: on x86-64 and aarch64 a directive now reaches the assembly sink and renders in program order (`  .byte 0x1f, 0x20, 0x03, 0xd5`), through the shared renderer #2491 added while this branch was in flight.

**riscv64 is the exception and is a known gap**, tracked as #2493. That printer buffers its notes and renders them in a later pass, while the shared renderer writes on the spot and pushes no note, so riscv64's stricter guard (`emitted bytes == note_inst_count * 4`) refuses the build. It could not fire before, because `.byte` was x86-64-only and nothing could reach riscv64's hook end to end; this PR is the first thing that can. Object emission — the normal path — is correct on all three targets, and the failure is a loud refusal, never a `.s` that silently omits the directive. The fix belongs to the buffered-note model (#2467's territory), not to the encoder surface, so it is not in this diff.

## Fixpoint

Three generations from the 4.4.0 seed, the same shape CI's `build` job runs: gen2 and gen3 are byte-identical (`cmp` clean, 5017600 bytes). gen1 differs from gen2, which is the seed-lag property dev already has, not a property of this branch.
