### PR TITLE
fix(driver): run build steps through exec.run_shell with the project root as cwd

### DIFF
--- a/int/run.sh
+++ b/int/run.sh
@@ -226,6 +226,17 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
         rm -rf "$dir/out/int"
         mkdir -p "$dir/out/int"
 
+        # drop the step stamp cache so every `[step]` re-runs for this build.
+        # mach skips a step whose stamp matches and whose outputs all exist, and
+        # neither depends on the compiler, so a stamp written by an EARLIER
+        # harness run made later runs skip the step engine entirely - a case that
+        # asserts on step output kept passing against a compiler that could no
+        # longer run a step at all, which is the exact defect #2578 is. CI never
+        # saw it (fresh checkout, no stamps); only local iteration did, in the
+        # direction that reports green. the outputs are left alone: with no stamp
+        # the step always runs, and a step that fails is a build failure.
+        rm -rf "$dir/out/.steps"
+
         # the compiler that builds the case. normally the from-source compiler
         # itself; a self-host case first cross-builds that compiler to the leg
         # target and drives it under the leg's run-mode, so the case is compiled by

--- a/int/surface/step shell posix/assets/seed with space.txt
+++ b/int/surface/step shell posix/assets/seed with space.txt
@@ -1,0 +1,1 @@
+step-ran

--- a/int/surface/step shell posix/assets/seed.txt
+++ b/int/surface/step shell posix/assets/seed.txt
@@ -1,0 +1,1 @@
+step-ran

--- a/int/surface/step shell posix/case.conf
+++ b/int/surface/step shell posix/case.conf
@@ -1,0 +1,14 @@
+# the posix half of the `[step]` working-directory contract (#2587).
+#
+# THE SPACE IN THIS DIRECTORY'S NAME IS THE FIXTURE, exactly as in the windows
+# sibling: the case dir is the project root, so the space in the root can only
+# come from here. do not rename this directory to kebab-case.
+#
+# the posix path never had the windows quoting defect -- execve takes argv
+# directly, with no joiner to mismatch -- but it carried the same `cd '<root>'
+# && ` prefix, so a root containing a `'` would have broken it the same way.
+# the prefix is gone on both platforms now, and this case is the regression
+# guard for the posix side: it must keep passing with a space in the root and
+# quotes in the command.
+run: exec
+targets: linux linux-arm64 linux-riscv64 darwin-aarch64 darwin-x86_64

--- a/int/surface/step shell posix/expect.txt
+++ b/int/surface/step shell posix/expect.txt
@@ -1,0 +1,2 @@
+plain=1
+quoted=1

--- a/int/surface/step shell posix/mach.toml
+++ b/int/surface/step shell posix/mach.toml
@@ -1,0 +1,69 @@
+[project]
+id = "step-shell-posix"
+version = "1.0.0"
+src = "src"
+out = "out"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.step-shell-posix]
+kind = "bin"
+entry = "main.mach"
+out = "bin/step-shell-posix"
+targets = ["*"]
+link = []
+need = ["plain", "quoted"]
+
+# relative paths, so this step asserts the child's working directory is the
+# project root -- a root whose absolute path contains a space.
+[step.plain]
+cmd = "cp assets/seed.txt out/gen/plain.txt"
+in = ["assets/seed.txt"]
+out = ["out/gen/plain.txt"]
+need = []
+
+# quote-in-command: the arguments are quoted because their paths contain
+# spaces. execve hands argv through untouched, so this asserts the command text
+# reaches `sh` intact rather than being re-quoted on the way.
+[step.quoted]
+cmd = "cp \"assets/seed with space.txt\" \"out/gen/quoted out.txt\""
+in = ["assets/seed with space.txt"]
+out = ["out/gen/quoted out.txt"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/step shell posix/src/main.mach
+++ b/int/surface/step shell posix/src/main.mach
@@ -1,0 +1,43 @@
+# posix `[step]` surface case (#2587)
+#
+# both markers are written by build steps running under the host interpreter and
+# embedded at compile time, so the build cannot link unless the steps actually
+# spawned, ran in the project root, and produced their outputs.
+#
+# `plain` proves the step ran with the root as its working directory: its paths
+# are relative, and this root's absolute path contains a space. `quoted` proves
+# the command text reaches `sh` intact, quotes and all, rather than being
+# re-quoted on the way through the spawn.
+
+use std.runtime;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+use p: std.print;
+
+#[embed("../out/gen/plain.txt")]
+val PLAIN: [_]u8;
+
+#[embed("../out/gen/quoted out.txt")]
+val QUOTED: [_]u8;
+
+val WANT: str = "step-ran";
+
+# the copied payload carries no line terminator, so both markers are the seed
+# bytes exactly
+fun matches(bytes: *u8) bool {
+    var i: i64 = 0;
+    for (i < 8) {
+        if (bytes[i] != WANT[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+#[symbol("main")]
+fun main() i64 {
+    p.printlnf("plain={}", matches(?PLAIN[0]));
+    p.printlnf("quoted={}", matches(?QUOTED[0]));
+    ret 0;
+}

--- a/int/surface/step shell windows/assets/seed with space.txt
+++ b/int/surface/step shell windows/assets/seed with space.txt
@@ -1,0 +1,1 @@
+step-ran

--- a/int/surface/step shell windows/assets/seed.txt
+++ b/int/surface/step shell windows/assets/seed.txt
@@ -1,0 +1,1 @@
+step-ran

--- a/int/surface/step shell windows/case.conf
+++ b/int/surface/step shell windows/case.conf
@@ -1,0 +1,17 @@
+# a `[step]` on a native windows host, in a project root containing a space.
+#
+# THE SPACE IN THIS DIRECTORY'S NAME IS THE FIXTURE. the harness builds each case
+# with the case directory as cwd, so the case dir *is* the project root, and the
+# only way to put a space in the root is to put one here. do not rename this
+# directory to kebab-case: that silently deletes half the coverage (#2587).
+#
+# mach used to prepend `cd /d "<root>" && ` to the step command, which put the
+# root inside the command string. the argv joiner escapes that with the CRT
+# convention (embedded `"` -> `\"`), which cmd.exe does not implement, so `cd`
+# received literal quotes and backslashes and reported `Path not found.` --
+# every step on windows failed, and a root with a space is the common case.
+#
+# both markers are embedded at compile time, so a step that did not run, or ran
+# in the wrong directory, cannot produce a linkable binary.
+run: exec
+targets: windows

--- a/int/surface/step shell windows/expect.txt
+++ b/int/surface/step shell windows/expect.txt
@@ -1,0 +1,2 @@
+plain=1
+quoted=1

--- a/int/surface/step shell windows/mach.toml
+++ b/int/surface/step shell windows/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id = "step-shell-windows"
+version = "1.0.0"
+src = "src"
+out = "out"
+
+[target.windows]
+isa = "x86_64"
+os = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.step-shell-windows]
+kind = "bin"
+entry = "main.mach"
+out = "bin/step-shell-windows.exe"
+targets = ["*"]
+link = []
+need = ["plain", "quoted"]
+
+# cmd.exe syntax deliberately: this case exists to prove the host interpreter is
+# what runs the command. the paths are relative, so this step also asserts the
+# child's working directory is the project root -- a root whose absolute path
+# contains a space, per the directory name.
+[step.plain]
+cmd = "copy assets\\seed.txt out\\gen\\plain.txt"
+in = ["assets/seed.txt"]
+out = ["out/gen/plain.txt"]
+need = []
+
+# quote-in-command: both arguments are quoted because their paths contain
+# spaces. the CRT argv convention escapes those quotes as \" , which cmd.exe
+# takes literally, so this step only survives if the interpreter's own quoting
+# rules are honoured rather than the argv joiner's (#2587).
+[step.quoted]
+cmd = "copy \"assets\\seed with space.txt\" \"out\\gen\\quoted out.txt\""
+in = ["assets/seed with space.txt"]
+out = ["out/gen/quoted out.txt"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/step shell windows/src/main.mach
+++ b/int/surface/step shell windows/src/main.mach
@@ -1,0 +1,44 @@
+# windows `[step]` surface case (#2578, #2587)
+#
+# both markers are written by build steps running under the host interpreter and
+# embedded at compile time, so the build cannot link unless the steps actually
+# spawned, ran in the project root, and produced their outputs.
+#
+# `plain` proves the step ran with the root as its working directory: its paths
+# are relative, and this root's absolute path contains a space. `quoted` proves
+# the interpreter's own command-line rules are honoured: its arguments carry
+# quotes, which the CRT argv convention escapes as \" and cmd.exe takes
+# literally.
+
+use std.runtime;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+use p: std.print;
+
+#[embed("../out/gen/plain.txt")]
+val PLAIN: [_]u8;
+
+#[embed("../out/gen/quoted out.txt")]
+val QUOTED: [_]u8;
+
+val WANT: str = "step-ran";
+
+# the copied payload carries no line terminator, so both markers are the seed
+# bytes exactly
+fun matches(bytes: *u8) bool {
+    var i: i64 = 0;
+    for (i < 8) {
+        if (bytes[i] != WANT[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+#[symbol("main")]
+fun main() i64 {
+    p.printlnf("plain={}", matches(?PLAIN[0]));
+    p.printlnf("quoted={}", matches(?QUOTED[0]));
+    ret 0;
+}

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "a35a0c4645785596929ae62700f4bd9c74ddb609"
+commit = "231fe98577e80ebb2df715dc51193d3030ae5905"

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -952,34 +952,6 @@ fun run_one_step(a: *A.Allocator, p: *project.Project, step: *manifest.StepDef, 
     print.print(msg);
     str_free(a, msg);
 
-    var shell_name: *u8 = "/bin/sh";
-    var shell_flag: *u8 = "-c";
-    $if ($mach.build.os == $mach.os.windows) {
-        shell_name = "cmd.exe";
-        shell_flag = "/c";
-    }
-
-    var full_cmd: str;
-    $if ($mach.build.os == $mach.os.windows) {
-        full_cmd = sfmt(a, "cd /d \"{}\" && {}", project_root, expanded_cmd);
-    }
-    $or {
-        full_cmd = sfmt(a, "cd '{}' && {}", project_root, expanded_cmd);
-    }
-
-    val res_argv: R.Result[**u8, str] = A.allocate[*u8](a, 4);
-    if (R.is_err[**u8, str](res_argv)) {
-        if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
-        str_free(a, expanded_cmd);
-        str_free(a, full_cmd);
-        ret R.err[bool, str]("out of memory");
-    }
-    val argv: **u8 = R.unwrap_ok[**u8, str](res_argv);
-    argv[0] = shell_name;
-    argv[1] = shell_flag;
-    argv[2] = full_cmd::*u8;
-    argv[3] = nil;
-
     # inject the active target tuple so a step's cmd/script can branch on it (#1964).
     val isa_env: str = sfmt(a, "MACH_TARGET_ISA={}", v.isa);
     val os_env:  str = sfmt(a, "MACH_TARGET_OS={}", v.os);
@@ -987,22 +959,25 @@ fun run_one_step(a: *A.Allocator, p: *project.Project, step: *manifest.StepDef, 
     val env: **u8 = step_env(a, isa_env, os_env, abi_env);
     if (env == nil) {
         str_free(a, isa_env); str_free(a, os_env); str_free(a, abi_env);
-        A.deallocate[*u8](a, argv, 4);
         if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
         str_free(a, expanded_cmd);
-        str_free(a, full_cmd);
         ret R.err[bool, str]("out of memory");
     }
 
-    val res_run: R.Result[exec.ExitStatus, str] = exec.run(shell_name::str, argv, env);
+    # the root is the child's working directory, applied by the spawn itself, and the
+    # interpreter and its per-platform quoting belong to run_shell (mach-std #422/#424).
+    # this used to prepend `cd <root> &&`, which put the root inside the command string:
+    # on windows the argv joiner escapes with the CRT convention, which `cmd.exe` does
+    # not parse, so the `cd` saw literal quotes and backslashes and every step failed
+    # (#2578, #2587). the root never enters the command text now, so there is no
+    # convention to mismatch on either platform.
+    val res_run: R.Result[exec.ExitStatus, str] = exec.run_shell(expanded_cmd, project_root, env);
 
     step_env_free(a, env);
     str_free(a, isa_env);
     str_free(a, os_env);
     str_free(a, abi_env);
-    A.deallocate[*u8](a, argv, 4);
     str_free(a, expanded_cmd);
-    str_free(a, full_cmd);
 
     if (R.is_err[exec.ExitStatus, str](res_run)) {
         if (stampable) { str_free(a, hex); str_free(a, stamp_path); }


### PR DESCRIPTION
Every `[step]` failed on a native Windows host. This is the mach side of the chain that mach-std 0.23.0 unblocked, and it is what mach-glfw#32's Windows leg is dying on today.

## The defect

mach built the step command as

```mach
full_cmd = sfmt(a, "cd /d \"{}\" && {}", project_root, expanded_cmd);
```

and passed it as one argv element. The argv joiner escapes with the **CRT convention** — an embedded `"` becomes `\"` — which `cmd.exe` does not implement. cmd stripped the outer quote pair and took the rest literally, so `cd` received a path carrying quotes and backslashes and reported `Path not found.`

The prefix was unconditional, so this broke **every** step, and a project root containing a space is the common case on Windows (`C:\Users\Foo Bar\...`).

## The fix

The `cd` prefix only existed because the spawn API could not set the child's working directory. mach-std 0.23.0 adds one, so the root leaves the command string entirely:

```mach
val res_run = exec.run_shell(expanded_cmd, project_root, env);
```

`run_shell` resolves the interpreter from `%ComSpec%` (posix: `sh -c`), applies the cwd **in the child**, and owns the per-platform quoting. There is no longer a place for the two conventions to disagree, on either platform, and the posix side's own exposure to a root containing `'` goes with it.

This deletes the shell-name/flag selection, the `full_cmd` construction, and the argv allocation — `mach.lang.driver.shell`, the helper #2589 was building toward, is never needed. #2589 can be closed unmerged.

## Fixtures

Two surface cases, `int/surface/step shell windows` and `int/surface/step shell posix`.

**The space in each case directory's name is the fixture.** The harness builds with the case dir as cwd, so the case dir *is* the project root, and that is the only place a space in the root can come from. Both markers are `#[embed]`ed at compile time, so a step that did not run, or ran in the wrong directory, cannot produce a linkable binary. Each case also carries a step whose arguments are quoted because their paths contain spaces — the quote-in-command half.

**Neither case is vacuous.** The Windows case, run under Wine against a compiler built from this branch with `config.mach` reverted to dev:

```
UNFIXED:  step plain: copy assets\seed.txt out\gen\plain.txt
          error: failed to execute build step          <- mach-glfw#32's signature

FIXED:    step plain: copy assets\seed.txt out\gen\plain.txt
                  1 file(s) copied
          step quoted: copy "assets\seed with space.txt" "out\gen\quoted out.txt"
                  1 file(s) copied
          -> prog.exe prints plain=1 quoted=1, matching the golden
```

The posix case guards the direction this fix could break rather than the original bug (the posix path never had the quoting defect — `execve` takes argv directly). Against a compiler handed the wrong cwd it fails on the missing input; against a correct one it passes.

The `windows` leg is `windows-latest`, **native**, cadence `pr`, so this settles on a real Windows runner every PR rather than under Wine.

## A harness bug found while proving the above

The first sabotage run **passed**, which it should not have. mach skips a step whose stamp matches and whose outputs all exist. Neither fact depends on the compiler, and `run.sh` only cleared `out/int`, so a stamp written by an *earlier* harness run made every later run skip the step engine entirely.

So a case asserting on step output kept passing against a compiler that could not run a step at all — which is exactly the defect #2578 is. CI never saw it, because a fresh checkout has no stamps; only local iteration did, in the direction that reports green. The Windows fixture was vacuous on the machine where it was being developed, and would have looked fine.

`run.sh` now drops `out/.steps` before each case build. Outputs are left alone: with no stamp the step always runs, and a step that fails is a build failure. This is the same shape as #2592 and #2593 — a test reporting something other than what it verified — so it is worth noting beyond this PR.

## Verification

- `mach test .` — 1163 passed, 0 failed.
- `int/run.sh --target linux` — **all cases pass**, with the stamp change in place, so the other step-carrying cases (`2543-bsd-ar-extended-name`, `2558-dep-step-home`, the `pe-*` family) still pass when their steps genuinely re-run.
- `check-target-matrix.sh` — 303 case×leg pairs OK.
- Windows A/B above, under Wine 11.14.

**Caveat on record:** the local Windows A/B is Wine, not real Windows. The `int windows` leg on this PR is the real runner and is what actually settles it.

## Dependency

`mach.lock` advances mach-std from `a35a0c4` (0.21.0) to `231fe98` (v0.23.0), which is where `run_shell` lives. The `ref` stays `branch/main`, consistent with all 62 int cases; #2592 tracks the systemic pin-and-lock question, which should move all of them at once rather than one case here.

Closes #2578
Closes #2587
