### PR TITLE
docs(cli): name artifacts by the V2 schema, not the dead [bin.*] tables

### DIFF
--- a/doc/language/comptime.md
+++ b/doc/language/comptime.md
@@ -37,7 +37,7 @@ The parser distinguishes these by structure:
 | `$project.{id,version,name,description}` | project metadata | `[project]` in `mach.toml` |
 | `$project.version.{major,minor,patch}` | structured version components | `[project].version` |
 | `$project.target.{os,arch,abi}` | the selected target's declared tuple, as strings | the selected `mach.toml` target |
-| `$bin.name` | the artifact being built | the selected build unit (`[bin.*]` / `[lib.*]`) |
+| `$bin.name` | the artifact being built | the selected build unit (`[artifact.*]`) |
 
 `$project.target.*` carries the manifest's declared **string** spellings
 (`"linux"`, `"x86_64"`, `"sysv64"`), distinct from `$mach.build.*`'s numeric tags

--- a/src/cli/args.mach
+++ b/src/cli/args.mach
@@ -53,8 +53,8 @@ pub val SEL: [SEL_N]FlagSpec = [SEL_N]FlagSpec{
     FlagSpec{ name: "--target",  has_value: true, doc: "select a [target.<name>] entry" },
     FlagSpec{ name: "--profile", has_value: true, doc: "select a build profile (debug / release / ...)" },
     FlagSpec{ name: "-o",        has_value: true, doc: "override the linked-binary path (build/run/test)" },
-    FlagSpec{ name: "--bin",     has_value: true, doc: "narrow the build to one [bin.<name>] artifact" },
-    FlagSpec{ name: "--lib",     has_value: true, doc: "narrow the build to one [lib.<name>] artifact" },
+    FlagSpec{ name: "--bin",     has_value: true, doc: "narrow the build to one kind = \"bin\" artifact" },
+    FlagSpec{ name: "--lib",     has_value: true, doc: "narrow the build to one library artifact (static / shared)" },
 };
 
 # readout flags: verbosity and quiet. shared by build/run/test/doc.

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -4,7 +4,7 @@
 # and output templates, `[target.*]` platforms for linux/windows/darwin on the
 # host isa - each target's abi derived from the os's self-declared native
 # convention, and any os with no composable tuple on the host skipped - one
-# `[bin.*]`/`[lib.*]` artifact, debug/release profiles, and a `[deps.mach-std]`
+# `[artifact.*]` artifact, debug/release profiles, and a `[dep.mach-std]`
 # dependency) plus a starter source module. For a binary the
 # generated `src/main.mach` is a standard-library hello world; a library gets a
 # bare `src/lib.mach` root. The command then syncs `mach-std` into `dep/mach-std`
@@ -211,8 +211,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 # Emits a `[project]` block (id, version, src/dep dirs, output-path templates,
 # and `module` for a library), `[target.<os>-<isa>]` blocks for linux/windows/darwin
 # on the host isa (each abi derived from the os's native convention, uncomposable
-# oses skipped), one `[bin.<id>]` or `[lib.<id>]` artifact, debug/release profiles,
-# and the `[deps.mach-std]` dependency.
+# oses skipped), one `[artifact.<id>]` (`kind = "bin"` or a library kind), debug/release
+# profiles, and the `[dep.mach-std]` dependency.
 # ---
 # path:   destination path for the manifest
 # id:     project id (already validated)

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -161,7 +161,7 @@ fun open_asm(p: *driver.Project, asm_base: *u8, fqn: intern.StrId, file: *fs.Fil
     ret open_artifact_at(p.alloc, @path_out, file, w);
 }
 
-# the selected artifact's product name (the `[bin.<name>]`), resolved to a
+# the selected artifact's product name (the `[artifact.<name>]`), resolved to a
 # borrowed null-terminated string, or "" when unset
 #
 # This is the writer's stable signing identity (the Mach-O code-signing

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -130,7 +130,7 @@ pub rec LinkInput {
 # phases:       ordered, goal- and manifest-derived execution list
 # sel_target:   the cell's target selector (empty selects the manifest default)
 # sel_artifact: the cell's artifact selector
-# want_lib:     the selected artifact is a `[lib.*]` (disambiguates a name)
+# want_lib:     the selected artifact is a library (disambiguates a name)
 # has_artifact: an artifact is named
 # subsystem:    the environment this cell's executable declares it runs under,
 #               settled from `--subsystem` over the artifact's `subsystem` key
@@ -334,7 +334,7 @@ fun oom_plan() R.Result[BuildPlan, outcome.Fail] {
 # ---
 # tname:    the cell's target selector (empty selects the manifest default)
 # aname:    the cell's artifact selector
-# want_lib: the artifact selector names a `[lib.*]`
+# want_lib: the artifact selector names a library
 # ret:      whether the cell exists, or the failure that made it unresolvable
 fun cell_declared(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                   tname: str, aname: str, want_lib: bool) R.Result[bool, str] {
@@ -356,7 +356,7 @@ fun cell_declared(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
 # ---
 # tname:        the cell's target selector (empty selects the manifest default)
 # aname:        the cell's artifact selector
-# want_lib:     the artifact selector names a `[lib.*]`
+# want_lib:     the artifact selector names a library
 # has_artifact: an artifact is named
 # ret:          the resolved unit, or the failure to render
 fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry,

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -63,9 +63,9 @@ use mach.lang.target.of;
 #              (`.ir`) alongside each object - the final post-pipeline IR the
 #              object is built from, so it varies with the optimization level
 # profile:     --profile <name> selected build profile (nil when not given)
-# bin:         --bin <name> narrows a build to one `[bin.*]` artifact (nil
+# bin:         --bin <name> narrows a build to one `kind = "bin"` artifact (nil
 #              when not given)
-# lib:         --lib <name> narrows a build to one `[lib.*]` artifact (nil
+# lib:         --lib <name> narrows a build to one library artifact (nil
 #              when not given)
 # all_targets: --all-targets was passed; build every declared target rather
 #              than the manifest default
@@ -187,7 +187,7 @@ pub rec LinkToken {
 # target:       selected target name; empty selects the manifest default
 # profile:      selected profile name; empty selects the manifest default
 # artifact:     selected artifact name; empty selects the manifest default
-# want_lib:     the named artifact is a `[lib.*]` (disambiguates a name)
+# want_lib:     the named artifact is a library (disambiguates a name)
 # all_targets:  build every declared target rather than the manifest default
 # goal:         what the build produces
 # opt:          settled optimization pipeline level (explicit `-O*` wins, else
@@ -454,7 +454,7 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
 # base:      the invocation's composed request
 # target:    the cell's target selector (empty selects the manifest default)
 # artifact:  the cell's artifact selector
-# want_lib:  the artifact selector names a `[lib.*]`
+# want_lib:  the artifact selector names a library
 # subsystem: the environment the cell's executable declares it runs under, as the
 #            planner settled it (`--subsystem` over the artifact's key)
 # ret:       the cell's request

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -597,8 +597,7 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
 
     # V2 dependency entry resolution:
     # First, try to get the first [artifact.<name>].entry.
-    # If not found, try [lib.<name>].entry.
-    # If not found, try [bin.<name>].entry.
+    # If not found, try [artifact.<name>].entry.
     # Otherwise, default to "lib.mach".
     var dep_entry_file: str = "";
     val arts_tab: *toml.Table = toml.get_table(?t, "artifact");

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -2203,7 +2203,7 @@ fun resolve_project_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth
 }
 
 # resolves a `$bin.<field>` path to the selected artifact's metadata. `name` is
-# the artifact being built (`[bin.<name>]` / `[lib.<name>]`); it is unavailable
+# the artifact being built (`[artifact.<name>]`); it is unavailable
 # for a v1 manifest, which has no artifact stanza
 fun resolve_bin_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32) R.Result[CTValue, str] {
     if (depth != 2)                       { ret R.err[CTValue, str]("unknown `$bin.*` path"); }


### PR DESCRIPTION
`mach help build` advertised the two narrowing flags against the V1 manifest schema:

```
  --bin <value>         narrow the build to one [bin.<name>] artifact
  --lib <value>         narrow the build to one [lib.<name>] artifact
```

Those tables do not exist. V2 declares `[artifact.<name>]` with a `kind` key, and a manifest spelling `[bin.x]` fails with `mach.toml: no [artifact.*] artifacts declared`. The flag names are fine, only the help strings named the dead tables.

Now:

```
  --bin <value>         narrow the build to one kind = "bin" artifact
  --lib <value>         narrow the build to one library artifact (static / shared)
```

While there, the same V1 spelling had propagated beyond the shipped help into source comments (`init`, `comptime`, `build/request`, `build/plan`, `build/emit`, `driver/deps`) and into `doc/language/comptime.md`. Those are corrected in the same pass, so no reader is pointed at the dead schema from anywhere. `mach init` itself already emitted `[artifact.*]` and `[dep.*]` correctly; only its comment was stale.

`mach test .` green (1163/1163).

Closes #2600