### PR TITLE
feat(asm): aarch64 system registers, named and by encoding

### DIFF
--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -83,6 +83,45 @@ does not fit in a byte is refused. Raw bytes are an instruction stream the parse
 cannot read, so the block's clobber set becomes **every register in every bank** —
 which is why a real mnemonic is always preferable where one exists.
 
+## System registers (aarch64)
+
+`mrs` and `msr` name a system register by its architectural name, in either case:
+
+```mach
+asm aarch64 {
+    mrs x0, cntvct_el0        # the virtual counter
+    mrs x1, CNTFRQ_EL0        # ... and its frequency, capitalized as ARM spells it
+    msr vbar_el1, x2          # install an exception vector base
+    msr daifset, 0xf          # mask every interrupt
+}
+```
+
+The named set covers what freestanding code reaches for — the generic timer, the
+exception vectors and their syndrome registers, the MMU control registers, the thread
+pointers, and enough identification registers to detect a CPU. It is deliberately not
+exhaustive: **any** system register is also nameable by its encoding, exactly as ARM and
+GNU as spell it, which is what makes the surface complete rather than a list that always
+lags the architecture:
+
+```mach
+asm aarch64 {
+    mrs x0, s3_3_c14_c0_2     # the same register as `mrs x0, cntvct_el0`
+}
+```
+
+`op0` must be 2 or 3 — the whole of the `mrs` / `msr` register space — and each remaining
+field is bounded by its own width. A field the architecture cannot hold is refused rather
+than truncated, because a truncated selector would name a *different* register than the
+text does.
+
+`msr <field>, #imm` writes a PSTATE field (`daifset`, `daifclr`, `spsel`, `pan`, `uao`,
+`ssbs`, `dit`, `tco`). The architecture spells these by name only, so there is no numeric
+escape for this form.
+
+Access permission is not checked: whether a register is writable depends on the exception
+level the code runs at, which the compiler does not know. Writing a register that is
+read-only at the current level traps at run time, as the architecture defines.
+
 ## What the compiler infers
 
 - **Operand direction.** Position within an instruction determines whether

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -337,35 +337,233 @@ val MSR_IMM_BASE: u32 = 0xD500401F;
 val MSR_REG_BASE: u32 = 0xD5100000;
 val MRS_BASE:     u32 = 0xD5300000;
 
+# longest system-register or PSTATE-field name the parser accepts, with its terminator
+#
+# Sized to the surface rather than guessed: `id_aa64isar0_el1` is sixteen characters, one
+# more than the buffer this replaced could hold, so the longest names in the table would
+# have been refused as "too long" while the table listed them (#2480).
+val A64_SYSREG_NAME_MAX: usize = 32;
+
+# true when `name` equals the lowercase `want`, ignoring ASCII case
+#
+# ARM's manuals capitalize a system register (`CNTVCT_EL0`), assembly sources usually do
+# not, and nothing in mach's pipeline case-folds asm text. Folding HERE rather than
+# spelling both cases per row is what keeps the tables below from doubling into a
+# lowercase half that can be forgotten one register at a time (#2480).
+fun a64_name_eq(name: str, want: str) bool {
+    val n: usize = str_len(name);
+    if (n != str_len(want)) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        var c: u32 = name[i]::u32;
+        if (c >= 'A'::u32 && c <= 'Z'::u32) { c = c + ('a'::u32 - 'A'::u32); }
+        if (c != want[i]::u32) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# read one decimal field of a numeric system-register name, bounded by `max`
+#
+# A FIELD THE ARCHITECTURE CANNOT HOLD IS REFUSED, NOT MASKED. `a64_sysreg_pack`
+# truncates each selector to its own width, so an accepted `s3_9_c0_c0_0` would encode
+# op1 = 1 and read a DIFFERENT register than the one written - a working-looking program
+# reading the wrong system register, which is the failure mode this whole surface has to
+# avoid.
+# ---
+# name: the full register name
+# pos:  cursor into `name`, advanced past the digits read
+# max:  the largest value this field may hold
+# out:  receives the parsed value
+# ret:  true when one in-range decimal field was read
+fun a64_sysreg_field(name: str, pos: *usize, max: u32, out: *u32) bool {
+    val n: usize = str_len(name);
+    var i: usize = @pos;
+    var v: u32 = 0;
+    var digits: u32 = 0;
+    for (i < n && name[i]::u32 >= '0'::u32 && name[i]::u32 <= '9'::u32) {
+        v      = v * 10 + (name[i]::u32 - '0'::u32);
+        digits = digits + 1;
+        if (digits > 2) { ret false; }
+        i = i + 1;
+    }
+    if (digits == 0 || v > max) { ret false; }
+    @pos = i;
+    @out = v;
+    ret true;
+}
+
+# consume one literal character of a numeric system-register name, ignoring ASCII case
+fun a64_sysreg_char(name: str, pos: *usize, want: char) bool {
+    if (@pos >= str_len(name)) { ret false; }
+    var c: u32 = name[@pos]::u32;
+    if (c >= 'A'::u32 && c <= 'Z'::u32) { c = c + ('a'::u32 - 'A'::u32); }
+    if (c != want::u32) { ret false; }
+    @pos = @pos + 1;
+    ret true;
+}
+
+# the selectors of the architectural `s<op0>_<op1>_c<CRn>_c<CRm>_<op2>` spelling
+#
+# THE ESCAPE IS WHAT MAKES THIS SURFACE FINITE. A name table can never be complete - the
+# architecture adds registers faster than any compiler tracks them, and an implementation
+# may define its own - so the general answer is the encoding itself, spelled the way ARM
+# and GNU as spell it. `mrs x0, s3_3_c14_c0_2` is `mrs x0, cntvct_el0`, and this
+# equivalence is asserted byte-for-byte in the tests rather than assumed.
+#
+# op0 IS RESTRICTED TO 2 AND 3, which is the whole of the MRS / MSR register space. An
+# op0 of 0 or 1 selects the SYS / SYSL instruction space (`dc`, `ic`, `at`, `tlbi`) -
+# different instructions with their own mnemonics - and `a64_emit_sysreg` bakes the high
+# bit of op0 into its base word, so accepting `s1_...` here would silently encode op0 = 3
+# and address a register nobody named.
+fun a64_sysreg_numeric(name: str, op0_out: *u32, op1_out: *u32, crn_out: *u32, crm_out: *u32, op2_out: *u32) bool {
+    var i: usize = 0;
+    if (!a64_sysreg_char(name, ?i, 's'::char)) { ret false; }
+
+    var op0: u32 = 0;
+    if (!a64_sysreg_field(name, ?i, 3, ?op0)) { ret false; }
+    if (op0 < 2)                              { ret false; }
+    if (!a64_sysreg_char(name, ?i, '_'::char)) { ret false; }
+
+    var op1: u32 = 0;
+    if (!a64_sysreg_field(name, ?i, 7, ?op1))  { ret false; }
+    if (!a64_sysreg_char(name, ?i, '_'::char)) { ret false; }
+
+    var crn: u32 = 0;
+    if (!a64_sysreg_char(name, ?i, 'c'::char)) { ret false; }
+    if (!a64_sysreg_field(name, ?i, 15, ?crn)) { ret false; }
+    if (!a64_sysreg_char(name, ?i, '_'::char)) { ret false; }
+
+    var crm: u32 = 0;
+    if (!a64_sysreg_char(name, ?i, 'c'::char)) { ret false; }
+    if (!a64_sysreg_field(name, ?i, 15, ?crm)) { ret false; }
+    if (!a64_sysreg_char(name, ?i, '_'::char)) { ret false; }
+
+    var op2: u32 = 0;
+    if (!a64_sysreg_field(name, ?i, 7, ?op2)) { ret false; }
+    # trailing text means this is not the numeric form at all.
+    if (i != str_len(name)) { ret false; }
+
+    @op0_out = op0; @op1_out = op1; @crn_out = crn; @crm_out = crm; @op2_out = op2;
+    ret true;
+}
+
 # the (op1, op2) of a PSTATE field writable by `msr <field>, #imm`
 #
-# The immediate rides CRm, so the field itself contributes only op1 and op2. DIT is the
-# data-independent-timing mode: with it set, the ARM architecture guarantees that the
-# timing of the instructions in its scope does not depend on their data values, which is
-# the hardware half of the constant-time story (#1643). It is EL0-writable, so a
-# userspace program may set it for itself.
+# The immediate rides CRm, so the field itself contributes only op1 and op2. There is no
+# numeric escape for this form - the architecture spells a PSTATE field by name only - so
+# this table is the whole surface, and it holds every field the MSR-immediate encoding
+# defines.
 #
-# ARM spells these fields in capitals and mach's asm text is matched verbatim - nothing
-# in the pipeline case-folds - so both spellings are accepted rather than forcing a
-# reader to write the one this table happened to pick.
+# DIT is the data-independent-timing mode: with it set, the ARM architecture guarantees
+# that the timing of the instructions in its scope does not depend on their data values,
+# which is the hardware half of the constant-time story (#1643). It is EL0-writable, so a
+# userspace program may set it for itself. DAIFSet / DAIFClr are the interrupt mask a trap
+# handler runs behind, which is why a kernel needs them (#2480).
+#
+# EVERY PAIR BELOW WAS READ OFF `llvm-mc -triple=aarch64 --show-encoding`, decoding op1
+# from bits[18:16] and op2 from bits[7:5] of the word it produced for `msr <field>, #1` -
+# not derived on paper, and not read back from this encoder.
 fun a64_pstate_field(name: str, op1_out: *u32, op2_out: *u32) bool {
-    if (str_equals(name, "DIT") || str_equals(name, "dit")) {
-        @op1_out = 3; @op2_out = 2; ret true;
-    }
+    if (a64_name_eq(name, "daifset")) { @op1_out = 3; @op2_out = 6; ret true; }
+    if (a64_name_eq(name, "daifclr")) { @op1_out = 3; @op2_out = 7; ret true; }
+    if (a64_name_eq(name, "spsel"))   { @op1_out = 0; @op2_out = 5; ret true; }
+    if (a64_name_eq(name, "pan"))     { @op1_out = 0; @op2_out = 4; ret true; }
+    if (a64_name_eq(name, "uao"))     { @op1_out = 0; @op2_out = 3; ret true; }
+    if (a64_name_eq(name, "ssbs"))    { @op1_out = 3; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "dit"))     { @op1_out = 3; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "tco"))     { @op1_out = 3; @op2_out = 4; ret true; }
     ret false;
 }
 
 # the (op0, op1, CRn, CRm, op2) of a system register named by `msr`/`mrs`
 #
-# DIT is both a PSTATE field and a system register: the immediate form writes the mode
-# bit directly, and the register form is how a program reads it back to confirm the mode
+# DIT is both a PSTATE field and a system register: the immediate form writes the mode bit
+# directly, and the register form is how a program reads it back to confirm the mode
 # actually engaged. Same name, different encodings - which is why the two lookups are
 # separate tables rather than one.
+#
+# EVERY ROW BELOW WAS DECODED FROM `llvm-mc -triple=aarch64 --show-encoding` for `mrs x0,
+# <name>`, taking op0 from bit[19], op1 from bits[18:16], CRn from [15:12], CRm from
+# [11:8] and op2 from [7:5]. A row derived on paper is a register read that works, returns
+# a plausible number, and is the wrong register - the exact defect no test written beside
+# the same reasoning would catch.
+#
+# THE TABLE IS DELIBERATELY NOT EXHAUSTIVE, and cannot be: it names what freestanding code
+# actually reaches for - the generic timer, the exception vectors and their syndrome
+# registers, the MMU control registers, the thread pointers, and enough identification
+# registers to detect a CPU. Everything else is spelled by `s<op0>_<op1>_c<CRn>_c<CRm>_
+# <op2>`, which addresses the whole space.
+#
+# ACCESS PERMISSION IS NOT MODELLED, and that is a decision rather than an omission.
+# Whether a register is readable or writable depends on the current exception level -
+# CNTFRQ_EL0 is writable at EL1 and read-only at EL0 - and a compiler that does not know
+# the EL its code will run at cannot decide it. Refusing a write to a register that is
+# read-only at SOME level would refuse correct kernel code; the architecture's own answer
+# (an UNDEFINED exception at run time) is left to stand.
 fun a64_sysreg(name: str, op0_out: *u32, op1_out: *u32, crn_out: *u32, crm_out: *u32, op2_out: *u32) bool {
-    if (str_equals(name, "DIT") || str_equals(name, "dit")) {
-        @op0_out = 3; @op1_out = 3; @crn_out = 4; @crm_out = 2; @op2_out = 5; ret true;
-    }
-    ret false;
+    # the generic timer: the counter, its frequency, and the virtual / physical timer
+    # control, comparison and countdown registers.
+    if (a64_name_eq(name, "cntvct_el0"))    { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 0; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "cntpct_el0"))    { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 0; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "cntfrq_el0"))    { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "cntv_ctl_el0"))  { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 3; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "cntv_cval_el0")) { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 3; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "cntv_tval_el0")) { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 3; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "cntp_ctl_el0"))  { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 2; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "cntp_cval_el0")) { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 2; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "cntp_tval_el0")) { @op0_out = 3; @op1_out = 3; @crn_out = 14; @crm_out = 2; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "cntkctl_el1"))   { @op0_out = 3; @op1_out = 0; @crn_out = 14; @crm_out = 1; @op2_out = 0; ret true; }
+
+    # the EL1 exception state: the vector base a trap handler installs, the return
+    # address and saved state, and the syndrome / fault address a handler decodes.
+    if (a64_name_eq(name, "vbar_el1"))  { @op0_out = 3; @op1_out = 0; @crn_out = 12; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "elr_el1"))   { @op0_out = 3; @op1_out = 0; @crn_out =  4; @crm_out = 0; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "spsr_el1"))  { @op0_out = 3; @op1_out = 0; @crn_out =  4; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "esr_el1"))   { @op0_out = 3; @op1_out = 0; @crn_out =  5; @crm_out = 2; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "far_el1"))   { @op0_out = 3; @op1_out = 0; @crn_out =  6; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "sp_el0"))    { @op0_out = 3; @op1_out = 0; @crn_out =  4; @crm_out = 1; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "sp_el1"))    { @op0_out = 3; @op1_out = 4; @crn_out =  4; @crm_out = 1; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "spsel"))     { @op0_out = 3; @op1_out = 0; @crn_out =  4; @crm_out = 2; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "currentel")) { @op0_out = 3; @op1_out = 0; @crn_out =  4; @crm_out = 2; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "daif"))      { @op0_out = 3; @op1_out = 3; @crn_out =  4; @crm_out = 2; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "nzcv"))      { @op0_out = 3; @op1_out = 3; @crn_out =  4; @crm_out = 2; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "dit"))       { @op0_out = 3; @op1_out = 3; @crn_out =  4; @crm_out = 2; @op2_out = 5; ret true; }
+
+    # the EL2 twins, reached by code that boots at EL2 and drops to EL1.
+    if (a64_name_eq(name, "vbar_el2"))  { @op0_out = 3; @op1_out = 4; @crn_out = 12; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "elr_el2"))   { @op0_out = 3; @op1_out = 4; @crn_out =  4; @crm_out = 0; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "spsr_el2"))  { @op0_out = 3; @op1_out = 4; @crn_out =  4; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "esr_el2"))   { @op0_out = 3; @op1_out = 4; @crn_out =  5; @crm_out = 2; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "far_el2"))   { @op0_out = 3; @op1_out = 4; @crn_out =  6; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "sctlr_el2")) { @op0_out = 3; @op1_out = 4; @crn_out =  1; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "hcr_el2"))   { @op0_out = 3; @op1_out = 4; @crn_out =  1; @crm_out = 1; @op2_out = 0; ret true; }
+
+    # the EL1 MMU control: the system control register, the translation control and its
+    # two base registers, and the memory attribute indirection.
+    if (a64_name_eq(name, "sctlr_el1")) { @op0_out = 3; @op1_out = 0; @crn_out =  1; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "tcr_el1"))   { @op0_out = 3; @op1_out = 0; @crn_out =  2; @crm_out = 0; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "ttbr0_el1")) { @op0_out = 3; @op1_out = 0; @crn_out =  2; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "ttbr1_el1")) { @op0_out = 3; @op1_out = 0; @crn_out =  2; @crm_out = 0; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "mair_el1"))  { @op0_out = 3; @op1_out = 0; @crn_out = 10; @crm_out = 2; @op2_out = 0; ret true; }
+
+    # the thread pointers, including the read-only EL0 one a userspace TLS ABI uses.
+    if (a64_name_eq(name, "tpidr_el0"))   { @op0_out = 3; @op1_out = 3; @crn_out = 13; @crm_out = 0; @op2_out = 2; ret true; }
+    if (a64_name_eq(name, "tpidrro_el0")) { @op0_out = 3; @op1_out = 3; @crn_out = 13; @crm_out = 0; @op2_out = 3; ret true; }
+    if (a64_name_eq(name, "tpidr_el1"))   { @op0_out = 3; @op1_out = 0; @crn_out = 13; @crm_out = 0; @op2_out = 4; ret true; }
+
+    # identification: which core this is, which core within the cluster, the cache
+    # geometry, and the feature registers a run-time capability check reads.
+    if (a64_name_eq(name, "midr_el1"))         { @op0_out = 3; @op1_out = 0; @crn_out = 0; @crm_out = 0; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "mpidr_el1"))        { @op0_out = 3; @op1_out = 0; @crn_out = 0; @crm_out = 0; @op2_out = 5; ret true; }
+    if (a64_name_eq(name, "ctr_el0"))          { @op0_out = 3; @op1_out = 3; @crn_out = 0; @crm_out = 0; @op2_out = 1; ret true; }
+    if (a64_name_eq(name, "dczid_el0"))        { @op0_out = 3; @op1_out = 3; @crn_out = 0; @crm_out = 0; @op2_out = 7; ret true; }
+    if (a64_name_eq(name, "id_aa64pfr0_el1"))  { @op0_out = 3; @op1_out = 0; @crn_out = 0; @crm_out = 4; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "id_aa64isar0_el1")) { @op0_out = 3; @op1_out = 0; @crn_out = 0; @crm_out = 6; @op2_out = 0; ret true; }
+    if (a64_name_eq(name, "id_aa64mmfr0_el1")) { @op0_out = 3; @op1_out = 0; @crn_out = 0; @crm_out = 7; @op2_out = 0; ret true; }
+
+    # anything the table does not name is spelled by its encoding.
+    ret a64_sysreg_numeric(name, op0_out, op1_out, crn_out, crm_out, op2_out);
 }
 
 # a three-register data-processing word - Rm[20:16], Rn[9:5], Rd[4:0]
@@ -4253,8 +4451,8 @@ fun a64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, s
     }
     if (pat == A64P_MSR) {
         if (n != 2) { ret R.err[bool, str]("encode: inline-asm msr expects a system register or PSTATE field and a source"); }
-        var nbuf: [16]u8;
-        if (!iasm.copy_region(c.body, s.arg_lo[0], s.arg_hi[0], ?nbuf[0], 16)) {
+        var nbuf: [A64_SYSREG_NAME_MAX]u8;
+        if (!iasm.copy_region(c.body, s.arg_lo[0], s.arg_hi[0], ?nbuf[0], A64_SYSREG_NAME_MAX)) {
             ret R.err[bool, str]("encode: inline-asm msr destination name is too long");
         }
         # the SECOND operand picks the form, and with it which table names the first:
@@ -4285,8 +4483,8 @@ fun a64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, s
     if (pat == A64P_MRS) {
         if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm mrs expects Xt, <sysreg>"); }
         if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm mrs destination must be a register"); }
-        var mbuf: [16]u8;
-        if (!iasm.copy_region(c.body, s.arg_lo[1], s.arg_hi[1], ?mbuf[0], 16)) {
+        var mbuf: [A64_SYSREG_NAME_MAX]u8;
+        if (!iasm.copy_region(c.body, s.arg_lo[1], s.arg_hi[1], ?mbuf[0], A64_SYSREG_NAME_MAX)) {
             ret R.err[bool, str]("encode: inline-asm mrs system register name is too long");
         }
         var m0: u32 = 0; var m1: u32 = 0; var mn: u32 = 0; var mm: u32 = 0; var m2: u32 = 0;
@@ -6399,6 +6597,260 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_sysreg_moves" {
     ret bad;
 }
 
+# assemble one inline-asm statement and compare its single word against `want` (test
+# helper)
+#
+# Runs the whole block path a real body takes, so a golden is a fact about the shipping
+# parser and emitter rather than about a test-only path beside them.
+fun t_word(text: str, want: u32) bool {
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    val r: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, text);
+    var ok: bool = false;
+    if (!R.is_err[bool, str](r) && st.buf.len == 4) { ok = read_word(?st.buf, 0) == want; }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret ok;
+}
+
+# true when one inline-asm statement is refused with a message naming `want` (test
+# helper)
+#
+# Matching on a substring of the diagnostic, not merely on failure, is what keeps a
+# refusal test from passing on the wrong refusal.
+fun t_word_refused(text: str, want: str) bool {
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    val r: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, text);
+    var ok: bool = false;
+    if (R.is_err[bool, str](r)) { ok = str_contains(R.unwrap_err[bool, str](r), want); }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret ok;
+}
+
+# every system register the name table holds reads back byte-exact (#2480)
+#
+# EVERY WORD BELOW CAME FROM `llvm-mc -triple=aarch64 --show-encoding`, one statement at a
+# time, and each table row was DECODED FROM that word rather than derived on paper. That
+# direction matters: a wrong op1 or CRm produces a program that assembles, runs, returns a
+# plausible number and reads the wrong register - a defect no amount of reasoning beside
+# the same table would catch, and the reason #2236 wanted an independent assembler in the
+# loop.
+#
+# The table is not exhaustive and cannot be; what it names is what freestanding code
+# reaches for. The escape below covers the rest.
+test "mach.lang.target.isa.arm64.encode:inline_asm_sysreg_reads_are_byte_exact" {
+    var bad: i32 = 0;
+
+    # timer
+    if (!t_word("mrs x0, cntvct_el0", 0xD53BE040)) { bad = 1; }
+    if (!t_word("mrs x0, cntpct_el0", 0xD53BE020)) { bad = 1; }
+    if (!t_word("mrs x0, cntfrq_el0", 0xD53BE000)) { bad = 1; }
+    if (!t_word("mrs x0, cntv_ctl_el0", 0xD53BE320)) { bad = 1; }
+    if (!t_word("mrs x0, cntv_cval_el0", 0xD53BE340)) { bad = 1; }
+    if (!t_word("mrs x0, cntv_tval_el0", 0xD53BE300)) { bad = 1; }
+    if (!t_word("mrs x0, cntp_ctl_el0", 0xD53BE220)) { bad = 1; }
+    if (!t_word("mrs x0, cntp_cval_el0", 0xD53BE240)) { bad = 1; }
+    if (!t_word("mrs x0, cntp_tval_el0", 0xD53BE200)) { bad = 1; }
+    if (!t_word("mrs x0, cntkctl_el1", 0xD538E100)) { bad = 1; }
+    # exception
+    if (!t_word("mrs x0, vbar_el1", 0xD538C000)) { bad = 1; }
+    if (!t_word("mrs x0, elr_el1", 0xD5384020)) { bad = 1; }
+    if (!t_word("mrs x0, spsr_el1", 0xD5384000)) { bad = 1; }
+    if (!t_word("mrs x0, esr_el1", 0xD5385200)) { bad = 1; }
+    if (!t_word("mrs x0, far_el1", 0xD5386000)) { bad = 1; }
+    if (!t_word("mrs x0, sp_el0", 0xD5384100)) { bad = 1; }
+    if (!t_word("mrs x0, sp_el1", 0xD53C4100)) { bad = 1; }
+    if (!t_word("mrs x0, spsel", 0xD5384200)) { bad = 1; }
+    if (!t_word("mrs x0, currentel", 0xD5384240)) { bad = 1; }
+    if (!t_word("mrs x0, daif", 0xD53B4220)) { bad = 1; }
+    if (!t_word("mrs x0, nzcv", 0xD53B4200)) { bad = 1; }
+    if (!t_word("mrs x0, dit", 0xD53B42A0)) { bad = 1; }
+    # el2
+    if (!t_word("mrs x0, vbar_el2", 0xD53CC000)) { bad = 1; }
+    if (!t_word("mrs x0, elr_el2", 0xD53C4020)) { bad = 1; }
+    if (!t_word("mrs x0, spsr_el2", 0xD53C4000)) { bad = 1; }
+    if (!t_word("mrs x0, esr_el2", 0xD53C5200)) { bad = 1; }
+    if (!t_word("mrs x0, far_el2", 0xD53C6000)) { bad = 1; }
+    if (!t_word("mrs x0, sctlr_el2", 0xD53C1000)) { bad = 1; }
+    if (!t_word("mrs x0, hcr_el2", 0xD53C1100)) { bad = 1; }
+    # mmu
+    if (!t_word("mrs x0, sctlr_el1", 0xD5381000)) { bad = 1; }
+    if (!t_word("mrs x0, tcr_el1", 0xD5382040)) { bad = 1; }
+    if (!t_word("mrs x0, ttbr0_el1", 0xD5382000)) { bad = 1; }
+    if (!t_word("mrs x0, ttbr1_el1", 0xD5382020)) { bad = 1; }
+    if (!t_word("mrs x0, mair_el1", 0xD538A200)) { bad = 1; }
+    # tls
+    if (!t_word("mrs x0, tpidr_el0", 0xD53BD040)) { bad = 1; }
+    if (!t_word("mrs x0, tpidrro_el0", 0xD53BD060)) { bad = 1; }
+    if (!t_word("mrs x0, tpidr_el1", 0xD538D080)) { bad = 1; }
+    # id
+    if (!t_word("mrs x0, midr_el1", 0xD5380000)) { bad = 1; }
+    if (!t_word("mrs x0, mpidr_el1", 0xD53800A0)) { bad = 1; }
+    if (!t_word("mrs x0, ctr_el0", 0xD53B0020)) { bad = 1; }
+    if (!t_word("mrs x0, dczid_el0", 0xD53B00E0)) { bad = 1; }
+    if (!t_word("mrs x0, id_aa64pfr0_el1", 0xD5380400)) { bad = 1; }
+    if (!t_word("mrs x0, id_aa64isar0_el1", 0xD5380600)) { bad = 1; }
+    if (!t_word("mrs x0, id_aa64mmfr0_el1", 0xD5380700)) { bad = 1; }
+
+    ret bad;
+}
+
+# the writable registers encode their `msr <sysreg>, Xt` direction byte-exact
+#
+# Read and write share one field layout and differ only in the base word, so a swapped
+# base is the one mistake the read goldens above could not catch. `llvm-mc` refuses a
+# write to a register that is read-only at every exception level (CNTVCT_EL0, the ID
+# registers), so those are absent here by construction rather than by choice.
+test "mach.lang.target.isa.arm64.encode:inline_asm_sysreg_writes_are_byte_exact" {
+    var bad: i32 = 0;
+
+    if (!t_word("msr cntfrq_el0, x1", 0xD51BE001)) { bad = 1; }
+    if (!t_word("msr cntv_ctl_el0, x1", 0xD51BE321)) { bad = 1; }
+    if (!t_word("msr cntv_cval_el0, x1", 0xD51BE341)) { bad = 1; }
+    if (!t_word("msr cntv_tval_el0, x1", 0xD51BE301)) { bad = 1; }
+    if (!t_word("msr cntp_ctl_el0, x1", 0xD51BE221)) { bad = 1; }
+    if (!t_word("msr cntp_cval_el0, x1", 0xD51BE241)) { bad = 1; }
+    if (!t_word("msr cntp_tval_el0, x1", 0xD51BE201)) { bad = 1; }
+    if (!t_word("msr cntkctl_el1, x1", 0xD518E101)) { bad = 1; }
+    if (!t_word("msr vbar_el1, x1", 0xD518C001)) { bad = 1; }
+    if (!t_word("msr elr_el1, x1", 0xD5184021)) { bad = 1; }
+    if (!t_word("msr spsr_el1, x1", 0xD5184001)) { bad = 1; }
+    if (!t_word("msr esr_el1, x1", 0xD5185201)) { bad = 1; }
+    if (!t_word("msr far_el1, x1", 0xD5186001)) { bad = 1; }
+    if (!t_word("msr sp_el0, x1", 0xD5184101)) { bad = 1; }
+    if (!t_word("msr sp_el1, x1", 0xD51C4101)) { bad = 1; }
+    if (!t_word("msr spsel, x1", 0xD5184201)) { bad = 1; }
+    if (!t_word("msr daif, x1", 0xD51B4221)) { bad = 1; }
+    if (!t_word("msr nzcv, x1", 0xD51B4201)) { bad = 1; }
+    if (!t_word("msr dit, x1", 0xD51B42A1)) { bad = 1; }
+    if (!t_word("msr vbar_el2, x1", 0xD51CC001)) { bad = 1; }
+    if (!t_word("msr elr_el2, x1", 0xD51C4021)) { bad = 1; }
+    if (!t_word("msr spsr_el2, x1", 0xD51C4001)) { bad = 1; }
+    if (!t_word("msr esr_el2, x1", 0xD51C5201)) { bad = 1; }
+    if (!t_word("msr far_el2, x1", 0xD51C6001)) { bad = 1; }
+    if (!t_word("msr sctlr_el2, x1", 0xD51C1001)) { bad = 1; }
+    if (!t_word("msr hcr_el2, x1", 0xD51C1101)) { bad = 1; }
+    if (!t_word("msr sctlr_el1, x1", 0xD5181001)) { bad = 1; }
+    if (!t_word("msr tcr_el1, x1", 0xD5182041)) { bad = 1; }
+    if (!t_word("msr ttbr0_el1, x1", 0xD5182001)) { bad = 1; }
+    if (!t_word("msr ttbr1_el1, x1", 0xD5182021)) { bad = 1; }
+    if (!t_word("msr mair_el1, x1", 0xD518A201)) { bad = 1; }
+    if (!t_word("msr tpidr_el0, x1", 0xD51BD041)) { bad = 1; }
+    if (!t_word("msr tpidrro_el0, x1", 0xD51BD061)) { bad = 1; }
+    if (!t_word("msr tpidr_el1, x1", 0xD518D081)) { bad = 1; }
+
+    ret bad;
+}
+
+# every PSTATE field the `msr <field>, #imm` form defines, byte-exact (#2480)
+#
+# The immediate rides CRm, so each golden pins the field's op1 / op2 AND the immediate's
+# placement at once. DAIFSet / DAIFClr are what a trap handler masks interrupts with,
+# which is the half of #2480 that had no workaround at all: unlike a register move, the
+# MSR-immediate form has no numeric escape in the architecture, so a missing field name is
+# a missing capability.
+test "mach.lang.target.isa.arm64.encode:inline_asm_pstate_fields_are_byte_exact" {
+    var bad: i32 = 0;
+
+    if (!t_word("msr daifset, 0xf", 0xD5034FDF)) { bad = 1; }
+    if (!t_word("msr daifclr, 0xf", 0xD5034FFF)) { bad = 1; }
+    if (!t_word("msr daifset, 2", 0xD50342DF)) { bad = 1; }
+    if (!t_word("msr spsel, 1", 0xD50041BF)) { bad = 1; }
+    if (!t_word("msr pan, 1", 0xD500419F)) { bad = 1; }
+    if (!t_word("msr uao, 1", 0xD500417F)) { bad = 1; }
+    if (!t_word("msr ssbs, 1", 0xD503413F)) { bad = 1; }
+    if (!t_word("msr dit, 1", 0xD503415F)) { bad = 1; }
+    if (!t_word("msr tco, 1", 0xD503419F)) { bad = 1; }
+    if (!t_word("msr daifclr, 0", 0xD50340FF)) { bad = 1; }
+
+    ret bad;
+}
+
+# a system register is named by its ENCODING when no name is listed, and the two
+# spellings produce the same word (#2480)
+#
+# This is what makes the surface finite. A name table can never be complete - the
+# architecture keeps adding registers, and an implementation may define its own - so the
+# general answer is `s<op0>_<op1>_c<CRn>_c<CRm>_<op2>`, exactly as ARM and GNU as spell
+# it. The equivalence is asserted against the named row beside it, not assumed.
+test "mach.lang.target.isa.arm64.encode:inline_asm_sysreg_numeric_escape" {
+    var bad: i32 = 0;
+
+    # the escape and the name are the same instruction.
+    if (!t_word("mrs x0, s3_3_c14_c0_2", 0xD53BE040))  { bad = 1; }
+    if (!t_word("mrs x19, s3_3_c14_c0_2", 0xD53BE053)) { bad = 1; }
+    if (!t_word("msr s3_0_c12_c0_0, x1", 0xD518C001))  { bad = 1; }
+
+    # op0 = 2 is the other half of the register space, and every field at its maximum
+    # still encodes: `s3_7_c15_c15_7` fills op1, CRn, CRm and op2.
+    if (!t_word("mrs x0, s2_0_c0_c0_0", 0xD5300000))   { bad = 1; }
+    if (!t_word("mrs x5, s3_7_c15_c15_7", 0xD53FFFE5)) { bad = 1; }
+
+    # ARM capitalizes; assembly sources usually do not. both spellings are one register,
+    # for the escape and for a name.
+    if (!t_word("mrs x0, S3_3_C14_C0_2", 0xD53BE040)) { bad = 1; }
+    if (!t_word("mrs x0, CNTVCT_EL0", 0xD53BE040))    { bad = 1; }
+    if (!t_word("mrs x0, CntVct_El0", 0xD53BE040))    { bad = 1; }
+
+    # A FIELD THE ARCHITECTURE CANNOT HOLD IS REFUSED, NOT MASKED. `a64_sysreg_pack`
+    # truncates each selector, so every one of these would otherwise encode a DIFFERENT
+    # register than the text names - `s3_9_...` as op1 = 1, `s1_...` as op0 = 3.
+    if (!t_word_refused("mrs x0, s3_9_c0_c0_0", "unsupported inline-asm mrs system register"))  { bad = 1; }
+    if (!t_word_refused("mrs x0, s3_0_c16_c0_0", "unsupported inline-asm mrs system register")) { bad = 1; }
+    if (!t_word_refused("mrs x0, s3_0_c0_c16_0", "unsupported inline-asm mrs system register")) { bad = 1; }
+    if (!t_word_refused("mrs x0, s3_0_c0_c0_8", "unsupported inline-asm mrs system register"))  { bad = 1; }
+    if (!t_word_refused("mrs x0, s1_0_c0_c0_0", "unsupported inline-asm mrs system register"))  { bad = 1; }
+    if (!t_word_refused("mrs x0, s0_0_c0_c0_0", "unsupported inline-asm mrs system register"))  { bad = 1; }
+
+    # a malformed escape is not a register either: a missing field, a missing `c`, and
+    # trailing text after a complete one.
+    if (!t_word_refused("mrs x0, s3_3_c14_c0", "unsupported inline-asm mrs system register"))    { bad = 1; }
+    if (!t_word_refused("mrs x0, s3_3_14_c0_2", "unsupported inline-asm mrs system register"))   { bad = 1; }
+    if (!t_word_refused("mrs x0, s3_3_c14_c0_2x", "unsupported inline-asm mrs system register")) { bad = 1; }
+    if (!t_word_refused("mrs x0, s_3_c14_c0_2", "unsupported inline-asm mrs system register"))   { bad = 1; }
+
+    # and a name nobody defined is still refused, which is what keeps a typo from
+    # becoming a silent register read.
+    if (!t_word_refused("mrs x0, cntvct_el9", "unsupported inline-asm mrs system register")) { bad = 1; }
+    if (!t_word_refused("msr frobnicate, x1", "unsupported inline-asm msr system register")) { bad = 1; }
+    # a PSTATE field is a separate table with no escape, so an unknown one says so.
+    if (!t_word_refused("msr frobnicate, 1", "unsupported inline-asm msr PSTATE field")) { bad = 1; }
+
+    ret bad;
+}
+
+# the longest register names in the table fit the parser's name buffer (#2480)
+#
+# `id_aa64isar0_el1` is sixteen characters, one past the buffer this replaced, so before
+# `A64_SYSREG_NAME_MAX` the table could list a register the parser would then refuse as
+# "too long" - a table row that reads as support and is not. The refusal for a genuinely
+# oversized name still fires.
+test "mach.lang.target.isa.arm64.encode:inline_asm_sysreg_name_length" {
+    var bad: i32 = 0;
+
+    if (!t_word("mrs x0, id_aa64isar0_el1", 0xD5380600)) { bad = 1; }
+    if (!t_word("mrs x0, id_aa64mmfr0_el1", 0xD5380700)) { bad = 1; }
+    if (!t_word_refused("mrs x0, this_name_is_far_longer_than_any_system_register", "too long")) { bad = 1; }
+
+    ret bad;
+}
+
 # `cset Xd/Wd, <cond>` round-trips through the inline-asm assembler, byte-exact
 # against llvm-mc. darwin's aarch64 syscall wrappers use `cset x9, cs` to capture the
 # carry-on-error flag (#1714)
@@ -7305,8 +7757,19 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     # flags, so a bitwise test here would match every pattern sharing a set bit.
     if (a64_pattern(flags) == A64P_BCOND) { ret ct.asm_branch_flags(); }
 
-    # unconditional control transfer, system registers, and the traps: the target of
-    # each is public by construction.
+    # unconditional control transfer and the traps: the target of each is public by
+    # construction.
+    #
+    # THE SYSTEM-REGISTER MOVES ARE HERE FOR A DIFFERENT REASON, and it is worth stating
+    # now that the name table reaches a whole architecture's worth of registers rather
+    # than DIT alone (#2480). WHICH register a move names is part of the instruction
+    # word, fixed at assembly time and never an operand, so it cannot be secret; and the
+    # move's latency does not vary with the value it carries. That holds for a counter
+    # read (`mrs Xt, CNTVCT_EL0`) exactly as for any other: the read is fixed-latency in
+    # its operands, and observing a clock is not a channel that reveals a secret THIS
+    # program holds - a secret reaching a branch or an address is, and both are checked
+    # separately. What would change the answer is a register whose access time depended
+    # on a value the program supplies; the architecture defines none.
     if (code == A64M_B   || code == A64M_BL  || code == A64M_BLR || code == A64M_BR ||
         code == A64M_RET || code == A64M_SVC || code == A64M_BRK ||
         code == A64M_NOP || code == A64M_MSR || code == A64M_MRS) {


### PR DESCRIPTION
Closes #2480.

`a64_sysreg` held exactly one entry — DIT — so `mrs x0, dit` assembled and every other system register was refused. That meant no generic timer on aarch64 (`CNTVCT_EL0` / `CNTFRQ_EL0`) and, worse, no `VBAR_EL1`: no exception vector base, therefore no trap handler, therefore no syscall layer on the target at all. The PSTATE-field table was likewise a single row, so `msr daifset, 0xf` — how a trap handler masks interrupts — had no spelling either.

The encode path was already correct, which is why this is a table change plus one escape.

## What changed

- **`a64_sysreg` populated**, grouped by what freestanding code actually reaches for: the generic timer (10 registers), the EL1 exception state (12), the EL2 twins for code that boots at EL2 and drops (7), the EL1 MMU control registers (5), the thread pointers (3), and identification (7).
- **`a64_pstate_field` populated** with every field the MSR-immediate encoding defines: `daifset`, `daifclr`, `spsel`, `pan`, `uao`, `ssbs`, `dit`, `tco`.
- **The numeric escape** `s<op0>_<op1>_c<CRn>_c<CRm>_<op2>`, which is the general answer — a name table can never be complete, and this addresses the whole space. `mrs x0, s3_3_c14_c0_2` is `mrs x0, cntvct_el0`, asserted byte-for-byte against the named row rather than assumed.
- **Case-insensitive names.** ARM capitalizes, assembly sources usually do not, and nothing in the pipeline case-folds. The old table spelled both cases per row (`"DIT" || "dit"`); at forty rows that is eighty entries whose lowercase half can be forgotten one register at a time.
- **`A64_SYSREG_NAME_MAX`.** The parser's name buffer was 16 bytes, and `id_aa64isar0_el1` is 16 characters — the table would have listed registers the parser then refused as "too long".

## How each encoding was derived

**From `llvm-mc -triple=aarch64 --show-encoding`, one statement at a time — and in that direction.** Each table row was *decoded from* the word llvm-mc produced for `mrs x0, <name>` (op0 from bit 19, op1 from [18:16], CRn [15:12], CRm [11:8], op2 [7:5]), not derived on paper and then confirmed. That matters here more than usual: a wrong op1 or CRm produces a program that assembles, runs, returns a plausible number, and reads the wrong register — the defect #2236 found in a hand-written packer, and one that no test written beside the same reasoning would catch. PSTATE pairs came the same way from `msr <field>, #1`.

The method validates against the repo's own history: it reproduces the DIT row already in the table and the DIT goldens in `inline_asm_sysreg_moves`, which were hand-verified when #2352 landed.

Independently confirmed end to end: a freestanding aarch64 object built from a probe body and disassembled with `llvm-objdump` decodes every statement back to the register the source named, including the escape and the uppercase spelling:

```
   0: d53be040  mrs x0, CNTVCT_EL0
   4: d53be001  mrs x1, CNTFRQ_EL0
   8: d53be042  mrs x2, CNTVCT_EL0     <- written `s3_3_c14_c0_2`
   c: d518c003  msr VBAR_EL1, x3
  10: d5034fdf  msr DAIFSet, #0xf
  14: d5034fff  msr DAIFClr, #0xf
  18: d5384244  mrs x4, CurrentEL
  1c: d51bd045  msr TPIDR_EL0, x5
```

## Refusals, and why they are part of the encoding correctness

`a64_sysreg_pack` truncates each selector to its own width, so an out-of-range field would not fail — it would silently encode a *different* register. Every one of these is refused and tested:

| written | would have encoded |
|---|---|
| `s3_9_c0_c0_0` | op1 = 1 |
| `s3_0_c16_c0_0` | CRn = 0 |
| `s3_0_c0_c0_8` | op2 = 0 |
| `s1_0_c0_c0_0` | op0 = 3 (the emitter bakes op0's high bit into its base) |

`op0` is restricted to 2 and 3, which is the whole of the `mrs` / `msr` register space; 0 and 1 select the SYS / SYSL instruction space (`dc`, `ic`, `at`, `tlbi`), which are different instructions with their own mnemonics.

## Mutation checks

Each on a full build + `mach test`, then reverted:

| perturbation | result |
|---|---|
| `cntvct_el0` op1 3 → 1 | `inline_asm_sysreg_reads_are_byte_exact` and `inline_asm_sysreg_numeric_escape` FAIL |
| `daifset` op2 6 → 7 (collides with `daifclr`) | `inline_asm_pstate_fields_are_byte_exact` FAILs |
| escape op1 bound 7 → 15 and op0 floor 2 → 0 | `inline_asm_sysreg_numeric_escape` FAILs |

## Constant-time classification (#2230)

No new mnemonics: `msr` and `mrs` already exist and are already classified `CT_OP_NONE`, so the `#[oblivious]` surface does not widen by a row. What did change is how much that row now reaches, so I stated the reason where it lives rather than leaving it grouped under the branch-target rationale beside it: **which** register a move names is part of the instruction word, fixed at assembly time and never an operand, so it cannot be secret, and the move's latency does not vary with the value it carries. That holds for a counter read exactly as for any other — observing a clock is not a channel that reveals a secret this program holds, and a secret reaching a branch or an address is checked separately. Nothing arrives through the decode hook here, so #2477's decode-channel coverage test is untouched and still passes.

## Verification

- `mach test` through the from-source compiler: **1050 passed, 0 failed** (1045 on dev + 5 new tests: byte-exact reads, byte-exact writes, PSTATE fields, the numeric escape and its refusals, and the name-length bound).
- End-to-end `linux-arm64` object, disassembled with `llvm-objdump`.
- Fixpoint at the final pre-ready push.

## Known limitation, pre-existing and out of scope

`mrs` / `msr` in inline asm break `--emit-asm`: neither `emit_msr_imm` nor `a64_emit_sysreg` notifies the assembly printer, so the totality guard refuses the build (`inline-asm instruction 'mrs x0, dit' emitted machine code the assembly printer was not notified of`). Verified on the released 4.4.0 seed, so this predates the branch — the mnemonics already existed and already had the hole; naming more registers does not widen it. It is the same family as #2493 and wants a printer form, not an encoder change. Happy to take it as a follow-up.