### PR TITLE
fix(link): key relocations by symbol index, not by symbol name

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -329,37 +329,36 @@ fun pack_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_symbols));
     }
 
-    val res_relocs: R.Result[bool, str] = pack_relocs(?image, enc, text_sec, placements, placement_count);
+    # relocations are recorded by target name and bound to symbol indices only
+    # after pack_globals, because a global's aggregate initializer may point at a
+    # global that pass has not packed yet. binding also declares any target no
+    # pass defined, which is what makes it genuinely external.
+    var deferred: obj.DeferredRelocs = obj.deferred_init(s.alloc);
+
+    val res_relocs: R.Result[bool, str] = pack_relocs(?deferred, enc, text_sec, placements, placement_count);
     # re-home the retained PC<->source rows the same way symbols are, while the
     # placements are still live, so the #1699 line producer reads final section
     # offsets. infallible (in-place offset math), so no error to thread.
     pack_rows(enc, placements, placement_count, text_sec);
     if (placements != nil) { A.deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
     if (R.is_err[bool, str](res_relocs)) {
+        obj.deferred_dnit(?deferred);
         obj.dnit(?image);
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_relocs));
     }
 
-    val res_globals: R.Result[bool, str] = pack_globals(s, tgt, ?image, irmod);
+    val res_globals: R.Result[bool, str] = pack_globals(s, tgt, ?image, ?deferred, irmod);
     if (R.is_err[bool, str](res_globals)) {
+        obj.deferred_dnit(?deferred);
         obj.dnit(?image);
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_globals));
     }
 
-    val res_reloc_externs: R.Result[bool, str] = pack_reloc_externs(?image, enc);
-    if (R.is_err[bool, str](res_reloc_externs)) {
+    val res_bind: R.Result[bool, str] = obj.flush_deferred(?image, ?deferred);
+    obj.deferred_dnit(?deferred);
+    if (R.is_err[bool, str](res_bind)) {
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_reloc_externs));
-    }
-
-    # an aggregate constant's `&G` / function-pointer leaf may target a symbol
-    # defined in another module (cross-object reference). every such data-section
-    # relocation target that this object has not defined is declared undefined so
-    # the linker binds it - the data analog of pack_reloc_externs.
-    val res_data_externs: R.Result[bool, str] = pack_data_reloc_externs(?image);
-    if (R.is_err[bool, str](res_data_externs)) {
-        obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_data_externs));
+        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_bind));
     }
 
     # when `-g` is on and the target resolved a debug-info producer (elf / mach-o ->
@@ -513,20 +512,23 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
     ret R.ok[bool, str](true);
 }
 
-# attach every pending relocation from the encoder to its section
+# record every pending relocation from the encoder against its section
 #
 # The encoder tags each relocation with its abstract kind (`of.RK_*`) and the
 # interned target-symbol name; the format writer maps the kind to its machine
 # type at emit time. The symbol target is unchanged (resolved by the linker), so
-# a cross-section call from a re-homed site just works.
+# a cross-section call from a re-homed site just works. A target this image never
+# defines - a symbol named only from an inline-asm body, like the entry `main`
+# called from the runtime `_start` asm - is declared a STT_FUNC extern when the
+# records bind.
 # ---
-# image:           object image being built
+# deferred:        out - the recorded relocations, bound once symbols are complete
 # enc:             encoder output supplying the pending relocations
 # text_sec:        index of the `.text` section a non-sectioned site patches
 # placements:      the sectioned-function ranges, in increasing text offset
 # placement_count: number of placements
 # ret:             true on success, or an error string
-fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
+fun pack_relocs(deferred: *obj.DeferredRelocs, enc: *encode.EncoderOutput,
                 text_sec: u32, placements: *SectionPlacement, placement_count: u32) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < enc.reloc_count) {
@@ -534,14 +536,15 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
 
         val site: PlacedSite = site_placed(placements, placement_count, text_sec, pr.offset);
 
-        var rel: of.Relocation;
-        rel.section = site.sec;
-        rel.offset  = site.off;
-        rel.kind    = pr.kind;
-        rel.symbol  = pr.sym;
-        rel.addend  = pr.addend::i64;
+        var rec: obj.DeferredReloc;
+        rec.section      = site.sec;
+        rec.offset       = site.off;
+        rec.kind         = pr.kind;
+        rec.name         = pr.sym;
+        rec.addend       = pr.addend::i64;
+        rec.extern_flags = of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
 
-        val res_rel: R.Result[bool, str] = obj.add_relocation(image, rel);
+        val res_rel: R.Result[bool, str] = obj.defer_relocation(deferred, rec);
         if (R.is_err[bool, str](res_rel)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](res_rel));
         }
@@ -633,7 +636,7 @@ fun section_bytes_copy(image: *of.ObjectImage, src: *u8, len: u32) R.Result[*u8,
 }
 
 fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImage,
-                 irmod: *ir.Module) R.Result[bool, str] {
+                 deferred: *obj.DeferredRelocs, irmod: *ir.Module) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < irmod.global_len) {
         val g: *ir.Global = ?irmod.globals[i];
@@ -646,7 +649,7 @@ fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImag
             # GLOBAL binding is required: an undefined symbol the linker resolves
             # against another object's definition cannot be local. without it the
             # ELF writer emits STB_LOCAL and the reference fails to bind. matches
-            # the extern function decls and pack_data_reloc_externs.
+            # the extern function decls and the deferred-relocation binding.
             val flags: u32 = of.SYM_OBJ_FLAG_OBJECT | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
             val res_extern: R.Result[bool, str] = image_extern_symbol_add(image, g.name, flags);
             if (R.is_err[bool, str](res_extern)) { ret res_extern; }
@@ -823,7 +826,7 @@ fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImag
         # rodata global already packed in this same loop). the ELF writer emits a
         # `.rela.<section>` for any section carrying these.
         if (g.init.kind == value.VAL_CONST_AGG) {
-            val res_agg: R.Result[bool, str] = pack_agg_relocs(image, ?g.init, sec_idx);
+            val res_agg: R.Result[bool, str] = pack_agg_relocs(deferred, ?g.init, sec_idx);
             if (R.is_err[bool, str](res_agg)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_agg)); }
         }
         i = i + 1;
@@ -837,90 +840,32 @@ fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImag
 # address of its target symbol plus the recorded addend. The abstract abs64 kind
 # is format-independent, so no target is needed.
 # ---
-# image:   object image being built
-# init:    the VAL_CONST_AGG initializer carrying the side-table
-# sec_idx: index of the section the relocations patch
-# ret:     true on success, or an error string
-fun pack_agg_relocs(image: *of.ObjectImage, init: *value.Value, sec_idx: u32) R.Result[bool, str] {
+# deferred: out - the recorded relocations, bound once symbols are complete
+# init:     the VAL_CONST_AGG initializer carrying the side-table
+# sec_idx:  index of the section the relocations patch
+# ret:      true on success, or an error string
+fun pack_agg_relocs(deferred: *obj.DeferredRelocs, init: *value.Value, sec_idx: u32) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < init.data.agg.reloc_count) {
         val ar: *value.AggReloc = ?init.data.agg.relocs[i];
 
-        var rel: of.Relocation;
-        rel.section = sec_idx;
-        rel.offset  = ar.offset;
-        rel.kind    = of.RK_ABS64;
-        rel.symbol  = ar.symbol;
-        rel.addend  = ar.addend;
+        # a leaf may name a symbol packed later in this same pass, or one defined
+        # in another module entirely; either way the record binds after every
+        # defining pass has run. the leaf's own flavour picks the flags the target
+        # is declared with if it turns out to be the cross-module case.
+        var flags: u32 = of.SYM_OBJ_FLAG_OBJECT | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
+        if (ar.is_fn) { flags = of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL; }
 
-        val res_rel: R.Result[bool, str] = obj.add_relocation(image, rel);
+        var rec: obj.DeferredReloc;
+        rec.section      = sec_idx;
+        rec.offset       = ar.offset;
+        rec.kind         = of.RK_ABS64;
+        rec.name         = ar.symbol;
+        rec.addend       = ar.addend;
+        rec.extern_flags = flags;
+
+        val res_rel: R.Result[bool, str] = obj.defer_relocation(deferred, rec);
         if (R.is_err[bool, str](res_rel)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_rel)); }
-
-        # a function-pointer leaf targeting a symbol this object has not defined is
-        # a cross-module reference: declare a STT_FUNC extern stub now. every local
-        # function is already defined (pack_symbols ran before pack_globals), so an
-        # undefined fn-target is genuinely external. object (global) targets are
-        # left to pack_data_reloc_externs, which a later-packed global may still
-        # define.
-        if (ar.is_fn && ar.symbol != intern.STR_NIL && !image_has_symbol(image, ar.symbol)) {
-            val flags: u32 = of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
-            val res_extern: R.Result[bool, str] = image_extern_symbol_add(image, ar.symbol, flags);
-            if (R.is_err[bool, str](res_extern)) { ret res_extern; }
-        }
-        i = i + 1;
-    }
-    ret R.ok[bool, str](true);
-}
-
-# declare an undefined extern symbol for every function-relocation target this
-# image references but has not declared
-#
-# Covers a symbol named only from an inline-asm body (e.g. the entry `main`,
-# called from the runtime `_start` asm), which leaves no IR function or global
-# declaration for the earlier symbol passes to catch. Without a matching
-# symbol-table entry the object writer would map the relocation to the null
-# symbol (index 0), so the linker would see no target name. A target already
-# defined or declared here is left alone, so a symbol is never declared twice.
-# ---
-# image: object image being built (its symbol table already holds every defined
-#        and IR-declared extern symbol)
-# enc:   encoder output supplying the pending relocations
-# ret:   true on success, or an error string
-fun pack_reloc_externs(image: *of.ObjectImage, enc: *encode.EncoderOutput) R.Result[bool, str] {
-    var i: u32 = 0;
-    for (i < enc.reloc_count) {
-        val name: intern.StrId = enc.relocations[i].sym;
-        if (name == intern.STR_NIL)        { i = i + 1; cnt; }
-        if (image_has_symbol(image, name)) { i = i + 1; cnt; }
-
-        val flags: u32 = of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
-        val res_extern: R.Result[bool, str] = image_extern_symbol_add(image, name, flags);
-        if (R.is_err[bool, str](res_extern)) { ret res_extern; }
-        i = i + 1;
-    }
-    ret R.ok[bool, str](true);
-}
-
-# declare an undefined extern symbol for every data-relocation target this image
-# references but has not defined
-#
-# Covers aggregate-constant data relocations whose `&G` / function-pointer leaf
-# names a symbol defined in another module; a target already defined or declared
-# here is left alone (no double declaration). The data analog of
-# pack_reloc_externs.
-# ---
-# image: object image being built (its symbol table holds every defined symbol)
-# ret:   true on success, or an error string
-fun pack_data_reloc_externs(image: *of.ObjectImage) R.Result[bool, str] {
-    var i: u32 = 0;
-    for (i < image.reloc_count) {
-        val name: intern.StrId = image.relocations[i].symbol;
-        if (name == intern.STR_NIL)        { i = i + 1; cnt; }
-        if (image_has_symbol(image, name)) { i = i + 1; cnt; }
-
-        val flags: u32 = of.SYM_OBJ_FLAG_OBJECT | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
-        val res_extern: R.Result[bool, str] = image_extern_symbol_add(image, name, flags);
-        if (R.is_err[bool, str](res_extern)) { ret res_extern; }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1027,21 +972,6 @@ fun image_extern_symbol_add(image: *of.ObjectImage, name: intern.StrId, flags: u
     val res_sym: R.Result[u32, str] = obj.add_symbol(image, sym);
     if (R.is_err[u32, str](res_sym)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_sym)); }
     ret R.ok[bool, str](true);
-}
-
-# true when the image's symbol table already holds a symbol named `name`
-# (defined here or already declared extern)
-# ---
-# image: object image being searched
-# name:  the symbol name to match
-# ret:   true when a symbol of that name is present
-fun image_has_symbol(image: *of.ObjectImage, name: intern.StrId) bool {
-    var i: u32 = 0;
-    for (i < image.symbol_count) {
-        if (image.symbols[i].name == name) { ret true; }
-        i = i + 1;
-    }
-    ret false;
 }
 
 # resolve the section and offset an encoder-blob site maps to after excision

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -2561,11 +2561,20 @@ fun add_reloc(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind,
 # ret:    ok(true), or an allocation error
 fun add_reloc_addend(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind,
                      sym: intern.StrId, addend: i64) R.Result[bool, str] {
+    # every debug relocation targets a symbol this image already carries: a
+    # function packed before the producer ran, or a section anchor the producer
+    # itself added. a target that is not there is a producer bug, not a symbol to
+    # declare extern.
+    val sym_ix: u32 = obj.symbol_index(image, sym);
+    if (sym_ix == of.SYMBOL_NONE) {
+        ret R.err[bool, str]("dwarf: relocation target absent from the image symbol table");
+    }
+
     var rel: of.Relocation;
     rel.section = sec;
     rel.offset  = offset;
     rel.kind    = kind;
-    rel.symbol  = sym;
+    rel.sym     = sym_ix;
     rel.addend  = addend;
     ret obj.add_relocation(image, rel);
 }

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -2512,9 +2512,9 @@ fun gather_funcs(image: *of.ObjectImage, mirmod: *mir.MirModule, text_sec: u32, 
     }
 }
 
-# intern "<base>#suffix", a per-module-unique local name for a debug-section anchor
-# (the linker keys relocations on the symbol name, so the anchor must not collide
-# across objects)
+# intern "<base>#suffix", a per-module-unique name for a debug-section anchor
+# (global targets resolve across objects by symbol name, so the anchor must not
+# collide across objects)
 # ---
 # itn:     the session interner
 # base:    the module name text
@@ -3875,9 +3875,9 @@ fun install(s: *session.Session, image: *of.ObjectImage, itn: *intern.Interner,
     ret R.ok[bool, str](true);
 }
 
-# add a per-module-unique GLOBAL anchor symbol at offset 0 of a debug section (the
-# linker keys relocations on the symbol name, so relocs into a concatenated debug
-# section resolve to this module's contribution)
+# add a per-module-unique GLOBAL anchor symbol at offset 0 of a debug section
+# (global targets resolve across objects by symbol name, so relocs into a
+# concatenated debug section resolve to this module's contribution)
 # ---
 # image: the object image
 # name:  the interned anchor name

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4659,7 +4659,7 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     val tpath: str = fs.temp_path(?tf);
 
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, tpath::*u8, "anon_section_syms"::*u8, LINK_EXE, false);
+        link_modules(?s, ?tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, tpath::*u8, "anon_section_syms"::*u8, LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -4690,6 +4690,124 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     # by matching two unwritten fields.
     if (via_section == 0 || via_name == 0)  { vector.dnit[u8](?b); ret 1; }
     if (via_section != via_name)            { vector.dnit[u8](?b); ret 1; }
+
+    vector.dnit[u8](?b);
+    session.dnit(?s);
+    ret 0;
+}
+
+# coff section symbols carry their section name rather than elf's empty name, but
+# two input sections may still have the same name. prove the pe path keeps those
+# local identities distinct: each section-symbol relocation must equal a unique
+# named anchor in the same input section, and the two sections must not alias.
+test "mach.lang.be.linker.patch_relocations:duplicate_coff_section_symbols_stay_distinct" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] =
+        target.select(?reg, "x86_64", "windows", "win64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val text: intern.StrId = lt_name(?s, ".text");
+    val rdata: intern.StrId = lt_name(?s, ".rdata");
+    val data: intern.StrId = lt_name(?s, ".data");
+    val anchor_a: intern.StrId = lt_name(?s, "rdata_anchor_a");
+    val anchor_b: intern.StrId = lt_name(?s, "rdata_anchor_b");
+    val entry: intern.StrId = lt_name(?s, tgt.os.entry_symbol);
+    if (text == intern.STR_NIL || rdata == intern.STR_NIL || data == intern.STR_NIL) { ret 1; }
+    if (anchor_a == intern.STR_NIL || anchor_b == intern.STR_NIL
+        || entry == intern.STR_NIL) { ret 1; }
+
+    var tb: [16]u8;
+    var ra: [16]u8;
+    var rb: [16]u8;
+    var db: [40]u8;
+    var i: u32 = 0;
+    for (i < 16) { tb[i] = 0x90; ra[i] = 0xA1; rb[i] = 0xB2; i = i + 1; }
+    i = 0;
+    for (i < 40) { db[i] = 0; i = i + 1; }
+    i = 0;
+    for (i < 8) { db[i] = 0xEE; i = i + 1; }
+
+    var secs: [4]of.Section;
+    secs[0].name = text;  secs[0].kind = of.SK_TEXT;   secs[0].bytes = ?tb[0];
+    secs[0].len = 16; secs[0].align = 16;
+    secs[1].name = rdata; secs[1].kind = of.SK_RODATA; secs[1].bytes = ?ra[0];
+    secs[1].len = 16; secs[1].align = 16;
+    secs[2].name = rdata; secs[2].kind = of.SK_RODATA; secs[2].bytes = ?rb[0];
+    secs[2].len = 16; secs[2].align = 16;
+    secs[3].name = data;  secs[3].kind = of.SK_DATA;   secs[3].bytes = ?db[0];
+    secs[3].len = 40; secs[3].align = 8;
+
+    var syms: [5]of.Symbol;
+    syms[0].name = rdata; syms[0].section = 1; syms[0].offset = 0;
+    syms[0].size = 0; syms[0].flags = 0;
+    syms[1].name = rdata; syms[1].section = 2; syms[1].offset = 0;
+    syms[1].size = 0; syms[1].flags = 0;
+    syms[2].name = anchor_a; syms[2].section = 1; syms[2].offset = 8;
+    syms[2].size = 0; syms[2].flags = 0;
+    syms[3].name = anchor_b; syms[3].section = 2; syms[3].offset = 8;
+    syms[3].size = 0; syms[3].flags = 0;
+    syms[4].name = entry;    syms[4].section = 0; syms[4].offset = 0; syms[4].size = 16;
+    syms[4].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var relocs: [4]of.Relocation;
+    relocs[0].section = 3; relocs[0].offset = 8;  relocs[0].kind = of.RK_ABS64;
+    relocs[0].sym = 0; relocs[0].addend = 8;
+    relocs[1].section = 3; relocs[1].offset = 16; relocs[1].kind = of.RK_ABS64;
+    relocs[1].sym = 2; relocs[1].addend = 0;
+    relocs[2].section = 3; relocs[2].offset = 24; relocs[2].kind = of.RK_ABS64;
+    relocs[2].sym = 1; relocs[2].addend = 8;
+    relocs[3].section = 3; relocs[3].offset = 32; relocs[3].kind = of.RK_ABS64;
+    relocs[3].sym = 3; relocs[3].addend = 0;
+
+    var mods: [1]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "coff_section_syms"), ?secs[0], 4,
+                       ?syms[0], 5, ?relocs[0], 4);
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_section_syms");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val lr: R.Result[bool, str] =
+        link_modules(?s, ?tgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, tpath::*u8,
+                     "coff_section_syms"::*u8, LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
+    if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rr)) { ret 1; }
+    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+
+    var site: usize = b.len;
+    var scan: usize = 0;
+    for (scan + 40 <= b.len) {
+        if (b.data[scan] == 0xEE && b.data[scan + 7] == 0xEE) { site = scan; scan = b.len; }
+        or { scan = scan + 1; }
+    }
+    if (site + 40 > b.len) { vector.dnit[u8](?b); ret 1; }
+
+    var values: [4]u64;
+    var v: u32 = 0;
+    for (v < 4) {
+        i = 0;
+        for (i < 8) {
+            values[v] = values[v] | (b.data[site + 8 + v::usize * 8 + i::usize]::u64 << (i * 8));
+            i = i + 1;
+        }
+        v = v + 1;
+    }
+
+    if (values[0] == 0 || values[2] == 0) { vector.dnit[u8](?b); ret 1; }
+    if (values[0] != values[1] || values[2] != values[3]) { vector.dnit[u8](?b); ret 1; }
+    if (values[0] == values[2]) { vector.dnit[u8](?b); ret 1; }
 
     vector.dnit[u8](?b);
     session.dnit(?s);

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4653,6 +4653,53 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     var mods: [1]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "anon_secs"), ?secs[0], 3, ?syms[0], 4, ?relocs[0], 2);
 
+    # the relocatable path must remap each input symbol index into the merged
+    # image before the format writer serializes it. round-trip that output through
+    # elf and prove the anonymous target still names rodata rather than the first
+    # empty-name symbol in text.
+    val etr: R.Result[target.Target, str] =
+        target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[target.Target, str](etr)) { ret 1; }
+    var etgt: target.Target = R.unwrap_ok[target.Target, str](etr);
+
+    val otf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "anon_section_obj");
+    if (R.is_err[fs.TempFile, str](otf_r)) { ret 1; }
+    var otf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](otf_r);
+    val opath: str = fs.temp_path(?otf);
+    val olr: R.Result[bool, str] =
+        link_modules(?s, ?etgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, opath::*u8,
+                     "anon_section_obj"::*u8, LINK_RELOCATABLE, false,
+                     of.SUBSYSTEM_CONSOLE);
+    if (R.is_err[bool, str](olr)) { fs.temp_close_and_remove(?otf); ret 1; }
+
+    val orb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, opath);
+    fs.temp_close_and_remove(?otf);
+    if (R.is_err[Vector[u8], str](orb)) { ret 1; }
+    var ob: Vector[u8] = R.unwrap_ok[Vector[u8], str](orb);
+    var carried: of.ObjectImage;
+    val opr: R.Result[bool, str] =
+        etgt.of.parse_object(?alloc, ?s.interner, ob.data, ob.len, ?carried);
+    if (R.is_err[bool, str](opr)) { vector.dnit[u8](?ob); ret 1; }
+
+    var saw_section: bool = false;
+    var saw_anchor: bool = false;
+    var cr: u32 = 0;
+    for (cr < carried.reloc_count) {
+        val rr: *of.Relocation = ?carried.relocations[cr];
+        if (rr.sym >= carried.symbol_count) { obj.dnit(?carried); vector.dnit[u8](?ob); ret 1; }
+        val cs: *of.Symbol = ?carried.symbols[rr.sym];
+        if (cs.section >= carried.section_count
+            || carried.sections[cs.section].kind != of.SK_RODATA) {
+            obj.dnit(?carried); vector.dnit[u8](?ob); ret 1;
+        }
+        if (rr.addend == 8 && cs.name == anon && cs.offset == 0) { saw_section = true; }
+        if (rr.addend == 0 && cs.name == anchor && cs.offset == 8) { saw_anchor = true; }
+        cr = cr + 1;
+    }
+    obj.dnit(?carried);
+    vector.dnit[u8](?ob);
+    if (!saw_section || !saw_anchor) { ret 1; }
+
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "anon_section_syms");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -516,6 +516,14 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     init_merged(merged, debug_names, debug_count);
     var merged_to_out: *u32 = nil;
 
+    # the input-symbol -> merged-image-symbol map, indexed by (module, symbol) via
+    # `sym_base`'s prefix sum. filled by build_merged_image and read by relocation
+    # carry, which rewrites each carried relocation's target index into the merged
+    # image's own symbol space.
+    val sym_total: u32 = total_symbols(modules, module_count);
+    var sym_base: *u32 = nil;
+    var sym_out:  *u32 = nil;
+
     # first pass over every input section: tally per-kind length and alignment,
     # and remember each input section's placement (merged index + offset). the
     # placements live in a flat array indexed by (module, section) via a prefix
@@ -525,7 +533,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (sec_total > 0) {
         val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
         if (R.is_err[*Placement, str](pr)) {
-            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
             ret R.err[bool, str](R.unwrap_err[*Placement, str](pr));
         }
         placements = R.unwrap_ok[*Placement, str](pr);
@@ -535,10 +543,27 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     var sec_base: *u32 = nil;
     val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
     if (R.is_err[*u32, str](br)) {
-        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[*u32, str](br));
     }
     sec_base = R.unwrap_ok[*u32, str](br);
+
+    val syb_r: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
+    if (R.is_err[*u32, str](syb_r)) {
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
+        ret R.err[bool, str](R.unwrap_err[*u32, str](syb_r));
+    }
+    sym_base = R.unwrap_ok[*u32, str](syb_r);
+    fill_symbol_bases(modules, module_count, sym_base);
+
+    if (sym_total > 0) {
+        val syo_r: R.Result[*u32, str] = A.zallocate[u32](alloc, sym_total::usize);
+        if (R.is_err[*u32, str](syo_r)) {
+            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
+            ret R.err[bool, str](R.unwrap_err[*u32, str](syo_r));
+        }
+        sym_out = R.unwrap_ok[*u32, str](syo_r);
+    }
 
     # Final executable/shared links may discard only function atoms whose weak
     # definition actually lost global resolution. A relocatable link receives an
@@ -547,7 +572,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         build_atom_plan(s, modules, module_count, codegen_count, sec_base,
                         sec_total, patching, tgt.isa, ?atoms);
     if (R.is_err[bool, str](atom_r)) {
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](atom_r));
     }
 
@@ -555,7 +580,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         accumulate_sections(s, modules, module_count, merged, debug_names, debug_count,
                             placements, sec_base, ?strm, ?atoms);
     if (R.is_err[bool, str](acc_r)) {
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
@@ -566,7 +591,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (tgt.of.produces_image && mode == LINK_EXE) {
         val ei_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.entry_symbol);
         if (R.is_err[intern.StrId, str](ei_r)) {
-            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
             ret R.err[bool, str](R.unwrap_err[intern.StrId, str](ei_r));
         }
         reorder_flat_entry_first(modules, module_count, merged, placements, sec_base,
@@ -593,7 +618,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                         assign_vaddrs, ?atoms);
     if (R.is_err[bool, str](collect_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](collect_r));
     }
 
@@ -603,7 +628,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val img_r: R.Result[of.ObjectImage, str] = obj.init(alloc, ?s.interner, image_name(modules, module_count));
     if (R.is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](img_r));
     }
     out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
@@ -614,18 +639,18 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[*u32, str](mto_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[*u32, str](mto_r));
     }
     merged_to_out = R.unwrap_ok[*u32, str](mto_r);
 
     val build_r: R.Result[bool, str] =
         build_merged_image(s, ?out_img, modules, module_count, merged, merged_count,
-                           placements, sec_base, merged_to_out, ?strm, ?atoms);
+                           placements, sec_base, merged_to_out, sym_base, sym_out, ?strm, ?atoms);
     if (R.is_err[bool, str](build_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
@@ -652,7 +677,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
             }
         }
@@ -665,7 +690,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
             ret R.err[bool, str](R.unwrap_err[bool, str](patch_r));
         }
 
@@ -683,7 +708,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         free_dynstate(alloc, ?dyn);
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
 
         if (R.is_err[bool, str](emit_r)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
@@ -694,11 +719,12 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # library (relocatable): carry the input relocations forward unpatched and
     # write the single merged object through the format's object writer.
     val carry_r: R.Result[bool, str] =
-        carry_relocations(?out_img, modules, module_count, placements, sec_base, merged_to_out);
+        carry_relocations(?out_img, modules, module_count, placements, sec_base, merged_to_out,
+                          sym_base, sym_out);
     if (R.is_err[bool, str](carry_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
         ret R.err[bool, str](R.unwrap_err[bool, str](carry_r));
     }
 
@@ -706,7 +732,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
 
     obj.dnit(?out_img);
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, ?strm, ?atoms);
+    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms);
 
     if (R.is_err[bool, str](obj_r)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](obj_r));
@@ -2013,29 +2039,6 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         var rw: u32 = 0;
         m = 0;
         for (m < module_count) {
-            var locals: map.Map[intern.StrId, u32] =
-                map.init[intern.StrId, u32](s.alloc, map.hash_u32, map.eq_u32);
-            var sy: u32 = 0;
-            for (sy < modules[m].symbol_count) {
-                val local: *of.Symbol = ?modules[m].symbols[sy];
-                if (local.section != of.SECTION_EXTERNAL
-                    && local.section < modules[m].section_count
-                    && (local.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0
-                    && R.is_err[*u32, str](map.get[intern.StrId, u32](?locals, ?local.name))) {
-                    val li: R.Result[bool, str] =
-                        map.insert[intern.StrId, u32](?locals, local.name, sy);
-                    if (R.is_err[bool, str](li)) {
-                        map.dnit[intern.StrId, u32](?locals);
-                        map.dnit[intern.StrId, AtomWinner](?winners);
-                        A.deallocate[AtomRelocRef](s.alloc, refs, reloc_total::usize);
-                        A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
-                        A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-                        ret R.err[bool, str](R.unwrap_err[bool, str](li));
-                    }
-                }
-                sy = sy + 1;
-            }
-
             var ri: u32 = 0;
             for (ri < modules[m].reloc_count) {
                 refs[rw].target_section = 0xFFFFFFFF;
@@ -2062,19 +2065,25 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 refs[rw].text_bias_max = traits.text_bias_max;
 
                 val r: *of.Relocation = ?modules[m].relocations[ri];
-                val lr: R.Result[*u32, str] =
-                    map.get[intern.StrId, u32](?locals, ?r.symbol);
-                if (R.is_ok[*u32, str](lr)) {
-                    refs[rw].target_module = m;
-                    refs[rw].target_symbol = @R.unwrap_ok[*u32, str](lr);
-                }
-                or {
-                    val wr: R.Result[*AtomWinner, str] =
-                        map.get[intern.StrId, AtomWinner](?winners, ?r.symbol);
-                    if (R.is_ok[*AtomWinner, str](wr)) {
-                        val winner: *AtomWinner = R.unwrap_ok[*AtomWinner, str](wr);
-                        refs[rw].target_module = winner.module;
-                        refs[rw].target_symbol = winner.symbol;
+                # an object-private target is module `m`'s own symbol, named by
+                # index; a global (or extern) target resolves to the cross-object
+                # winner by name.
+                if (r.sym < modules[m].symbol_count) {
+                    val target_sym: *of.Symbol = ?modules[m].symbols[r.sym];
+                    if ((target_sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0
+                        && target_sym.section != of.SECTION_EXTERNAL
+                        && target_sym.section < modules[m].section_count) {
+                        refs[rw].target_module = m;
+                        refs[rw].target_symbol = r.sym;
+                    }
+                    or {
+                        val wr: R.Result[*AtomWinner, str] =
+                            map.get[intern.StrId, AtomWinner](?winners, ?target_sym.name);
+                        if (R.is_ok[*AtomWinner, str](wr)) {
+                            val winner: *AtomWinner = R.unwrap_ok[*AtomWinner, str](wr);
+                            refs[rw].target_module = winner.module;
+                            refs[rw].target_symbol = winner.symbol;
+                        }
                     }
                 }
                 if (refs[rw].target_module != 0xFFFFFFFF) {
@@ -2089,7 +2098,6 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 rw = rw + 1;
                 ri = ri + 1;
             }
-            map.dnit[intern.StrId, u32](?locals);
             m = m + 1;
         }
         sort.sort[AtomRelocRef](refs, reloc_total::usize, atom_reloc_ref_cmp);
@@ -2329,6 +2337,36 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
         m = m + 1;
     }
     ret total;
+}
+
+# sum the symbol counts of every input image
+# ---
+# modules:      the input image array
+# module_count: number of input images
+# ret:          the total symbol count across every image
+fun total_symbols(modules: *of.ObjectImage, module_count: u32) u32 {
+    var total: u32 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        total = total + modules[m].symbol_count;
+        m = m + 1;
+    }
+    ret total;
+}
+
+# fill `sym_base` with each module's prefix offset into the flat symbol arrays
+# ---
+# modules:      the input image array
+# module_count: number of input images
+# sym_base:     out - per-module prefix offset, one entry per module
+fun fill_symbol_bases(modules: *of.ObjectImage, module_count: u32, sym_base: *u32) {
+    var base: u32 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        sym_base[m] = base;
+        base = base + modules[m].symbol_count;
+        m = m + 1;
+    }
 }
 
 # tally each merged section's length and alignment and
@@ -2673,11 +2711,14 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
 # placements:    per-input-section placement (merged index + offset)
 # sec_base:      per-module prefix offset into `placements`
 # merged_to_out: out - per-slot output-section index (0xFFFFFFFF when empty)
+# sym_base:      per-module prefix offset into `sym_out`
+# sym_out:       out - per-input-symbol merged-image symbol index (of.SYMBOL_NONE
+#                when the symbol was not carried), or nil when unwanted
 # ret:           ok(true) on success, or an error string
 fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
                        modules: *of.ObjectImage, module_count: u32,
                        merged: *MergedSection, merged_count: u32, placements: *Placement, sec_base: *u32,
-                       merged_to_out: *u32, strm: *StrMerge,
+                       merged_to_out: *u32, sym_base: *u32, sym_out: *u32, strm: *StrMerge,
                        atoms: *AtomPlan) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
@@ -2758,6 +2799,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
     for (m < module_count) {
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
+            if (sym_out != nil) { sym_out[sym_base[m] + sy] = of.SYMBOL_NONE; }
             val isym: *of.Symbol = ?modules[m].symbols[sy];
             if (isym.section == of.SECTION_EXTERNAL || isym.section >= modules[m].section_count) {
                 sy = sy + 1; cnt;
@@ -2779,6 +2821,9 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 
             val sa: R.Result[u32, str] = obj.add_symbol(out_img, osym);
             if (R.is_err[u32, str](sa)) { ret R.err[bool, str](R.unwrap_err[u32, str](sa)); }
+            if (sym_out != nil) {
+                sym_out[sym_base[m] + sy] = R.unwrap_ok[u32, str](sa);
+            }
 
             sy = sy + 1;
         }
@@ -2796,11 +2841,13 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 # recorded as a `PltFixup` for the writer to redirect to the import's PLT stub
 # and patching is deferred
 #
-# a relocation in module `m` references its target symbol by name, but a LOCAL
-# (object-private) target is resolved against module `m`'s own definition - never
-# the cross-object `sym_locs` table, which holds only globals - so identically
-# named locals in different modules resolve to the correct same-object symbol.
-# GLOBAL targets (and undefined externs) resolve by name through `sym_locs`.
+# a relocation in module `m` references its target by index into `m`'s own symbol
+# array. a LOCAL (object-private) target is therefore resolved directly against
+# that definition - never the cross-object `sym_locs` table, which holds only
+# globals - so neither identically named locals in different modules nor the
+# several same-named (`st_name = 0`) section symbols within one foreign object can
+# alias one another. GLOBAL targets (and undefined externs) resolve by name
+# through `sym_locs`, which is what cross-object binding is defined on.
 # ---
 # s:            shared session, for diagnostics
 # out_img:      the merged image whose section bytes are patched in place
@@ -2821,28 +2868,11 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
                      dyn: *DynState, strm: *StrMerge, arch: *isa.IsaVTable,
                      atoms: *AtomPlan) R.Result[bool, str] {
-    val alloc: *A.Allocator = s.alloc;
-
     var m: u32 = 0;
     for (m < module_count) {
-        # build module m's local-name -> vaddr index once, replacing the per-
-        # relocation linear symbol-table scan (an O(relocations x symbols) hot path
-        # on a self-host link). the index holds only LOCALs; GLOBAL targets resolve
-        # through the cross-object sym_locs table. the map is always freed after the
-        # module's relocations are patched, regardless of outcome.
-        var local_map: map.Map[intern.StrId, u64] =
-            map.init[intern.StrId, u64](alloc, map.hash_u32, map.eq_u32);
-        val br: R.Result[bool, str] =
-            build_local_index(modules, m, placements, sec_base, ?local_map, atoms);
-        if (R.is_err[bool, str](br)) {
-            map.dnit[intern.StrId, u64](?local_map);
-            ret R.err[bool, str](R.unwrap_err[bool, str](br));
-        }
-
         val pr: R.Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, strm,
+            placements, sec_base, merged_to_out, sym_locs, dyn, strm,
             arch, m < codegen_count, atoms);
-        map.dnit[intern.StrId, u64](?local_map);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
 
         m = m + 1;
@@ -2850,42 +2880,32 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
     ret R.ok[bool, str](true);
 }
 
-# fill `out` with module `m`'s LOCAL (object-private) symbol
-# definitions, name -> final virtual address. the first definition of a name wins,
-# mirroring the linear scan it replaces. EXTERNAL, out-of-range, and GLOBAL symbols
-# are excluded - globals live in the cross-object table
+# the final virtual address of module `m`'s object-private symbol `sy`
+#
+# A LOCAL target is resolved straight from its own definition: the symbol names
+# its defining section and offset, and the placement of that section carries the
+# vaddr. No name is consulted, so the several `st_name = 0` section symbols a
+# foreign object carries stay distinct (#2520).
 # ---
 # modules:    the input image array
-# m:          index of the module whose locals are indexed
+# m:          index of the module owning the symbol
+# sy:         index of the symbol within module `m`
 # placements: per-input-section placement (carries final vaddrs)
 # sec_base:   per-module prefix offset into `placements`
-# out:        out - the local-name -> virtual-address index to fill
-# ret:        ok(true) on success, or an error string
-fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, sec_base: *u32,
-                      out: *map.Map[intern.StrId, u64],
-                      atoms: *AtomPlan) R.Result[bool, str] {
-    var sy: u32 = 0;
-    for (sy < modules[m].symbol_count) {
-        val sym: *of.Symbol = ?modules[m].symbols[sy];
-        if (sym.section == of.SECTION_EXTERNAL)        { sy = sy + 1; cnt; }
-        if (sym.section >= modules[m].section_count)   { sy = sy + 1; cnt; }
-        if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0) { sy = sy + 1; cnt; }
-
-        if (R.is_err[*u64, str](map.get[intern.StrId, u64](out, ?sym.name))) {
-            val flat: u32 = sec_base[m] + sym.section;
-            if (atom_offset_dead(atoms, flat, sym.offset)) { sy = sy + 1; cnt; }
-            val va: u64 = placements[flat].vaddr
-                + atom_live_offset(atoms, flat, sym.offset)::u64;
-            val ins: R.Result[bool, str] = map.insert[intern.StrId, u64](out, sym.name, va);
-            if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
-        }
-        sy = sy + 1;
-    }
-    ret R.ok[bool, str](true);
+# atoms:      the dead-atom plan, for the live-offset remap
+# out_va:     out - the symbol's final virtual address, when live
+# ret:        true when the symbol has a live address, false when atom-dropped
+fun local_symbol_vaddr(modules: *of.ObjectImage, m: u32, sy: u32, placements: *Placement,
+                       sec_base: *u32, atoms: *AtomPlan, out_va: *u64) bool {
+    val sym: *of.Symbol = ?modules[m].symbols[sy];
+    val flat: u32 = sec_base[m] + sym.section;
+    if (atom_offset_dead(atoms, flat, sym.offset)) { ret false; }
+    @out_va = placements[flat].vaddr + atom_live_offset(atoms, flat, sym.offset)::u64;
+    ret true;
 }
 
 # apply every relocation in module `m` into the merged
-# bytes. a LOCAL target resolves through `local_map` (module `m`'s private index);
+# bytes. a LOCAL target resolves directly from module `m`'s own symbol array;
 # a GLOBAL target (or an undefined extern) resolves by name through `sym_locs`, and
 # an unresolved pc-relative call to a function import is deferred as a PltFixup
 # ---
@@ -2898,7 +2918,6 @@ fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, 
 # merged_to_out: per-merged-slot output-section index (from build_merged_image)
 # sym_locs:      the global symbol table, for GLOBAL/extern target resolution
 # dyn:           dynamic-link state; out - collects import call-site fixups
-# local_map:     module `m`'s LOCAL-name -> virtual-address index
 # strm:          the deduped .debug_str table, for strp remap (inactive to skip)
 # arch:          active instruction-set vtable, owning the relocation packer
 # codegen_image: true when module `m` is an in-memory compiler image
@@ -2907,26 +2926,18 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
                              placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
-                             local_map: *map.Map[intern.StrId, u64], strm: *StrMerge,
+                             strm: *StrMerge,
                              arch: *isa.IsaVTable, codegen_image: bool,
                              atoms: *AtomPlan) R.Result[bool, str] {
-    # locate module m's .debug_str section and its anchor symbol once: a strp
-    # relocation is exactly one whose target is that anchor. resolving it remaps the
-    # string to its deduped offset rather than the concatenated placement (#1708).
+    # locate module m's .debug_str section once: a strp relocation is exactly one
+    # whose target symbol is defined in it. resolving it remaps the string to its
+    # deduped offset rather than the concatenated placement (#1708).
     var str_sec: u32 = 0xFFFFFFFF;
-    var str_anchor: intern.StrId = intern.STR_NIL;
     if (strm.active) {
         var scx: u32 = 0;
         for (scx < modules[m].section_count) {
             if (modules[m].sections[scx].kind == of.SK_DEBUG && modules[m].sections[scx].name == strm.name) { str_sec = scx; }
             scx = scx + 1;
-        }
-        if (str_sec != 0xFFFFFFFF) {
-            var syx: u32 = 0;
-            for (syx < modules[m].symbol_count) {
-                if (modules[m].symbols[syx].section == str_sec) { str_anchor = modules[m].symbols[syx].name; }
-                syx = syx + 1;
-            }
         }
     }
 
@@ -2975,26 +2986,37 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
         val patch_off: u32 = pl.offset + live_off;
 
+        # the relocation's target, indexed into module `m`'s own symbol array. an
+        # index past the array is a producer contract violation - reject it rather
+        # than resolve against an arbitrary symbol.
+        if (r.sym >= modules[m].symbol_count) {
+            ret R.err[bool, str]("linker: relocation references a symbol outside its module's symbol table");
+        }
+        val target: *of.Symbol = ?modules[m].symbols[r.sym];
+        val target_name: intern.StrId = target.name;
+
         # a strp into .debug_str: remap it to the string's deduped offset instead of
-        # resolving the anchor's placement. skips the normal apply_one below (#1708).
-        if (strm.active && str_anchor != intern.STR_NIL && r.symbol == str_anchor) {
-            val sp: R.Result[bool, str] = resolve_strp(s, modules, m, str_sec, r, strm,
+        # resolving the target's placement. skips the normal apply_one below (#1708).
+        if (strm.active && str_sec != 0xFFFFFFFF && target.section == str_sec) {
+            val sp: R.Result[bool, str] = resolve_strp(s, modules, m, str_sec, r, target_name, strm,
                 dst, patch_off, out_img.sections[out_ix].len, patch_va, arch);
             if (R.is_err[bool, str](sp)) { ret R.err[bool, str](R.unwrap_err[bool, str](sp)); }
             ri = ri + 1; cnt;
         }
 
-        # locate the target symbol's final virtual address. a LOCAL target is
-        # private to module `m`; resolve it through `m`'s local index. GLOBAL targets
+        # locate the target symbol's final virtual address. an object-private target
+        # is resolved straight from its own definition in module `m`. GLOBAL targets
         # (and undefined externs) resolve by name via sym_locs.
         var sym_va: u64 = 0;
-        val lvm: R.Result[*u64, str] = map.get[intern.StrId, u64](local_map, ?r.symbol);
-        if (R.is_ok[*u64, str](lvm)) {
-            sym_va = @R.unwrap_ok[*u64, str](lvm);
+        if ((target.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0
+            && target.section != of.SECTION_EXTERNAL) {
+            if (!local_symbol_vaddr(modules, m, r.sym, placements, sec_base, atoms, ?sym_va)) {
+                ret R.err[bool, str](undef_message(s, target_name));
+            }
         }
         or {
             val sl: R.Result[*SymbolLoc, str] =
-                map.get[intern.StrId, SymbolLoc](sym_locs, ?r.symbol);
+                map.get[intern.StrId, SymbolLoc](sym_locs, ?target_name);
             if (R.is_ok[*SymbolLoc, str](sl)) {
                 sym_va = R.unwrap_ok[*SymbolLoc, str](sl).vaddr;
             }
@@ -3005,7 +3027,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                 # a GOT fixup (the writer builds its GOT slot + GLOB_DAT). any other
                 # unresolved reference - a call against a data import, an absolute
                 # reference to any import - is rejected as undefined.
-                val imp: R.Result[u32, str] = dynstate_import_index(dyn, r.symbol);
+                val imp: R.Result[u32, str] = dynstate_import_index(dyn, target_name);
                 if (R.is_ok[u32, str](imp) && is_call_kind(r.kind)
                     && dynstate_import_is_func(dyn, R.unwrap_ok[u32, str](imp))) {
                     val rec_r: R.Result[bool, str] = dynstate_add_fixup(s, dyn,
@@ -3022,12 +3044,12 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                     if (R.is_err[bool, str](rec_g)) { ret R.err[bool, str](R.unwrap_err[bool, str](rec_g)); }
                     ri = ri + 1; cnt;
                 }
-                ret R.err[bool, str](undef_message(s, r.symbol));
+                ret R.err[bool, str](undef_message(s, target_name));
             }
         }
 
         val pr: R.Result[bool, str] =
-            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, r.symbol, arch);
+            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, target_name, arch);
         if (R.is_err[bool, str](pr)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](pr));
         }
@@ -3062,6 +3084,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
 # m:         index of the module owning the relocation
 # str_sec:   index of module `m`'s `.debug_str` section
 # r:         the strp relocation (addend is the string offset within `.debug_str`)
+# sym_name:  the relocation target's interned name, for diagnostics
 # strm:      the deduped `.debug_str` table (buffer + offset map)
 # dst:       the merged output-section bytes to patch
 # patch_off: byte offset of the patch site within `dst`
@@ -3070,7 +3093,8 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
 # arch:      active instruction-set vtable, owning the relocation packer
 # ret:       ok(true) once the deduped offset is written, or an error string
 fun resolve_strp(s: *session.Session, modules: *of.ObjectImage, m: u32, str_sec: u32,
-                 r: *of.Relocation, strm: *StrMerge, dst: *u8, patch_off: u32, sec_len: u32,
+                 r: *of.Relocation, sym_name: intern.StrId, strm: *StrMerge,
+                 dst: *u8, patch_off: u32, sec_len: u32,
                  patch_va: u64, arch: *isa.IsaVTable) R.Result[bool, str] {
     val ssec: *of.Section = ?modules[m].sections[str_sec];
     if (ssec.bytes == nil || r.addend < 0 || r.addend::u64 >= ssec.len::u64) {
@@ -3095,7 +3119,7 @@ fun resolve_strp(s: *session.Session, modules: *of.ObjectImage, m: u32, str_sec:
 
     # write the deduped offset as the strp value: RK_ABS32 into a non-loadable section,
     # so `sym_va` is the debug-section-relative offset itself and the addend is zero.
-    ret apply_one(s, r.kind, dst, patch_off, sec_len, ded_off::u64, 0, patch_va, r.symbol, arch);
+    ret apply_one(s, r.kind, dst, patch_off, sec_len, ded_off::u64, 0, patch_va, sym_name, arch);
 }
 
 # reset a DynState to the empty (static-link) state. its plan and
@@ -3170,7 +3194,7 @@ fun import_symbol_live(modules: *of.ObjectImage, module_count: u32,
         var ri: u32 = 0;
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
-            if (r.symbol == symbol_name) {
+            if (of.reloc_symbol_name(?modules[m], r) == symbol_name) {
                 saw = true;
                 if (reloc_source_live(modules, m, r, sec_base, atoms)) { ret true; }
             }
@@ -3189,7 +3213,7 @@ fun has_call_reloc(modules: *of.ObjectImage, module_count: u32,
         var ri: u32 = 0;
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
-            if (r.symbol == symbol_name && is_call_kind(r.kind)
+            if (of.reloc_symbol_name(?modules[m], r) == symbol_name && is_call_kind(r.kind)
                 && reloc_source_live(modules, m, r, sec_base, atoms)) {
                 ret true;
             }
@@ -3747,6 +3771,13 @@ fun apply_one(s: *session.Session, kind: of.RelocKind,
 # in relocatable mode, copy each input relocation onto the
 # output image rebased to the merged section indices, leaving the bytes
 # unpatched so a later link can resolve them
+#
+# A carried relocation's target index is in its own module's symbol space, so it
+# is rewritten through `sym_out` into the merged image's. `build_merged_image`
+# drops undefined externs (an executable resolves them), but a relocatable output
+# must still declare every target it references or the object it writes is
+# unlinkable; an undefined target is therefore appended to the merged symbol table
+# on first reference and reused after.
 # ---
 # out_img:       out - the merged image the relocations are carried onto
 # modules:       the input image array (source of the relocations)
@@ -3754,9 +3785,12 @@ fun apply_one(s: *session.Session, kind: of.RelocKind,
 # placements:    per-input-section placement (merged index + offset)
 # sec_base:      per-module prefix offset into `placements`
 # merged_to_out: per-merged-slot output-section index (from build_merged_image)
+# sym_base:      per-module prefix offset into `sym_out`
+# sym_out:       per-input-symbol merged-image symbol index (from build_merged_image)
 # ret:           ok(true) on success, or an error string
 fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module_count: u32,
-                     placements: *Placement, sec_base: *u32, merged_to_out: *u32) R.Result[bool, str] {
+                     placements: *Placement, sec_base: *u32, merged_to_out: *u32,
+                     sym_base: *u32, sym_out: *u32) R.Result[bool, str] {
     var m: u32 = 0;
     for (m < module_count) {
         var ri: u32 = 0;
@@ -3770,6 +3804,9 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
             if (r.offset > modules[m].sections[r.section].len) {
                 ret R.err[bool, str]("linker: relocation offset is past the end of its section");
             }
+            if (r.sym >= modules[m].symbol_count) {
+                ret R.err[bool, str]("linker: relocation references a symbol outside its module's symbol table");
+            }
 
             val flat: u32 = sec_base[m] + r.section;
             val pl: *Placement = ?placements[flat];
@@ -3780,11 +3817,21 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
                 ret R.err[bool, str]("linker: relocation targets a section with no merged output");
             }
 
+            val slot: u32 = sym_base[m] + r.sym;
+            if (sym_out[slot] == of.SYMBOL_NONE) {
+                var usym: of.Symbol = modules[m].symbols[r.sym];
+                usym.section = of.SECTION_EXTERNAL;
+                usym.offset  = 0;
+                val sa: R.Result[u32, str] = obj.add_symbol(out_img, usym);
+                if (R.is_err[u32, str](sa)) { ret R.err[bool, str](R.unwrap_err[u32, str](sa)); }
+                sym_out[slot] = R.unwrap_ok[u32, str](sa);
+            }
+
             var orel: of.Relocation;
             orel.section = out_ix;
             orel.offset  = pl.offset + r.offset;
             orel.kind    = r.kind;
-            orel.symbol  = r.symbol;
+            orel.sym     = sym_out[slot];
             orel.addend  = r.addend;
 
             val ar: R.Result[bool, str] = obj.add_relocation(out_img, orel);
@@ -4165,10 +4212,17 @@ fun free_scratch(alloc: *A.Allocator, placements: *Placement, sec_total: u32,
                 sec_base: *u32, module_count: u32,
                 merged: *MergedSection, merged_count: u32,
                 debug_names: *intern.StrId, debug_count: u32,
-                merged_to_out: *u32, strm: *StrMerge, atoms: *AtomPlan) {
+                merged_to_out: *u32, sym_base: *u32, sym_out: *u32, sym_total: u32,
+                strm: *StrMerge, atoms: *AtomPlan) {
     free_placements(alloc, placements, sec_total);
     if (sec_base != nil && module_count > 0) {
         A.deallocate[u32](alloc, sec_base, module_count::usize);
+    }
+    if (sym_base != nil && module_count > 0) {
+        A.deallocate[u32](alloc, sym_base, module_count::usize);
+    }
+    if (sym_out != nil && sym_total > 0) {
+        A.deallocate[u32](alloc, sym_out, sym_total::usize);
     }
     if (merged != nil && merged_count > 0) {
         A.deallocate[MergedSection](alloc, merged, merged_count::usize);
@@ -4710,9 +4764,9 @@ test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
 
     var relocs: [2]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 10; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = dead_ext; relocs[0].addend = -4;
+    relocs[0].sym = 4; relocs[0].addend = -4;
     relocs[1].section = 0; relocs[1].offset = 26; relocs[1].kind = of.RK_PC32;
-    relocs[1].symbol = live_ext; relocs[1].addend = -4;
+    relocs[1].sym = 5; relocs[1].addend = -4;
 
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "winners"), ?win_sec[0], 1,
@@ -4988,7 +5042,7 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
 
     var refs: [1]of.Relocation;
     refs[0].section = 1; refs[0].offset = 0; refs[0].kind = of.RK_ABS64;
-    refs[0].symbol = text; refs[0].addend = 0;
+    refs[0].sym = 0; refs[0].addend = 0;
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
                        nil::*of.Relocation, 0);
@@ -5059,7 +5113,7 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
 
     var reloc: [1]of.Relocation;
     reloc[0].section = 0; reloc[0].offset = 0; reloc[0].kind = of.RK_ABS64;
-    reloc[0].symbol = base; reloc[0].addend = 16;
+    reloc[0].sym = 0; reloc[0].addend = 16;
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
                        nil::*of.Relocation, 0);
@@ -5089,7 +5143,7 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     val pc_local: R.Result[bool, str] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
     if (R.is_err[bool, str](pc_local) || plan.active) { ret 1; }
-    reloc[0].symbol = tail;
+    reloc[0].sym = 2;
     reloc[0].kind = of.RK_PLT32;
 
     # link_mixed places compiler images first. module 1 is therefore parsed when
@@ -5103,7 +5157,7 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     # the anchor before [8,16), addend three plus the canonical four-byte bias
     # remains at seven, while an eight-byte field-to-next-ip bias reaches eleven
     # inside the candidate. this therefore requires the parsed upper bound.
-    reloc[0].symbol = base;
+    reloc[0].sym = 0;
     reloc[0].addend = 3;
     val parsed_plt_trailing: R.Result[bool, str] =
         build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
@@ -5112,7 +5166,7 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     # with two compiler-produced images, module 1's PC32 is known to hold an
     # instruction relocation. its field-to-next-ip bias is at least four, so
     # tail-4 cannot reach backward into the candidate.
-    reloc[0].symbol = tail;
+    reloc[0].sym = 2;
     reloc[0].addend = -4;
     reloc[0].kind = of.RK_PC32;
     val codegen_pc: R.Result[bool, str] =
@@ -5179,7 +5233,7 @@ test "mach.lang.be.linker.atom_plan:rv64_plt_pair_boundary" {
 
     var reloc: [1]of.Relocation;
     reloc[0].section = 0; reloc[0].offset = 4; reloc[0].kind = of.RK_PLT32;
-    reloc[0].symbol = ext; reloc[0].addend = 0;
+    reloc[0].sym = 1; reloc[0].addend = 0;
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
                        nil::*of.Relocation, 0);

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4564,6 +4564,128 @@ test "mach.lang.be.linker.link_modules:flat_entry_leads_regardless_of_order" {
     ret 0;
 }
 
+# a relocation against an anonymous section symbol resolves to that section, not
+# to whichever anonymous symbol the module happens to declare first (#2520)
+#
+# Every ELF STT_SECTION symbol carries `st_name = 0`, so a real C object holds
+# several symbols under the empty name - miniaudio.o has eight. This is that
+# object's shape reduced to its essentials: a `.text` section symbol and a
+# `.rodata` section symbol, both anonymous and local. Resolving a target by name
+# aliased the second to the first, so a string reference resolved into code and
+# reading a pointer out of the table produced instruction bytes.
+#
+# The assertion is on the resolved value, and pins it without depending on the
+# image layout: two abs64 sites in `.data` address the same `.rodata` byte, one
+# through the anonymous section symbol plus an addend (the form at fault) and one
+# through a named symbol defined at that byte (the path that always worked). They
+# must resolve to the same address. Under the aliasing they differ, because the
+# first resolves into `.text`.
+test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_distinct" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "freestanding", "sysv64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+    # a flat image carries no headers, so the merged section bytes are the file and
+    # the `.data` patch sites are its trailing bytes.
+    if (!tgt.of.produces_image) { ret 1; }
+
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val text:   intern.StrId = lt_name(?s, ".text");
+    val rodata: intern.StrId = lt_name(?s, ".rodata.str1.1");
+    val data:   intern.StrId = lt_name(?s, ".data.rel.ro.local");
+    val anon:   intern.StrId = lt_name(?s, "");
+    val anchor: intern.StrId = lt_name(?s, "rodata_anchor");
+    val entry:  intern.StrId = lt_name(?s, tgt.os.entry_symbol);
+    if (text == intern.STR_NIL || rodata == intern.STR_NIL || data == intern.STR_NIL) { ret 1; }
+    if (anon == intern.STR_NIL || anchor == intern.STR_NIL || entry == intern.STR_NIL) { ret 1; }
+
+    var tb: [16]u8;
+    var rb: [16]u8;
+    var db: [24]u8;
+    var i: u32 = 0;
+    for (i < 16) { tb[i] = 0x90; rb[i] = 0x00; i = i + 1; }
+    # `.data` opens with a marker the merge never rewrites, so the two patch sites
+    # that follow it are found by content rather than by assuming a section order.
+    for (i < 24) { db[i] = 0x00; i = i + 1; }
+    i = 0;
+    for (i < 8) { db[i] = 0xEE; i = i + 1; }
+
+    var secs: [3]of.Section;
+    secs[0].name = text;   secs[0].kind = of.SK_TEXT;   secs[0].bytes = ?tb[0];
+    secs[0].len = 16; secs[0].align = 16;
+    secs[1].name = rodata; secs[1].kind = of.SK_RODATA; secs[1].bytes = ?rb[0];
+    secs[1].len = 16; secs[1].align = 16;
+    secs[2].name = data;   secs[2].kind = of.SK_DATA;   secs[2].bytes = ?db[0];
+    secs[2].len = 24; secs[2].align = 8;
+
+    # the two section symbols share the empty name, exactly as a parsed C object's
+    # do. `.text`'s comes first, so a name-keyed lookup returns it for both.
+    var syms: [4]of.Symbol;
+    syms[0].name = anon;   syms[0].section = 0; syms[0].offset = 0; syms[0].size = 0; syms[0].flags = 0;
+    syms[1].name = anon;   syms[1].section = 1; syms[1].offset = 0; syms[1].size = 0; syms[1].flags = 0;
+    syms[2].name = anchor; syms[2].section = 1; syms[2].offset = 8; syms[2].size = 0;
+    syms[2].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    syms[3].name = entry;  syms[3].section = 0; syms[3].offset = 0; syms[3].size = 0;
+    syms[3].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var relocs: [2]of.Relocation;
+    relocs[0].section = 2; relocs[0].offset = 8;  relocs[0].kind = of.RK_ABS64;
+    relocs[0].sym = 1; relocs[0].addend = 8;
+    relocs[1].section = 2; relocs[1].offset = 16; relocs[1].kind = of.RK_ABS64;
+    relocs[1].sym = 2; relocs[1].addend = 0;
+
+    var mods: [1]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "anon_secs"), ?secs[0], 3, ?syms[0], 4, ?relocs[0], 2);
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "anon_section_syms");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val lr: R.Result[bool, str] =
+        link_modules(?s, ?tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, tpath::*u8, "anon_section_syms"::*u8, LINK_EXE, false);
+    if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rr)) { ret 1; }
+    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+
+    # locate `.data` by its marker, then read the two pointers that follow it.
+    if (b.len < 24) { vector.dnit[u8](?b); ret 1; }
+    var site: usize = b.len;
+    var scan: usize = 0;
+    for (scan + 24 <= b.len) {
+        if (b.data[scan] == 0xEE && b.data[scan + 7] == 0xEE) { site = scan; scan = b.len; }
+        or { scan = scan + 1; }
+    }
+    if (site + 24 > b.len) { vector.dnit[u8](?b); ret 1; }
+
+    var via_section: u64 = 0;
+    var via_name:    u64 = 0;
+    i = 0;
+    for (i < 8) {
+        via_section = via_section | (b.data[site + 8 + i::usize]::u64 << (i * 8));
+        via_name    = via_name    | (b.data[site + 16 + i::usize]::u64 << (i * 8));
+        i = i + 1;
+    }
+
+    # a zero pair would mean the sites were never found, so the check cannot pass
+    # by matching two unwritten fields.
+    if (via_section == 0 || via_name == 0)  { vector.dnit[u8](?b); ret 1; }
+    if (via_section != via_name)            { vector.dnit[u8](?b); ret 1; }
+
+    vector.dnit[u8](?b);
+    session.dnit(?s);
+    ret 0;
+}
+
 # weak/strong symbol resolution is order-independent (#1257)
 test "mach.lang.be.linker.collect_symbols:weak_strong_order_independent" {
     var alloc: A.Allocator;

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -149,6 +149,166 @@ pub fun add_relocation(o: *of.ObjectImage, rel: of.Relocation) R.Result[bool, st
     ret R.ok[bool, str](true);
 }
 
+# the index of the image symbol named `name`, or `of.SYMBOL_NONE` when the image
+# carries no such symbol
+#
+# Only sound on an image whose symbol names are unique, which every image this
+# builder assembles is: the back end names each function, global, and extern
+# once. A parsed foreign image is not searched this way - its relocations already
+# carry indices, and its section symbols share the empty name (#2520).
+# ---
+# o:    the image whose symbol table is searched
+# name: the interned symbol name to find
+# ret:  the symbol's index, or of.SYMBOL_NONE
+pub fun symbol_index(o: *of.ObjectImage, name: intern.StrId) u32 {
+    if (name == intern.STR_NIL) { ret of.SYMBOL_NONE; }
+    var i: u32 = 0;
+    for (i < o.symbol_count) {
+        if (o.symbols[i].name == name) { ret i; }
+        i = i + 1;
+    }
+    ret of.SYMBOL_NONE;
+}
+
+# one relocation recorded before its target symbol is known to the image
+# ---
+# section:      index of the section being patched
+# offset:       byte offset of the patch site within that section
+# kind:         abstract relocation kind (one of of.RK_*)
+# name:         interned name of the target symbol
+# addend:       constant added to the resolved symbol address
+# extern_flags: the symbol flags the target is declared with when no pass in this
+#               image ever defines it
+pub rec DeferredReloc {
+    section:      u32;
+    offset:       u32;
+    kind:         of.RelocKind;
+    name:         intern.StrId;
+    addend:       i64;
+    extern_flags: u32;
+}
+
+# relocations awaiting a complete symbol table
+#
+# `of.Relocation` binds its target by symbol index, but the back end emits
+# relocations before the pass that defines their targets has run - a global's
+# aggregate initializer can point at a global packed later in the same pass. The
+# relocations therefore accumulate here by name and bind in one pass once every
+# defining pass has run, which is also the point at which a target that is still
+# undeclared is known to be genuinely external.
+# ---
+# alloc: allocator backing `items`
+# items: the recorded relocations, `count` of them in `cap` slots
+# count: number of recorded relocations
+# cap:   allocated slot count
+pub rec DeferredRelocs {
+    alloc: *A.Allocator;
+    items: *DeferredReloc;
+    count: u32;
+    cap:   u32;
+}
+
+# an empty deferred-relocation list; allocates nothing until the first record
+# ---
+# a:   allocator every growth of the list draws from
+# ret: the empty list
+pub fun deferred_init(a: *A.Allocator) DeferredRelocs {
+    var d: DeferredRelocs;
+    d.alloc = a;
+    d.items = nil;
+    d.count = 0;
+    d.cap   = 0;
+    ret d;
+}
+
+# release the list's storage and reset it to empty
+# ---
+# d: the list to tear down
+pub fun deferred_dnit(d: *DeferredRelocs) {
+    if (d.items != nil && d.cap > 0) {
+        A.deallocate[DeferredReloc](d.alloc, d.items, d.cap::usize);
+    }
+    d.items = nil;
+    d.count = 0;
+    d.cap   = 0;
+}
+
+# record one relocation to bind later, growing the list by doubling
+# ---
+# d:   the list to record into
+# rec: the relocation to record
+# ret: true on success, or an allocation error
+pub fun defer_relocation(d: *DeferredRelocs, rec: DeferredReloc) R.Result[bool, str] {
+    if (d.count == d.cap) {
+        var next: u32 = 8;
+        if (d.cap > 0) { next = d.cap * 2; }
+        var grown: *DeferredReloc = nil;
+        if (d.items == nil) {
+            val ar: R.Result[*DeferredReloc, str] = A.allocate[DeferredReloc](d.alloc, next::usize);
+            if (R.is_err[*DeferredReloc, str](ar)) { ret R.err[bool, str](R.unwrap_err[*DeferredReloc, str](ar)); }
+            grown = R.unwrap_ok[*DeferredReloc, str](ar);
+        }
+        or {
+            val rr: R.Result[*DeferredReloc, str] =
+                A.reallocate[DeferredReloc](d.alloc, d.items, d.cap::usize, next::usize);
+            if (R.is_err[*DeferredReloc, str](rr)) { ret R.err[bool, str](R.unwrap_err[*DeferredReloc, str](rr)); }
+            grown = R.unwrap_ok[*DeferredReloc, str](rr);
+        }
+        d.items = grown;
+        d.cap   = next;
+    }
+    d.items[d.count] = rec;
+    d.count = d.count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# bind every recorded relocation onto the image and clear the list
+#
+# A target the image already carries binds to that symbol's index. A target it
+# does not is declared as an undefined external from the record's `extern_flags`
+# and bound to the new entry, so a relocation never reaches the writer pointing
+# at a symbol the image does not hold. A record with no target name is a producer
+# bug and is rejected rather than bound to symbol 0.
+# ---
+# o:   the image the relocations are appended to
+# d:   the recorded relocations; emptied on success
+# ret: true once every record is bound, or the first error
+pub fun flush_deferred(o: *of.ObjectImage, d: *DeferredRelocs) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < d.count) {
+        val pend: *DeferredReloc = ?d.items[i];
+        if (pend.name == intern.STR_NIL) {
+            ret R.err[bool, str]("codegen: relocation has no target symbol");
+        }
+
+        var sym_ix: u32 = symbol_index(o, pend.name);
+        if (sym_ix == of.SYMBOL_NONE) {
+            var ext: of.Symbol;
+            ext.name    = pend.name;
+            ext.section = of.SECTION_EXTERNAL;
+            ext.offset  = 0;
+            ext.size    = 0;
+            ext.flags   = pend.extern_flags;
+            val sa: R.Result[u32, str] = add_symbol(o, ext);
+            if (R.is_err[u32, str](sa)) { ret R.err[bool, str](R.unwrap_err[u32, str](sa)); }
+            sym_ix = R.unwrap_ok[u32, str](sa);
+        }
+
+        var rel: of.Relocation;
+        rel.section = pend.section;
+        rel.offset  = pend.offset;
+        rel.kind    = pend.kind;
+        rel.sym     = sym_ix;
+        rel.addend  = pend.addend;
+        val ar: R.Result[bool, str] = add_relocation(o, rel);
+        if (R.is_err[bool, str](ar)) { ret R.err[bool, str](R.unwrap_err[bool, str](ar)); }
+
+        i = i + 1;
+    }
+    d.count = 0;
+    ret R.ok[bool, str](true);
+}
+
 # map a name id from a child interner's id space into its base's id space
 #
 # Ids below `base_len` are already base ids and pass through; ids at or above it
@@ -171,9 +331,10 @@ fun remap_name(id: intern.StrId, base_len: usize, remap: *intern.StrId) intern.S
 #
 # A parallel-codegen worker builds its module's image in a private arena against a
 # child interner; this re-homes that image onto the destination (session)
-# allocator and rewrites its four name fields - the image name, each section name,
-# each symbol name, and each relocation's target symbol - through `remap` so they
-# resolve against the shared interner the linker keys on. Section byte buffers are
+# allocator and rewrites its three name fields - the image name, each section name,
+# and each symbol name - through `remap` so they resolve against the shared
+# interner the linker keys on. A relocation carries a symbol index rather than a
+# name, and the copy preserves symbol positions, so it needs no remap. Section byte buffers are
 # copied verbatim (they encode no interned ids - only self-contained bytes and
 # per-section offsets), so the re-homed image is byte-for-byte what a serial build
 # would have produced. The source image is left intact for the caller to free with
@@ -233,13 +394,9 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
         val rr: R.Result[*of.Relocation, str] = A.allocate[of.Relocation](dst_alloc, src.reloc_count::usize);
         if (R.is_err[*of.Relocation, str](rr)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Relocation, str](rr)); }
         img.relocations = R.unwrap_ok[*of.Relocation, str](rr);
-        var i: u32 = 0;
-        for (i < src.reloc_count) {
-            var rel: of.Relocation = src.relocations[i];
-            rel.symbol = remap_name(src.relocations[i].symbol, base_len, remap);
-            img.relocations[i] = rel;
-            i = i + 1;
-        }
+        # a relocation's target is a symbol index into this same image, which the
+        # copy preserves position-for-position, so nothing about it is remapped.
+        memory.copy[of.Relocation](img.relocations, src.relocations, src.reloc_count::usize);
         img.reloc_count = src.reloc_count;
     }
 
@@ -333,7 +490,7 @@ fun t_debug_produce(img: *of.ObjectImage) R.Result[bool, str] {
     rel.section = sec_idx;
     rel.offset  = 0;
     rel.kind    = of.RK_ABS32;
-    rel.symbol  = sym.name;
+    rel.sym     = R.unwrap_ok[u32, str](yr);
     rel.addend  = 0;
     ret add_relocation(img, rel);
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4389,7 +4389,8 @@ fun ut_has_direct_call_reloc(image: *of.ObjectImage, callee_name: intern.StrId) 
     var i: u32 = 0;
     for (i < image.reloc_count) {
         val rel: *of.Relocation = ?image.relocations[i];
-        if ((rel.kind == of.RK_PLT32 || rel.kind == of.RK_PC32) && rel.symbol == callee_name) { ret true; }
+        if ((rel.kind == of.RK_PLT32 || rel.kind == of.RK_PC32)
+            && of.reloc_symbol_name(image, rel) == callee_name) { ret true; }
         i = i + 1;
     }
     ret false;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -156,6 +156,11 @@ pub val SYM_OBJ_FLAG_OBJECT:   u32 = 0x10;
 # sentinel `Symbol.section` value marking an undefined (external) symbol
 pub val SECTION_EXTERNAL: u32 = 0xFFFFFFFF;
 
+# sentinel `Relocation.sym` value marking a relocation with no target symbol.
+# no relocation kind the back end emits resolves without a target, so a consumer
+# that reaches one reports it rather than resolving it against index 0
+pub val SYMBOL_NONE: u32 = 0xFFFFFFFF;
+
 # loadable-segment permission flags, combined as a bitmask in
 # `LoadSegment.flags`. format-neutral; each format maps them to its own segment
 # permission bits (ELF PF_*, Mach-O VM_PROT_*)
@@ -203,17 +208,24 @@ pub rec Symbol {
 # `kind` is an abstract relocation kind (a closed `RK_*` enum owned here); the
 # format writer maps it to a machine type with a plain integer compare, no
 # interner involved.
+#
+# `sym` indexes the owning image's `symbols` array, matching how every object
+# format on disk encodes a relocation target (ELF `r_info`, COFF
+# `SymbolTableIndex`, Mach-O `r_symbolnum`). A name cannot serve as the key: a
+# module may hold several distinct symbols under one name, and an ELF section
+# symbol carries `st_name = 0`, so every section symbol in an object shares the
+# empty name (#2520).
 # ---
 # section: index of the section being patched
 # offset:  byte offset of the patch site within that section
 # kind:    abstract relocation kind (one of RK_*)
-# symbol:  interned name of the referenced symbol
+# sym:     index of the referenced symbol in the image's `symbols` array
 # addend:  constant added to the resolved symbol address
 pub rec Relocation {
     section: u32;
     offset:  u32;
     kind:    RelocKind;
-    symbol:  intern.StrId;
+    sym:     u32;
     addend:  i64;
 }
 
@@ -1036,6 +1048,21 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_GOT_LO12)     { ret "got_lo12"; }
     if (kind == RK_ABS16)        { ret "abs16"; }
     ret "unknown";
+}
+
+# the interned name of a relocation's target symbol
+#
+# Relocations key on a symbol index, but a target's *name* is still what
+# cross-object resolution and diagnostics need, and it is only ever read through
+# the owning image. An out-of-range or absent index yields STR_NIL, which every
+# caller treats as unresolvable rather than aliasing it to symbol 0.
+# ---
+# img: the image owning both the relocation and the symbol array it indexes
+# r:   the relocation whose target name is wanted
+# ret: the target's interned name, or STR_NIL when `r.sym` names no symbol
+pub fun reloc_symbol_name(img: *ObjectImage, r: *Relocation) intern.StrId {
+    if (r.sym >= img.symbol_count) { ret intern.STR_NIL; }
+    ret img.symbols[r.sym].name;
 }
 
 # covers_isa reads the format's self-declared coverage: a listed arch matches, an

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3784,7 +3784,8 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
     # the relocation indexes past the image symbol table - the producer-invariant
-    # violation #1196 must surface as an error, not silently alias the first section symbol.
+    # violation #1196 must surface as an error, not silently alias
+    # the first section symbol.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
     relocs[0].sym = 1; relocs[0].addend = 0;
@@ -3806,7 +3807,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
     fs.temp_close_and_remove(?tf);
 
     if (!R.is_err[bool, str](em))                                   { ret 1; }
-    if (!str_contains(R.unwrap_err[bool, str](em), "ghost_symbol")) { ret 1; }
+    if (!str_contains(R.unwrap_err[bool, str](em), "unresolved symbol")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1649,8 +1649,8 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     out.symbol_count  = sym_n;
     out.reloc_count   = rel_n;
 
-    # map a COFF symbol-table record index -> ObjectImage symbol index, so a
-    # relocation's SymbolTableIndex resolves to the interned symbol name.
+    # map a COFF symbol-table record index -> ObjectImage symbol index, preserving
+    # the relocation target's identity even when several symbols share a name.
     val res_map: R.Result[*i32, str] = A.zallocate[i32](alloc, (num_records + 1)::usize);
     if (R.is_err[*i32, str](res_map)) { ret R.err[bool, str]("coff: symbol map alloc failed"); }
     var rec_map: *i32 = R.unwrap_ok[*i32, str](res_map);

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -386,43 +386,17 @@ fun write_decimal(buf: *u8, off: usize, width: usize, value: u32) {
     }
 }
 
-# build a name->index map over the image symbol table so the relocation passes
-# resolve targets in O(reloc + symbol) rather than O(reloc x symbol). the first
-# symbol of a given name wins, matching the lowest-index scan a linear lookup
-# would return; a STR_NIL-named symbol is skipped so a STR_NIL relocation target
-# stays unresolved. the caller owns the returned map and must `map.dnit` it
-fun build_reloc_sym_map(img: *of.ObjectImage) R.Result[map.Map[intern.StrId, u32], str] {
-    var idx: map.Map[intern.StrId, u32] =
-        map.init[intern.StrId, u32](img.alloc, map.hash_u32, map.eq_u32);
-    var i: u32 = 0;
-    for (i < img.symbol_count) {
-        if (img.symbols[i].name != intern.STR_NIL
-            && !map.contains[intern.StrId, u32](?idx, ?img.symbols[i].name)) {
-            val ins: R.Result[bool, str] =
-                map.insert[intern.StrId, u32](?idx, img.symbols[i].name, i);
-            if (R.is_err[bool, str](ins)) {
-                map.dnit[intern.StrId, u32](?idx);
-                ret R.err[map.Map[intern.StrId, u32], str](R.unwrap_err[bool, str](ins));
-            }
-        }
-        i = i + 1;
-    }
-    ret R.ok[map.Map[intern.StrId, u32], str](idx);
-}
-
-# resolve a relocation's target symbol to its index in the image symbol table via
-# a prebuilt name->index map. every relocation must name a symbol the image
-# defines or declares extern (the back end guarantees this - `pack_reloc_externs`
-# declares an extern for any named target the module did not define, and lowering
-# panics before emitting a nameless target). a miss is therefore a back-end
-# invariant violation, returned as an error naming the symbol rather than silently
-# aliased to index 0 (the first section symbol), which would corrupt the link
-fun reloc_sym_index(img: *of.ObjectImage, idx: *map.Map[intern.StrId, u32], sym: intern.StrId) R.Result[u32, str] {
-    if (sym != intern.STR_NIL) {
-        val g: R.Result[*u32, str] = map.get[intern.StrId, u32](idx, ?sym);
-        if (!R.is_err[*u32, str](g)) { ret R.ok[u32, str](@R.unwrap_ok[*u32, str](g)); }
-    }
-    ret R.err[u32, str](unresolved_reloc_message(img.interner, img.alloc, sym));
+# resolve a relocation's target to its index in the image symbol table. every
+# relocation must reference a symbol the image defines or declares extern (the
+# back end guarantees this - relocation binding declares an extern for any named
+# target the module did not define, and lowering panics before emitting a nameless
+# target). an out-of-range index is therefore a producer invariant violation,
+# returned as an error rather than silently aliased to index 0 (the first section
+# symbol), which would corrupt the link
+fun reloc_sym_index(img: *of.ObjectImage, r: *of.Relocation) R.Result[u32, str] {
+    if (r.sym < img.symbol_count) { ret R.ok[u32, str](r.sym); }
+    ret R.err[u32, str](unresolved_reloc_message(img.interner, img.alloc,
+        of.reloc_symbol_name(img, r)));
 }
 
 # build the "coff: unresolved relocation symbol: <name>" diagnostic, interned so
@@ -438,21 +412,12 @@ fun unresolved_reloc_message(itn: *intern.Interner, alloc: *A.Allocator, sym: in
 # unresolved target fails the emit naming the symbol instead of silently writing
 # a relocation against the first section symbol
 fun validate_reloc_symbols(img: *of.ObjectImage) R.Result[bool, str] {
-    val mr: R.Result[map.Map[intern.StrId, u32], str] = build_reloc_sym_map(img);
-    if (R.is_err[map.Map[intern.StrId, u32], str](mr)) {
-        ret R.err[bool, str](R.unwrap_err[map.Map[intern.StrId, u32], str](mr));
-    }
-    var idx: map.Map[intern.StrId, u32] = R.unwrap_ok[map.Map[intern.StrId, u32], str](mr);
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: R.Result[u32, str] = reloc_sym_index(img, ?idx, img.relocations[i].symbol);
-        if (R.is_err[u32, str](r)) {
-            map.dnit[intern.StrId, u32](?idx);
-            ret R.err[bool, str](R.unwrap_err[u32, str](r));
-        }
+        val r: R.Result[u32, str] = reloc_sym_index(img, ?img.relocations[i]);
+        if (R.is_err[u32, str](r)) { ret R.err[bool, str](R.unwrap_err[u32, str](r)); }
         i = i + 1;
     }
-    map.dnit[intern.StrId, u32](?idx);
     ret R.ok[bool, str](true);
 }
 
@@ -1369,19 +1334,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
     # relocation lands in its owning section's slot, advancing that section's reloc
     # cursor. `reloc_offsets` is no longer read after the section-header pass, so it
     # doubles as the per-section write cursor (each starts at the section's reloc
-    # base from the layout pass and ends one past its last record). a name->index
-    # map resolves each target in O(1), keeping the pass O(reloc + symbol).
-    val smr: R.Result[map.Map[intern.StrId, u32], str] = build_reloc_sym_map(img);
-    if (R.is_err[map.Map[intern.StrId, u32], str](smr)) {
-        A.deallocate[u32](alloc, counts, num_secs::usize);
-        A.deallocate[usize](alloc, data_offsets, (num_secs + 1)::usize);
-        A.deallocate[usize](alloc, reloc_offsets, (num_secs + 1)::usize);
-        A.deallocate[u32](alloc, sec_name_offsets, (num_secs + 1)::usize);
-        if (sym_remap != nil) { A.deallocate[u32](alloc, sym_remap, num_syms::usize); }
-        A.deallocate[u8](alloc, buf, total_file_size);
-        ret R.err[bool, str](R.unwrap_err[map.Map[intern.StrId, u32], str](smr));
-    }
-    var sym_map: map.Map[intern.StrId, u32] = R.unwrap_ok[map.Map[intern.StrId, u32], str](smr);
+    # base from the layout pass and ends one past its last record).
     var ri: u32 = 0;
     for (ri < img.reloc_count) {
         val rsec: u32 = img.relocations[ri].section;
@@ -1390,7 +1343,7 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
         # validate_reloc_symbols proved every reloc resolves, and a relocated
         # section implies symbols, so sym_remap is non-nil and the lookup cannot
         # miss; the first section symbol is never silently aliased.
-        val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, ?sym_map, img.relocations[ri].symbol));
+        val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, ?img.relocations[ri]));
         bin.write_u32_le(buf, ro + 4, sym_remap[rsi]);
         # validate_reloc_kinds proved every kind maps, so this lookup cannot miss;
         # ADDR64 is never silently substituted.
@@ -1398,7 +1351,6 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
         reloc_offsets[rsec] = ro + RELOCATION_SIZE;
         ri = ri + 1;
     }
-    map.dnit[intern.StrId, u32](?sym_map);
 
     # symbol table: a section symbol (+ aux record) per section, then the image
     # symbols. the section symbol is class STATIC, value 0, 1-based section
@@ -1874,10 +1826,12 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
             out.relocations[idx].addend = read_inplace_addend(?out.sections[s], r_type, r_off);
 
             val rec: u32 = bin.read_u32_le(buf, ro + 4);
+            # rec_map already resolves the COFF record to its ObjectImage symbol
+            # index, which is what the relocation carries.
             if (rec < num_records && rec_map[rec] >= 0) {
-                out.relocations[idx].symbol = out.symbols[rec_map[rec]::u32].name;
+                out.relocations[idx].sym = rec_map[rec]::u32;
             } or {
-                out.relocations[idx].symbol = intern.STR_NIL;
+                out.relocations[idx].sym = of.SYMBOL_NONE;
             }
             rel_i = rel_i + 1;
             k = k + 1;
@@ -1912,47 +1866,21 @@ fun is_flagless_extern(sym: *of.Symbol) bool {
 # preceded by a `call`/`jmp rel32` opcode, 0xE8/0xE9) but whose symbol record
 # encodes Type 0. this serves foreign COFF inputs from toolchains that leave an
 # undefined import's type at 0; mach's own emitter already stamps DT_FUNCTION on
-# such imports (codegen `pack_reloc_externs`), so the candidate set below is empty
-# for mach-produced objects and the pass returns before allocating. the flagless
-# undefined externs are indexed by name once, so each call reloc is an O(1) lookup
-# rather than a full symbol-table scan (issue #1231)
+# such imports (codegen's relocation binding), so the pass changes nothing for
+# mach-produced objects. each relocation names its target by index, so the sweep
+# is a single O(relocation) pass with no side table (issue #1231)
 fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) R.Result[bool, str] {
     if (out == nil || out.reloc_count == 0 || out.symbol_count == 0) {
         ret R.ok[bool, str](true);
     }
 
-    # candidates are undefined externs still missing the function bit - the only
-    # symbols inference can change. mach objects have none, so the common path
-    # returns here without allocating.
-    var candidates: u32 = 0;
-    var si: u32 = 0;
-    for (si < out.symbol_count) {
-        if (is_flagless_extern(?out.symbols[si])) { candidates = candidates + 1; }
-        si = si + 1;
-    }
-    if (candidates == 0) { ret R.ok[bool, str](true); }
-
-    # index those candidates by name so each call reloc is an O(1) lookup rather
-    # than a full symbol-table scan.
-    var idx: map.Map[intern.StrId, u32] =
-        map.init[intern.StrId, u32](out.alloc, map.hash_u32, map.eq_u32);
-    si = 0;
-    for (si < out.symbol_count) {
-        if (is_flagless_extern(?out.symbols[si])) {
-            val ins: R.Result[bool, str] =
-                map.insert[intern.StrId, u32](?idx, out.symbols[si].name, si);
-            if (R.is_err[bool, str](ins)) {
-                map.dnit[intern.StrId, u32](?idx);
-                ret R.err[bool, str](R.unwrap_err[bool, str](ins));
-            }
-        }
-        si = si + 1;
-    }
-
     var ri: u32 = 0;
     for (ri < out.reloc_count) {
         val r: *of.Relocation = ?out.relocations[ri];
-        if (r.symbol == intern.STR_NIL)                    { ri = ri + 1; cnt; }
+        if (r.sym >= out.symbol_count)                     { ri = ri + 1; cnt; }
+        # the only symbols inference can change are undefined externs still
+        # missing the function bit; mach objects have none.
+        if (!is_flagless_extern(?out.symbols[r.sym]))      { ri = ri + 1; cnt; }
         if (r.kind != of.RK_PC32 && r.kind != of.RK_PLT32) { ri = ri + 1; cnt; }
         if (r.section >= out.section_count)                { ri = ri + 1; cnt; }
         val sec: *of.Section = ?out.sections[r.section];
@@ -1961,15 +1889,11 @@ fun infer_extern_function_flags_from_calls(out: *of.ObjectImage) R.Result[bool, 
         val op: u8 = sec.bytes[r.offset::usize - 1];
         if (op != 0xE8 && op != 0xE9) { ri = ri + 1; cnt; }
 
-        val g: R.Result[*u32, str] = map.get[intern.StrId, u32](?idx, ?r.symbol);
-        if (R.is_err[*u32, str](g)) { ri = ri + 1; cnt; }
-        val sidx: u32 = @R.unwrap_ok[*u32, str](g);
-        out.symbols[sidx].flags =
-            out.symbols[sidx].flags | of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_GLOBAL;
+        out.symbols[r.sym].flags =
+            out.symbols[r.sym].flags | of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_GLOBAL;
         ri = ri + 1;
     }
 
-    map.dnit[intern.StrId, u32](?idx);
     ret R.ok[bool, str](true);
 }
 
@@ -3549,9 +3473,9 @@ test "mach.lang.target.of.coff:emit_parse_round_trip" {
     # placeholder so the byte round-trip below holds.
     var relocs: [2]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[2].name; relocs[0].addend = -4;
+    relocs[0].sym = 2; relocs[0].addend = -4;
     relocs[1].section = 0; relocs[1].offset = 4; relocs[1].kind = of.RK_ABS64;
-    relocs[1].symbol = syms[1].name; relocs[1].addend = 0;
+    relocs[1].sym = 1; relocs[1].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -3645,9 +3569,9 @@ test "mach.lang.target.of.coff:emit_parse_round_trip" {
     for (rj < out.reloc_count) {
         if (out.relocations[rj].section != 0) { ret 1; }
         if (out.relocations[rj].offset == 1 && out.relocations[rj].kind == of.RK_PC32
-            && out.relocations[rj].symbol == syms[2].name) { saw_pc32 = true; }
+            && of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name) { saw_pc32 = true; }
         if (out.relocations[rj].offset == 4 && out.relocations[rj].kind == of.RK_ABS64
-            && out.relocations[rj].symbol == syms[1].name) { saw_abs64 = true; }
+            && of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[1].name) { saw_abs64 = true; }
         rj = rj + 1;
     }
     if (!saw_pc32 || !saw_abs64) { ret 1; }
@@ -3687,7 +3611,7 @@ test "mach.lang.target.of.coff:relro_round_trip" {
     # an abs64 relocated pointer in the RELRO section, carrying a non-zero addend.
     var relocs: [1]of.Relocation;
     relocs[0].section = 2; relocs[0].offset = 0; relocs[0].kind = of.RK_ABS64;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0x20;
+    relocs[0].sym = 0; relocs[0].addend = 0x20;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -3786,7 +3710,7 @@ test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
 
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[1].name; relocs[0].addend = 0;
+    relocs[0].sym = 1; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -3859,13 +3783,11 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
     syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
-    # the relocation targets a symbol interned but absent from the image symbol
-    # table - the back-end-invariant violation #1196 must surface as an error,
-    # not silently alias the first section symbol.
-    val ghost: intern.StrId = t_intern(?i, "ghost_symbol");
+    # the relocation indexes past the image symbol table - the producer-invariant
+    # violation #1196 must surface as an error, not silently alias the first section symbol.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = ghost; relocs[0].addend = 0;
+    relocs[0].sym = 1; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -3930,7 +3852,7 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     # weak body bytes are unchanged and the carve's byte round-trip holds.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 12; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[2].name; relocs[0].addend = -4;
+    relocs[0].sym = 2; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4009,7 +3931,7 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     var saw_reloc: bool = false;
     var rj: u32 = 0;
     for (rj < out.reloc_count) {
-        if (out.relocations[rj].symbol == syms[2].name && out.relocations[rj].offset == 4) {
+        if (of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name && out.relocations[rj].offset == 4) {
             # its section must be the COMDAT carrier, i.e. the weak symbol's section.
             var wsec: u32 = of.SECTION_EXTERNAL;
             var sj: u32 = 0;
@@ -4494,7 +4416,7 @@ test "mach.lang.target.of.coff:call_target_import_function_flag" {
 
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[1].name; relocs[0].addend = -4;
+    relocs[0].sym = 1; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4572,7 +4494,7 @@ test "mach.lang.target.of.coff.infer_extern_function_flags_from_calls:foreign_ca
 
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[1].name; relocs[0].addend = -4;
+    relocs[0].sym = 1; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4929,7 +4851,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unsupported_reloc_kind" {
     # over the 4-byte field); it must now fail naming the kind.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_GOTPCREL;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -5011,7 +4933,7 @@ test "mach.lang.target.of.coff.coff_parse_object:rejects_unmapped_type" {
 
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -5087,7 +5009,7 @@ test "mach.lang.target.of.coff.coff_emit_object:reloc_count_overflow" {
     var r: u32 = 0;
     for (r < nrel) {
         relocs[r].section = 0; relocs[r].offset = 0; relocs[r].kind = of.RK_PC32;
-        relocs[r].symbol = syms[0].name; relocs[r].addend = 0;
+        relocs[r].sym = 0; relocs[r].addend = 0;
         r = r + 1;
     }
 

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1845,8 +1845,8 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     # even when every reference is a call relocation. recover the function bit from
     # the reloc stream so dynamic-import discovery can still bind those call targets
     # through import stubs. mach's own emitter always stamps DT_FUNCTION on a
-    # call-target import (codegen `pack_reloc_externs`), so this never fires for
-    # mach-produced objects - see issue #1231.
+    # call-target import (codegen's deferred relocation binding), so this never
+    # fires for mach-produced objects - see issue #1231.
     val inf: R.Result[bool, str] = infer_extern_function_flags_from_calls(out);
 
     A.deallocate[i32](alloc, rec_map, (num_records + 1)::usize);

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4639,7 +4639,7 @@ test "mach.lang.target.of.elf.parse_object:x86_64_unwind_section_admitted" {
     # clang/gcc both emit into `.rela.eh_frame`
     var relocs: [1]of.Relocation;
     relocs[0].section = 1; relocs[0].offset = 8; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4306,7 +4306,8 @@ test "mach.lang.target.of.elf.emit_object:unresolved_symbol" {
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
     # the relocation indexes past the image symbol table - the producer-invariant
-    # violation #1196 must surface as an error, not silently alias the reserved undefined entry (index 0).
+    # violation #1196 must surface as an error, not silently alias
+    # the reserved undefined entry (index 0).
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
     relocs[0].sym = 1; relocs[0].addend = 0;
@@ -4328,7 +4329,7 @@ test "mach.lang.target.of.elf.emit_object:unresolved_symbol" {
     fs.temp_close_and_remove(?tf);
 
     if (!R.is_err[bool, str](em))                                   { ret 1; }
-    if (!str_contains(R.unwrap_err[bool, str](em), "ghost_symbol")) { ret 1; }
+    if (!str_contains(R.unwrap_err[bool, str](em), "unresolved symbol")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -480,11 +480,11 @@ fun strtab_size(img: *of.ObjectImage) usize {
 # resolve a relocation's target to its index in the image symbol table
 #
 # Every relocation must reference a symbol the image defines or declares extern
-# (the back end guarantees this - `pack_reloc_externs` declares an extern for any
-# named target the module did not define, and lowering panics before emitting a
-# nameless target). An out-of-range or absent index is therefore a producer
-# invariant violation, returned as an error rather than silently aliased to index
-# 0 (the reserved undefined entry), which would corrupt the link.
+# (the back end guarantees this - deferred relocation binding declares an extern
+# for any named target the module did not define, and lowering panics before
+# emitting a nameless target). an out-of-range or absent index is therefore a
+# producer invariant violation, returned as an error rather than silently aliased
+# to index 0 (the reserved undefined entry), which would corrupt the link.
 # ---
 # img: the object image whose symbol table bounds the index
 # r:   the relocation whose target index is checked

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -455,30 +455,22 @@ fun strtab_size(img: *of.ObjectImage) usize {
     ret len;
 }
 
-# resolve a relocation's target symbol to its index in the image symbol table
+# resolve a relocation's target to its index in the image symbol table
 #
-# Every relocation must name a symbol the image defines or declares extern (the
-# back end guarantees this - `pack_reloc_externs` declares an extern for any named
-# target the module did not define, and lowering panics before emitting a nameless
-# target). A miss is therefore a back-end invariant violation, returned as an error
-# naming the symbol rather than silently aliased to index 0 (the reserved undefined
-# entry), which would corrupt the link.
+# Every relocation must reference a symbol the image defines or declares extern
+# (the back end guarantees this - `pack_reloc_externs` declares an extern for any
+# named target the module did not define, and lowering panics before emitting a
+# nameless target). An out-of-range or absent index is therefore a producer
+# invariant violation, returned as an error rather than silently aliased to index
+# 0 (the reserved undefined entry), which would corrupt the link.
 # ---
-# img: the object image whose symbol table is searched
-# sym: the interned target symbol name to resolve
-# ret: ok(symbol index), or an error naming the unresolved symbol
-fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) R.Result[u32, str] {
-    if (sym != intern.STR_NIL) {
-        var i: u32 = 0;
-        for (i < img.symbol_count) {
-            # both ids live in the same session interner, so a direct integer
-            # compare is correct - matching the COFF writer (no per-symbol resolve
-            # + str_equals, which was an O(relocs x symbols x len) hot path).
-            if (img.symbols[i].name == sym) { ret R.ok[u32, str](i); }
-            i = i + 1;
-        }
-    }
-    ret R.err[u32, str](unresolved_reloc_message(img.interner, img.alloc, sym));
+# img: the object image whose symbol table bounds the index
+# r:   the relocation whose target index is checked
+# ret: ok(symbol index), or an error naming the unresolved target
+fun reloc_sym_index(img: *of.ObjectImage, r: *of.Relocation) R.Result[u32, str] {
+    if (r.sym < img.symbol_count) { ret R.ok[u32, str](r.sym); }
+    ret R.err[u32, str](unresolved_reloc_message(img.interner, img.alloc,
+        of.reloc_symbol_name(img, r)));
 }
 
 # build the "elf: unresolved relocation symbol: <name>" diagnostic
@@ -506,7 +498,7 @@ fun unresolved_reloc_message(itn: *intern.Interner, alloc: *A.Allocator, sym: in
 fun validate_reloc_symbols(img: *of.ObjectImage) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: R.Result[u32, str] = reloc_sym_index(img, img.relocations[i].symbol);
+        val r: R.Result[u32, str] = reloc_sym_index(img, ?img.relocations[i]);
         if (R.is_err[u32, str](r)) { ret R.err[bool, str](R.unwrap_err[u32, str](r)); }
         i = i + 1;
     }
@@ -967,7 +959,7 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
                     # validate_reloc_symbols proved every reloc resolves, and a
                     # relocated section implies symbols, so sym_remap is non-nil
                     # and the lookup cannot miss; index 0 is never silently used.
-                    val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
+                    val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, ?img.relocations[ri]));
                     val elf_sym: u64 = sym_remap[rsi]::u64;
                     # validate_reloc_kinds proved every kind maps, so the lookup
                     # cannot miss; index 0 / abs64 is never silently substituted.
@@ -4167,11 +4159,13 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
                 }
                 out.relocations[idx].kind = R.unwrap_ok[of.RelocKind, str](rk);
                 # r_sym indexes the on-disk symtab (1-based, index 0 reserved),
-                # so the ObjectImage symbol is r_sym - 1.
+                # so the ObjectImage symbol is r_sym - 1. carried as an index, not
+                # a name: every STT_SECTION symbol has st_name = 0, so section
+                # symbols are indistinguishable by name (#2520).
                 if (r_sym > 0 && (r_sym - 1) < sym_i) {
-                    out.relocations[idx].symbol = out.symbols[r_sym - 1].name;
+                    out.relocations[idx].sym = r_sym - 1;
                 } or {
-                    out.relocations[idx].symbol = intern.STR_NIL;
+                    out.relocations[idx].sym = of.SYMBOL_NONE;
                 }
                 rel_i = rel_i + 1;
                 ri = ri + 1;
@@ -4311,13 +4305,11 @@ test "mach.lang.target.of.elf.emit_object:unresolved_symbol" {
     syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
     syms[0].size = 16; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
 
-    # the relocation targets a symbol interned but absent from the image symbol
-    # table - the back-end-invariant violation #1196 must surface as an error,
-    # not silently alias the reserved undefined entry (index 0).
-    val ghost: intern.StrId = t_intern(?i, "ghost_symbol");
+    # the relocation indexes past the image symbol table - the producer-invariant
+    # violation #1196 must surface as an error, not silently alias the reserved undefined entry (index 0).
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = ghost; relocs[0].addend = 0;
+    relocs[0].sym = 1; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4374,7 +4366,7 @@ test "mach.lang.target.of.elf.emit_object:unmapped_reloc_kind" {
     # the 4-byte field); it must now fail naming the kind.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_ADDR32NB;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4517,7 +4509,7 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
 
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4597,9 +4589,9 @@ test "mach.lang.target.of.elf.parse_object:riscv_machine_roundtrip" {
     # and R_RISCV_PCREL_HI20 (23). a parser keyed on x86_64 would read type 2 as PC32.
     var relocs: [2]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_ABS64;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
     relocs[1].section = 0; relocs[1].offset = 8; relocs[1].kind = of.RK_PCREL_HI20;
-    relocs[1].symbol = syms[0].name; relocs[1].addend = 0;
+    relocs[1].sym = 0; relocs[1].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -546,24 +546,18 @@ fun reloc_entries_for_section(img: *of.ObjectImage, sec_idx: u32, arch_id: u32) 
     ret n;
 }
 
-# resolve a relocation's target symbol to its index in the image symbol table.
-# Every relocation names a symbol the image defines or declares extern (a
-# back-end invariant); a miss is an error naming the symbol, never aliased to
-# index 0
+# resolve a relocation's target to its index in the image symbol table.
+# Every relocation references a symbol the image defines or declares extern (a
+# producer invariant); an out-of-range index is an error naming the target, never
+# aliased to index 0
 # ---
-# img: the object image whose symbol table is searched
-# sym: the interned target symbol name to resolve
-# ret: ok(symbol index), or an error naming the unresolved symbol
-fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) R.Result[u32, str] {
-    if (sym != intern.STR_NIL) {
-        var i: u32 = 0;
-        for (i < img.symbol_count) {
-            if (img.symbols[i].name == sym) { ret R.ok[u32, str](i); }
-            i = i + 1;
-        }
-    }
+# img: the object image whose symbol table bounds the index
+# r:   the relocation whose target index is checked
+# ret: ok(symbol index), or an error naming the unresolved target
+fun reloc_sym_index(img: *of.ObjectImage, r: *of.Relocation) R.Result[u32, str] {
+    if (r.sym < img.symbol_count) { ret R.ok[u32, str](r.sym); }
     ret R.err[u32, str](bin.name_message(img.interner, img.alloc, "macho: unresolved relocation symbol: ",
-                                         bin.resolve_name(img.interner, sym), "macho: relocation references an unresolved symbol"));
+                                         bin.resolve_name(img.interner, of.reloc_symbol_name(img, r)), "macho: relocation references an unresolved symbol"));
 }
 
 # verify every relocation's target symbol resolves, up front before any output is
@@ -574,7 +568,7 @@ fun reloc_sym_index(img: *of.ObjectImage, sym: intern.StrId) R.Result[u32, str] 
 fun validate_reloc_symbols(img: *of.ObjectImage) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < img.reloc_count) {
-        val r: R.Result[u32, str] = reloc_sym_index(img, img.relocations[i].symbol);
+        val r: R.Result[u32, str] = reloc_sym_index(img, ?img.relocations[i]);
         if (R.is_err[u32, str](r)) { ret R.err[bool, str](R.unwrap_err[u32, str](r)); }
         i = i + 1;
     }
@@ -1294,7 +1288,7 @@ fun emit_object(isa_vt: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resul
             for (ri < img.reloc_count) {
                 if (img.relocations[ri].section == sp) {
                     val radr: u32 = base + img.relocations[ri].offset;
-                    val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, img.relocations[ri].symbol));
+                    val rsi: u32 = R.unwrap_ok[u32, str](reloc_sym_index(img, ?img.relocations[ri]));
                     val symnum: u32 = remap[rsi];
                     val mr: MachoReloc = R.unwrap_ok[MachoReloc, str](macho_reloc_for(img.interner, alloc, arch_id, img.relocations[ri].kind));
                     if (needs_addend_entry(arch_id, img.relocations[ri].kind, img.relocations[ri].addend)) {
@@ -3661,7 +3655,7 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                     out.relocations[rel_i].section = sec_i;
                     out.relocations[rel_i].offset  = address;
                     out.relocations[rel_i].kind    = kind;
-                    out.relocations[rel_i].symbol  = out.symbols[symnum].name;
+                    out.relocations[rel_i].sym     = symnum;
                     out.relocations[rel_i].addend  = recover_addend(out, sec_i, address, cputype, kind, pcrel, pending, have_pending);
                     rel_i = rel_i + 1;
                     pending = 0;
@@ -3828,11 +3822,11 @@ fun ts_x64_roundtrip() u8 {
 
     var relocs: [3]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1;  relocs[0].kind = of.RK_PLT32;
-    relocs[0].symbol = syms[2].name; relocs[0].addend = -4;
+    relocs[0].sym = 2; relocs[0].addend = -4;
     relocs[1].section = 0; relocs[1].offset = 8;  relocs[1].kind = of.RK_PC32;
-    relocs[1].symbol = syms[1].name; relocs[1].addend = -4;
+    relocs[1].sym = 1; relocs[1].addend = -4;
     relocs[2].section = 0; relocs[2].offset = 16; relocs[2].kind = of.RK_ABS64;
-    relocs[2].symbol = syms[1].name; relocs[2].addend = 0;
+    relocs[2].sym = 1; relocs[2].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -3901,9 +3895,9 @@ fun ts_x64_roundtrip() u8 {
     var rj: u32 = 0;
     for (rj < out.reloc_count) {
         val rr: *of.Relocation = ?out.relocations[rj];
-        if (rr.offset == 1 && rr.kind == of.RK_PLT32 && rr.symbol == syms[2].name && rr.addend == -4) { ok_plt = true; }
-        if (rr.offset == 8 && rr.kind == of.RK_PC32 && rr.symbol == syms[1].name && rr.addend == -4)  { ok_pc = true; }
-        if (rr.offset == 16 && rr.kind == of.RK_ABS64 && rr.symbol == syms[1].name && rr.addend == 0) { ok_abs = true; }
+        if (rr.offset == 1 && rr.kind == of.RK_PLT32 && of.reloc_symbol_name(?out, rr) == syms[2].name && rr.addend == -4) { ok_plt = true; }
+        if (rr.offset == 8 && rr.kind == of.RK_PC32 && of.reloc_symbol_name(?out, rr) == syms[1].name && rr.addend == -4)  { ok_pc = true; }
+        if (rr.offset == 16 && rr.kind == of.RK_ABS64 && of.reloc_symbol_name(?out, rr) == syms[1].name && rr.addend == 0) { ok_abs = true; }
         rj = rj + 1;
     }
     if (!ok_plt || !ok_pc || !ok_abs) { ret 1; }
@@ -3943,7 +3937,7 @@ fun ts_relro_roundtrip() u8 {
     # that must survive the in-place fold/recover round-trip.
     var relocs: [1]of.Relocation;
     relocs[0].section = 2; relocs[0].offset = 0; relocs[0].kind = of.RK_ABS64;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0x10;
+    relocs[0].sym = 0; relocs[0].addend = 0x10;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4027,15 +4021,15 @@ fun ts_arm64_roundtrip() u8 {
 
     var relocs: [5]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0;  relocs[0].kind = of.RK_PAGE21;
-    relocs[0].symbol = syms[1].name; relocs[0].addend = 0;
+    relocs[0].sym = 1; relocs[0].addend = 0;
     relocs[1].section = 0; relocs[1].offset = 4;  relocs[1].kind = of.RK_ADD_LO12;
-    relocs[1].symbol = syms[1].name; relocs[1].addend = 0;
+    relocs[1].sym = 1; relocs[1].addend = 0;
     relocs[2].section = 0; relocs[2].offset = 8;  relocs[2].kind = of.RK_LDST64_LO12;
-    relocs[2].symbol = syms[1].name; relocs[2].addend = 0x10;
+    relocs[2].sym = 1; relocs[2].addend = 0x10;
     relocs[3].section = 0; relocs[3].offset = 12; relocs[3].kind = of.RK_PLT32;
-    relocs[3].symbol = syms[2].name; relocs[3].addend = 0;
+    relocs[3].sym = 2; relocs[3].addend = 0;
     relocs[4].section = 1; relocs[4].offset = 0;  relocs[4].kind = of.RK_ABS64;
-    relocs[4].symbol = syms[0].name; relocs[4].addend = 0x20;
+    relocs[4].sym = 0; relocs[4].addend = 0x20;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4080,11 +4074,11 @@ fun ts_arm64_roundtrip() u8 {
     var rj: u32 = 0;
     for (rj < out.reloc_count) {
         val rr: *of.Relocation = ?out.relocations[rj];
-        if (rr.section == 0 && rr.offset == 0 && rr.kind == of.RK_PAGE21 && rr.symbol == syms[1].name)                     { ok_page = true; }
-        if (rr.section == 0 && rr.offset == 4 && rr.kind == of.RK_ADD_LO12 && rr.symbol == syms[1].name)                   { ok_add = true; }
-        if (rr.section == 0 && rr.offset == 8 && rr.kind == of.RK_LDST64_LO12 && rr.symbol == syms[1].name && rr.addend == 0x10) { ok_ldst = true; }
-        if (rr.section == 0 && rr.offset == 12 && rr.kind == of.RK_PLT32 && rr.symbol == syms[2].name)                     { ok_br = true; }
-        if (rr.section == 1 && rr.offset == 0 && rr.kind == of.RK_ABS64 && rr.symbol == syms[0].name && rr.addend == 0x20) { ok_abs = true; }
+        if (rr.section == 0 && rr.offset == 0 && rr.kind == of.RK_PAGE21 && of.reloc_symbol_name(?out, rr) == syms[1].name)                     { ok_page = true; }
+        if (rr.section == 0 && rr.offset == 4 && rr.kind == of.RK_ADD_LO12 && of.reloc_symbol_name(?out, rr) == syms[1].name)                   { ok_add = true; }
+        if (rr.section == 0 && rr.offset == 8 && rr.kind == of.RK_LDST64_LO12 && of.reloc_symbol_name(?out, rr) == syms[1].name && rr.addend == 0x10) { ok_ldst = true; }
+        if (rr.section == 0 && rr.offset == 12 && rr.kind == of.RK_PLT32 && of.reloc_symbol_name(?out, rr) == syms[2].name)                     { ok_br = true; }
+        if (rr.section == 1 && rr.offset == 0 && rr.kind == of.RK_ABS64 && of.reloc_symbol_name(?out, rr) == syms[0].name && rr.addend == 0x20) { ok_abs = true; }
         rj = rj + 1;
     }
     if (!ok_page || !ok_add || !ok_ldst || !ok_br || !ok_abs) { ret 1; }
@@ -4141,7 +4135,7 @@ fun ts_many_sections_coalesce() u8 {
 
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
-    relocs[0].symbol = syms[1].name; relocs[0].addend = -4;
+    relocs[0].sym = 1; relocs[0].addend = -4;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -4174,7 +4168,7 @@ fun ts_many_sections_coalesce() u8 {
     # the relocation still names the section-255 local, and that local round-trips
     # as a defined rodata local - not the overflow's undefined external.
     if (out.reloc_count != 1)                      { ret 1; }
-    if (out.relocations[0].symbol != syms[1].name) { ret 1; }
+    if (of.reloc_symbol_name(?out, ?out.relocations[0]) != syms[1].name) { ret 1; }
 
     var found: bool = false;
     var si: u32 = 0;
@@ -4978,7 +4972,7 @@ fun ts_unsupported_kind() u8 {
     # RK_ADDR32NB is COFF image-relative, never mapped by Mach-O.
     var relocs: [1]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_ADDR32NB;
-    relocs[0].symbol = syms[0].name; relocs[0].addend = 0;
+    relocs[0].sym = 0; relocs[0].addend = 0;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;
@@ -5216,7 +5210,7 @@ fun ts_object_debug_roundtrip() u8 {
     # with the string's byte offset (3) as the addend.
     var relocs: [1]of.Relocation;
     relocs[0].section = 1; relocs[0].offset = 0; relocs[0].kind = of.RK_ABS32;
-    relocs[0].symbol = syms[1].name; relocs[0].addend = 3;
+    relocs[0].sym = 1; relocs[0].addend = 3;
 
     var img: of.ObjectImage;
     img.alloc = ?alloc;


### PR DESCRIPTION
Closes #2520

## Root cause

`of.Relocation` identified its target symbol by interned name. ELF gives every `STT_SECTION` symbol `st_name = 0`, so all section symbols in an object intern to the same empty string. The linker's local-symbol index kept the first definition of a name, causing every section-relative relocation to resolve against whichever anonymous section symbol appeared first, normally `.text`.

The real miniaudio object contains 934 such relocations and eight anonymous section symbols. Its backend-name table therefore resolved into executable bytes; the resulting invalid `const char *` caused the observed crash in `__strlen_avx2`.

The reduced cases confirmed the same failure across:

- `R_X86_64_32S` against `.rodata`
- `R_X86_64_PC32` against `.rodata` / `.data.rel.ro.local`
- `R_X86_64_64` against `.rodata.str1.1`

Named-symbol controls using the same relocation forms remained correct.

## Fix

Relocations now bind their target by index into their owning image's symbol array, matching the native representation in ELF `r_info`, COFF `SymbolTableIndex`, and Mach-O `r_symbolnum`:

```text
symbol: intern.StrId  ->  sym: u32
```

Local targets resolve directly from their indexed definition. Global and undefined targets continue to resolve by name through the cross-object symbol table.

The representation change is format-generic and propagated through:

- ELF, COFF, and Mach-O readers and writers
- codegen and DWARF relocation producers
- the generic linker, liveness analysis, and relocatable-output carry path
- COFF call-target inference and weak-section splitting
- parallel-codegen image rehoming

Codegen records relocations by name only while its symbol table is incomplete, then binds every record to a symbol index in one pass. This also declares genuinely undefined targets and replaces the two older extern-backfill sweeps.

## Regression coverage

- A flat-link test carries two anonymous ELF-style section symbols with the same empty name and compares the section-relative result against a named anchor at the exact same byte.
- A PE/COFF-path test carries two distinct `.rdata` section symbols with the same name. Four ABS64 sites prove each section-symbol target equals its own named anchor while the two target sections remain distinct. Reintroducing the old name-keyed lookup makes this test fail.
- Existing ELF, COFF, and Mach-O emit/parse tests now exercise indexed relocation targets.

`IMAGE_REL_AMD64_ADDR32NB` application and exact RVA assertions remain scoped to #2535. COFF already parses and emits that kind, but the x86-64 applier does not yet implement `S + A - ImageBase`; this PR deliberately does not fold #2535 into #2520.

## Verification

Local verification after merging current `dev`:

- Original isolated #2520 acceptance gate: both PIC and non-PIC reduced probes pass exact-value assertions across 32S, PC32, and ABS64; the named-symbol regression controls also pass.
- mach-audio `play` builds and runs to completion against the real vendored miniaudio object.
- mach-audio: 36 passed, 0 failed.
- Debug self-host fixpoint: byte-identical `b == c`.
- In-source tests: 1088 passed, 0 failed.
- Release self-host fixpoint: byte-identical `b == c`; focused release-built regression passes.
- Incremental determinism: clean, warm no-op, and post-edit builds match.
- Integration target matrix: 268 case/leg pairs validated.
- Linux integration lane passes.
- RISC-V integration lane passes; two local dependency-clone races were rerun individually and passed in both debug and release.
