### PR TITLE
fix(elf): admit x86_64's SHT_X86_64_UNWIND .eh_frame in the object reader

### DIFF
--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4603,6 +4603,110 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
     ret 0;
 }
 
+# clang/lld type `.eh_frame` SHT_X86_64_UNWIND (0x70000001) rather than gcc/gas's
+# SHT_PROGBITS. before the fix the reader admitted only SHT_PROGBITS/SHT_NOBITS,
+# so the section was dropped and `.rela.eh_frame`'s relocation resolved to
+# SECTION_EXTERNAL instead of the real section - which the linker then rejected
+# as an out-of-range section (#2516)
+test "mach.lang.target.of.elf.parse_object:x86_64_unwind_section_admitted" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var of_reg: of.OfRegistry = of.registry_init();
+    val rr: R.Result[bool, str] = register(?of_reg);
+    if (R.is_err[bool, str](rr)) { ret 1; }
+
+    var seam: isa.RelocSeam = t_seam(t_x64_elf_reloc_type::*u8);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var eh_bytes: [16]u8;
+    k = 0;
+    for (k < 16) { eh_bytes[k] = 0; k = k + 1; }
+
+    var secs: [2]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+    secs[1].name = t_intern(?i, ".eh_frame"); secs[1].kind = of.SK_RODATA;
+    secs[1].bytes = ?eh_bytes[0]; secs[1].len = 16; secs[1].align = 8;
+
+    var syms: [1]of.Symbol;
+    syms[0].name = t_intern(?i, "qz_answer"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    # the FDE's initial-location field: PC32 against the function, the shape
+    # clang/gcc both emit into `.rela.eh_frame`
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 1; relocs[0].offset = 8; relocs[0].kind = of.RK_PC32;
+    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 2;
+    img.symbols = ?syms[0]; img.symbol_count = 1;
+    img.relocations = ?relocs[0]; img.reloc_count = 1;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "elf_unwind");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    # retype `.eh_frame`'s sh_type from SHT_PROGBITS to SHT_X86_64_UNWIND - the
+    # one field that differs from the gcc/gas encoding. it is the only section
+    # here with SHF_ALLOC and no other flags (`.text` also carries SHF_EXECINSTR).
+    val e_shoff:     usize = bin.read_u64_le(buf.data, 40)::usize;
+    val e_shentsize: usize = bin.read_u16_le(buf.data, 58)::usize;
+    val e_shnum:     usize = bin.read_u16_le(buf.data, 60)::usize;
+    var eh_hdr: usize = 0;
+    var found:  bool  = false;
+    var sh: usize = 0;
+    for (sh < e_shnum) {
+        val so: usize = e_shoff + sh * e_shentsize;
+        val ty:    u32 = bin.read_u32_le(buf.data, so + 4);
+        val flags: u64 = bin.read_u64_le(buf.data, so + 8);
+        if (ty == SHT_PROGBITS && flags == SHF_ALLOC) { eh_hdr = so; found = true; }
+        sh = sh + 1;
+    }
+    if (!found) { ret 1; }
+    bin.write_u32_le(buf.data, eh_hdr + 4, SHT_X86_64_UNWIND);
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 1; }
+    if (out.section_count != 2)  { ret 1; }
+
+    var eh_idx: i32 = -1;
+    var s: u32 = 0;
+    for (s < out.section_count) {
+        if (str_equals(bin.resolve_name(?i, out.sections[s].name), ".eh_frame")) { eh_idx = s::i32; }
+        s = s + 1;
+    }
+    if (eh_idx < 0)                                     { ret 1; }
+    if (out.sections[eh_idx::u32].kind != of.SK_RODATA)  { ret 1; }
+    if (out.sections[eh_idx::u32].len != 16)             { ret 1; }
+    if (out.sections[eh_idx::u32].bytes == nil)          { ret 1; }
+
+    # the regression check: the relocation must name the real section, not the
+    # SECTION_EXTERNAL sentinel a lost sec_map entry produced before the fix.
+    if (out.reloc_count != 1)                   { ret 1; }
+    if (out.relocations[0].section != eh_idx::u32) { ret 1; }
+    ret 0;
+}
+
 # a riscv object round-trips its relocations through emit_object / parse_object: the
 # parser keys the reverse map on the object's own e_machine (243), so R_RISCV_64 (type
 # 2) reads back as RK_ABS64 and R_RISCV_PCREL_HI20 / _LO12_I as their kinds - even

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -67,9 +67,25 @@ val SHT_DYNAMIC:  u32 = 6;
 val SHT_NOBITS:   u32 = 8;
 val SHT_DYNSYM:   u32 = 11;
 
+# the processor-specific section-type range (psABI). a `sh_type` in here has no
+# fixed meaning on its own - it is defined per `e_machine`, so the reader never
+# admits the range as a group, only the specific per-arch types below that are
+# confirmed to carry ordinary section bytes the same way SHT_PROGBITS does
+val SHT_LOPROC: u32 = 0x70000000;
+val SHT_HIPROC: u32 = 0x7FFFFFFF;
+
+# x86-64 psABI: clang/lld type `.eh_frame` SHT_X86_64_UNWIND (SHT_LOPROC + 1)
+# rather than gcc/gas's SHT_PROGBITS. the bytes, alignment, and flags are
+# identical - only the type tag differs - so the reader must admit it on x86_64
+# objects the same way it admits SHT_PROGBITS
+val SHT_X86_64_UNWIND: u32 = 0x70000001;
+
 # the RISC-V build-attributes section type (SHT_LOPROC + 3). pub so the riscv64
 # ISA's `BuildAttributes` descriptor names it; the writer reads the type off the
-# descriptor rather than the arch id, the section-type analogue of `elf_machine`
+# descriptor rather than the arch id, the section-type analogue of `elf_machine`.
+# unlike SHT_X86_64_UNWIND this is not admitted by the general object reader:
+# it carries structured ULEB128 attribute records, not raw section bytes, and
+# (unlike .eh_frame) nothing relocates into it
 pub val SHT_RISCV_ATTRIBUTES: u32 = 0x70000003;
 
 # ELF section header flags
@@ -135,6 +151,12 @@ pub val R_RISCV_32_PCREL:     u32 = 57;
 # not collide with each other, but riscv reuses x86_64's low numbers with different
 # meanings, so a riscv object must be mapped through its own table
 val EM_RISCV: u16 = 243;
+
+# the ELF e_machine id for x86_64. also used to gate admission of
+# SHT_X86_64_UNWIND: the processor-specific range is per-machine, so the value
+# must not be treated as PROGBITS-equivalent on an object stamped with a
+# different e_machine
+val EM_X86_64: u16 = 62;
 
 # the format-version byte that opens an ELF build-attributes section ('A', the only
 # version defined). the same container the ARM EABI and the RISC-V psABI use, so it
@@ -3864,6 +3886,23 @@ fun bad_magic_message(itn: *intern.Interner, alloc: *A.Allocator, buf: *u8) str 
     ret fallback;
 }
 
+# true when a section of type `ty` in an object stamped with e_machine `machine`
+# carries ordinary section bytes the reader can copy verbatim, the same as
+# SHT_PROGBITS/SHT_NOBITS. the processor-specific range (SHT_LOPROC..SHT_HIPROC)
+# is per-machine, so a type in that range is admitted only through an explicit
+# per-arch allowlist below, never as a blanket range match - a type this function
+# rejects is dropped by the caller exactly as an unrecognised generic type is
+# ---
+# ty:      the section's sh_type
+# machine: the object's e_machine, disambiguating the processor-specific range
+# ret:     true if the section's bytes should be read and laid out like PROGBITS
+fun section_has_bytes(ty: u32, machine: u16) bool {
+    if (ty == SHT_PROGBITS || ty == SHT_NOBITS) { ret true; }
+    if (ty < SHT_LOPROC || ty > SHT_HIPROC) { ret false; }
+    if (machine == EM_X86_64 && ty == SHT_X86_64_UNWIND) { ret true; }
+    ret false;
+}
+
 # parse a relocatable ELF64 object into an ObjectImage
 #
 # Reads the section, symbol, and relocation tables of a `.o` produced by
@@ -3955,15 +3994,16 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
         sh = sh + 1;
     }
 
-    # count progbits/nobits sections and total relocations for allocation.
+    # count progbits/nobits (and arch-equivalent) sections and total relocations
+    # for allocation.
     var sec_n: u32 = 0;
     var rel_n: u32 = 0;
     sh = 0;
     for (sh < e_shnum) {
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
         val ty: u32 = bin.read_u32_le(buf, so + 4);
-        if (ty == SHT_PROGBITS || ty == SHT_NOBITS) { sec_n = sec_n + 1; }
-        if (ty == SHT_RELA)                         { rel_n = rel_n + (bin.read_u64_le(buf, so + 32)::usize / RELA_SIZE)::u32; }
+        if (section_has_bytes(ty, e_machine)) { sec_n = sec_n + 1; }
+        if (ty == SHT_RELA)                   { rel_n = rel_n + (bin.read_u64_le(buf, so + 32)::usize / RELA_SIZE)::u32; }
         sh = sh + 1;
     }
     val sym_n: u32 = symtab_count;
@@ -4018,7 +4058,7 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
         sec_map[sh] = -1;
         val so: usize = e_shoff + sh::usize * e_shentsize::usize;
         val ty: u32 = bin.read_u32_le(buf, so + 4);
-        if (ty == SHT_PROGBITS || ty == SHT_NOBITS) {
+        if (section_has_bytes(ty, e_machine)) {
             val flags: u64 = bin.read_u64_le(buf, so + 8);
 
             var sec_name: str = "";
@@ -4195,10 +4235,9 @@ fun t_intern(itn: *intern.Interner, s: str) intern.StrId {
     ret R.unwrap_ok[intern.StrId, str](r);
 }
 
-# the ELF e_machine ids the writer tests stamp their vtables with. EM_RISCV is
-# declared above because the production reverse parse map keys on it; these two are
-# needed only to describe a test vtable honestly
-val EM_X86_64:  u16 = 62;
+# the ELF e_machine id the writer tests stamp aarch64 test vtables with.
+# EM_RISCV and EM_X86_64 are declared above because production code keys on
+# them; this one is needed only to describe a test vtable honestly
 val EM_AARCH64: u16 = 183;
 
 # an ISA vtable that describes an architecture and binds no back half (test helper)


### PR DESCRIPTION
## Summary

clang/lld type `.eh_frame` `SHT_X86_64_UNWIND` (`SHT_LOPROC + 1` = `0x70000001`) rather than gcc/gas's `SHT_PROGBITS`. The ELF reader's section-type admission predicate (`parse_object`'s counting and populate passes) admitted only `SHT_PROGBITS`/`SHT_NOBITS`, so a clang-emitted `.eh_frame` was silently dropped, leaving its `.rela.eh_frame` relocation pointing at no section — the linker then rejected the object with `relocation names an out-of-range section`.

- Root cause confirmed independently (not just from the filed diagnosis): compiled the repro's `qz.c` with both gcc and clang and inspected section headers with `readelf` — `.eh_frame` is `PROGBITS` for gcc, `X86_64_UNWIND` for clang.
- Fix: a new `section_has_bytes(ty, machine)` predicate replaces the two `ty == SHT_PROGBITS || ty == SHT_NOBITS` admission sites. It admits `SHT_PROGBITS`/`SHT_NOBITS` unconditionally, and admits a processor-specific type (`SHT_LOPROC..SHT_HIPROC`) only through an explicit per-`e_machine` allowlist — currently just `SHT_X86_64_UNWIND` on `x86_64` — never the whole range.
- Checked the other two ISAs mach targets for an analogous rejection: cross-compiled the repro with `clang --target=aarch64-linux-gnu` and `--target=riscv64-linux-gnu`. Both type `.eh_frame` as plain `SHT_PROGBITS` — no fix needed there. riscv64's one real processor-specific section, `SHT_RISCV_ATTRIBUTES` (`.riscv.attributes`), is non-`SHF_ALLOC` structured attribute data (not PROGBITS-equivalent program bytes) and nothing relocates into it, so it correctly stays unadmitted — it's unrelated to this bug and out of scope.
- Regression test in the existing `parse_object` unit-test style: builds a synthetic object with an `.eh_frame`-named section, retypes it to `SHT_X86_64_UNWIND` post-emit (mirroring what clang actually produces), and asserts the section survives and its relocation resolves to the real section rather than the `SECTION_EXTERNAL` sentinel a lost `sec_map` entry produced before the fix.

## Verification

- `mach build . -o a && ./a build . -o b && ./b build . -o c && cmp b c` — fixpoint converges (matches CI's `build-linux` job).
- `./c test .` — 1081 passed, 0 failed (including the new test; `mach.lang.target.of.elf` went from 27 to 28).
- End-to-end, using the fixed compiler against a minimal project (`ext fun qz_answer() i32;`):
  - unfixed installed `mach` (4.4.0): `clang.o` reproduces `error: linker: relocation names an out-of-range section`; `clang.a` (archive-wrapped) reproduces the same.
  - fixed compiler: `clang.o`, `clang.a`, and `gcc.o` all link and the program exits with `42` (the C function's return value) in every case.

Closes #2516