### PR TITLE
feat(link): read COFF short import records from import libraries

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -170,7 +170,7 @@ produce_panic_exit() {
 }
 
 # read_le_uint <file> <offset> <size>
-# print the unsigned little-endian integer of <size> bytes (2 or 4) at <offset>.
+# print the unsigned little-endian integer of <size> bytes (1, 2, or 4) at <offset>.
 # od reads in host byte order; every CI runner is little-endian.
 read_le_uint() {
     dd if="$1" bs=1 skip="$2" count="$3" 2>/dev/null | od -An -tu"$3" | tr -d ' \n'
@@ -290,13 +290,19 @@ produce_pe_imports() {
 
         t=0
         while :; do
-            entry=$(read_le_uint "$bin" $((thunk_off + t * 8)) 8)
-            [ "$entry" -eq 0 ] && break
-            # bit 63 set marks an ordinal import, which names no symbol
-            if [ $((entry >> 63)) -eq 1 ]; then
-                echo "$dll:#$((entry & 0xFFFF))" >>"$out"
+            thunk=$((thunk_off + t * 8))
+            entry_lo=$(read_le_uint "$bin" "$thunk" 4)
+            entry_hi=$(read_le_uint "$bin" $((thunk + 4)) 4)
+            [ "$entry_lo" -eq 0 ] && [ "$entry_hi" -eq 0 ] && break
+            # Inspect bit 63 as a byte. A by-ordinal thunk is an unsigned u64
+            # above the shell's signed arithmetic range, so reading the whole
+            # value into `$((...))` would overflow before the test.
+            top=$(read_le_uint "$bin" $((thunk + 7)) 1)
+            if [ $((top & 128)) -ne 0 ]; then
+                ordinal=$(read_le_uint "$bin" "$thunk" 2)
+                echo "$dll:#$ordinal" >>"$out"
             else
-                hn_off=$(pe_rva_to_off "$bin" "$sec" "$nsec" $((entry & 0x7FFFFFFF))) || return 2
+                hn_off=$(pe_rva_to_off "$bin" "$sec" "$nsec" "$entry_lo") || return 2
                 echo "$dll:$(read_cstr "$bin" $((hn_off + 2)))" >>"$out"
             fi
             t=$((t + 1))

--- a/int/surface/pe-import-library/case.conf
+++ b/int/surface/pe-import-library/case.conf
@@ -1,0 +1,6 @@
+# a mingw/LLVM-shaped import library must be consumed and each symbol bound to the
+# DLL its record names (#2525). the fixture is generated with coreutils so no LLVM
+# is needed on the leg; cross-build the win64 PE on linux and read the import table.
+run: pe-imports
+targets: linux
+build-target: windows

--- a/int/surface/pe-import-library/expect.windows.txt
+++ b/int/surface/pe-import-library/expect.windows.txt
@@ -1,0 +1,3 @@
+kernel32.dll:ExitProcess
+kernel32.dll:Sleep
+user32.dll:MessageBeep

--- a/int/surface/pe-import-library/expect.windows.txt
+++ b/int/surface/pe-import-library/expect.windows.txt
@@ -1,3 +1,4 @@
+demo.dll:ExportName
 kernel32.dll:ExitProcess
 kernel32.dll:Sleep
 user32.dll:#123

--- a/int/surface/pe-import-library/expect.windows.txt
+++ b/int/surface/pe-import-library/expect.windows.txt
@@ -1,3 +1,3 @@
 kernel32.dll:ExitProcess
 kernel32.dll:Sleep
-user32.dll:MessageBeep
+user32.dll:#123

--- a/int/surface/pe-import-library/mach.toml
+++ b/int/surface/pe-import-library/mach.toml
@@ -1,0 +1,42 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["implib"]
+need = []
+
+[link.implib]
+source = "local"
+path = "{project.out}/lib/libwin.a"
+os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[step.implib]
+cmd = "sh mkimplib.sh {project.out}/lib/libwin.a"
+in = ["mkimplib.sh"]
+out = ["{project.out}/lib/libwin.a"]
+need = []

--- a/int/surface/pe-import-library/mkimplib.sh
+++ b/int/surface/pe-import-library/mkimplib.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
 # build an import library the way llvm-dlltool would, using coreutils alone so the
 # case needs no LLVM on the leg. each member is a COFF short import record
-# (IMPORT_OBJECT_HEADER): Sig1=0, Sig2=0xFFFF, Version=0 (what separates it from a
-# /bigobj object), Machine=0x8664, then SizeOfData bytes holding the NUL-terminated
-# symbol name followed by the NUL-terminated DLL name. The records cover both
-# by-name and by-ordinal loader bindings.
+# (IMPORT_OBJECT_HEADER): Sig1=0, Sig2=0xFFFF, Version=0, Machine=0x8664, then
+# SizeOfData bytes holding the NUL-terminated public symbol name followed by the
+# NUL-terminated DLL name and, for EXPORTAS, the distinct loader export name. a
+# /bigobj header shares the signature but carries its fixed ClassID. the records
+# cover direct name, explicit export-name, and ordinal loader bindings.
 set -eu
 out=$1
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-# record <file> <symbol> <dll> <hint-or-ordinal> <flags>
+# record <file> <symbol> <dll> <hint-or-ordinal> <flags> [export-name]
 record() {
     f=$1; sym=$2; dll=$3; hint=$4; flags=$5
+    export_name=${6-}
     n=$(( ${#sym} + 1 + ${#dll} + 1 ))
+    if [ -n "$export_name" ]; then n=$(( n + ${#export_name} + 1 )); fi
     # header: sig1, sig2, version, machine(0x8664 LE), timestamp, size(LE u32),
     # ordinal/hint, then type/name-type
     printf '\000\000\377\377\000\000\144\206\000\000\000\000' >"$f"
@@ -23,15 +26,17 @@ record() {
         $(( hint & 255 )) $(( (hint >> 8) & 255 )) \
         $(( flags & 255 )) $(( (flags >> 8) & 255 )))" >>"$f"
     printf '%s\000%s\000' "$sym" "$dll" >>"$f"
+    if [ -n "$export_name" ]; then printf '%s\000' "$export_name" >>"$f"; fi
 }
 
 record "$tmp/a" Sleep       kernel32.dll 0   4  # code, by name
 record "$tmp/b" ExitProcess kernel32.dll 0   4  # code, by name
 record "$tmp/c" MessageBeep user32.dll   123 0  # code, by ordinal
+record "$tmp/d" PublicName  demo.dll     7   16 ExportName # code, EXPORTAS
 
 mkdir -p "$(dirname "$out")"
 printf '!<arch>\n' >"$out"
-for m in a b c; do
+for m in a b c d; do
     sz=$(wc -c <"$tmp/$m")
     # ar member header: 16 name, 12 mtime, 6 uid, 6 gid, 8 mode, 10 size, 2 magic.
     # a fixed mtime/uid/gid keeps the generated archive byte-stable across runs.

--- a/int/surface/pe-import-library/mkimplib.sh
+++ b/int/surface/pe-import-library/mkimplib.sh
@@ -3,28 +3,31 @@
 # case needs no LLVM on the leg. each member is a COFF short import record
 # (IMPORT_OBJECT_HEADER): Sig1=0, Sig2=0xFFFF, Version=0 (what separates it from a
 # /bigobj object), Machine=0x8664, then SizeOfData bytes holding the NUL-terminated
-# symbol name followed by the NUL-terminated DLL name.
+# symbol name followed by the NUL-terminated DLL name. The records cover both
+# by-name and by-ordinal loader bindings.
 set -eu
 out=$1
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-# record <file> <symbol> <dll>
+# record <file> <symbol> <dll> <hint-or-ordinal> <flags>
 record() {
-    f=$1; sym=$2; dll=$3
+    f=$1; sym=$2; dll=$3; hint=$4; flags=$5
     n=$(( ${#sym} + 1 + ${#dll} + 1 ))
     # header: sig1, sig2, version, machine(0x8664 LE), timestamp, size(LE u32),
-    # ordinal/hint, then type/name-type (NameType=1, bind by name)
+    # ordinal/hint, then type/name-type
     printf '\000\000\377\377\000\000\144\206\000\000\000\000' >"$f"
     printf "$(printf '\\%03o\\%03o\\%03o\\%03o' \
         $(( n & 255 )) $(( (n >> 8) & 255 )) $(( (n >> 16) & 255 )) $(( (n >> 24) & 255 )))" >>"$f"
-    printf '\000\000\004\000' >>"$f"
+    printf "$(printf '\\%03o\\%03o\\%03o\\%03o' \
+        $(( hint & 255 )) $(( (hint >> 8) & 255 )) \
+        $(( flags & 255 )) $(( (flags >> 8) & 255 )))" >>"$f"
     printf '%s\000%s\000' "$sym" "$dll" >>"$f"
 }
 
-record "$tmp/a" Sleep       kernel32.dll
-record "$tmp/b" ExitProcess kernel32.dll
-record "$tmp/c" MessageBeep user32.dll
+record "$tmp/a" Sleep       kernel32.dll 0   4  # code, by name
+record "$tmp/b" ExitProcess kernel32.dll 0   4  # code, by name
+record "$tmp/c" MessageBeep user32.dll   123 0  # code, by ordinal
 
 mkdir -p "$(dirname "$out")"
 printf '!<arch>\n' >"$out"

--- a/int/surface/pe-import-library/mkimplib.sh
+++ b/int/surface/pe-import-library/mkimplib.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# build an import library the way llvm-dlltool would, using coreutils alone so the
+# case needs no LLVM on the leg. each member is a COFF short import record
+# (IMPORT_OBJECT_HEADER): Sig1=0, Sig2=0xFFFF, Version=0 (what separates it from a
+# /bigobj object), Machine=0x8664, then SizeOfData bytes holding the NUL-terminated
+# symbol name followed by the NUL-terminated DLL name.
+set -eu
+out=$1
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# record <file> <symbol> <dll>
+record() {
+    f=$1; sym=$2; dll=$3
+    n=$(( ${#sym} + 1 + ${#dll} + 1 ))
+    # header: sig1, sig2, version, machine(0x8664 LE), timestamp, size(LE u32),
+    # ordinal/hint, then type/name-type (NameType=1, bind by name)
+    printf '\000\000\377\377\000\000\144\206\000\000\000\000' >"$f"
+    printf "$(printf '\\%03o\\%03o\\%03o\\%03o' \
+        $(( n & 255 )) $(( (n >> 8) & 255 )) $(( (n >> 16) & 255 )) $(( (n >> 24) & 255 )))" >>"$f"
+    printf '\000\000\004\000' >>"$f"
+    printf '%s\000%s\000' "$sym" "$dll" >>"$f"
+}
+
+record "$tmp/a" Sleep       kernel32.dll
+record "$tmp/b" ExitProcess kernel32.dll
+record "$tmp/c" MessageBeep user32.dll
+
+mkdir -p "$(dirname "$out")"
+printf '!<arch>\n' >"$out"
+for m in a b c; do
+    sz=$(wc -c <"$tmp/$m")
+    # ar member header: 16 name, 12 mtime, 6 uid, 6 gid, 8 mode, 10 size, 2 magic.
+    # a fixed mtime/uid/gid keeps the generated archive byte-stable across runs.
+    printf '%-16s%-12s%-6s%-6s%-8s%-10s\140\n' 'imp.o/' '0' '0' '0' '644' "$sz" >>"$out"
+    cat "$tmp/$m" >>"$out"
+    # members are padded to an even offset
+    if [ $(( sz % 2 )) -ne 0 ]; then printf '\n' >>"$out"; fi
+done

--- a/int/surface/pe-import-library/src/main.mach
+++ b/int/surface/pe-import-library/src/main.mach
@@ -5,10 +5,12 @@
 ext fun Sleep(ms: u32);
 ext fun MessageBeep(kind: u32);
 ext fun ExitProcess(code: u32);
+ext fun PublicName();
 
 #[symbol("mainCRTStartup")]
 pub fun _start() {
     Sleep(0);
     MessageBeep(0);
+    PublicName();
     ExitProcess(0);
 }

--- a/int/surface/pe-import-library/src/main.mach
+++ b/int/surface/pe-import-library/src/main.mach
@@ -1,0 +1,14 @@
+# nothing here attributes anything: no #[library] decorator and no manifest
+# `symbols` claim. the import library alone says which DLL provides each symbol,
+# carrying the loader's own name and ordinal rather than anything hand-written
+# (#2525). two DLLs keep per-DLL routing the observable.
+ext fun Sleep(ms: u32);
+ext fun MessageBeep(kind: u32);
+ext fun ExitProcess(code: u32);
+
+#[symbol("mainCRTStartup")]
+pub fun _start() {
+    Sleep(0);
+    MessageBeep(0);
+    ExitProcess(0);
+}

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3357,23 +3357,22 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         dyn.info.lib_count = total_libs;
     }
 
-    # an import record IS the attribution for its symbol, so record it before the
-    # undefined externs are walked below. it names the loader's own DLL, so it never
-    # depends on a manifest claim or a decorator having guessed the same name. a
-    # `#[library]` or manifest claim that disagrees is a hard error rather than a
-    # silent loss, matching how the two manifest-side sources already conflict.
+    # an import record is authoritative for this link without becoming session
+    # state: a project may build several artifacts from different import libraries.
+    # validate any source/manifest attribution against the record's canonical loader
+    # identity, accepting a logical alias of that same dependency.
     var am: u32 = 0;
     for (am < module_count) {
         var ai: u32 = 0;
         for (ai < modules[am].import_count) {
             val d: *of.ImportDecl = ?modules[am].imports[ai];
             val prev: O.Option[intern.StrId] = session.import_library(s, d.symbol);
-            if (O.is_some[intern.StrId](prev) && O.unwrap[intern.StrId](prev) != d.library) {
+            if (O.is_some[intern.StrId](prev)
+                && !declared_attribution_matches(dynlibs, dynlib_count, implicit_ptr,
+                    O.unwrap[intern.StrId](prev), d.library)) {
                 ret R.err[bool, str](declared_conflict_message(
                     s, d.symbol, O.unwrap[intern.StrId](prev), d.library));
             }
-            val rr: R.Result[bool, str] = session.register_import_library(s, d.symbol, d.library);
-            if (R.is_err[bool, str](rr)) { ret R.err[bool, str](R.unwrap_err[bool, str](rr)); }
             ai = ai + 1;
         }
         am = am + 1;
@@ -3423,13 +3422,16 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
 
             val idx: u32 = dyn.info.import_count;
             dyn.info.imports[idx].symbol    = sym.name;
+            val decl: *of.ImportDecl = declared_import_for(modules, module_count, sym.name);
             # pin the import to the library its `#[library]` attribution named, when
             # present. a directive naming a library not among this link's
             # dependencies is a hard error. an unattributed import stays DYNLIB_ANY
             # on a flat-namespace format (ELF), but is a hard error on a two-level
             # namespace (PE, Mach-O) where the image must name a providing library
-            # per import.
-            val lib_opt: O.Option[intern.StrId] = session.import_library(s, sym.name);
+            # per import. a short import declaration overrides an equivalent
+            # source/manifest alias with its exact loader spelling for this link.
+            var lib_opt: O.Option[intern.StrId] = session.import_library(s, sym.name);
+            if (decl != nil) { lib_opt = O.some[intern.StrId](decl.library); }
             if (O.is_some[intern.StrId](lib_opt)) {
                 val want: intern.StrId = O.unwrap[intern.StrId](lib_opt);
                 var li_opt: O.Option[u32] =
@@ -3461,8 +3463,8 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             # emit an ordinal thunk instead of silently changing it to by-name.
             dyn.info.imports[idx].ordinal = 0;
             dyn.info.imports[idx].by_ordinal = false;
-            val decl: *of.ImportDecl = declared_import_for(modules, module_count, sym.name);
             if (decl != nil) {
+                dyn.info.imports[idx].symbol = decl.import_name;
                 dyn.info.imports[idx].ordinal = decl.ordinal;
                 dyn.info.imports[idx].by_ordinal = !decl.by_name;
             }
@@ -3622,6 +3624,25 @@ fun declared_import_for(modules: *of.ObjectImage, module_count: u32,
         m = m + 1;
     }
     ret nil;
+}
+
+# whether an existing source/manifest attribution identifies the loader an import
+# record names. an attribution may use either the dependency's logical alias or
+# its loader name; both are equivalent only when they resolve to this exact loader
+fun declared_attribution_matches(dynlibs: *of.DynLib, count: u32,
+                                 implicit: *of.DynLib,
+                                 attributed: intern.StrId, loader: intern.StrId) bool {
+    if (attributed == loader) { ret true; }
+    var i: u32 = 0;
+    for (i < count) {
+        if ((dynlibs[i].name == attributed || dynlibs[i].soname == attributed)
+            && dynlibs[i].soname == loader) { ret true; }
+        i = i + 1;
+    }
+    if (implicit != nil
+        && (implicit.name == attributed || implicit.soname == attributed)
+        && implicit.soname == loader) { ret true; }
+    ret false;
 }
 
 # whether the dependency requirements carry a logical or loader name
@@ -4475,6 +4496,8 @@ fun lt_image(s: *session.Session, name: intern.StrId,
     img.symbol_count = symbol_count;
     img.relocations = relocations;
     img.reloc_count = reloc_count;
+    img.imports = nil;
+    img.import_count = 0;
     ret img;
 }
 
@@ -4514,6 +4537,9 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     if (!O.is_some[u32](loader) || O.unwrap[u32](loader) != 0)   { ret 1; }
     if (!O.is_some[u32](other) || O.unwrap[u32](other) != 1)     { ret 1; }
     if (O.is_some[u32](missing) || unique_dynlib_count(?libs[0], 3) != 2) { ret 1; }
+    if (!declared_attribution_matches(?libs[0], 3, nil::*of.DynLib, 41, 73)) { ret 1; }
+    if (!declared_attribution_matches(?libs[0], 3, nil::*of.DynLib, 73, 73)) { ret 1; }
+    if (declared_attribution_matches(?libs[0], 3, nil::*of.DynLib, 41, 74))  { ret 1; }
 
     # a logical name may alias the same loader, but it may not equal another
     # dependency's loader name: that spelling would select two providers.
@@ -4537,6 +4563,67 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     if (!dynlib_identity_collision(?reversed[0], 2, nil::*of.DynLib,
                                    ?first, ?second, ?identity)) { ret 1; }
     if (identity != 73) { ret 1; }
+    ret 0;
+}
+
+# a short-import declaration builds a loader binding without persisting an
+# attribution in the shared session, which may link a later artifact
+test "mach.lang.be.linker.build_dynamic_info:declared_import_is_link_local" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] =
+        target.select(?reg, "x86_64", "windows", "win64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    val symbol: intern.StrId = lt_name(?s, "PublicName");
+    val export_name: intern.StrId = lt_name(?s, "ExportName");
+    val library: intern.StrId = lt_name(?s, "demo.dll");
+    if (symbol == intern.STR_NIL || export_name == intern.STR_NIL
+        || library == intern.STR_NIL) { ret 1; }
+
+    var sym: of.Symbol;
+    sym.name = symbol;
+    sym.section = of.SECTION_EXTERNAL;
+    sym.offset = 0;
+    sym.size = 0;
+    sym.flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN
+              | of.SYM_OBJ_FLAG_FUNCTION;
+    var decl: of.ImportDecl;
+    decl.symbol = symbol;
+    decl.import_name = export_name;
+    decl.library = library;
+    decl.ordinal = 7;
+    decl.by_name = true;
+    decl.is_code = true;
+    var module: of.ObjectImage =
+        lt_image(?s, lt_name(?s, "import-user"), nil::*of.Section, 0,
+                 ?sym, 1, nil::*of.Relocation, 0);
+    module.imports = ?decl;
+    module.import_count = 1;
+
+    var locs: map.Map[intern.StrId, SymbolLoc] =
+        map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
+    var dyn: DynState;
+    init_dynstate(?dyn);
+    val built: R.Result[bool, str] =
+        build_dynamic_info(?s, ?tgt, ?dyn, ?module, 1, ?locs,
+                           nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
+    if (R.is_err[bool, str](built)) { ret 1; }
+    if (dyn.info.lib_count != 1 || dyn.info.libs[0].soname != library
+        || dyn.info.import_count != 1 || dyn.info.imports[0].symbol != export_name
+        || dyn.info.imports[0].lib_index != 0 || dyn.info.imports[0].ordinal != 7
+        || dyn.info.imports[0].by_ordinal
+        || O.is_some[intern.StrId](session.import_library(?s, symbol))) { ret 1; }
+
+    free_dynstate(?alloc, ?dyn);
+    map.dnit[intern.StrId, SymbolLoc](?locs);
+    session.dnit(?s);
     ret 0;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -468,8 +468,11 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val pie: bool = (mode == LINK_EXE) && (target_requires_pie(tgt) || pie_opt_in);
     # a dynamic link is requested when shared dependencies are present or the image
     # is position-independent, and the output is an executable; libraries/
-    # relocatables ignore dependencies.
-    val dynamic: bool = (mode == LINK_EXE) && (dynlib_count > 0 || pie);
+    # relocatables ignore dependencies. an import library brings its dependencies in
+    # through its members rather than the link inputs, so a declared import counts
+    # the same as a shared-library input here (#2525).
+    val dynamic: bool = (mode == LINK_EXE)
+        && (dynlib_count > 0 || pie || has_declared_imports(modules, module_count));
     # both a PIE executable and a shared object need a position-independent layout
     # (based a page above the OS base, with a base-relocation set collected during
     # patching).
@@ -854,6 +857,8 @@ fun grow_modules(alloc: *A.Allocator, modules: **of.ObjectImage, count: *u32, ca
     slot.symbol_count  = 0;
     slot.relocations   = nil;
     slot.reloc_count   = 0;
+    slot.imports       = nil;
+    slot.import_count  = 0;
 
     @count = old + 1;
     ret R.ok[u32, str](old);
@@ -3293,7 +3298,11 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     # Emit each canonical loader dependency once even when several logical names
     # alias it. Attribution below maps every alias back to this compact index.
     val explicit_libs: u32 = unique_dynlib_count(dynlibs, dynlib_count);
-    val total_libs: u32 = explicit_libs + implicit;
+    # an import library names its DLLs in its members rather than as link inputs, so
+    # a DLL only a declared import mentions still becomes a dependency (#2525)
+    val declared_libs: u32 =
+        declared_library_count(modules, module_count, dynlibs, dynlib_count, implicit_ptr);
+    val total_libs: u32 = explicit_libs + implicit + declared_libs;
     if (total_libs > 0) {
         val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, total_libs::usize);
         if (R.is_err[*of.DynLib, str](lr)) { ret R.err[bool, str](R.unwrap_err[*of.DynLib, str](lr)); }
@@ -3325,7 +3334,49 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             dyn.info.libs[explicit_libs].soname = implicit_soname;
             dyn.info.libs[explicit_libs].rpath  = intern.STR_NIL;
         }
+        # the declared-import DLLs, appended after the inputs so an explicitly linked
+        # dependency keeps its index. the loader name is the record's own spelling and
+        # doubles as the logical name, since no manifest named it.
+        var dw: u32 = explicit_libs + implicit;
+        var dm: u32 = 0;
+        for (dm < module_count) {
+            var di: u32 = 0;
+            for (di < modules[dm].import_count) {
+                val lib: intern.StrId = modules[dm].imports[di].library;
+                if (!dynlib_name_present(dynlibs, dynlib_count, implicit_ptr, lib)
+                    && !emitted_lib_present(dyn.info.libs, dw, lib)) {
+                    dyn.info.libs[dw].name   = lib;
+                    dyn.info.libs[dw].soname = lib;
+                    dyn.info.libs[dw].rpath  = intern.STR_NIL;
+                    dw = dw + 1;
+                }
+                di = di + 1;
+            }
+            dm = dm + 1;
+        }
         dyn.info.lib_count = total_libs;
+    }
+
+    # an import record IS the attribution for its symbol, so record it before the
+    # undefined externs are walked below. it names the loader's own DLL, so it never
+    # depends on a manifest claim or a decorator having guessed the same name. a
+    # `#[library]` or manifest claim that disagrees is a hard error rather than a
+    # silent loss, matching how the two manifest-side sources already conflict.
+    var am: u32 = 0;
+    for (am < module_count) {
+        var ai: u32 = 0;
+        for (ai < modules[am].import_count) {
+            val d: *of.ImportDecl = ?modules[am].imports[ai];
+            val prev: O.Option[intern.StrId] = session.import_library(s, d.symbol);
+            if (O.is_some[intern.StrId](prev) && O.unwrap[intern.StrId](prev) != d.library) {
+                ret R.err[bool, str](declared_conflict_message(
+                    s, d.symbol, O.unwrap[intern.StrId](prev), d.library));
+            }
+            val rr: R.Result[bool, str] = session.register_import_library(s, d.symbol, d.library);
+            if (R.is_err[bool, str](rr)) { ret R.err[bool, str](R.unwrap_err[bool, str](rr)); }
+            ai = ai + 1;
+        }
+        am = am + 1;
     }
 
     dyn.import_map = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
@@ -3381,8 +3432,14 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             val lib_opt: O.Option[intern.StrId] = session.import_library(s, sym.name);
             if (O.is_some[intern.StrId](lib_opt)) {
                 val want: intern.StrId = O.unwrap[intern.StrId](lib_opt);
-                val li_opt: O.Option[u32] =
+                var li_opt: O.Option[u32] =
                     dynlib_index_of(dynlibs, dynlib_count, implicit_ptr, want);
+                # a library named only by an import library is not among the inputs,
+                # so it is found in the emitted set the declared appends extended
+                if (!O.is_some[u32](li_opt)) {
+                    li_opt = emitted_lib_index(dyn.info.libs, explicit_libs + implicit,
+                                               dyn.info.lib_count, want);
+                }
                 if (!O.is_some[u32](li_opt)) { ret R.err[bool, str](pinned_lib_message(s, sym.name, want)); }
                 dyn.info.imports[idx].lib_index = O.unwrap[u32](li_opt);
             }
@@ -3526,6 +3583,109 @@ fun dynlib_soname_present(dynlibs: *of.DynLib, count: u32,
         i = i + 1;
     }
     ret false;
+}
+
+# whether any input image declares an import, i.e. an import library member was
+# among the link inputs. the dependency it names makes the link dynamic even when
+# no shared library was passed as an input
+fun has_declared_imports(modules: *of.ObjectImage, module_count: u32) bool {
+    var m: u32 = 0;
+    for (m < module_count) {
+        if (modules[m].import_count > 0) { ret true; }
+        m = m + 1;
+    }
+    ret false;
+}
+
+# whether the dependency requirements carry a logical or loader name
+fun dynlib_name_present(dynlibs: *of.DynLib, count: u32,
+                        implicit: *of.DynLib, name: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < count) {
+        if (dynlibs[i].name == name || dynlibs[i].soname == name) { ret true; }
+        i = i + 1;
+    }
+    if (implicit != nil && (implicit.name == name || implicit.soname == name)) { ret true; }
+    ret false;
+}
+
+# whether a loader name is already among the dependencies emitted so far
+fun emitted_lib_present(libs: *of.DynLib, count: u32, name: intern.StrId) bool {
+    var i: u32 = 0;
+    for (i < count) {
+        if (libs[i].soname == name) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the emitted index of a dependency carrying `name`, searching the emitted array
+# from `start`. used for the declared-import range, which the input requirement
+# list does not contain and `dynlib_index_of` therefore cannot find
+fun emitted_lib_index(libs: *of.DynLib, start: u32, count: u32,
+                      name: intern.StrId) O.Option[u32] {
+    if (libs == nil) { ret O.none[u32](); }
+    var i: u32 = start;
+    for (i < count) {
+        if (libs[i].name == name || libs[i].soname == name) { ret O.some[u32](i); }
+        i = i + 1;
+    }
+    ret O.none[u32]();
+}
+
+# number of distinct libraries named only by declared imports - those the link
+# inputs did not already supply. sizing the dependency array exactly, so the count
+# here and the append below must agree on what counts as already present
+fun declared_library_count(modules: *of.ObjectImage, module_count: u32,
+                           dynlibs: *of.DynLib, dynlib_count: u32,
+                           implicit: *of.DynLib) u32 {
+    var n: u32 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        var i: u32 = 0;
+        for (i < modules[m].import_count) {
+            val lib: intern.StrId = modules[m].imports[i].library;
+            if (!dynlib_name_present(dynlibs, dynlib_count, implicit, lib)
+                && !declared_library_seen_before(modules, module_count, m, i, lib)) {
+                n = n + 1;
+            }
+            i = i + 1;
+        }
+        m = m + 1;
+    }
+    ret n;
+}
+
+# whether an earlier declared import already named this library, in the same
+# module-then-index order the append walks
+fun declared_library_seen_before(modules: *of.ObjectImage, module_count: u32,
+                                 upto_m: u32, upto_i: u32, lib: intern.StrId) bool {
+    var m: u32 = 0;
+    for (m <= upto_m && m < module_count) {
+        var i: u32 = 0;
+        var end: u32 = modules[m].import_count;
+        if (m == upto_m) { end = upto_i; }
+        for (i < end) {
+            if (modules[m].imports[i].library == lib) { ret true; }
+            i = i + 1;
+        }
+        m = m + 1;
+    }
+    ret false;
+}
+
+# name the two claimants when an import record disagrees with a source or manifest
+# attribution, so the contradiction is resolved by an edit rather than by order
+fun declared_conflict_message(s: *session.Session, sym: intern.StrId,
+                              had: intern.StrId, decl: intern.StrId) str {
+    val fallback: str = "an import library contradicts an existing library attribution";
+    val n: O.Option[str] = intern.lookup(?s.interner, sym);
+    val a: O.Option[str] = intern.lookup(?s.interner, had);
+    val b: O.Option[str] = intern.lookup(?s.interner, decl);
+    if (!O.is_some[str](n) || !O.is_some[str](a) || !O.is_some[str](b)) { ret fallback; }
+    val p1: str = join3(s, "import '", O.unwrap[str](n), "' is attributed to library '", fallback);
+    val p2: str = join3(s, p1, O.unwrap[str](a), "' but an import library declares it in '", fallback);
+    ret join3(s, p2, O.unwrap[str](b), "'", fallback);
 }
 
 # number of distinct canonical loader dependencies in the requirement list

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3456,6 +3456,16 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             dyn.info.imports[idx].is_func   =
                 ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0)
                 || has_call_reloc(modules, module_count, sym.name, sec_base, atoms);
+            # short import records also carry the loader's hint or ordinal. Keep
+            # that binding metadata beside the source symbol so the PE writer can
+            # emit an ordinal thunk instead of silently changing it to by-name.
+            dyn.info.imports[idx].ordinal = 0;
+            dyn.info.imports[idx].by_ordinal = false;
+            val decl: *of.ImportDecl = declared_import_for(modules, module_count, sym.name);
+            if (decl != nil) {
+                dyn.info.imports[idx].ordinal = decl.ordinal;
+                dyn.info.imports[idx].by_ordinal = !decl.by_name;
+            }
             val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?dyn.import_map, sym.name, idx);
             if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
             dyn.info.import_count = idx + 1;
@@ -3595,6 +3605,23 @@ fun has_declared_imports(modules: *of.ObjectImage, module_count: u32) bool {
         m = m + 1;
     }
     ret false;
+}
+
+# the short-import declaration for `symbol`, or nil when the import came from
+# source/manifest attribution alone. Conflicting libraries were rejected before
+# dynamic-plan construction, so the first matching declaration is authoritative.
+fun declared_import_for(modules: *of.ObjectImage, module_count: u32,
+                        symbol: intern.StrId) *of.ImportDecl {
+    var m: u32 = 0;
+    for (m < module_count) {
+        var i: u32 = 0;
+        for (i < modules[m].import_count) {
+            if (modules[m].imports[i].symbol == symbol) { ret ?modules[m].imports[i]; }
+            i = i + 1;
+        }
+        m = m + 1;
+    }
+    ret nil;
 }
 
 # whether the dependency requirements carry a logical or loader name

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -52,6 +52,8 @@ pub fun init(a: *A.Allocator, interner: *intern.Interner, name: intern.StrId) R.
     o.symbol_count  = 0;
     o.relocations   = nil;
     o.reloc_count   = 0;
+    o.imports       = nil;
+    o.import_count  = 0;
     ret R.ok[of.ObjectImage, str](o);
 }
 
@@ -87,6 +89,12 @@ pub fun dnit(o: *of.ObjectImage) {
         A.deallocate[of.Relocation](o.alloc, o.relocations, o.reloc_count::usize);
         o.relocations = nil;
         o.reloc_count = 0;
+    }
+
+    if (o.imports != nil) {
+        A.deallocate[of.ImportDecl](o.alloc, o.imports, o.import_count::usize);
+        o.imports      = nil;
+        o.import_count = 0;
     }
 }
 

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -265,17 +265,19 @@ pub rec ObjectImage {
 # rather than anything a manifest had to guess. The linker turns each into a
 # dependency plus the attribution that binds the symbol to it.
 # ---
-# symbol:  interned imported symbol name as the referencing object spells it
-# library: interned loader name of the providing library (e.g. "kernel32.dll")
-# ordinal: the export ordinal when the record binds by ordinal, else 0
-# by_name: true when the loader binds by name; false binds by `ordinal`
-# is_code: true for a function import, false for data
+# symbol:      interned imported symbol name as the referencing object spells it
+# import_name: interned export name the loader resolves for a by-name import
+# library:     interned loader name of the providing library (e.g. "kernel32.dll")
+# ordinal:     export ordinal for ordinal binding, or loader hint for name binding
+# by_name:     true when the loader binds by `import_name`; false binds by `ordinal`
+# is_code:     true for a function import, false for data
 pub rec ImportDecl {
-    symbol:  intern.StrId;
-    library: intern.StrId;
-    ordinal: u16;
-    by_name: bool;
-    is_code: bool;
+    symbol:      intern.StrId;
+    import_name: intern.StrId;
+    library:     intern.StrId;
+    ordinal:     u16;
+    by_name:     bool;
+    is_code:     bool;
 }
 
 # one dynamic dependency of a linked image: a shared library that must be loaded
@@ -303,7 +305,8 @@ pub rec DynLib {
 # points call sites at. format-neutral so PE `.idata` and Mach-O dyld bind reuse
 # the same model.
 # ---
-# symbol:    interned imported symbol name (the `ext` name, e.g. "getpid")
+# symbol:    interned loader symbol name, normally the `ext` name (e.g. "getpid")
+#            but possibly a distinct PE export named by a short import record
 # lib_index: index into the image's `DynLib` list of the providing library, or
 #            DYNLIB_ANY when the binding is left to the loader's global search
 # is_func:   true for a code (call) import needing a call-thunk; false for data

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -247,6 +247,35 @@ pub rec ObjectImage {
 
     relocations: *Relocation;
     reloc_count: u32;
+
+    # imports this image DECLARES rather than defines, from an archive member that
+    # is an import record instead of an object (#2525). empty for every ordinary
+    # object, and for formats whose archives carry no such member
+    imports:      *ImportDecl;
+    import_count: u32;
+}
+
+# one import an archive member declares: a symbol, and the shared library that
+# provides it
+#
+# An import library's member is not an object at all - it defines nothing and
+# instead states "this symbol comes from that library" (a PE short import record,
+# `IMPORT_OBJECT_HEADER`). It is the authoritative symbol->library mapping the
+# two-level-namespace formats need, carrying the true loader name and ordinal
+# rather than anything a manifest had to guess. The linker turns each into a
+# dependency plus the attribution that binds the symbol to it.
+# ---
+# symbol:  interned imported symbol name as the referencing object spells it
+# library: interned loader name of the providing library (e.g. "kernel32.dll")
+# ordinal: the export ordinal when the record binds by ordinal, else 0
+# by_name: true when the loader binds by name; false binds by `ordinal`
+# is_code: true for a function import, false for data
+pub rec ImportDecl {
+    symbol:  intern.StrId;
+    library: intern.StrId;
+    ordinal: u16;
+    by_name: bool;
+    is_code: bool;
 }
 
 # one dynamic dependency of a linked image: a shared library that must be loaded

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -307,10 +307,15 @@ pub rec DynLib {
 # lib_index: index into the image's `DynLib` list of the providing library, or
 #            DYNLIB_ANY when the binding is left to the loader's global search
 # is_func:   true for a code (call) import needing a call-thunk; false for data
+# ordinal:   PE import ordinal when `by_ordinal`, otherwise the loader hint
+# by_ordinal: bind the PE import by `ordinal` rather than by `symbol`; ignored by
+#             formats whose import model has no ordinal binding
 pub rec DynImport {
     symbol:    intern.StrId;
     lib_index: u32;
     is_func:   bool;
+    ordinal:   u16;
+    by_ordinal: bool;
 }
 
 # sentinel `DynImport.lib_index` marking an import not pinned to a specific

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -122,6 +122,22 @@ val BIGOBJ_MIN_VERSION:         u16   = 2;
 val BIGOBJ_HEADER_SIZE:         usize = 56;
 val BIGOBJ_SYMBOL_SIZE:         usize = 20;
 
+# the short import record (`IMPORT_OBJECT_HEADER`), the member an import library
+# carries instead of an object: it defines nothing and states that one symbol is
+# provided by one DLL. it opens with the SAME Sig1/Sig2 pair as /bigobj, so the
+# two are told apart by the field directly after it - a /bigobj header carries
+# Version >= BIGOBJ_MIN_VERSION, a short import record always carries 0. Version
+# is the discriminator rather than /bigobj's ClassID because it sits at a fixed
+# offset present in both shapes, so no size check has to precede the test.
+#
+# header: Sig1, Sig2, Version, Machine, TimeDateStamp, SizeOfData, OrdinalOrHint,
+# then a bitfield of Type (2 bits) and NameType (3 bits). `SizeOfData` bytes
+# follow, holding the NUL-terminated symbol name then the NUL-terminated DLL name.
+val IMPORT_OBJECT_VERSION:     u16   = 0;
+val IMPORT_OBJECT_HEADER_SIZE: usize = 20;
+val IMPORT_OBJECT_TYPE_CODE:   u16   = 0;
+val IMPORT_OBJECT_ORDINAL:     u16   = 0;
+
 # COFF file-header characteristics for a linked PE image
 val IMAGE_FILE_RELOCS_STRIPPED:     u16 = 0x0001;
 val IMAGE_FILE_EXECUTABLE_IMAGE:    u16 = 0x0002;
@@ -1588,6 +1604,112 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
 # buf_size: length of `buf`
 # out:      image to populate (its arrays are allocated here)
 # ret:      ok(true) on success, or an error string
+# parse a short import record into an image that DECLARES one import
+#
+# The record is an import library's unit of content: it defines no code or data,
+# so the image carries no sections, symbols or relocations and exactly one
+# `of.ImportDecl`. That declaration is the authoritative symbol->library mapping
+# for a two-level namespace, carrying the loader's own DLL name and ordinal.
+#
+# The two NUL-terminated names live in the `SizeOfData` payload after the header,
+# symbol first then DLL. Both are bounded against the payload before being read,
+# so a truncated or hostile member errors here rather than running off the end.
+# ---
+# alloc:    allocator recorded on the image for its arrays
+# itn:      interner the two names are interned into
+# buf:      the member bytes
+# buf_size: length of `buf`
+# out:      image to populate
+# ret:      ok(true) on success, or an error string
+fun coff_parse_import_record(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8,
+                             buf_size: usize, out: *of.ObjectImage) R.Result[bool, str] {
+    if (buf_size < IMPORT_OBJECT_HEADER_SIZE) {
+        ret R.err[bool, str]("coff: import record too small");
+    }
+    if (itn == nil) { ret R.err[bool, str]("coff: no interner for parse"); }
+    if (bin.read_u16_le(buf, 6) != IMAGE_FILE_MACHINE_AMD64) {
+        ret R.err[bool, str]("coff: not an x86-64 import record");
+    }
+
+    val data_size: usize = bin.read_u32_le(buf, 12)::usize;
+    val vr: R.Result[bool, str] = bin.require_region(buf_size, IMPORT_OBJECT_HEADER_SIZE,
+        data_size, "coff: import record name data out of bounds");
+    if (R.is_err[bool, str](vr)) { ret R.err[bool, str](R.unwrap_err[bool, str](vr)); }
+
+    val hint_ord: u16 = bin.read_u16_le(buf, 16);
+    val flags:    u16 = bin.read_u16_le(buf, 18);
+
+    # the symbol name, then the DLL name, each NUL-terminated within the payload
+    val base: usize = IMPORT_OBJECT_HEADER_SIZE;
+    val limit: usize = base + data_size;
+    var sym_end: usize = base;
+    for (sym_end < limit && buf[sym_end] != 0) { sym_end = sym_end + 1; }
+    if (sym_end >= limit) { ret R.err[bool, str]("coff: import record symbol name is unterminated"); }
+    val dll_start: usize = sym_end + 1;
+    var dll_end: usize = dll_start;
+    for (dll_end < limit && buf[dll_end] != 0) { dll_end = dll_end + 1; }
+    if (dll_end >= limit) { ret R.err[bool, str]("coff: import record library name is unterminated"); }
+    if (sym_end == base)      { ret R.err[bool, str]("coff: import record has an empty symbol name"); }
+    if (dll_end == dll_start) { ret R.err[bool, str]("coff: import record has an empty library name"); }
+
+    # both names are NUL-terminated inside the payload, checked above, so each can
+    # be interned in place without copying
+    val sym_r: R.Result[intern.StrId, str] = intern.intern(itn, (?buf[base])::str);
+    if (R.is_err[intern.StrId, str](sym_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sym_r)); }
+    val dll_r: R.Result[intern.StrId, str] = intern.intern(itn, (?buf[dll_start])::str);
+    if (R.is_err[intern.StrId, str](dll_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](dll_r)); }
+
+    val ir: R.Result[*of.ImportDecl, str] = A.zallocate[of.ImportDecl](alloc, 1::usize);
+    if (R.is_err[*of.ImportDecl, str](ir)) { ret R.err[bool, str](R.unwrap_err[*of.ImportDecl, str](ir)); }
+
+    out.alloc         = alloc;
+    out.interner      = itn;
+    out.sections      = nil;
+    out.section_count = 0;
+    out.symbols       = nil;
+    out.symbol_count  = 0;
+    out.relocations   = nil;
+    out.reloc_count   = 0;
+    out.imports       = R.unwrap_ok[*of.ImportDecl, str](ir);
+    out.import_count  = 1;
+
+    out.imports[0].symbol  = R.unwrap_ok[intern.StrId, str](sym_r);
+    out.imports[0].library = R.unwrap_ok[intern.StrId, str](dll_r);
+    # NameType 0 (ORDINAL) is the only spelling that binds by ordinal; every other
+    # value names the export and the hint field is only a lookup accelerator.
+    out.imports[0].by_name = ((flags >> 2) & 0x7) != IMPORT_OBJECT_ORDINAL;
+    out.imports[0].ordinal = hint_ord;
+    out.imports[0].is_code = (flags & 0x3) == IMPORT_OBJECT_TYPE_CODE;
+    ret R.ok[bool, str](true);
+}
+
+# whether every section this object carries is an `.idata$` fragment - the shape
+# of an import library's import-directory bookkeeping members, which hold no code
+# or data of the program's own. an ordinary object never carries only these
+# ---
+# buf:          the object bytes
+# secthdr_base: offset of the section header table, already bounds-checked
+# num_secs:     number of section headers
+# ret:          true when the object is import-directory bookkeeping only
+fun coff_is_idata_bookkeeping(buf: *u8, secthdr_base: usize, num_secs: u32) bool {
+    if (num_secs == 0) { ret false; }
+    var i: u32 = 0;
+    for (i < num_secs) {
+        val off: usize = secthdr_base + i::usize * SECTION_HEADER_SIZE;
+        # the inline 8-byte name field; `.idata$<n>` always fits, so a long-name
+        # ("/nnn") indirection never spells one
+        if (buf[off]     != 0x2E) { ret false; }   # '.'
+        if (buf[off + 1] != 0x69) { ret false; }   # 'i'
+        if (buf[off + 2] != 0x64) { ret false; }   # 'd'
+        if (buf[off + 3] != 0x61) { ret false; }   # 'a'
+        if (buf[off + 4] != 0x74) { ret false; }   # 't'
+        if (buf[off + 5] != 0x61) { ret false; }   # 'a'
+        if (buf[off + 6] != 0x24) { ret false; }   # '$'
+        i = i + 1;
+    }
+    ret true;
+}
+
 fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_size: usize, out: *of.ObjectImage) R.Result[bool, str] {
     if (buf == nil || out == nil || buf_size < 4) {
         ret R.err[bool, str]("coff: object too small");
@@ -1600,7 +1722,14 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     # tell the formats apart.
     val sig1: u16 = bin.read_u16_le(buf, 0);
     val sig2: u16 = bin.read_u16_le(buf, 2);
-    val bigobj: bool = sig1 == IMAGE_FILE_MACHINE_UNKNOWN && sig2 == BIGOBJ_SIG2;
+    val anon: bool = sig1 == IMAGE_FILE_MACHINE_UNKNOWN && sig2 == BIGOBJ_SIG2;
+
+    # an import library's member shares that signature pair; Version separates it
+    # from a /bigobj object before either header shape is otherwise read.
+    if (anon && buf_size >= 6 && bin.read_u16_le(buf, 4) == IMPORT_OBJECT_VERSION) {
+        ret coff_parse_import_record(alloc, itn, buf, buf_size, out);
+    }
+    val bigobj: bool = anon;
 
     var num_secs:     u32   = 0;
     var symtab_off:   usize = 0;
@@ -1656,6 +1785,19 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     out.sections = nil;
     out.symbols = nil;
     out.relocations = nil;
+    out.imports = nil;
+    out.import_count = 0;
+
+    # an import library also carries the traditional import-directory construction:
+    # `.idata$` fragments wired together by ADDR32NB relocations, which a linker that
+    # merges them would assemble into the import table. mach synthesizes its whole
+    # `.idata` from the dynamic plan instead, and the short import records already
+    # carried the mapping, so those members contribute nothing and are dropped whole
+    # rather than merged into an image that would then conflict with the synthesized
+    # directory.
+    if (coff_is_idata_bookkeeping(buf, secthdr_base, num_secs)) {
+        ret R.ok[bool, str](true);
+    }
 
     # count total relocations across sections and total non-aux symbol records.
     var rel_n: u32 = 0;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -125,15 +125,15 @@ val BIGOBJ_SYMBOL_SIZE:         usize = 20;
 # the short import record (`IMPORT_OBJECT_HEADER`), the member an import library
 # carries instead of an object: it defines nothing and states that one symbol is
 # provided by one DLL. it opens with the SAME Sig1/Sig2 pair as /bigobj, so the
-# two are told apart by the field directly after it - a /bigobj header carries
-# Version >= BIGOBJ_MIN_VERSION, a short import record always carries 0. Version
-# is the discriminator rather than /bigobj's ClassID because it sits at a fixed
-# offset present in both shapes, so no size check has to precede the test.
+# two are told apart by the complete /bigobj discriminator: a sufficiently large
+# header with Version >= BIGOBJ_MIN_VERSION and the fixed /bigobj ClassID. Every
+# other member with the shared signature is a short import record. This mirrors
+# the format's structural discriminator without constraining future import-header
+# versions.
 #
 # header: Sig1, Sig2, Version, Machine, TimeDateStamp, SizeOfData, OrdinalOrHint,
 # then a bitfield of Type (2 bits) and NameType (3 bits). `SizeOfData` bytes
 # follow, holding the NUL-terminated symbol name then the NUL-terminated DLL name.
-val IMPORT_OBJECT_VERSION:     u16   = 0;
 val IMPORT_OBJECT_HEADER_SIZE: usize = 20;
 val IMPORT_OBJECT_TYPE_CODE:   u16   = 0;
 val IMPORT_OBJECT_ORDINAL:     u16   = 0;
@@ -187,6 +187,7 @@ val PE_FILE_ALIGN:       u64   = 0x200;
 # one IMAGE_IMPORT_DESCRIPTOR (20 bytes) and one PE thunk slot (8 bytes, PE32+)
 val IMPORT_DESCRIPTOR_SIZE: usize = 20;
 val THUNK_SIZE:             usize = 8;
+val IMPORT_ORDINAL_FLAG64:  u64   = 0x8000000000000000;
 # the per-function import stub: `jmp qword [rip+disp32]` through the IAT slot
 val IMPORT_STUB_SIZE:       usize = 6;
 # one RUNTIME_FUNCTION table row (`BeginAddress`, `EndAddress`, `UnwindInfoAddress`)
@@ -1724,12 +1725,16 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     val sig2: u16 = bin.read_u16_le(buf, 2);
     val anon: bool = sig1 == IMAGE_FILE_MACHINE_UNKNOWN && sig2 == BIGOBJ_SIG2;
 
-    # an import library's member shares that signature pair; Version separates it
-    # from a /bigobj object before either header shape is otherwise read.
-    if (anon && buf_size >= 6 && bin.read_u16_le(buf, 4) == IMPORT_OBJECT_VERSION) {
+    # an import library's member shares that signature pair. /bigobj is the more
+    # restrictive shape: it must be large enough for its header, carry a supported
+    # version, and carry the fixed ClassID. Anything else with the pair is a short
+    # import record, as specified for import-library pseudo-objects.
+    val bigobj: bool = anon && buf_size >= BIGOBJ_HEADER_SIZE
+        && bin.read_u16_le(buf, 4) >= BIGOBJ_MIN_VERSION
+        && bigobj_class_id_matches(buf, 12);
+    if (anon && !bigobj) {
         ret coff_parse_import_record(alloc, itn, buf, buf_size, out);
     }
-    val bigobj: bool = anon;
 
     var num_secs:     u32   = 0;
     var symtab_off:   usize = 0;
@@ -2705,11 +2710,12 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
         lay.iat_size = (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE::u64;
         ioff = ioff + (lay.nimp + dyn.lib_count)::usize * THUNK_SIZE;
 
-        # hint/name table: one (hint:u16 + name + NUL, 2-byte aligned) per import.
+        # hint/name table: one (hint:u16 + name + NUL, 2-byte aligned) per
+        # by-name import. Ordinal imports encode the ordinal directly in the thunk.
         ioff = bin.align_up(ioff, 2);
         var i: u32 = 0;
         for (i < dyn.import_count) {
-            if (dyn.imports[i].is_func) {
+            if (dyn.imports[i].is_func && !dyn.imports[i].by_ordinal) {
                 ioff = ioff + 2 + name_len_z(itn, dyn.imports[i].symbol);
                 ioff = bin.align_up(ioff, 2);
             }
@@ -3033,10 +3039,9 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
 # RVAs are recovered by `write_pe_stubs` and `patch_pe_fixups` (recomputed by the
 # same import ordinal), so this lays the same offsets `compute_pe_layout` used
 #
-# the ILT and IAT are identical on disk (both are by-name thunks pointing at the
-# hint/name entries); the loader overwrites each IAT thunk with the resolved
-# function address. a thunk with bit 63 set would be an import-by-ordinal; every
-# thunk here is an RVA into the hint/name table (import-by-name).
+# the ILT and IAT are identical on disk. A by-name thunk points at its hint/name
+# entry; an ordinal thunk carries bit 63 plus the 16-bit ordinal directly. The
+# loader overwrites each IAT thunk with the resolved function address.
 fun write_pe_imports(itn: *intern.Interner, buf: *u8, lay: *PeLayout, dyn: *of.DynamicInfo) {
     val sec_off: usize = lay.idata_sec.file_off;
     val sec_rva: u64   = lay.idata_sec.rva;
@@ -3070,16 +3075,21 @@ fun write_pe_imports(itn: *intern.Interner, buf: *u8, lay: *PeLayout, dyn: *of.D
         var imp: u32 = 0;
         for (imp < dyn.import_count) {
             if (dyn.imports[imp].is_func && import_lib_of(dyn, imp) == lib) {
-                val hint_rva: u64 = sec_rva + hcur::u64;
-                # hint = 0; the loader falls back to a binary search by name.
-                bin.write_u16_le(buf, sec_off + hcur, 0);
-                hcur = hcur + 2;
-                hcur = hcur + bin.write_str(buf, sec_off + hcur, bin.resolve_name(itn, dyn.imports[imp].symbol));
-                hcur = bin.align_up(hcur, 2);
+                var thunk: u64 = 0;
+                if (dyn.imports[imp].by_ordinal) {
+                    thunk = IMPORT_ORDINAL_FLAG64 | dyn.imports[imp].ordinal::u64;
+                }
+                or {
+                    thunk = sec_rva + hcur::u64;
+                    bin.write_u16_le(buf, sec_off + hcur, dyn.imports[imp].ordinal);
+                    hcur = hcur + 2;
+                    hcur = hcur + bin.write_str(buf, sec_off + hcur,
+                        bin.resolve_name(itn, dyn.imports[imp].symbol));
+                    hcur = bin.align_up(hcur, 2);
+                }
 
-                # ILT[thunk_ix] and IAT[thunk_ix] = RVA of the hint/name entry.
-                bin.write_u64_le(buf, sec_off + ilt_off + thunk_ix::usize * THUNK_SIZE, hint_rva);
-                bin.write_u64_le(buf, sec_off + iat_off + thunk_ix::usize * THUNK_SIZE, hint_rva);
+                bin.write_u64_le(buf, sec_off + ilt_off + thunk_ix::usize * THUNK_SIZE, thunk);
+                bin.write_u64_le(buf, sec_off + iat_off + thunk_ix::usize * THUNK_SIZE, thunk);
                 thunk_ix = thunk_ix + 1;
             }
             imp = imp + 1;
@@ -3879,9 +3889,9 @@ test "mach.lang.target.of.coff:relro_round_trip" {
 # a REL32 addend translates the COFF next-byte-relative (P+4) convention on both
 # parse and emit (#1409)
 # a short import record parses to a declaration rather than an object, and is told
-# apart from /bigobj by Version alone - the two share the Sig1/Sig2 pair, and
-# before #2525 the record was misclassified as /bigobj and rejected for being
-# smaller than a /bigobj header
+# apart from /bigobj by the latter's version and ClassID - the two share the
+# Sig1/Sig2 pair, and before #2525 the record was misclassified as /bigobj and
+# rejected for being smaller than a /bigobj header
 test "mach.lang.target.of.coff.coff_parse_object:short_import_record" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -3919,13 +3929,14 @@ test "mach.lang.target.of.coff.coff_parse_object:short_import_record" {
     if (!img.imports[0].by_name) { ret 1; }
     if (!img.imports[0].is_code) { ret 1; }
 
-    # Version >= 2 is a /bigobj header, not an import record: the same leading bytes
-    # must take the object path and fail its own size check, not this one
+    # Version alone cannot make this a /bigobj header. Without the fixed ClassID it
+    # remains an import record, so a future header version with the same payload
+    # shape is not misclassified.
     rec[4] = BIGOBJ_MIN_VERSION::u8;
     var img2: of.ObjectImage;
     val br: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?rec[0], 39, ?img2);
-    if (R.is_ok[bool, str](br)) { ret 1; }
-    if (!str_equals(R.unwrap_err[bool, str](br), "coff: bigobj object too small")) { ret 1; }
+    if (R.is_err[bool, str](br)) { ret 1; }
+    if (img2.import_count != 1) { ret 1; }
     ret 0;
 }
 
@@ -5495,6 +5506,8 @@ fun t_iat_slots_exact(i: *intern.Interner, counts: *u32, nlib: u32) bool {
             imports[total].symbol = t_intern(i, "fn");
             imports[total].lib_index = l;
             imports[total].is_func = true;
+            imports[total].ordinal = 0;
+            imports[total].by_ordinal = false;
             total = total + 1;
             j = j + 1;
         }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -133,10 +133,16 @@ val BIGOBJ_SYMBOL_SIZE:         usize = 20;
 #
 # header: Sig1, Sig2, Version, Machine, TimeDateStamp, SizeOfData, OrdinalOrHint,
 # then a bitfield of Type (2 bits) and NameType (3 bits). `SizeOfData` bytes
-# follow, holding the NUL-terminated symbol name then the NUL-terminated DLL name.
+# follow, holding the NUL-terminated symbol name then the NUL-terminated DLL name;
+# `IMPORT_OBJECT_NAME_EXPORTAS` adds the distinct export name as a third string.
 val IMPORT_OBJECT_HEADER_SIZE: usize = 20;
-val IMPORT_OBJECT_TYPE_CODE:   u16   = 0;
-val IMPORT_OBJECT_ORDINAL:     u16   = 0;
+val IMPORT_OBJECT_TYPE_CODE:       u16 = 0;
+val IMPORT_OBJECT_TYPE_CONST:      u16 = 2;
+val IMPORT_OBJECT_ORDINAL:         u16 = 0;
+val IMPORT_OBJECT_NAME:            u16 = 1;
+val IMPORT_OBJECT_NAME_NOPREFIX:   u16 = 2;
+val IMPORT_OBJECT_NAME_UNDECORATE: u16 = 3;
+val IMPORT_OBJECT_NAME_EXPORTAS:   u16 = 4;
 
 # COFF file-header characteristics for a linked PE image
 val IMAGE_FILE_RELOCS_STRIPPED:     u16 = 0x0001;
@@ -1612,9 +1618,10 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
 # `of.ImportDecl`. That declaration is the authoritative symbol->library mapping
 # for a two-level namespace, carrying the loader's own DLL name and ordinal.
 #
-# The two NUL-terminated names live in the `SizeOfData` payload after the header,
-# symbol first then DLL. Both are bounded against the payload before being read,
-# so a truncated or hostile member errors here rather than running off the end.
+# The NUL-terminated names live in the `SizeOfData` payload after the header:
+# symbol first, then DLL, then a distinct export name for NAME_EXPORTAS. Every
+# string is bounded against the payload before being read, so a truncated or
+# hostile member errors here rather than running off the end.
 # ---
 # alloc:    allocator recorded on the image for its arrays
 # itn:      interner the two names are interned into
@@ -1639,6 +1646,17 @@ fun coff_parse_import_record(alloc: *A.Allocator, itn: *intern.Interner, buf: *u
 
     val hint_ord: u16 = bin.read_u16_le(buf, 16);
     val flags:    u16 = bin.read_u16_le(buf, 18);
+    val import_type: u16 = flags & 0x3;
+    val name_type:   u16 = (flags >> 2) & 0x7;
+    if (import_type > IMPORT_OBJECT_TYPE_CONST) {
+        ret R.err[bool, str]("coff: import record has an invalid import type");
+    }
+    if (name_type > IMPORT_OBJECT_NAME_EXPORTAS) {
+        ret R.err[bool, str]("coff: import record has an invalid name type");
+    }
+    if ((flags & 0xFFE0) != 0) {
+        ret R.err[bool, str]("coff: import record has nonzero reserved flags");
+    }
 
     # the symbol name, then the DLL name, each NUL-terminated within the payload
     val base: usize = IMPORT_OBJECT_HEADER_SIZE;
@@ -1653,12 +1671,47 @@ fun coff_parse_import_record(alloc: *A.Allocator, itn: *intern.Interner, buf: *u
     if (sym_end == base)      { ret R.err[bool, str]("coff: import record has an empty symbol name"); }
     if (dll_end == dll_start) { ret R.err[bool, str]("coff: import record has an empty library name"); }
 
-    # both names are NUL-terminated inside the payload, checked above, so each can
-    # be interned in place without copying
+    # both required names are NUL-terminated inside the payload, checked above, so
+    # each can be interned in place without copying
     val sym_r: R.Result[intern.StrId, str] = intern.intern(itn, (?buf[base])::str);
     if (R.is_err[intern.StrId, str](sym_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sym_r)); }
     val dll_r: R.Result[intern.StrId, str] = intern.intern(itn, (?buf[dll_start])::str);
     if (R.is_err[intern.StrId, str](dll_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](dll_r)); }
+
+# the first string is the public/link symbol. NameType selects the export name
+    # placed in the PE hint/name table: unchanged, with one decoration prefix
+    # removed, undecorated through the first '@', or an explicit third string.
+    var import_name_r: R.Result[intern.StrId, str] = sym_r;
+    if (name_type == IMPORT_OBJECT_NAME_NOPREFIX || name_type == IMPORT_OBJECT_NAME_UNDECORATE) {
+        var name_start: usize = base;
+        if (buf[name_start] == '?'::u8 || buf[name_start] == '@'::u8 || buf[name_start] == '_'::u8) {
+            name_start = name_start + 1;
+        }
+        var name_end: usize = sym_end;
+        if (name_type == IMPORT_OBJECT_NAME_UNDECORATE) {
+            name_end = name_start;
+            for (name_end < sym_end && buf[name_end] != '@'::u8) { name_end = name_end + 1; }
+        }
+        if (name_end == name_start) {
+            ret R.err[bool, str]("coff: import record resolves to an empty export name");
+        }
+        import_name_r = intern.intern_bytes(itn, (?buf[name_start])::str, name_end - name_start);
+    }
+    or (name_type == IMPORT_OBJECT_NAME_EXPORTAS) {
+        val export_start: usize = dll_end + 1;
+        var export_end: usize = export_start;
+        for (export_end < limit && buf[export_end] != 0) { export_end = export_end + 1; }
+        if (export_end >= limit) {
+            ret R.err[bool, str]("coff: import record export name is unterminated");
+        }
+        if (export_end == export_start) {
+            ret R.err[bool, str]("coff: import record has an empty export name");
+        }
+        import_name_r = intern.intern(itn, (?buf[export_start])::str);
+    }
+    if (R.is_err[intern.StrId, str](import_name_r)) {
+        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](import_name_r));
+    }
 
     val ir: R.Result[*of.ImportDecl, str] = A.zallocate[of.ImportDecl](alloc, 1::usize);
     if (R.is_err[*of.ImportDecl, str](ir)) { ret R.err[bool, str](R.unwrap_err[*of.ImportDecl, str](ir)); }
@@ -1674,13 +1727,12 @@ fun coff_parse_import_record(alloc: *A.Allocator, itn: *intern.Interner, buf: *u
     out.imports       = R.unwrap_ok[*of.ImportDecl, str](ir);
     out.import_count  = 1;
 
-    out.imports[0].symbol  = R.unwrap_ok[intern.StrId, str](sym_r);
-    out.imports[0].library = R.unwrap_ok[intern.StrId, str](dll_r);
-    # NameType 0 (ORDINAL) is the only spelling that binds by ordinal; every other
-    # value names the export and the hint field is only a lookup accelerator.
-    out.imports[0].by_name = ((flags >> 2) & 0x7) != IMPORT_OBJECT_ORDINAL;
-    out.imports[0].ordinal = hint_ord;
-    out.imports[0].is_code = (flags & 0x3) == IMPORT_OBJECT_TYPE_CODE;
+    out.imports[0].symbol      = R.unwrap_ok[intern.StrId, str](sym_r);
+    out.imports[0].import_name = R.unwrap_ok[intern.StrId, str](import_name_r);
+    out.imports[0].library     = R.unwrap_ok[intern.StrId, str](dll_r);
+    out.imports[0].by_name     = name_type != IMPORT_OBJECT_ORDINAL;
+    out.imports[0].ordinal     = hint_ord;
+    out.imports[0].is_code     = import_type == IMPORT_OBJECT_TYPE_CODE;
     ret R.ok[bool, str](true);
 }
 
@@ -3923,8 +3975,10 @@ test "mach.lang.target.of.coff.coff_parse_object:short_import_record" {
     if (img.reloc_count != 0)   { ret 1; }
 
     val sn: O.Option[str] = intern.lookup(?i, img.imports[0].symbol);
+    val en: O.Option[str] = intern.lookup(?i, img.imports[0].import_name);
     val ln: O.Option[str] = intern.lookup(?i, img.imports[0].library);
     if (!O.is_some[str](sn) || !str_equals(O.unwrap[str](sn), "Sleep"))        { ret 1; }
+    if (!O.is_some[str](en) || !str_equals(O.unwrap[str](en), "Sleep"))        { ret 1; }
     if (!O.is_some[str](ln) || !str_equals(O.unwrap[str](ln), "kernel32.dll")) { ret 1; }
     if (!img.imports[0].by_name) { ret 1; }
     if (!img.imports[0].is_code) { ret 1; }
@@ -3937,6 +3991,78 @@ test "mach.lang.target.of.coff.coff_parse_object:short_import_record" {
     val br: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?rec[0], 39, ?img2);
     if (R.is_err[bool, str](br)) { ret 1; }
     if (img2.import_count != 1) { ret 1; }
+    ret 0;
+}
+
+# short-import NameType values preserve the public/link symbol while deriving the
+# possibly different export name the PE loader must resolve
+test "mach.lang.target.of.coff.coff_parse_object:short_import_name_types" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    # NAME_NOPREFIX: "_Sleep" is referenced publicly but binds export "Sleep".
+    var np: [40]u8;
+    var z: usize = 0;
+    for (z < 40) { np[z] = 0; z = z + 1; }
+    np[2] = 0xFF; np[3] = 0xFF; np[6] = 0x64; np[7] = 0x86;
+    np[12] = 20; np[18] = (IMPORT_OBJECT_NAME_NOPREFIX << 2)::u8;
+    val np_sym: str = "_Sleep";
+    val dll: str = "kernel32.dll";
+    var k: usize = 0;
+    for (k < 6)  { np[20 + k] = np_sym[k]::u8; k = k + 1; }
+    k = 0;
+    for (k < 12) { np[27 + k] = dll[k]::u8; k = k + 1; }
+    var np_img: of.ObjectImage;
+    val np_r: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?np[0], 40, ?np_img);
+    if (R.is_err[bool, str](np_r)) { ret 1; }
+    val np_public: O.Option[str] = intern.lookup(?i, np_img.imports[0].symbol);
+    val np_export: O.Option[str] = intern.lookup(?i, np_img.imports[0].import_name);
+    if (!O.is_some[str](np_public) || !str_equals(O.unwrap[str](np_public), "_Sleep")) { ret 1; }
+    if (!O.is_some[str](np_export) || !str_equals(O.unwrap[str](np_export), "Sleep"))  { ret 1; }
+
+    # NAME_UNDECORATE additionally truncates the stdcall suffix at the first '@'.
+    var ud: [42]u8;
+    z = 0;
+    for (z < 42) { ud[z] = 0; z = z + 1; }
+    ud[2] = 0xFF; ud[3] = 0xFF; ud[6] = 0x64; ud[7] = 0x86;
+    ud[12] = 22; ud[18] = (IMPORT_OBJECT_NAME_UNDECORATE << 2)::u8;
+    val ud_sym: str = "_Sleep@4";
+    k = 0;
+    for (k < 8)  { ud[20 + k] = ud_sym[k]::u8; k = k + 1; }
+    k = 0;
+    for (k < 12) { ud[29 + k] = dll[k]::u8; k = k + 1; }
+    var ud_img: of.ObjectImage;
+    val ud_r: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?ud[0], 42, ?ud_img);
+    if (R.is_err[bool, str](ud_r)) { ret 1; }
+    val ud_public: O.Option[str] = intern.lookup(?i, ud_img.imports[0].symbol);
+    val ud_export: O.Option[str] = intern.lookup(?i, ud_img.imports[0].import_name);
+    if (!O.is_some[str](ud_public) || !str_equals(O.unwrap[str](ud_public), "_Sleep@4")) { ret 1; }
+    if (!O.is_some[str](ud_export) || !str_equals(O.unwrap[str](ud_export), "Sleep"))    { ret 1; }
+
+    # NAME_EXPORTAS carries an explicit third string, as emitted by llvm-dlltool
+    # for an x86-64 `PublicName == ExportName` definition.
+    var ea: [51]u8;
+    z = 0;
+    for (z < 51) { ea[z] = 0; z = z + 1; }
+    ea[2] = 0xFF; ea[3] = 0xFF; ea[6] = 0x64; ea[7] = 0x86;
+    ea[12] = 31; ea[18] = (IMPORT_OBJECT_NAME_EXPORTAS << 2)::u8;
+    val ea_sym: str = "PublicName";
+    val ea_dll: str = "demo.dll";
+    val ea_export_name: str = "ExportName";
+    k = 0;
+    for (k < 10) { ea[20 + k] = ea_sym[k]::u8; k = k + 1; }
+    k = 0;
+    for (k < 8)  { ea[31 + k] = ea_dll[k]::u8; k = k + 1; }
+    k = 0;
+    for (k < 10) { ea[40 + k] = ea_export_name[k]::u8; k = k + 1; }
+    var ea_img: of.ObjectImage;
+    val ea_r: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?ea[0], 51, ?ea_img);
+    if (R.is_err[bool, str](ea_r)) { ret 1; }
+    val ea_public: O.Option[str] = intern.lookup(?i, ea_img.imports[0].symbol);
+    val ea_export: O.Option[str] = intern.lookup(?i, ea_img.imports[0].import_name);
+    if (!O.is_some[str](ea_public) || !str_equals(O.unwrap[str](ea_public), "PublicName")) { ret 1; }
+    if (!O.is_some[str](ea_export) || !str_equals(O.unwrap[str](ea_export), "ExportName")) { ret 1; }
     ret 0;
 }
 
@@ -3971,6 +4097,17 @@ test "mach.lang.target.of.coff.coff_parse_object:malformed_import_record" {
     var img2: of.ObjectImage;
     val r2: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?unterm[0], 24, ?img2);
     if (R.is_ok[bool, str](r2)) { ret 1; }
+
+    # the three reserved NameType values and the high reserved bits are rejected
+    # instead of silently changing the loader binding.
+    unterm[18] = (5 << 2)::u8;
+    var img3: of.ObjectImage;
+    val r3: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?unterm[0], 24, ?img3);
+    if (R.is_ok[bool, str](r3)) { ret 1; }
+    unterm[18] = 0x20;
+    var img4: of.ObjectImage;
+    val r4: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?unterm[0], 24, ?img4);
+    if (R.is_ok[bool, str](r4)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3878,6 +3878,91 @@ test "mach.lang.target.of.coff:relro_round_trip" {
 
 # a REL32 addend translates the COFF next-byte-relative (P+4) convention on both
 # parse and emit (#1409)
+# a short import record parses to a declaration rather than an object, and is told
+# apart from /bigobj by Version alone - the two share the Sig1/Sig2 pair, and
+# before #2525 the record was misclassified as /bigobj and rejected for being
+# smaller than a /bigobj header
+test "mach.lang.target.of.coff.coff_parse_object:short_import_record" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    # header + "Sleep\0kernel32.dll\0"
+    var rec: [39]u8;
+    var z: usize = 0;
+    for (z < 39) { rec[z] = 0; z = z + 1; }
+    rec[2] = 0xFF; rec[3] = 0xFF;          # Sig2
+    rec[6] = 0x64; rec[7] = 0x86;          # Machine = AMD64
+    rec[12] = 19;                          # SizeOfData = 19
+    rec[18] = 0x04;                        # NameType = 1 (by name), Type = 0 (code)
+    val sym: str = "Sleep";
+    val dll: str = "kernel32.dll";
+    var k: usize = 0;
+    for (k < 5)  { rec[20 + k] = sym[k]::u8; k = k + 1; }
+    k = 0;
+    for (k < 12) { rec[26 + k] = dll[k]::u8; k = k + 1; }
+
+    var img: of.ObjectImage;
+    val pr: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?rec[0], 39, ?img);
+    if (R.is_err[bool, str](pr)) { ret 1; }
+
+    # it declares an import and defines nothing
+    if (img.import_count != 1)  { ret 1; }
+    if (img.section_count != 0) { ret 1; }
+    if (img.symbol_count != 0)  { ret 1; }
+    if (img.reloc_count != 0)   { ret 1; }
+
+    val sn: O.Option[str] = intern.lookup(?i, img.imports[0].symbol);
+    val ln: O.Option[str] = intern.lookup(?i, img.imports[0].library);
+    if (!O.is_some[str](sn) || !str_equals(O.unwrap[str](sn), "Sleep"))        { ret 1; }
+    if (!O.is_some[str](ln) || !str_equals(O.unwrap[str](ln), "kernel32.dll")) { ret 1; }
+    if (!img.imports[0].by_name) { ret 1; }
+    if (!img.imports[0].is_code) { ret 1; }
+
+    # Version >= 2 is a /bigobj header, not an import record: the same leading bytes
+    # must take the object path and fail its own size check, not this one
+    rec[4] = BIGOBJ_MIN_VERSION::u8;
+    var img2: of.ObjectImage;
+    val br: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?rec[0], 39, ?img2);
+    if (R.is_ok[bool, str](br)) { ret 1; }
+    if (!str_equals(R.unwrap_err[bool, str](br), "coff: bigobj object too small")) { ret 1; }
+    ret 0;
+}
+
+# a truncated or unterminated record is rejected rather than read past its payload
+test "mach.lang.target.of.coff.coff_parse_object:malformed_import_record" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    # SizeOfData claims more bytes than the buffer holds
+    var over: [24]u8;
+    var z: usize = 0;
+    for (z < 24) { over[z] = 0; z = z + 1; }
+    over[2] = 0xFF; over[3] = 0xFF;
+    over[6] = 0x64; over[7] = 0x86;
+    over[12] = 64;
+    var img1: of.ObjectImage;
+    val r1: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?over[0], 24, ?img1);
+    if (R.is_ok[bool, str](r1)) { ret 1; }
+
+    # the payload never terminates the symbol name, so no library name follows
+    var unterm: [24]u8;
+    z = 0;
+    for (z < 24) { unterm[z] = 0x41; z = z + 1; }
+    unterm[0] = 0; unterm[1] = 0;
+    unterm[2] = 0xFF; unterm[3] = 0xFF;
+    unterm[4] = 0; unterm[5] = 0;
+    unterm[6] = 0x64; unterm[7] = 0x86;
+    unterm[8] = 0; unterm[9] = 0; unterm[10] = 0; unterm[11] = 0;
+    unterm[12] = 4; unterm[13] = 0; unterm[14] = 0; unterm[15] = 0;
+    unterm[16] = 0; unterm[17] = 0; unterm[18] = 4; unterm[19] = 0;
+    var img2: of.ObjectImage;
+    val r2: R.Result[bool, str] = coff_parse_object(?alloc, ?i, ?unterm[0], 24, ?img2);
+    if (R.is_ok[bool, str](r2)) { ret 1; }
+    ret 0;
+}
+
 test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
     var alloc: A.Allocator;
     page.make(?alloc);

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -3984,6 +3984,8 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     out.sections = nil;
     out.symbols = nil;
     out.relocations = nil;
+    out.imports = nil;
+    out.import_count = 0;
 
     if (sec_n > 0) {
         val rsec: R.Result[*of.Section, str] = A.zallocate[of.Section](alloc, sec_n::usize);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -3363,6 +3363,8 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     out.sections = nil;
     out.symbols = nil;
     out.relocations = nil;
+    out.imports = nil;
+    out.import_count = 0;
 
     # first pass: tally sections (over every LC_SEGMENT_64) and locate the symtab.
     var sec_n:       u32 = 0;


### PR DESCRIPTION
## What

Mach misclassified COFF short import records as bigobj files and could not consume standard LLVM or MinGW import libraries. This branch parses those records as authoritative symbol-to-DLL declarations and feeds their dependencies and attribution into the existing dynamic-link plan. Consumers need no source decorator or manifest symbol claim.

Bigobj detection now uses its complete version-plus-ClassID discriminator. Short import hint and ordinal metadata is preserved through DynamicInfo, including PE import-by-ordinal thunks.

## Design notes

- Import-library members can introduce DLL dependencies even though those DLLs are not explicit link inputs.
- Traditional all-idata bookkeeping members are ignored because Mach synthesizes the PE import directory from the dynamic plan.
- A short import declaration that contradicts source or manifest attribution is a hard error.
- ADDR32NB support for ordinary object relocations remains separately tracked by #2535.

## Verification

- Real llvm-dlltool archive linked from Linux; llvm-readobj reports Sleep and ExitProcess bound to kernel32.dll.
- Hermetic integration case covers two DLLs, by-name imports, and an import by ordinal.
- 1088 unit tests pass.
- Full Linux integration lane passes all 127 cases.
- Target matrix validates 269 case/leg pairs.
- Debug self-host fixpoint is byte-identical.

Closes #2525