### PR TITLE
fix(coff): sum PE content aggregates off the emitted section table

### DIFF
--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3863,33 +3863,8 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     bin.write_u16_le(buf, oh, PE32PLUS_MAGIC);
     buf[oh + 2] = 14; buf[oh + 3] = 0;            # linker version (cosmetic)
 
-    # SizeOfCode / SizeOfInitializedData / SizeOfUninitializedData (cosmetic sums).
-    var code_size: u64 = 0;
-    var idata_size: u64 = 0;
-    var udata_size: u64 = 0;
-    var li: u32 = 0;
-    for (li < seg_count) {
-        if ((segs[li].flags & of.SEG_FLAG_EXECUTE) != 0) { code_size = code_size + lay.seg_secs[li].file_size::u64; }
-        or { idata_size = idata_size + lay.seg_secs[li].file_size::u64; }
-        if (segs[li].bytes == nil) { udata_size = udata_size + segs[li].memsz::u64; }
-        li = li + 1;
-    }
-    if (lay.have_idata) { idata_size = idata_size + lay.idata_sec.file_size::u64; }
-    if (lay.have_xdata) { idata_size = idata_size + lay.xdata_sec.file_size::u64; }
-    if (lay.have_pdata) { idata_size = idata_size + lay.pdata_sec.file_size::u64; }
-    if (lay.have_rsrc)  { idata_size = idata_size + lay.rsrc_sec.file_size::u64; }
-    if (lay.have_reloc) { idata_size = idata_size + lay.reloc_sec.file_size::u64; }
-    var dsi: u32 = 0;
-    for (dsi < debug_count) {
-        idata_size = idata_size + lay.debug_secs[dsi].file_size::u64;
-        dsi = dsi + 1;
-    }
-    if (code_size > 0xFFFFFFFF || idata_size > 0xFFFFFFFF || udata_size > 0xFFFFFFFF) {
-        ret R.err[bool, str]("coff: PE aggregate section sizes exceed 32-bit header fields");
-    }
-    bin.write_u32_le(buf, oh + 4, code_size::u32);
-    bin.write_u32_le(buf, oh + 8, idata_size::u32);
-    bin.write_u32_le(buf, oh + 12, udata_size::u32);
+    # SizeOfCode / SizeOfInitializedData / SizeOfUninitializedData are summed off
+    # the section table once it is written, below.
 
     # AddressOfEntryPoint (RVA), BaseOfCode (RVA of the first segment).
     bin.write_u32_le(buf, oh + 16, (entry - lay.image_base)::u32);
@@ -3960,9 +3935,10 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     # tracks the same accumulation order the string table's bytes were written in
     # (linker segments, then debug sections - see `compute_pe_layout` and the
     # string-table write in `write_pe`).
-    var pos: usize = oh + OPTIONAL_HEADER_SIZE;
+    val sec_table: usize = oh + OPTIONAL_HEADER_SIZE;
+    var pos: usize = sec_table;
     var str_pos: usize = 4;
-    li = 0;
+    var li: u32 = 0;
     for (li < seg_count) {
         # a segment the linker carries with no file bytes is bss (uninitialized).
         val has_data: bool = segs[li].bytes != nil && segs[li].filesz > 0;
@@ -4020,7 +3996,48 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
         pos = pos + SECTION_HEADER_SIZE;
         di = di + 1;
     }
+
+    # the three content aggregates, summed off the section table just written so
+    # each field counts exactly the sections whose characteristics claim that
+    # content class - there is no second rule to drift from (#2588).
+    var code_size:  u64 = 0;
+    var idata_size: u64 = 0;
+    var udata_size: u64 = 0;
+    sum_pe_section_content(buf, sec_table, lay.sec_total, ?code_size, ?idata_size, ?udata_size);
+    if (code_size > 0xFFFFFFFF || idata_size > 0xFFFFFFFF || udata_size > 0xFFFFFFFF) {
+        ret R.err[bool, str]("coff: PE aggregate section sizes exceed 32-bit header fields");
+    }
+    bin.write_u32_le(buf, oh + 4, code_size::u32);
+    bin.write_u32_le(buf, oh + 8, idata_size::u32);
+    bin.write_u32_le(buf, oh + 12, udata_size::u32);
+
     ret R.ok[bool, str](true);
+}
+
+# sum an emitted PE section table into the optional header's three content
+# aggregates. code and initialized data sum SizeOfRawData - the bytes the loader
+# reads from the file; uninitialized data has none, so it sums VirtualSize
+# ---
+# buf:       the PE image buffer
+# sec_table: the section table's byte offset
+# nsec:      the number of section headers
+# code:      out, SizeOfCode
+# idata:     out, SizeOfInitializedData
+# udata:     out, SizeOfUninitializedData
+fun sum_pe_section_content(buf: *u8, sec_table: usize, nsec: u32,
+                           code: *u64, idata: *u64, udata: *u64) {
+    @code = 0; @idata = 0; @udata = 0;
+    var s: u32 = 0;
+    for (s < nsec) {
+        val sh:    usize = sec_table + s::usize * SECTION_HEADER_SIZE;
+        val chars: u32   = bin.read_u32_le(buf, sh + 36);
+        val raw:   u64   = bin.read_u32_le(buf, sh + 16)::u64;
+        val vsize: u64   = bin.read_u32_le(buf, sh + 8)::u64;
+        if ((chars & IMAGE_SCN_CNT_CODE) != 0)               { @code  = @code  + raw; }
+        if ((chars & IMAGE_SCN_CNT_INITIALIZED_DATA) != 0)   { @idata = @idata + raw; }
+        if ((chars & IMAGE_SCN_CNT_UNINITIALIZED_DATA) != 0) { @udata = @udata + vsize; }
+        s = s + 1;
+    }
 }
 
 # whether the linker's base-relocation set touches load segment `ls` - the
@@ -6855,9 +6872,139 @@ test "mach.lang.target.of.coff.write_section_name_field:long_name_no_overflow" {
     ret 0;
 }
 
+# check an emitted PE image's three optional-header content aggregates against a
+# walk of its own section table, restating the rule independently of the writer:
+# SizeOfCode sums SizeOfRawData over every IMAGE_SCN_CNT_CODE section,
+# SizeOfInitializedData the same over every CNT_INITIALIZED_DATA section, and
+# SizeOfUninitializedData sums VirtualSize over every CNT_UNINITIALIZED_DATA
+# section (which has no raw bytes). counts of the code and initialized-data
+# sections come back so a caller can pin that the image really carries the
+# sections whose accounting it means to be testing (#2588)
+fun ts_pe_aggregates_match(file: *u8, code_secs: *u32, idata_secs: *u32) u8 {
+    val pe:        usize = bin.read_u32_le(file, 0x3C)::usize;
+    val ch:        usize = pe + PE_SIGNATURE_SIZE;
+    val oh:        usize = ch + COFF_HEADER_SIZE;
+    val nsec:      u32   = bin.read_u16_le(file, ch + 2)::u32;
+    val sec_table: usize = oh + bin.read_u16_le(file, ch + 16)::usize;
+
+    var code:  u64 = 0;
+    var idata: u64 = 0;
+    var udata: u64 = 0;
+    @code_secs = 0;
+    @idata_secs = 0;
+    var s: u32 = 0;
+    for (s < nsec) {
+        val sh:    usize = sec_table + s::usize * SECTION_HEADER_SIZE;
+        val chars: u32   = bin.read_u32_le(file, sh + 36);
+        if ((chars & IMAGE_SCN_CNT_CODE) != 0) {
+            code = code + bin.read_u32_le(file, sh + 16)::u64;
+            @code_secs = @code_secs + 1;
+        }
+        if ((chars & IMAGE_SCN_CNT_INITIALIZED_DATA) != 0) {
+            idata = idata + bin.read_u32_le(file, sh + 16)::u64;
+            @idata_secs = @idata_secs + 1;
+        }
+        if ((chars & IMAGE_SCN_CNT_UNINITIALIZED_DATA) != 0) {
+            udata = udata + bin.read_u32_le(file, sh + 8)::u64;
+        }
+        s = s + 1;
+    }
+
+    if (bin.read_u32_le(file, oh + 4)::u64 != code)   { ret 1; }
+    if (bin.read_u32_le(file, oh + 8)::u64 != idata)  { ret 1; }
+    if (bin.read_u32_le(file, oh + 12)::u64 != udata) { ret 1; }
+    ret 0;
+}
+
+# a dynamic PE carries two IMAGE_SCN_CNT_CODE sections - the `.text` load segment
+# and the synthesized `.itext` import stubs - and SizeOfCode must count both.
+# counting the load segments alone (the shape #2588 records) reports a SizeOfCode
+# that omits a real code section while SizeOfInitializedData counts every
+# synthesized one, so the two neighbouring fields disagree about what a section is
+fun ts_pe_import_stub_accounting() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+    var data_bytes: [8]u8;
+    k = 0;
+    for (k < 8) { data_bytes[k] = 0xAA; k = k + 1; }
+
+    val base: u64 = 0x140001000;
+    val pg:   u64 = 0x1000;
+    var segs: [3]of.LoadSegment;
+    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+    segs[1].vaddr = base + pg;     segs[1].filesz = 8;  segs[1].memsz = 8;
+    segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;   segs[1].bytes = ?data_bytes[0];
+    segs[2].vaddr = base + pg * 2; segs[2].filesz = 0;  segs[2].memsz = 32;
+    segs[2].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;   segs[2].bytes = nil;
+
+    var libs: [1]of.DynLib;
+    libs[0].name = t_intern(?i, "kernel32"); libs[0].soname = t_intern(?i, "kernel32.dll");
+    libs[0].rpath = intern.STR_NIL;
+
+    var imps: [2]of.DynImport;
+    imps[0].symbol = t_intern(?i, "ExitProcess"); imps[0].lib_index = 0;
+    imps[0].is_func = true; imps[0].ordinal = 0; imps[0].by_ordinal = false;
+    imps[1].symbol = t_intern(?i, "GetLastError"); imps[1].lib_index = 0;
+    imps[1].is_func = true; imps[1].ordinal = 0; imps[1].by_ordinal = false;
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = ?libs[0]; dyn.lib_count = 1;
+    dyn.imports = ?imps[0]; dyn.import_count = 2;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil::*of.BaseReloc; dyn.base_reloc_count = 0;
+    dyn.pie = false;
+    dyn.import_addr_fixups = nil::*of.ImportAddrFixup; dyn.import_addr_fixup_count = 0;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_stub_acct");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val em: R.Result[bool, str] = coff_emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 3,
+                                                      4096, base - PE_SECTION_ALIGN, base,
+                                                      nil::*of.ExecFunction, 0, ?dyn,
+                                                      nil::*of.PltFixup, 0, nil::*of.Section, 0,
+                                                      nil::*of.Section, 0,
+                                                      fs.temp_path(?tf)::*u8, "coffstub"::*u8,
+                                                      of.image_options_default(of.SUBSYSTEM_CONSOLE));
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    val file: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    var code_secs:  u32 = 0;
+    var idata_secs: u32 = 0;
+    if (ts_pe_aggregates_match(file.data, ?code_secs, ?idata_secs) != 0) { ret 1; }
+    # `.text` and `.itext`; the accounting above is vacuous without the second.
+    if (code_secs != 2) { ret 1; }
+    # `.data` and `.idata`.
+    if (idata_secs != 2) { ret 1; }
+
+    # SizeOfCode strictly exceeds the `.text` section's raw size on its own.
+    val pe:        usize = bin.read_u32_le(file.data, 0x3C)::usize;
+    val ch:        usize = pe + PE_SIGNATURE_SIZE;
+    val oh:        usize = ch + COFF_HEADER_SIZE;
+    val sec_table: usize = oh + bin.read_u16_le(file.data, ch + 16)::usize;
+    if (bin.read_u32_le(file.data, oh + 4) <= bin.read_u32_le(file.data, sec_table + 16)) { ret 1; }
+    ret 0;
+}
+
+# SizeOfCode counts the synthesized `.itext` import-stub section, not only the
+# executable load segments (#2588)
+test "mach.lang.target.of.coff.coff_emit_dyn_exec:import_stub_code_accounting" {
+    if (ts_pe_import_stub_accounting() != 0) { ret 1; }
+    ret 0;
+}
+
 # PE resource options add one read-only initialized `.rsrc` section, publish its
-# data directory, and carry the manifest leaf byte-for-byte. The initialized-data
-# aggregate includes the synthesized section's aligned raw size.
+# data directory, and carry the manifest leaf byte-for-byte. Both content
+# aggregates are pinned against a walk of the emitted section table.
 test "mach.lang.target.of.coff.coff_emit_exec:resource_directory_and_accounting" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -6909,6 +7056,12 @@ test "mach.lang.target.of.coff.coff_emit_exec:resource_directory_and_accounting"
     val dd: usize = oh + 112 + IMAGE_DIRECTORY_ENTRY_RESOURCE::usize * DATA_DIR_SIZE;
     if (bin.read_u32_le(file.data, dd) != rsrc_rva
         || bin.read_u32_le(file.data, dd + 4) != rsrc_vsize) { ret 1; }
+    # every aggregate agrees with a walk of the section table, and the `.rsrc`
+    # section's aligned raw size is part of the initialized-data total.
+    var code_secs:  u32 = 0;
+    var idata_secs: u32 = 0;
+    if (ts_pe_aggregates_match(file.data, ?code_secs, ?idata_secs) != 0) { ret 1; }
+    if (code_secs != 1 || idata_secs != 1)                   { ret 1; }
     if (bin.read_u32_le(file.data, oh + 8) != rsrc_raw_size) { ret 1; }
 
     # Root entries are RT_VERSION then RT_MANIFEST. Follow the manifest's


### PR DESCRIPTION
Closes #2588

## What

`write_pe_headers` computed `SizeOfCode` over the executable load segments only, while `SizeOfInitializedData` summed the load segments plus every synthesized section. The `.itext` import-stub section carries `IMAGE_SCN_CNT_CODE` and so was missing from the first field while its neighbour counted every synthesized section it had.

Rather than adding `.itext` to the old loop (which leaves two parallel rules to drift apart the next time a section is synthesized), all three content aggregates are now summed off the section table the writer has just emitted, keyed on each header's own characteristics: `SizeOfCode` and `SizeOfInitializedData` sum `SizeOfRawData` over `IMAGE_SCN_CNT_CODE` / `IMAGE_SCN_CNT_INITIALIZED_DATA` sections, `SizeOfUninitializedData` sums `VirtualSize` over `IMAGE_SCN_CNT_UNINITIALIZED_DATA` ones (they have no raw bytes). The aggregate write moved after the section table for that reason.

## Observed

Cross-built `int/surface/pe-import-claim` for `--target windows`, two `IMAGE_SCN_CNT_CODE` sections of 0x200 raw bytes each:

```
before: SizeOfCode: 512   SizeOfInitializedData: 1536
after:  SizeOfCode: 1024  SizeOfInitializedData: 1536
```

## Tests

`mach.lang.target.of.coff.coff_emit_dyn_exec:import_stub_code_accounting` is new: it emits a dynamic PE with two function imports, walks the section table, and checks all three aggregates against it, then pins that the image really carries two code sections and that `SizeOfCode` strictly exceeds `.text`'s raw size on its own. Against the old rule it fails:

```
mach.lang.target.of.coff          44 ok     1 FAIL    122ms
  FAIL  mach.lang.target.of.coff.coff_emit_dyn_exec:import_stub_code_accounting  ./src/lang/target/of/coff.mach:7006  (exit 1)
```

`coff_emit_exec:resource_directory_and_accounting` now runs the same section-table walk (via the shared `ts_pe_aggregates_match` helper, which restates the rule independently of the writer) in addition to its existing `.rsrc` assertion.

## The byte-identity note in the issue

7d72b24a reverted this in #2561 to keep resource-free output byte-identical with the pre-PR compiler. That is not an invariant the repo holds itself to and it cannot survive an intentional correction to a header field: what is actually pinned is the self-host fixpoint (`b == c`) and `int/lib/check-determinism.sh`'s same-compiler determinism, neither of which this touches. Only PE images that carry imports change, and only in `SizeOfCode`. The correct rule is now pinned by the test above rather than by an unstated one.

## Verified

- `mach test .`: 1164 passed, 0 failed (was 1163).
- `int/run.sh --target linux`: all cases passed.
- Self-host fixpoint: stage2 and stage3 compare byte-identical.
- PE inspection is structural (`llvm-objdump -h`, `llvm-readobj --file-headers`) on a linux host. Both fields are informational and ignored by the Windows loader, so there is no runtime behaviour to check on a windows runner.