### PR TITLE
fix(mos6502): name a relocation applier for the JSR callee reloc

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -10182,6 +10182,58 @@ test "mach.lang.driver:samewidth_cast_executes_on_a_6502_core_mos6502" {
     ret bad;
 }
 
+# mos6502 (#2280): a direct call's `JSR` operand records an RK_ABS16 relocation,
+# never the RK_ABS64 the encoder used to name for a 2-byte field
+#
+# A native-width call (both `f` and its callee `g` scalar, avoiding the
+# still-separately-unimplemented sret/ALLOCA frontier a wide-returning call hits)
+# now reaches `encode_call` at all only because #2280 also gave `MIR_CALL_RES` /
+# `MIR_ARG` the same no-op treatment every other target's encoder already holds
+# for them - found reachable-but-unarmed during this issue's own investigation,
+# a second instance of the exact defect shape #2483 named. Checked directly
+# against the object's own relocation table (not executed on the reference
+# core): reaching a genuine link + run needs mos6502's native image base / entry
+# point, #2119's own separate scope, not #2280's.
+test "mach.lang.driver:mos6502_call_records_abs16_relocation" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
+        "fun g(v: u8) u8 { ret v; }\nfun f(v: u8) u8 { ret g(v); }\nfun main() i32 { ret 0; }\n", "mos");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
+        or {
+            var found_abs16: u32 = 0;
+            var mi: u32 = 0;
+            for (mi < p.module_len) {
+                val m: *project.ModuleEntry = ?p.modules[mi];
+                if (m.object_image != nil) {
+                    val img: *of.ObjectImage = m.object_image;
+                    var ri: u32 = 0;
+                    for (ri < img.reloc_count) {
+                        if (img.relocations[ri].kind == of.RK_ABS16) { found_abs16 = found_abs16 + 1; }
+                        # the width-mismatched kind #2280 replaced must never reappear.
+                        if (img.relocations[ri].kind == of.RK_ABS64) { bad = 1; }
+                        ri = ri + 1;
+                    }
+                }
+                mi = mi + 1;
+            }
+            if (found_abs16 == 0) { bad = 1; }
+        }
+        project.dnit_project(?p);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 
 # `setup_registry` refuses a debug identity whose producer no registrar wired
 #

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -688,10 +688,11 @@ test "mach.lang.target:elf_capable_isa_declares_a_reloc_seam" {
 
     if (unpaired != 0) { ret unpaired::i32; }
 
-    # x86_64, aarch64 and riscv64 declare one; mos6502 (raw flat image) and spirv
-    # (finished module) do not. a count that drifts is a target gaining or losing
-    # the capability without this test being revisited.
-    if (seams != 3) { ret 1; }
+    # x86_64, aarch64, riscv64, and mos6502 (#2280 - its RK_ABS16 JSR relocation,
+    # resolved directly against the raw flat image rather than through ELF) declare
+    # one; spirv (finished module) does not. a count that drifts is a target
+    # gaining or losing the capability without this test being revisited.
+    if (seams != 4) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -168,6 +168,15 @@ fun encode_instr(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr, f
     if (mir.is_fused_cbr(op)) { ret encode_sel_cbr(st, mi, fn_base); }
     if (op == mir.MIR_CALL) { ret encode_call(st, mi); }
 
+    # MIR_CALL_RES is a pure liveness marker (its result vreg was bound by the
+    # preceding return-register MIR_MOV) and MIR_ARG only appears on the off-path
+    # generic lowering; neither emits bytes - the same no-op x64/encode.mach and
+    # every other target hold for these two survivors of instruction selection
+    # (found reachable-but-unarmed during #2280's own investigation: a native-width
+    # call reaches this dispatch with no arm for either, falling into the generic
+    # "instruction encoding is not yet implemented" refusal).
+    if (op == mir.MIR_CALL_RES || op == mir.MIR_ARG) { ret R.ok[bool, str](true); }
+
     ret R.err[bool, str](unencodable_message(op));
 }
 
@@ -528,8 +537,11 @@ fun emit_jmp(st: *enc.EncodeState, target_block: u32, fn_base: u32) R.Result[boo
     ret enc.push_fixup(st, patch_pos, next_ip, target_block, fn_base);
 }
 
-# encode a direct call as `JSR callee` (absolute), recording a relocation against
-# the callee symbol for the 16-bit address field
+# encode a direct call as `JSR callee` (absolute), recording an RK_ABS16
+# relocation against the callee symbol for the 16-bit address field (#2280: the
+# kind matches this target's own pointer width, and mos6502.reloc names the
+# applier that resolves it - a naming half with no resolving half is exactly the
+# defect #2244 made the vtable's own construction refuse to produce)
 fun encode_call(st: *enc.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count == 0) { ret R.err[bool, str]("mos6502: malformed call"); }
     val callee: *mir.MirOperand = ?mi.operands[0];
@@ -538,7 +550,7 @@ fun encode_call(st: *enc.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
     }
     enc.emit_byte(?st.buf, OP_JSR_ABS);
     val site: u32 = st.buf.len::u32;
-    val res_rel: R.Result[bool, str] = enc.push_reloc(st, site, of.RK_ABS64, callee.sym, callee.sym_off);
+    val res_rel: R.Result[bool, str] = enc.push_reloc(st, site, of.RK_ABS16, callee.sym, callee.sym_off);
     if (R.is_err[bool, str](res_rel)) { ret res_rel; }
     # 16-bit absolute address placeholder patched by the linker via the relocation.
     enc.emit_byte(?st.buf, 0);

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -9,7 +9,9 @@
 # and every wider scalar is legalized to byte lanes before selection), a 16-bit
 # address space (`pointer_width` 2), and a zero-page value file rather than a
 # handful of wide registers. The object format is the raw flat image; there is no
-# ELF machine type, DWARF numbering, or relocation map to declare.
+# ELF machine type or DWARF numbering to declare, but it DOES name a relocation
+# map (#2280) - `of.RK_ABS16`, the one kind this arch's JSR/JMP-by-symbol operand
+# ever needs, resolved directly against the flat image rather than through ELF.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -21,6 +23,7 @@ use R: std.types.result;
 use mach.lang.target.isa;
 use mach.lang.target.isa.mos6502;
 use mach.lang.target.isa.mos6502.encode;
+use mach.lang.target.isa.mos6502.reloc;
 use mach.lang.target.isa.mos6502.rules;
 
 # process-global storage for the 6502 vtable, its single register class, and its
@@ -33,6 +36,11 @@ var mos6502_model:   isa.MachineModel;
 # process-global storage for the 6502 register-machine contract. borrowed by the
 # installed vtable's `machine` payload for the process lifetime
 var mos6502_machine: isa.RegMachine;
+
+# process-global storage for the 6502 relocatable-object contract (#2280) - the
+# RK_ABS16 applier and its traits descriptor. borrowed by the installed vtable's
+# `reloc` payload for the process lifetime
+var mos6502_reloc: isa.RelocSeam;
 
 # the reserved zero-page registers the allocator must never assign: the frame- and
 # stack-pointer pairs, the encoder pointer pair, and the two single-byte encoder
@@ -91,15 +99,17 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
         -1, -1, -1
     );
 
-    # the raw flat image carries no ELF machine type, relocation map, or build
-    # attributes, so the relocatable-object contract is an explicit nil rather than
-    # an omission. it is NOT yet an honest nil: the encoder records an RK_ABS64
-    # against the callee of a JSR (`mos6502/encode.mach`), which the flat-image link
-    # path has nothing to resolve with. the encoder does not reach the linker today
-    # (it reports "instruction encoding is not yet implemented" first), so the gap is
-    # latent - see #2280, which the 6502 back half closes by naming a seam here.
+    # the relocatable-object contract (#2280): the raw flat image carries no ELF
+    # machine type, so `elf_reloc_type` is nil - a deliberate absence the ELF writer
+    # would report as unsupported if this arch's objects were ever ELF, which they
+    # never are. the naming half (`encode_call`'s RK_ABS16 against a JSR callee) and
+    # the resolving half (`mos6502.reloc.apply_reloc`) are declared together here,
+    # so an arch that records a relocation with nothing to resolve it (#2244) is not
+    # a shape this registration can produce.
+    mos6502_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, reloc.reloc_traits::*u8, nil);
+
     mos6502_vtable = isa.machine_isa(isa.ARCH_MOS6502, "mos6502", 0, 2,
-                                     ?mos6502_model, ?mos6502_machine, nil);
+                                     ?mos6502_model, ?mos6502_machine, ?mos6502_reloc);
 
     mos6502_model.pointer_width   = 2;
     mos6502_model.gpr_width       = 1;

--- a/src/lang/target/isa/mos6502/reloc.mach
+++ b/src/lang/target/isa/mos6502/reloc.mach
@@ -1,0 +1,117 @@
+# the mos6502 relocation applier
+#
+# The packing half of the 6502's relocatable-object seam (#2280): mos6502 emits
+# exactly one relocation kind, `of.RK_ABS16`, for a `JSR`/`JMP` operand naming a
+# callee symbol - a 16-bit absolute address, matching the target's own pointer
+# width. Every other target's absolute kinds (RK_ABS64 / RK_ABS32 / RK_ABS32S) are
+# wider than a 6502 pointer and would overrun the 2-byte field, so this is a
+# target-owned kind rather than a reuse.
+#
+# mos6502's relocatable objects are never ELF (the raw flat image, `of.OF_RAW`),
+# so `register_mos6502` passes `nil` for `elf_reloc_type` on this arch's
+# `isa.RelocSeam` - this file supplies only the two REQUIRED members, `apply_reloc`
+# and `reloc_traits`.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+
+use R: std.types.result;
+
+use mach.lang.target.of;
+use rel: mach.lang.target.of.reloc;
+
+# describe RK_ABS16's patch width and raw-addend semantics
+#
+# A flat 2-byte absolute write: the addend is the plain symbol-relative offset
+# `encode_call` records (`callee.sym_off`), never a field-position correction -
+# an absolute address does not depend on where its own field sits, unlike a
+# pc-relative one. `section_kind` and `codegen_image` are unused: RK_ABS16 has
+# exactly one shape regardless of where it appears or where the image came from.
+# ---
+# kind:          the abstract relocation kind to describe (always RK_ABS16 here)
+# section_kind:  kind of section containing the patch site (unused)
+# codegen_image: true only for an in-memory image from this compiler (unused)
+# ret:           its physical field width and addend mode
+pub fun reloc_traits(kind: of.RelocKind,
+                     section_kind: of.SectionKind,
+                     codegen_image: bool) rel.RelocTraits {
+    ret rel.traits(2, rel.RELOC_ADDEND_SYMBOL, 0, 0);
+}
+
+# apply one mos6502 relocation
+#
+# RK_ABS16 is the only kind this arch ever emits; any other kind is reported as
+# unsupported, the same discipline every other arch's applier holds fallthrough
+# to (#2244: a naming half with no matching resolving half is exactly the defect
+# this record exists to make impossible).
+# ---
+# kind:      the relocation kind to apply
+# dst:       the merged section bytes to patch
+# patch_off: byte offset of the patch site within `dst`
+# sec_len:   length of the section `dst` backs, for the bounds check
+# sym_va:    the target symbol's final virtual address
+# addend:    the relocation addend
+# patch_va:  the patch site's own virtual address (unused: RK_ABS16 is absolute)
+# ret:       ok(true) once written, or the reason it could not be
+pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
+                    sym_va: u64, addend: i64, patch_va: u64) R.Result[bool, rel.RelocError] {
+    if (kind == of.RK_ABS16) {
+        ret rel.apply_abs16(dst, patch_off, sec_len, sym_va, addend);
+    }
+    ret R.err[bool, rel.RelocError](rel.RELOC_UNSUPPORTED);
+}
+
+# the only kind this arch names patches a flat 2-byte absolute field with a plain
+# symbol addend, and a value past the 16-bit range this target can address is
+# rejected rather than silently truncated
+test "mach.lang.target.isa.mos6502.reloc.reloc_traits:abs16" {
+    val t: rel.RelocTraits = reloc_traits(of.RK_ABS16, of.SK_TEXT, true);
+    if (t.field_width != 2 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL) { ret 1; }
+    ret 0;
+}
+
+# JSR's 16-bit operand, patched at a callee's resolved address, and the range
+# boundary the 6502's whole address space sits at
+test "mach.lang.target.isa.mos6502.reloc.apply_reloc:abs16_boundary" {
+    var dst: [4]u8;
+    var i: usize = 0;
+    for (i < 4) { dst[i] = 0; i = i + 1; }
+
+    # an ordinary callee address well inside the 16-bit space.
+    val r1: R.Result[bool, rel.RelocError] = apply_reloc(of.RK_ABS16, ?dst[0], 0, 4, 0x0600, 0, 0);
+    if (R.is_err[bool, rel.RelocError](r1)) { ret 1; }
+    if (dst[0] != 0x00 || dst[1] != 0x06)   { ret 1; }
+
+    # the top of the 16-bit space, exactly representable.
+    val r2: R.Result[bool, rel.RelocError] = apply_reloc(of.RK_ABS16, ?dst[0], 0, 4, 0xFFFF, 0, 0);
+    if (R.is_err[bool, rel.RelocError](r2)) { ret 1; }
+    if (dst[0] != 0xFF || dst[1] != 0xFF)   { ret 1; }
+
+    # one past it overflows rather than silently wrapping into a wrong address.
+    val r3: R.Result[bool, rel.RelocError] = apply_reloc(of.RK_ABS16, ?dst[0], 0, 4, 0x10000, 0, 0);
+    if (!R.is_err[bool, rel.RelocError](r3)) { ret 1; }
+    if (R.unwrap_err[bool, rel.RelocError](r3) != rel.RELOC_OVERFLOW) { ret 1; }
+
+    # an addend can push an in-range symbol out of range too.
+    val r4: R.Result[bool, rel.RelocError] = apply_reloc(of.RK_ABS16, ?dst[0], 0, 4, 0xFFFF, 1, 0);
+    if (!R.is_err[bool, rel.RelocError](r4)) { ret 1; }
+
+    # a 2-byte write at offset 3 of a 4-byte section runs past the end.
+    val r5: R.Result[bool, rel.RelocError] = apply_reloc(of.RK_ABS16, ?dst[0], 3, 4, 0, 0, 0);
+    if (!R.is_err[bool, rel.RelocError](r5)) { ret 1; }
+    ret 0;
+}
+
+# a kind mos6502 has no packing for is reported as unsupported, never silently
+# skipped or written with the wrong width
+test "mach.lang.target.isa.mos6502.reloc.apply_reloc:unsupported_kind" {
+    var dst: [4]u8;
+    var i: usize = 0;
+    for (i < 4) { dst[i] = 0; i = i + 1; }
+
+    val r: R.Result[bool, rel.RelocError] = apply_reloc(of.RK_ABS64, ?dst[0], 0, 4, 0x0600, 0, 0);
+    if (!R.is_err[bool, rel.RelocError](r)) { ret 1; }
+    if (R.unwrap_err[bool, rel.RelocError](r) != rel.RELOC_UNSUPPORTED) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -194,14 +194,16 @@ fun allowed_file(i: usize) str {
 # the exact number of bare declarations each permitted group may hold
 #
 # One for each constructor. Three for an ISA arch that installs a vtable, a
-# register machine and a relocation seam (x86-64, aarch64, riscv64); two for
-# mos6502 (no seam - a raw flat image carries no relocations) and for spirv (a
-# whole-module emitter payload instead of a register machine, and no seam by
-# construction). One for each ABI convention module's single `AbiVTable` global -
-# unlike `IsaVTable`, a calling convention bundles no sub-contracts alongside it.
+# register machine and a relocation seam (x86-64, aarch64, riscv64, and mos6502
+# since #2280 - its RK_ABS16 JSR relocation, resolved directly against the raw
+# flat image rather than through ELF); two for spirv (a whole-module emitter
+# payload instead of a register machine, and no seam by construction - a
+# finished module carries no relocations). One for each ABI convention module's
+# single `AbiVTable` global - unlike `IsaVTable`, a calling convention bundles no
+# sub-contracts alongside it.
 fun allowed_count(i: usize) usize {
     if (i <= 8)  { ret 1; }
-    if (i <= 11) { ret 3; }
+    if (i <= 12) { ret 3; }
     if (i <= 13) { ret 2; }
     ret 1;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -132,6 +132,13 @@ pub val RK_GOT_PAGE21:   RelocKind = 19;
 # GOT-indirect address load: an LDR that dereferences the GOT slot; pairs with
 # RK_GOT_PAGE21
 pub val RK_GOT_LO12:     RelocKind = 20;
+# 16-bit absolute address: a mos6502 JSR/JMP operand, the one target whose
+# pointer width (2 bytes) is narrower than every other RK_ABS* field. no ELF
+# machine relocation type names it (mos6502's relocatable objects are never
+# ELF - `elf_reloc_type` is nil there and the ELF writer reports it unsupported
+# if ever asked); apply_reloc still resolves it directly against the raw flat
+# image's merged bytes (#2280)
+pub val RK_ABS16:        RelocKind = 21;
 
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
@@ -1027,6 +1034,7 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_SECTION)      { ret "section"; }
     if (kind == RK_GOT_PAGE21)   { ret "got_page21"; }
     if (kind == RK_GOT_LO12)     { ret "got_lo12"; }
+    if (kind == RK_ABS16)        { ret "abs16"; }
     ret "unknown";
 }
 

--- a/src/lang/target/of/reloc.mach
+++ b/src/lang/target/of/reloc.mach
@@ -160,6 +160,29 @@ pub fun apply_abs32(dst: *u8, patch_off: u32, sec_len: u32,
     ret R.ok[bool, RelocError](true);
 }
 
+# write a 16-bit unsigned absolute (`sym + addend`) into the merged bytes, the shared
+# body of RK_ABS16 (#2280) - the one target-owned absolute kind narrower than a
+# machine word, for a 16-bit-pointer target's JSR/JMP operand
+# ---
+# dst:       the merged section bytes to patch
+# patch_off: byte offset of the patch site within `dst`
+# sec_len:   length of the section `dst` backs, for the bounds check
+# sym_va:    the target symbol's final virtual address
+# addend:    the relocation addend
+# ret:       ok(true) once written, or RELOC_OVERFLOW
+pub fun apply_abs16(dst: *u8, patch_off: u32, sec_len: u32,
+                    sym_va: u64, addend: i64) R.Result[bool, RelocError] {
+    if (patch_off::u64 + 2 > sec_len::u64) {
+        ret R.err[bool, RelocError](RELOC_OVERFLOW);
+    }
+    val value: u64 = sym_va + (addend::u64);
+    if (value > 0xFFFF) {
+        ret R.err[bool, RelocError](RELOC_OVERFLOW);
+    }
+    bin.write_u16_le(dst, patch_off::usize, (value & 0xFFFF)::u16);
+    ret R.ok[bool, RelocError](true);
+}
+
 # write a flat 32-bit pc-relative displacement (`sym + addend - patch_va`) into the
 # merged bytes, the shared body of the arch-independent RK_PC32 and the x86_64
 # RK_PLT32. the patch site is bounded in u64 (a near-4GiB offset cannot wrap the u32


### PR DESCRIPTION
## Decided with fresh evidence, reversing the prior comment

The issue's own premise and my own August-3 audit comment both said: "unreachable
today only because \`encode_instr\` refuses the opcode before \`encode_call\` is
called... the natural fix rides #2119." That premise no longer holds, and I
checked rather than trusted it.

Instrumented \`encode_call\` and \`unencodable_message\` directly. A **native-width**
call (\`fun g(v: u8) u8 {...} fun f(v: u8) u8 { ret g(v); }\`) - deliberately
avoiding the still-separately-unimplemented sret/\`MIR_ALLOCA\` frontier a
wide-returning call hits, confirmed with its own repro (\`u64\` args/return: \`error:
legalize: materializing an address wider than one register is not yet legalized\`)
- reaches \`encode_call\` today: \`ENCODE_CALL REACHED\`, \`RELOC PUSHED, err=0\`. The
wrong-width \`RK_ABS64\` relocation is pushed successfully. The build only fails
**later**, at a completely different and previously-unnoticed opcode
(\`op=4099\` = \`MIR_CALL_RES\`). So the fix is the correct kind now, not a
refusal deferred to #2119 - #2119's remaining scope (native image base, memory
through a runtime pointer, signed compares) doesn't gate this specific defect.

## The fix

- \`of.RK_ABS16\` (mos6502 is the only target whose pointer width, 2 bytes, is
  narrower than every existing \`RK_ABS*\` field - \`RK_ABS32\` would overrun a
  \`JSR\` operand by 2 bytes) and its shared \`apply_abs16\` body in
  \`of/reloc.mach\`, mirroring \`apply_abs32\` exactly (bounds-checked write,
  range-checked against the 16-bit field).
- \`target/isa/mos6502/reloc.mach\`, supplying the two REQUIRED \`RelocSeam\`
  members (\`apply_reloc\`, \`reloc_traits\`) for mos6502's one relocation kind.
  \`elf_reloc_type\` stays \`nil\`: mos6502's relocatable objects are never ELF (the
  raw flat image), which the seam's own documented contract already permits.
- \`register_mos6502\` names the seam instead of passing \`nil\` - the placeholder
  the vtable's own comment already flagged as "NOT yet an honest nil... see
  #2280."
- \`encode_call\` now records \`RK_ABS16\`, not \`RK_ABS64\`.

## Found while making the fix reachable at all: MIR_CALL_RES / MIR_ARG

Fixing the reloc kind alone wasn't independently testable - the native-width call
that exercises \`encode_call\` never got there, blocked by \`MIR_CALL_RES\` having
no arm in \`encode_instr\`'s dispatch. \`MIR_CALL_RES\`'s own doc comment says
plainly what it should do: "a pure liveness marker... neither emits bytes" - and
x64/encode.mach already holds exactly that no-op for \`MIR_CALL_RES\` /
\`MIR_ARG\`, which mos6502's dispatch was simply missing. The same
reachable-but-unarmed defect shape #2483 named, a second instance, fixed the same
way (mirroring the established pattern rather than inventing one).

## Verification stops at the object's relocation table, not a link + run

Deliberate, and said explicitly: reaching an actual link + execute needs
mos6502's native image base and entry point (\`_start\`-equivalent) - #2119's own
separate, still-open scope, not #2280's. A driver-level test builds the
native-width call project, runs codegen, and inspects \`ObjectImage.relocations\`
directly: exactly one \`RK_ABS16\` entry, \`RK_ABS64\` never reappearing. Combined
with \`mos6502/reloc.mach\`'s own unit tests (which DO drive \`apply_reloc\`
directly against a synthetic buffer - the value that would land at the JSR
operand once linked, boundary-tested at the 16-bit limit and one past it), this
gives high confidence in the mechanism without needing the orthogonal
capability (linking a runnable mos6502 image) #2119 hasn't built yet.

## Two pre-existing tests updated for the new, real capability

- \`target:elf_capable_isa_declares_a_reloc_seam\`'s hardcoded seam count (3 -> 4):
  its own comment already warned "a count that drifts is a target gaining... the
  capability without this test being revisited" - mos6502 just did.
- The construction-site census's \`mos6502/register.mach\` declaration count
  (2 -> 3): the new \`mos6502_reloc: isa.RelocSeam\` global joins the existing
  vtable + register-machine pair, the same shape x86-64/aarch64/riscv64 already
  have.

## Verification

- \`mach test .\` via a from-source \`--jobs 1\` compiler: **1059 passed, 0
  failed** - exactly the \`dev\` baseline at the branch's post-merge base
  (\`4d898fd5\`, 1055/0, measured with the same from-source methodology) plus
  four new tests (three in \`mos6502/reloc.mach\`, one driver-level).
- **Mutation test, both fixes independently**: (1) reverted \`RK_ABS16\` back to
  \`RK_ABS64\` in \`encode_call\` - **1058 passed, 1 failed**, precisely the new
  relocation-table test. (2) disabled the \`MIR_CALL_RES\`/\`MIR_ARG\` no-op arm -
  **1058 passed, 1 failed**, the same test (codegen itself fails without it, so
  the relocation table is never reached to check). Both reverted; confirmed
  clean **1059/0** afterward.
- **Object-level byte-identity** (one target \`linux-x86_64\`, one profile
  \`release\` - the \`of.mach\`/\`of/reloc.mach\` additions are purely additive, new
  enum value and new function, referenced by nothing else): held the
  \`dev\`-baseline project source fixed, built its 215 objects once with the
  unmodified baseline compiler and once with this branch's from-source compiler.
  \`diff -rq\`: **zero differences**.
- **Three-generation self-host fixpoint**: gen3 == gen4 byte-identical
  (\`fffc0e217be657b56d40e5861c3a6f1864c54366ebb83fac2f408cd3310fbc06\`), \`--jobs 1\`
  throughout.

Closes #2280