### PR TITLE
fix(link): rename over the target instead of truncating it in place

### DIFF
--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -383,12 +383,32 @@ pub fun write_atomic(itn: *intern.Interner, a: *A.Allocator, path: *u8, buf: *u8
         ret R.err[bool, str](cm);
     }
 
-    val res_rename: O.Option[str] = fs.rename(tmp, path::str);
+    var res_rename: O.Option[str] = fs.rename(tmp, path::str);
     if (O.is_some[str](res_rename)) {
-        val cm: str = io_message(itn, a, rename_op, path::str, O.unwrap[str](res_rename), rename_generic);
-        fs.remove_file(tmp);
-        A.deallocate[u8](a, tmp, str_len(tmp) + 1);
-        ret R.err[bool, str](cm);
+        # `rename` replacing an existing destination is POSIX-atomic but not
+        # universal: Windows' underlying MoveFile does not replace an existing
+        # file (mach-std's `os.rename` wraps the non-replacing `MoveFileA`,
+        # briar-systems/mach-std#414), so the first attempt fails here on every
+        # target host whenever `path` already exists - the common case, since
+        # this function exists specifically for REBUILDING an existing output.
+        # Falling back to remove-then-retry recovers the common case at the cost
+        # of a brief window (between the remove and the retry) where `path` does
+        # not exist, rather than a true atomic swap - the best available without
+        # a replacing primitive. If the remove fails, nothing was touched and the
+        # original rename error is reported unchanged.
+        if (O.is_some[str](fs.remove_file(path::str))) {
+            val cm: str = io_message(itn, a, rename_op, path::str, O.unwrap[str](res_rename), rename_generic);
+            fs.remove_file(tmp);
+            A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+            ret R.err[bool, str](cm);
+        }
+        res_rename = fs.rename(tmp, path::str);
+        if (O.is_some[str](res_rename)) {
+            val cm: str = io_message(itn, a, rename_op, path::str, O.unwrap[str](res_rename), rename_generic);
+            fs.remove_file(tmp);
+            A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+            ret R.err[bool, str](cm);
+        }
     }
 
     A.deallocate[u8](a, tmp, str_len(tmp) + 1);

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -14,16 +14,21 @@
 
 use std.memory;
 use std.format;
+use std.crypto.rand;
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.path.Path;
 
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use fs: std.filesystem;
+use spath: std.types.path;
 
 use mach.lang.intern;
 use mach.lang.target.of;
@@ -298,6 +303,98 @@ pub fun io_message(itn: *intern.Interner, a: *A.Allocator, op: str, path: str, o
     ret message_finish(itn, a, buf, str_len(buf), generic);
 }
 
+# write `buf` to `path` by creating a same-directory temp file and atomically
+# renaming it over `path`, rather than truncating `path` in place
+#
+# Writing in place fails with ETXTBSY when `path` is a binary a process is
+# currently executing (or, for a shared object, has mapped executable) - the
+# self-rebuild case #2475 names. Standard toolchain behavior (gcc/clang/go) is
+# to link to a temp file and rename over the target instead: a running process
+# keeps its unlinked image while `path` serves the new binary on the next
+# invocation, and a build killed mid-write never leaves a half-written file at
+# `path` - the temp file is either renamed whole or removed.
+#
+# The temp file MUST share `path`'s directory: `rename` fails with EXDEV
+# across filesystems, and a build output routinely lands on a different
+# filesystem than the OS temp directory (contrast `fs.temp_create`). The temp
+# name carries no exclusivity guarantee (a single random 64-bit suffix, no
+# O_EXCL retry) - collisions are gcc-`ccXXXXXX`-rare and, unlike `path` itself,
+# a clobbered temp file for a concurrent build of the same output belongs to
+# a build that was already racing this one.
+# ---
+# itn:            interner backing the returned diagnostic
+# a:              allocator for the transient temp-path text
+# path:           final destination path
+# buf:            bytes to write
+# len:            byte length of `buf`
+# mode:           permission bits for the created file
+# create_op:      leading diagnostic text for a temp-file create failure
+# create_generic: fallback text when `create_op` cannot be interned
+# write_op:       leading diagnostic text for a write failure
+# write_generic:  fallback text when `write_op` cannot be interned
+# rename_op:      leading diagnostic text for the final rename failure
+# rename_generic: fallback text when `rename_op` cannot be interned
+# ret:              ok(true) on success, or an interned diagnostic naming `path`
+pub fun write_atomic(itn: *intern.Interner, a: *A.Allocator, path: *u8, buf: *u8, len: usize, mode: i32,
+                      create_op: str, create_generic: str,
+                      write_op: str, write_generic: str,
+                      rename_op: str, rename_generic: str) R.Result[bool, str] {
+    val dir_r: R.Result[Path, str] = spath.parent(a, path::str);
+    if (R.is_err[Path, str](dir_r)) { ret R.err[bool, str](R.unwrap_err[Path, str](dir_r)); }
+    val dir: Path = R.unwrap_ok[Path, str](dir_r);
+
+    val name_r: R.Result[str, str] = format.sprint(a, ".{}.tmp{}", spath.filename(path::str), rand.u64());
+    if (R.is_err[str, str](name_r)) {
+        A.deallocate[u8](a, dir, str_len(dir) + 1);
+        ret R.err[bool, str](R.unwrap_err[str, str](name_r));
+    }
+    val tmp_name: str = R.unwrap_ok[str, str](name_r);
+
+    val tmp_r: R.Result[Path, str] = spath.join(a, dir, tmp_name);
+    A.deallocate[u8](a, dir, str_len(dir) + 1);
+    A.deallocate[u8](a, tmp_name, str_len(tmp_name) + 1);
+    if (R.is_err[Path, str](tmp_r)) { ret R.err[bool, str](R.unwrap_err[Path, str](tmp_r)); }
+    val tmp: Path = R.unwrap_ok[Path, str](tmp_r);
+
+    val res_file: R.Result[fs.File, str] = fs.create(tmp, mode);
+    if (R.is_err[fs.File, str](res_file)) {
+        val cm: str = io_message(itn, a, create_op, path::str, R.unwrap_err[fs.File, str](res_file), create_generic);
+        A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+        ret R.err[bool, str](cm);
+    }
+    var f: fs.File = R.unwrap_ok[fs.File, str](res_file);
+    val res_write: R.Result[usize, str] = fs.write(f, buf, len);
+    fs.close(f);
+    if (R.is_err[usize, str](res_write)) {
+        val cm: str = io_message(itn, a, write_op, path::str, R.unwrap_err[usize, str](res_write), write_generic);
+        fs.remove_file(tmp);
+        A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+        ret R.err[bool, str](cm);
+    }
+    # `fs.write` is one `write(2)` call, not a loop to completion: a short write
+    # (a resource limit, an interrupting signal) returns ok() with a byte count
+    # under `len` rather than an error. Left unchecked, that truncated temp file
+    # would still rename over `path`, replacing a good executable with a broken
+    # one and reporting success.
+    if (R.unwrap_ok[usize, str](res_write) != len) {
+        val cm: str = io_message(itn, a, write_op, path::str, "short write", write_generic);
+        fs.remove_file(tmp);
+        A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+        ret R.err[bool, str](cm);
+    }
+
+    val res_rename: O.Option[str] = fs.rename(tmp, path::str);
+    if (O.is_some[str](res_rename)) {
+        val cm: str = io_message(itn, a, rename_op, path::str, O.unwrap[str](res_rename), rename_generic);
+        fs.remove_file(tmp);
+        A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+        ret R.err[bool, str](cm);
+    }
+
+    A.deallocate[u8](a, tmp, str_len(tmp) + 1);
+    ret R.ok[bool, str](true);
+}
+
 # count the relocations targeting each section of `img` in one pass, returning a
 # `section_count`-long array (`counts[s]` = relocations patching section `s`)
 #
@@ -356,5 +453,113 @@ test "mach.lang.target.of.bin.region_ok:wrap_around" {
     if (!region_ok(0x10, 8, 8)) { ret 1; }
     # one byte over: len exceeds remaining space -> false
     if (region_ok(0x10, 8, 9)) { ret 1; }
+    ret 0;
+}
+
+# write_atomic lands the requested bytes at `path`, readable back afterward
+test "mach.lang.target.of.bin.write_atomic:replaces_target_content" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "atomic_dst");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val dst: str = fs.temp_path(?tf);
+    fs.temp_close(?tf);
+
+    var content: [4]u8;
+    content[0] = 0xDE; content[1] = 0xAD; content[2] = 0xBE; content[3] = 0xEF;
+
+    val wr: R.Result[bool, str] = write_atomic(?itn, ?alloc, dst::*u8, ?content[0], 4, 0o644,
+        "test: create", "test: create failed", "test: write", "test: write failed",
+        "test: rename", "test: rename failed");
+    if (R.is_err[bool, str](wr)) { fs.remove_file(dst); ret 1; }
+
+    val or_: R.Result[fs.File, str] = fs.open(dst);
+    if (R.is_err[fs.File, str](or_)) { ret 1; }
+    val rf: fs.File = R.unwrap_ok[fs.File, str](or_);
+    var readback: [4]u8;
+    val rr: R.Result[usize, str] = fs.read(rf, ?readback[0], 4);
+    fs.close(rf);
+    fs.remove_file(dst);
+    if (R.is_err[usize, str](rr))              { ret 1; }
+    if (R.unwrap_ok[usize, str](rr) != 4)      { ret 1; }
+    if (readback[0] != 0xDE || readback[1] != 0xAD
+     || readback[2] != 0xBE || readback[3] != 0xEF) { ret 1; }
+
+    ret 0;
+}
+
+# the mechanism #2475 exists for: a handle opened on `path` BEFORE the replace -
+# standing in for a process that `execve`'d the old image - keeps reading the old
+# bytes after `write_atomic` returns, because the rename repoints the directory
+# entry without touching the inode the open handle already resolved to. A fresh
+# open of the same path sees the new content. This is the in-process form of the
+# ETXTBSY repro (#2475): a rebuild that truncated `path` in place would instead
+# corrupt the still-open handle's view, or fail outright while a real execve'd
+# process holds it.
+test "mach.lang.target.of.bin.write_atomic:open_handle_survives_replace" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "atomic_live");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val dst: str = fs.temp_path(?tf);
+
+    var old_content: [4]u8;
+    old_content[0] = 0x11; old_content[1] = 0x22; old_content[2] = 0x33; old_content[3] = 0x44;
+    val ww: R.Result[usize, str] = fs.write(tf.file, ?old_content[0], 4);
+    if (R.is_err[usize, str](ww)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val or_: R.Result[fs.File, str] = fs.open(dst);
+    if (R.is_err[fs.File, str](or_)) { fs.temp_close_and_remove(?tf); ret 1; }
+    val held: fs.File = R.unwrap_ok[fs.File, str](or_);
+    fs.temp_close(?tf);
+
+    var new_content: [4]u8;
+    new_content[0] = 0xAA; new_content[1] = 0xBB; new_content[2] = 0xCC; new_content[3] = 0xDD;
+    val wr: R.Result[bool, str] = write_atomic(?itn, ?alloc, dst::*u8, ?new_content[0], 4, 0o644,
+        "test: create", "test: create failed", "test: write", "test: write failed",
+        "test: rename", "test: rename failed");
+    if (R.is_err[bool, str](wr)) { fs.close(held); fs.remove_file(dst); ret 1; }
+
+    var readback_old: [4]u8;
+    val rr_old: R.Result[usize, str] = fs.read(held, ?readback_old[0], 4);
+    fs.close(held);
+    if (R.is_err[usize, str](rr_old)) { fs.remove_file(dst); ret 1; }
+    if (readback_old[0] != 0x11 || readback_old[1] != 0x22
+     || readback_old[2] != 0x33 || readback_old[3] != 0x44) { fs.remove_file(dst); ret 1; }
+
+    val or2: R.Result[fs.File, str] = fs.open(dst);
+    if (R.is_err[fs.File, str](or2)) { ret 1; }
+    val fresh: fs.File = R.unwrap_ok[fs.File, str](or2);
+    var readback_new: [4]u8;
+    val rr_new: R.Result[usize, str] = fs.read(fresh, ?readback_new[0], 4);
+    fs.close(fresh);
+    fs.remove_file(dst);
+    if (R.is_err[usize, str](rr_new)) { ret 1; }
+    if (readback_new[0] != 0xAA || readback_new[1] != 0xBB
+     || readback_new[2] != 0xCC || readback_new[3] != 0xDD) { ret 1; }
+
+    ret 0;
+}
+
+# a destination whose directory does not exist fails cleanly through the
+# caller-supplied create diagnostic, rather than a crash or a silent no-op
+test "mach.lang.target.of.bin.write_atomic:missing_directory_fails_cleanly" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var buf: [4]u8;
+    buf[0] = 1; buf[1] = 2; buf[2] = 3; buf[3] = 4;
+
+    val wr: R.Result[bool, str] = write_atomic(?itn, ?alloc, "/mach-2475-no-such-dir/target"::*u8, ?buf[0], 4, 0o644,
+        "test: create", "test: create failed", "test: write", "test: write failed",
+        "test: rename", "test: rename failed");
+    if (R.is_ok[bool, str](wr)) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2872,19 +2872,12 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
     if (uw_all != nil && func_count > 0) { A.deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
 
-    val res_file: R.Result[fs.File, str] = fs.create(path, 0o755);
-    if (R.is_err[fs.File, str](res_file)) {
-        val cm: str = bin.io_message(itn, alloc, "coff: cannot create executable", path::str, R.unwrap_err[fs.File, str](res_file), "coff: could not create executable file");
-        A.deallocate[u8](alloc, buf, total_size);
-        ret R.err[bool, str](cm);
-    }
-    var f: fs.File = R.unwrap_ok[fs.File, str](res_file);
-    val res_write: R.Result[usize, str] = fs.write(f, buf, total_size);
-    fs.close(f);
+    val res: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "coff: cannot create executable", "coff: could not create executable file",
+        "coff: PE write failed on", "coff: PE write failed",
+        "coff: PE rename failed on", "coff: PE rename failed");
     A.deallocate[u8](alloc, buf, total_size);
-
-    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](bin.io_message(itn, alloc, "coff: PE write failed on", path::str, R.unwrap_err[usize, str](res_write), "coff: PE write failed")); }
-    ret R.ok[bool, str](true);
+    ret res;
 }
 
 # serialize the `.idata` section - the import directory table,

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1565,19 +1565,12 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     if (debug_offs != nil)      { A.deallocate[usize](alloc, debug_offs, debug_count::usize); }
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
-    val res_file: R.Result[fs.File, str] = fs.create(path, 0o755);
-    if (R.is_err[fs.File, str](res_file)) {
-        val cm: str = bin.io_message(itn, alloc, "elf: cannot create executable", path::str, R.unwrap_err[fs.File, str](res_file), "elf: could not create executable file");
-        A.deallocate[u8](alloc, buf, total_size);
-        ret R.err[bool, str](cm);
-    }
-    var f: fs.File = R.unwrap_ok[fs.File, str](res_file);
-    val res_write: R.Result[usize, str] = fs.write(f, buf, total_size);
-    fs.close(f);
+    val res: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "elf: cannot create executable", "elf: could not create executable file",
+        "elf: exec write failed on", "elf: exec write failed",
+        "elf: exec rename failed on", "elf: exec rename failed");
     A.deallocate[u8](alloc, buf, total_size);
-
-    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](bin.io_message(itn, alloc, "elf: exec write failed on", path::str, R.unwrap_err[usize, str](res_write), "elf: exec write failed")); }
-    ret R.ok[bool, str](true);
+    ret res;
 }
 
 # whether the ELF header + `phdr_count` program headers fit the single page the linker
@@ -2031,19 +2024,12 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
-    val res_file: R.Result[fs.File, str] = fs.create(path, 0o755);
-    if (R.is_err[fs.File, str](res_file)) {
-        val cm: str = bin.io_message(itn, alloc, "elf: cannot create PIE executable", path::str, R.unwrap_err[fs.File, str](res_file), "elf: could not create PIE executable file");
-        A.deallocate[u8](alloc, buf, total_size);
-        ret R.err[bool, str](cm);
-    }
-    var f: fs.File = R.unwrap_ok[fs.File, str](res_file);
-    val res_write: R.Result[usize, str] = fs.write(f, buf, total_size);
-    fs.close(f);
+    val res: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "elf: cannot create PIE executable", "elf: could not create PIE executable file",
+        "elf: pie write failed on", "elf: pie write failed",
+        "elf: pie rename failed on", "elf: pie rename failed");
     A.deallocate[u8](alloc, buf, total_size);
-
-    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](bin.io_message(itn, alloc, "elf: pie write failed on", path::str, R.unwrap_err[usize, str](res_write), "elf: pie write failed")); }
-    ret R.ok[bool, str](true);
+    ret res;
 }
 
 # write the program-header table for a static-PIE executable
@@ -2560,19 +2546,12 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     if (exp_str != nil)     { A.deallocate[usize](alloc, exp_str, nexp::usize); }
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
-    val res_file: R.Result[fs.File, str] = fs.create(path, 0o755);
-    if (R.is_err[fs.File, str](res_file)) {
-        val cm: str = bin.io_message(itn, alloc, "elf: cannot create shared object", path::str, R.unwrap_err[fs.File, str](res_file), "elf: could not create shared-object file");
-        A.deallocate[u8](alloc, buf, total_size);
-        ret R.err[bool, str](cm);
-    }
-    var f: fs.File = R.unwrap_ok[fs.File, str](res_file);
-    val res_write: R.Result[usize, str] = fs.write(f, buf, total_size);
-    fs.close(f);
+    val res: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "elf: cannot create shared object", "elf: could not create shared-object file",
+        "elf: shared write failed on", "elf: shared write failed",
+        "elf: shared rename failed on", "elf: shared rename failed");
     A.deallocate[u8](alloc, buf, total_size);
-
-    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](bin.io_message(itn, alloc, "elf: shared write failed on", path::str, R.unwrap_err[usize, str](res_write), "elf: shared write failed")); }
-    ret R.ok[bool, str](true);
+    ret res;
 }
 
 # the ELF machine JUMP_SLOT (PLT) relocation type for an ISA
@@ -2980,19 +2959,12 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
-    val res_file: R.Result[fs.File, str] = fs.create(path, 0o755);
-    if (R.is_err[fs.File, str](res_file)) {
-        val cm: str = bin.io_message(itn, alloc, "elf: cannot create dynamic executable", path::str, R.unwrap_err[fs.File, str](res_file), "elf: could not create dynamic executable file");
-        A.deallocate[u8](alloc, buf, total_size);
-        ret R.err[bool, str](cm);
-    }
-    var f: fs.File = R.unwrap_ok[fs.File, str](res_file);
-    val res_write: R.Result[usize, str] = fs.write(f, buf, total_size);
-    fs.close(f);
+    val res: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "elf: cannot create dynamic executable", "elf: could not create dynamic executable file",
+        "elf: dyn-exec write failed on", "elf: dyn-exec write failed",
+        "elf: dyn-exec rename failed on", "elf: dyn-exec rename failed");
     A.deallocate[u8](alloc, buf, total_size);
-
-    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](bin.io_message(itn, alloc, "elf: dyn-exec write failed on", path::str, R.unwrap_err[usize, str](res_write), "elf: dyn-exec write failed")); }
-    ret R.ok[bool, str](true);
+    ret res;
 }
 
 # place every synthesized dynamic structure at a file offset and virtual address

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1323,14 +1323,18 @@ fun emit_object(isa_vt: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resul
     ret wr;
 }
 
-# write `buf` to `path`, framing a clear I/O diagnostic on failure
+# write `buf` to `path` in place, framing a clear I/O diagnostic on failure
+#
+# Object output only - never mapped executable, so unlike the exec/dyn-exec
+# writers (`bin.write_atomic`) it has no ETXTBSY hazard and needs no
+# temp-file-and-rename.
 # ---
 # itn:   interner backing the I/O diagnostic (may be nil)
 # alloc: allocator backing the diagnostic
 # path:  null-terminated output path
 # buf:   the bytes to write
 # len:   number of bytes to write
-# label: the leading text for the diagnostic ("macho: object" / "macho: exec")
+# label: the leading text for the diagnostic ("macho: object")
 # ret:   ok(true) on success, or an I/O error
 fun write_file(itn: *intern.Interner, alloc: *A.Allocator, path: *u8, buf: *u8, len: usize, label: str) R.Result[bool, str] {
     val rf: R.Result[fs.File, str] = fs.create(path, 0o755);
@@ -1942,7 +1946,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     macho_dwarf_free(alloc, ?dw, debug_count);
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
-    val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: exec");
+    val wr: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "macho: exec", "macho: could not create output file",
+        "macho: exec", "macho: write failed",
+        "macho: exec", "macho: rename failed");
     A.deallocate[u8](alloc, buf, total_size);
     ret wr;
 }
@@ -3309,7 +3316,10 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # segment bytes, the bind/symbol tables, and the call-site fixups are all placed.
     write_code_signature(buf, sig_off, name, sig_off, 0, exec_limit);
 
-    val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: dyn-exec");
+    val wr: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
+        "macho: dyn-exec", "macho: could not create output file",
+        "macho: dyn-exec", "macho: write failed",
+        "macho: dyn-exec", "macho: rename failed");
     A.deallocate[u8](alloc, buf, total_size);
     ret wr;
 }


### PR DESCRIPTION
Closes #2475.

`mach build` linked the executable in place (`fs.create` on `path`, truncating it
directly), so rebuilding a binary a process is currently executing failed with
`elf: cannot create executable '<path>': text file busy` (ETXTBSY) - observed with
bmos-mach's `bmos` tool, whose `build` subcommand rebuilds itself.

## The fix

`bin.write_atomic` (new, in the shared `target/of/bin` module): create a temp file
in the **same directory** as the target (a `path.parent(path)` + a random 64-bit
suffix), write the buffer, close, then `fs.rename` the temp over the target.
Standard toolchain behavior (gcc/clang/go). Two properties, both load-bearing:

1. **A running process keeps its unlinked image.** `rename` repoints the directory
   entry; it never touches the inode an already-open handle (or an `execve`d
   process's mapped text) resolved to. The path serves the new binary on the next
   invocation.
2. **A killed/failed build never leaves a half-written executable at the target.**
   The temp file is either renamed whole on full success, or removed on any
   failure (create, write, or the rename itself) - `path` is never opened for
   writing at all until the swap is atomic.

The temp file **must** share the target's directory - `rename` fails with EXDEV
across filesystems, and a build output routinely lands on a different filesystem
than the OS temp directory (mach-std's own `fs.temp_create` is unsuitable for
exactly this reason).

## Scope: which writers changed

Every writer that can produce a **mapped-executable** artifact - the ETXTBSY
hazard applies to a currently-running process's text (an executable) or a
`dlopen`ed shared object's mapped segments, not to something nothing ever
`execve`s or maps `PROT_EXEC`:

- ELF: static exec, PIE exec, shared object (`.so`), dynamic exec (4 call sites)
- COFF: PE executable (1 call site)
- Mach-O: exec, dyn-exec (2 call sites, redirected off the shared `write_file`
  helper they used to share with the object writer)

**Left unchanged** (same in-place `fs.create`+`fs.write` pattern, but not the
hazard this issue names, and out of scope per the task):
- **Object files** (ELF/COFF `.o`, Mach-O's `write_file` object call) - build
  intermediates, never mapped executable by a running process.
- **Raw images** (`target/of/raw.mach`) - freestanding/embedded targets (e.g.
  mos6502); never `execve`d by the host OS as a live process at that path.
- **Static archives** (`target/of/ar.mach`, `fs.write_bytes`) and **SPIR-V
  modules** (`target/of/spv.mach`, `fs.write_bytes`) - never directly executed.

All four of these share the identical hazard-free shape, so this is a scoping
call, not an oversight - flagging per the task instructions in case a future
`.so`-adjacent case (e.g. archive members) argues for revisiting.

## A short-write gap found while verifying, fixed in the same function

None of the six original call sites checked the byte count `fs.write` returned
against the requested length - `fs.write` is one `write(2)` call, not a loop to
completion, so a short write (a resource limit, an interrupting signal) returned
`ok()` under length and was reported as **success**, silently truncating the
output. Found live (below); `write_atomic` now treats a short write as a write
failure, cleans up the temp file, and leaves the target untouched - the same
"never half-written" property, extended to a failure mode the original code
didn't recognize as a failure at all. This exists nowhere else adjacent (every
other writer's `fs.write` call has the same gap, pre-existing, out of scope here)
- worth a follow-up issue if it's judged worth chasing outside the executable
writers.

## Repro (shell, before/after)

**Before** (dev @ `da7b2b1e`, prior to this branch):
```
$ ./out/linux-x86_64/debug/bin/mach build .
error: elf: cannot create executable './out/linux-x86_64/debug/bin/mach': text file busy
```
(hit by construction: the compiler tried to relink itself while it was the
process running the build - exactly bmos's self-rebuild shape.)

**After** (this branch): the same self-rebuild succeeds -
```
$ ./out/linux-x86_64/debug/bin/mach build .
$ echo $?
0
```

**Property 1 demonstrated live** - a background process holds the binary open
across a concurrent rebuild of the same path:
```
$ ($BIN test . > bg.log 2>&1; echo BG_EXIT:$? >> bg.log) &
$ sleep 0.05 && $BIN build . -o $BIN   # rebuilds the path the bg process is running
$ echo REBUILD_EXIT:$?
REBUILD_EXIT:0
$ wait; tail -2 bg.log
1035 passed, 0 failed, 1035 total  (576ms)
BG_EXIT:0
```
Both the concurrent rebuild and the already-running test process complete clean.

**Property 2 demonstrated live** - a forced create failure (read-only output
directory) leaves a pre-existing target untouched and orphans no temp file:
```
$ echo OLD-BINARY-CONTENT-DO-NOT-TOUCH > rodir/target && chmod 555 rodir
$ $BIN build . -o rodir/target
error: elf: cannot create executable 'rodir/target': permission denied
$ cat rodir/target
OLD-BINARY-CONTENT-DO-NOT-TOUCH
$ ls rodir/
target          # no orphaned .target.tmp<N>
```

**The short-write gap, live** (before the fix in this branch): a `ulimit -f`
low enough to truncate the write reported `EXIT:0` and silently wrote a 1024-byte
`target` in place of the real ~5 MB executable. After the fix: the same `ulimit`
now fails cleanly (`elf: exec write failed on '...': short write`), the
pre-existing target is untouched, and no temp file is orphaned.

I'm pasting these as shell repros rather than reaching them from `mach test`
because two of the failure modes (an unwritable output directory, an
interrupting `RLIMIT_FSIZE`) aren't reachable through anything `std.filesystem`
exposes to a test (no `chmod`/rlimit primitive) - noted per the task's allowance.

## Unit tests added (`target/of/bin.mach`)

- `write_atomic:replaces_target_content` - happy path, byte-for-byte.
- `write_atomic:open_handle_survives_replace` - **the in-process form of the
  ETXTBSY repro**: opens a handle on the target *before* the replace (standing in
  for a process that `execve`'d the old image), calls `write_atomic`, and asserts
  the already-open handle still reads the *old* bytes while a fresh `open` of the
  same path sees the *new* ones - the exact POSIX guarantee (`rename` repoints the
  directory entry, not the inode an open handle already resolved to) that makes
  the self-rebuild case safe.
- `write_atomic:missing_directory_fails_cleanly` - a destination whose directory
  doesn't exist fails through the caller's diagnostic rather than a crash or a
  silent no-op.

## Verification

| bar | result |
|---|---|
| `mach test` (from-source compiler) | 1040 / 0 (was 1035 on dev before this branch; +5: the 3 `write_atomic` tests plus 2 unrelated tests that landed on dev from concurrent work between fetch and this push) |
| `B == C` self-host fixpoint | byte-identical |
| self-rebuild repro | ETXTBSY reproduced on dev, resolved on this branch (both pasted above) |
| create-failure repro | pre-existing target untouched, no orphaned temp (pasted above) |
| write-failure repro (short write) | now fails cleanly instead of silently truncating (pasted above) |
| concurrent running-process repro | background process and concurrent rebuild of its own path both complete clean (pasted above) |

Disjointness check: not claimed - dev moved during this branch's life (concurrent
peer work), so a full re-verify was run instead of a diff-based skip.


## Windows CI caught a real cross-platform gap in `fs.rename` itself

The first push failed 22 tests on both Windows lanes - every `write_atomic`
call site, since every one of those tests rebuilds an output that already
exists. Root cause: `mach-std`'s Windows `os.rename` wraps the non-replacing
`MoveFileA`, unlike Linux/Darwin's POSIX `rename(2)`, which atomically replaces
an existing destination. Filed as
[briar-systems/mach-std#414](https://github.com/briar-systems/mach-std/issues/414)
- the real fix (`MoveFileExA` + `MOVEFILE_REPLACE_EXISTING`) belongs there and
benefits every `fs.rename` caller, not just this one.

Pending that, `write_atomic` now falls back to remove-then-retry when the first
rename fails: if `fs.remove_file(path)` also fails, nothing was touched and the
original rename error is reported unchanged; if it succeeds, the retry recovers
the common case at the cost of a brief window where `path` doesn't exist,
rather than a true atomic swap. All Windows lanes are green after this fallback
(pushed as a second commit, `950f52f8`).
