### PR TITLE
test(link): use Darwin C symbol spelling

### DIFF
--- a/int/regression/2543-bsd-ar-extended-name/shim.s
+++ b/int/regression/2543-bsd-ar-extended-name/shim.s
@@ -1,6 +1,6 @@
 .text
-.globl bsd_archive_value
+.globl _bsd_archive_value
 .p2align 4, 0x90
-bsd_archive_value:
+_bsd_archive_value:
     movl $42, %eax
     retq

--- a/int/regression/2543-bsd-ar-extended-name/src/main.mach
+++ b/int/regression/2543-bsd-ar-extended-name/src/main.mach
@@ -1,6 +1,5 @@
-# The function is defined only by the BSD-format archive. Its exact unprefixed
-# assembly spelling keeps this test focused on archive framing, independent of
-# Darwin C-symbol decoration support.
+# The function is defined only by the BSD-format archive. Its assembly symbol
+# uses Darwin's leading-underscore C ABI spelling, matching a real foreign object.
 use std.runtime;
 use std.types.size.usize;
 


### PR DESCRIPTION
## Summary

- define the BSD archive fixture symbol with Darwin's leading-underscore C ABI spelling
- align the fixture documentation with the foreign-object contract established by #2533

## Verification

- the focused regression fails on combined dev with undefined `_bsd_archive_value`
- the focused regression passes in debug and release after this change

Closes #2547