### PR TITLE
test(build): pin artifact identity as load-bearing in the build-config key

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7883,6 +7883,91 @@ test "mach.lang.build.engine.execute_warm_all:two_artifacts_both_link" {
     ret bad;
 }
 
+# the artifact identity in the build-config cache key is LOAD-BEARING, not
+# conservative padding: `$bin.name` folds the artifact being built into every
+# module's comptime context, so one source file legitimately compiles to
+# different code per artifact.
+#
+# The identity reaches the key through two REDUNDANT sites:
+# `write_semantic_fields` hashes `artifact` / `want_lib` into the request's
+# semantic hash, and `write_build_config` folds `config.bin_name` explicitly.
+# (`config.defines` rides the same fold and is per-artifact by construction, but
+# contributes nothing while `BuildUnit.defines` is nil.) Measured by mutation:
+# removing EITHER site alone leaves the cache correctly keyed and this test
+# still passes; removing BOTH makes the two artifacts share one compilation of
+# the shared module and this test fails. So this guards the last line of
+# defence - which is exactly the state anyone chasing artifact-axis cache
+# sharing arrives at, since no reuse appears until both are gone.
+#
+# That reuse is the artifact-axis form of the stale-reuse miscompile that closed
+# #1827 wontfix, and the reason #2485 was closed the same way. The failure mode
+# is SILENT - no diagnostic, no crash, just the second artifact carrying the
+# first one's code - so the assertion is on the delivered bytes.
+test "mach.lang.build.engine.execute_warm:bin_name_keys_the_artifact_cache" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    # one shared module, compiled into both artifacts, whose body forks on which
+    # artifact is being built - the two binaries must not agree.
+    var names: [3]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach"; names[2] = "shared.mach";
+    var texts: [3]str;
+    texts[0] = ut_cc3(?alloc, "use uniontest.shared.sh;\n#[symbol(\"", ut_entry_symbol(), "\")]\nfun sa() i32 { ret sh(); }\n");
+    texts[1] = ut_cc3(?alloc, "use uniontest.shared.sh;\n#[symbol(\"", ut_entry_symbol(), "\")]\nfun sb() i32 { ret sh(); }\n");
+    texts[2] = "pub fun sh() i32 { $if ($bin.name == \"alpha\") { ret 111; } ret 222; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_two_bins(), ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    # both units on ONE session: the sharing the key has to defeat
+    var bad: i32 = 0;
+    if (bp.units.len != 2) { bad = 1; }
+
+    val r0: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r0)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val bo0: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r0);
+    val r1: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 1, ?s, ?alloc, nil, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r1)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val bo1: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r1);
+
+    if (!bo0.ok || !bo1.ok)                               { bad = 1; }
+    if (bo0.artifacts.len != 1 || bo1.artifacts.len != 1) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+
+    val f0: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, bo0.artifacts.data[0].path);
+    val f1: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, bo1.artifacts.data[0].path);
+    if (R.is_err[Vector[u8], str](f0) || R.is_err[Vector[u8], str](f1)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val v0: Vector[u8] = R.unwrap_ok[Vector[u8], str](f0);
+    val v1: Vector[u8] = R.unwrap_ok[Vector[u8], str](f1);
+
+    var differ: bool = false;
+    if (v0.len != v1.len) { differ = true; }
+    or {
+        var i: usize = 0;
+        for (i < v0.len) {
+            if (v0.data[i] != v1.data[i]) { differ = true; brk; }
+            i = i + 1;
+        }
+    }
+    if (!differ) { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
 # warm engine failure path: the fail event must carry the intact error text.
 # plan against a valid manifest, break the manifest on disk, execute_warm with
 # a render seam installed - the engine's per-call manifest load fails with a


### PR DESCRIPTION
Converts "removing artifact identity from the query key is a silent miscompile" from a finding into a test that fails. No behaviour change — one test.

### Why

`$bin.name` is a documented public comptime intrinsic (`doc/language/comptime.md`) that folds the artifact being built into every module's comptime context. So one source file legitimately compiles to different code per artifact, and the artifact identity in the build-config cache key is **semantics, not conservative padding**. Nothing recorded that, and the cost of learning it the hard way is a silent miscompile — no diagnostic, no crash, just the second artifact shipping the first one's code.

This came out of the #2485 design phase. That issue was closed wontfix; this is the part worth keeping.

### The test

Two artifacts on one warm session, both compiling a shared module whose body forks on `$bin.name`. The two linked binaries must differ. The assertion is on the delivered bytes, because that is where the failure is observable.

### Mutation-verified, and the result refined the claim

The lead's bar was that it fail for the right reason. Measured, not assumed — and the measurement corrected my first draft of the comment:

| mutation | test |
|---|---|
| none | passes |
| drop `artifact`/`want_lib` from `write_semantic_fields` | **passes** |
| drop `config.bin_name` from `write_build_config` | **passes** |
| drop both | **fails** |

The two keying sites are **redundant** — removing either alone leaves the cache correctly keyed. My initial comment claimed dropping any one site would break it; that was wrong and is now corrected in the code.

So this guards the *last line of defence*. That is still the right place for it: no cache reuse appears until both sites are gone, so anyone chasing artifact-axis sharing necessarily arrives at exactly that state and trips this.

`config.defines` rides the same fold and is per-artifact by construction, but contributes nothing while `BuildUnit.defines` is nil — noted in the comment so it is not mistaken for a third live site.

### Verified

- `mach test` through a from-source compiler: 1056 passed, 0 failed (exactly +1 from the merge base, one file touched).
- B == C fixpoint at the final push.

Refs #2485, #1827.