### PR TITLE
fix(int): restore the required need key on the pe-resources-native fixture

### DIFF
--- a/int/surface/pe-resources-native/mach.toml
+++ b/int/surface/pe-resources-native/mach.toml
@@ -25,6 +25,7 @@ entry = "main.mach"
 out = "bin/game-app.exe"
 targets = ["*"]
 link = ["kernel32"]
+need = []
 icon = "assets/app.ico"
 manifest = "assets/app.manifest"
 


### PR DESCRIPTION
Unblocks the `int windows` leg, which fails on every branch right now.

`ca84ed04` (in #2561) dropped the `pe-resources-native` fixture's `[step.icon]`
block and deleted the artifact's `need = ["icon"]` line with it, without
replacing it with `need = []`. `need` is a required artifact key
(`src/lang/manifest.mach:873-875`), so the manifest was rejected before
compilation and the case has never built on any host. That commit was the last
on its branch, never ran CI, and was merged with `--admin` during the
2026-08-06 Actions outage — so PE resources shipped in v4.7.0 with no executing
test coverage.

The fixture declares no build steps, so the empty list is the correct value —
this restores what the case asserts rather than weakening it.

## Verification

The fixture now builds, and its resource tree has been validated against the
PE/COFF spec for the first time. Full findings are in the PR thread.

Closes #2579
