### PR TITLE
docs(secrecy): spell address-of as ? and deref as @

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -50,8 +50,9 @@ rec Key { d: ^[32]u8; }
 fun first(k: Key) ^u8 { ret k.d[0]; }            # element of a secret array is ^u8
 ```
 
-`&T` of a `^T` value is the public pointer `*^T` (the address is public, the
-pointee secret), and dereferencing `*^T` recovers the secret `^T`.
+Taking the address of a `^T` value with `?` gives the public pointer `*^T` (the
+address is public, the pointee secret), and dereferencing it with `@` recovers
+the secret `^T`.
 
 ## Gates
 


### PR DESCRIPTION
`doc/language/secrecy.md:53` named `&T` as address-of. Mach has no `&` address-of operator — `?` takes an address, `@` dereferences, and `&` is bitwise-and only (`doc/language/operators.md:84-85`, `grammar.md:475-476`).

Reworded the sentence; the rest of it was already correct.

Closes #2601