### PR TITLE
fix(lower): give the unknown-escape diagnostic a location

### DIFF
--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -154,8 +154,11 @@ LIT_STR  ::= '"' { str-char } '"'
 
 The lexer captures the raw span between the quotes and treats `\` as an
 escape that consumes the next character (so an escaped quote does not
-terminate the literal). Escape decoding happens later
-(`comptime.eval_lit_char`); the recognized escapes are:
+terminate the literal). Escape decoding happens later — in
+`comptime.eval_lit_char` / `comptime.eval_lit_str` for a comptime-evaluated
+literal, and in `me/lower/expr.lit_decode_escape` (an intentional mirror of the
+same table, #2472) for one lowered as ordinary runtime code. The recognized
+escapes are:
 
 ```
 char escapes:   \n  \t  \r  \\  \'  \0  \xHH

--- a/doc/language/literals.md
+++ b/doc/language/literals.md
@@ -26,6 +26,10 @@ val c: u8 = 'M';
 
 Char escapes: `\n` `\t` `\r` `\\` `\'` `\0` `\xHH`.
 
+This set is deliberately minimal — there is no `\a` `\b` `\f` `\v`. Any other
+byte, control characters included, is written `\xHH` (e.g. `\x08` for
+backspace, `\x07` for bell).
+
 ## String
 
 A sequence of characters in double quotes, producing a `*u8` pointing at

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -863,6 +863,80 @@ fun ut_lower_ok(src: str) i32 {
     ret code;
 }
 
+# the located sibling of `ut_lower_rejects`: 0 when `src` fails at LOWER with an
+# error diagnostic containing `needle` whose primary span is EXACTLY
+# [want_offset, want_offset + want_len) - not merely present in the sink, but
+# pointed at the right bytes. Pins the located form #2472 requires: a bare,
+# span-less message propagated to the top-level printer without ever reaching
+# `p.s.diags` at all, so `ut_lower_rejects` alone (message-only) would not have
+# caught a regression back to that shape.
+# ---
+# src:         the one-file fixture
+# needle:      substring the diagnostic message must contain
+# want_offset: expected byte offset of the diagnostic's primary span
+# want_len:    expected byte length of the diagnostic's primary span
+# ret:         0 on a match, 1 otherwise
+fun ut_lower_rejects_at(src: str, needle: str, want_offset: usize, want_len: usize) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var code: i32 = 1;
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](se)) {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_err[bool, outcome.Fail](le)) {
+            var i: usize = 0;
+            for (i < p.s.diags.len) {
+                if (p.s.diags.items[i].severity == diagnostic.SEVERITY_ERROR
+                 && ut_str_contains(p.s.diags.items[i].message, needle)
+                 && p.s.diags.items[i].loc.span.offset == want_offset
+                 && p.s.diags.items[i].loc.span.len    == want_len) {
+                    code = 0;
+                }
+                i = i + 1;
+            }
+        }
+    }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret code;
+}
+
+# a malformed escape in a plain (non-comptime) string literal fires a LOCATED
+# diagnostic at LOWER - #2472 found it bare, with no file/line/snippet, unlike
+# every other fe/sema diagnostic. Root cause: sema never decodes string content
+# (matching comptime.eval's own deferral - #2465's sibling design), so the
+# escape table only runs during ME lowering, whose bare `str` error used to
+# propagate to the top-level printer without ever reaching the diagnostic sink.
+#
+# The span (offset 30, len 4) is the literal token `"\b"` itself, empirically
+# the exact position `mach build` points its caret at on this fixture -
+# `error --> file:1:31` (1-indexed column = offset + 1 on a single-line file).
+#
+# `\b` itself stays UNSUPPORTED: the escape set (`\n \t \r \\ \' \" \0 \xHH`) is
+# a deliberately minimal one, identical in comptime.eval's decoder and here, and
+# already the exact set `doc/language/literals.md` documents - `\b` is not an
+# oversight alongside `\a` `\f` `\v`, all equally absent. `\x08` is the
+# documented spelling and must keep compiling clean.
+test "mach.lang.driver:unknown_escape_has_location" {
+    var bad: i32 = 0;
+    if (ut_lower_rejects_at("fun main() i32 { val s: *u8 = \"\\b\"; ret 0; }\n",
+        "lower: unknown escape sequence in string literal", 30, 4) != 0) { bad = 1; }
+    if (ut_lower_ok("fun main() i32 { val s: *u8 = \"\\x08\"; ret 0; }\n") != 0) { bad = 1; }
+    ret bad;
+}
+
 # a vector op reaching instruction selection always resolves to DEFINED behavior
 # -- never an ICE, never a silent miscompile. driving real vector ops (a pointer
 # lane-wise add and a full-arity literal) through the HOST backend on each CI

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -255,10 +255,17 @@ fun lower_lit_char(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Val
 # decoded into the materialised bytes, matching the documented string-literal
 # semantics and comptime.eval's eval_lit_str. The decoded content is interned
 # (giving a stable byte sequence) and the Value borrows the interned bytes.
+#
+# A malformed escape is a lowering-time discovery (sema does not itself decode
+# string content, matching comptime.eval's own deferral), so it is filed here as
+# a located diagnostic against the literal's span rather than left to propagate
+# as a bare string - the same convention `report_expr` uses elsewhere in this
+# file (#2472).
 # ---
 # ctx: per-module lowering context
 # e:   the resolved string-literal node
-# ret: a *u8 pointer Value into the rodata global, or an error
+# ret: a *u8 pointer Value into the rodata global, or an error (already reported
+#      when the failure was a malformed escape; the returned message is empty)
 pub fun lower_lit_str(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value, str] {
     val res_ptr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
     if (R.is_err[ir_type.IrTypeId, str](res_ptr)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ptr)); }
@@ -272,7 +279,10 @@ pub fun lower_lit_str(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.
     }
 
     val res_sid: R.Result[intern.StrId, str] = intern_str_lit(ctx, inner);
-    if (R.is_err[intern.StrId, str](res_sid)) { ret R.err[value.Value, str](R.unwrap_err[intern.StrId, str](res_sid)); }
+    if (R.is_err[intern.StrId, str](res_sid)) {
+        diagnostic.error(?ctx.s.diags, ctx.a.file_id, e.span, R.unwrap_err[intern.StrId, str](res_sid));
+        ret R.err[value.Value, str]("");
+    }
     val opt_bytes: O.Option[str] = intern.lookup(?ctx.s.interner, R.unwrap_ok[intern.StrId, str](res_sid));
     if (O.is_none[str](opt_bytes)) { ret R.err[value.Value, str]("lower: string literal lookup failed"); }
     val bytes: str = O.unwrap[str](opt_bytes);


### PR DESCRIPTION
Closes #2472.

`"\b"` in a string literal reported a bare `error: lower: unknown escape sequence
in string literal` - no file, no line, no snippet, unlike every other fe/sema
diagnostic. Hit during bmos-mach's monitor, where backspace handling wanted 0x08;
`\x08` worked fine, `\b` did not exist and reported with no way to find the site
in a multi-module build.

## Root cause

Sema never decodes string-literal content - `comptime.eval` defers escape
decoding the same way, to its own `decode_escape`. So the escape table only
actually runs during ME lowering, in `me/lower/expr.lit_decode_escape` (an
intentional mirror of `comptime.eval`'s table, per its docstring). `lower_lit_str`
let that function's bare `str` error propagate all the way to `lower_fail`
(`driver/passes.mach`), which decides how to render a lowering failure:

```mach
fun lower_fail(p: *project.Project, emsg: str) outcome.Fail {
    if (diagnostic.has_errors(?p.s.diags)) { ret outcome.reported(); }
    ret outcome.user(emsg);
}
```

Nothing had ever called `diagnostic.error` on this path, so `p.s.diags` stayed
empty and `lower_fail` fell to `outcome.user(emsg)` - the plain, unpositioned
top-level printer. Every *other* `me/lower` diagnostic in the same file already
follows the located convention (`report_expr`, and the several direct
`diagnostic.error(?ctx.s.diags, ctx.a.file_id, span, message)` call sites) - this
one just never got wired up when the escape table was added.

## Fix (thread the span, not a new path)

`lower_lit_str` now catches `intern_str_lit`'s error and files it at the
literal's own span, mirroring `report_expr` exactly:

```mach
val res_sid: R.Result[intern.StrId, str] = intern_str_lit(ctx, inner);
if (R.is_err[intern.StrId, str](res_sid)) {
    diagnostic.error(?ctx.s.diags, ctx.a.file_id, e.span, R.unwrap_err[intern.StrId, str](res_sid));
    ret R.err[value.Value, str]("");
}
```

The empty-message return matches the file's established "already reported"
convention (see `report_expr`'s docstring) - the diagnostic sink is the
user-facing message; the render step prints nothing further. This covers every
error `intern_str_lit`/`lit_decode_escape` can return (unknown escape,
incomplete escape, invalid `\x`, an allocation failure), not just the one text
in the issue.

**Before / after**, same repro:
```
$ mach build .
error: lower: unknown escape sequence in string literal
```
```
$ mach build .
error: lower: unknown escape sequence in string literal
 --> ./src/bin/main.mach:2:18
  |
2 |     val s: *u8 = "\b";
  |                  ^^^^

1 error / 0 warnings
```

## The `\b` question

Stays **out** of the escape set. `\n \t \r \\ \' \" \0 \xHH` is:
- identical in both decoders (`comptime.eval`'s `decode_escape` and
  `me/lower`'s `lit_decode_escape`, which the latter's docstring already flags
  as an intentional mirror),
- exactly what `doc/language/literals.md` already documented before this PR.

`\b` is not the one oversight - `\a`, `\f`, `\v` are equally absent from both
the code and the docs. That's a deliberately minimal set (the common ones,
plus a general `\xHH` escape hatch for everything else), not a `\b`-shaped gap.
`\x08` is, and remains, the documented spelling. `literals.md` now says this
explicitly (`\xHH` covers `\a`/`\b`/`\f`/`\v` and any other byte), and
`grammar.md`'s escape-decoding note now names both decoders instead of only
`comptime.eval_lit_char`, since this PR is what makes the asymmetry between
them relevant to a reader.

## Verification

| bar | result |
|---|---|
| `mach test` (from-source compiler) | 1055 / 0 |
| `B == C` self-host fixpoint | byte-identical |
| repro (before/after) | pasted above, both directions confirmed live |
| `\x08` still compiles clean | confirmed (`ut_lower_ok`, and manually) |

New test `mach.lang.driver:unknown_escape_has_location` (`driver/tests.mach`)
pins both the message **and** the exact span: fixture
`fun main() i32 { val s: *u8 = "\b"; ret 0; }\n` is asserted to fail at LOWER
with a diagnostic containing `lower: unknown escape sequence in string literal`
whose primary span is `[30, 34)` - the `"\b"` token itself, empirically the
same position `mach build` points its caret at (`file:1:31`, 1-indexed). This is
stronger than a message-only check: the pre-fix code would have failed this
test even on message content, because the diagnostic never reached `p.s.diags`
at all (it was `outcome.user(emsg)`, not `outcome.reported()`) - so this test
would not have passed against the old behavior even by accident. A second
assertion pins `\x08` as clean.

Disjointness check: not claimed - dev moved during this branch's life
(concurrent peer work), so a full re-verify was run instead of a diff-based skip.
