### PR TITLE
feat(link): PE subsystem selection for windows executables

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -113,6 +113,7 @@ unit's inputs — prints it, and exits without compiling or linking.
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
 | `--jobs <n>`   | count          | codegen worker threads (default: host CPUs; `1` serialises) |
 | `--pie`        | —              | emit a position-independent (ET_DYN) executable for ASLR instead of the default fixed-address one; opt-in (see below) |
+| `--subsystem <k>` | `console`\|`gui` | the environment a windows executable declares it runs under, overriding the artifact's `subsystem` key (see below) |
 | `-L <dir>`     | dir            | add a search directory for `-l`-resolved inputs; repeatable |
 | `-l <name>`    | name           | link a named object, archive, or target-format shared library, resolved through the `-L` dirs (see below); repeatable |
 | `--explain`    | —              | print the resolved build plan and exit without building |
@@ -126,6 +127,15 @@ linker emits a position-independent `ET_DYN` image the kernel loads at a
 randomized base (ASLR), self-relocated by the runtime before `main` (no `ld.so`).
 It applies to a static executable; combining `--pie` with a dynamic `-l<lib>`
 dependency is rejected.
+
+`--subsystem` overrides the selected artifact's
+[`subsystem`](manifest.md#artifactname) key for this invocation, with the usual
+precedence — the flag wins over the manifest, and the manifest over the `console`
+default. `gui` writes `IMAGE_SUBSYSTEM_WINDOWS_GUI` into the PE optional header so
+the Windows loader starts the process without attaching a console window; `console`
+is the default and what mach has always emitted. Only the PE writer reads it, so
+passing the flag on a non-windows target is accepted and changes nothing about the
+output — the same inertness the manifest key has.
 
 ### External link inputs
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -73,6 +73,7 @@ out     = "bin/demo"                   # output path, relative to the project ou
 targets = ["*"]                        # which declared targets build it ("*" = all)
 link    = []                           # [link.X] names this artifact links
 need    = []                           # [step.X] names this artifact demands directly
+# subsystem = "gui"                    # optional: windows console/GUI selector
 
 [dep.std]                              # a dependency
 git = "https://github.com/briar-systems/mach-std"
@@ -352,6 +353,7 @@ reads the selected artifact's name.
 | `targets` | yes | Array of declared target names this artifact builds for; `["*"]` means every declared target. |
 | `link`    | yes | Array of `[link.X]` names this artifact links (see below). `[]` for none. |
 | `need`    | yes | Array of `[step.X]` names this artifact demands directly, for step outputs that are not themselves link inputs. `[]` for none. |
+| `subsystem` | no | `"console"` (default) or `"gui"` — the environment a windows executable declares it runs under (see below). |
 
 - **`bin`** links an executable at the resolved `out` path.
 - **`static`** materialises a real `ar` archive at the resolved `out` path — the
@@ -362,6 +364,36 @@ reads the selected artifact's name.
 
 Per-target extension or per-target entry is not a per-cell exception table — it is a
 second artifact stanza, so the condition stays visible like everything else.
+
+### `subsystem` — the windows console/GUI selector
+
+```toml
+[artifact.game]
+kind = "bin"
+entry = "main.mach"
+out = "bin/game.exe"
+targets = ["*"]
+link = []
+need = []
+subsystem = "gui"
+```
+
+A PE executable records in its optional header which environment it wants, and the
+Windows loader honours it: `"console"` gets a console window attached to the
+process, `"gui"` does not. mach defaults to `"console"`, which is what every PE it
+has ever emitted declares, so an artifact that omits the key is byte-identical to
+one built before the key existed. A graphical application sets `"gui"` to stop an
+empty console from opening behind it on launch.
+
+The key takes no `os` filter, and it is not an error on a linux or darwin target.
+Only the PE writer consumes it — ELF, Mach-O, and flat images have no such field —
+so on any other target the key is accepted and inert, changing nothing about the
+output. That matches how `[link.X]` entries carry `os`/`isa`/`abi` axes on every
+declaration and simply do not apply to the cells they do not match: the manifest
+stays one declaration read by every build, rather than a per-platform file.
+
+`--subsystem console|gui` overrides the key for one invocation; see
+[cli.md](cli.md#mach-build).
 
 ## `[link.<name>]` — link requirements
 

--- a/src/cli/args.mach
+++ b/src/cli/args.mach
@@ -67,10 +67,11 @@ pub val RDO: [RDO_N]FlagSpec = [RDO_N]FlagSpec{
 };
 
 # codegen flags: emission and codegen posture. shared by build/run/test/doc.
-pub val CGEN_N: usize = 6;
+pub val CGEN_N: usize = 7;
 pub val CGEN: [CGEN_N]FlagSpec = [CGEN_N]FlagSpec{
     FlagSpec{ name: "--all-targets", has_value: false, doc: "build every declared target rather than the manifest default" },
     FlagSpec{ name: "--pie",         has_value: false, doc: "emit a position-independent (ET_DYN) executable" },
+    FlagSpec{ name: "--subsystem",   has_value: true,  doc: "console | gui; the environment a windows executable declares (overrides the artifact's subsystem key; inert off windows)" },
     FlagSpec{ name: "-g",            has_value: false, doc: "emit debug info for this build (overrides the profile's debug key)" },
     FlagSpec{ name: "--emit-asm",    has_value: false, doc: "emit per-module .s assembly text beside each object" },
     FlagSpec{ name: "--emit-ir",     has_value: false, doc: "emit per-module .ir SSA text beside each object" },
@@ -250,6 +251,7 @@ pub fun parse(argc: usize, argv: **u8) R.Result[request.CliArgs, str] {
     c.pie         = util.flag_exists(argc, argv, "--pie");
     c.g           = util.flag_exists(argc, argv, "-g");
 
+    c.subsystem = flag_value_get(nil, argc, argv, "--subsystem");
     c.target    = flag_value_get(nil, argc, argv, "--target");
     c.output    = flag_value_get(nil, argc, argv, "-o");
     c.profile   = flag_value_get(nil, argc, argv, "--profile");

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -261,10 +261,12 @@ rec StrMerge {
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # pie:          the build opted into a position-independent executable (`--pie`)
+# subsystem:    the environment the executable declares it runs under (PE only)
 # ret:          true once the artifact is written, or an error string
 pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
              obj_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
-             out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+             out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
+             subsystem: of.Subsystem) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -290,7 +292,7 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     # after linking regardless of outcome.
     val r: R.Result[bool, str] =
         link_modules(s, tgt, modules, module_count, 0, dynlibs, dynlib_count,
-                     out_path, name, mode, pie);
+                     out_path, name, mode, pie, subsystem);
     free_modules(alloc, modules, module_count);
     ret r;
 }
@@ -316,10 +318,12 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # pie:          the build opted into a position-independent executable (`--pie`)
+# subsystem:    the environment the executable declares it runs under (PE only)
 # ret:          true once the artifact is written, or an error string
 pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
                     image_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
-                    out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+                    out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
+                    subsystem: of.Subsystem) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -328,7 +332,7 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
         ret R.err[bool, str]("link: no input objects");
     }
     ret link_modules(s, tgt, images, image_count, image_count, dynlibs,
-                     dynlib_count, out_path, name, mode, pie);
+                     dynlib_count, out_path, name, mode, pie, subsystem);
 }
 
 # combine the project's in-memory codegen images with on-disk external link
@@ -360,12 +364,14 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # pie:          the build opted into a position-independent executable (`--pie`)
+# subsystem:    the environment the executable declares it runs under (PE only)
 # ret:          true once the artifact is written, or an error string
 pub fun link_mixed(s: *session.Session, tgt: *target.Target,
                    images: *of.ObjectImage, image_count: u32,
                    obj_paths: **u8, obj_count: u32,
                    dynlibs: *of.DynLib, dynlib_count: u32,
-                   out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+                   out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
+                   subsystem: of.Subsystem) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -406,7 +412,7 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 
     val r: R.Result[bool, str] =
         link_modules(s, tgt, combined, total, image_count, dynlibs, dynlib_count,
-                     out_path, name, mode, pie);
+                     out_path, name, mode, pie, subsystem);
 
     # tear down only the parsed external images (the project images are caller-owned)
     # and free the `combined` wrapper without dnit'ing its shallow-copied slots.
@@ -443,11 +449,13 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
 # name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # pie_opt_in:   the build opted into a position-independent executable (`--pie`)
+# subsystem:    the environment the executable declares it runs under (PE only)
 # ret:          true once the artifact is written, or an error string
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
-                 out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool) R.Result[bool, str] {
+                 out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
+                 subsystem: of.Subsystem) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     # a shared object is always position-independent: the loader maps it at an
     # arbitrary base and slides its in-image absolute pointers, so it takes the same
@@ -674,10 +682,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
             emit_r = emit_shared_object(s, tgt, ?out_img, merged, modules, module_count, ?sym_locs, ?dyn, out_path);
         }
         or (dynamic) {
-            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, ?dyn, out_path, name);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, ?dyn, out_path, name, subsystem);
         }
         or {
-            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, nil::*DynState, out_path, name);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, nil::*DynState, out_path, name, subsystem);
         }
 
         free_dynstate(alloc, ?dyn);
@@ -942,10 +950,12 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
 # dyn:      the dynamic-link plan + fixups, or nil for a static executable
 # out_path: null-terminated output file path
 # name:     null-terminated product name; the writer's stable signing identity
+# subsystem: the environment the executable declares it runs under (PE only)
 # ret:      true once the executable is written, or an error string
 fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.ObjectImage,
                     merged: *MergedSection, sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                    dyn: *DynState, out_path: *u8, name: *u8) R.Result[bool, str] {
+                    dyn: *DynState, out_path: *u8, name: *u8,
+                    subsystem: of.Subsystem) R.Result[bool, str] {
     if (dyn == nil && tgt.of.emit_exec == nil) {
         ret R.err[bool, str]("link: object format cannot write executables");
     }
@@ -986,11 +996,11 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
 
     var emit_r: R.Result[bool, str] = R.ok[bool, str](true);
     if (dyn == nil) {
-        emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name);
+        emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name, subsystem);
     }
     or {
         emit_r = tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry,
-                                      funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, dbg, dbg_count, out_path, name);
+                                      funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, dbg, dbg_count, out_path, name, subsystem);
     }
 
     if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
@@ -4490,7 +4500,7 @@ test "mach.lang.be.linker.link_modules:flat_entry_leads_regardless_of_order" {
 
     # both modules are in-memory codegen images (codegen_count == 2), static exe.
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false);
+        link_modules(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -308,7 +308,7 @@ pub fun emit_shared_library(p: *driver.Project, unit: *plan.BuildUnit, paths: **
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, nil::*of.DynLib, 0, solib, artifact_product_name(p), linker.LINK_SHARED, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, len, nil::*of.DynLib, 0, solib, artifact_product_name(p), linker.LINK_SHARED, ctx.req.pie, ctx.req.subsystem);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -333,7 +333,7 @@ pub fun link_executable(p: *driver.Project, paths: **u8, len: u32,
                         dynlibs: *of.DynLib, dynlib_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, len, dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, ctx.req.subsystem);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -386,7 +386,7 @@ pub fun link_flat_images(p: *driver.Project, images: *of.ObjectImage, exe_path: 
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, ctx.req.subsystem);
     A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
@@ -424,7 +424,7 @@ pub fun link_mixed_images(p: *driver.Project, images: *of.ObjectImage,
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
         linker.link_mixed(p.s, ?p.target, ordered, p.topo_len, ext_paths, ext_count,
-                          dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+                          dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, ctx.req.subsystem);
     A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -334,7 +334,7 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
         ret r;
     }
     val reqp: *request.BuildRequest = R.unwrap_ok[*request.BuildRequest, str](res_rq);
-    @reqp = request.for_cell(bp.request, unit.sel_target, unit.sel_artifact, unit.want_lib);
+    @reqp = request.for_cell(bp.request, unit.sel_target, unit.sel_artifact, unit.want_lib, unit.subsystem);
 
     val begin_r: R.Result[driver.Project, outcome.Fail] = driver.begin_build(s, ?m, reqp, ev);
     if (R.is_err[driver.Project, outcome.Fail](begin_r)) {
@@ -851,8 +851,8 @@ fun link_flat(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, ev: *re
     }
 
     # a flat image has no external link inputs, so the config is the output
-    # path / product / pie. reuse the prior artifact when no link input
-    # changed (a cold build always re-links).
+    # path / product / pie / subsystem. reuse the prior artifact when no link
+    # input changed (a cold build always re-links).
     val cfg_r: R.Result[bool, outcome.Fail] = set_link_config_input(p, artifact::*u8, emit.artifact_product_name(p), linker.LINK_EXE::u32, nil, 0, nil, 0);
     if (R.is_err[bool, outcome.Fail](cfg_r)) { ret cfg_r; }
     val relink_r: R.Result[bool, outcome.Fail] = driver.run_link_pass(p);
@@ -1002,6 +1002,9 @@ fun write_link_config(fb: *dq.FpBuf, p: *driver.Project, out_path: *u8, product:
     val a1: R.Result[bool, str] = dq.fp_u32(fb, pie_axis);            if (R.is_err[bool, str](a1)) { ret a1; }
     val a2: R.Result[bool, str] = dq.fp_cstr(fb, out_path);           if (R.is_err[bool, str](a2)) { ret a2; }
     val a3: R.Result[bool, str] = dq.fp_cstr(fb, product);            if (R.is_err[bool, str](a3)) { ret a3; }
+    # the writer stamps the declared subsystem into the image header, so a flip
+    # changes the binary without changing any object.
+    val a6: R.Result[bool, str] = dq.fp_u32(fb, ctx.req.subsystem::u32); if (R.is_err[bool, str](a6)) { ret a6; }
 
     # each static external input (a `.o` / `.a` baked into the output) is folded by
     # PATH and by CONTENT: a same-path rebuild of a vendored archive changes the

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -132,6 +132,8 @@ pub rec LinkInput {
 # sel_artifact: the cell's artifact selector
 # want_lib:     the selected artifact is a `[lib.*]` (disambiguates a name)
 # has_artifact: an artifact is named
+# subsystem:    the environment this cell's executable declares it runs under,
+#               settled from `--subsystem` over the artifact's `subsystem` key
 pub rec BuildUnit {
     target_entry: *project.TargetEntry;
     profile:      str;
@@ -148,6 +150,7 @@ pub rec BuildUnit {
     sel_artifact: str;
     want_lib:     bool;
     has_artifact: bool;
+    subsystem:    of.Subsystem;
 }
 
 # the settled request the planner consumes, re-exported for the RFC spelling
@@ -403,6 +406,15 @@ fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
     u.sel_artifact = aname;
     u.want_lib     = want_lib;
     u.has_artifact = has_artifact;
+
+    # the subsystem this cell declares: an explicit `--subsystem` is a
+    # per-invocation override that wins outright, else the artifact's key (which
+    # defaults to console). the key is accepted on every target and consumed only
+    # by the PE writer, so a non-windows cell settles it and emits as before.
+    u.subsystem = of.SUBSYSTEM_CONSOLE;
+    if (bu.artifact != nil) { u.subsystem = bu.artifact.subsystem; }
+    if (req.subsystem_flag == request.SUBSYSTEM_FLAG_CONSOLE) { u.subsystem = of.SUBSYSTEM_CONSOLE; }
+    if (req.subsystem_flag == request.SUBSYSTEM_FLAG_GUI)     { u.subsystem = of.SUBSYSTEM_GUI; }
 
     val pn_opt: O.Option[str] = intern.lookup(itn, bu.profile_name);
     if (O.is_none[str](pn_opt)) { ret R.err[BuildUnit, outcome.Fail](outcome.user("internal: profile name not interned")); }

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -42,6 +42,7 @@ use mach.lang.build.outcome;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.pipeline;
+use mach.lang.target.of;
 
 # the parsed command line shared across subcommands - the raw invoker choices
 # `compose` settles into a BuildRequest
@@ -69,6 +70,7 @@ use mach.lang.me.pipeline;
 # all_targets: --all-targets was passed; build every declared target rather
 #              than the manifest default
 # pie:         --pie was passed; emit a position-independent (ET_DYN) executable
+# subsystem:   raw `--subsystem` value (nil when not given); compose validates it
 # g:           -g was passed; force debug-info emission on for this invocation
 # opt_set:     an explicit `-O0`/`-O1`/`-O2` was passed (a per-invocation
 #              override that wins over the profile's `opt`)
@@ -92,6 +94,7 @@ pub rec CliArgs {
     lib:         *u8;
     all_targets: bool;
     pie:         bool;
+    subsystem:   *u8;
     g:           bool;
     opt_set:      bool;
     opt_release:  bool;
@@ -137,6 +140,18 @@ fun ascii_suffix_equals(text: *u8, suffix: *u8) bool {
     ret true;
 }
 
+# the `--subsystem` selection, before any artifact is bound
+#
+# `compose` validates the flag but cannot settle it: an invocation may name a
+# whole matrix, so no artifact - and therefore no manifest `subsystem` key - is
+# resolved yet. The planner binds each cell's artifact and settles the flag
+# against it, the same split `-o` takes against the artifact's `out` template.
+pub def SubsystemFlag: u8;
+
+pub val SUBSYSTEM_FLAG_NONE:    SubsystemFlag = 0;
+pub val SUBSYSTEM_FLAG_CONSOLE: SubsystemFlag = 1;
+pub val SUBSYSTEM_FLAG_GUI:     SubsystemFlag = 2;
+
 # what the build produces
 pub def BuildGoal: u8;
 
@@ -176,6 +191,12 @@ pub rec LinkToken {
 #               the profile's `opt`, else the debug pipeline)
 # debug:        emit debug info (`-g` wins, else the profile's `debug`)
 # pie:          emit a position-independent executable (`--pie`)
+# subsystem_flag: the invocation's `--subsystem` selection, unsettled until a cell
+#               binds an artifact (see SubsystemFlag)
+# subsystem:    the settled environment this cell's executable declares it runs
+#               under; `for_cell` installs what the planner resolved, and only the
+#               PE writer consumes it. console on the invocation request, which
+#               binds no artifact
 # simd:         the profile's resolved SIMD strictness posture
 # vectorize:    the profile's resolved auto-vectorization lever
 # float_reassoc: the profile's resolved permission to reassociate float arithmetic
@@ -205,6 +226,8 @@ pub rec BuildRequest {
     opt:          u8;
     debug:        bool;
     pie:          bool;
+    subsystem_flag: SubsystemFlag;
+    subsystem:      of.Subsystem;
     simd:          manifest.SimdMode;
     vectorize:     bool;
     float_reassoc: bool;
@@ -241,6 +264,8 @@ pub fun defaults() BuildRequest {
     r.opt          = pipeline.OPT_DEBUG;
     r.debug        = false;
     r.pie          = false;
+    r.subsystem_flag = SUBSYSTEM_FLAG_NONE;
+    r.subsystem      = of.SUBSYSTEM_CONSOLE;
     r.simd          = manifest.SIMD_SCALARIZE;
     r.vectorize     = true;
     r.float_reassoc = false;
@@ -348,6 +373,18 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
 
     r.debug     = cli.g || pf.debug;
     r.pie       = cli.pie;
+
+    # `--subsystem` is validated here and settled by the planner, which is the
+    # first place an artifact (and its manifest key) is bound.
+    if (cli.subsystem != nil) {
+        val ss: str = cli.subsystem::str;
+        if (str_equals(ss, "console"))  { r.subsystem_flag = SUBSYSTEM_FLAG_CONSOLE; }
+        or (str_equals(ss, "gui"))      { r.subsystem_flag = SUBSYSTEM_FLAG_GUI; }
+        or {
+            ret R.err[BuildRequest, outcome.Fail](outcome.user("--subsystem expects \"console\" or \"gui\""));
+        }
+    }
+
     r.simd          = pf.simd;
     r.vectorize     = pf.vectorize;
     r.float_reassoc = pf.float_reassoc;
@@ -400,23 +437,31 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
 
 # derive one matrix cell's request from the invocation request
 #
-# A cell differs from the invocation only in its selection: the (target,
-# artifact) pair the planner enumerated. Every other settled decision - the
-# profile and everything it decided, the codegen levels, the link inputs -
-# applies to every cell unchanged, so the derivation is a copy with the
-# selection swapped. The vectors are shared with the base request (the cell
-# never grows them).
+# A cell differs from the invocation in its selection - the (target, artifact)
+# pair the planner enumerated - and in the decisions that selection settles.
+# Every other settled decision - the profile and everything it decided, the
+# codegen levels, the link inputs - applies to every cell unchanged, so the
+# derivation is a copy with those swapped. The vectors are shared with the base
+# request (the cell never grows them).
+#
+# `subsystem` is the artifact-derived half: the invocation carries only the
+# `--subsystem` flag, since no artifact is bound until the planner resolves the
+# cell, and the planner hands the settled value back here.
 # ---
-# base:     the invocation's composed request
-# target:   the cell's target selector (empty selects the manifest default)
-# artifact: the cell's artifact selector
-# want_lib: the artifact selector names a `[lib.*]`
-# ret:      the cell's request
-pub fun for_cell(base: *BuildRequest, target: str, artifact: str, want_lib: bool) BuildRequest {
+# base:      the invocation's composed request
+# target:    the cell's target selector (empty selects the manifest default)
+# artifact:  the cell's artifact selector
+# want_lib:  the artifact selector names a `[lib.*]`
+# subsystem: the environment the cell's executable declares it runs under, as the
+#            planner settled it (`--subsystem` over the artifact's key)
+# ret:       the cell's request
+pub fun for_cell(base: *BuildRequest, target: str, artifact: str, want_lib: bool,
+                 subsystem: of.Subsystem) BuildRequest {
     var r: BuildRequest = @base;
-    r.target   = target;
-    r.artifact = artifact;
-    r.want_lib = want_lib;
+    r.target    = target;
+    r.artifact  = artifact;
+    r.want_lib  = want_lib;
+    r.subsystem = subsystem;
     ret r;
 }
 
@@ -464,7 +509,9 @@ pub val HASH_SIZE: usize = 32;
 # compute); `emit_ir` / `emit_asm` (per-module `.ir` / `.s` side artifacts dumped
 # from the already-computed IR, a plan-level concern); `out` and the link inputs
 # `link_tokens` / `lib_dirs` (they reach the build through Q_LINK_CONFIG, never a
-# per-module compute).
+# per-module compute); `subsystem` / `subsystem_flag` (a header field the
+# executable writer stamps at link time - no module's object differs, so it too
+# reaches the build through Q_LINK_CONFIG).
 #
 # request_hash writes these first, then the OUT fields; semantic_hash writes only
 # these. A new request field MUST be placed deliberately: here when it changes a
@@ -493,17 +540,21 @@ fun write_semantic_fields(e: *binary.Encoder, r: *BuildRequest) bool {
 # covers BEYOND the compilation semantics
 #
 # Scheduling (`jobs`), the per-module side emissions (`emit_ir` / `emit_asm`,
-# plan-level), the output path (`out`), and the link inputs (`link_tokens` /
-# `lib_dirs`, which reach the build through Q_LINK_CONFIG, never a per-module
-# compute). A change to any of them re-links or re-emits but never re-resolves,
-# re-types, re-lowers, or re-codegens a module - so semantic_hash omits them and
-# request_hash appends them after the semantic fields.
+# plan-level), the output path (`out`), the executable's declared subsystem, and
+# the link inputs (`link_tokens` / `lib_dirs`, which reach the build through
+# Q_LINK_CONFIG, never a per-module compute). A change to any of them re-links or
+# re-emits but never re-resolves, re-types, re-lowers, or re-codegens a module -
+# so semantic_hash omits them and request_hash appends them after the semantic
+# fields. Only the settled `subsystem` is written: `subsystem_flag` is one of its
+# two inputs, so folding it too would key the identity on provenance rather than
+# on what the writer stamps.
 fun write_request_extra(e: *binary.Encoder, r: *BuildRequest) bool {
     var ok: bool = true;
     ok = ok && R.is_ok[usize, str](binary.write_u32(e, r.jobs));
     ok = ok && hb(e, r.emit_ir);
     ok = ok && hb(e, r.emit_asm);
     ok = ok && hs(e, r.out);
+    ok = ok && R.is_ok[usize, str](binary.write_u8(e, r.subsystem));
     ok = ok && R.is_ok[usize, str](binary.write_u32(e, r.link_tokens.len::u32));
     var ti: usize = 0;
     for (ti < r.link_tokens.len) {
@@ -609,8 +660,9 @@ test "mach.lang.build.request.is_object_path:shared_library_suffixes" {
     ret 0;
 }
 
-# a cell derivation swaps exactly the selection; every other settled decision
-# and the shared link-input vectors carry over unchanged
+# a cell derivation swaps the selection and the subsystem the planner settled for
+# it; every other settled decision and the shared link-input vectors carry over
+# unchanged
 test "mach.lang.build.request.for_cell:swaps_selection_only" {
     var base: BuildRequest = defaults();
     base.project_root = "/r";
@@ -620,14 +672,18 @@ test "mach.lang.build.request.for_cell:swaps_selection_only" {
     base.debug        = true;
     base.jobs         = 7;
 
-    val c: BuildRequest = for_cell(?base, "tb", "libb", true);
+    val c: BuildRequest = for_cell(?base, "tb", "libb", true, of.SUBSYSTEM_GUI);
     if (!str_equals(c.target, "tb"))       { ret 1; }
     if (!str_equals(c.artifact, "libb"))   { ret 1; }
     if (!c.want_lib)                       { ret 1; }
+    if (c.subsystem != of.SUBSYSTEM_GUI)   { ret 1; }
     if (c.opt != pipeline.OPT_RELEASE)     { ret 1; }
     if (!c.debug)                          { ret 1; }
     if (c.jobs != 7)                       { ret 1; }
     if (!str_equals(c.project_root, "/r")) { ret 1; }
+
+    # the base is untouched: it binds no artifact, so it settles no subsystem.
+    if (base.subsystem != of.SUBSYSTEM_CONSOLE) { ret 1; }
     ret 0;
 }
 
@@ -676,6 +732,16 @@ test "mach.lang.build.request.semantic_hash:omits_nonsemantic_fields" {
     rb.out      = "/tmp/out.bin";
     if (R.is_err[bool, str](semantic_hash(?alloc, ?rb, ?d[0]))) { ret 1; }
     if (!dig_eq(?base[0], ?d[0])) { ret 1; }
+
+    # the declared subsystem is a link-time header field: no module's object
+    # differs, so it is a semantic no-op while the full identity still diverges.
+    rb = ra;
+    rb.subsystem = of.SUBSYSTEM_GUI;
+    if (R.is_err[bool, str](semantic_hash(?alloc, ?rb, ?d[0]))) { ret 1; }
+    if (!dig_eq(?base[0], ?d[0])) { ret 1; }
+    if (R.is_err[bool, str](request_hash(?alloc, ?ra, ?rqa[0]))) { ret 1; }
+    if (R.is_err[bool, str](request_hash(?alloc, ?rb, ?rqb[0]))) { ret 1; }
+    if (dig_eq(?rqa[0], ?rqb[0])) { ret 1; }
 
     # a compilation-semantics change still diverges: opt.
     rb = ra;

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -382,7 +382,7 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
     paths[shared_len] = entry_path;
 
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, total, dynlibs, dynlib_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+        linker.link(p.s, ?p.target, paths, total, dynlibs, dynlib_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, ctx.req.subsystem);
     A.deallocate[*u8](p.alloc, paths, total::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
@@ -623,7 +623,7 @@ test "mach.lang.build.testing:coff_final_link_discards_losing_weak_body" {
     if (bad == 0) {
         val lr: R.Result[bool, str] =
             linker.link(?s, ?tgt, ?one[0], 1, nil, 0, epath::*u8,
-                        "coff-atom-test", linker.LINK_EXE, false);
+                        "coff-atom-test", linker.LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
         if (R.is_err[bool, str](lr)) { bad = 1; }
     }
     if (bad == 0) {
@@ -638,7 +638,7 @@ test "mach.lang.build.testing:coff_final_link_discards_losing_weak_body" {
     if (bad == 0) {
         val lr: R.Result[bool, str] =
             linker.link(?s, ?tgt, ?both[0], 2, nil, 0, epath::*u8,
-                        "coff-atom-test", linker.LINK_EXE, false);
+                        "coff-atom-test", linker.LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
         if (R.is_err[bool, str](lr)) { bad = 1; }
     }
     if (bad == 0) {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -28,6 +28,7 @@ use tgt: mach.lang.target;
 use mach.lang.target.isa;
 use mach.lang.target.os;
 use mach.lang.target.abi;
+use mach.lang.target.of;
 
 # the project manifest filename, resolved relative to a project root
 pub val MANIFEST_FILE: str = "mach.toml";
@@ -84,6 +85,7 @@ pub rec ArtifactDef {
     need:         *intern.StrId;
     need_count:   u32;
     is_lib:       bool;
+    subsystem:    of.Subsystem;
 }
 
 pub rec ProfileDef {
@@ -491,6 +493,26 @@ fun parse_simd_mode(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: b
     ret R.err[SimdMode, str](simd_err(alloc, name, v));
 }
 
+# parse an artifact's OPTIONAL `subsystem` selector (#2508): the environment a
+# windows executable declares it runs under. Absent it defaults to console -- the
+# image mach has always written, so an absent key leaves the output byte-identical
+# to a build that never heard of the key. The key is accepted on every target and
+# consumed only by the PE writer, matching the manifest's existing treatment of
+# target-filtered keys. Only "console" / "gui" are valid values
+fun parse_subsystem(alloc: *A.Allocator, label: str, sub: *toml.Table) R.Result[of.Subsystem, str] {
+    val v: *toml.Value = toml.get(sub, "subsystem");
+    if (v == nil)                  { ret R.ok[of.Subsystem, str](of.SUBSYSTEM_CONSOLE); }
+    if (v.tag != toml.TYPE_STRING) { ret R.err[of.Subsystem, str](subsystem_err(alloc, label, v)); }
+    if (str_equals(v.data.string, "console")) { ret R.ok[of.Subsystem, str](of.SUBSYSTEM_CONSOLE); }
+    if (str_equals(v.data.string, "gui"))     { ret R.ok[of.Subsystem, str](of.SUBSYSTEM_GUI); }
+    ret R.err[of.Subsystem, str](subsystem_err(alloc, label, v));
+}
+
+fun subsystem_err(alloc: *A.Allocator, label: str, v: *toml.Value) str {
+    ret sfmt(alloc, "mach.toml: {}.subsystem must be \"console\" or \"gui\" (got {})",
+        label, opt_value_text(alloc, v));
+}
+
 fun simd_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
     ret sfmt(alloc, "mach.toml: profile '{}': simd must be \"scalarize\" or \"require\" (got {})",
         name, opt_value_text(alloc, v));
@@ -538,8 +560,11 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
             || str_equals(k, "platform") || str_equals(k, "base");
     }
     if (kind == TK_ARTIFACT) {
-        ret str_equals(k, "kind") || str_equals(k, "entry") || str_equals(k, "out")
-            || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need");
+        if (str_equals(k, "kind") || str_equals(k, "entry") || str_equals(k, "out")
+            || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need")) { ret true; }
+        # the optional windows `subsystem` selector (#2508); absent defaults to console
+        if (str_equals(k, "subsystem")) { ret true; }
+        ret false;
     }
     if (kind == TK_PROFILE) {
         if (str_equals(k, "opt") || str_equals(k, "debug") || str_equals(k, "simd")) { ret true; }
@@ -812,6 +837,10 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
         a.need       = need_val.items;
         a.need_count = need_val.count;
     }
+
+    val res_subsystem: R.Result[of.Subsystem, str] = parse_subsystem(alloc, label, sub);
+    if (R.is_err[of.Subsystem, str](res_subsystem)) { ret R.err[ArtifactDef, str](R.unwrap_err[of.Subsystem, str](res_subsystem)); }
+    a.subsystem = R.unwrap_ok[of.Subsystem, str](res_subsystem);
 
     ret R.ok[ArtifactDef, str](a);
 }
@@ -2309,6 +2338,45 @@ test "mach.lang.manifest.parse:float_reassoc_optional_and_off" {
         if (R.is_err[ResolvedProfile, str](re)) { code = 1; }
         or { if (R.unwrap_ok[ResolvedProfile, str](re).float_reassoc) { code = 1; } }
     }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #2508: an artifact's OPTIONAL `subsystem` selector parses to console when absent
+# -- the image mach has always written -- and to gui only when asked for. The key is
+# accepted on every target (it is the PE writer that consumes it), so no os filter
+# gates the parse, and a value outside the two spellings is a specific error rather
+# than a silent default.
+test "mach.lang.manifest.parse:subsystem_optional_and_console" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+    val art:  str = "[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[]\nneed=[]\n";
+
+    # absent -> console
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head, art));
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](a).artifacts[0].subsystem != of.SUBSYSTEM_CONSOLE) { code = 1; } }
+
+    # "gui" -> gui
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}{}", head, art, "subsystem=\"gui\"\n"));
+    if (R.is_err[Manifest, str](b)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](b).artifacts[0].subsystem != of.SUBSYSTEM_GUI) { code = 1; } }
+
+    # an explicit "console" reads the same as absence
+    val c: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}{}", head, art, "subsystem=\"console\"\n"));
+    if (R.is_err[Manifest, str](c)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](c).artifacts[0].subsystem != of.SUBSYSTEM_CONSOLE) { code = 1; } }
+
+    # an unknown spelling is the specific manifest error
+    val d: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}{}", head, art, "subsystem=\"windows\"\n"));
+    if (R.is_ok[Manifest, str](d) || !str_contains(R.unwrap_err[Manifest, str](d), "subsystem must be \"console\" or \"gui\"")) { code = 1; }
+
+    # a non-string is rejected the same way
+    val e: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}{}", head, art, "subsystem=2\n"));
+    if (R.is_ok[Manifest, str](e) || !str_contains(R.unwrap_err[Manifest, str](e), "subsystem must be \"console\" or \"gui\"")) { code = 1; }
 
     arena.dnit(?ar);
     ret code;

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -979,7 +979,7 @@ test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
 
     # enter at the image base; the raw writer rejects any other entry.
     val em: R.Result[bool, str] =
-        t.of.emit_exec(?alloc, ?itn, t.isa, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8);
+        t.of.emit_exec(?alloc, ?itn, t.isa, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -451,6 +451,18 @@ pub rec ExportSym {
     is_func: bool;
 }
 
+# the environment an executable image declares it runs under
+#
+# Only PE carries this as an image field (the optional header's Subsystem, which
+# decides whether the Windows loader attaches a console to the process); every
+# other format ignores it, so a non-windows target accepts the selection and
+# emits exactly as before. Console is zero, so a defaulted value reproduces the
+# image mach has always written.
+pub def Subsystem: u8;
+
+pub val SUBSYSTEM_CONSOLE: Subsystem = 0;
+pub val SUBSYSTEM_GUI:     Subsystem = 1;
+
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path
 #
@@ -516,9 +528,11 @@ pub def ParserFn: fun(*A.Allocator, *intern.Interner, *u8, usize, *ObjectImage) 
 # arg 12: null-terminated product name (the artifact's stable identity, independent
 #        of the `-o` output path); used as the Mach-O code-signing identifier and
 #        ignored by formats that do not sign
+# arg 13: the environment the image declares it runs under; written to the PE
+#        optional header's Subsystem field and ignored by every other format
 # ret:   true on success, or an error string
 pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
-                    *ExecFunction, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
+                    *ExecFunction, u32, *Section, u32, *u8, *u8, Subsystem) R.Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load
 # segments into a dynamically-linked executable, framing the format's
@@ -558,9 +572,11 @@ pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment
 # arg 15: null-terminated product name (the artifact's stable identity, independent
 #         of the `-o` output path); used as the Mach-O code-signing identifier and
 #         ignored by formats that do not sign
+# arg 16: the environment the image declares it runs under; written to the PE
+#         optional header's Subsystem field and ignored by every other format
 # ret:    true on success, or an error string
 pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
-                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
+                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *Section, u32, *u8, *u8, Subsystem) R.Result[bool, str];
 
 # a shared-library writer: serializes the linker's laid-out load segments into a
 # shared object (ELF `.so`, PE `.dll`, Mach-O `.dylib`), framing the format's

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -23,7 +23,7 @@
 # `coff_emit_dyn_exec` (with a dynamic-import plan). The writer frames the
 # linker's load segments in a PE container: DOS header + stub, PE signature, COFF
 # file header, the PE32+ optional header (ImageBase, SectionAlignment/
-# FileAlignment, console subsystem, data directories), the section table, and the
+# FileAlignment, the declared subsystem, data directories), the section table, and the
 # `.idata` import directory + IAT built from the `of.DynamicInfo` plan (one
 # IMAGE_IMPORT_DESCRIPTOR per DynLib, an ILT/IAT thunk per DynImport, a hint/name
 # table). Each `PltFixup` call site is redirected to an import stub that jumps
@@ -132,6 +132,7 @@ val IMAGE_FILE_LARGE_ADDRESS_AWARE: u16 = 0x0020;
 # PE32+ optional-header magic and Windows-subsystem / DLL-characteristics fields
 # the loader reads to map and start the image
 val PE32PLUS_MAGIC:                u16 = 0x020B;
+val IMAGE_SUBSYSTEM_WINDOWS_GUI:   u16 = 2;
 val IMAGE_SUBSYSTEM_WINDOWS_CUI:   u16 = 3;
 # the image opts in to ASLR (the loader maps it at a randomized base and applies the
 # `.reloc` fixups) and is compatible with hardware DEP / no-execute data pages
@@ -2684,13 +2685,15 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
 # func_count: number of entries in funcs
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (PE does not sign here)
+# subsystem:  the environment the image declares; the optional header's Subsystem
 # ret:        ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-                   func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                   func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+                   subsystem: of.Subsystem) R.Result[bool, str] {
     # a static PE carries no dynamic plan, so it resolves no interned names; the
     # interner is forwarded only so a write failure can be located on its path.
-    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, debug, debug_count, path);
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, debug, debug_count, path, subsystem);
 }
 
 # serialize laid-out load segments into a dynamically-linked
@@ -2718,13 +2721,14 @@ fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaV
 # debug_count: number of debug sections
 # path:        null-terminated output file path
 # name:        product name; accepted for of.DynExecFn conformance (PE does not sign)
+# subsystem:   the environment the image declares; the optional header's Subsystem
 # ret:         ok(true) on success, or an error string
 fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                        seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                        func_count: u32, dyn: *of.DynamicInfo,
                        fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32,
-                       path: *u8, name: *u8) R.Result[bool, str] {
-    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, debug, debug_count, path);
+                       path: *u8, name: *u8, subsystem: of.Subsystem) R.Result[bool, str] {
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, debug, debug_count, path, subsystem);
 }
 
 # the shared PE32+ executable writer behind `coff_emit_exec` (static)
@@ -2737,7 +2741,8 @@ fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.
 fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
              seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
              dyn: *of.DynamicInfo,
-             fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8) R.Result[bool, str] {
+             fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8,
+             subsystem: of.Subsystem) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("coff: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("coff: nil exec path"); }
     if (isa_vt.id != isa.ARCH_X86_64) {
@@ -2866,7 +2871,7 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     # the headers, then the section table. a position-independent image (Windows ASLR)
     # clears RELOCS_STRIPPED and sets DYNAMIC_BASE.
     val pie: bool = dyn != nil && dyn.pie;
-    write_pe_headers(buf, ?lay, segs, seg_count, entry, pie, itn, dyn, debug, debug_count);
+    write_pe_headers(buf, ?lay, segs, seg_count, entry, pie, itn, dyn, debug, debug_count, subsystem);
 
     if (debug_secs != nil) { A.deallocate[PeSection](alloc, debug_secs, debug_count::usize); }
     A.deallocate[PeSection](alloc, seg_secs, seg_count::usize);
@@ -3206,7 +3211,8 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, se
 # entry vaddr relative to ImageBase. called last so the section RVAs/offsets the
 # layout fixed are known
 fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32, entry: u64, pie: bool,
-                     itn: *intern.Interner, dyn: *of.DynamicInfo, debug: *of.Section, debug_count: u32) {
+                     itn: *intern.Interner, dyn: *of.DynamicInfo, debug: *of.Section, debug_count: u32,
+                     subsystem: of.Subsystem) {
     # DOS header: 'MZ', e_lfanew (offset 0x3C) -> the PE signature. the rest of
     # the DOS stub is left zero - Windows reads only the magic and e_lfanew.
     buf[0] = 'M'; buf[1] = 'Z';
@@ -3273,9 +3279,12 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     bin.write_u32_le(buf, oh + 60, lay.header_size::u32);
     bin.write_u32_le(buf, oh + 64, 0);
 
-    # Subsystem (console), DllCharacteristics (NX-compatible always; DYNAMIC_BASE / ASLR
-    # for a position-independent image).
-    bin.write_u16_le(buf, oh + 68, IMAGE_SUBSYSTEM_WINDOWS_CUI);
+    # Subsystem (GUI suppresses the console the loader would otherwise attach),
+    # DllCharacteristics (NX-compatible always; DYNAMIC_BASE / ASLR for a
+    # position-independent image).
+    var subsys: u16 = IMAGE_SUBSYSTEM_WINDOWS_CUI;
+    if (subsystem == of.SUBSYSTEM_GUI) { subsys = IMAGE_SUBSYSTEM_WINDOWS_GUI; }
+    bin.write_u16_le(buf, oh + 68, subsys);
     var dllchars: u16 = IMAGE_DLLCHARACTERISTICS_NX_COMPAT;
     if (pie) { dllchars = dllchars | IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE; }
     bin.write_u16_le(buf, oh + 70, dllchars);
@@ -4410,7 +4419,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffexe"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffexe"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
@@ -4452,6 +4461,76 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     if (first_rva != bin.align_up_u64(hdr_size::u64, sect_align::u64)::u32) { ret 1; }
 
     ret 0;
+}
+
+# the #2508 subsystem knob: a GUI selection stamps IMAGE_SUBSYSTEM_WINDOWS_GUI and
+# changes NOTHING else. emitting the same segments twice - once console, once GUI -
+# must produce images of equal length differing at exactly the two Subsystem bytes,
+# which proves both halves of the contract at once: the selection reaches the
+# optional header, and the console default is the image mach has always written
+test "mach.lang.target.of.coff.coff_emit_exec:subsystem_selection" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    val base:  u64 = 0x140001000;
+    val entry: u64 = base + 4;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    val cui: R.Result[Vector[u8], str] = emit_subsystem_image(?alloc, ?i, ?isa_vt, ?segs[0], entry, of.SUBSYSTEM_CONSOLE);
+    if (R.is_err[Vector[u8], str](cui)) { ret 1; }
+    val con: Vector[u8] = R.unwrap_ok[Vector[u8], str](cui);
+
+    val gr: R.Result[Vector[u8], str] = emit_subsystem_image(?alloc, ?i, ?isa_vt, ?segs[0], entry, of.SUBSYSTEM_GUI);
+    if (R.is_err[Vector[u8], str](gr)) { ret 1; }
+    val gui: Vector[u8] = R.unwrap_ok[Vector[u8], str](gr);
+
+    if (con.len != gui.len) { ret 1; }
+
+    val pe_off: usize = bin.read_u32_le(con.data, 0x3C)::usize;
+    val oh:     usize = pe_off + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE;
+    if (bin.read_u16_le(con.data, oh + 68) != IMAGE_SUBSYSTEM_WINDOWS_CUI) { ret 1; }
+    if (bin.read_u16_le(gui.data, oh + 68) != IMAGE_SUBSYSTEM_WINDOWS_GUI) { ret 1; }
+
+    # every byte outside the Subsystem field is identical.
+    var b: usize = 0;
+    for (b < con.len) {
+        if (b != oh + 68 && b != oh + 69) {
+            if (con.data[b] != gui.data[b]) { ret 1; }
+        }
+        b = b + 1;
+    }
+    ret 0;
+}
+
+# emit a one-segment static PE under `subsystem` and read it back, so the
+# subsystem test can compare two whole images byte for byte
+fun emit_subsystem_image(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
+                         segs: *of.LoadSegment, entry: u64, subsystem: of.Subsystem) R.Result[Vector[u8], str] {
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "coff_subsys");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[Vector[u8], str]("temp create failed"); }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: R.Result[bool, str] = coff_emit_exec(alloc, itn, isa_vt, segs, 1, 4096, entry, nil, 0,
+                                                 nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffsubsys"::*u8,
+                                                 subsystem);
+    if (R.is_err[bool, str](em)) {
+        fs.temp_close_and_remove(?tf);
+        ret R.err[Vector[u8], str](R.unwrap_err[bool, str](em));
+    }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    ret rb;
 }
 
 # the real #1211 path: mach's codegen stamps DT_FUNCTION on a call-target import,
@@ -4651,7 +4730,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffunwind"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "coffunwind"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
@@ -5294,7 +5373,7 @@ fun ts_pe_debug_sections() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
 
     val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry,
-                                                 nil, 0, ?dbg[0], 2, fs.temp_path(?tf)::*u8, "coffdbg"::*u8);
+                                                 nil, 0, ?dbg[0], 2, fs.temp_path(?tf)::*u8, "coffdbg"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
@@ -5422,7 +5501,7 @@ fun ts_dyn_exec_relro_naming() u8 {
     val em: R.Result[bool, str] = coff_emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 5, 4096, base,
                                                       nil::*of.ExecFunction, 0, ?dyn,
                                                       nil::*of.PltFixup, 0, nil::*of.Section, 0,
-                                                      fs.temp_path(?tf)::*u8, "coffrelro"::*u8);
+                                                      fs.temp_path(?tf)::*u8, "coffrelro"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1272,10 +1272,12 @@ fun copy_segment_bytes(buf: *u8, segs: *of.LoadSegment, seg_offsets: *usize, seg
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (ELF does not sign)
+# subsystem:  accepted for of.ExecFn conformance; ELF declares no subsystem
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+              subsystem: of.Subsystem) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil exec path"); }
 
@@ -2776,11 +2778,13 @@ fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
 # fixup_count: number of fixups
 # path:        null-terminated output file path
 # name:        product name; accepted for of.DynExecFn conformance (ELF does not sign)
+# subsystem:   accepted for of.DynExecFn conformance; ELF declares no subsystem
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                   func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
-                  fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+                  subsystem: of.Subsystem) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil dyn-exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil dyn-exec path"); }
     if (dyn == nil)     { ret R.err[bool, str]("elf: nil dynamic plan"); }
@@ -5659,7 +5663,7 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 67, 4096, 0x401000,
                                                 nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
-                                                nil::*of.Section, 0, tpath::*u8, "dynoverflow"::*u8);
+                                                nil::*of.Section, 0, tpath::*u8, "dynoverflow"::*u8, of.SUBSYSTEM_CONSOLE);
     fs.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;
@@ -5707,7 +5711,7 @@ test "mach.lang.target.of.elf.emit_exec:debug_sections_nonalloc" {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000,
-                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "elfdbg"::*u8);
+                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "elfdbg"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1720,10 +1720,12 @@ fun macho_dwarf_free(alloc: *A.Allocator, d: *MachoDwarf, debug_count: u32) {
 # func_count: number of entries in funcs (unused)
 # path:       null-terminated output file path
 # name:       null-terminated product name; the filename-stable code-sign identifier
+# subsystem:  accepted for of.ExecFn conformance; Mach-O declares no subsystem
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
-              debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+              subsystem: of.Subsystem) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
     val arch_id: u32 = isa_vt.id;
@@ -2829,11 +2831,13 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # fixup_count: number of fixups
 # path:        null-terminated output file path
 # name:        null-terminated product name; the filename-stable code-sign identifier
+# subsystem:   accepted for of.DynExecFn conformance; Mach-O declares no subsystem
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+                  subsystem: of.Subsystem) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil dyn-exec path"); }
     # the debug-section channel is framed into a non-mapped __DWARF segment placed
@@ -4299,7 +4303,7 @@ fun ts_exec_x64() u8 {
 
     # the product name is deliberately not the temp-file basename, to prove the
     # code-sign identifier tracks the name, not the output path.
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoexe"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoexe"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4375,7 +4379,7 @@ fun ts_exec_arm64() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val tpath: str = fs.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoa64"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoa64"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4501,7 +4505,7 @@ fun ts_dyn_exec(arch_id: u32) u8 {
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
                                                 nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1,
-                                                ?dbg[0], 1, tpath::*u8, "machodyn"::*u8);
+                                                ?dbg[0], 1, tpath::*u8, "machodyn"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4728,7 +4732,7 @@ fun t_emit_dyn(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTabl
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val em: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count, 0x4000, entry,
                                                 nil::*of.ExecFunction, 0, dyn, nil::*of.PltFixup, 0,
-                                                nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "machoseg"::*u8);
+                                                nil::*of.Section, 0, fs.temp_path(?tf)::*u8, "machoseg"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) {
         fs.temp_close_and_remove(?tf);
         ret R.err[Vector[u8], str](R.unwrap_err[bool, str](em));
@@ -4932,7 +4936,7 @@ fun ts_exec_merges_read_only() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 3, pg, base,
                                             nil::*of.ExecFunction, 0, nil::*of.Section, 0,
-                                            fs.temp_path(?tf)::*u8, "machoexecro"::*u8);
+                                            fs.temp_path(?tf)::*u8, "machoexecro"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
     fs.temp_close_and_remove(?tf);
@@ -5111,7 +5115,7 @@ fun ts_exec_debug_roundtrip() u8 {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
-                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "machodbg"::*u8);
+                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "machodbg"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -154,10 +154,12 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (a flat image is unsigned)
+# subsystem:  accepted for of.ExecFn conformance; a flat image declares no subsystem
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+              subsystem: of.Subsystem) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("raw: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("raw: nil exec path"); }
     # the debug-section channel is accepted for of.ExecFn conformance and ignored: a
@@ -211,11 +213,13 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # fixup_count: number of fixups
 # path:       null-terminated output file path
 # name:       product name; accepted for of.DynExecFn conformance (always unsupported)
+# subsystem:  accepted for of.DynExecFn conformance (always unsupported)
 # ret:        the unsupported-format error
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8,
+                  subsystem: of.Subsystem) R.Result[bool, str] {
     ret R.err[bool, str](RAW_UNSUPPORTED);
 }
 
@@ -333,7 +337,7 @@ test "mach.lang.target.of.raw.emit_exec:flat_layout" {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawflat"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawflat"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -399,7 +403,7 @@ test "mach.lang.target.of.raw.emit_exec:bss_is_stored_as_zeroes" {
     val tpath: str = fs.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawbss"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawbss"::*u8, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -442,7 +446,7 @@ test "mach.lang.target.of.raw.emit_exec:entry_must_be_base" {
 
     # entry 0x1008 != image base 0x1000 must be rejected.
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, nil::*of.Section, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, nil::*of.Section, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8, of.SUBSYSTEM_CONSOLE);
     if (!R.is_err[bool, str](em))                                { ret 1; }
     if (!str_contains(R.unwrap_err[bool, str](em), "base"))      { ret 1; }
     ret 0;


### PR DESCRIPTION
## What

Adds an optional `subsystem` key to `[artifact.<name>]` with a `--subsystem` CLI override, so a graphical Windows application no longer opens a console window behind it on launch.

```toml
[artifact.game]
kind = "bin"
subsystem = "gui"   # windows-only; "console" (default) | "gui"
```

Maps to `IMAGE_SUBSYSTEM_WINDOWS_GUI` (2) vs `IMAGE_SUBSYSTEM_WINDOWS_CUI` (3) in the PE32+ optional header.

## How

The selector rides the object-format layer as `of.Subsystem` and reaches the writers through the `ExecFn` / `DynExecFn` contract, the same way the product name was added. Console is zero, so a defaulted value reproduces the image mach has always written. Only the PE writer consumes it — ELF, Mach-O, and flat images declare no such field, so the key is accepted and inert off windows, matching how `[link.X]` carries filter axes on every declaration.

`compose` cannot settle the selection: an invocation may name a whole matrix, so no artifact is bound yet (#2474). It validates the flag; the planner binds each cell's artifact, settles the flag over the artifact's key onto the `BuildUnit`, and `for_cell` installs the result on the cell's request. The settled value is folded into `Q_LINK_CONFIG` (so a flip re-links instead of reusing a stale artifact) and into `request_hash` but **not** `semantic_hash` — the writer stamps it at link time, so no module's object differs.

## Verification

**Scope: structural only. No Windows binary was executed** — the emitted PEs were inspected as bytes, not run. See "Manual validation" below.

New in-source tests:
- `mach.lang.target.of.coff.coff_emit_exec:subsystem_selection` — emits the same segments console and GUI, asserting the images differ at exactly the two Subsystem bytes (proving both the selection and the unchanged default at once).
- `mach.lang.manifest.parse:subsystem_optional_and_console` — absent/console/gui plus the two rejection paths.
- `mach.lang.build.request.for_cell:swaps_selection_only` extended for the settled value.

Beyond those, a compiler built from the merge-base (`08cc7178`) and one built from this branch each emitted a windows-x86_64 PE, compared byte for byte:

| case | Subsystem | bytes differing from default |
|---|---|---|
| key absent | 3 | — (**byte-identical to the pre-change compiler**) |
| `subsystem = "gui"` | 2 | exactly 1 (the Subsystem field) |
| `--subsystem gui` | 2 | exactly 1 |
| `--subsystem console` over a `gui` key | 3 | 0 (CLI precedence) |

- **Non-windows inert**: a linux-x86_64 build with `subsystem = "gui"` and with `--subsystem gui` is byte-identical to one without.
- **Warm-cache re-link**: flipping the key without clearing `out/` correctly re-links (3 → 2 → 3). Without the `Q_LINK_CONFIG` fold this silently reused the stale binary.
- **Self-host fixpoint converged** (`b == c`), and the full corpus passes: `1082 passed, 0 failed`. Both re-confirmed after merging current `dev`.

## Manual validation (not done here)

The loader behaviour this feature exists for — a `gui` image starting with no console window attached — requires running the binary under Windows and was **not** verified. What is verified is that the optional-header Subsystem field holds the value the Windows loader reads to make that decision. A reviewer with a Windows host may want to confirm the observable behaviour once.

## Out of scope (reported, not fixed)

A trailing value flag with no value is silently ignored (`mach build . --subsystem`, and likewise `--target` / `--profile`). This is pre-existing CLI behavior — the baseline compiler does the same — so it is left alone here.

Closes #2508