### PR TITLE
fix(linker): keep debug relocations out of atom liveness

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -8738,6 +8738,83 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
     ret 0;
 }
 
+# a -g additivity regression (#2572): a crossing reference sourced from a debug
+# section is DWARF describing the code, not code reaching it, so it must not keep a
+# losing weak atom alive. debug relocations exist only under -g, so indexing them
+# made the -g link retain duplicate weak bodies the no-g link discarded, growing
+# .text and shifting every later PT_LOAD. the identical relocation in a non-debug
+# section still retains the atom, so the exclusion is keyed on the section kind
+# rather than on the geometry.
+test "mach.lang.be.linker.atom_plan:debug_crossing_does_not_retain_loser" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    if (x64 == nil) { ret 1; }
+
+    val dup: intern.StrId = lt_name(?s, "crossI3u64E");
+    val base: intern.StrId = lt_name(?s, "section_base");
+    val tail: intern.StrId = lt_name(?s, "tail");
+    val text: intern.StrId = lt_name(?s, ".text");
+    val info: intern.StrId = lt_name(?s, ".debug_info");
+    val weak_flags: u32 =
+        of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    val strong_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    var a_bytes: [8]u8;
+    var b_bytes: [24]u8;
+    var b_info: [8]u8;
+    var a_sec: [1]of.Section;
+    var b_secs: [2]of.Section;
+    a_sec[0].name = text; a_sec[0].kind = of.SK_TEXT; a_sec[0].bytes = ?a_bytes[0];
+    a_sec[0].len = 8; a_sec[0].align = 1;
+    b_secs[0].name = text; b_secs[0].kind = of.SK_TEXT; b_secs[0].bytes = ?b_bytes[0];
+    b_secs[0].len = 24; b_secs[0].align = 1;
+    b_secs[1].name = info; b_secs[1].kind = of.SK_DEBUG; b_secs[1].bytes = ?b_info[0];
+    b_secs[1].len = 8; b_secs[1].align = 1;
+
+    var a_syms: [1]of.Symbol;
+    var b_syms: [3]of.Symbol;
+    a_syms[0].name = dup; a_syms[0].section = 0; a_syms[0].offset = 0;
+    a_syms[0].size = 8; a_syms[0].flags = weak_flags;
+    b_syms[0].name = base; b_syms[0].section = 0; b_syms[0].offset = 0;
+    b_syms[0].size = 0; b_syms[0].flags = 0;
+    b_syms[1].name = dup; b_syms[1].section = 0; b_syms[1].offset = 8;
+    b_syms[1].size = 8; b_syms[1].flags = weak_flags;
+    b_syms[2].name = tail; b_syms[2].section = 0; b_syms[2].offset = 16;
+    b_syms[2].size = 8; b_syms[2].flags = strong_flags;
+
+    # a DWARF code address written as `section_base + 16`: the anchor sits before
+    # the losing copy of `dup` at [8,16) and the effective target lands after it,
+    # exactly the DW_AT_low_pc shape that used to veto the discard.
+    var reloc: [1]of.Relocation;
+    reloc[0].section = 1; reloc[0].offset = 0; reloc[0].kind = of.RK_ABS64;
+    reloc[0].sym = 0; reloc[0].addend = 16;
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_image(?s, lt_name(?s, "winner"), ?a_sec[0], 1, ?a_syms[0], 1,
+                       nil::*of.Relocation, 0);
+    mods[1] = lt_image(?s, lt_name(?s, "loser"), ?b_secs[0], 2, ?b_syms[0], 3,
+                       ?reloc[0], 1);
+    var bases: [2]u32;
+    var plan: AtomPlan;
+    init_atom_plan(?plan);
+    val from_debug: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
+    if (R.is_err[bool, str](from_debug) || !plan.active || plan.drop_count != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    # the same crossing reference from a text section still retains the atom, so
+    # the discard turns on the source section kind and not on the addend geometry.
+    b_secs[1].kind = of.SK_TEXT;
+    val from_text: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
+    if (R.is_err[bool, str](from_text) || plan.active) { ret 1; }
+    ret 0;
+}
+
 # a live relocation through a local/section anchor before a losing atom keeps the
 # atom when its unchanged addend reaches across the removed interval. this covers
 # effective targets after the atom as well as targets inside it

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -2576,7 +2576,12 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
 
     # index relocation targets once. candidate checks then inspect only references
     # to symbols in that candidate's section instead of rescanning every relocation
-    # for every duplicate weak body.
+    # for every duplicate weak body. relocations sourced from a debug section are
+    # left unindexed: debug information describes code, so it must never be what
+    # keeps code alive. indexing them made the -g link retain duplicate weak bodies
+    # the no-g link discarded, which is a -g additivity violation (#2572); a DWARF
+    # reference to a discarded body resolves through the surviving winner, or to the
+    # dead-code sentinel (#2384), on the patch path instead.
     var reloc_total64: u64 = 0;
     m = 0;
     for (m < module_count) {
@@ -2618,6 +2623,12 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 refs[rw].source_module = m;
                 refs[rw].reloc = ri;
                 val relocation: *of.Relocation = ?modules[m].relocations[ri];
+                if (relocation.section < modules[m].section_count
+                    && modules[m].sections[relocation.section].kind == of.SK_DEBUG) {
+                    rw = rw + 1;
+                    ri = ri + 1;
+                    cnt;
+                }
                 var traits: rel.RelocTraits;
                 if (relocation.section < modules[m].section_count) {
                     traits = atom_reloc_traits(


### PR DESCRIPTION
Closes #2572

## Root cause

`build_atom_plan` (`src/lang/be/linker.mach`) indexes every input relocation and
vetoes discarding a losing weak function body whose extent is crossed by a
surviving reference — symbol offsets are remapped by the atom compaction but raw
relocation addends are not, so a crossing reference would silently retarget.

That index included relocations sourced from **debug** sections, which exist only
under `-g`. A DWARF code-address reference — `.debug_info`'s `anchor + offset`
`DW_AT_low_pc` form, emitted as `RK_ABS64` against the enclosing function symbol —
reaching across a duplicate weak body made that body ineligible for discard.

Instrumenting the veto on a self-build shows the whole delta: 14 losing weak
bodies retained under `-g`, zero under no-`g`, and **every** veto sourced from a
`SK_DEBUG` section:

```
VETO-REF sym=_M3std9allocatorN14allocateI3u32E cm=86 start=90382 end=90958
         srcsec=.debug_info seckind=5 addend=5055
         anchor=_M3std11collections3mapN35growI3u32N4mach4lang2me2ir6DbgVarEE
...14 total, all seckind=5 (SK_DEBUG)
```

Net effect: `-g` retained 5184 bytes of duplicate weak function bodies that the
no-`g` link dropped, so `.text` grew (`0x81138e` vs `0x80ff4e`) and every later
`PT_LOAD` shifted — failing cd.yml's whole-compiler additivity capstone (#1963)
on both linux ISAs. Darwin passes because its lane does not run that step.

Nothing in the middle end or codegen is implicated: per-module `.s` output and
every object's `.text` are byte-identical between the two builds. The divergence
is entirely in the internal linker's atom plan.

## Fix

Relocations whose source section is `SK_DEBUG` are left unindexed. Debug
information describes code; it must never be what keeps code alive, nor what
changes code layout. The atom plan is now identical with and without `-g`.

The patch path is unchanged: a DWARF reference to a discarded body still resolves
through the surviving winner, or to the dead-code sentinel (#2384).

## Verification

`./c build . --profile release -g` vs non-`g`, cd.yml's exact normalization and
per-`PT_LOAD` comparison, run against a local self-host fixpoint:

- **x86_64-linux** (native): `self-additive: OK (5 PT_LOAD segments identical)`
- **aarch64-linux**: same check, stage-2/3 and both final builds under
  `qemu-aarch64` user emulation

## Guard

A `build_atom_plan` regression asserting a debug-sourced crossing reference does
not retain a losing weak atom, while the identical relocation in a non-debug
section still does.