### PR TITLE
fix(sema): fold a global initialiser that references a same-module global

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -8680,6 +8680,116 @@ test "mach.lang.driver:qualified_const_ignores_leaf_import_shadow" {
     ret bad;
 }
 
+# a same-module global initialiser that references ANOTHER same-module global
+# folds, even when that other global's own initialiser needed a cross-module
+# resolution to fold (#2486)
+#
+# `A`'s initialiser needs the module-qualified member resolver, which exists only
+# once lowering starts (load-time registration runs before name resolution, so it
+# cannot fold `A` and never binds it). Before the fix nothing rebound `A`'s
+# lowering-time fold back into the comptime table, so `B`'s bare `A` reference never
+# found it - the identical shape one scope closer than `a.BASE` was rejected.
+# Checking the folded VALUE (not merely a clean lower) is the point: `0x1000 + 0x48 +
+# 8 = 0x1050` proves the chain folded through both hops, and `p()`'s own read of `B`
+# proves a same-module `val` whose initialiser needed the fix reads back correctly
+# too - the same comptime table backs both.
+test "mach.lang.driver:same_module_global_folds_through_cross_module_base" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\nval A: u64 = a.BASE + 0x48;\nval B: u64 = A + 8;\npub fun p() u64 { ret B; }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val BASE: u64 = 0x1000;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    if (ut_count_errors(?p.s.diags) != 0) { bad = 1; }
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (ut_const_uses(m, 0x1050) != 1) { bad = 1; }  # B folded through A folded through a.BASE
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a same-module global initialiser cannot forward-reference a global declared
+# LATER in the same file, when both need lowering-time folding (#2486)
+#
+# Declaration order is a real constraint here, not an incidental one: both
+# load-time registration and lowering walk a module's decls in source order, in
+# one forward pass with no fixpoint, so nothing revisits `B` once `A` later binds.
+# `B`'s initialiser gets the SAME diagnostic every other non-constant initialiser
+# gets - not a new, special-cased message - because from the evaluator's
+# perspective `A` genuinely is not yet a comptime constant when `B` is folded.
+test "mach.lang.driver:same_module_forward_reference_is_refused" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\nval B: u64 = A + 8;\nval A: u64 = a.BASE + 0x48;\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val BASE: u64 = 0x1000;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    if (!ut_diag_has(?p.s.diags, "global initialiser of `B` must be a constant expression")) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a genuine cycle between two same-module globals is refused by name, not looped
+# (#2486)
+#
+# Neither `X` nor `Y` can ever bind - the single forward pass reaches each once and
+# neither's dependency is bound yet - so both are reported, each naming itself, and
+# lowering completes (this test itself terminating is half the proof) rather than
+# recursing or hanging.
+test "mach.lang.driver:same_module_global_cycle_is_refused" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "val X: u64 = Y;\nval Y: u64 = X;\nfun main() i32 { ret 0; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    if (!ut_diag_has(?p.s.diags, "global initialiser of `X` must be a constant expression")) { bad = 1; }
+    if (!ut_diag_has(?p.s.diags, "global initialiser of `Y` must be a constant expression")) { bad = 1; }
+    if (ut_count_errors(?p.s.diags) != 2) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
 # a qualified member the module does not export is still an error, so keying the
 # constant fold on the declaring module did not turn a missing name into a
 # silent miss (#2223)

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -381,7 +381,7 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
 
     var init_val: value.Value = value.const_int(0, gty);
     if (d.data.bind.init != id.EXPR_NIL) {
-        val res_fold: R.Result[value.Value, str] = fold_global_init(ctx, d.data.bind.init, gty);
+        val res_fold: R.Result[value.Value, str] = fold_global_init(ctx, d.data.bind.init, gty, bare);
         if (R.is_err[value.Value, str](res_fold)) {
             # a non-constant initialiser is a build error, located on the binding's
             # name and naming the symbol (#1289) rather than aborting with a bare,
@@ -1008,12 +1008,27 @@ fun terminate_orphan_blocks(ctx: *context.LowerContext) R.Result[bool, str] {
 #      same width / sign semantics `lower_cast` lowers.
 #   5. a type-introspection intrinsic (`$size_of` / `$align_of` / `$offset_of`)
 #      whose layout is backend-owned, folded via the path function bodies use.
+#
+# THE SCALAR FOLD ALSO BINDS `name` INTO `ctx.ctx` (#2486). A module-qualified
+# reference to another module's global (`other.BASE`) already resolves through
+# that module's ComptimeCtx, pre-populated by `register_val_for_load`'s load-time
+# walk - but that walk runs BEFORE name resolution exists, so it cannot fold an
+# initialiser that itself needs the module-member resolver installed here at
+# lowering. Binding the fold's result under the SAME name, in the SAME
+# `ctx.ctx`, the moment it succeeds is what makes a later same-module reference
+# (a sibling initialiser earlier in this file, an `$if`) see it too: one
+# folding path, reached from whichever pass manages to fold this initialiser
+# first, rather than a lowering-only copy the comptime evaluator never learns
+# of. `name` is `intern.STR_NIL` for a fold with nothing to register under (a
+# decorator argument), which skips the bind.
 # ---
-# ctx: the context
-# eid: the initialiser expression
-# gty: the global's IR type
-# ret: the constant initialiser Value, or an error
-fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.IrTypeId) R.Result[value.Value, str] {
+# ctx:  the context
+# eid:  the initialiser expression
+# gty:  the global's IR type
+# name: the global's bare interned name to bind a scalar fold under, or
+#       `intern.STR_NIL` for an unnamed fold
+# ret:  the constant initialiser Value, or an error
+fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.IrTypeId, name: intern.StrId) R.Result[value.Value, str] {
     # a `nil` constant - bare or wrapped in pointer casts - is the null constant
     # the global is emitted with, regardless of the cast chain (every cast of the
     # null address preserves it). recognised here so a fun- or pointer-typed
@@ -1030,7 +1045,12 @@ fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.Ir
     # for a wasted comptime.eval pass.
     val opt_ct: O.Option[comptime.CTValue] = try_comptime(ctx, eid);
     if (O.is_some[comptime.CTValue](opt_ct)) {
-        ret expr.const_value_of_init(ctx, eid, O.unwrap[comptime.CTValue](opt_ct));
+        val cv: comptime.CTValue = O.unwrap[comptime.CTValue](opt_ct);
+        if (name != intern.STR_NIL) {
+            val res_bind: R.Result[bool, str] = comptime.bind(ctx.ctx, name, cv);
+            if (R.is_err[bool, str](res_bind)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_bind)); }
+        }
+        ret expr.const_value_of_init(ctx, eid, cv);
     }
 
     val opt_init: O.Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
@@ -1207,7 +1227,7 @@ fun global_align_of(ctx: *context.LowerContext, d: *decl.Decl) R.Result[u32, str
     if (R.is_err[ir_type.IrTypeId, str](res_u64)) { ret R.err[u32, str](R.unwrap_err[ir_type.IrTypeId, str](res_u64)); }
     val u64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_u64);
 
-    val res_fold: R.Result[value.Value, str] = fold_global_init(ctx, arg, u64t);
+    val res_fold: R.Result[value.Value, str] = fold_global_init(ctx, arg, u64t, intern.STR_NIL);
     if (R.is_err[value.Value, str](res_fold)) {
         val res_diag: R.Result[bool, str] = diagnostic.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, "`align` decorator requires a compile-time constant argument");
         if (R.is_err[bool, str](res_diag)) { ret R.err[u32, str](R.unwrap_err[bool, str](res_diag)); }


### PR DESCRIPTION
Closes #2486

A global initialiser that derives from a global in ANOTHER module folded fine (`other.BASE + 0x48`), but the identical shape deriving from a global in the SAME module (`A + 8`) was rejected as non-constant. The more local case was the one that failed.

## Mechanism (step 3)

`register_val_for_load` (`src/lang/driver/load.mach`) walks a module's `val` decls in source order at **load time**, folding each initialiser via `comptime.eval` and, when it succeeds, binding the result into the module's `ComptimeCtx` by bare name - the same table `eval_ident`'s bare-identifier lookup reads for a same-module reference, and the same table the module-qualified member resolver (`resolve_module_member_const`) reads for a cross-module reference on behalf of an importer.

That load-time walk runs **before name resolution exists** (load precedes resolve), so it cannot fold an initialiser that itself needs the module-qualified member resolver - that resolver is installed only when a module's **lowering** pass starts (`context.init_context`). Per its own documented contract, `register_val_for_load` silently skips a non-foldable initialiser rather than erroring, so `A: u64 = other.BASE + 0x48` is never bound at load time.

Lowering later folds `A`'s initialiser successfully, once the resolver exists - `fold_global_init` uses the exact same `comptime.eval` call. But nothing rebound that result back into the `ComptimeCtx`. So when `B: u64 = A + 8` is folded moments later in the same forward pass, `eval_ident("A")` still finds nothing bound - the load-time skip was never undone.

## Fix (step 4)

`fold_global_init` now binds a successful scalar comptime fold into `ctx.ctx` under the global's bare name, mirroring exactly what `register_val_for_load` already does at load time. Both passes converge on one postcondition - **a global that folds is bound** - regardless of which pass manages to fold it first. `eval_ident` and the module-member resolver keep reading the same one table; no second evaluator, no parallel lookup.

The other `fold_global_init` call site (`global_align_of`, an `#[align(...)]` decorator argument) passes `intern.STR_NIL` to skip the bind - there is no name to register an unnamed fold under.

## Ordering / cycles (step 5)

Both the load-time walk and lowering process a module's decls in **source order**, in one forward pass with no fixpoint - this was already true before this fix and I did not change it. So:

- **Forward reference** (`val B = A + 8;` with `A` declared *after* `B`, where `A` itself needs lowering-time-only folding): refused with the existing `global initialiser of 'B' must be a constant expression` diagnostic. No new code - from the evaluator's perspective `A` genuinely is not yet bound when `B` is folded.
- **Genuine cycle** (`val X = Y; val Y = X;`): both `X` and `Y` are refused by name with the same diagnostic; the pass completes rather than looping (neither can ever bind, so there is no recursion to begin with).

I chose **declaration order matters, refused with a clear pre-existing message** over building a dependency-order solver, since the whole surrounding architecture (load-time registration, lowering) is already a single forward pass with no fixpoint - matching that is the minimal, non-speculative fix; a real solver would be new architecture, not a bug fix.

## Testing (step 6)

Three new tests in `src/lang/driver/tests.mach`, following the shape of the existing `qualified_const_ignores_*` cross-module const-fold tests (`ut_lower_n` + `ut_const_uses`/`ut_diag_has`):

- `same_module_global_folds_through_cross_module_base` - the repro's accept case, asserting the folded **value** (`0x1000 + 0x48 + 8 = 0x1050`) reaches a function body's `ret`, not merely that it compiles; also proves a same-module `val` whose own initialiser needed the fix reads back correctly from a function body
- `same_module_forward_reference_is_refused` - the reverse-declaration-order case
- `same_module_global_cycle_is_refused` - the cycle case, asserting both names are reported and the pass terminates

## Verification (step 7)

`mach test .` with the freshly built compiler: **1076 passed, 0 failed** (was 1073 on this branch's base; `mach.lang.driver.tests` grew from 167 to 170, exactly the three new tests - no other suite changed count). Manually verified the exact issue repro, both correctly-ordered and forward-ordered variants, and the cycle case via `mach build --emit-asm` / plain build, reading back the folded constant from the emitted assembly.