### PR TITLE
fix(infra): resolve the CI seed from the latest published release

### DIFF
--- a/.github/actions/seed-mach/action.yml
+++ b/.github/actions/seed-mach/action.yml
@@ -1,0 +1,84 @@
+name: seed mach
+description: put the released mach seed compiler for this runner's host on PATH
+
+# the seed is the released compiler every lane bootstraps from. it resolves through
+# repos/{owner}/{repo}/releases/latest, which serves the newest *published* release and
+# never a draft or a prerelease. an untagged `gh release download` instead takes whatever
+# release the client considers newest, so a draft holding one hand-uploaded archive
+# silently became the seed for every lane and broke each one whose host archive it did
+# not carry (#2573). resolution lives here, once, so no call site can reintroduce that.
+
+inputs:
+  token:
+    description: token used to read the release
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  tag:
+    description: tag of the release the seed came from
+    value: ${{ steps.resolve.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    # every lane seeds from its own host's archive: the seed has to exec on the runner,
+    # whatever it is later asked to build for. the host archive is named after the
+    # resolved release, so it is derived, never a matrix field that can drift from runs-on.
+    - name: resolve the seed release
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS/$RUNNER_ARCH" in
+          Linux/X64)     host=x86_64-linux;    ext=tar.gz ;;
+          Linux/ARM64)   host=aarch64-linux;   ext=tar.gz ;;
+          Windows/X64)   host=x86_64-windows;  ext=zip ;;
+          macOS/X64)     host=x86_64-darwin;   ext=tar.gz ;;
+          macOS/ARM64)   host=aarch64-darwin;  ext=tar.gz ;;
+          *) echo "::error::no mach seed archive is published for host $RUNNER_OS/$RUNNER_ARCH"; exit 1 ;;
+        esac
+
+        # first line is the tag, the rest are the release's asset names
+        listing="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name, .assets[].name')"
+        tag="$(printf '%s\n' "$listing" | head -1)"
+        names="$(printf '%s\n' "$listing" | tail -n +2)"
+        asset="mach-${tag#v}-$host.$ext"
+
+        if ! printf '%s\n' "$names" | grep -Fxq "$asset"; then
+          echo "::error::the latest published release $tag carries no $asset — it holds: $(printf '%s' "$names" | tr '\n' ' ')"
+          exit 1
+        fi
+
+        # a relative directory keeps every path here portable to the windows runner's bash
+        mkdir -p .mach-seed
+        gh release download "$tag" -R "$GITHUB_REPOSITORY" -p "$asset" -D .mach-seed
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "asset=$asset" >> "$GITHUB_OUTPUT"
+        echo "seeding from $tag ($asset)"
+
+    - name: install the seed
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ASSET: ${{ steps.resolve.outputs.asset }}
+      run: |
+        set -euo pipefail
+        tar -xzf ".mach-seed/$ASSET" -C .mach-seed mach
+        chmod +x .mach-seed/mach
+        echo "$PWD/.mach-seed" >> "$GITHUB_PATH"
+
+    # GITHUB_PATH only takes effect in later steps, so callers fetch the seed in one step
+    # and use it in the next
+    - name: install the seed
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ASSET: ${{ steps.resolve.outputs.asset }}
+      run: |
+        $dir = Join-Path $PWD '.mach-seed'
+        Expand-Archive -Path (Join-Path $dir $env:ASSET) -DestinationPath $dir -Force
+        Add-Content -Path $env:GITHUB_PATH -Value $dir

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,23 +42,13 @@ jobs:
         include:
           - target: x86_64-linux
             runs-on: ubuntu-latest
-            seed: mach-*-x86_64-linux.tar.gz
           - target: aarch64-linux
             runs-on: ubuntu-24.04-arm
-            seed: mach-*-aarch64-linux.tar.gz
     steps:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: ${{ matrix.seed }}
-        run: |
-          set -euo pipefail
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
-          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
+        uses: ./.github/actions/seed-mach
 
       - name: build fixpoint
         run: |
@@ -148,7 +138,6 @@ jobs:
         include:
           - target: x86_64-windows
             runs-on: windows-latest
-            seed: mach-*-x86_64-windows.zip
     defaults:
       run:
         shell: pwsh
@@ -156,16 +145,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: ${{ matrix.seed }}
-        run: |
-          $seed = Join-Path $env:RUNNER_TEMP 'seed'
-          New-Item -ItemType Directory -Path $seed -Force | Out-Null
-          gh release download -R $env:GITHUB_REPOSITORY -p $env:SEED -D $seed
-          $zip = Get-ChildItem -Path $seed -Filter $env:SEED | Select-Object -First 1
-          Expand-Archive -Path $zip.FullName -DestinationPath $seed -Force
-          Add-Content -Path $env:GITHUB_PATH -Value $seed
+        uses: ./.github/actions/seed-mach
 
       - name: build fixpoint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,13 @@ jobs:
         include:
           - target: x86_64-linux
             runs-on: ubuntu-latest
-            seed: mach-*-x86_64-linux.tar.gz
           - target: aarch64-linux
             runs-on: ubuntu-24.04-arm
-            seed: mach-*-aarch64-linux.tar.gz
     steps:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: ${{ matrix.seed }}
-        run: |
-          set -euo pipefail
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
-          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
+        uses: ./.github/actions/seed-mach
 
       - name: build fixpoint
         run: |
@@ -139,23 +129,13 @@ jobs:
         include:
           - target: x86_64-linux
             runs-on: ubuntu-latest
-            seed: mach-*-x86_64-linux.tar.gz
           - target: aarch64-linux
             runs-on: ubuntu-24.04-arm
-            seed: mach-*-aarch64-linux.tar.gz
     steps:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: ${{ matrix.seed }}
-        run: |
-          set -euo pipefail
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
-          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
+        uses: ./.github/actions/seed-mach
 
       - name: build release fixpoint
         run: |
@@ -185,7 +165,6 @@ jobs:
         include:
           - target: x86_64-windows
             runs-on: windows-latest
-            seed: mach-*-x86_64-windows.zip
     defaults:
       run:
         shell: pwsh
@@ -193,16 +172,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: ${{ matrix.seed }}
-        run: |
-          $seed = Join-Path $env:RUNNER_TEMP 'seed'
-          New-Item -ItemType Directory -Path $seed -Force | Out-Null
-          gh release download -R $env:GITHUB_REPOSITORY -p $env:SEED -D $seed
-          $zip = Get-ChildItem -Path $seed -Filter $env:SEED | Select-Object -First 1
-          Expand-Archive -Path $zip.FullName -DestinationPath $seed -Force
-          Add-Content -Path $env:GITHUB_PATH -Value $seed
+        uses: ./.github/actions/seed-mach
 
       - name: build fixpoint
         run: |
@@ -271,7 +241,6 @@ jobs:
         include:
           - target: x86_64-windows
             runs-on: windows-latest
-            seed: mach-*-x86_64-windows.zip
     defaults:
       run:
         shell: pwsh
@@ -279,16 +248,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: ${{ matrix.seed }}
-        run: |
-          $seed = Join-Path $env:RUNNER_TEMP 'seed'
-          New-Item -ItemType Directory -Path $seed -Force | Out-Null
-          gh release download -R $env:GITHUB_REPOSITORY -p $env:SEED -D $seed
-          $zip = Get-ChildItem -Path $seed -Filter $env:SEED | Select-Object -First 1
-          Expand-Archive -Path $zip.FullName -DestinationPath $seed -Force
-          Add-Content -Path $env:GITHUB_PATH -Value $seed
+        uses: ./.github/actions/seed-mach
 
       - name: build release fixpoint
         run: |
@@ -364,39 +324,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm binutils spirv-tools
 
-      - name: build the from-source compiler
-        if: runner.os != 'Windows'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          case "${{ runner.arch }}" in
-            X64)   seed='mach-*-x86_64-linux.tar.gz' ;;
-            ARM64) seed='mach-*-aarch64-linux.tar.gz' ;;
-            *) echo "::error::unsupported host arch ${{ runner.arch }}"; exit 1 ;;
-          esac
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$seed" -D "$tmp"
-          tar -xzf "$tmp"/$seed -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
-          mach dep pull
-          mach build . -o m
-
       # the seed lands on PATH via GITHUB_PATH, which only takes effect in later
       # steps, so the fetch and the build are separate (as in the build lanes).
-      - name: fetch released mach (windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: mach-*-x86_64-windows.zip
+      - name: fetch released mach
+        uses: ./.github/actions/seed-mach
+
+      - name: build the from-source compiler
+        if: runner.os != 'Windows'
         run: |
-          $seed = Join-Path $env:RUNNER_TEMP 'seed'
-          New-Item -ItemType Directory -Path $seed -Force | Out-Null
-          gh release download -R $env:GITHUB_REPOSITORY -p $env:SEED -D $seed
-          $zip = Get-ChildItem -Path $seed -Filter $env:SEED | Select-Object -First 1
-          Expand-Archive -Path $zip.FullName -DestinationPath $seed -Force
-          Add-Content -Path $env:GITHUB_PATH -Value $seed
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
 
       - name: build the from-source compiler (windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -36,15 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: fetch released mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SEED: mach-*-x86_64-linux.tar.gz
-        run: |
-          set -euo pipefail
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
-          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
+        uses: ./.github/actions/seed-mach
 
       - name: cross-build the darwin seed
         env:

--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -46,18 +46,13 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.int-matrix.outputs.include) }}
-    env:
-      GH_TOKEN: ${{ github.token }}
-      SEED: mach-*-x86_64-linux.tar.gz
     steps:
       - uses: actions/checkout@v6
+      - name: fetch released mach
+        uses: ./.github/actions/seed-mach
       - name: cross-build the from-source compiler
         run: |
           set -euo pipefail
-          tmp="$(mktemp -d)"
-          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
-          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
-          chmod +x /usr/local/bin/mach
           mach dep pull
           mach build . -o m
           ./m build . --target ${{ matrix.target }} --profile release -o mach-${{ matrix.target }}


### PR DESCRIPTION
Closes #2573

Every seed fetch called `gh release download` with no tag, so the seed resolved to whatever release the client considered newest. With the v4.7.0 draft present (one hand-uploaded `mach-4.7.0-x86_64-linux.tar.gz`), that is the draft, and every lane whose host archive it lacks dies in `fetch released mach` with `no assets match the file pattern` — confirmed on run 31140741120, and absent from runs predating the draft.

## What changed

`.github/actions/seed-mach` now owns seed resolution:

- resolves through `repos/{owner}/{repo}/releases/latest`, which by construction never serves a draft or a prerelease
- derives the host archive from `RUNNER_OS`/`RUNNER_ARCH` and the resolved tag, so the name is asserted rather than globbed
- fails with the resolved tag, the wanted archive and the release's actual asset list
- installs to `.mach-seed` on `GITHUB_PATH`; only extraction is split by platform (tar vs `Expand-Archive`), the resolution is one copy for both

Nine call sites across ci.yml, cd.yml, int-main.yml and darwin-lane.yml become `uses: ./.github/actions/seed-mach`. The integration job's separate windows / non-windows fetch steps collapse into one. The per-matrix `seed:` patterns are gone: every lane seeds from its own host, so they duplicated `runs-on`.

The v4.7.0 draft is untouched — deleting it would hide the defect, not fix it.

## Verification

Resolution logic run against the live repo with the draft still present: all five host combinations resolve to **v4.6.0**, and an unsupported host is rejected.

```
RESOLVED Linux/X64     -> v4.6.0 mach-4.6.0-x86_64-linux.tar.gz
RESOLVED Linux/ARM64   -> v4.6.0 mach-4.6.0-aarch64-linux.tar.gz
RESOLVED Windows/X64   -> v4.6.0 mach-4.6.0-x86_64-windows.zip
RESOLVED macOS/X64     -> v4.6.0 mach-4.6.0-x86_64-darwin.tar.gz
RESOLVED macOS/ARM64   -> v4.6.0 mach-4.6.0-aarch64-darwin.tar.gz
::error::no mach seed archive is published for host Linux/RISCV64
```

The acceptance test is this PR's own CI: `build x86_64-windows`, `build aarch64-linux`, `release x86_64-windows`, `release aarch64-linux`, `int windows` and `int linux-arm64` green with the draft still in place.

## Also checked

cd.yml's `verify archive completeness` guard is sound and needs no change: it compares the artifacts the run itself produced against the target set read out of the build matrices, so an asset hand-uploaded to a release cannot make an incomplete release publishable.