### PR TITLE
fix(driver): name the dep and the fix when a path dep is unresolved

### DIFF
--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -9,6 +9,7 @@
 
 use std.data.toml;
 use fs: std.filesystem;
+use std.format;
 use std.text.string.str_free;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -498,6 +499,42 @@ fun requirement_in(arr: *manifest.LinkRequirement, count: u32,
     ret false;
 }
 
+# the diagnostic for a dep whose manifest could not be read (#2471)
+#
+# Distinguishes the two real causes: the vendor location itself is missing - an
+# unresolved dep on a clean checkout, where `mach dep pull` is the fix - from a
+# vendor location that exists but whose manifest failed to open or parse for some
+# other reason, where `parse_toml_file`'s message already names the path and the
+# OS error. Naming the dep either way is what the bare passthrough this replaces
+# never did.
+# ---
+# s:       session, for interning the returned message
+# alias:   the dep's `[dep.<alias>]` name
+# dep_dir: the dep's vendor root, checked for existence to pick the diagnosis
+# read_err: `parse_toml_file`'s error (path- and OS-message-qualified already)
+# ret:     the owned, interned diagnostic
+fun diag_dep_manifest_error(s: *session.Session, alias: str, dep_dir: str, read_err: str) str {
+    val fallback: str = "dep manifest unreadable; run `mach dep pull`";
+    var res_msg: R.Result[str, str];
+    if (!fs.exists(dep_dir)) {
+        res_msg = format.sprint(s.build_alloc,
+            "dependency '{}' is not resolved (missing '{}'); run `mach dep pull`", alias, dep_dir);
+    }
+    or {
+        res_msg = format.sprint(s.build_alloc, "dep '{}': {}", alias, read_err);
+    }
+    if (R.is_err[str, str](res_msg)) { ret fallback; }
+    val buf: str = R.unwrap_ok[str, str](res_msg);
+
+    val ir: R.Result[intern.StrId, str] = intern.intern(?s.interner, buf);
+    str_free(s.build_alloc, buf);
+    if (R.is_err[intern.StrId, str](ir)) { ret fallback; }
+
+    val nm: O.Option[str] = intern.lookup(?s.interner, R.unwrap_ok[intern.StrId, str](ir));
+    if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
+    ret fallback;
+}
+
 # load a dep's own mach.toml to recover its [project].id and source
 # dir. vendor layout follows doc/dependencies.md:
 # <project_root>/<dir_dep>/<alias>/
@@ -516,8 +553,9 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     val tr: R.Result[toml.Table, str] = parse_toml_file(s.build_alloc, toml_path);
     str_free(s.build_alloc, toml_path);
     if (R.is_err[toml.Table, str](tr)) {
+        val msg: str = diag_dep_manifest_error(s, alias, dep_dir, R.unwrap_err[toml.Table, str](tr));
         str_free(s.build_alloc, dep_dir);
-        ret R.err[project.DepEntry, str](R.unwrap_err[toml.Table, str](tr));
+        ret R.err[project.DepEntry, str](msg);
     }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](tr);
 
@@ -626,9 +664,17 @@ fun build_dep_root(alloc: *A.Allocator, project_root: str, dir_dep: str, alias: 
 }
 
 # read `path` and parse its contents into a TOML Table, freeing the file text
+#
+# A read failure is reported with `path` and the OS message attached, never the
+# bare OS message alone (#2471) - every caller propagates this string as its own
+# error, so this is the one place that fixes all of them.
 pub fun parse_toml_file(alloc: *A.Allocator, path: str) R.Result[toml.Table, str] {
     val rb: R.Result[str, str] = fs.read_string(alloc, path);
-    if (R.is_err[str, str](rb)) { ret R.err[toml.Table, str](R.unwrap_err[str, str](rb)); }
+    if (R.is_err[str, str](rb)) {
+        val res_msg: R.Result[str, str] = format.sprint(alloc, "cannot read '{}': {}", path, R.unwrap_err[str, str](rb));
+        if (R.is_err[str, str](res_msg)) { ret R.err[toml.Table, str](R.unwrap_err[str, str](rb)); }
+        ret R.err[toml.Table, str](R.unwrap_ok[str, str](res_msg));
+    }
     val src_text: str = R.unwrap_ok[str, str](rb);
     val rt: R.Result[toml.Table, str] = toml.parse(alloc, src_text);
     str_free(alloc, src_text);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2508,6 +2508,46 @@ test "mach.lang.driver:dep_closure_registers_transitive" {
     ret bad;
 }
 
+# a project declaring a path dep that was never pulled (clean checkout, no dep/,
+# no mach.lock) fails with a diagnostic naming the dep and the fix command, not
+# the bare OS message a raw read failure used to surface with no path or dep
+# attached at all (#2471)
+test "mach.lang.driver:dep_unresolved_names_dep_and_fix" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "fun main() i32 { ret 0; }\n";
+    # ./vendor/absdep is declared but never written: `mach dep pull` never ran.
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_dep_root_one(?alloc, "absdep", "./vendor/absdep"), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p);
+        bad = 1;
+    }
+    or {
+        val msg: str = R.unwrap_err[project.Project, outcome.Fail](pr).message;
+        if (!ut_str_contains(msg, "'absdep'"))     { bad = 1; }
+        if (!ut_str_contains(msg, "not resolved")) { bad = 1; }
+        if (!ut_str_contains(msg, "mach dep pull")) { bad = 1; }
+        if (ut_str_contains(msg, "no such file"))  { bad = 1; }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
 test "mach.lang.driver:reload_rebuild_dedup_sources_by_path" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }


### PR DESCRIPTION
Closes #2471.

## Bug

On a clean checkout (no `dep/`, no `mach.lock`), `mach build .` on a project with
`[dep.*]` entries failed with a bare `error: no such file or directory` - no dep
named, no path, no hint that `mach dep pull` is the fix. Hit independently twice.

**Before:**

```
$ mach build .
error: no such file or directory
```

**After** (from-source build):

```
$ mach build .
error: dependency 'absdep' is not resolved (missing './dep/absdep'); run `mach dep pull`
$ mach dep pull
linked absdep -> ../absdep
wrote mach.lock
$ mach build .
error: undefined entry symbol '_start'; ...   # dep resolution succeeded; this is
                                               # the fixture's own missing runtime,
                                               # unrelated to dep resolution
```

## Direction

Chose the **diagnostic** direction, not auto-pull. Auto-pulling deps as a `build`
side effect would make `build` do implicit network/filesystem work it doesn't do
today - a bigger, owner-level call this fix doesn't make. A diagnostic that names
the dep, the path it wanted, and the exact command closes the actual friction (not
knowing what to run) without changing what `build` does.

## Root cause

`resolve_dep` reads a dep's own `mach.toml` via `parse_toml_file`, whose read
failure was the bare OS message (`fs.read_string`'s `os.message(errno)`) with
nothing else attached - no path, no dep name - and every caller up the chain
(`resolve_dep` → project config loading → the top-level CLI printer) just
propagated it untouched.

## Fix

Two tiers:

1. **`parse_toml_file`** (7 call sites across `deps.mach`/`config.mach`) now
   attaches the path to a read failure: `"cannot read '<path>': <os message>"`.
   A broad, low-risk win - every one of its callers' errors gets at least this
   much context for free.
2. **`resolve_dep`**, which already has the dep's `alias` in scope, goes further:
   a new `diag_dep_manifest_error` distinguishes the vendor directory not existing
   at all (the unresolved-dep case this issue is about) from it existing but its
   manifest failing to read/parse for some other reason. The first case reports
   `"dependency '<alias>' is not resolved (missing '<dir>'); run `mach dep pull`"`;
   the second reports `"dep '<alias>': <parse_toml_file's now path-qualified error>"`.

## Verification

| bar | result |
|---|---|
| repro (before) | bare `error: no such file or directory` |
| repro (after) | `error: dependency 'absdep' is not resolved (missing './dep/absdep'); run \`mach dep pull\`` |
| repro, after running the suggested command | dep resolves; build proceeds past dep resolution |
| `mach test` | 1041 / 0 (1 new: `dep_unresolved_names_dep_and_fix`, pinning the new diagnostic's text and the absence of the retired bare message) |
| `B == C` fixpoint | byte-identical |

Branched off `dev` at `7ed07460`; dev moved by four merges before this push,
including `src/lang/driver/tests.mach` (a shared file, not disjoint) - merged dev
in, auto-merged cleanly (the overlap was unrelated mos6502 test code far from this
PR's insertion point), and re-ran the full bar (build, `mach test` 1041/0, B==C
fixpoint) on the merged tree.
