### PR TITLE
feat(link): pin symbol→DLL import mapping for static archives on PE

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -183,6 +183,36 @@ requirements can set a cross-platform logical identity explicitly with their
 `library` key. Manifest requirements are resolved before CLI inputs, giving a
 stable, deterministic link order.
 
+##### Attributing imports on a two-level namespace
+
+PE and Mach-O record imports **per dependency**: the image names which library
+provides each symbol, unlike ELF's flat global search. Every import therefore
+needs an attribution, and an unattributed one is a hard link error rather than a
+guess. Resolution never opens a library to find out — no export table is read on
+any host — so the mapping comes entirely from the link's own declarations, and
+cross-linking a Windows PE from Linux needs no target DLL on disk.
+
+Two declarations supply it:
+
+- `#[library("name")]` on an `ext` declaration, for a symbol your Mach source
+  declares. See [language/ext-fun.md](language/ext-fun.md#library-attribution).
+- `symbols = [...]` on a `[link.X]` entry, for a symbol your source never
+  declares — the Win32 or system references a **static archive leaves
+  undefined**. Merging an `.a` pulls in its members' undefined symbols, and those
+  have no Mach declaration to decorate, so the providing library is named in the
+  manifest instead. See [manifest.md](manifest.md#linkname--link-requirements).
+
+Both write the same attribution, so a symbol may be claimed only once: a
+`symbols` entry that contradicts another entry's claim, or a `#[library]`
+decorator's, is an error naming both claimants rather than a silent
+order-dependent win. Repeating an identical claim is accepted, which is what an
+`export = true` entry reaching a consumer through both the cascade and its own
+manifest does.
+
+On ELF the loader resolves imports by global search, so neither declaration
+changes the emitted binary; both are still validated against the link's
+dependencies.
+
 Exit codes: `0` ok, `1` user error (missing project path, no `mach.toml`,
 unknown target, compile errors, an unresolvable link input), `2` internal error.
 

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -61,6 +61,11 @@ ext fun WSAStartup(ver: u16, data: *u8) i32;
 - An `ext` import with no `library` is unattributed. PE and Mach-O require every
   dynamic import to identify its provider, so an unattributed import is a hard
   link error on those targets.
+- A symbol with **no `ext` declaration at all** — one a linked static archive
+  leaves undefined — has nothing to decorate. Its provider is named from the
+  manifest instead, by the `symbols` key on the `[link.X]` entry that supplies
+  it; see [manifest.md](../manifest.md#linkname--link-requirements). The two
+  declarations write the same attribution, so a symbol may be claimed only once.
 
 `library` composes with `symbol`: the rename sets the imported symbol's name,
 `library` sets the dependency it is imported from. On one decl the import is emitted

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -378,6 +378,7 @@ the same entries, so nothing behaves differently as a dependency.
 | `name`    | shape | Library/framework name — required for `source = "system"`/`"framework"`, forbidden for `"local"`. |
 | `path`    | shape | File path — required for `source = "local"`, forbidden otherwise. A template (see below). |
 | `library` | no | Stable logical name used by `#[library("...")]`; defaults to the `[link.<name>]` table name. |
+| `symbols` | no | Array of symbol names this dependency provides, attributing imports that have no `ext` declaration to decorate (see below). Omit for none. |
 | `os`      | yes | Filter axis: a canonical `os` value, `"*"` (any), an array of values, or `[]` (none). |
 | `isa`     | yes | Filter axis over `isa`, same forms. |
 | `abi`     | yes | Filter axis over `abi`, same forms. |
@@ -402,6 +403,37 @@ compatibility. Selecting two dependencies that map the same logical name to
 different loader names in one build is an error. A logical name that equals a
 different dependency's canonical loader name is likewise rejected, so
 attribution never depends on requirement order.
+
+`symbols` names the symbols the dependency provides. On a two-level-namespace
+format (PE, Mach-O) every import must identify its provider, and `#[library]` can
+only attribute a symbol your Mach source declares. A **vendored static archive**
+leaves its own undefined references — the Win32 calls inside a `glfw3.a`, say —
+with no declaration to decorate, so the entry that provides them claims them:
+
+```toml
+[link.kernel32]
+source  = "system"
+name    = "kernel32.dll"
+library = "kernel32"
+symbols = ["Sleep", "CreateFileW", "CloseHandle"]
+os      = "windows"
+isa     = "*"
+abi     = "*"
+export  = true
+```
+
+Nothing reads a library's export table to derive this, so the claim is what makes
+cross-linking a PE from a Linux host work with no target DLL present. Claims
+travel with the entry, so `export = true` cascades them to consumers and a
+C-binding project declares them once.
+
+A symbol may be claimed only once per link: two selected entries claiming it, or a
+claim contradicting a `#[library]` decorator, is an error naming both claimants
+rather than an order-dependent win — repeating the *same* claim is fine. Listing a
+symbol twice within one entry is rejected, and so is a claim on an entry that
+resolves to a **static** input, which defines symbols rather than importing them.
+On ELF the key is accepted and validated but changes no emitted bytes, since that
+loader resolves imports by global search.
 
 Whether an input links **statically** or **dynamically** follows the resolved file
 — a loose `.o` or static `.a` links statically; ELF `.so`, Mach-O `.dylib`,

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -12,6 +12,9 @@
 #                 execution cannot observe (PE ASLR bit, macho PIE bit). dispatched
 #                 on the artifact's own magic, so it is independent of how the case
 #                 maps to a leg. no LLVM; reads little-endian fields (every runner is LE).
+#   pe-imports  — like field, but walks the PE import directory and reports every
+#                 `<dll>:<symbol>` binding (#2510). PE-only; the observable for
+#                 two-level-namespace attribution, which execution cannot check.
 #   relro       — like field, but walks the ELF program headers for a PT_GNU_RELRO
 #                 (the static-PIE RELRO region). ELF-only; used by the elf-relro guard.
 #   flat-loader — load an os=freestanding, of=raw flat image via a tiny C loader
@@ -199,6 +202,110 @@ field_elf() {
     bin=$1
     etype=$(read_le_uint "$bin" 16 2)
     echo "e_type=$etype"
+}
+
+# read_cstr <file> <offset> — print the NUL-terminated string at <offset>. splitting
+# the byte window on NUL and taking the first record ends the string exactly where
+# the format does; a name longer than the window is not a case this suite writes.
+read_cstr() {
+    dd if="$1" bs=1 skip="$2" count=256 2>/dev/null | tr '\0' '\n' | head -n 1
+}
+
+# pe_rva_to_off <file> <sec_table_off> <nsec> <rva>
+# map an image RVA to a file offset through the section table. a section covers
+# [VirtualAddress, VirtualAddress + max(VirtualSize, SizeOfRawData)); the raw
+# window is the larger bound because a section whose VirtualSize rounds below its
+# raw size still owns those bytes on disk.
+pe_rva_to_off() {
+    bin=$1; sec=$2; nsec=$3; rva=$4
+    i=0
+    while [ "$i" -lt "$nsec" ]; do
+        base=$((sec + i * 40))
+        vaddr=$(read_le_uint "$bin" $((base + 12)) 4)
+        vsize=$(read_le_uint "$bin" $((base + 8)) 4)
+        rsize=$(read_le_uint "$bin" $((base + 16)) 4)
+        praw=$(read_le_uint "$bin" $((base + 20)) 4)
+        span=$vsize
+        [ "$rsize" -gt "$span" ] && span=$rsize
+        if [ "$rva" -ge "$vaddr" ] && [ "$rva" -lt $((vaddr + span)) ]; then
+            echo $((praw + rva - vaddr))
+            return 0
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# produce_pe_imports <runmode> <target> <binary>
+# emit the PE import table's symbol->DLL bindings, one `<dll>:<symbol>` line per
+# imported function, sorted. this is the fact the two-level-namespace attribution
+# rules decide (#2510) and the one execution cannot observe: a wrongly attributed
+# import still links and still runs on the host that happens to export it, so only
+# the emitted descriptor distinguishes a correct binding from a lucky one.
+#
+# walks the PE32+ headers with coreutils alone (no LLVM on the linux legs): the
+# import data directory is entry 1 of the optional header's directory array, which
+# for PE32+ begins at optional-header offset 112, i.e. e_lfanew + 24 + 112.
+produce_pe_imports() {
+    bin=$3
+    elfanew=$(read_le_uint "$bin" 60 4)
+    nsec=$(read_le_uint "$bin" $((elfanew + 6)) 2)
+    optsize=$(read_le_uint "$bin" $((elfanew + 20)) 2)
+    sec=$((elfanew + 24 + optsize))
+
+    magic=$(read_le_uint "$bin" $((elfanew + 24)) 2)
+    if [ "$magic" != "523" ]; then
+        echo "int: pe-imports: not a PE32+ image (optional-header magic $magic)" >&2
+        return 2
+    fi
+
+    imp_rva=$(read_le_uint "$bin" $((elfanew + 24 + 112 + 8)) 4)
+    if [ "$imp_rva" -eq 0 ]; then
+        echo "no-import-table"
+        return 0
+    fi
+    imp_off=$(pe_rva_to_off "$bin" "$sec" "$nsec" "$imp_rva") || {
+        echo "int: pe-imports: import directory RVA $imp_rva is in no section" >&2
+        return 2
+    }
+
+    out=$(mktemp)
+    d=0
+    while :; do
+        desc=$((imp_off + d * 20))
+        ilt_rva=$(read_le_uint "$bin" "$desc" 4)
+        name_rva=$(read_le_uint "$bin" $((desc + 12)) 4)
+        iat_rva=$(read_le_uint "$bin" $((desc + 16)) 4)
+        # the descriptor array ends at an all-zero entry
+        if [ "$ilt_rva" -eq 0 ] && [ "$name_rva" -eq 0 ] && [ "$iat_rva" -eq 0 ]; then break; fi
+
+        name_off=$(pe_rva_to_off "$bin" "$sec" "$nsec" "$name_rva") || return 2
+        dll=$(read_cstr "$bin" "$name_off")
+
+        # prefer the ILT; a linker may leave it zero and describe imports through
+        # the IAT alone, which holds the same thunk encoding before the loader runs
+        thunks=$ilt_rva
+        [ "$thunks" -eq 0 ] && thunks=$iat_rva
+        thunk_off=$(pe_rva_to_off "$bin" "$sec" "$nsec" "$thunks") || return 2
+
+        t=0
+        while :; do
+            entry=$(read_le_uint "$bin" $((thunk_off + t * 8)) 8)
+            [ "$entry" -eq 0 ] && break
+            # bit 63 set marks an ordinal import, which names no symbol
+            if [ $((entry >> 63)) -eq 1 ]; then
+                echo "$dll:#$((entry & 0xFFFF))" >>"$out"
+            else
+                hn_off=$(pe_rva_to_off "$bin" "$sec" "$nsec" $((entry & 0x7FFFFFFF))) || return 2
+                echo "$dll:$(read_cstr "$bin" $((hn_off + 2)))" >>"$out"
+            fi
+            t=$((t + 1))
+        done
+        d=$((d + 1))
+    done
+
+    LC_ALL=C sort "$out"
+    rm -f "$out"
 }
 
 # produce_field <runmode> <target> <binary>
@@ -685,6 +792,7 @@ produce() {
         relro-fault) produce_relro_fault "$@" ;;
         panic-exit)  produce_panic_exit "$@" ;;
         field)       produce_field "$@" ;;
+        pe-imports)  produce_pe_imports "$@" ;;
         relro)       produce_relro "$@" ;;
         flat-loader) produce_flat_loader "$@" ;;
         built)       produce_built "$@" ;;

--- a/int/surface/pe-import-claim-cascade/case.conf
+++ b/int/surface/pe-import-claim-cascade/case.conf
@@ -1,0 +1,7 @@
+# the `export = true` cascade must carry a [link.X]'s `symbols` claims to a
+# consumer that declares no link entries of its own (#2510). the consumer's
+# requirement outlives the dependency manifest it was built from, so this is also
+# the regression guard for the claim array's ownership.
+run: pe-imports
+targets: linux
+build-target: windows

--- a/int/surface/pe-import-claim-cascade/expect.windows.txt
+++ b/int/surface/pe-import-claim-cascade/expect.windows.txt
@@ -1,0 +1,2 @@
+kernel32.dll:ExitProcess
+kernel32.dll:Sleep

--- a/int/surface/pe-import-claim-cascade/mach.toml
+++ b/int/surface/pe-import-claim-cascade/mach.toml
@@ -1,0 +1,31 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[dep.prov]
+path = "provider"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/pe-import-claim-cascade/provider/mach.toml
+++ b/int/surface/pe-import-claim-cascade/provider/mach.toml
@@ -1,0 +1,15 @@
+[project]
+id = "prov"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[link.kernel32]
+source = "system"
+name = "kernel32.dll"
+library = "kernel32"
+symbols = ["Sleep"]
+os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = true

--- a/int/surface/pe-import-claim-cascade/provider/src/lib.mach
+++ b/int/surface/pe-import-claim-cascade/provider/src/lib.mach
@@ -1,0 +1,7 @@
+# no #[library] decorator anywhere: the exported [link.kernel32] entry's `symbols`
+# claim is the only thing that can attribute this import
+ext fun Sleep(ms: u32);
+
+pub fun provided() {
+    Sleep(0);
+}

--- a/int/surface/pe-import-claim-cascade/src/main.mach
+++ b/int/surface/pe-import-claim-cascade/src/main.mach
@@ -1,0 +1,13 @@
+# the consumer declares NO link entries of its own. both the kernel32 dependency
+# and the claim attributing `Sleep` arrive through the dependency's `export = true`
+# cascade, which is the path a requirement outlives its manifest on (#2510)
+use prov.lib;
+
+#[library("kernel32")]
+ext fun ExitProcess(code: u32);
+
+#[symbol("mainCRTStartup")]
+pub fun _start() {
+    lib.provided();
+    ExitProcess(0);
+}

--- a/int/surface/pe-import-claim/case.conf
+++ b/int/surface/pe-import-claim/case.conf
@@ -1,0 +1,7 @@
+# a [link.X]'s `symbols` claim must attribute an undefined import that carries no
+# #[library] decorator, and route it to that entry's DLL (#2510). cross-build the
+# win64 PE on the linux leg and read the import table host-side; no windows runner
+# is needed, and no DLL is consulted at link time on any host.
+run: pe-imports
+targets: linux
+build-target: windows

--- a/int/surface/pe-import-claim/expect.windows.txt
+++ b/int/surface/pe-import-claim/expect.windows.txt
@@ -1,0 +1,3 @@
+kernel32.dll:ExitProcess
+kernel32.dll:Sleep
+user32.dll:MessageBeep

--- a/int/surface/pe-import-claim/mach.toml
+++ b/int/surface/pe-import-claim/mach.toml
@@ -1,0 +1,48 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["kernel32", "user32"]
+need = []
+
+[link.kernel32]
+source = "system"
+name = "kernel32.dll"
+library = "kernel32"
+symbols = ["Sleep"]
+os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.user32]
+source = "system"
+name = "user32.dll"
+library = "user32"
+symbols = ["MessageBeep"]
+os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/pe-import-claim/src/main.mach
+++ b/int/surface/pe-import-claim/src/main.mach
@@ -1,0 +1,24 @@
+# manifest-declared symbol claiming on PE (#2510). `Sleep` and `MessageBeep` carry
+# no #[library] decorator: they stand in for the Win32 references a vendored static
+# archive leaves undefined, which reach the link with no Mach declaration to
+# decorate. their providing DLL comes from the `symbols` key on each [link.X].
+#
+# two DLLs are deliberate. with one import descriptor a linker that bound every
+# import to the first dependency would still produce the expected table, so the
+# case would pass while routing was broken; splitting the claims across kernel32
+# and user32 makes the per-DLL binding the observable.
+ext fun Sleep(ms: u32);
+
+ext fun MessageBeep(kind: u32);
+
+# the decorator path still works and must land in the same descriptor as the
+# manifest-claimed kernel32 import
+#[library("kernel32")]
+ext fun ExitProcess(code: u32);
+
+#[symbol("mainCRTStartup")]
+pub fun _start() {
+    Sleep(0);
+    MessageBeep(0);
+    ExitProcess(0);
+}

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -724,7 +724,12 @@ fun resolve_and_store_input(p: *driver.Project, req: *manifest.LinkRequirement,
     }
     val li: plan.LinkInput = R.unwrap_ok[plan.LinkInput, outcome.Fail](lr);
     if (li.kind == plan.LINK_DYNAMIC) {
+        val cr: R.Result[bool, outcome.Fail] = register_link_claims(p, req);
+        if (R.is_err[bool, outcome.Fail](cr)) { ret cr; }
         ret append_dynlib(p, ?li, dynlibs, dynlib_len);
+    }
+    if (req.symbol_count > 0) {
+        ret R.err[bool, outcome.Fail](outcome.user(static_claim_message(p, req)));
     }
     # the STATIC text is already an exact-size copy on the build allocator.
     if (static_path_present(paths, @written, li.text)) {
@@ -734,6 +739,78 @@ fun resolve_and_store_input(p: *driver.Project, req: *manifest.LinkRequirement,
     paths[@written] = li.text::*u8;
     @written = @written + 1;
     ret R.ok[bool, outcome.Fail](true);
+}
+
+# pin each symbol a dynamic dependency claims to that dependency's logical name
+#
+# The `#[library]` decorator can only attribute an import that has a Mach `ext`
+# declaration; a symbol reaching the link from a static archive member has none,
+# so on a two-level-namespace format (PE, Mach-O) the linker has no provider to
+# name and rejects it. A `[link.X]`'s `symbols` list supplies that attribution
+# from the manifest, feeding the same session map the decorator writes, so
+# `build_dynamic_info` binds the import with no further change.
+#
+# A claim that contradicts a standing attribution - another selected entry's, or
+# a `#[library]` decorator's - is a hard error rather than a silent overwrite,
+# so the emitted import table never depends on requirement order. Re-registering
+# the identical pin is a no-op, which is what a requirement reached through both
+# the project's own entries and the export cascade does.
+# ---
+# p:   the project carrying the session that owns the attribution map
+# req: the resolved dynamic requirement whose claims to register
+# ret: ok(true) on success, or the conflict as a Fail
+fun register_link_claims(p: *driver.Project, req: *manifest.LinkRequirement) R.Result[bool, outcome.Fail] {
+    var i: u32 = 0;
+    for (i < req.symbol_count) {
+        val sym: intern.StrId = req.symbols[i];
+        val prev: O.Option[intern.StrId] = session.import_library(p.s, sym);
+        if (O.is_some[intern.StrId](prev)) {
+            val had: intern.StrId = O.unwrap[intern.StrId](prev);
+            if (had != req.library) {
+                ret R.err[bool, outcome.Fail](outcome.user(
+                    claim_conflict_message(p, sym, had, req.library)));
+            }
+            i = i + 1;
+            cnt;
+        }
+        if (R.is_err[bool, str](session.register_import_library(p.s, sym, req.library))) {
+            ret R.err[bool, outcome.Fail](outcome.internal("out of memory"));
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, outcome.Fail](true);
+}
+
+# name both claimants so the manifest edit that resolves the ambiguity is obvious
+fun claim_conflict_message(p: *driver.Project, sym: intern.StrId,
+                           first: intern.StrId, second: intern.StrId) str {
+    val n: O.Option[str] = intern.lookup(?p.s.interner, sym);
+    val a: O.Option[str] = intern.lookup(?p.s.interner, first);
+    val b: O.Option[str] = intern.lookup(?p.s.interner, second);
+    if (!O.is_some[str](n) || !O.is_some[str](a) || !O.is_some[str](b)) {
+        ret "one symbol is claimed by two link libraries";
+    }
+    val r: R.Result[str, str] = str_join(p.alloc,
+        "symbol '", O.unwrap[str](n), "' is claimed by link library '",
+        O.unwrap[str](a), "' and '", O.unwrap[str](b),
+        "'; a symbol may name only one providing library");
+    if (R.is_err[str, str](r)) { ret R.unwrap_err[str, str](r); }
+    ret R.unwrap_ok[str, str](r);
+}
+
+# a static input defines symbols rather than importing them, so a `symbols` claim
+# on one is a manifest mistake worth naming rather than ignoring
+fun static_claim_message(p: *driver.Project, req: *manifest.LinkRequirement) str {
+    val t: O.Option[str] = intern.lookup(?p.s.interner, req.text);
+    if (!O.is_some[str](t)) {
+        ret "a link entry that resolves to a static input cannot claim symbols";
+    }
+    val r: R.Result[str, str] = str_join(p.alloc,
+        "link entry '", O.unwrap[str](t),
+        "' resolves to a static input, which defines symbols rather than importing them; ",
+        "remove its 'symbols' key");
+    if (R.is_err[str, str](r)) { ret R.unwrap_err[str, str](r); }
+    ret R.unwrap_ok[str, str](r);
 }
 
 # whether an exact static input path is already in the written prefix

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -781,6 +781,53 @@ fun register_link_claims(p: *driver.Project, req: *manifest.LinkRequirement) R.R
     ret R.ok[bool, outcome.Fail](true);
 }
 
+# a claim reaches the linker as an attribution, an identical re-claim is tolerated
+# (the export cascade re-walks a requirement the project also names itself), and a
+# contradicting claim is refused rather than resolved by order
+test "mach.lang.build.emit.register_link_claims:pins_and_rejects_conflicts" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var p: driver.Project;
+    p.s = ?s;
+    p.alloc = ?alloc;
+
+    val sym_r:  R.Result[intern.StrId, str] = intern.intern(?s.interner, "Sleep");
+    val k32_r:  R.Result[intern.StrId, str] = intern.intern(?s.interner, "kernel32");
+    val u32_r:  R.Result[intern.StrId, str] = intern.intern(?s.interner, "user32");
+    if (R.is_err[intern.StrId, str](sym_r) || R.is_err[intern.StrId, str](k32_r)
+        || R.is_err[intern.StrId, str](u32_r)) { session.dnit(?s); ret 1; }
+    var syms: [1]intern.StrId;
+    syms[0] = R.unwrap_ok[intern.StrId, str](sym_r);
+
+    var req: manifest.LinkRequirement;
+    req.source       = manifest.LINK_SYSTEM;
+    req.text         = R.unwrap_ok[intern.StrId, str](k32_r);
+    req.library      = R.unwrap_ok[intern.StrId, str](k32_r);
+    req.symbols      = ?syms[0];
+    req.symbol_count = 1;
+
+    var code: i32 = 0;
+    if (R.is_err[bool, outcome.Fail](register_link_claims(?p, ?req))) { code = 1; }
+
+    val got: O.Option[intern.StrId] = session.import_library(?s, syms[0]);
+    if (!O.is_some[intern.StrId](got) || O.unwrap[intern.StrId](got) != req.library) { code = 1; }
+
+    # the same pin again is a no-op, not a conflict
+    if (R.is_err[bool, outcome.Fail](register_link_claims(?p, ?req))) { code = 1; }
+
+    # a second entry claiming the same symbol for a different library is refused
+    var other: manifest.LinkRequirement = req;
+    other.library = R.unwrap_ok[intern.StrId, str](u32_r);
+    if (R.is_ok[bool, outcome.Fail](register_link_claims(?p, ?other))) { code = 1; }
+
+    session.dnit(?s);
+    ret code;
+}
+
 # name both claimants so the manifest edit that resolves the ambiguity is obvious
 fun claim_conflict_message(p: *driver.Project, sym: intern.StrId,
                            first: intern.StrId, second: intern.StrId) str {

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -411,6 +411,7 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
                 val root_out_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.project_out);
                 if (O.is_none[str](root_out_opt)) {
                     free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
+                    manifest.free_link_claims(p.alloc, buf, w);
                     A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
                     ret R.err[bool, str]("internal: project output not interned");
                 }
@@ -419,14 +420,17 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
                     manifest.link_requirement(p.alloc, ?p.s.interner, l, O.unwrap[str](root_out_opt), ?cv);
                 if (R.is_err[manifest.LinkRequirement, str](req_r)) {
                     free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
+                    manifest.free_link_claims(p.alloc, buf, w);
                     A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
                     ret R.err[bool, str](R.unwrap_err[manifest.LinkRequirement, str](req_r));
                 }
-                val req: manifest.LinkRequirement = R.unwrap_ok[manifest.LinkRequirement, str](req_r);
+                var req: manifest.LinkRequirement = R.unwrap_ok[manifest.LinkRequirement, str](req_r);
                 if (!requirement_in(buf, w, ?req) && !requirement_in(own_libs, own_count, ?req)) {
                     buf[w] = req;
                     w = w + 1;
                 }
+                # a duplicate is dropped here, so its claim copy is released
+                or { manifest.free_link_claims(p.alloc, ?req, 1); }
             }
             li = li + 1;
         }

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -503,6 +503,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
         for (i < c.target_count) {
             val te: *TargetEntry = ?c.targets[i];
             if (te.libs != nil && te.lib_count > 0) {
+                manifest.free_link_claims(alloc, te.libs, te.lib_count);
                 A.deallocate[manifest.LinkRequirement](alloc, te.libs, te.lib_count::usize);
             }
             i = i + 1;
@@ -516,6 +517,7 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
         A.deallocate[intern.StrId](alloc, c.defines, c.define_count::usize);
     }
     if (c.cascade_libs != nil && c.cascade_lib_count > 0) {
+        manifest.free_link_claims(alloc, c.cascade_libs, c.cascade_lib_count);
         A.deallocate[manifest.LinkRequirement](alloc, c.cascade_libs, c.cascade_lib_count::usize);
     }
     if (c.steps != nil && c.step_count > 0) {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -3169,6 +3169,66 @@ test "mach.lang.manifest.parse:link_library_requires_nonempty_string" {
     ret code;
 }
 
+# the `symbols` claim list (#2510): absent leaves the entry claiming nothing (the
+# behaviour every pre-existing manifest must keep), a listed array parses in order,
+# and the malformed shapes are strict errors rather than partially-read lists
+test "mach.lang.manifest.parse:link_symbols_claim" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # absent: no claims, so an existing manifest attributes exactly as before.
+    val none: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head,
+        "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
+    if (R.is_err[Manifest, str](none)) { code = 1; }
+    or {
+        val m: Manifest = R.unwrap_ok[Manifest, str](none);
+        if (m.links[0].symbol_count != 0 || m.links[0].symbols != nil) { code = 1; }
+    }
+
+    # listed: parsed in declaration order and interned.
+    val two: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head,
+        "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nsymbols=[\"Sleep\",\"ExitProcess\"]\nos=\"*\"\nisa=[\"*\"]\nabi=[\"*\"]\nexport=false\n"));
+    if (R.is_err[Manifest, str](two)) { code = 1; }
+    or {
+        val m: Manifest = R.unwrap_ok[Manifest, str](two);
+        if (m.links[0].symbol_count != 2) { code = 1; }
+        or {
+            if (!str_equals(idstr(?itn, m.links[0].symbols[0]), "Sleep")) { code = 1; }
+            if (!str_equals(idstr(?itn, m.links[0].symbols[1]), "ExitProcess")) { code = 1; }
+        }
+    }
+
+    # a bare string is not accepted: one symbol is still a list, so the shape never
+    # depends on the count.
+    val scalar: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head,
+        "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nsymbols=\"Sleep\"\n"));
+    if (R.is_ok[Manifest, str](scalar)
+        || !str_equals(R.unwrap_err[Manifest, str](scalar), "mach.toml: [link.k].symbols must be an array of strings")) { code = 1; }
+
+    # a non-string element is rejected rather than skipped.
+    val typed: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head,
+        "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nsymbols=[\"Sleep\",1]\n"));
+    if (R.is_ok[Manifest, str](typed)
+        || !str_equals(R.unwrap_err[Manifest, str](typed), "mach.toml: [link.k].symbols must be an array of strings")) { code = 1; }
+
+    # an empty name would claim nothing under a name no symbol carries.
+    val blank: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head,
+        "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nsymbols=[\"\"]\n"));
+    if (R.is_ok[Manifest, str](blank)
+        || !str_equals(R.unwrap_err[Manifest, str](blank), "mach.toml: [link.k].symbols has an empty symbol name")) { code = 1; }
+
+    # a repeat inside one entry is a manifest mistake, not a silent dedup.
+    val dup: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head,
+        "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nsymbols=[\"Sleep\",\"Sleep\"]\n"));
+    if (R.is_ok[Manifest, str](dup)
+        || !str_equals(R.unwrap_err[Manifest, str](dup), "mach.toml: [link.k].symbols lists 'Sleep' twice")) { code = 1; }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
 test "mach.lang.manifest.parse:link_filter_empty_string_error" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -139,6 +139,10 @@ pub rec LinkDef {
     library:     intern.StrId;
     lib_name:    intern.StrId;
     path:        intern.StrId;
+    # symbols this dependency claims to provide, attributing imports that reach the
+    # link from a static archive member and so carry no `#[library]` decl
+    symbols:      *intern.StrId;
+    symbol_count: u32;
     os:          *intern.StrId;
     os_count:    u32;
     os_present:  bool;
@@ -153,13 +157,18 @@ pub rec LinkDef {
 
 # one target-matched link requirement carried into a build
 # ---
-# source:  the declared local, system, or framework semantics
-# text:    expanded local path or concrete system/framework name
-# library: stable logical name used by `#[library]` attribution
+# source:       the declared local, system, or framework semantics
+# text:         expanded local path or concrete system/framework name
+# library:      stable logical name used by `#[library]` attribution
+# symbols:      symbols this dependency claims to provide
+# symbol_count: number of claimed symbols
 pub rec LinkRequirement {
     source:  LinkSource;
     text:    intern.StrId;
     library: intern.StrId;
+
+    symbols:      *intern.StrId;
+    symbol_count: u32;
 }
 
 pub rec StepDef {
@@ -557,6 +566,7 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     }
     if (kind == TK_LINK) {
         ret str_equals(k, "source") || str_equals(k, "name") || str_equals(k, "path") || str_equals(k, "library")
+            || str_equals(k, "symbols")
             || str_equals(k, "os") || str_equals(k, "isa") || str_equals(k, "abi") || str_equals(k, "export");
     }
     if (kind == TK_STEP) {
@@ -966,6 +976,36 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
                 ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
             }
             d.library = intern_unwrap(itn, library_s);
+        }
+
+        d.symbols      = nil;
+        d.symbol_count = 0;
+        val symbols_v: *toml.Value = toml.get(sub, "symbols");
+        if (symbols_v != nil) {
+            if (symbols_v.tag != toml.TYPE_ARRAY) {
+                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label));
+            }
+            val res_syms: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?symbols_v.data.array,
+                sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label));
+            if (R.is_err[StrArr, str](res_syms)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_syms)); }
+            val syms: StrArr = R.unwrap_ok[StrArr, str](res_syms);
+            var si: u32 = 0;
+            for (si < syms.count) {
+                if (str_empty(idstr(itn, syms.items[si]))) {
+                    ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols has an empty symbol name", label));
+                }
+                var sj: u32 = 0;
+                for (sj < si) {
+                    if (syms.items[sj] == syms.items[si]) {
+                        ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols lists '{}' twice",
+                                                  label, idstr(itn, syms.items[si])));
+                    }
+                    sj = sj + 1;
+                }
+                si = si + 1;
+            }
+            d.symbols      = syms.items;
+            d.symbol_count = syms.count;
         }
 
         val name_val: str = toml.get_str(sub, "name");
@@ -1502,6 +1542,8 @@ pub fun link_requirement(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef
     var req: LinkRequirement;
     req.source  = l.source;
     req.library = l.library;
+    req.symbols      = l.symbols;
+    req.symbol_count = l.symbol_count;
     if (l.source == LINK_LOCAL) {
         val raw_path: str = idstr(itn, l.path);
         val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, v);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1197,6 +1197,7 @@ pub fun dnit(m: *Manifest, alloc: *A.Allocator) {
             free_strarr(alloc, l.os, l.os_count);
             free_strarr(alloc, l.isa, l.isa_count);
             free_strarr(alloc, l.abi, l.abi_count);
+            free_strarr(alloc, l.symbols, l.symbol_count);
             i = i + 1;
         }
         A.deallocate[LinkDef](alloc, m.links, m.link_count::usize);
@@ -1221,6 +1222,26 @@ pub fun dnit(m: *Manifest, alloc: *A.Allocator) {
 fun free_strarr(alloc: *A.Allocator, items: *intern.StrId, count: u32) {
     if (items != nil && count > 0) {
         A.deallocate[intern.StrId](alloc, items, count::usize);
+    }
+}
+
+# release the claim arrays `link_requirement` copied onto `alloc` for the first
+# `count` populated requirements; the caller still owns the requirement array
+#
+# `count` is the populated prefix, not the allocation's capacity: a partly filled
+# buffer would otherwise read claim pointers out of uninitialized entries.
+# ---
+# alloc: allocator the claim copies were made on
+# items: the requirement array, or nil
+# count: number of populated requirements to release
+pub fun free_link_claims(alloc: *A.Allocator, items: *LinkRequirement, count: u32) {
+    if (items == nil) { ret; }
+    var i: u32 = 0;
+    for (i < count) {
+        free_strarr(alloc, items[i].symbols, items[i].symbol_count);
+        items[i].symbols      = nil;
+        items[i].symbol_count = 0;
+        i = i + 1;
     }
 }
 
@@ -1530,8 +1551,14 @@ fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
 }
 
 # resolve a matched link entry without discarding its declared source semantics
+#
+# The requirement owns its claim array rather than borrowing the entry's. A
+# requirement outlives the manifest it came from on the export cascade, which
+# tears down the dependency manifests before the link reads the claims, so a
+# borrow would dangle. Release it with `free_link_claims` when the requirement
+# is dropped.
 # ---
-# alloc:    allocator used while expanding a local path
+# alloc:    allocator used while expanding a local path and owning the claim copy
 # itn:      interner owning the requirement text and stable library name
 # l:        target-matched manifest entry
 # proj_out: expanded project output root for a local path
@@ -1542,16 +1569,28 @@ pub fun link_requirement(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef
     var req: LinkRequirement;
     req.source  = l.source;
     req.library = l.library;
-    req.symbols      = l.symbols;
-    req.symbol_count = l.symbol_count;
+    req.symbols      = nil;
+    req.symbol_count = 0;
+    if (l.symbol_count > 0) {
+        val cr: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](alloc, l.symbol_count::usize);
+        if (R.is_err[*intern.StrId, str](cr)) { ret R.err[LinkRequirement, str](R.unwrap_err[*intern.StrId, str](cr)); }
+        req.symbols = R.unwrap_ok[*intern.StrId, str](cr);
+        var si: u32 = 0;
+        for (si < l.symbol_count) { req.symbols[si] = l.symbols[si]; si = si + 1; }
+        req.symbol_count = l.symbol_count;
+    }
     if (l.source == LINK_LOCAL) {
         val raw_path: str = idstr(itn, l.path);
         val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, v);
-        if (R.is_err[str, str](expanded_r)) { ret R.err[LinkRequirement, str](R.unwrap_err[str, str](expanded_r)); }
+        if (R.is_err[str, str](expanded_r)) {
+            free_strarr(alloc, req.symbols, req.symbol_count);
+            ret R.err[LinkRequirement, str](R.unwrap_err[str, str](expanded_r));
+        }
         val expanded: str = R.unwrap_ok[str, str](expanded_r);
         val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded);
         str_free(alloc, expanded);
         if (R.is_err[intern.StrId, str](res_int)) {
+            free_strarr(alloc, req.symbols, req.symbol_count);
             ret R.err[LinkRequirement, str](R.unwrap_err[intern.StrId, str](res_int));
         }
         req.text = R.unwrap_ok[intern.StrId, str](res_int);
@@ -2000,11 +2039,14 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
                 if (link_matches_target(itn, found_l, t)) {
                     val req_r: R.Result[LinkRequirement, str] = link_requirement(alloc, itn, found_l, proj_out, v);
                     if (R.is_err[LinkRequirement, str](req_r)) {
+                        free_link_claims(alloc, buf, w);
                         A.deallocate[LinkRequirement](alloc, buf, max::usize);
                         ret R.err[bool, str](R.unwrap_err[LinkRequirement, str](req_r));
                     }
-                    val req: LinkRequirement = R.unwrap_ok[LinkRequirement, str](req_r);
+                    var req: LinkRequirement = R.unwrap_ok[LinkRequirement, str](req_r);
                     if (!requirement_in_buf(buf, w, ?req)) { buf[w] = req; w = w + 1; }
+                    # a duplicate is dropped here, so its claim copy is released
+                    or { free_link_claims(alloc, ?req, 1); }
                 }
             }
             li = li + 1;
@@ -3224,6 +3266,56 @@ test "mach.lang.manifest.parse:link_symbols_claim" {
         "[link.k]\nsource=\"system\"\nname=\"kernel32.dll\"\nsymbols=[\"Sleep\",\"Sleep\"]\n"));
     if (R.is_ok[Manifest, str](dup)
         || !str_equals(R.unwrap_err[Manifest, str](dup), "mach.toml: [link.k].symbols lists 'Sleep' twice")) { code = 1; }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
+# a requirement must OWN its claim array, not borrow the entry's (#2510). on the
+# export cascade the dependency manifest is torn down before the link reads the
+# claims, so a borrow dangles - and a behavioural test cannot see that, since
+# freed storage usually still holds the old bytes. this asserts the invariant
+# directly: distinct storage, and the values survive the entry's array being
+# freed and its slots overwritten
+test "mach.lang.manifest.link_requirement:owns_its_claim_array" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val sleep_r: R.Result[intern.StrId, str] = intern.intern(?itn, "Sleep");
+    val k32_r:   R.Result[intern.StrId, str] = intern.intern(?itn, "kernel32");
+    if (R.is_err[intern.StrId, str](sleep_r) || R.is_err[intern.StrId, str](k32_r)) { arena.dnit(?ar); ret 1; }
+    val sleep: intern.StrId = R.unwrap_ok[intern.StrId, str](sleep_r);
+
+    val owned_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](?alloc, 1::usize);
+    if (R.is_err[*intern.StrId, str](owned_r)) { arena.dnit(?ar); ret 1; }
+    var l: LinkDef;
+    l.source       = LINK_SYSTEM;
+    l.name         = R.unwrap_ok[intern.StrId, str](k32_r);
+    l.library      = R.unwrap_ok[intern.StrId, str](k32_r);
+    l.lib_name     = R.unwrap_ok[intern.StrId, str](k32_r);
+    l.path         = intern.STR_NIL;
+    l.symbols      = R.unwrap_ok[*intern.StrId, str](owned_r);
+    l.symbol_count = 1;
+    l.symbols[0]   = sleep;
+
+    var v: TmplVars;
+    val req_r: R.Result[LinkRequirement, str] = link_requirement(?alloc, ?itn, ?l, "", ?v);
+    if (R.is_err[LinkRequirement, str](req_r)) { arena.dnit(?ar); ret 1; }
+    var req: LinkRequirement = R.unwrap_ok[LinkRequirement, str](req_r);
+
+    # distinct storage is the invariant; a borrow would alias here
+    if (req.symbols == l.symbols) { code = 1; }
+    if (req.symbol_count != 1 || req.symbols[0] != sleep) { code = 1; }
+
+    # release the entry's array as `dnit` does, then overwrite the slot it held.
+    # an aliasing requirement would read the overwrite back.
+    free_strarr(?alloc, l.symbols, l.symbol_count);
+    l.symbols[0] = intern.STR_NIL;
+    if (req.symbols[0] != sleep) { code = 1; }
+
+    free_link_claims(?alloc, ?req, 1);
+    if (req.symbols != nil || req.symbol_count != 0) { code = 1; }
 
     arena.dnit(?ar);
     ret code;


### PR DESCRIPTION
## What

A symbol that reaches the link from a static archive member has no Mach `ext`
declaration, so `#[library]` cannot attribute it. On a two-level-namespace
format (PE, Mach-O) the linker requires every import to name its provider, so
the link is rejected — and no manifest spelling could fix it.

Verified as a real failure before changing anything: a static `.a` exporting
`nap` and referencing undefined `Sleep`, cross-linked for windows-x86_64 from
linux with a `[link.kernel32]` entry selected, fails with

```
error: dynamic import 'Sleep' has no #[library] attribution; ...
```

Two findings that narrowed the fix:

- **Not a cross-compilation problem.** The linker never opens a DLL or reads an
  export table on any host; this fails identically when building natively on
  Windows. The issue's concern about target DLLs not being on disk is moot.
- **Not structural.** `of.DynImport.lib_index` and the per-DLL `.idata` emitter
  already exist and are correct. Only the *source* of the mapping was missing,
  so the vendored-import-stub fallback design is not needed.

## How

Adds a `symbols` key to `[link.X]`: an entry declares the symbols it provides.
Claims register into the same session map `#[library]` writes, so
`build_dynamic_info` binds the import with no change. Claims travel on the
`LinkRequirement`, so `export = true` cascades them to consumers — a C-binding
repo declares them once.

Deliberately strict, no silent fallbacks:

- A claim contradicting a standing attribution (another entry's, or a
  `#[library]` decorator's) is a hard error, so the emitted import table never
  depends on requirement order. Re-registering an identical pin is a no-op,
  which is what a requirement reached through both the project's own entries and
  the export cascade does.
- A claim on an entry resolving to a static input is rejected: a static input
  defines symbols rather than importing them.

## Verification

- New `int/surface/pe-import-claim`: cross-links a win64 PE from the linux leg
  and asserts the import table via a new `pe-imports` producer. Claims are split
  across kernel32 and user32 so **per-DLL routing** is the observable — a linker
  binding everything to the first descriptor would still pass a single-DLL
  golden. Confirmed load-bearing by deliberately mis-routing a claim and
  watching the case fail.
- The `pe-imports` producer was cross-checked against `objdump -x` on the same
  binary; both report the identical bindings.
- Full in-source suite: 1080 passed, 0 failed.
- `int/lib/check-target-matrix.sh`: 267 case×leg pairs OK.
- Existing `pe-aslr` and `pe-import-attribution` cases still pass, so the
  unattributed-import rejection is unchanged where no claim is declared.

## Note on coverage

The CI case exercises the attribution mechanism through undecorated `ext`
declarations rather than a real `.a`, because the harness builds one project
with one compiler invocation and has no hermetic way to produce a COFF archive
as a fixture. The archive path itself was verified manually with the two-project
repro described above; `build_dynamic_info` treats archive members and
first-party modules identically once merged, so the attribution coverage is the
same. Flagging it rather than implying the archive origin is covered in CI.

Closes #2510