### PR TITLE
feat(link): emit PE .rsrc resources (icon, version info, manifest)

### DIFF
--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -352,6 +352,8 @@ reads the selected artifact's name.
 | `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
 | `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
 | `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
+| `icon`    | no  | Windows only. Path to an `.ico` container, relative to the project root. Every image the container embeds is carried into the executable. |
+| `manifest` | no | Windows only. Path to an XML application manifest, relative to the project root. Embedded byte for byte. |
 
 - **`bin`** links an executable at the resolved `out` path.
 - **`static`** materialises a real `ar` archive at the resolved `out` path — the
@@ -362,6 +364,49 @@ reads the selected artifact's name.
 
 Per-target extension or per-target entry is not a per-cell exception table — it is a
 second artifact stanza, so the condition stays visible like everything else.
+
+### Windows resources
+
+`icon` and `manifest` are the PE resource inputs. They are accepted on every
+target and read only when the build cell's OS is `windows`; a linux or darwin
+build of the same artifact parses them, ignores them, and emits exactly the image
+it emitted before they were declared. That is the same posture every windows-only
+artifact key takes — the key is inert per target, never rejected per target — so
+one artifact stanza still covers every platform it ships to.
+
+```toml
+[artifact.game]
+kind = "bin"
+entry = "main.mach"
+out = "bin/game.exe"
+targets = ["*"]
+link = []
+need = []
+icon = "assets/game.ico"
+manifest = "assets/game.manifest"
+```
+
+What lands in the PE's `.rsrc` section:
+
+- `RT_ICON` — one entry per image embedded in the `.ico`, carried through
+  unmodified, plus the `RT_GROUP_ICON` directory that names them. Explorer picks
+  the size it wants, so ship every size you care about in the one container.
+- `RT_VERSION` — a `VS_VERSIONINFO` block. Its fixed header is built from
+  `[project].version`, read as up to four dot-separated numeric components
+  (`4.5.0` becomes `4.5.0.0`, and a trailing pre-release tag like `-rc1` is
+  ignored). The artifact's name fills the product and internal-name strings.
+- `RT_MANIFEST` — the `manifest` file, byte for byte. Mach does not parse, rewrite,
+  or validate it; what the file holds is what the executable declares.
+
+Both keys are optional and independent. With neither set the artifact gets no
+`.rsrc` section at all and the emitted image is byte-identical to one built before
+resource emission existed. Both paths use `/` separators like every other manifest
+path, and a declared file that cannot be read fails the link rather than silently
+dropping the resource. Editing an icon or a manifest re-links on the next build
+even though no source changed, because both are fingerprinted by content.
+
+There is no `.rc` surface and no dependency on `rc.exe` or `windres`: resource
+emission is part of mach's own PE writer.
 
 ## `[link.<name>]` — link requirements
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -264,7 +264,8 @@ rec StrMerge {
 # ret:          true once the artifact is written, or an error string
 pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
              obj_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
-             out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+             out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
+             rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -290,7 +291,7 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     # after linking regardless of outcome.
     val r: R.Result[bool, str] =
         link_modules(s, tgt, modules, module_count, 0, dynlibs, dynlib_count,
-                     out_path, name, mode, pie);
+                     out_path, name, mode, pie, rsrc);
     free_modules(alloc, modules, module_count);
     ret r;
 }
@@ -319,7 +320,8 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
 # ret:          true once the artifact is written, or an error string
 pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
                     image_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
-                    out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+                    out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
+                    rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -328,7 +330,7 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
         ret R.err[bool, str]("link: no input objects");
     }
     ret link_modules(s, tgt, images, image_count, image_count, dynlibs,
-                     dynlib_count, out_path, name, mode, pie);
+                     dynlib_count, out_path, name, mode, pie, rsrc);
 }
 
 # combine the project's in-memory codegen images with on-disk external link
@@ -365,7 +367,8 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
                    images: *of.ObjectImage, image_count: u32,
                    obj_paths: **u8, obj_count: u32,
                    dynlibs: *of.DynLib, dynlib_count: u32,
-                   out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+                   out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
+                   rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -406,7 +409,7 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 
     val r: R.Result[bool, str] =
         link_modules(s, tgt, combined, total, image_count, dynlibs, dynlib_count,
-                     out_path, name, mode, pie);
+                     out_path, name, mode, pie, rsrc);
 
     # tear down only the parsed external images (the project images are caller-owned)
     # and free the `combined` wrapper without dnit'ing its shallow-copied slots.
@@ -447,7 +450,8 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
-                 out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool) R.Result[bool, str] {
+                 out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
+                 rsrc: *of.ResourceInfo) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     # a shared object is always position-independent: the loader maps it at an
     # arbitrary base and slides its in-image absolute pointers, so it takes the same
@@ -674,10 +678,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
             emit_r = emit_shared_object(s, tgt, ?out_img, merged, modules, module_count, ?sym_locs, ?dyn, out_path);
         }
         or (dynamic) {
-            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, ?dyn, out_path, name);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, ?dyn, out_path, name, rsrc);
         }
         or {
-            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, nil::*DynState, out_path, name);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, nil::*DynState, out_path, name, rsrc);
         }
 
         free_dynstate(alloc, ?dyn);
@@ -945,7 +949,8 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
 # ret:      true once the executable is written, or an error string
 fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.ObjectImage,
                     merged: *MergedSection, sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                    dyn: *DynState, out_path: *u8, name: *u8) R.Result[bool, str] {
+                    dyn: *DynState, out_path: *u8, name: *u8,
+                    rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (dyn == nil && tgt.of.emit_exec == nil) {
         ret R.err[bool, str]("link: object format cannot write executables");
     }
@@ -986,11 +991,11 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
 
     var emit_r: R.Result[bool, str] = R.ok[bool, str](true);
     if (dyn == nil) {
-        emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name);
+        emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name, rsrc);
     }
     or {
         emit_r = tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry,
-                                      funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, dbg, dbg_count, out_path, name);
+                                      funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, dbg, dbg_count, out_path, name, rsrc);
     }
 
     if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
@@ -4490,7 +4495,7 @@ test "mach.lang.be.linker.link_modules:flat_entry_leads_regardless_of_order" {
 
     # both modules are in-memory codegen images (codegen_count == 2), static exe.
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false);
+        link_modules(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false, nil);
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -174,6 +174,102 @@ pub fun artifact_product_name(p: *driver.Project) *u8 {
     ret ""::*u8;
 }
 
+# the artifact's resource inputs plus the buffers backing them
+#
+# `info` is what the writer sees; the two vectors own the bytes it points at and
+# outlive the link call. `present` is false when the artifact declares neither
+# key, which is the path that leaves the image byte-identical to a resourceless
+# build.
+rec LoadedResources {
+    info:     of.ResourceInfo;
+    icon_buf: Vector[u8];
+    man_buf:  Vector[u8];
+    present:  bool;
+}
+
+# read the selected artifact's declared resource files into `out`
+#
+# The writer is handed bytes rather than paths: the link-config fingerprint
+# already folds these files by content, so the writer never opens one and stays
+# testable against an in-memory input. Both paths are project-relative and
+# resolve against the project root like every other manifest path. A declared
+# file that cannot be read is an error, never a silently dropped resource.
+# ---
+# p:   the project carrying the session and selected artifact config
+# out: the record to populate; `present` false when the artifact declares none
+# ret: ok(true), or the read failure as an error string
+fun load_artifact_resources(p: *driver.Project, out: *LoadedResources) R.Result[bool, str] {
+    out.present          = false;
+    out.info.icon        = nil;
+    out.info.icon_len    = 0;
+    out.info.app_manifest     = nil;
+    out.info.app_manifest_len = 0;
+    out.info.version     = "";
+    out.info.product     = "";
+
+    val icon_rel: str = config_path(p, p.config.icon);
+    val man_rel:  str = config_path(p, p.config.app_manifest);
+    if (str_empty(icon_rel) && str_empty(man_rel)) { ret R.ok[bool, str](true); }
+
+    val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    if (!str_empty(icon_rel)) {
+        val r: R.Result[Vector[u8], str] = read_project_file(p, ctx.req.project_root, icon_rel);
+        if (R.is_err[Vector[u8], str](r)) { ret R.err[bool, str](R.unwrap_err[Vector[u8], str](r)); }
+        out.icon_buf      = R.unwrap_ok[Vector[u8], str](r);
+        out.info.icon     = out.icon_buf.data;
+        out.info.icon_len = out.icon_buf.len;
+    }
+    if (!str_empty(man_rel)) {
+        val r: R.Result[Vector[u8], str] = read_project_file(p, ctx.req.project_root, man_rel);
+        if (R.is_err[Vector[u8], str](r)) {
+            if (out.info.icon != nil) { vector.dnit[u8](?out.icon_buf); }
+            ret R.err[bool, str](R.unwrap_err[Vector[u8], str](r));
+        }
+        out.man_buf               = R.unwrap_ok[Vector[u8], str](r);
+        out.info.app_manifest     = out.man_buf.data;
+        out.info.app_manifest_len = out.man_buf.len;
+    }
+
+    val ver: O.Option[str] = intern.lookup(?p.s.interner, p.config.version);
+    if (O.is_some[str](ver)) { out.info.version = O.unwrap[str](ver); }
+    out.info.product = artifact_product_name(p)::str;
+    out.present      = true;
+    ret R.ok[bool, str](true);
+}
+
+# release the buffers `load_artifact_resources` read; safe on a `present` false record
+fun free_artifact_resources(out: *LoadedResources) {
+    if (out.info.icon != nil)         { vector.dnit[u8](?out.icon_buf); }
+    if (out.info.app_manifest != nil) { vector.dnit[u8](?out.man_buf); }
+}
+
+# the writer-facing pointer for a loaded resource set: nil when none was declared
+fun resource_arg(out: *LoadedResources) *of.ResourceInfo {
+    if (out.present) { ret ?out.info; }
+    ret nil;
+}
+
+# resolve an interned project-relative manifest path, or "" when unset
+fun config_path(p: *driver.Project, id: intern.StrId) str {
+    val s: O.Option[str] = intern.lookup(?p.s.interner, id);
+    if (O.is_some[str](s)) { ret O.unwrap[str](s); }
+    ret "";
+}
+
+# read a project-relative file into an owned byte vector
+fun read_project_file(p: *driver.Project, root: str, rel: str) R.Result[Vector[u8], str] {
+    val jr: R.Result[str, str] = path.join(p.alloc, root, rel);
+    if (R.is_err[str, str](jr)) { ret R.err[Vector[u8], str](R.unwrap_err[str, str](jr)); }
+    val abs: str = R.unwrap_ok[str, str](jr);
+    val rr: R.Result[Vector[u8], str] = fs.read_bytes(p.alloc, abs);
+    if (R.is_err[Vector[u8], str](rr)) {
+        val msg: R.Result[str, str] = str_join(p.alloc, "cannot read resource file ", abs);
+        if (R.is_ok[str, str](msg)) { ret R.err[Vector[u8], str](R.unwrap_ok[str, str](msg)); }
+        ret R.err[Vector[u8], str]("cannot read resource file");
+    }
+    ret rr;
+}
+
 # free the per-member symbol-name arrays, then the member array; the member data
 # buffers are borrowed from the parallel read-vector array (see free_read_bufs)
 fun free_members(alloc: *A.Allocator, members: *ar.ArMember, cap: u32) {
@@ -308,7 +404,7 @@ pub fun emit_shared_library(p: *driver.Project, unit: *plan.BuildUnit, paths: **
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, nil::*of.DynLib, 0, solib, artifact_product_name(p), linker.LINK_SHARED, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, len, nil::*of.DynLib, 0, solib, artifact_product_name(p), linker.LINK_SHARED, ctx.req.pie, nil);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -332,8 +428,12 @@ pub fun emit_shared_library(p: *driver.Project, unit: *plan.BuildUnit, paths: **
 pub fun link_executable(p: *driver.Project, paths: **u8, len: u32,
                         dynlibs: *of.DynLib, dynlib_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    var lr: LoadedResources;
+    val res_rsrc: R.Result[bool, str] = load_artifact_resources(p, ?lr);
+    if (R.is_err[bool, str](res_rsrc)) { ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_rsrc))); }
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, len, dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, resource_arg(?lr));
+    free_artifact_resources(?lr);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -385,8 +485,12 @@ pub fun link_flat_images(p: *driver.Project, images: *of.ObjectImage, exe_path: 
     val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    var lr: LoadedResources;
+    val res_rsrc: R.Result[bool, str] = load_artifact_resources(p, ?lr);
+    if (R.is_err[bool, str](res_rsrc)) { ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_rsrc))); }
     val res_link: R.Result[bool, str] =
-        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, resource_arg(?lr));
+    free_artifact_resources(?lr);
     A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
@@ -422,9 +526,14 @@ pub fun link_mixed_images(p: *driver.Project, images: *of.ObjectImage,
     val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    var lr: LoadedResources;
+    val res_rsrc: R.Result[bool, str] = load_artifact_resources(p, ?lr);
+    if (R.is_err[bool, str](res_rsrc)) { ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_rsrc))); }
     val res_link: R.Result[bool, str] =
         linker.link_mixed(p.s, ?p.target, ordered, p.topo_len, ext_paths, ext_count,
-                          dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+                          dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie,
+                          resource_arg(?lr));
+    free_artifact_resources(?lr);
     A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -38,7 +38,9 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_copy;
+use std.types.string.str_empty;
 use std.types.string.str_join;
+use std.types.path;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -989,6 +991,33 @@ pub fun set_link_config_input(p: *driver.Project, out_path: *u8, product: *u8, o
     ret R.ok[bool, outcome.Fail](true);
 }
 
+# an interned config string, or "" when unset
+fun config_str(p: *driver.Project, id: intern.StrId) str {
+    val s: O.Option[str] = intern.lookup(?p.s.interner, id);
+    if (O.is_some[str](s)) { ret O.unwrap[str](s); }
+    ret "";
+}
+
+# fold one project-relative resource input by path and by content
+#
+# An unset input folds a single zero, so adding a key to a manifest that had none
+# still advances the fingerprint. A declared file that cannot be read folds as
+# absent rather than failing here - the link itself reports the missing file with
+# a path in the message.
+fun fp_resource_input(fb: *dq.FpBuf, p: *driver.Project, id: intern.StrId) R.Result[bool, str] {
+    val rel: str = config_str(p, id);
+    if (str_empty(rel)) { ret dq.fp_u32(fb, 0); }
+
+    val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    val jr: R.Result[str, str] = path.join(p.alloc, ctx.req.project_root, rel);
+    if (R.is_err[str, str](jr)) { ret R.err[bool, str](R.unwrap_err[str, str](jr)); }
+    val abs: str = R.unwrap_ok[str, str](jr);
+
+    val a0: R.Result[bool, str] = dq.fp_u32(fb, 1);           if (R.is_err[bool, str](a0)) { ret a0; }
+    val a1: R.Result[bool, str] = dq.fp_cstr(fb, abs::*u8);   if (R.is_err[bool, str](a1)) { ret a1; }
+    ret dq.fp_file_content(fb, p.alloc, abs::*u8);
+}
+
 # append the link-only configuration bytes into `fb` in a stable order. every input
 # that can change the linked binary without changing a module's object appears here,
 # so a change to any of them advances Q_LINK_CONFIG and re-links
@@ -1002,6 +1031,18 @@ fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product:
     val a1: R.Result[bool, str] = dq.fp_u32(fb, pie_axis);            if (R.is_err[bool, str](a1)) { ret a1; }
     val a2: R.Result[bool, str] = dq.fp_cstr(fb, out_path);           if (R.is_err[bool, str](a2)) { ret a2; }
     val a3: R.Result[bool, str] = dq.fp_cstr(fb, product);            if (R.is_err[bool, str](a3)) { ret a3; }
+
+    # the artifact's resource inputs are baked into the image, so editing an icon
+    # or an application manifest changes the binary without changing any module's
+    # object; both are folded by path and by content, like the static external
+    # inputs below. the project version reaches the image through RT_VERSION and is
+    # folded as text, not as its interner id, so two versions can never alias.
+    val ai: R.Result[bool, str] = fp_resource_input(fb, p, p.config.icon);
+    if (R.is_err[bool, str](ai)) { ret ai; }
+    val am: R.Result[bool, str] = fp_resource_input(fb, p, p.config.app_manifest);
+    if (R.is_err[bool, str](am)) { ret am; }
+    val av: R.Result[bool, str] = dq.fp_cstr(fb, config_str(p, p.config.version)::*u8);
+    if (R.is_err[bool, str](av)) { ret av; }
 
     # each static external input (a `.o` / `.a` baked into the output) is folded by
     # PATH and by CONTENT: a same-path rebuild of a vendored archive changes the

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -382,7 +382,7 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
     paths[shared_len] = entry_path;
 
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, total, dynlibs, dynlib_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, total, dynlibs, dynlib_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, nil);
     A.deallocate[*u8](p.alloc, paths, total::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
@@ -623,7 +623,7 @@ test "mach.lang.build.testing:coff_final_link_discards_losing_weak_body" {
     if (bad == 0) {
         val lr: R.Result[bool, str] =
             linker.link(?s, ?tgt, ?one[0], 1, nil, 0, epath::*u8,
-                        "coff-atom-test", linker.LINK_EXE, false);
+                        "coff-atom-test", linker.LINK_EXE, false, nil);
         if (R.is_err[bool, str](lr)) { bad = 1; }
     }
     if (bad == 0) {
@@ -638,7 +638,7 @@ test "mach.lang.build.testing:coff_final_link_discards_losing_weak_body" {
     if (bad == 0) {
         val lr: R.Result[bool, str] =
             linker.link(?s, ?tgt, ?both[0], 2, nil, 0, epath::*u8,
-                        "coff-atom-test", linker.LINK_EXE, false);
+                        "coff-atom-test", linker.LINK_EXE, false, nil);
         if (R.is_err[bool, str](lr)) { bad = 1; }
     }
     if (bad == 0) {

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -213,7 +213,13 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     p.config.name         = m.name;
     p.config.description  = m.description;
     # the artifact name feeds `$bin.name`; STR_NIL when the selection bound none.
-    if (bu.artifact != nil) { p.config.bin_name = bu.artifact.name; }
+    p.config.icon         = intern.STR_NIL;
+    p.config.app_manifest = intern.STR_NIL;
+    if (bu.artifact != nil) {
+        p.config.bin_name     = bu.artifact.name;
+        p.config.icon         = bu.artifact.icon;
+        p.config.app_manifest = bu.artifact.app_manifest;
+    }
     p.config.module       = intern.STR_NIL;
     if (m.artifact_count > 0) {
         p.config.module = m.artifacts[0].entry;

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -139,6 +139,11 @@ pub rec DepEntry {
 # description:  interned `[project].description` metadata; read by
 #               `$project.description`. STR_NIL when the manifest omits it
 # bin_name:     interned name of the selected artifact; read by `$bin.name`
+# icon:         interned project-relative `[artifact.<name>].icon`; read by the
+#               PE writer's resource emission. STR_NIL when the manifest omits it
+# app_manifest: interned project-relative `[artifact.<name>].manifest` - the
+#               windows application manifest, read by the PE writer's resource
+#               emission. STR_NIL when the manifest omits it
 # module:       interned `[project].module` - the src-relative module a bare
 #               project-id import of this project resolves to; STR_NIL when none
 # dir_src:      interned `[project].src` (default "src")
@@ -163,6 +168,8 @@ pub rec ProjectConfig {
     name:         intern.StrId;
     description:  intern.StrId;
     bin_name:     intern.StrId;
+    icon:         intern.StrId;
+    app_manifest: intern.StrId;
     module:       intern.StrId;
     dir_src:      intern.StrId;
     dir_dep:      intern.StrId;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -84,6 +84,11 @@ pub rec ArtifactDef {
     need:         *intern.StrId;
     need_count:   u32;
     is_lib:       bool;
+    # windows resource inputs, project-relative; STR_NIL when unset. inert on
+    # every other target, like `subsystem`. `app_manifest` is the `manifest` key -
+    # the application manifest, not this file.
+    icon:         intern.StrId;
+    app_manifest: intern.StrId;
 }
 
 pub rec ProfileDef {
@@ -539,7 +544,8 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     }
     if (kind == TK_ARTIFACT) {
         ret str_equals(k, "kind") || str_equals(k, "entry") || str_equals(k, "out")
-            || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need");
+            || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need")
+            || str_equals(k, "icon") || str_equals(k, "manifest");
     }
     if (kind == TK_PROFILE) {
         if (str_equals(k, "opt") || str_equals(k, "debug") || str_equals(k, "simd")) { ret true; }
@@ -755,6 +761,8 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.link_count   = 0;
     a.need         = nil;
     a.need_count   = 0;
+    a.icon         = intern.STR_NIL;
+    a.app_manifest = intern.STR_NIL;
     a.name         = intern_unwrap(itn, name);
 
     val kind_s: str = toml.get_str(sub, "kind");
@@ -811,6 +819,22 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
         val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
         a.need       = need_val.items;
         a.need_count = need_val.count;
+    }
+
+    # the windows resource inputs are optional on every target; a non-windows
+    # build parses and carries them, and the PE writer is the only reader.
+    val icon_s: str = toml.get_str(sub, "icon");
+    if (!str_empty(icon_s)) {
+        val res_check_icon: R.Result[bool, str] = check_path(alloc, icon_s, sfmt(alloc, "{}.icon", label));
+        if (R.is_err[bool, str](res_check_icon)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_check_icon)); }
+        a.icon = intern_unwrap(itn, icon_s);
+    }
+
+    val man_s: str = toml.get_str(sub, "manifest");
+    if (!str_empty(man_s)) {
+        val res_check_man: R.Result[bool, str] = check_path(alloc, man_s, sfmt(alloc, "{}.manifest", label));
+        if (R.is_err[bool, str](res_check_man)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_check_man)); }
+        a.app_manifest = intern_unwrap(itn, man_s);
     }
 
     ret R.ok[ArtifactDef, str](a);
@@ -3186,6 +3210,64 @@ test "mach.lang.manifest.resolve_build_unit:artifact_target_filter" {
         val uw: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
         if (R.is_ok[BuildUnit, str](uw) || !str_contains(R.unwrap_err[BuildUnit, str](uw), "does not support target")) { code = 1; }
     }
+    arena.dnit(?ar);
+    ret code;
+}
+
+fun ts_art_res_base() str {
+    ret "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n";
+}
+
+test "mach.lang.manifest.parse:artifact_resource_keys" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val set_src: str = sfmt(?alloc, "{}icon=\"assets/app.ico\"\nmanifest=\"assets/app.manifest\"\n", ts_art_res_base());
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, set_src);
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](a);
+        if (m.artifact_count != 1) { code = 1; }
+        or {
+            if (!str_equals(idstr(?itn, m.artifacts[0].icon), "assets/app.ico")) { code = 1; }
+            if (!str_equals(idstr(?itn, m.artifacts[0].app_manifest), "assets/app.manifest")) { code = 1; }
+        }
+    }
+
+    # both keys are optional; omitting them leaves the artifact resource-free, which
+    # is what keeps a resourceless image byte-identical to the pre-#2509 emission.
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, ts_art_res_base());
+    if (R.is_err[Manifest, str](b)) { code = 1; }
+    or {
+        var m2: Manifest = R.unwrap_ok[Manifest, str](b);
+        if (m2.artifacts[0].icon != intern.STR_NIL) { code = 1; }
+        if (m2.artifacts[0].app_manifest != intern.STR_NIL) { code = 1; }
+    }
+
+    # a windows-only key is still parsed on a non-windows-only manifest: the key is
+    # inert per target, never rejected per target.
+    val c_src: str = sfmt(?alloc, "{}icon=\"assets/app.ico\"\n", ts_art_res_base());
+    val c: R.Result[Manifest, str] = tparse(?alloc, ?itn, c_src);
+    if (R.is_err[Manifest, str](c)) { code = 1; }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.parse:artifact_resource_path_separator" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val ic_src: str = sfmt(?alloc, "{}icon=\"assets\\\\app.ico\"\n", ts_art_res_base());
+    val ic: R.Result[Manifest, str] = tparse(?alloc, ?itn, ic_src);
+    if (R.is_ok[Manifest, str](ic) || !str_contains(R.unwrap_err[Manifest, str](ic), "[artifact.app].icon contains a")) { code = 1; }
+
+    val mn_src: str = sfmt(?alloc, "{}manifest=\"assets\\\\app.manifest\"\n", ts_art_res_base());
+    val mn: R.Result[Manifest, str] = tparse(?alloc, ?itn, mn_src);
+    if (R.is_ok[Manifest, str](mn) || !str_contains(R.unwrap_err[Manifest, str](mn), "[artifact.app].manifest contains a")) { code = 1; }
+
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -979,7 +979,7 @@ test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
 
     # enter at the image base; the raw writer rejects any other entry.
     val em: R.Result[bool, str] =
-        t.of.emit_exec(?alloc, ?itn, t.isa, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8);
+        t.of.emit_exec(?alloc, ?itn, t.isa, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -451,6 +451,30 @@ pub rec ExportSym {
     is_func: bool;
 }
 
+# the resource inputs an executable image carries alongside its code
+#
+# Only PE materializes these (a `.rsrc` section holding the icon, the version
+# block, and the application manifest); every other format ignores the record, so
+# a non-windows target accepts the manifest's resource keys and emits exactly as
+# before. The writer is handed bytes, never paths - the build layer owns reading
+# the files so the link cache can fingerprint their contents. A nil pointer here
+# is the no-resources path, which reproduces the pre-resource image byte for byte.
+# ---
+# icon:         raw ICO container bytes, or nil when the artifact declares no icon
+# icon_len:     length of icon
+# app_manifest: raw application-manifest XML, byte-preserved, or nil when none
+# app_manifest_len: length of app_manifest
+# version:      the project version, the VS_VERSIONINFO fixed block's source
+# product:      the artifact name, the version block's product/internal name
+pub rec ResourceInfo {
+    icon:         *u8;
+    icon_len:     usize;
+    app_manifest: *u8;
+    app_manifest_len: usize;
+    version:      str;
+    product:      str;
+}
+
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path
 #
@@ -516,9 +540,11 @@ pub def ParserFn: fun(*A.Allocator, *intern.Interner, *u8, usize, *ObjectImage) 
 # arg 12: null-terminated product name (the artifact's stable identity, independent
 #        of the `-o` output path); used as the Mach-O code-signing identifier and
 #        ignored by formats that do not sign
+# arg 13: the image's resource inputs, or nil when the artifact declares none;
+#        written to the PE `.rsrc` section and ignored by every other format
 # ret:   true on success, or an error string
 pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
-                    *ExecFunction, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
+                    *ExecFunction, u32, *Section, u32, *u8, *u8, *ResourceInfo) R.Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load
 # segments into a dynamically-linked executable, framing the format's
@@ -558,9 +584,11 @@ pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment
 # arg 15: null-terminated product name (the artifact's stable identity, independent
 #         of the `-o` output path); used as the Mach-O code-signing identifier and
 #         ignored by formats that do not sign
+# arg 16: the image's resource inputs, or nil when the artifact declares none;
+#         written to the PE `.rsrc` section and ignored by every other format
 # ret:    true on success, or an error string
 pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
-                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
+                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *Section, u32, *u8, *u8, *ResourceInfo) R.Result[bool, str];
 
 # a shared-library writer: serializes the linker's laid-out load segments into a
 # shared object (ELF `.so`, PE `.dll`, Mach-O `.dylib`), framing the format's

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -5687,3 +5687,288 @@ test "mach.lang.target.of.coff.coff_serialize_image:bigobj_round_trip" {
     A.deallocate[of.Section](?alloc, secs, n::usize);
     ret bad;
 }
+
+# a two-image ICO container in `buf`: the 6-byte ICONDIR, two 16-byte directory
+# entries, then the two image payloads. returns the container length
+fun ts_build_ico(buf: *u8) usize {
+    val n0:   usize = 8;
+    val n1:   usize = 12;
+    val off0: usize = 6 + 32;
+    val off1: usize = off0 + n0;
+
+    bin.write_u16_le(buf, 0, 0);
+    bin.write_u16_le(buf, 2, 1);
+    bin.write_u16_le(buf, 4, 2);
+
+    buf[6] = 16; buf[7] = 16; buf[8] = 0; buf[9] = 0;
+    bin.write_u16_le(buf, 10, 1);
+    bin.write_u16_le(buf, 12, 32);
+    bin.write_u32_le(buf, 14, n0::u32);
+    bin.write_u32_le(buf, 18, off0::u32);
+
+    buf[22] = 32; buf[23] = 32; buf[24] = 0; buf[25] = 0;
+    bin.write_u16_le(buf, 26, 1);
+    bin.write_u16_le(buf, 28, 32);
+    bin.write_u32_le(buf, 30, n1::u32);
+    bin.write_u32_le(buf, 34, off1::u32);
+
+    var k: usize = 0;
+    for (k < n0) { buf[off0 + k] = (0xA0 + k)::u8; k = k + 1; }
+    k = 0;
+    for (k < n1) { buf[off1 + k] = (0x50 + k)::u8; k = k + 1; }
+    ret off1 + n1;
+}
+
+# locate a section by name in the emitted section table, reporting its RVA,
+# virtual size, file offset, and characteristics
+fun ts_find_section(d: *u8, sec_table: usize, nsec: u32, want: str,
+                    rva: *u32, vsize: *u32, rawptr: *u32, chars: *u32) bool {
+    var s: u32 = 0;
+    for (s < nsec) {
+        val sh: usize = sec_table + s::usize * SECTION_HEADER_SIZE;
+        var match: bool = true;
+        var j: usize = 0;
+        for (j < 8) {
+            var w: u8 = 0;
+            if (j < str_len(want)) { w = want[j]; }
+            if (d[sh + j] != w) { match = false; }
+            j = j + 1;
+        }
+        if (match) {
+            @vsize  = bin.read_u32_le(d, sh + 8);
+            @rva    = bin.read_u32_le(d, sh + 12);
+            @rawptr = bin.read_u32_le(d, sh + 20);
+            @chars  = bin.read_u32_le(d, sh + 36);
+            ret true;
+        }
+        s = s + 1;
+    }
+    ret false;
+}
+
+# resolve one (type, name, language) leaf in the `.rsrc` tree based at `base`,
+# reporting its data entry's RVA and byte length. false when absent, or when a
+# level carries the wrong subdirectory flag
+fun ts_rsrc_leaf(d: *u8, base: usize, tid: u32, nid: u32, lid: u32,
+                 out_rva: *u32, out_size: *u32) bool {
+    val sub: u32 = 0x80000000;
+    val mask: u32 = 0x7FFFFFFF;
+
+    val nt: u32 = bin.read_u16_le(d, base + 14)::u32;
+    var a: u32 = 0;
+    for (a < nt) {
+        val ea: usize = base + 16 + a::usize * 8;
+        if (bin.read_u32_le(d, ea) == tid) {
+            val toff: u32 = bin.read_u32_le(d, ea + 4);
+            if ((toff & sub) == 0) { ret false; }
+            val tb: usize = base + (toff & mask)::usize;
+            val nn: u32 = bin.read_u16_le(d, tb + 14)::u32;
+            var b: u32 = 0;
+            for (b < nn) {
+                val eb: usize = tb + 16 + b::usize * 8;
+                if (bin.read_u32_le(d, eb) == nid) {
+                    val noff: u32 = bin.read_u32_le(d, eb + 4);
+                    if ((noff & sub) == 0) { ret false; }
+                    val nb: usize = base + (noff & mask)::usize;
+                    val nl: u32 = bin.read_u16_le(d, nb + 14)::u32;
+                    var c: u32 = 0;
+                    for (c < nl) {
+                        val ec: usize = nb + 16 + c::usize * 8;
+                        if (bin.read_u32_le(d, ec) == lid) {
+                            val doff: u32 = bin.read_u32_le(d, ec + 4);
+                            if ((doff & sub) != 0) { ret false; }
+                            val db: usize = base + doff::usize;
+                            @out_rva  = bin.read_u32_le(d, db);
+                            @out_size = bin.read_u32_le(d, db + 4);
+                            ret true;
+                        }
+                        c = c + 1;
+                    }
+                    ret false;
+                }
+                b = b + 1;
+            }
+            ret false;
+        }
+        a = a + 1;
+    }
+    ret false;
+}
+
+# coff_emit_exec frames the artifact's resource inputs into a `.rsrc` section and
+# points the RESOURCE data directory at it: the ICO decomposes into one RT_ICON
+# leaf per embedded image plus an RT_GROUP_ICON directory, the project version
+# becomes an RT_VERSION block, and the application manifest is carried through
+# byte for byte. falsifies a writer that mislays the tree, truncates a payload,
+# writes a section-relative offset where the format wants an image RVA, or lets
+# the manifest bytes drift
+fun ts_pe_rsrc_tree() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+    val base:  u64 = 0x140001000;
+    val entry: u64 = base;
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    var ico: [64]u8;
+    val ico_len: usize = ts_build_ico(?ico[0]);
+
+    val man: str = "<assembly manifestVersion=\"1.0\"/>";
+    var ri: of.ResourceInfo;
+    ri.icon             = ?ico[0];
+    ri.icon_len         = ico_len;
+    ri.app_manifest     = man::*u8;
+    ri.app_manifest_len = str_len(man);
+    ri.version          = "9.4.2";
+    ri.product          = "coffrsrc";
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_rsrc");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry,
+                                                 nil, 0, nil::*of.Section, 0, fs.temp_path(?tf)::*u8,
+                                                 "coffrsrc"::*u8, ?ri);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+    val d: *u8 = buf.data;
+
+    val pe_off:   usize = bin.read_u32_le(d, 0x3C)::usize;
+    val ch:       usize = pe_off + 4;
+    val nsec:     u32   = bin.read_u16_le(d, ch + 2)::u32;
+    val opt_size: usize = bin.read_u16_le(d, ch + 16)::usize;
+    val oh:       usize = ch + 20;
+    val sec_table: usize = oh + opt_size;
+
+    var rva: u32 = 0; var vsize: u32 = 0; var rawptr: u32 = 0; var chars: u32 = 0;
+    if (!ts_find_section(d, sec_table, nsec, ".rsrc", ?rva, ?vsize, ?rawptr, ?chars)) { ret 1; }
+    if (chars != (IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ)) { ret 1; }
+
+    # the RESOURCE data directory must name exactly the section just found.
+    val dd: usize = oh + 112;
+    if (bin.read_u32_le(d, dd + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE) != rva)         { ret 1; }
+    if (bin.read_u32_le(d, dd + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE + 4) != vsize)   { ret 1; }
+
+    val rb_base: usize = rawptr::usize;
+    # four resource types: RT_ICON, RT_GROUP_ICON, RT_VERSION, RT_MANIFEST.
+    if (bin.read_u16_le(d, rb_base + 12) != 0) { ret 1; }
+    if (bin.read_u16_le(d, rb_base + 14) != 4) { ret 1; }
+
+    var lr: u32 = 0; var ls: u32 = 0;
+
+    # each RT_ICON leaf carries its embedded image verbatim, keyed 1..n.
+    var e: usize = 0;
+    for (e < 2) {
+        if (!ts_rsrc_leaf(d, rb_base, rs.RT_ICON, (e + 1)::u32, 0, ?lr, ?ls)) { ret 1; }
+        val want_len: u32 = bin.read_u32_le(?ico[0], 6 + e * 16 + 8);
+        val want_off: u32 = bin.read_u32_le(?ico[0], 6 + e * 16 + 12);
+        if (ls != want_len) { ret 1; }
+        # the data entry's OffsetToData is an image RVA, not a section offset.
+        if (lr < rva || lr::usize - rva::usize + ls::usize > vsize::usize) { ret 1; }
+        val at: usize = rb_base + (lr - rva)::usize;
+        var j: usize = 0;
+        for (j < ls::usize) {
+            if (d[at + j] != ico[want_off::usize + j]) { ret 1; }
+            j = j + 1;
+        }
+        e = e + 1;
+    }
+
+    # the group directory names both icons: 6-byte header then 14 bytes per entry.
+    if (!ts_rsrc_leaf(d, rb_base, rs.RT_GROUP_ICON, 1, 0, ?lr, ?ls)) { ret 1; }
+    if (ls::usize != 6 + 2 * 14) { ret 1; }
+    val gat: usize = rb_base + (lr - rva)::usize;
+    if (bin.read_u16_le(d, gat + 4) != 2) { ret 1; }
+    if (bin.read_u16_le(d, gat + 6 + 12) != 1)      { ret 1; }
+    if (bin.read_u16_le(d, gat + 6 + 14 + 12) != 2) { ret 1; }
+
+    # the version block's fixed header follows the root node's key and padding.
+    if (!ts_rsrc_leaf(d, rb_base, rs.RT_VERSION, 1, 0, ?lr, ?ls)) { ret 1; }
+    val vat: usize = rb_base + (lr - rva)::usize;
+    if (bin.read_u16_le(d, vat) != ls::u16)          { ret 1; }
+    if (bin.read_u32_le(d, vat + 40) != 0xFEEF04BD)  { ret 1; }
+    if (bin.read_u32_le(d, vat + 48) != 0x00090004)  { ret 1; }
+    if (bin.read_u32_le(d, vat + 52) != 0x00020000)  { ret 1; }
+
+    # the application manifest is carried through untouched.
+    if (!ts_rsrc_leaf(d, rb_base, rs.RT_MANIFEST, 1, 0, ?lr, ?ls)) { ret 1; }
+    if (ls::usize != str_len(man)) { ret 1; }
+    val mat: usize = rb_base + (lr - rva)::usize;
+    var m: usize = 0;
+    for (m < str_len(man)) {
+        if (d[mat + m] != man[m]) { ret 1; }
+        m = m + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.target.of.coff.coff_emit_exec:rsrc_tree" {
+    ret ts_pe_rsrc_tree()::i32;
+}
+
+# an artifact that declares no resource inputs emits no `.rsrc` section and
+# leaves the RESOURCE data directory empty, so the image is the one mach wrote
+# before resource emission existed. this is the in-CI form of the byte-identity
+# guarantee; falsifies a writer that emits an empty section or a stale directory
+# entry when the plan is absent
+fun ts_pe_no_rsrc() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+    val base:  u64 = 0x140001000;
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_nrsrc");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, base,
+                                                 nil, 0, nil::*of.Section, 0, fs.temp_path(?tf)::*u8,
+                                                 "coffnorsrc"::*u8, nil);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+    val d: *u8 = buf.data;
+
+    val pe_off:   usize = bin.read_u32_le(d, 0x3C)::usize;
+    val ch:       usize = pe_off + 4;
+    val nsec:     u32   = bin.read_u16_le(d, ch + 2)::u32;
+    val opt_size: usize = bin.read_u16_le(d, ch + 16)::usize;
+    val oh:       usize = ch + 20;
+
+    var rva: u32 = 0; var vsize: u32 = 0; var rawptr: u32 = 0; var chars: u32 = 0;
+    if (ts_find_section(d, oh + opt_size, nsec, ".rsrc", ?rva, ?vsize, ?rawptr, ?chars)) { ret 1; }
+    if (nsec != 1) { ret 1; }
+
+    val dd: usize = oh + 112;
+    if (bin.read_u32_le(d, dd + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE) != 0)     { ret 1; }
+    if (bin.read_u32_le(d, dd + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE + 4) != 0) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.target.of.coff.coff_emit_exec:no_rsrc_when_unset" {
+    ret ts_pe_no_rsrc()::i32;
+}

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -55,6 +55,7 @@ use mach.lang.intern;
 use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.of.bin;
+use rs: mach.lang.target.of.rsrc;
 
 # COFF machine type for x86-64
 val IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
@@ -140,6 +141,7 @@ val IMAGE_DLLCHARACTERISTICS_NX_COMPAT: u16 = 0x0100;
 
 # data-directory indices in the PE32+ optional header
 val IMAGE_DIRECTORY_ENTRY_IMPORT:    u32 = 1;
+val IMAGE_DIRECTORY_ENTRY_RESOURCE:  u32 = 2;
 val IMAGE_DIRECTORY_ENTRY_EXCEPTION: u32 = 3;
 val IMAGE_DIRECTORY_ENTRY_BASERELOC: u32 = 5;
 val IMAGE_DIRECTORY_ENTRY_IAT:       u32 = 12;
@@ -2005,6 +2007,7 @@ rec PeSection {
 # import_dir_*:  the import directory span within .idata (the IMPORT directory)
 # nimp:          number of function imports (IAT/stub/hint-name entries)
 # exception_*:   the .pdata span (EXCEPTION data directory target)
+# resource_*:    the .rsrc span (RESOURCE data directory target)
 # sec_total:     number of section-table entries
 rec PeLayout {
     image_base:  u64;
@@ -2016,6 +2019,7 @@ rec PeLayout {
     xdata_sec:   PeSection;
     pdata_sec:   PeSection;
     reloc_sec:   PeSection;
+    rsrc_sec:    PeSection;
     iat_rva:     u64;
     iat_size:    u64;
     import_dir_rva:  u64;
@@ -2024,12 +2028,15 @@ rec PeLayout {
     exception_size:  u64;
     basereloc_rva:   u64;
     basereloc_size:  u64;
+    resource_rva:    u64;
+    resource_size:   u64;
     nimp:        u32;
     have_stub:   bool;
     have_idata:  bool;
     have_xdata:  bool;
     have_pdata:  bool;
     have_reloc:  bool;
+    have_rsrc:   bool;
     sec_total:   u32;
     # non-allocated debug sections (discardable), placed above the loaded sections;
     # `debug_secs` is a caller-provided array of `debug_count` entries. a debug name
@@ -2466,7 +2473,8 @@ fun collect_function_unwind(segs: *of.LoadSegment, seg_count: u32, funcs: *of.Ex
 fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32,
                       dyn: *of.DynamicInfo, seg_secs: *PeSection,
                       xdata_vsize: usize, pdata_vsize: usize,
-                      debug: *of.Section, debug_count: u32, debug_secs: *PeSection) usize {
+                      debug: *of.Section, debug_count: u32, debug_secs: *PeSection,
+                      res_img: *rs.RsrcImage) usize {
     lay.nimp      = func_import_count(dyn);
     lay.seg_secs  = seg_secs;
     lay.have_stub = lay.nimp > 0;
@@ -2474,6 +2482,7 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
     lay.have_xdata = xdata_vsize > 0;
     lay.have_pdata = pdata_vsize > 0;
     lay.have_reloc = dyn != nil && dyn.base_reloc_count > 0;
+    lay.have_rsrc  = res_img != nil;
     lay.debug_secs  = debug_secs;
     lay.debug_count = debug_count;
     lay.strtab_off  = 0;
@@ -2486,6 +2495,7 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
     if (lay.have_idata) { nsec = nsec + 1; }
     if (lay.have_xdata) { nsec = nsec + 1; }
     if (lay.have_pdata) { nsec = nsec + 1; }
+    if (lay.have_rsrc)  { nsec = nsec + 1; }
     if (lay.have_reloc) { nsec = nsec + 1; }
     nsec = nsec + debug_count;
     lay.sec_total = nsec;
@@ -2611,6 +2621,22 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
         rva = rva + bin.align_up_u64(lay.pdata_sec.vsize, PE_SECTION_ALIGN);
     }
 
+    # the .rsrc section (read-only): the resource directory tree. its data entries
+    # carry image RVAs, so the blob can only be serialized once this assigns the
+    # section's own RVA - measured here, written in `write_pe`.
+    if (lay.have_rsrc) {
+        rva = bin.align_up_u64(rva, PE_SECTION_ALIGN);
+        val res_size: usize = rs.size(res_img);
+        lay.rsrc_sec.rva       = rva;
+        lay.rsrc_sec.vsize     = res_size::u64;
+        lay.rsrc_sec.file_off  = file_off;
+        lay.rsrc_sec.file_size = bin.align_up(res_size, PE_FILE_ALIGN::usize);
+        lay.resource_rva       = rva;
+        lay.resource_size      = res_size::u64;
+        file_off = file_off + lay.rsrc_sec.file_size;
+        rva = rva + bin.align_up_u64(res_size::u64, PE_SECTION_ALIGN);
+    }
+
     # the .reloc section (read-only, discardable): the base-relocation blocks the loader
     # applies after ASLR slides the image. the fixup RVAs read the segment RVAs assigned
     # above, so the base_relocs must already be sorted (the writer sorts before this).
@@ -2687,10 +2713,11 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
 # ret:        ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-                   func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                   func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+                   rsrc: *of.ResourceInfo) R.Result[bool, str] {
     # a static PE carries no dynamic plan, so it resolves no interned names; the
     # interner is forwarded only so a write failure can be located on its path.
-    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, debug, debug_count, path);
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, debug, debug_count, path, rsrc);
 }
 
 # serialize laid-out load segments into a dynamically-linked
@@ -2723,8 +2750,8 @@ fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.
                        seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                        func_count: u32, dyn: *of.DynamicInfo,
                        fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32,
-                       path: *u8, name: *u8) R.Result[bool, str] {
-    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, debug, debug_count, path);
+                       path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, debug, debug_count, path, rsrc);
 }
 
 # the shared PE32+ executable writer behind `coff_emit_exec` (static)
@@ -2737,7 +2764,8 @@ fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.
 fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
              seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
              dyn: *of.DynamicInfo,
-             fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8) R.Result[bool, str] {
+             fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8,
+             rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("coff: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("coff: nil exec path"); }
     if (isa_vt.id != isa.ARCH_X86_64) {
@@ -2793,12 +2821,32 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
         sort.sort[of.BaseReloc](dyn.base_relocs, dyn.base_reloc_count::usize, base_reloc_cmp);
     }
 
+    # the resource blob is built once: the layout needs its size and the section
+    # write needs its bytes, and a second build could disagree with the first. a nil
+    # plan leaves `have_rsrc` false and the image identical to a resourceless one.
+    var res_img: rs.RsrcImage;
+    var res_ptr: *rs.RsrcImage = nil;
+    if (rsrc != nil) {
+        val rr: R.Result[rs.RsrcImage, str] = rs.build(alloc, rsrc.icon, rsrc.icon_len,
+                                                       rsrc.app_manifest, rsrc.app_manifest_len,
+                                                       rsrc.version, rsrc.product);
+        if (R.is_err[rs.RsrcImage, str](rr)) {
+            if (debug_secs != nil) { A.deallocate[PeSection](alloc, debug_secs, debug_count::usize); }
+            A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
+            if (uw_all != nil && func_count > 0) { A.deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
+            ret R.err[bool, str](R.unwrap_err[rs.RsrcImage, str](rr));
+        }
+        res_img = R.unwrap_ok[rs.RsrcImage, str](rr);
+        res_ptr = ?res_img;
+    }
+
     var lay: PeLayout;
     val total_size: usize = compute_pe_layout(itn, ?lay, segs, seg_count, dyn, seg_secs, xdata_vsize, pdata_vsize,
-                                              debug, debug_count, debug_secs);
+                                              debug, debug_count, debug_secs, res_ptr);
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
+        if (res_ptr != nil) { rs.dnit(alloc, res_ptr); }
         if (debug_secs != nil) { A.deallocate[PeSection](alloc, debug_secs, debug_count::usize); }
         A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
         if (uw_all != nil && func_count > 0) { A.deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
@@ -2850,12 +2898,14 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     if (lay.have_idata)                   { write_pe_imports(itn, buf, ?lay, dyn); }
     if (lay.have_stub)                    { write_pe_stubs(buf, ?lay, dyn); }
     if (lay.have_xdata || lay.have_pdata) { write_pe_unwind(buf, ?lay, uw_all, uw_count); }
+    if (lay.have_rsrc)                    { rs.emit(res_ptr, buf, lay.rsrc_sec.file_off, lay.rsrc_sec.rva); }
     if (lay.have_reloc)                   { write_reloc_section(buf, lay.reloc_sec.file_off, dyn, seg_secs); }
 
     # redirect each import call site to its stub (a non-import call site never
     # reaches here - the linker only records fixups for function imports).
     val fx_r: R.Result[bool, str] = patch_pe_fixups(buf, ?lay, dyn, fixups, fixup_count, segs, seg_count);
     if (R.is_err[bool, str](fx_r)) {
+        if (res_ptr != nil) { rs.dnit(alloc, res_ptr); }
         A.deallocate[u8](alloc, buf, total_size);
         if (debug_secs != nil) { A.deallocate[PeSection](alloc, debug_secs, debug_count::usize); }
         A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
@@ -2868,6 +2918,7 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     val pie: bool = dyn != nil && dyn.pie;
     write_pe_headers(buf, ?lay, segs, seg_count, entry, pie, itn, dyn, debug, debug_count);
 
+    if (res_ptr != nil) { rs.dnit(alloc, res_ptr); }
     if (debug_secs != nil) { A.deallocate[PeSection](alloc, debug_secs, debug_count::usize); }
     A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
     if (uw_all != nil && func_count > 0) { A.deallocate[FunctionUnwind](alloc, uw_all, func_count::usize); }
@@ -3297,6 +3348,12 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
         bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE, lay.iat_rva::u32);
         bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_IAT::usize * DATA_DIR_SIZE + 4, lay.iat_size::u32);
     }
+    # RESOURCE directory (index 2) - the .rsrc resource tree the loader and the
+    # shell read the icon, version block, and application manifest out of.
+    if (lay.have_rsrc) {
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE, lay.resource_rva::u32);
+        bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE + 4, lay.resource_size::u32);
+    }
     # EXCEPTION directory (index 3) - the RUNTIME_FUNCTION table in .pdata.
     if (lay.have_pdata) {
         bin.write_u32_le(buf, dd + IMAGE_DIRECTORY_ENTRY_EXCEPTION::usize * DATA_DIR_SIZE, lay.exception_rva::u32);
@@ -3342,6 +3399,11 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     }
     if (lay.have_pdata) {
         write_pe_section_header(buf, pos, ".pdata", ?str_pos, ?lay.pdata_sec,
+            IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ);
+        pos = pos + SECTION_HEADER_SIZE;
+    }
+    if (lay.have_rsrc) {
+        write_pe_section_header(buf, pos, ".rsrc", ?str_pos, ?lay.rsrc_sec,
             IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ);
         pos = pos + SECTION_HEADER_SIZE;
     }
@@ -4410,7 +4472,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffexe"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffexe"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
@@ -4651,7 +4713,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffunwind"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffunwind"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
@@ -5294,7 +5356,7 @@ fun ts_pe_debug_sections() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
 
     val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry,
-                                                 nil, 0, ?dbg[0], 2, fs.temp_path(?tf)::*u8, "coffdbg"::*u8);
+                                                 nil, 0, ?dbg[0], 2, fs.temp_path(?tf)::*u8, "coffdbg"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
@@ -5422,7 +5484,7 @@ fun ts_dyn_exec_relro_naming() u8 {
     val em: R.Result[bool, str] = coff_emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 5, 4096, base,
                                                       nil::*of.ExecFunction, 0, ?dyn,
                                                       nil::*of.PltFixup, 0, nil::*of.Section, 0,
-                                                      fs.temp_path(?tf)::*u8, "coffrelro"::*u8);
+                                                      fs.temp_path(?tf)::*u8, "coffrelro"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1272,10 +1272,11 @@ fun copy_segment_bytes(buf: *u8, segs: *of.LoadSegment, seg_offsets: *usize, seg
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (ELF does not sign)
+# rsrc:     accepted for conformance; ELF carries no resources
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil exec path"); }
 
@@ -2776,11 +2777,12 @@ fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
 # fixup_count: number of fixups
 # path:        null-terminated output file path
 # name:        product name; accepted for of.DynExecFn conformance (ELF does not sign)
+# rsrc:     accepted for conformance; ELF carries no resources
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                   func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
-                  fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil dyn-exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil dyn-exec path"); }
     if (dyn == nil)     { ret R.err[bool, str]("elf: nil dynamic plan"); }
@@ -5659,7 +5661,7 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 67, 4096, 0x401000,
                                                 nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
-                                                nil::*of.Section, 0, tpath::*u8, "dynoverflow"::*u8);
+                                                nil::*of.Section, 0, tpath::*u8, "dynoverflow"::*u8, nil);
     fs.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;
@@ -5707,7 +5709,7 @@ test "mach.lang.target.of.elf.emit_exec:debug_sections_nonalloc" {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000,
-                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "elfdbg"::*u8);
+                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "elfdbg"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1720,10 +1720,11 @@ fun macho_dwarf_free(alloc: *A.Allocator, d: *MachoDwarf, debug_count: u32) {
 # func_count: number of entries in funcs (unused)
 # path:       null-terminated output file path
 # name:       null-terminated product name; the filename-stable code-sign identifier
+# rsrc:     accepted for conformance; Mach-O carries no resources
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
-              debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              debug: *of.Section, debug_count: u32, path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
     val arch_id: u32 = isa_vt.id;
@@ -2829,11 +2830,12 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # fixup_count: number of fixups
 # path:        null-terminated output file path
 # name:        null-terminated product name; the filename-stable code-sign identifier
+# rsrc:     accepted for conformance; Mach-O carries no resources
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil dyn-exec path"); }
     # the debug-section channel is framed into a non-mapped __DWARF segment placed
@@ -4299,7 +4301,7 @@ fun ts_exec_x64() u8 {
 
     # the product name is deliberately not the temp-file basename, to prove the
     # code-sign identifier tracks the name, not the output path.
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoexe"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoexe"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4375,7 +4377,7 @@ fun ts_exec_arm64() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val tpath: str = fs.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoa64"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoa64"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4501,7 +4503,7 @@ fun ts_dyn_exec(arch_id: u32) u8 {
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
                                                 nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1,
-                                                ?dbg[0], 1, tpath::*u8, "machodyn"::*u8);
+                                                ?dbg[0], 1, tpath::*u8, "machodyn"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4728,7 +4730,7 @@ fun t_emit_dyn(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTabl
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val em: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count, 0x4000, entry,
                                                 nil::*of.ExecFunction, 0, dyn, nil::*of.PltFixup, 0,
-                                                nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "machoseg"::*u8);
+                                                nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "machoseg"::*u8, nil);
     if (R.is_err[bool, str](em)) {
         fs.temp_close_and_remove(?tf);
         ret R.err[Vector[u8], str](R.unwrap_err[bool, str](em));
@@ -4932,7 +4934,7 @@ fun ts_exec_merges_read_only() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 3, pg, base,
                                             nil::*of.ExecFunction, 0, nil::*of.Section, 0,
-                                            fs.temp_path(?tf)::*u8, "machoexecro"::*u8);
+                                            fs.temp_path(?tf)::*u8, "machoexecro"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
     fs.temp_close_and_remove(?tf);
@@ -5111,7 +5113,7 @@ fun ts_exec_debug_roundtrip() u8 {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
-                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "machodbg"::*u8);
+                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "machodbg"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -154,10 +154,11 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (a flat image is unsigned)
+# rsrc:     accepted for conformance; a flat image carries no resources
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("raw: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("raw: nil exec path"); }
     # the debug-section channel is accepted for of.ExecFn conformance and ignored: a
@@ -211,11 +212,12 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # fixup_count: number of fixups
 # path:       null-terminated output file path
 # name:       product name; accepted for of.DynExecFn conformance (always unsupported)
+# rsrc:     accepted for conformance; a flat image carries no resources
 # ret:        the unsupported-format error
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8, rsrc: *of.ResourceInfo) R.Result[bool, str] {
     ret R.err[bool, str](RAW_UNSUPPORTED);
 }
 
@@ -333,7 +335,7 @@ test "mach.lang.target.of.raw.emit_exec:flat_layout" {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawflat"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawflat"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -399,7 +401,7 @@ test "mach.lang.target.of.raw.emit_exec:bss_is_stored_as_zeroes" {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawbss"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawbss"::*u8, nil);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -442,7 +444,7 @@ test "mach.lang.target.of.raw.emit_exec:entry_must_be_base" {
 
     # entry 0x1008 != image base 0x1000 must be rejected.
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, nil::*of.Section, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, nil::*of.Section, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8, nil);
     if (!R.is_err[bool, str](em))                                { ret 1; }
     if (!str_contains(R.unwrap_err[bool, str](em), "base"))      { ret 1; }
     ret 0;

--- a/src/lang/target/of/rsrc.mach
+++ b/src/lang/target/of/rsrc.mach
@@ -1,0 +1,992 @@
+# PE `.rsrc` resource-blob builder
+#
+# `build` parses a Windows ICO container and packages it, a generated
+# VS_VERSIONINFO block, and an optional caller-supplied manifest into a sorted
+# leaf list; `size` / `emit` lay that list out as the three-level
+# (type/name/lang) resource directory tree a PE loader walks. Both share one
+# layout pass (`walk`) so they cannot disagree on a byte.
+#
+# The one invariant worth remembering throughout: every `IMAGE_RESOURCE_
+# DIRECTORY_ENTRY.OffsetToData` (at all three directory levels) is relative to
+# the start of the `.rsrc` section, but the `OffsetToData` inside the leaf
+# `IMAGE_RESOURCE_DATA_ENTRY` is an absolute image RVA (`base_rva` plus the
+# section-relative payload offset) - the one asymmetry the format has.
+
+use std.allocator.page;
+use std.memory;
+use std.types.bool.bool;
+use std.types.size.usize;
+use std.types.char.char;
+use std.types.char.char_is_digit;
+use std.types.string.str;
+use std.types.string.str_len;
+
+use A: std.allocator;
+use R: std.types.result;
+
+use mach.lang.target.of.bin;
+
+# resource type IDs (RT_*)
+pub val RT_ICON:       u32 = 3;
+pub val RT_GROUP_ICON: u32 = 14;
+pub val RT_VERSION:    u32 = 16;
+pub val RT_MANIFEST:   u32 = 24;
+
+# fixed on-disk structure sizes for the resource directory tree
+val DIR_HEADER_SIZE:  usize = 16; # IMAGE_RESOURCE_DIRECTORY
+val DIR_ENTRY_SIZE:   usize = 8;  # IMAGE_RESOURCE_DIRECTORY_ENTRY
+val DATA_ENTRY_SIZE:  usize = 16; # IMAGE_RESOURCE_DATA_ENTRY
+
+# marks a directory entry's OffsetToData as pointing at a child directory
+# rather than an IMAGE_RESOURCE_DATA_ENTRY
+val SUBDIR_FLAG: u32 = 0x80000000;
+
+val ICONDIR_SIZE:         usize = 6;
+val ICONDIRENTRY_SIZE:    usize = 16;
+val GRPICONDIRENTRY_SIZE: usize = 14;
+
+# one resource leaf: its three-level coordinate and its payload bytes
+pub rec ResEntry {
+    type_id: u32;
+    name_id: u32;
+    lang_id: u32;
+    bytes:   *u8;
+    len:     usize;
+}
+
+# a built resource image: the sorted leaf list plus the buffers `build` generated
+pub rec RsrcImage {
+    entries:     *ResEntry;
+    entry_count: u32;
+    group_icon:     *u8;
+    group_icon_len: usize;
+    version:        *u8;
+    version_len:    usize;
+}
+
+# a heap buffer and its length, the shape `build_group_icon` / `build_version` hand back
+rec Bytes {
+    bytes: *u8;
+    len:   usize;
+}
+
+# a manifest version string's leading four dot-separated numeric components
+rec ParsedVersion {
+    major: u32;
+    minor: u32;
+    patch: u32;
+    build: u32;
+}
+
+# the distinct type_id groups and (type_id, name_id) groups in a sorted entries array
+rec GroupCounts {
+    n_types: u32;
+    n_names: u32;
+}
+
+# parse up to four leading dot-separated decimal components of a manifest
+# version string ("4.5.0") into (major, minor, patch, build). stops at the
+# first character that is neither a digit nor '.'; a missing, empty, or
+# non-numeric component is 0. never errors.
+# ---
+# version: the manifest version string (may be nil)
+# ret:     the parsed components, all zero for nil or non-numeric input
+fun parse_version(version: str) ParsedVersion {
+    var v: ParsedVersion;
+    v.major = 0; v.minor = 0; v.patch = 0; v.build = 0;
+    if (version == nil) { ret v; }
+
+    var comps: [4]u32;
+    comps[0] = 0; comps[1] = 0; comps[2] = 0; comps[3] = 0;
+
+    val len: usize = str_len(version);
+    var idx: usize = 0;
+    var cur: u32 = 0;
+    var i: usize = 0;
+    for (i < len && idx < 4) {
+        val c: char = version[i];
+        if (char_is_digit(c)) {
+            cur = cur * 10 + ((c - '0')::u32);
+            i = i + 1;
+            cnt;
+        }
+        if (c == '.') {
+            comps[idx] = cur;
+            idx = idx + 1;
+            cur = 0;
+            i = i + 1;
+            cnt;
+        }
+        brk;
+    }
+    if (idx < 4) { comps[idx] = cur; }
+
+    v.major = comps[0]; v.minor = comps[1]; v.patch = comps[2]; v.build = comps[3];
+    ret v;
+}
+
+# validate an ICONDIR + ICONDIRENTRY[] container without dereferencing anything
+# out of bounds
+# ---
+# icon:     the ICO container bytes
+# icon_len: length of icon
+# ret:      the image count on success, or a "rsrc: " prefixed diagnostic
+fun validate_ico(icon: *u8, icon_len: usize) R.Result[u16, str] {
+    if (!bin.region_ok(icon_len, 0, ICONDIR_SIZE)) {
+        ret R.err[u16, str]("rsrc: icon buffer too small for header");
+    }
+    val reserved: u16 = bin.read_u16_le(icon, 0);
+    val itype:    u16 = bin.read_u16_le(icon, 2);
+    val count:    u16 = bin.read_u16_le(icon, 4);
+    if (reserved != 0) { ret R.err[u16, str]("rsrc: icon reserved field must be 0"); }
+    if (itype != 1)    { ret R.err[u16, str]("rsrc: icon type field must be 1"); }
+    if (count == 0)    { ret R.err[u16, str]("rsrc: icon directory is empty"); }
+
+    val dir_len: usize = count::usize * ICONDIRENTRY_SIZE;
+    if (!bin.region_ok(icon_len, ICONDIR_SIZE, dir_len)) {
+        ret R.err[u16, str]("rsrc: icon directory runs past end of buffer");
+    }
+
+    var i: u16 = 0;
+    for (i < count) {
+        val ent_off:       usize = ICONDIR_SIZE + i::usize * ICONDIRENTRY_SIZE;
+        val bytes_in_res:  u32   = bin.read_u32_le(icon, ent_off + 8);
+        val image_offset:  u32   = bin.read_u32_le(icon, ent_off + 12);
+        if (!bin.region_ok(icon_len, image_offset::usize, bytes_in_res::usize)) {
+            ret R.err[u16, str]("rsrc: icon image data runs past end of buffer");
+        }
+        i = i + 1;
+    }
+
+    ret R.ok[u16, str](count);
+}
+
+# generate a GRPICONDIR + GRPICONDIRENTRY[] payload from a validated ICO's
+# per-image metadata
+# ---
+# alloc: allocator for the generated buffer
+# icon:  the validated ICO container bytes
+# count: image count, as returned by validate_ico
+# ret:   the generated buffer and its length, or an allocation error
+fun build_group_icon(alloc: *A.Allocator, icon: *u8, count: u16) R.Result[Bytes, str] {
+    val len: usize = ICONDIR_SIZE + count::usize * GRPICONDIRENTRY_SIZE;
+    val res: R.Result[*u8, str] = A.zallocate[u8](alloc, len);
+    if (R.is_err[*u8, str](res)) { ret R.err[Bytes, str](R.unwrap_err[*u8, str](res)); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res);
+
+    bin.write_u16_le(buf, 0, 0);     # reserved
+    bin.write_u16_le(buf, 2, 1);     # type
+    bin.write_u16_le(buf, 4, count);
+
+    var i: u16 = 0;
+    for (i < count) {
+        val src_off: usize = ICONDIR_SIZE + i::usize * ICONDIRENTRY_SIZE;
+        val dst_off: usize = ICONDIR_SIZE + i::usize * GRPICONDIRENTRY_SIZE;
+        buf[dst_off]     = icon[src_off];     # width
+        buf[dst_off + 1] = icon[src_off + 1]; # height
+        buf[dst_off + 2] = icon[src_off + 2]; # color_count
+        buf[dst_off + 3] = icon[src_off + 3]; # reserved
+        bin.write_u16_le(buf, dst_off + 4,  bin.read_u16_le(icon, src_off + 4)); # planes
+        bin.write_u16_le(buf, dst_off + 6,  bin.read_u16_le(icon, src_off + 6)); # bit_count
+        bin.write_u32_le(buf, dst_off + 8,  bin.read_u32_le(icon, src_off + 8)); # bytes_in_res
+        bin.write_u16_le(buf, dst_off + 12, i + 1);                              # id
+        i = i + 1;
+    }
+
+    var out: Bytes;
+    out.bytes = buf;
+    out.len   = len;
+    ret R.ok[Bytes, str](out);
+}
+
+# UTF-16LE byte length of `s` widened one code unit per ASCII byte, including
+# the NUL terminator
+fun wide_len(s: str) usize {
+    ret (str_len(s) + 1) * 2;
+}
+
+# write `s` widened to UTF-16LE with a NUL terminator at buf[off..]; returns
+# the bytes written (== wide_len(s))
+fun write_wide(buf: *u8, off: usize, s: str) usize {
+    val len: usize = str_len(s);
+    var i: usize = 0;
+    for (i < len) {
+        bin.write_u16_le(buf, off + i * 2, s[i]::u16);
+        i = i + 1;
+    }
+    bin.write_u16_le(buf, off + len * 2, 0);
+    ret (len + 1) * 2;
+}
+
+# a childless VS_VERSIONINFO node's own content length: header + widened key
+# (padded to 4) + value, not yet padded for any children
+fun node_own_len(key: str, value_len: usize) usize {
+    val after_key: usize = bin.align_up(6 + wide_len(key), 4);
+    ret after_key + value_len;
+}
+
+# the size of a back-to-back run of children, each individually 4-byte
+# aligned relative to the block start, with no trailing padding after the
+# last one - mirrors a node's own wLength excluding its trailing pad
+fun children_block_len(lens: *usize, count: usize) usize {
+    var total: usize = 0;
+    var i: usize = 0;
+    for (i < count) {
+        if (i > 0) { total = bin.align_up(total, 4); }
+        total = total + lens[i];
+        i = i + 1;
+    }
+    ret total;
+}
+
+# write a VS_VERSIONINFO node's wLength/wValueLength/wType header and widened
+# key; returns the (4-byte-aligned) offset where its value begins
+fun write_node_head(buf: *u8, off: usize, w_length: usize, w_value_length: usize,
+                     w_type: u16, key: str) usize {
+    bin.write_u16_le(buf, off,     w_length::u16);
+    bin.write_u16_le(buf, off + 2, w_value_length::u16);
+    bin.write_u16_le(buf, off + 4, w_type);
+    val key_len: usize = write_wide(buf, off + 6, key);
+    ret bin.align_up(off + 6 + key_len, 4);
+}
+
+# write the 13-u32 VS_FIXEDFILEINFO value at buf[off..off+52]
+fun write_fixedfileinfo(buf: *u8, off: usize, v: ParsedVersion) {
+    val vms: u32 = (v.major << 16) | v.minor;
+    val vls: u32 = (v.patch << 16) | v.build;
+    bin.write_u32_le(buf, off,      0xFEEF04BD); # dwSignature
+    bin.write_u32_le(buf, off + 4,  0x00010000); # dwStrucVersion
+    bin.write_u32_le(buf, off + 8,  vms);        # dwFileVersionMS
+    bin.write_u32_le(buf, off + 12, vls);        # dwFileVersionLS
+    bin.write_u32_le(buf, off + 16, vms);        # dwProductVersionMS
+    bin.write_u32_le(buf, off + 20, vls);        # dwProductVersionLS
+    bin.write_u32_le(buf, off + 24, 0x3F);       # dwFileFlagsMask
+    bin.write_u32_le(buf, off + 28, 0);          # dwFileFlags
+    bin.write_u32_le(buf, off + 32, 0x00040004); # dwFileOS (VOS_NT_WINDOWS32)
+    bin.write_u32_le(buf, off + 36, 1);          # dwFileType (VFT_APP)
+    bin.write_u32_le(buf, off + 40, 0);          # dwFileSubtype
+    bin.write_u32_le(buf, off + 44, 0);          # dwFileDateMS
+    bin.write_u32_le(buf, off + 48, 0);          # dwFileDateLS
+}
+
+# generate a VS_VERSIONINFO payload: VS_FIXEDFILEINFO, a StringFileInfo /
+# StringTable("040904B0") with five String children, and a VarFileInfo / Var
+# translation pair
+# ---
+# alloc:   allocator for the generated buffer
+# version: manifest version string ("4.5.0"), used verbatim for the
+#          FileVersion/ProductVersion strings and parsed for VS_FIXEDFILEINFO
+# product: product name, used for InternalName/OriginalFilename/ProductName
+# ret:     the generated buffer and its length, or an allocation error
+fun build_version(alloc: *A.Allocator, version: str, product: str) R.Result[Bytes, str] {
+    val parsed: ParsedVersion = parse_version(version);
+
+    var str_keys: [5]str;
+    var str_vals: [5]str;
+    str_keys[0] = "FileVersion";      str_vals[0] = version;
+    str_keys[1] = "InternalName";     str_vals[1] = product;
+    str_keys[2] = "OriginalFilename"; str_vals[2] = product;
+    str_keys[3] = "ProductName";      str_vals[3] = product;
+    str_keys[4] = "ProductVersion";   str_vals[4] = version;
+
+    var str_val_lens: [5]usize; # each String's value, widened + NUL, in bytes
+    var str_lens:     [5]usize; # each String node's own wLength (leaf: no children)
+    var i: usize = 0;
+    for (i < 5) {
+        str_val_lens[i] = wide_len(str_vals[i]);
+        str_lens[i]     = node_own_len(str_keys[i], str_val_lens[i]);
+        i = i + 1;
+    }
+
+    val langcp_key: str = "040904B0";
+    val stringtable_own_len:      usize = node_own_len(langcp_key, 0);
+    val stringtable_children_len: usize = children_block_len(?str_lens[0], 5);
+    val stringtable_len:          usize = bin.align_up(stringtable_own_len, 4) + stringtable_children_len;
+
+    val stringfileinfo_own_len: usize = node_own_len("StringFileInfo", 0);
+    var stringtable_lens: [1]usize;
+    stringtable_lens[0] = stringtable_len;
+    val stringfileinfo_children_len: usize = children_block_len(?stringtable_lens[0], 1);
+    val stringfileinfo_len: usize = bin.align_up(stringfileinfo_own_len, 4) + stringfileinfo_children_len;
+
+    val var_len: usize = node_own_len("Translation", 4); # leaf, no children
+
+    val varfileinfo_own_len: usize = node_own_len("VarFileInfo", 0);
+    var var_lens: [1]usize;
+    var_lens[0] = var_len;
+    val varfileinfo_children_len: usize = children_block_len(?var_lens[0], 1);
+    val varfileinfo_len: usize = bin.align_up(varfileinfo_own_len, 4) + varfileinfo_children_len;
+
+    val root_own_len: usize = node_own_len("VS_VERSION_INFO", 52);
+    var root_lens: [2]usize;
+    root_lens[0] = stringfileinfo_len;
+    root_lens[1] = varfileinfo_len;
+    val root_children_len: usize = children_block_len(?root_lens[0], 2);
+    val total_len: usize = bin.align_up(root_own_len, 4) + root_children_len;
+
+    val res: R.Result[*u8, str] = A.zallocate[u8](alloc, total_len);
+    if (R.is_err[*u8, str](res)) { ret R.err[Bytes, str](R.unwrap_err[*u8, str](res)); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res);
+
+    val root_value_off: usize = write_node_head(buf, 0, total_len, 52, 0, "VS_VERSION_INFO");
+    write_fixedfileinfo(buf, root_value_off, parsed);
+    val root_children_off: usize = bin.align_up(root_value_off + 52, 4);
+
+    val sfi_off: usize = root_children_off;
+    val sfi_value_off: usize = write_node_head(buf, sfi_off, stringfileinfo_len, 0, 1, "StringFileInfo");
+    val st_off: usize = bin.align_up(sfi_value_off, 4);
+    val st_value_off: usize = write_node_head(buf, st_off, stringtable_len, 0, 1, langcp_key);
+
+    var cursor: usize = bin.align_up(st_value_off, 4);
+    i = 0;
+    for (i < 5) {
+        # wValueLength for a String node is the value's UTF-16 CHARACTER count
+        # including the NUL terminator, not a byte count - the classic mistake
+        # this structure invites.
+        val chars: usize = str_val_lens[i] / 2;
+        val value_off: usize = write_node_head(buf, cursor, str_lens[i], chars, 1, str_keys[i]);
+        write_wide(buf, value_off, str_vals[i]);
+        cursor = cursor + str_lens[i];
+        if (i < 4) { cursor = bin.align_up(cursor, 4); }
+        i = i + 1;
+    }
+
+    val vfi_off: usize = bin.align_up(sfi_off + stringfileinfo_len, 4);
+    val vfi_value_off: usize = write_node_head(buf, vfi_off, varfileinfo_len, 0, 1, "VarFileInfo");
+    val var_off: usize = bin.align_up(vfi_value_off, 4);
+    val var_value_off: usize = write_node_head(buf, var_off, var_len, 4, 0, "Translation");
+    bin.write_u32_le(buf, var_value_off, 0x04B00409); # Translation: langid 0x0409, codepage 0x04B0
+
+    var out: Bytes;
+    out.bytes = buf;
+    out.len   = total_len;
+    ret R.ok[Bytes, str](out);
+}
+
+# build the sorted leaf list and generated payloads for a `.rsrc` section
+# ---
+# alloc:        allocator that owns the returned image's entries/group_icon/version
+# icon:         an ICO container's bytes, or nil to omit RT_ICON/RT_GROUP_ICON
+# icon_len:     length of icon
+# manifest:     an application manifest's bytes, or nil to omit RT_MANIFEST
+# manifest_len: length of manifest
+# version:      manifest version string ("4.5.0") for VS_VERSIONINFO
+# product:      product name for VS_VERSIONINFO
+# ret:          the built image, or a "rsrc: " prefixed diagnostic
+pub fun build(alloc: *A.Allocator, icon: *u8, icon_len: usize, manifest: *u8, manifest_len: usize,
+              version: str, product: str) R.Result[RsrcImage, str] {
+    val has_icon: bool = icon != nil;
+    var icon_count: u16 = 0;
+    if (has_icon) {
+        val vr: R.Result[u16, str] = validate_ico(icon, icon_len);
+        if (R.is_err[u16, str](vr)) { ret R.err[RsrcImage, str](R.unwrap_err[u16, str](vr)); }
+        icon_count = R.unwrap_ok[u16, str](vr);
+    }
+    val has_manifest: bool = manifest != nil;
+
+    var entry_count: u32 = 1; # RT_VERSION is always present
+    if (has_icon)     { entry_count = entry_count + icon_count::u32 + 1; } # icons + group icon
+    if (has_manifest) { entry_count = entry_count + 1; }
+
+    val res_entries: R.Result[*ResEntry, str] = A.zallocate[ResEntry](alloc, entry_count::usize);
+    if (R.is_err[*ResEntry, str](res_entries)) {
+        ret R.err[RsrcImage, str](R.unwrap_err[*ResEntry, str](res_entries));
+    }
+    val entries: *ResEntry = R.unwrap_ok[*ResEntry, str](res_entries);
+
+    var group_icon:     *u8   = nil;
+    var group_icon_len: usize = 0;
+    var idx: u32 = 0;
+
+    # leaves come out in (type_id, name_id, lang_id) ascending order by
+    # construction: RT_ICON(3) < RT_GROUP_ICON(14) < RT_VERSION(16) <
+    # RT_MANIFEST(24), and icon name_ids already ascend 1..count
+    if (has_icon) {
+        var i: u16 = 0;
+        for (i < icon_count) {
+            val ent_off: usize = ICONDIR_SIZE + i::usize * ICONDIRENTRY_SIZE;
+            entries[idx].type_id = RT_ICON;
+            entries[idx].name_id = (i + 1)::u32;
+            entries[idx].lang_id = 0;
+            entries[idx].bytes   = (icon::usize + bin.read_u32_le(icon, ent_off + 12)::usize)::*u8;
+            entries[idx].len     = bin.read_u32_le(icon, ent_off + 8)::usize;
+            idx = idx + 1;
+            i = i + 1;
+        }
+
+        val gi_r: R.Result[Bytes, str] = build_group_icon(alloc, icon, icon_count);
+        if (R.is_err[Bytes, str](gi_r)) {
+            A.deallocate[ResEntry](alloc, entries, entry_count::usize);
+            ret R.err[RsrcImage, str](R.unwrap_err[Bytes, str](gi_r));
+        }
+        val gi: Bytes = R.unwrap_ok[Bytes, str](gi_r);
+        group_icon     = gi.bytes;
+        group_icon_len = gi.len;
+
+        entries[idx].type_id = RT_GROUP_ICON;
+        entries[idx].name_id = 1;
+        entries[idx].lang_id = 0;
+        entries[idx].bytes   = group_icon;
+        entries[idx].len     = group_icon_len;
+        idx = idx + 1;
+    }
+
+    val ver_r: R.Result[Bytes, str] = build_version(alloc, version, product);
+    if (R.is_err[Bytes, str](ver_r)) {
+        if (group_icon != nil) { A.deallocate[u8](alloc, group_icon, group_icon_len); }
+        A.deallocate[ResEntry](alloc, entries, entry_count::usize);
+        ret R.err[RsrcImage, str](R.unwrap_err[Bytes, str](ver_r));
+    }
+    val ver: Bytes = R.unwrap_ok[Bytes, str](ver_r);
+
+    entries[idx].type_id = RT_VERSION;
+    entries[idx].name_id = 1;
+    entries[idx].lang_id = 0;
+    entries[idx].bytes   = ver.bytes;
+    entries[idx].len     = ver.len;
+    idx = idx + 1;
+
+    if (has_manifest) {
+        entries[idx].type_id = RT_MANIFEST;
+        entries[idx].name_id = 1;
+        entries[idx].lang_id = 0;
+        entries[idx].bytes   = manifest;
+        entries[idx].len     = manifest_len;
+        idx = idx + 1;
+    }
+
+    var img: RsrcImage;
+    img.entries        = entries;
+    img.entry_count    = entry_count;
+    img.group_icon     = group_icon;
+    img.group_icon_len = group_icon_len;
+    img.version        = ver.bytes;
+    img.version_len    = ver.len;
+    ret R.ok[RsrcImage, str](img);
+}
+
+# count the distinct type_id groups and (type_id, name_id) groups across a
+# sorted, duplicate-free entries array in one forward pass
+fun count_groups(entries: *ResEntry, entry_count: u32) GroupCounts {
+    var c: GroupCounts;
+    c.n_types = 0; c.n_names = 0;
+    var i: u32 = 0;
+    for (i < entry_count) {
+        val new_type: bool = i == 0 || entries[i].type_id != entries[i - 1].type_id;
+        val new_name: bool = new_type || entries[i].name_id != entries[i - 1].name_id;
+        if (new_type) { c.n_types = c.n_types + 1; }
+        if (new_name) { c.n_names = c.n_names + 1; }
+        i = i + 1;
+    }
+    ret c;
+}
+
+# number of distinct name_ids in the type group starting at entries[i]
+fun names_in_type_at(entries: *ResEntry, entry_count: u32, i: u32) u32 {
+    val t: u32 = entries[i].type_id;
+    var n: u32 = 0;
+    var j: u32 = i;
+    for (j < entry_count && entries[j].type_id == t) {
+        if (j == i || entries[j].name_id != entries[j - 1].name_id) { n = n + 1; }
+        j = j + 1;
+    }
+    ret n;
+}
+
+# number of lang entries in the (type, name) group starting at entries[i]
+fun langs_in_name_at(entries: *ResEntry, entry_count: u32, i: u32) u32 {
+    val t:  u32 = entries[i].type_id;
+    val nm: u32 = entries[i].name_id;
+    var n: u32 = 0;
+    var j: u32 = i;
+    for (j < entry_count && entries[j].type_id == t && entries[j].name_id == nm) {
+        n = n + 1;
+        j = j + 1;
+    }
+    ret n;
+}
+
+# lay out the three-level resource directory tree and, when buf is non-nil,
+# write it at buf[off..]; returns the total blob size either way, so `size`
+# and `emit` cannot disagree
+# ---
+# img:      the built image, entries already sorted by (type_id, name_id, lang_id)
+# buf:      destination buffer, or nil to only measure
+# off:      byte offset of the `.rsrc` section within buf (ignored when buf is nil)
+# base_rva: the `.rsrc` section's image RVA (ignored when buf is nil)
+# ret:      the total blob size
+fun walk(img: *RsrcImage, buf: *u8, off: usize, base_rva: u64) usize {
+    val entries:     *ResEntry = img.entries;
+    val entry_count: u32       = img.entry_count;
+    val do_write:    bool      = buf != nil;
+
+    val counts: GroupCounts = count_groups(entries, entry_count);
+
+    val root_size:    usize = DIR_HEADER_SIZE + DIR_ENTRY_SIZE * counts.n_types::usize;
+    val level2_off:   usize = root_size;
+    val level2_size:  usize = DIR_HEADER_SIZE * counts.n_types::usize + DIR_ENTRY_SIZE * counts.n_names::usize;
+    val level3_off:   usize = level2_off + level2_size;
+    val level3_size:  usize = DIR_HEADER_SIZE * counts.n_names::usize + DIR_ENTRY_SIZE * entry_count::usize;
+    val data_off:     usize = level3_off + level3_size;
+    val data_size:    usize = DATA_ENTRY_SIZE * entry_count::usize;
+    val payload_off0: usize = data_off + data_size;
+
+    if (do_write) {
+        bin.write_u32_le(buf, off,      0);                    # Characteristics
+        bin.write_u32_le(buf, off + 4,  0);                    # TimeDateStamp
+        bin.write_u16_le(buf, off + 8,  0);                    # MajorVersion
+        bin.write_u16_le(buf, off + 10, 0);                    # MinorVersion
+        bin.write_u16_le(buf, off + 12, 0);                    # NumberOfNamedEntries
+        bin.write_u16_le(buf, off + 14, counts.n_types::u16);  # NumberOfIdEntries
+    }
+
+    var root_entry_off: usize = DIR_HEADER_SIZE; # next free slot in the root's entry array
+    var l2_dir_off:     usize = level2_off;       # current type's level-2 directory offset
+    var l2_entry_off:   usize = 0;                # next free slot in that directory's entry array
+    var l3_dir_off:     usize = level3_off;       # current name's level-3 directory offset
+    var l3_entry_off:   usize = 0;                # next free slot in that directory's entry array
+    var payload_cursor: usize = payload_off0;
+
+    var cur_type_names: u32 = 0;
+    var cur_name_langs: u32 = 0;
+
+    var i: u32 = 0;
+    for (i < entry_count) {
+        val t:  u32 = entries[i].type_id;
+        val nm: u32 = entries[i].name_id;
+        val new_type: bool = i == 0 || t != entries[i - 1].type_id;
+        val new_name: bool = new_type || nm != entries[i - 1].name_id;
+
+        if (new_type) {
+            cur_type_names = names_in_type_at(entries, entry_count, i);
+            if (do_write) {
+                bin.write_u32_le(buf, off + root_entry_off,     t);
+                bin.write_u32_le(buf, off + root_entry_off + 4, (l2_dir_off::u32) | SUBDIR_FLAG);
+                bin.write_u32_le(buf, off + l2_dir_off,      0);
+                bin.write_u32_le(buf, off + l2_dir_off + 4,  0);
+                bin.write_u16_le(buf, off + l2_dir_off + 8,  0);
+                bin.write_u16_le(buf, off + l2_dir_off + 10, 0);
+                bin.write_u16_le(buf, off + l2_dir_off + 12, 0);
+                bin.write_u16_le(buf, off + l2_dir_off + 14, cur_type_names::u16);
+            }
+            root_entry_off = root_entry_off + DIR_ENTRY_SIZE;
+            l2_entry_off   = l2_dir_off + DIR_HEADER_SIZE;
+        }
+
+        if (new_name) {
+            cur_name_langs = langs_in_name_at(entries, entry_count, i);
+            if (do_write) {
+                bin.write_u32_le(buf, off + l2_entry_off,     nm);
+                bin.write_u32_le(buf, off + l2_entry_off + 4, (l3_dir_off::u32) | SUBDIR_FLAG);
+                bin.write_u32_le(buf, off + l3_dir_off,      0);
+                bin.write_u32_le(buf, off + l3_dir_off + 4,  0);
+                bin.write_u16_le(buf, off + l3_dir_off + 8,  0);
+                bin.write_u16_le(buf, off + l3_dir_off + 10, 0);
+                bin.write_u16_le(buf, off + l3_dir_off + 12, 0);
+                bin.write_u16_le(buf, off + l3_dir_off + 14, cur_name_langs::u16);
+            }
+            l2_entry_off = l2_entry_off + DIR_ENTRY_SIZE;
+            l3_entry_off = l3_dir_off + DIR_HEADER_SIZE;
+        }
+
+        val this_data_off: usize = data_off + i::usize * DATA_ENTRY_SIZE;
+        payload_cursor = bin.align_up(payload_cursor, 4);
+        val this_payload_off: usize = payload_cursor;
+
+        if (do_write) {
+            bin.write_u32_le(buf, off + l3_entry_off,     entries[i].lang_id);
+            bin.write_u32_le(buf, off + l3_entry_off + 4, this_data_off::u32);
+
+            # OffsetToData here is an image RVA (base_rva + this payload's
+            # section-relative offset) - every directory-entry offset above is
+            # section-relative instead; this is the one asymmetry in the format.
+            bin.write_u32_le(buf, off + this_data_off,      (base_rva + this_payload_off::u64)::u32);
+            bin.write_u32_le(buf, off + this_data_off + 4,  entries[i].len::u32);
+            bin.write_u32_le(buf, off + this_data_off + 8,  0);
+            bin.write_u32_le(buf, off + this_data_off + 12, 0);
+
+            if (entries[i].len > 0) {
+                memory.raw_copy((buf::usize + off + this_payload_off)::ptr, entries[i].bytes::ptr, entries[i].len);
+            }
+        }
+        l3_entry_off   = l3_entry_off + DIR_ENTRY_SIZE;
+        payload_cursor = payload_cursor + entries[i].len;
+
+        val last_in_name: bool = i + 1 == entry_count || entries[i + 1].type_id != t || entries[i + 1].name_id != nm;
+        val last_in_type: bool = i + 1 == entry_count || entries[i + 1].type_id != t;
+        if (last_in_name) { l3_dir_off = l3_dir_off + DIR_HEADER_SIZE + DIR_ENTRY_SIZE * cur_name_langs::usize; }
+        if (last_in_type) { l2_dir_off = l2_dir_off + DIR_HEADER_SIZE + DIR_ENTRY_SIZE * cur_type_names::usize; }
+
+        i = i + 1;
+    }
+
+    ret payload_cursor;
+}
+
+# total byte size of the `.rsrc` blob `emit` would write for img
+# ---
+# img: the built image
+# ret: the total blob size, including inter-payload alignment padding
+pub fun size(img: *RsrcImage) usize {
+    ret walk(img, nil, 0, 0);
+}
+
+# write the `.rsrc` blob for img at buf[off..off+size(img)]
+# ---
+# img:      the built image
+# buf:      destination buffer
+# off:      byte offset of the `.rsrc` section within buf
+# base_rva: the `.rsrc` section's image RVA
+pub fun emit(img: *RsrcImage, buf: *u8, off: usize, base_rva: u64) {
+    walk(img, buf, off, base_rva);
+}
+
+# free the entries/group_icon/version buffers build allocated
+# ---
+# alloc: the allocator build was given
+# img:   the image to release
+pub fun dnit(alloc: *A.Allocator, img: *RsrcImage) {
+    if (img == nil) { ret; }
+    A.deallocate[ResEntry](alloc, img.entries, img.entry_count::usize);
+    A.deallocate[u8](alloc, img.group_icon, img.group_icon_len);
+    A.deallocate[u8](alloc, img.version, img.version_len);
+}
+
+# build a synthetic 2-image ICO buffer: ICONDIR + 2 ICONDIRENTRY, then the two
+# images' raw bytes back to back
+fun ts_make_two_image_ico(buf: *u8) {
+    var z: usize = 0;
+    for (z < 48) { buf[z] = 0; z = z + 1; }
+
+    bin.write_u16_le(buf, 0, 0); # reserved
+    bin.write_u16_le(buf, 2, 1); # type
+    bin.write_u16_le(buf, 4, 2); # count
+
+    buf[6] = 16; buf[7] = 16; buf[8] = 0; buf[9] = 0;   # 16x16
+    bin.write_u16_le(buf, 10, 1);  # planes
+    bin.write_u16_le(buf, 12, 32); # bit_count
+    bin.write_u32_le(buf, 14, 4);  # bytes_in_res
+    bin.write_u32_le(buf, 18, 38); # image_offset
+
+    buf[22] = 32; buf[23] = 32; buf[24] = 0; buf[25] = 0; # 32x32
+    bin.write_u16_le(buf, 26, 1);  # planes
+    bin.write_u16_le(buf, 28, 32); # bit_count
+    bin.write_u32_le(buf, 30, 6);  # bytes_in_res
+    bin.write_u32_le(buf, 34, 42); # image_offset
+
+    buf[38] = 0xAA; buf[39] = 0xBB; buf[40] = 0xCC; buf[41] = 0xDD;
+    buf[42] = 1; buf[43] = 2; buf[44] = 3; buf[45] = 4; buf[46] = 5; buf[47] = 6;
+}
+
+fun ts_two_image_group_icon() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var ico: [48]u8;
+    ts_make_two_image_ico(?ico[0]);
+
+    val r: R.Result[RsrcImage, str] = build(?alloc, ?ico[0], 48, nil, 0, "1.0.0", "TestApp");
+    if (R.is_err[RsrcImage, str](r)) { ret 1; }
+    var img: RsrcImage = R.unwrap_ok[RsrcImage, str](r);
+
+    var bad: u8 = 0;
+    if (img.entry_count != 4) { bad = 1; }
+    or (img.entries[0].type_id != RT_ICON || img.entries[0].name_id != 1 || img.entries[0].len != 4) { bad = 1; }
+    or (img.entries[1].type_id != RT_ICON || img.entries[1].name_id != 2 || img.entries[1].len != 6) { bad = 1; }
+    or (img.entries[2].type_id != RT_GROUP_ICON || img.entries[2].name_id != 1)                      { bad = 1; }
+    or (img.entries[3].type_id != RT_VERSION)                                                        { bad = 1; }
+    or (img.group_icon_len != 6 + 2 * 14)                                                             { bad = 1; }
+
+    if (bad == 0) {
+        val gi: *u8 = img.group_icon;
+        if (bin.read_u16_le(gi, 4) != 2)          { bad = 1; } # count
+        or (gi[6] != 16)                          { bad = 1; } # icon 0 width
+        or (bin.read_u32_le(gi, 6 + 8) != 4)      { bad = 1; } # icon 0 bytes_in_res
+        or (bin.read_u16_le(gi, 6 + 12) != 1)     { bad = 1; } # icon 0 id
+        or (gi[6 + 14] != 32)                     { bad = 1; } # icon 1 width
+        or (bin.read_u32_le(gi, 6 + 14 + 8) != 6) { bad = 1; } # icon 1 bytes_in_res
+        or (bin.read_u16_le(gi, 6 + 14 + 12) != 2){ bad = 1; } # icon 1 id
+    }
+
+    dnit(?alloc, ?img);
+    ret bad;
+}
+
+# a synthetic 2-image ICO builds one RT_ICON leaf per image plus one
+# RT_GROUP_ICON, with id/bytes_in_res carried across into the group directory
+test "mach.lang.target.of.rsrc:build_two_image_ico" {
+    if (ts_two_image_group_icon() != 0) { ret 1; }
+    ret 0;
+}
+
+fun ts_malformed_ico() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # bad magic: type field must be 1
+    var bad_magic: [6]u8;
+    bin.write_u16_le(?bad_magic[0], 0, 0); # reserved
+    bin.write_u16_le(?bad_magic[0], 2, 2); # type (invalid)
+    bin.write_u16_le(?bad_magic[0], 4, 1); # count
+    val r1: R.Result[RsrcImage, str] = build(?alloc, ?bad_magic[0], 6, nil, 0, "1.0", "x");
+    if (R.is_ok[RsrcImage, str](r1)) { ret 1; }
+
+    # image data runs past the end of the buffer
+    var overrun: [22]u8;
+    var z: usize = 0;
+    for (z < 22) { overrun[z] = 0; z = z + 1; }
+    bin.write_u16_le(?overrun[0], 0, 0);    # reserved
+    bin.write_u16_le(?overrun[0], 2, 1);    # type
+    bin.write_u16_le(?overrun[0], 4, 1);    # count
+    bin.write_u32_le(?overrun[0], 14, 100); # bytes_in_res, far larger than the buffer
+    bin.write_u32_le(?overrun[0], 18, 22);  # image_offset: right at the buffer's end
+    val r2: R.Result[RsrcImage, str] = build(?alloc, ?overrun[0], 22, nil, 0, "1.0", "x");
+    if (R.is_ok[RsrcImage, str](r2)) { ret 1; }
+
+    ret 0;
+}
+
+# a bad-magic ICO and one whose image data runs past the buffer end are both
+# rejected, never producing a partial or corrupt image
+test "mach.lang.target.of.rsrc:build_rejects_malformed_ico" {
+    if (ts_malformed_ico() != 0) { ret 1; }
+    ret 0;
+}
+
+fun ts_version_parsing() u8 {
+    val v1: ParsedVersion = parse_version("4.5.0");
+    if (((v1.major << 16) | v1.minor) != 0x00040005) { ret 1; }
+    or (((v1.patch << 16) | v1.build) != 0x00000000) { ret 1; }
+
+    val v2: ParsedVersion = parse_version("1.2.3-alpha");
+    if (((v2.major << 16) | v2.minor) != 0x00010002) { ret 1; }
+    or (((v2.patch << 16) | v2.build) != 0x00030000) { ret 1; }
+
+    val v3: ParsedVersion = parse_version("not-a-version");
+    if (v3.major != 0 || v3.minor != 0 || v3.patch != 0 || v3.build != 0) { ret 1; }
+
+    ret 0;
+}
+
+# manifest version strings parse into dwFileVersionMS/LS: a full triple, a
+# string with a trailing non-numeric suffix, and non-numeric junk (all zeros)
+test "mach.lang.target.of.rsrc:parse_version_components" {
+    if (ts_version_parsing() != 0) { ret 1; }
+    ret 0;
+}
+
+fun ts_version_signature_and_length() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val r: R.Result[RsrcImage, str] = build(?alloc, nil, 0, nil, 0, "2.3.4", "App");
+    if (R.is_err[RsrcImage, str](r)) { ret 1; }
+    var img: RsrcImage = R.unwrap_ok[RsrcImage, str](r);
+
+    var bad: u8 = 0;
+    if (img.entry_count != 1)                                       { bad = 1; }
+    or (img.entries[0].type_id != RT_VERSION)                       { bad = 1; }
+    or (bin.read_u32_le(img.version, 40) != 0xFEEF04BD)             { bad = 1; } # dwSignature
+    or (bin.read_u16_le(img.version, 0)::usize != img.version_len)  { bad = 1; } # root wLength
+
+    dnit(?alloc, ?img);
+    ret bad;
+}
+
+# the VS_FIXEDFILEINFO signature lands at the fixed offset right after the
+# root key ("VS_VERSION_INFO" always widens to the same length), and the
+# root node's own wLength equals the whole generated buffer's length
+test "mach.lang.target.of.rsrc:version_signature_and_root_length" {
+    if (ts_version_signature_and_length() != 0) { ret 1; }
+    ret 0;
+}
+
+fun ts_size_matches_emit() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var manifest: [16]u8;
+    var z: usize = 0;
+    for (z < 16) { manifest[z] = (z + 1)::u8; z = z + 1; }
+
+    val r: R.Result[RsrcImage, str] = build(?alloc, nil, 0, ?manifest[0], 16, "1.0.0", "App");
+    if (R.is_err[RsrcImage, str](r)) { ret 1; }
+    var img: RsrcImage = R.unwrap_ok[RsrcImage, str](r);
+
+    val sz: usize = size(?img);
+
+    val buf_r: R.Result[*u8, str] = A.zallocate[u8](?alloc, sz + 16);
+    if (R.is_err[*u8, str](buf_r)) { dnit(?alloc, ?img); ret 1; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](buf_r);
+
+    var z2: usize = 0;
+    for (z2 < 16) { buf[sz + z2] = 0xAB; z2 = z2 + 1; }
+
+    emit(?img, buf, 0, 0x9000); # a realistic small section RVA, not an absolute VA
+
+    var bad: u8 = 0;
+    var z3: usize = 0;
+    for (z3 < 16) {
+        if (buf[sz + z3] != 0xAB) { bad = 1; }
+        z3 = z3 + 1;
+    }
+
+    A.deallocate[u8](?alloc, buf, sz + 16);
+    dnit(?alloc, ?img);
+    ret bad;
+}
+
+# size(img) matches the byte count emit actually writes: a sentinel planted
+# just past the reported size survives emitting into an oversized buffer
+test "mach.lang.target.of.rsrc:size_matches_emit_no_overrun" {
+    if (ts_size_matches_emit() != 0) { ret 1; }
+    ret 0;
+}
+
+fun ts_manifest_referenced() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var manifest: [12]u8;
+    var z: usize = 0;
+    for (z < 12) { manifest[z] = (0x40 + z)::u8; z = z + 1; }
+
+    val r: R.Result[RsrcImage, str] = build(?alloc, nil, 0, ?manifest[0], 12, "1.0.0", "App");
+    if (R.is_err[RsrcImage, str](r)) { ret 1; }
+    var img: RsrcImage = R.unwrap_ok[RsrcImage, str](r);
+
+    var bad: u8 = 0;
+    if (img.entry_count != 2)                                     { bad = 1; }
+    or (img.entries[1].type_id != RT_MANIFEST)                    { bad = 1; }
+    or (img.entries[1].bytes::usize != (?manifest[0])::usize)     { bad = 1; } # referenced, not copied
+    or (img.entries[1].len != 12)                                 { bad = 1; }
+
+    if (bad == 0) {
+        var z2: usize = 0;
+        for (z2 < 12) {
+            if (img.entries[1].bytes[z2] != manifest[z2]) { bad = 1; }
+            z2 = z2 + 1;
+        }
+    }
+
+    dnit(?alloc, ?img);
+    ret bad;
+}
+
+# the RT_MANIFEST leaf points directly at the caller's buffer - same address,
+# same length, unmodified content - never a copy
+test "mach.lang.target.of.rsrc:manifest_bytes_referenced_unmodified" {
+    if (ts_manifest_referenced() != 0) { ret 1; }
+    ret 0;
+}
+
+fun ts_full_tree_walk() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var ico: [26]u8;
+    var z: usize = 0;
+    for (z < 26) { ico[z] = 0; z = z + 1; }
+    bin.write_u16_le(?ico[0], 0, 0);
+    bin.write_u16_le(?ico[0], 2, 1);
+    bin.write_u16_le(?ico[0], 4, 1);
+    ico[6] = 16; ico[7] = 16;
+    bin.write_u16_le(?ico[0], 10, 1);
+    bin.write_u16_le(?ico[0], 12, 32);
+    bin.write_u32_le(?ico[0], 14, 4);  # bytes_in_res
+    bin.write_u32_le(?ico[0], 18, 22); # image_offset
+    ico[22] = 0x11; ico[23] = 0x22; ico[24] = 0x33; ico[25] = 0x44;
+
+    var manifest: [8]u8;
+    var m: usize = 0;
+    for (m < 8) { manifest[m] = (0x50 + m)::u8; m = m + 1; }
+
+    val r: R.Result[RsrcImage, str] = build(?alloc, ?ico[0], 26, ?manifest[0], 8, "3.1.4", "TreeApp");
+    if (R.is_err[RsrcImage, str](r)) { ret 1; }
+    var img: RsrcImage = R.unwrap_ok[RsrcImage, str](r);
+    if (img.entry_count != 4) { dnit(?alloc, ?img); ret 1; }
+
+    val sz: usize = size(?img);
+    val buf_r: R.Result[*u8, str] = A.zallocate[u8](?alloc, sz);
+    if (R.is_err[*u8, str](buf_r)) { dnit(?alloc, ?img); ret 1; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](buf_r);
+
+    val base_rva: u64 = 0x9000; # a realistic small section RVA, not an absolute VA
+    emit(?img, buf, 0, base_rva);
+
+    var bad: u8 = 0;
+    val n_types: u16 = bin.read_u16_le(buf, 14);
+    if (n_types != 4) { bad = 1; }
+
+    var seen_icon:  u8 = 0;
+    var seen_group: u8 = 0;
+    var seen_ver:   u8 = 0;
+    var seen_man:   u8 = 0;
+
+    if (bad == 0) {
+        var k: u16 = 0;
+        for (k < n_types) {
+            val root_ent: usize = 16 + k::usize * 8;
+            val tid:      u32   = bin.read_u32_le(buf, root_ent);
+            val l2_raw:   u32   = bin.read_u32_le(buf, root_ent + 4);
+            val l2_off:   usize = (l2_raw & ~SUBDIR_FLAG)::usize;
+
+            val l2_names: u16 = bin.read_u16_le(buf, l2_off + 14);
+            if (l2_names != 1) { bad = 1; }
+
+            val l2_ent:  usize = l2_off + 16;
+            val name_id: u32   = bin.read_u32_le(buf, l2_ent);
+            if (name_id != 1) { bad = 1; }
+            val l3_raw: u32   = bin.read_u32_le(buf, l2_ent + 4);
+            val l3_off: usize = (l3_raw & ~SUBDIR_FLAG)::usize;
+
+            val l3_langs: u16 = bin.read_u16_le(buf, l3_off + 14);
+            if (l3_langs != 1) { bad = 1; }
+
+            val l3_ent:   usize = l3_off + 16;
+            val lang_id:  u32   = bin.read_u32_le(buf, l3_ent);
+            if (lang_id != 0) { bad = 1; }
+            val data_off: usize = bin.read_u32_le(buf, l3_ent + 4)::usize;
+
+            val data_rva:    u32   = bin.read_u32_le(buf, data_off);
+            val data_size:   u32   = bin.read_u32_le(buf, data_off + 4);
+            val payload_off: usize = (data_rva::u64 - base_rva)::usize;
+
+            if (payload_off + data_size::usize > sz) { bad = 1; }
+
+            var expect_len: usize = 0;
+            if (tid == RT_ICON)       { expect_len = img.entries[0].len; seen_icon = 1; }
+            or (tid == RT_GROUP_ICON) { expect_len = img.group_icon_len; seen_group = 1; }
+            or (tid == RT_VERSION)    { expect_len = img.version_len;    seen_ver = 1; }
+            or (tid == RT_MANIFEST)   { expect_len = 8;                  seen_man = 1; }
+            or                        { bad = 1; }
+
+            if (data_size::usize != expect_len) { bad = 1; }
+
+            if (tid == RT_MANIFEST) {
+                var mi: usize = 0;
+                for (mi < 8) {
+                    if (buf[payload_off + mi] != manifest[mi]) { bad = 1; }
+                    mi = mi + 1;
+                }
+            }
+
+            k = k + 1;
+        }
+    }
+
+    if (seen_icon == 0 || seen_group == 0 || seen_ver == 0 || seen_man == 0) { bad = 1; }
+
+    A.deallocate[u8](?alloc, buf, sz);
+    dnit(?alloc, ?img);
+    ret bad;
+}
+
+# a full tree walk of a self-emitted blob: the three directory levels resolve
+# to exactly the expected (type, name, lang) triples, and each leaf's data
+# entry OffsetToData - base_rva lands inside the blob at that leaf's payload
+# with the right length (and, for the manifest, the right content)
+test "mach.lang.target.of.rsrc:full_tree_walk_round_trip" {
+    if (ts_full_tree_walk() != 0) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Emits a PE `.rsrc` section carrying the application icon, version metadata, and
application manifest, driven by two new manifest keys. No external resource
compiler is involved — resource emission is in-house alongside the rest of PE
emission.

```toml
[artifact.game]
kind = "bin"
icon = "assets/game.ico"          # ICO container; every embedded size carried over
manifest = "assets/game.manifest" # optional XML application manifest
```

- `RT_GROUP_ICON` + `RT_ICON` decomposed from the ICO container.
- `RT_VERSION`: `VS_VERSIONINFO` whose fixed block is sourced from `[project].version`.
- `RT_MANIFEST`: the given file, byte-preserved.
- Standard three-level resource directory tree (type -> id -> language), language-neutral.
- No `.rsrc` section at all when neither key is set, so output stays byte-identical to today.

### Schema shape

The issue's snippet shows a nested `[artifact.game.windows]` table, but its prose
specifies "same convention as `subsystem`" — and #2508's `subsystem` is a flat
artifact key. `doc/manifest.md` also states outright that a per-target artifact
condition "is not a per-cell exception table — it is a second artifact stanza",
and the schema has no nested-override precedent anywhere. These keys are
therefore flat `[artifact.<name>]` keys, windows-only and inert elsewhere,
exactly like `subsystem`. Capability is identical; only the spelling differs from
the issue's snippet. Flagging explicitly for review.

### Status

Draft — work in progress. Depends on #2508 landing first (shared edit sites in
`src/lang/target/of.mach` and `src/lang/manifest.mach`); `dev` will be merged in
and the whole thing re-verified before this is marked ready.

Closes #2509