### PR TITLE
fix(asm): notify the assembly printer from the sysreg and directive emitters

### DIFF
--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -391,7 +391,8 @@ pub rec ByteBuf {
 # notes:      buffered notifications, in emission order (nil until the first push)
 # note_count: number of buffered notifications
 # note_cap:   capacity of `notes`
-# note_insts: how many of the buffered notifications are instructions
+# note_insts: how many of the buffered notifications are one instruction-word wide
+#             (ASM_NOTE_INST and ASM_NOTE_BYTES alike)
 # claims:     instruction notifications accepted, buffered and streamed alike
 # refused:    notifications whose declared start was not where the last claim ended
 pub rec AsmSink {
@@ -413,25 +414,40 @@ pub rec AsmSink {
 pub val ASM_NOTE_INST:  u8 = 0;  # one emitted machine instruction
 pub val ASM_NOTE_FUNC:  u8 = 1;  # a function's heading; emits no bytes
 pub val ASM_NOTE_BLOCK: u8 = 2;  # a block's local label; emits no bytes
+pub val ASM_NOTE_BYTES: u8 = 3;  # one instruction-word-wide slice of a raw-byte
+                                  # directive's payload (`bytes`, `ASM_NOTE_BYTES_WIDTH`
+                                  # of them valid)
 
-# one buffered notification: a machine instruction the encoder emitted, or a
-# function / block heading
+# the payload width one buffered `ASM_NOTE_BYTES` note carries
+#
+# A printer that buffers its notifications accounts a directive exactly as it
+# accounts an instruction - one note per instruction-word's worth of bytes - so a
+# directive wider than one word is pushed as several notes, each this wide (#2493).
+# Every fixed-width ISA that buffers (today, only riscv64) emits four-byte words, so
+# one constant serves; a buffering target with a different fixed width would need
+# its own note kind rather than stretching this one.
+pub val ASM_NOTE_BYTES_WIDTH: usize = 4;
+
+# one buffered notification: a machine instruction the encoder emitted, a function /
+# block heading, or a slice of a raw-byte directive's payload
 #
 # `off` is the instruction's `.text` offset, kept correct by `insert_text` exactly
 # as the block and fixup offsets are, so a relaxation pass can find the note whose
 # text it is about to rewrite after any number of earlier growths.
 # ---
-# kind: ASM_NOTE_INST / ASM_NOTE_FUNC / ASM_NOTE_BLOCK
-# off:  `.text` byte offset of the instruction's first byte
-# inst: the emitted machine instruction (ASM_NOTE_INST)
-# name: the function's interned name (ASM_NOTE_FUNC)
-# id:   the block id (ASM_NOTE_BLOCK)
+# kind:  ASM_NOTE_INST / ASM_NOTE_FUNC / ASM_NOTE_BLOCK / ASM_NOTE_BYTES
+# off:   `.text` byte offset of the note's first byte (ASM_NOTE_INST, ASM_NOTE_BYTES)
+# inst:  the emitted machine instruction (ASM_NOTE_INST)
+# name:  the function's interned name (ASM_NOTE_FUNC)
+# id:    the block id (ASM_NOTE_BLOCK)
+# bytes: the payload slice, `ASM_NOTE_BYTES_WIDTH` bytes (ASM_NOTE_BYTES)
 pub rec AsmNote {
-    kind: u8;
-    off:  u32;
-    inst: isa.Inst;
-    name: intern.StrId;
-    id:   u32;
+    kind:  u8;
+    off:   u32;
+    inst:  isa.Inst;
+    name:  intern.StrId;
+    id:    u32;
+    bytes: [ASM_NOTE_BYTES_WIDTH]u8;
 }
 
 # initial capacity of a sink's note buffer
@@ -477,7 +493,9 @@ pub fun note_blank() AsmNote {
 # An instruction note claims its byte range exactly as an immediate render does, and
 # it needs no separate start: `AsmNote.off` is already the instruction's first byte,
 # so the note itself declares where its claim begins and the tiling check falls out
-# of the buffered path for free.
+# of the buffered path for free. `ASM_NOTE_BYTES` claims the same way - it is a
+# directive's payload, but it is exactly one instruction-word wide, so it counts
+# against `note_insts` (and the totality check built on it) identically (#2493).
 # ---
 # buf: the encoder byte sink carrying the assembly sink
 # n:   the notification to buffer
@@ -491,7 +509,7 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[bool, str] {
     }
     s.notes[s.note_count] = @n;
     s.note_count = s.note_count + 1;
-    if (n.kind == ASM_NOTE_INST) {
+    if (n.kind == ASM_NOTE_INST || n.kind == ASM_NOTE_BYTES) {
         s.note_insts = s.note_insts + 1;
         sink_claim(buf, n.off::usize);
     }
@@ -595,15 +613,17 @@ pub fun notes_reset(buf: *ByteBuf) {
     buf.asm.note_insts = 0;
 }
 
-# how many buffered notifications are instructions
+# how many buffered notifications are one instruction-word wide
 #
 # A fixed-width ISA turns this into a whole-function totality check - emitted bytes
-# must equal the instruction count times the instruction width - which covers the
-# out-of-sequence growth a relaxation pass produces, where the per-claim tiling in
-# `sink_claim` has no sequential cursor to check against.
+# must equal this count times the instruction width - which covers the out-of-sequence
+# growth a relaxation pass produces, where the per-claim tiling in `sink_claim` has no
+# sequential cursor to check against. A raw-byte directive's payload is not an
+# instruction, but it is exactly one word wide per `ASM_NOTE_BYTES` note, so it counts
+# here too rather than opening a blind spot the totality check cannot see (#2493).
 # ---
 # buf: the encoder byte sink
-# ret: the instruction-notification count, or 0 when no sink is buffering
+# ret: the instruction-word-notification count, or 0 when no sink is buffering
 pub fun note_inst_count(buf: *ByteBuf) u32 {
     if (!sink_active(buf)) { ret 0; }
     ret buf.asm.note_insts;
@@ -693,27 +713,24 @@ pub fun sink_claim(buf: *ByteBuf, start: usize) {
     s.claims    = s.claims + 1;
 }
 
-# render a raw-byte directive's payload into the sink and account for its bytes
+# write a raw-byte directive's payload as `  .byte 0x.., 0x.., ...\n`
 #
 # THE ONE PLACE `.byte` TEXT IS PRODUCED. A directive renders identically on every
 # target - it is a payload, not an instruction - so putting the text here rather than
 # in each printer means a target cannot render it differently, and a target added
 # later inherits it rather than reimplementing it (#2467).
 #
-# The per-ISA half is only WHEN to call this: a printer that renders on the spot
-# (x86-64, aarch64) calls it as the bytes are emitted, and one that buffers notes for
-# a later pass (riscv64) calls it from its own note walk, so the directive lands in
-# program order either way.
+# Pure text: no sink accounting. `render_bytes_directive` wraps this for a printer
+# that renders on the spot, claiming the bytes in the same call it writes them; one
+# that BUFFERS its notifications (riscv64, #2493) claims them once at push time and
+# calls this directly when the buffered note is replayed, so the claim is never made
+# twice for the same bytes.
 # ---
-# buf:   the encoder byte sink carrying the assembly sink
+# out:   destination writer
 # bytes: the payload
 # n:     number of payload bytes
-# start: `.text` offset of the payload's first byte
 # ret:   true on success, or the first write error
-pub fun render_bytes_directive(buf: *ByteBuf, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
-    if (!sink_active(buf)) { ret R.ok[bool, str](true); }
-    val out: *writer.Writer = buf.asm.out;
-
+pub fun render_bytes_text(out: *writer.Writer, bytes: *u8, n: usize) R.Result[bool, str] {
     val ri: R.Result[usize, str] = format.write_str(out, "  .byte ");
     if (R.is_err[usize, str](ri)) { ret R.err[bool, str](R.unwrap_err[usize, str](ri)); }
     var i: usize = 0;
@@ -734,7 +751,27 @@ pub fun render_bytes_directive(buf: *ByteBuf, bytes: *u8, n: usize, start: usize
     }
     val rn: R.Result[usize, str] = format.write_str(out, "\n");
     if (R.is_err[usize, str](rn)) { ret R.err[bool, str](R.unwrap_err[usize, str](rn)); }
+    ret R.ok[bool, str](true);
+}
 
+# render a raw-byte directive's payload into the sink and account for its bytes
+#
+# The per-ISA half is only WHEN to call this: a printer that renders on the spot
+# (x86-64, aarch64) calls it as the bytes are emitted, so the directive lands in
+# program order and is accounted in the same call. A printer that buffers its
+# notifications for a later pass (riscv64) claims the bytes at push time instead
+# (`ASM_NOTE_BYTES`) and calls `render_bytes_text` directly when it replays them,
+# never this function (#2493).
+# ---
+# buf:   the encoder byte sink carrying the assembly sink
+# bytes: the payload
+# n:     number of payload bytes
+# start: `.text` offset of the payload's first byte
+# ret:   true on success, or the first write error
+pub fun render_bytes_directive(buf: *ByteBuf, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
+    if (!sink_active(buf)) { ret R.ok[bool, str](true); }
+    val res: R.Result[bool, str] = render_bytes_text(buf.asm.out, bytes, n);
+    if (R.is_err[bool, str](res)) { ret res; }
     sink_claim(buf, start);
     ret R.ok[bool, str](true);
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1357,6 +1357,11 @@ fun emit_barrier(st: *encode.EncodeState, crm: u32) {
 # it. Rt is baked into the base as 0b11111.
 fun emit_msr_imm(st: *encode.EncodeState, op1: u32, op2: u32, imm: u32) {
     emit_word(st, MSR_IMM_BASE | ((op1 & 0x7) << 16) | ((imm & 0xF) << 8) | ((op2 & 0x7) << 5));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_SYSREG_IMM, MSR_IMM_BASE);
+    i.src1 = isa.make_imm((((op1 & 0x7) << 3) | (op2 & 0x7))::i64, 1);
+    i.src2 = isa.make_imm(imm::i64, 1);
+    printer.note_inst(?st.buf, ?i);
 }
 
 # fold a system register's five architectural selectors into one operand payload
@@ -1385,6 +1390,11 @@ fun a64_emit_sysreg(st: *encode.EncodeState, base: u32, packed: u32, rt: u32) {
     val op2: u32 = packed & 0x7;
     emit_word(st, base | ((op0 & 0x1) << 19) | (op1 << 16)
                        | (crn << 12) | (crm << 8) | (op2 << 5) | (rt & 0x1F));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_SYSREG, base);
+    i.dst  = printer.gp(rt, 8);
+    i.src1 = isa.make_imm(packed::i64, 4);
+    printer.note_inst(?st.buf, ?i);
 }
 
 # emit a store-release-exclusive word, whose status result rides bits[20:16]
@@ -6898,6 +6908,54 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_pstate_fields_are_byte_exact"
     if (!t_word("msr tco, 1", 0xD503419F)) { bad = 1; }
     if (!t_word("msr daifclr, 0", 0xD50340FF)) { bad = 1; }
 
+    ret bad;
+}
+
+# `mrs`/`msr` reach the assembly printer instead of refusing the build (#2501)
+#
+# Before the fix, `emit_msr_imm` and `a64_emit_sysreg` emitted their word without
+# notifying the sink: the bytes were unaccounted, and `check_accounted` refused the
+# whole `--emit-asm` run. This drives all three encoded shapes - `msr <pstatefield>,
+# #imm`, `msr <sysreg>, Xt`, and `mrs Xt, <sysreg>` - through a real sink and checks
+# the rendered text. A system register renders through its numeric
+# `s<op0>_<op1>_c<CRn>_c<CRm>_<op2>` spelling regardless of which name parsed it,
+# since that is the one spelling the printer can always produce without a reverse
+# name table (#2501).
+test "mach.lang.target.isa.arm64.encode:emit_asm_renders_sysreg_instructions" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = printer.test_sink_write;
+    printer.test_sink_reset();
+    var sink: encode.AsmSink = encode.sink_init(?w, ?interner);
+    st.buf.asm = ?sink;
+
+    val r1: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "mrs x0, cntvct_el0");
+    if (R.is_err[bool, str](r1)) { bad = 1; }
+    val r2: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "msr cntv_ctl_el0, x1");
+    if (R.is_err[bool, str](r2)) { bad = 1; }
+    val r3: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "msr daifset, 1");
+    if (R.is_err[bool, str](r3)) { bad = 1; }
+
+    # the shared byte-accounting guard `check_accounted` reads: nothing emitted was
+    # left unclaimed.
+    if (encode.sink_unaccounted(?st.buf) != 0) { bad = 1; }
+
+    val text: str = printer.test_sink_text();
+    if (!str_contains(text, "mrs x0, s3_3_c14_c0_2")) { bad = 1; }
+    if (!str_contains(text, "msr s3_3_c14_c3_1, x1")) { bad = 1; }
+    if (!str_contains(text, "msr daifset, #1"))       { bad = 1; }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
     ret bad;
 }
 

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -125,6 +125,14 @@ pub val FORM_NEON_LANE_RD: u8 = 18;
 # element. the vector destination is lane-indexed; a float source names its own lane
 # on `src3`
 pub val FORM_NEON_LANE_WR: u8 = 19;
+# `msr <pstatefield>, #imm` (`emit_msr_imm`) - the field's (op1, op2) pair rides
+# `src1` packed as `(op1 << 3) | op2`, the immediate rides `src2` (#2501)
+pub val FORM_SYSREG_IMM: u8 = 20;
+# `msr <sysreg>, Xt` or `mrs Xt, <sysreg>` (`a64_emit_sysreg`) - the sole register
+# rides `dst` regardless of direction, and the sysreg's five packed selectors
+# (`a64_sysreg_pack`'s encoding) ride `src1`; the base word alone says which
+# direction, so no extra flag is needed (#2501)
+pub val FORM_SYSREG: u8 = 21;
 
 # the instruction's symbol operand carries no relocation modifier
 pub val MOD_NONE: u8 = 0;
@@ -353,6 +361,8 @@ fun render_body(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
     if (i.form == FORM_IMM16)       { ret render_imm16(buf, i); }
     if (i.form == FORM_BARRIER)     { ret render_barrier(out, i); }
     if (i.form == FORM_STXR)        { ret render_stxr(buf, i); }
+    if (i.form == FORM_SYSREG_IMM)  { ret render_sysreg_imm(out, i); }
+    if (i.form == FORM_SYSREG)      { ret render_sysreg(out, i); }
     ret R.err[bool, str]("--emit-asm: an emitted aarch64 instruction has no renderable form");
 }
 
@@ -1306,6 +1316,106 @@ fun render_stxr(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
     ret emit_sep_operand(buf, i, ?i.src2, 2, false);
 }
 
+# render `msr <pstatefield>, #imm`, naming the field its (op1, op2) pair selects
+# ---
+# out: destination writer
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped field
+fun render_sysreg_imm(out: *writer.Writer, i: *Inst) R.Result[bool, str] {
+    if (i.base != 0xD500401F) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted PSTATE-field base word");
+    }
+    val packed: u32 = i.src1.imm::u32;
+    val name: str = pstate_field_name((packed >> 3) & 0x7, packed & 0x7);
+    if (name == nil) {
+        ret R.err[bool, str]("--emit-asm: an emitted aarch64 msr-immediate names no PSTATE field");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, "msr ");
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rn: R.Result[bool, str] = emit_str(out, name);
+    if (R.is_err[bool, str](rn)) { ret rn; }
+    val rc: R.Result[bool, str] = emit_str(out, ", ");
+    if (R.is_err[bool, str](rc)) { ret rc; }
+    ret emit_dec_imm(out, i.src2.imm);
+}
+
+# the PSTATE field name an (op1, op2) pair selects, the reverse of `a64_pstate_field`
+#
+# There is no numeric escape for a PSTATE field - unlike a system register, the
+# architecture spells it by name only - so this table, not a computed form, is the
+# whole of what a printer can say.
+# ---
+# op1: the encoded op1 field
+# op2: the encoded op2 field
+# ret: the field name, or nil for an unmodelled pair
+fun pstate_field_name(op1: u32, op2: u32) str {
+    if (op1 == 3 && op2 == 6) { ret "daifset"; }
+    if (op1 == 3 && op2 == 7) { ret "daifclr"; }
+    if (op1 == 0 && op2 == 5) { ret "spsel"; }
+    if (op1 == 0 && op2 == 4) { ret "pan"; }
+    if (op1 == 0 && op2 == 3) { ret "uao"; }
+    if (op1 == 3 && op2 == 1) { ret "ssbs"; }
+    if (op1 == 3 && op2 == 2) { ret "dit"; }
+    if (op1 == 3 && op2 == 4) { ret "tco"; }
+    ret nil;
+}
+
+# render `msr <sysreg>, Xt` or `mrs Xt, <sysreg>`, the base word alone naming the
+# direction
+# ---
+# out: destination writer
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_sysreg(out: *writer.Writer, i: *Inst) R.Result[bool, str] {
+    if (i.base == 0xD5300000) {
+        val rm: R.Result[bool, str] = emit_str(out, "mrs ");
+        if (R.is_err[bool, str](rm)) { ret rm; }
+        val rr: R.Result[bool, str] = emit_reg(out, ?i.dst, false);
+        if (R.is_err[bool, str](rr)) { ret rr; }
+        val rc: R.Result[bool, str] = emit_str(out, ", ");
+        if (R.is_err[bool, str](rc)) { ret rc; }
+        ret emit_sysreg_numeric(out, i.src1.imm::u32);
+    }
+    if (i.base == 0xD5100000) {
+        val rm: R.Result[bool, str] = emit_str(out, "msr ");
+        if (R.is_err[bool, str](rm)) { ret rm; }
+        val rn: R.Result[bool, str] = emit_sysreg_numeric(out, i.src1.imm::u32);
+        if (R.is_err[bool, str](rn)) { ret rn; }
+        val rc: R.Result[bool, str] = emit_str(out, ", ");
+        if (R.is_err[bool, str](rc)) { ret rc; }
+        ret emit_reg(out, ?i.dst, false);
+    }
+    ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted system-register base word");
+}
+
+# render a system register in its numeric `s<op0>_<op1>_c<CRn>_c<CRm>_<op2>` spelling
+#
+# EVERY REGISTER `a64_sysreg` NAMES ROUND-TRIPS THROUGH THIS SPELLING - the named
+# table resolves to the same five selectors the numeric escape does, so printing the
+# numeric form needs no reverse name table that could fall behind the forward one
+# (#2501).
+# ---
+# out:    destination writer
+# packed: the five selectors, packed as `a64_sysreg_pack` lays them out
+# ret:    true on success, or the first write error
+fun emit_sysreg_numeric(out: *writer.Writer, packed: u32) R.Result[bool, str] {
+    val op0: u32 = (packed >> 16) & 0x3;
+    val op1: u32 = (packed >> 12) & 0x7;
+    val crn: u32 = (packed >> 8) & 0xF;
+    val crm: u32 = (packed >> 4) & 0xF;
+    val op2: u32 = packed & 0x7;
+
+    val r0: R.Result[bool, str] = emit_indexed(out, "s", op0);
+    if (R.is_err[bool, str](r0)) { ret r0; }
+    val r1: R.Result[bool, str] = emit_indexed(out, "_", op1);
+    if (R.is_err[bool, str](r1)) { ret r1; }
+    val r2: R.Result[bool, str] = emit_indexed(out, "_c", crn);
+    if (R.is_err[bool, str](r2)) { ret r2; }
+    val r3: R.Result[bool, str] = emit_indexed(out, "_c", crm);
+    if (R.is_err[bool, str](r3)) { ret r3; }
+    ret emit_indexed(out, "_", op2);
+}
+
 # render one operand, preceded by the separator its position calls for
 #
 # An absent operand renders nothing and does not advance the position, so a form
@@ -1717,7 +1827,7 @@ pub fun test_sink_reset() {
 # the text the capture buffer holds, NUL-terminated
 # ---
 # ret: the captured text
-fun test_sink_text() str {
+pub fun test_sink_text() str {
     test_sink_buf[test_sink_len] = 0;
     ret (?test_sink_buf[0])::str;
 }

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -1555,21 +1555,39 @@ fun emit_one(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels, item:
         ret label_record_def(st, g, l, item.ref_num, st.buf.len::u32);
     }
     if (item.kind == AI_BYTES) {
-        val start: usize = st.buf.len;
-        var i: usize = 0;
-        for (i < item.byte_count) {
-            encode.emit_byte(?st.buf, item.bytes[i]);
-            i = i + 1;
-        }
-        # the payload's bytes must reach the assembly sink like any other emission.
         # a target that wires no hook is refused rather than left to emit a dump that
         # silently omits the directive - a dump missing instructions is worse than one
         # that fails (#2467).
-        if (encode.sink_active(?st.buf)) {
-            if (g.note_bytes == nil) {
-                ret R.err[bool, str]("--emit-asm: this target wires no raw-byte directive printer, so a `.byte` payload cannot be rendered");
+        if (encode.sink_active(?st.buf) && g.note_bytes == nil) {
+            ret R.err[bool, str]("--emit-asm: this target wires no raw-byte directive printer, so a `.byte` payload cannot be rendered");
+        }
+        # ONE WORD PER NOTIFICATION on a fixed-width target, exactly as an instruction
+        # is - `parse_directive` already refused anything not a whole number of words,
+        # so this never leaves a short remainder. A variable-width target (`g.word ==
+        # 0`) declares no word to chunk by, so its whole payload is one notification,
+        # as it always was.
+        #
+        # This is what a BUFFERING printer needs: `note_bytes` runs after every one of
+        # its words is actually in the text, matching how an instruction's own bytes
+        # precede its own notification, so the notification can claim exactly the
+        # bytes just written rather than a span spanning bytes not yet emitted (#2493).
+        # A printer that renders on the spot pays only a few more calls for a
+        # multi-word directive; the bytes and the rendered text are unchanged.
+        var step: usize = item.byte_count;
+        if (g.word != 0) { step = g.word::usize; }
+        var i: usize = 0;
+        for (i < item.byte_count) {
+            val start: usize = st.buf.len;
+            var k: usize = 0;
+            for (k < step) {
+                encode.emit_byte(?st.buf, item.bytes[i + k]);
+                k = k + 1;
             }
-            ret g.note_bytes(st, ?item.bytes[0], item.byte_count, start);
+            if (encode.sink_active(?st.buf)) {
+                val rn: R.Result[bool, str] = g.note_bytes(st, ?item.bytes[i], step, start);
+                if (R.is_err[bool, str](rn)) { ret rn; }
+            }
+            i = i + step;
         }
         ret R.ok[bool, str](true);
     }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -59,6 +59,7 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_equals;
+use std.types.string.str_index_of;
 use std.types.string.str_len;
 use std.types.string.str_region_equals;
 
@@ -5245,6 +5246,66 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directive_refusals" {
     ret bad;
 }
 
+# a raw-byte directive reaches the assembly printer and renders in program order,
+# rather than refusing the build (#2493)
+#
+# Before the fix, `asm_note_bytes` rendered the payload on the spot instead of
+# buffering it: the bytes were claimed but `note_insts` never grew, so
+# `check_accounted`'s totality guard - built on `note_inst_count() * WORD_SIZE` -
+# would find the counts unequal at the very next real instruction. This drives the
+# same path through a real sink: a directive spanning two instruction words (so a
+# single `ASM_NOTE_BYTES` push could not, by itself, cover it), then a real
+# instruction after it. It checks the exact equality `check_accounted` enforces, and
+# that the buffered notes render as the directive text, in order.
+test "mach.lang.target.isa.riscv64.encode:emit_asm_renders_data_directives" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = printer.test_sink_write;
+    printer.test_sink_reset();
+    var sink: encode.AsmSink = encode.sink_init(?w, ?interner);
+    st.buf.asm = ?sink;
+
+    val r1: R.Result[bool, str] =
+        rv_asm_text(?st, ?f, ?labels, ".byte 0x13, 0x05, 0x00, 0x00, 0x93, 0x05, 0x10, 0x00");
+    if (R.is_err[bool, str](r1)) { bad = 1; }
+    val r2: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "addi zero, zero, 0");
+    if (R.is_err[bool, str](r2)) { bad = 1; }
+
+    # the same equality `check_accounted` requires: every buffered word - real
+    # instruction or directive payload alike - is exactly `WORD_SIZE` bytes.
+    if (encode.note_inst_count(?st.buf) * WORD_SIZE != st.buf.len::u32) { bad = 1; }
+
+    val rr: R.Result[bool, str] = printer.render_notes(?st.buf);
+    if (R.is_err[bool, str](rr)) { bad = 1; }
+    or {
+        val text: str = printer.test_sink_text();
+        val di: O.Option[usize] = str_index_of(text, ".byte 0x13, 0x05, 0x00, 0x00");
+        val dj: O.Option[usize] = str_index_of(text, ".byte 0x93, 0x05, 0x10, 0x00");
+        val ii: O.Option[usize] = str_index_of(text, "addi zero, zero, 0");
+        if (O.is_none[usize](di) || O.is_none[usize](dj) || O.is_none[usize](ii)) { bad = 1; }
+        or {
+            # program order, not just presence: rendering immediately (the pre-fix
+            # behavior) would print the directive ahead of every buffered instruction
+            # around it.
+            if (O.unwrap[usize](di) >= O.unwrap[usize](dj)) { bad = 1; }
+            if (O.unwrap[usize](dj) >= O.unwrap[usize](ii)) { bad = 1; }
+        }
+    }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
 # a data directive's payload is an instruction stream the parser cannot read, so it
 # reaches every register in every bank
 #
@@ -6235,10 +6296,24 @@ fun t_copy_str(dst: *u8, at: usize, s: str) usize {
 
 # the `NoteBytesFn` the riscv64 grammar wires
 #
-# This printer BUFFERS its notes and renders them in a later pass, so a directive
-# written directly here would appear ahead of every instruction around it. It is
-# rendered on the spot only because an asm block's bytes are already final - no
-# relaxation rewrites inside one - so program order is the emission order (#2467).
+# BUFFERED, like every other riscv64 notification - not rendered on the spot. An asm
+# block's bytes are already final (no relaxation rewrites inside one), but the TEXT is
+# not: `render_notes` renders every note for the whole function, in order, only after
+# the function's layout has settled, so a directive rendered immediately here would
+# print ahead of every buffered instruction around it (#2493).
+#
+# `emit_one` calls this once per instruction word - `n` is always
+# `ASM_NOTE_BYTES_WIDTH`, a multi-word directive already split into one call per word -
+# so one push claims exactly the bytes this call covers, the same as an instruction's
+# own notification claims exactly its own bytes.
 fun asm_note_bytes(st: *encode.EncodeState, bytes: *u8, n: usize, start: usize) R.Result[bool, str] {
-    ret encode.render_bytes_directive(?st.buf, bytes, n, start);
+    var note: encode.AsmNote = encode.note_blank();
+    note.kind = encode.ASM_NOTE_BYTES;
+    note.off  = start::u32;
+    var j: usize = 0;
+    for (j < n) {
+        note.bytes[j] = bytes[j];
+        j = j + 1;
+    }
+    ret encode.note_push(?st.buf, ?note);
 }

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -94,6 +94,11 @@ fun render_note(out: *writer.Writer, interner: *intern.Interner, n: *enc.AsmNote
         if (R.is_err[bool, str](res_label)) { ret res_label; }
         ret emit_str(out, ":\n");
     }
+    if (n.kind == enc.ASM_NOTE_BYTES) {
+        # the accounting claim already happened when this note was pushed
+        # (`note_push`); only the text remains to be written (#2493).
+        ret enc.render_bytes_text(out, ?n.bytes[0], enc.ASM_NOTE_BYTES_WIDTH);
+    }
     ret render_inst(out, interner, ?n.inst);
 }
 
@@ -631,6 +636,44 @@ fun emit_name(out: *writer.Writer, interner: *intern.Interner, id: intern.StrId)
         ret R.err[bool, str]("--emit-asm: a symbol name did not resolve in the interner");
     }
     ret emit_str(out, O.unwrap[str](opt_name));
+}
+
+# a fixed capture buffer the rendering tests write into, and its writer
+#
+# The renderer's only output is a `writer.Writer`, so testing what it renders means
+# supplying one; this is the smallest possible in-memory sink.
+var test_sink_buf: [4096]u8;
+var test_sink_len: usize = 0;
+
+# append to the capture buffer, matching `writer.WriteFun`
+# ---
+# ctx: unused; the buffer is module state
+# buf: bytes to append
+# len: number of bytes
+# ret: the byte count, always accepted
+pub fun test_sink_write(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
+    var i: usize = 0;
+    for (i < len) {
+        if (test_sink_len < 4095) {
+            test_sink_buf[test_sink_len] = buf[i];
+            test_sink_len = test_sink_len + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+# discard everything the capture buffer holds
+pub fun test_sink_reset() {
+    test_sink_len = 0;
+}
+
+# the text the capture buffer holds, NUL-terminated
+# ---
+# ret: the captured text
+pub fun test_sink_text() str {
+    test_sink_buf[test_sink_len] = 0;
+    ret (?test_sink_buf[0])::str;
 }
 
 # the psABI register mnemonics name each bank's roles, so a rendered operand reads as


### PR DESCRIPTION
Closes #2501
Closes #2493

Both issues share one root cause: an emitter writes machine code without notifying the assembly-text printer, so `--emit-asm` refuses the build.

## aarch64 (#2501)

`emit_msr_imm` and `a64_emit_sysreg` emitted their word without calling `printer.note_inst`, unlike every other aarch64 emitter. Added:
- `FORM_SYSREG_IMM` / `FORM_SYSREG` printer forms
- A system register renders in its numeric `s<op0>_<op1>_c<CRn>_c<CRm>_<op2>` spelling - the one form the printer can always produce without a reverse name table
- A small PSTATE-field name table (`daifset`/`spsel`/... ) for the immediate form, since that one has no numeric escape

## riscv64 (#2493)

The `.byte`/`.word`/`.quad` directive path (fixed for a single word by #2491) rendered its payload immediately instead of buffering it. riscv64's own totality guard (`check_accounted`) counts buffered instruction-word notifications; a directive rendered on the spot claimed its bytes via the shared byte-accounting cursor but never grew that count, so the very next real instruction's check found the counts unequal. A multi-word payload additionally landed ahead of the buffered instructions around it once the function's notes were replayed (an ordering bug the immediate-render approach papered over only by accident, for exactly the single-word case #2491 tested).

Fix:
- Added a payload-carrying `ASM_NOTE_BYTES` note kind to the shared sink model (`src/lang/be/codegen/encode.mach`) so a directive is buffered exactly like an instruction - one note per instruction word - and replayed in program order alongside them
- `emit_one` (`src/lang/target/isa/asm.mach`) now chunks a raw-byte directive into one notification per instruction word on any fixed-width target (`g.word != 0`), restoring the emit-then-notify interleaving every other emitter already follows. `g.word == 0` targets (x86-64) are unaffected - one notification for the whole payload, as before
- `render_bytes_directive`'s text half is split out as `render_bytes_text` so the buffered path can render text without re-claiming bytes already accounted at push time

## Testing

- `mach.lang.target.isa.arm64.encode:emit_asm_renders_sysreg_instructions` - drives all three encoded shapes (`msr <pstatefield>, #imm`, `msr <sysreg>, Xt`, `mrs Xt, <sysreg>`) through a real sink and checks the rendered text
- `mach.lang.target.isa.riscv64.encode:emit_asm_renders_data_directives` - drives a two-word directive plus a following instruction through a real sink, checks the `check_accounted` equality holds, and checks the buffered notes render in program order
- `mach test .`: 1071 passed, 0 failed (up from 1069)
- Manually verified `--emit-asm` on both original repros plus multi-word directive variants for aarch64, riscv64, and x86-64 (unaffected)

Note: the riscv64 repro as literally stated in the issue - `asm riscv64 { .byte 0x13 }` (one byte) - is refused for a separate, correct, pre-existing reason (the word-alignment guard; a single byte can never stand alone on a fixed-width ISA). The actual notify bug needed a word-aligned multi-byte payload to reproduce, e.g. `.byte 0x13, 0x05, 0x00, 0x00`.