### PR TITLE
fix(legalize,mos6502): give MIR_BITCAST an arm, and its encoder retag

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -593,7 +593,9 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     # a declassify is a move plus a compile-time barrier; it legalizes exactly like a
     # move (the barrier matters only on the pre-legalize lowered MIR the #1648 re-derive
     # reads). legalize runs before isel, so it sees the un-retagged MIR_DECLASSIFY (#1646).
-    if (op == mir.MIR_MOV || op == mir.MIR_DECLASSIFY) {
+    # a bitcast (`:~`, and a same-width `::`) reinterprets bits at an UNCHANGED width -
+    # its own opcode contract - so it is a plain per-lane copy too, same as a move (#2483).
+    if (op == mir.MIR_MOV || op == mir.MIR_DECLASSIFY || op == mir.MIR_BITCAST) {
         ret R.ok[u32, str](nl);
     }
     if (op == mir.MIR_ADD || op == mir.MIR_SUB || op == mir.MIR_NEG) {
@@ -810,7 +812,7 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     if (is_shift(op)) {
         ret expand_shift(alloc, plan, f, mi, dst, cursor);
     }
-    if (op == mir.MIR_MOV || op == mir.MIR_DECLASSIFY) {
+    if (op == mir.MIR_MOV || op == mir.MIR_DECLASSIFY || op == mir.MIR_BITCAST) {
         ret expand_mov(alloc, plan, mi, dst, cursor);
     }
     if (op == mir.MIR_ADD || op == mir.MIR_SUB) {
@@ -1002,6 +1004,11 @@ fun expand_not(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 # hidden result-storage pointer arriving in, or returning through, a register the
 # convention names. It decomposes onto the consecutive register run starting there,
 # which is what naming one register for a multi-register value means.
+#
+# Also the MIR_BITCAST expansion (#2483): a bitcast reinterprets bits at an
+# UNCHANGED width - its own opcode contract, never a widening or narrowing one -
+# so it is exactly this same per-lane copy, source and destination lanes aligned
+# one to one with nothing to fill or drop.
 fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     val nl: u32 = wide_lane_count(plan, mi);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9888,29 +9888,22 @@ test "mach.lang.driver:shift_executes_on_a_6502_core_mos6502" {
 
 # build the source of a two-operand multiply probe module at width `bits`: both
 # operands arrive and the result leaves as `u64` (the ABI shape every mos6502 probe
-# in this file already uses). For a narrower `ty`, both operands are truncated to
-# it and multiplied at THAT width, then widened back, so the multiply itself
-# happens at `bits` wide while the function's own calling convention stays the one
-# this harness already exercises. `ty == "u64"` skips the cast pair entirely - a
-# same-width cast is its own untested legalize frontier (a bare BITCAST reaches no
-# arm in `expand_instr`), unrelated to #2344 and not this issue's to fix; `v * w`
-# directly exercises the identical multiply at the same width without it (test
-# helper)
+# in this file already uses), truncated to `ty` and multiplied at THAT width, then
+# widened back - so the multiply itself happens at `bits` wide while the function's
+# own calling convention stays the one this harness already exercises. Exercises
+# `ty == "u64"`'s redundant same-width cast pair too (#2483 gave it an arm; #2344
+# had this skip it as a then-untested legalize frontier, adjacent to that issue's
+# own scope) (test helper)
 # ---
 # buf: the source buffer to write
 # ty:  the multiply's own operand type (`u8` / `u16` / `u32` / `u64`)
 fun ut_mos_mul_src(buf: *u8, ty: str) usize {
     var w: usize = 0;
-    if (str_equals(ty, "u64")) {
-        w = ut_app(buf, w, "fun f(v: u64, w: u64) u64 { ret v * w; }\n");
-    }
-    or {
-        w = ut_app(buf, w, "fun f(v: u64, w: u64) u64 { ret ((v::");
-        w = ut_app(buf, w, ty);
-        w = ut_app(buf, w, ") * (w::");
-        w = ut_app(buf, w, ty);
-        w = ut_app(buf, w, "))::u64; }\n");
-    }
+    w = ut_app(buf, w, "fun f(v: u64, w: u64) u64 { ret ((v::");
+    w = ut_app(buf, w, ty);
+    w = ut_app(buf, w, ") * (w::");
+    w = ut_app(buf, w, ty);
+    w = ut_app(buf, w, "))::u64; }\n");
     w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
@@ -10052,6 +10045,118 @@ test "mach.lang.driver:mul_executes_on_a_6502_core_mos6502" {
         }
         A.deallocate[u8](?alloc, mem, UT_MOS_MEM);
     }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# build the source of a same-width-cast probe module at width `bits`: `v` is
+# narrowed to `ty`, then cast to `ty` AGAIN (the redundant same-width cast this
+# issue is about - a bare `MIR_BITCAST` at `bits` wide), then widened back to
+# `u64` (test helper)
+# ---
+# buf: the source buffer to write
+# ty:  the cast's own operand type (`u8` / `u16` / `u32` / `u64`)
+fun ut_mos_cast_src(buf: *u8, ty: str) usize {
+    var w: usize = 0;
+    w = ut_app(buf, w, "fun f(v: u64) u64 { ret ((v::");
+    w = ut_app(buf, w, ty);
+    w = ut_app(buf, w, ")::");
+    w = ut_app(buf, w, ty);
+    w = ut_app(buf, w, ")::u64; }\n");
+    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
+    buf[w] = 0;
+    ret w;
+}
+
+# the reference answer for a same-width cast at `bits` wide: an identity, masked
+# to the truncated width (test helper)
+fun ut_cast_ref(bits: u32, v: u64) u64 {
+    var mask: u64 = 0xFFFFFFFFFFFFFFFF;
+    if (bits < 64) { mask = (1::u64 << bits::u64) - 1; }
+    ret v & mask;
+}
+
+# sweep one width of the mos6502 same-width-cast work over a real build (test helper)
+# ---
+# s:     the session to build in
+# alloc: allocator for the source buffer and the memory image
+# bits:  the scalar width in bits
+# ty:    the scalar type name
+# ret:   0 when every value answered correctly at a fixed cycle count
+fun ut_mos_cast_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: str) i32 {
+    val sr: R.Result[*u8, str] = A.allocate[u8](alloc, 8192);
+    if (R.is_err[*u8, str](sr)) { ret 1; }
+    val srcbuf: *u8 = R.unwrap_ok[*u8, str](sr);
+    ut_mos_cast_src(srcbuf, ty);
+
+    val mr: R.Result[*u8, str] = A.zallocate[u8](alloc, UT_MOS_MEM);
+    if (R.is_err[*u8, str](mr)) { A.deallocate[u8](alloc, srcbuf, 8192); ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(s, alloc, srcbuf::str, "mos");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
+        or {
+            var text: *u8 = nil;
+            var tlen: u32 = 0;
+            var offs: [1]u32;
+            if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], 1))    { bad = 1; }
+            or (UT_MOS_CODE + tlen >= UT_MOS_ARGS)              { bad = 1; }
+            or {
+                ut_mos_load(text, tlen, mem);
+                var fixed: u32 = 0;
+                var vi: u32 = 0;
+                for (vi < UT_SHIFT_VALUES) {
+                    val v: u64 = ut_shift_value(vi);
+                    var got: u64 = 0;
+                    var cy:  u32 = 0;
+                    if (!ut_mos_run(mem, offs[0], 8, v, 0, ?got, ?cy)) { bad = 1; }
+                    or {
+                        if (got != ut_cast_ref(bits, v)) { bad = 1; }
+                        # a per-lane copy, straight-line like every other width
+                        # conversion on this target: one cycle count per value.
+                        if (vi == 0)     { fixed = cy; }
+                        or (cy != fixed) { bad = 1; }
+                    }
+                    vi = vi + 1;
+                }
+            }
+        }
+        project.dnit_project(?p);
+    }
+
+    A.deallocate[u8](alloc, mem, UT_MOS_MEM);
+    A.deallocate[u8](alloc, srcbuf, 8192);
+    ret bad;
+}
+
+# mos6502 (#2483): a same-width cast on a wide value BUILDS AND RUNS, executed on
+# a reference 6502 core
+#
+# The issue's own repro (`v::u64` on an already-`u64` value) reaches a bare
+# `MIR_BITCAST` at `bits` wide - reinterpreting bits at an UNCHANGED width, its
+# own opcode contract, never exercised on this target before because no existing
+# probe performed a same-width cast on a wide value. Swept at every width the
+# language's integers can name (`u8`/`u16`/`u32`/`u64`), each truncating `v` to
+# that width, casting it to itself (the bitcast under test), then widening back -
+# so the swept width IS the bitcast's own width, not merely the surrounding
+# function's calling convention.
+test "mach.lang.driver:samewidth_cast_executes_on_a_6502_core_mos6502" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    if (ut_mos_cast_sweep(?s, ?alloc, 8,  "u8")  != 0) { bad = 1; }
+    if (ut_mos_cast_sweep(?s, ?alloc, 16, "u16") != 0) { bad = 1; }
+    if (ut_mos_cast_sweep(?s, ?alloc, 32, "u32") != 0) { bad = 1; }
+    if (ut_mos_cast_sweep(?s, ?alloc, 64, "u64") != 0) { bad = 1; }
 
     session.dnit(?s);
     ret bad;

--- a/src/lang/target/isa/mos6502/rules.mach
+++ b/src/lang/target/isa/mos6502/rules.mach
@@ -116,7 +116,12 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     rules.Rule{ op: mir.MIR_FP_TO_UI, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_SI_TO_FP, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_UI_TO_FP, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_BITCAST,  gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
+    # unlike TRUNC/SEXT/ZEXT (never same-width, so always wide on a 1-byte lane and
+    # always intercepted by the width legalizer first), a BITCAST reinterprets bits
+    # at an UNCHANGED width and so reaches this encoder directly at native width too
+    # (#2483) - retagged to the same mos6502.MOV a plain move is, not left to pass
+    # through as the generic tag `encode_instr`'s dispatch never matches.
+    rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: mos6502.MOV::u32, expand: nil, expansion_length: 0 },
 
     # memory and address ops pass through to the encoder's zero-page / absolute /
     # frame-relative addressing.


### PR DESCRIPTION
## The opcode, confirmed by instrumentation

Instrumented \`unsupported_message\` directly (not inferred): the issue's repro
(\`v::u64\` on an already-\`u64\` value) prints \`op=30 width=8\` -
\`mir.MIR_BITCAST\`, confirming the #2478-author's read exactly. \`MIR_BITCAST\`'s
own opcode contract is "reinterpret a value's bits as a same-width type" -
source and destination lanes align one to one, nothing to fill or drop - so it
is exactly the shape \`expand_mov\` already handles. Fixed by adding
\`MIR_BITCAST\` to the same dispatch arm as \`MIR_MOV\`/\`MIR_DECLASSIFY\`, in both
\`expansion_count\` and \`expand_instr\` (they must agree exactly, per the file's
own stated contract).

## The audit: MIR_CMP_* is ALSO reachable and unarmed - a materially bigger finding

Went through every \`MirOpcode\` and checked which can reach \`expand_instr\`
without an arm, per the issue's own instruction to name the frontier rather than
patch one entry:

**Genuinely reachable, unarmed - the same defect shape, confirmed by
instrumentation:**
- \`MIR_CMP_EQ\` / \`MIR_CMP_NE\` / \`MIR_CMP_LT_S\` / \`MIR_CMP_LT_U\` / \`MIR_CMP_LE_S\`
  / \`MIR_CMP_LE_U\` - a wide comparison (\`v == w\` / \`v < w\` for \`u64\` operands)
  hits the identical generic fallback. Confirmed directly for \`CMP_EQ\` (\`op=15\`)
  and \`CMP_LT_U\` (\`op=18\`); the remaining four share the opcode family's shape
  and the same reachability path (no width-driven admission distinguishes them).
  **Not fixed here** - deliberately. A wide comparison needs a genuinely
  different algorithm (an AND/OR-reduction for equality, a lexicographic
  top-down lane walk for ordered comparison), comparable in design and
  verification effort to #2344's multiply, not "one more arm" alongside a
  same-width identity copy. Flagging to the team lead for its own issue rather
  than folding a second multi-day task into this one.

**Checked and confirmed NOT independently reachable today:**
- \`MIR_EXTRACT\` / \`MIR_INSERT\` / \`MIR_CALL_RES\` - every aggregate-field-access
  and multi-register-return repro tried (a local record with a wide field, a
  function calling another function returning \`u64\`) hits the pre-existing,
  already-named \`MIR_ALLOCA\` refusal first (\`"legalize: materializing an
  address wider than one register is not yet legalized on this target"\`,
  confirmed empirically both times). Nothing constructible in mach today reaches
  past that wall to exercise EXTRACT/INSERT/CALL_RES's own gaps on this target.
- \`MIR_FP_TRUNC\` / \`MIR_FP_EXT\` / \`MIR_FP_TO_SI\` / \`MIR_FP_TO_UI\` /
  \`MIR_SI_TO_FP\` / \`MIR_UI_TO_FP\` - blocked earlier, at \`mir.lower_ir\`
  (\`"target has no float/vector register bank"\`, confirmed empirically): mos6502
  has no float support at all, so these six never reach legalize.
- \`MIR_ASM\` - unreachable for mos6502 specifically, at the LANGUAGE level: an
  \`asm <isa> { }\` block's ISA tag is drawn from a closed set
  (\`x86_64\`/\`aarch64\`/\`riscv64\`, per \`doc/language/asm.md\`) that does not
  include mos6502, regardless of \`mos6502/rules.mach\` carrying its own
  (unreachable) \`RULE_PASS\` entry for it.
- \`MIR_PHI\` / \`MIR_CALL_IR\` - eliminated during lowering, a cross-target
  SSA-destruction invariant this file's own existing comments already establish
  (not re-derived here, just confirmed still true).
- \`MIR_SEL_*\` / \`MIR_VEC_EXTRACT\` / \`MIR_VEC_INSERT\` - structurally excluded:
  the \`MIR_SEL_*\` family is legalize's OWN pass's downstream output (post-isel,
  and legalize runs before isel), and the vector pseudo-ops are excluded by
  \`instr_is_vector\`'s check at the top of \`instr_needs_legalize\`.
- \`MIR_BR\` / \`MIR_CBR\` / \`MIR_RET\` / \`MIR_UNREACHABLE\` / \`MIR_ARG\` - control-flow
  terminators and the argument-marker pseudo-op; none carry a "value width" the
  legalize gate's width test is checking. Not independently instrumented (low
  suspicion given their role), but named here rather than silently assumed.

## A second instance of the same defect, found while making the fix testable

Fixing \`expand_instr\` alone left the issue's own acceptance bar
("the redundant-cast pair is exercised at every width") failing at \`u8\`: a
**native-width** bitcast (\`v::u8\` for an already-\`u8\` \`v\`) hit a DIFFERENT
error, \`"mos6502: instruction encoding is not yet implemented on this target"\`,
from the ENCODER rather than the legalizer. Traced to \`mos6502/rules.mach\`:
\`MIR_MOV\`/\`MIR_DECLASSIFY\` are \`RULE_RETAG\`'d to \`mos6502.MOV\`, but
\`MIR_BITCAST\` was left \`RULE_PASS\` - staying tagged \`mir.MIR_BITCAST\`, which
\`encode_instr\`'s dispatch table never matches. Unlike \`TRUNC\`/\`SEXT\`/\`ZEXT\`
(never same-width by their own opcode contracts, so always wide on a 1-byte
lane and always intercepted by the legalizer first - their own \`RULE_PASS\`
entries are correspondingly unreached), a same-width \`BITCAST\` reaches the
encoder directly too, so this half needed its own fix: retagged to
\`mos6502.MOV\`, matching \`MOV\`/\`DECLASSIFY\` exactly.

## Test changes

- #2478's \`u64\`-only skip in \`ut_mos_mul_src\` is removed; the redundant
  same-width cast pair is exercised at every width again, including the case
  that motivated the skip in the first place.
- A dedicated new test,
  \`driver:samewidth_cast_executes_on_a_6502_core_mos6502\`, sweeps the
  same-width cast itself (not merely riding inside a multiply) at
  \`u8\`/\`u16\`/\`u32\`/\`u64\`: truncate \`v\` to the width, cast it to itself (the
  bitcast under test), widen back - so the swept width is the bitcast's own,
  not just the surrounding function's calling convention. \`u8\` is the case that
  specifically exercises the native-width encoder fix; \`u16\`/\`u32\`/\`u64\`
  exercise the wide legalize fix.

## Verification

- \`mach test .\` via a from-source \`--jobs 1\` compiler: **1036 passed, 0
  failed** - exactly the \`dev\` baseline at the branch's post-merge base
  (\`7ed07460\`, 1035/0, measured with the same from-source methodology) plus the
  one new test block.
- **Mutation test, both fixes independently**: (1) dropped \`MIR_BITCAST\` from
  \`expand_instr\`'s dispatch (leaving \`expansion_count\` unchanged, so this
  isolates the dispatch itself, not a piece-count mismatch) - **1034 passed, 2
  failed**, both precisely the two dependent tests (#2478's multiply test, whose
  \`u64\` case rides the same cast, and the new dedicated cast test). (2) reverted
  the \`rules.mach\` retag back to \`RULE_PASS\` - **1035 passed, 1 failed**, only
  the new dedicated test's \`u8\` case, exactly the shape the encoder-level fix
  covers and the wide-legalize fix does not. Both reverted; confirmed clean
  **1036/0** afterward.
- **Object-level byte-identity** (mos6502-only change, per the bar - one target
  \`linux-x86_64\`, one profile \`release\`): held the \`dev\`-baseline project
  source fixed, built its 215 objects once with the unmodified baseline
  compiler and once with this branch's from-source compiler. \`diff -rq\`: **zero
  differences**.
- **Three-generation self-host fixpoint**: gen3 == gen4 byte-identical
  (\`9147394386d4fc0962f7407cc1f29c1777fcfcbcaec36ff5c2b6a97e42a27bf5\`),
  \`--jobs 1\` throughout.

Closes #2483