### PR TITLE
fix(link): satisfy the test entrypoint main before archive selection

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -6184,6 +6184,232 @@ test "mach.lang.be.linker.archive_resolution:entry_root" {
     ret 0;
 }
 
+# a generated test entrypoint defining `main` must satisfy that root before a
+# static archive is scanned, so an unrelated archive member also defining `main`
+# (a CRT startup stub) stays unselected and causes no duplicate. this is the
+# link-order fixture for the test dispatcher: the entry links ahead of the
+# archive (as the build path seeds the project's own `main`), the CRT startup
+# member (defining `mainCRTStartup`, referencing `main`) and a required helper
+# are selected, and the stub is not. linking the entry after the archive
+# reproduces #2562: the startup member pulls the stub's `main`, then the entry's
+# `main` collides
+test "mach.lang.be.linker.archive_resolution:test_entry_satisfies_main_before_archive" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { session.dnit(?s); ret 1; }
+    val tr: R.Result[target.Target, str] =
+        target.select(?reg, "x86_64", "windows", "win64");
+    if (R.is_err[target.Target, str](tr)) { session.dnit(?s); ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    val text:      intern.StrId = lt_name(?s, ".text");
+    val entry_sym: intern.StrId = lt_name(?s, "mainCRTStartup");
+    val main_sym:  intern.StrId = lt_name(?s, "main");
+    val helper:    intern.StrId = lt_name(?s, "helper");
+    if (text == intern.STR_NIL || entry_sym == intern.STR_NIL
+        || main_sym == intern.STR_NIL || helper == intern.STR_NIL) {
+        session.dnit(?s); ret 1;
+    }
+
+    val def_fn: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    val undef:  u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN;
+
+    var eb: [8]u8; var cb: [8]u8; var hb: [8]u8; var sb: [8]u8;
+    var i: u32 = 0;
+    for (i < 8) {
+        eb[i] = 0xCC; cb[i] = 0x90; hb[i] = 0xA5; sb[i] = 0x33;
+        i = i + 1;
+    }
+
+    # the generated test entrypoint: defines `main`, references `helper`
+    var entry_secs: [1]of.Section;
+    entry_secs[0].name = text; entry_secs[0].kind = of.SK_TEXT;
+    entry_secs[0].bytes = ?eb[0]; entry_secs[0].len = 8; entry_secs[0].align = 8;
+    var entry_syms: [2]of.Symbol;
+    entry_syms[0].name = main_sym; entry_syms[0].section = 0; entry_syms[0].offset = 0;
+    entry_syms[0].size = 8; entry_syms[0].flags = def_fn;
+    entry_syms[1].name = helper; entry_syms[1].section = of.SECTION_EXTERNAL;
+    entry_syms[1].offset = 0; entry_syms[1].size = 0; entry_syms[1].flags = undef;
+    var entry_img: of.ObjectImage = lt_image(?s, lt_name(?s, "test-entry"),
+        ?entry_secs[0], 1, ?entry_syms[0], 2, nil::*of.Relocation, 0);
+
+    # the required CRT startup: defines the OS entry `mainCRTStartup`, references `main`
+    var crt_secs: [1]of.Section;
+    crt_secs[0].name = text; crt_secs[0].kind = of.SK_TEXT;
+    crt_secs[0].bytes = ?cb[0]; crt_secs[0].len = 8; crt_secs[0].align = 8;
+    var crt_syms: [2]of.Symbol;
+    crt_syms[0].name = entry_sym; crt_syms[0].section = 0; crt_syms[0].offset = 0;
+    crt_syms[0].size = 8; crt_syms[0].flags = def_fn;
+    crt_syms[1].name = main_sym; crt_syms[1].section = of.SECTION_EXTERNAL;
+    crt_syms[1].offset = 0; crt_syms[1].size = 0; crt_syms[1].flags = undef;
+    var crt_img: of.ObjectImage = lt_image(?s, lt_name(?s, "crt"),
+        ?crt_secs[0], 1, ?crt_syms[0], 2, nil::*of.Relocation, 0);
+
+    # the required helper, selected because the entry references it
+    var helper_secs: [1]of.Section;
+    helper_secs[0].name = text; helper_secs[0].kind = of.SK_TEXT;
+    helper_secs[0].bytes = ?hb[0]; helper_secs[0].len = 8; helper_secs[0].align = 8;
+    var helper_syms: [1]of.Symbol;
+    helper_syms[0].name = helper; helper_syms[0].section = 0; helper_syms[0].offset = 0;
+    helper_syms[0].size = 8; helper_syms[0].flags = def_fn;
+    var helper_img: of.ObjectImage = lt_image(?s, lt_name(?s, "helper"),
+        ?helper_secs[0], 1, ?helper_syms[0], 1, nil::*of.Relocation, 0);
+
+    # the unrelated startup stub also defining `main`: must stay unselected
+    var stub_secs: [1]of.Section;
+    stub_secs[0].name = text; stub_secs[0].kind = of.SK_TEXT;
+    stub_secs[0].bytes = ?sb[0]; stub_secs[0].len = 8; stub_secs[0].align = 8;
+    var stub_syms: [1]of.Symbol;
+    stub_syms[0].name = main_sym; stub_syms[0].section = 0; stub_syms[0].offset = 0;
+    stub_syms[0].size = 8; stub_syms[0].flags = def_fn;
+    var stub_img: of.ObjectImage = lt_image(?s, lt_name(?s, "main-stub"),
+        ?stub_secs[0], 1, ?stub_syms[0], 1, nil::*of.Relocation, 0);
+
+    var entry_tf: fs.TempFile;
+    var crt_tf:   fs.TempFile;
+    var helper_tf: fs.TempFile;
+    var stub_tf:  fs.TempFile;
+    var ar_tf:    fs.TempFile;
+    var exe_tf:   fs.TempFile;
+    var have_entry: bool = false;
+    var have_crt:   bool = false;
+    var have_helper: bool = false;
+    var have_stub:  bool = false;
+    var have_ar:    bool = false;
+    var have_exe:   bool = false;
+
+    val er0: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_2562_entry");
+    if (R.is_err[fs.TempFile, str](er0)) { session.dnit(?s); ret 1; }
+    entry_tf = R.unwrap_ok[fs.TempFile, str](er0); have_entry = true;
+    val er1: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_2562_crt");
+    if (R.is_err[fs.TempFile, str](er1)) { remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe); session.dnit(?s); ret 1; }
+    crt_tf = R.unwrap_ok[fs.TempFile, str](er1); have_crt = true;
+    val er2: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_2562_helper");
+    if (R.is_err[fs.TempFile, str](er2)) { remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe); session.dnit(?s); ret 1; }
+    helper_tf = R.unwrap_ok[fs.TempFile, str](er2); have_helper = true;
+    val er3: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_2562_stub");
+    if (R.is_err[fs.TempFile, str](er3)) { remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe); session.dnit(?s); ret 1; }
+    stub_tf = R.unwrap_ok[fs.TempFile, str](er3); have_stub = true;
+    val er4: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_2562_ar");
+    if (R.is_err[fs.TempFile, str](er4)) { remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe); session.dnit(?s); ret 1; }
+    ar_tf = R.unwrap_ok[fs.TempFile, str](er4); have_ar = true;
+    val er5: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "mach_2562_exe");
+    if (R.is_err[fs.TempFile, str](er5)) { remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe); session.dnit(?s); ret 1; }
+    exe_tf = R.unwrap_ok[fs.TempFile, str](er5); have_exe = true;
+
+    val entry_path: str = fs.temp_path(?entry_tf);
+    val crt_path:   str = fs.temp_path(?crt_tf);
+    val helper_path: str = fs.temp_path(?helper_tf);
+    val stub_path:  str = fs.temp_path(?stub_tf);
+    val ar_path:    str = fs.temp_path(?ar_tf);
+    val exe_path:   str = fs.temp_path(?exe_tf);
+
+    if (O.is_some[str](fs.temp_close(?entry_tf))
+        || O.is_some[str](fs.temp_close(?crt_tf))
+        || O.is_some[str](fs.temp_close(?helper_tf))
+        || O.is_some[str](fs.temp_close(?stub_tf))
+        || O.is_some[str](fs.temp_close(?ar_tf))
+        || O.is_some[str](fs.temp_close(?exe_tf))) {
+        remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe);
+        session.dnit(?s); ret 1;
+    }
+
+    var bad: i32 = 0;
+    if (R.is_err[bool, str](obj.emit(?entry_img, ?tgt, entry_path::*u8))) { bad = 1; }
+    if (bad == 0 && R.is_err[bool, str](obj.emit(?crt_img, ?tgt, crt_path::*u8))) { bad = 1; }
+    if (bad == 0 && R.is_err[bool, str](obj.emit(?helper_img, ?tgt, helper_path::*u8))) { bad = 1; }
+    if (bad == 0 && R.is_err[bool, str](obj.emit(?stub_img, ?tgt, stub_path::*u8))) { bad = 1; }
+
+    # archive the crt, helper, and stub members; the entry stays a loose object
+    var crt_vec:    Vector[u8];
+    var helper_vec: Vector[u8];
+    var stub_vec:   Vector[u8];
+    var have_crt_v: bool = false;
+    var have_hlp_v: bool = false;
+    var have_stb_v: bool = false;
+    if (bad == 0) {
+        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, crt_path);
+        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
+        or { crt_vec = R.unwrap_ok[Vector[u8], str](rr); have_crt_v = true; }
+    }
+    if (bad == 0) {
+        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, helper_path);
+        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
+        or { helper_vec = R.unwrap_ok[Vector[u8], str](rr); have_hlp_v = true; }
+    }
+    if (bad == 0) {
+        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, stub_path);
+        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
+        or { stub_vec = R.unwrap_ok[Vector[u8], str](rr); have_stb_v = true; }
+    }
+
+    if (bad == 0) {
+        var crt_names:    [1]str; crt_names[0]    = "mainCRTStartup";
+        var helper_names: [1]str; helper_names[0] = "helper";
+        var stub_names:   [1]str; stub_names[0]   = "main";
+        var members: [3]ar.ArMember;
+        members[0].name = "crt.o";    members[0].data = crt_vec.data;    members[0].len = crt_vec.len;    members[0].sym_names = ?crt_names[0];    members[0].sym_count = 1;
+        members[1].name = "helper.o"; members[1].data = helper_vec.data; members[1].len = helper_vec.len; members[1].sym_names = ?helper_names[0]; members[1].sym_count = 1;
+        members[2].name = "stub.o";   members[2].data = stub_vec.data;   members[2].len = stub_vec.len;   members[2].sym_names = ?stub_names[0];   members[2].sym_count = 1;
+        val wr: R.Result[bool, str] = ar.write_archive(?alloc, ?members[0], 3, ar_path);
+        if (R.is_err[bool, str](wr)) { bad = 1; }
+    }
+
+    # the fix: the entry precedes the archive, so `main` is a satisfied root
+    # before selection. the crt and helper members are pulled; the stub is not,
+    # and the link produces a single `main`
+    if (bad == 0) {
+        var fix_paths: [2]*u8;
+        fix_paths[0] = entry_path::*u8;
+        fix_paths[1] = ar_path::*u8;
+        val lr: R.Result[bool, str] =
+            link(?s, ?tgt, ?fix_paths[0], 2, nil::*of.DynLib, 0, exe_path::*u8,
+                 "test-entry-fix", LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
+        if (R.is_err[bool, str](lr)) { bad = 1; }
+    }
+
+    # the bug: the entry follows the archive. the crt member's `main` reference
+    # pulls the stub's `main`, then the entry's `main` collides - #2562
+    if (bad == 0) {
+        var bug_paths: [2]*u8;
+        bug_paths[0] = ar_path::*u8;
+        bug_paths[1] = entry_path::*u8;
+        val lr: R.Result[bool, str] =
+            link(?s, ?tgt, ?bug_paths[0], 2, nil::*of.DynLib, 0, exe_path::*u8,
+                 "test-entry-bug", LINK_EXE, false, of.SUBSYSTEM_CONSOLE);
+        if (R.is_ok[bool, str](lr)) { bad = 1; }
+        or {
+            # the duplicate must name `main`, not some other symbol
+            val err: str = R.unwrap_err[bool, str](lr);
+            if (!str_equals(err, "multiple definition of 'main'")) { bad = 1; }
+        }
+    }
+
+    if (have_crt_v)  { vector.dnit[u8](?crt_vec); }
+    if (have_hlp_v)  { vector.dnit[u8](?helper_vec); }
+    if (have_stb_v)  { vector.dnit[u8](?stub_vec); }
+    remove_2562(?entry_tf, ?crt_tf, ?helper_tf, ?stub_tf, ?ar_tf, ?exe_tf, have_entry, have_crt, have_helper, have_stub, have_ar, have_exe);
+    session.dnit(?s);
+    ret bad;
+}
+
+# remove the #2562 fixture temp files that were actually created
+fun remove_2562(a: *fs.TempFile, b: *fs.TempFile, c: *fs.TempFile, d: *fs.TempFile,
+                e: *fs.TempFile, f: *fs.TempFile,
+                ha: bool, hb: bool, hc: bool, hd: bool, he: bool, hf: bool) {
+    if (ha) { fs.temp_remove(a); }
+    if (hb) { fs.temp_remove(b); }
+    if (hc) { fs.temp_remove(c); }
+    if (hd) { fs.temp_remove(d); }
+    if (he) { fs.temp_remove(e); }
+    if (hf) { fs.temp_remove(f); }
+}
+
 # An unresolved weak reference is optional and does not pull an archive member;
 # a strong unresolved reference to the same provider still does.
 test "mach.lang.be.linker.archive_resolution:undefined_weak_does_not_extract" {

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -377,9 +377,19 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
     if (R.is_err[**u8, str](res_paths)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
     val paths: **u8 = R.unwrap_ok[**u8, str](res_paths);
 
+    # the dispatcher entry defines the test `main`. archive member selection
+    # walks a link-order frontier, so the entry must precede any static archive
+    # (e.g. the MinGW CRT) whose startup member also defines `main`: placing it
+    # with the per-module objects makes `main` a satisfied root before the
+    # archive is scanned, so the unrelated startup member stays unselected. the
+    # ordinary build path reaches the same order by seeding the project's own
+    # `main` image ahead of the external inputs (#2530, #2562).
+    val per_module: u32 = p.topo_len;
     var i: u32 = 0;
-    for (i < shared_len) { paths[i] = shared[i]; i = i + 1; }
-    paths[shared_len] = entry_path;
+    for (i < per_module) { paths[i] = shared[i]; i = i + 1; }
+    paths[per_module] = entry_path;
+    var j: u32 = per_module;
+    for (j < shared_len) { paths[j + 1] = shared[j]; j = j + 1; }
 
     val res_link: R.Result[bool, str] =
         linker.link(p.s, ?p.target, paths, total, dynlibs, dynlib_len, exe_path, emit.artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, ctx.req.subsystem);


### PR DESCRIPTION
Closes #2562.

## Root cause

`mach test` assembled its link inputs as [shared objects..., entry], so the generated dispatcher entry defining `main` sat *after* the external inputs. Archive member selection walks a link-order frontier: scanning `libmingw32.lib` with `main` still unresolved pulled the CRT startup member defining `main`, which then collided with the entry's `main` (`error: multiple definition of main`). Ordinary binaries are unaffected because the build path seeds the project's own `main` image ahead of the external inputs (#2530).

## Fix

Insert the dispatcher entry at the per-module/external boundary (`p.topo_len`) in `link_one_test`, making `main` a satisfied root before any archive is scanned — the same order the build path already produces.

## Verification

- New regression test `archive_resolution:test_entry_satisfies_main_before_archive`: synthetic entry (defines `main`, references `helper`), CRT startup member (defines `mainCRTStartup`, references `main`), required helper, and an unrelated `main` stub in one archive. Entry-before-archive links cleanly and leaves the stub unselected; the reverse order reproduces the #2562 duplicate.
- Full suite on the branch compiler: **1140 passed, 0 failed**.

Unblocks native Windows `mach test` coverage in briar-systems/mach-audio#15 and mach-glfw#32.