### PR TITLE
feat(build): let a named artifact settle the target when it declares only one

### DIFF
--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -667,6 +667,23 @@ If a selection is well-formed but enumerates nothing — a `--target` no artifac
 lists — the build fails naming that target and the declared artifacts, rather than
 succeeding with an empty plan.
 
+### A named artifact can settle the target
+
+`--bin <name>` / `--lib <name>` with no `--target` lets the artifact decide, since
+its `targets` list may already leave only one answer:
+
+- exactly one declared target: that target is used, and `--target` would only
+  repeat what the manifest already said
+- several, one of which matches the host: the host target, as before
+- several, none matching the host: refused, naming the targets the artifact does
+  declare so the choice is visible without opening `mach.toml`
+
+An explicit `--target` always wins, including when it names a target the artifact
+does not list — that pair is still refused by name. This only applies to a named
+artifact: enumerating the artifact axis keeps the target fixed for the whole
+matrix, so a bare `mach build <path>` never widens into a target it was not asked
+for.
+
 ### `-o` names one output
 
 `-o` is accepted exactly when the selection resolves to a single build cell, and

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1460,9 +1460,78 @@ fun target_matches_host(itn: *intern.Interner, d: *TargetDef, host_os: u32, host
     ret (os_id == host_os && arch_id == host_arch);
 }
 
-fun resolve_target(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, selector: str) R.Result[ResolvedTarget, str] {
+# the target an explicitly named artifact pins on its own
+#
+# `--bin X` with no `--target` already carries the answer when X declares
+# exactly one target: there is nothing else the invocation could mean, and
+# demanding `--target` back is asking the user to repeat what the manifest
+# already said. Several declared targets keep host resolution, so the only
+# behaviour this adds is for the single-target case and for the diagnostic when
+# nothing the artifact declares can host the build.
+# ---
+# a:   the artifact the selection named
+# ret: the target the artifact pins, or nil when the artifact does not settle
+#      the choice and host resolution should decide
+fun artifact_pinned_target(itn: *intern.Interner, m: *Manifest, a: *ArtifactDef) *TargetDef {
     val host_os:   u32 = tgt.host_os_id();
     val host_arch: u32 = tgt.host_arch_id();
+
+    var only:       *TargetDef = nil;
+    var count:      u32 = 0;
+    var host_first: *TargetDef = nil;
+    var host_count: u32 = 0;
+    var i: u32 = 0;
+    for (i < m.target_count) {
+        if (artifact_supports_target(itn, a, m.targets[i].name)) {
+            if (count == 0) { only = ?m.targets[i]; }
+            count = count + 1;
+            if (target_matches_host(itn, ?m.targets[i], host_os, host_arch)) {
+                if (host_count == 0) { host_first = ?m.targets[i]; }
+                host_count = host_count + 1;
+            }
+        }
+        i = i + 1;
+    }
+    if (count == 1)      { ret only; }
+    if (host_count == 1) { ret host_first; }
+    ret nil;
+}
+
+# the comma-separated target names an artifact declares, for a diagnostic
+fun artifact_target_names(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, a: *ArtifactDef) str {
+    var s: str = "";
+    var i: u32 = 0;
+    for (i < m.target_count) {
+        if (artifact_supports_target(itn, a, m.targets[i].name)) {
+            if (!str_empty(s)) { s = sfmt(alloc, "{}, ", s); }
+            val opt_name: O.Option[str] = intern.lookup(itn, m.targets[i].name);
+            if (O.is_some[str](opt_name)) { s = sfmt(alloc, "{}{}", s, O.unwrap[str](opt_name)); }
+        }
+        i = i + 1;
+    }
+    ret s;
+}
+
+# resolve the target axis
+#
+# `art` is the artifact allowed to pin the target when the selector is empty,
+# or nil when the caller's target axis is fixed independently of any artifact.
+# An explicit selector (including `native`) always wins, so naming a target
+# still means exactly what it says.
+fun resolve_target(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, selector: str,
+                   art: *ArtifactDef) R.Result[ResolvedTarget, str] {
+    val host_os:   u32 = tgt.host_os_id();
+    val host_arch: u32 = tgt.host_arch_id();
+
+    if (str_empty(selector) && art != nil) {
+        val pinned: *TargetDef = artifact_pinned_target(itn, m, art);
+        if (pinned != nil) {
+            var rt: ResolvedTarget;
+            rt.target = pinned;
+            rt.warned = false;
+            ret R.ok[ResolvedTarget, str](rt);
+        }
+    }
 
     var name: str = selector;
     if (str_empty(name)) {
@@ -1942,7 +2011,13 @@ pub fun artifact_supports_target(itn: *intern.Interner, a: *ArtifactDef, tname: 
 # sel:   the cell's selection
 # ret:   whether the cell exists, or the failure that made it unresolvable
 pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[bool, str] {
-    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
+    # the enumerated axis fixes the target for the whole matrix, so no artifact
+    # pins it here: letting each artifact choose its own would silently widen
+    # a bare `mach build .` into targets the invocation never asked for. Where
+    # this predicate says yes the artifact does declare the resolved target, so
+    # `resolve_build_unit`'s pinning is a no-op on the same cell and the two
+    # still agree.
+    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[bool, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
     val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](res_target);
 
@@ -1953,7 +2028,14 @@ pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
 }
 
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
-    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target);
+    # a selection with no `--target` lets its artifact pin the target. resolving
+    # the artifact twice keeps the resolution order (and so the diagnostic a
+    # malformed selection gets) exactly as it was: an unresolvable artifact
+    # simply does not pin, and the errors below still fire in their old order.
+    var pin: *ArtifactDef = nil;
+    if (str_empty(sel.target)) { pin = resolve_artifact(itn, m, sel); }
+
+    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, pin);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
     val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](res_target);
 
@@ -1969,6 +2051,14 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     if (!artifact_supports_target(itn, a, rt.target.name)) {
         val art_name: str = idstr(itn, a.name);
         val tgt_name: str = idstr(itn, rt.target.name);
+        # the target was not named, so it came from the host and the artifact
+        # could not pin one: name what it does declare, which is the choice the
+        # user has to make.
+        if (str_empty(sel.target)) {
+            ret R.err[BuildUnit, str](sfmt(alloc,
+                "mach.toml: artifact '{}' declares no target for this host; select one with --target ({})",
+                art_name, artifact_target_names(alloc, itn, m, a)));
+        }
         ret R.err[BuildUnit, str](sfmt(alloc, "mach.toml: artifact '{}' does not support target '{}'", art_name, tgt_name));
     }
 
@@ -3553,6 +3643,110 @@ test "mach.lang.manifest.resolve_build_unit:artifact_target_filter" {
 
         val uw: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
         if (R.is_ok[BuildUnit, str](uw) || !str_contains(R.unwrap_err[BuildUnit, str](uw), "does not support target")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# a manifest declaring every host shape our runners can be, plus two
+# freestanding targets no host ever matches. the host-shaped targets make
+# `native` resolve the same way on every runner, so a case keyed on the
+# freestanding artifacts reads identically on linux, windows and darwin.
+fun ut_pin_manifest() str {
+    ret "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.linux-arm64]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[target.darwin-x86_64]\nisa=\"x86_64\"\nos=\"darwin\"\nabi=\"sysv64\"\n[target.darwin-arm64]\nisa=\"aarch64\"\nos=\"darwin\"\nabi=\"aapcs64\"\n[target.kernel]\nisa=\"x86_64\"\nos=\"freestanding\"\nabi=\"sysv64\"\n[target.kernel-arm]\nisa=\"aarch64\"\nos=\"freestanding\"\nabi=\"aapcs64\"\n[artifact.kernel]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/kernel\"\ntargets=[\"kernel\"]\nlink=[]\nneed=[]\n[artifact.both]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/both\"\ntargets=[\"kernel\",\"kernel-arm\"]\nlink=[]\nneed=[]\n[artifact.tool]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/tool\"\ntargets=[\"*\"]\nlink=[]\nneed=[]\n";
+}
+
+# an artifact declaring exactly one target settles the target itself (#2604).
+# `--bin kernel` said everything the invocation needed; before this, resolution
+# went to the host first and then refused the pair, so the user had to repeat
+# the artifact's own `targets` back as `--target`.
+test "mach.lang.manifest.resolve_build_unit:sole_target_artifact_pins_it" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, ut_pin_manifest());
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+
+        # no --target: the artifact's only target is the only thing it can mean
+        val uk: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "", "kernel", false, true));
+        if (R.is_err[BuildUnit, str](uk)) { code = 1; }
+        or {
+            val u: BuildUnit = R.unwrap_ok[BuildUnit, str](uk);
+            if (!str_equals(idstr(?itn, u.target_name), "kernel")) { code = 1; }
+        }
+
+        # an artifact that declares many still resolves the host, unchanged
+        val ut: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "", "tool", false, true));
+        if (R.is_err[BuildUnit, str](ut)) { code = 1; }
+        or {
+            val u: BuildUnit = R.unwrap_ok[BuildUnit, str](ut);
+            if (str_equals(idstr(?itn, u.target_name), "kernel")) { code = 1; }
+        }
+
+        # an explicit --target still means exactly what it says, including when
+        # it contradicts the artifact
+        val ux: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("linux", "", "kernel", false, true));
+        if (R.is_ok[BuildUnit, str](ux) || !str_contains(R.unwrap_err[BuildUnit, str](ux), "does not support target")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# several declared targets and none of them hosts the build: still an error,
+# but one that names the choice rather than the host target the user never
+# asked for (#2604).
+test "mach.lang.manifest.resolve_build_unit:no_hostable_target_lists_the_candidates" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, ut_pin_manifest());
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        val ub: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("", "", "both", false, true));
+        if (R.is_ok[BuildUnit, str](ub)) { code = 1; }
+        or {
+            val e: str = R.unwrap_err[BuildUnit, str](ub);
+            if (!str_contains(e, "declares no target for this host")) { code = 1; }
+            if (!str_contains(e, "kernel-arm")) { code = 1; }
+            if (!str_contains(e, "--target"))   { code = 1; }
+        }
+
+        # naming either one resolves it
+        val uk: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("kernel-arm", "", "both", false, true));
+        if (R.is_err[BuildUnit, str](uk)) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# the enumerated matrix axis is deliberately NOT narrowed by the artifact: a
+# bare `mach build .` must not widen into freestanding targets the invocation
+# never asked for, so `cell_supported` keeps resolving the host (#2604).
+test "mach.lang.manifest.cell_supported:enumerated_axis_is_not_pinned_by_the_artifact" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val res_manifest: R.Result[Manifest, str] = tparse(?alloc, ?itn, ut_pin_manifest());
+    if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        val ck: R.Result[bool, str] = cell_supported(?alloc, ?itn, ?m, mk_sel("", "", "kernel", false, true));
+        if (R.is_err[bool, str](ck)) { code = 1; }
+        or {
+            if (R.unwrap_ok[bool, str](ck)) { code = 1; }
+        }
+        # and the host-capable artifact is still an existing cell there
+        val ct: R.Result[bool, str] = cell_supported(?alloc, ?itn, ?m, mk_sel("", "", "tool", false, true));
+        if (R.is_err[bool, str](ct)) { code = 1; }
+        or {
+            if (!R.unwrap_ok[bool, str](ct)) { code = 1; }
+        }
     }
     arena.dnit(?ar);
     ret code;


### PR DESCRIPTION
`--bin X` with no `--target` resolved the host first and then refused the pair, so an artifact declaring exactly one target forced the user to repeat that target back as a flag carrying no information.

```
$ mach build . --bin kernel
error: mach.toml: artifact 'kernel' does not support target 'linux-x86_64'
$ mach build . --bin kernel --target kernel
(builds)
```

## The rule

Target resolution now takes the artifact that is allowed to pin it, and pins only where the answer is unambiguous:

- exactly one declared target: that target is used
- several, one matching the host: the host target, exactly as before
- several, none matching the host: refused, naming the targets the artifact declares

An explicit `--target` always wins, including when it names a target the artifact does not list. That pair is still refused by name, because you asked for a cell that does not exist.

## The enumerated axis is deliberately not narrowed

`cell_supported` keeps resolving the host with no artifact pinning it. Letting each artifact choose its own target on the enumerated axis would silently widen a bare `mach build .` into freestanding targets the invocation never asked for, which is a different change (and closer to #2474's territory).

The two paths still agree by construction: wherever `cell_supported` says yes, the artifact does declare the resolved host target, so pinning is provably a no-op on that same cell. `cell_supported:enumerated_axis_is_not_pinned_by_the_artifact` pins that decision so it cannot drift.

The artifact is resolved twice on the pinning path, once for narrowing and once as before. That is deliberate: it keeps the resolution order, and therefore the diagnostic a malformed selection receives, byte for byte what it was. An unresolvable artifact simply does not pin.

## Verified on the issue's own repro

A two-target manifest with a freestanding `kernel` artifact and a hosted `tool` artifact:

```
$ mach build . --bin kernel --explain
unit 1: kernel (bin)  target kernel  profile debug     # was: does not support target 'linux-x86_64'

$ mach build . --bin tool --explain
unit 1: tool (bin)  target linux-x86_64  profile debug # unchanged

$ mach build . --explain
unit 1: tool (bin)  target linux-x86_64  profile debug # unchanged, kernel still filtered out

$ mach build . --bin kernel --target linux-x86_64
error: mach.toml: artifact 'kernel' does not support target 'linux-x86_64'   # unchanged
```

And the several-targets-no-host case, which previously reported the host target the user never named:

```
$ mach build . --bin kernel        # targets = ["kernel", "kernel-arm"]
error: mach.toml: artifact 'kernel' declares no target for this host; select one with --target (kernel-arm, kernel)
```

## Tests

Three cases in `mach.lang.manifest`. They use a manifest declaring every host shape a runner can be plus two freestanding targets no host ever matches, so they read identically on the linux, windows and darwin legs rather than only on x86_64 linux.

Both behavioural cases were confirmed to fail against the unfixed resolver:

```
failures:
  mach.lang.manifest.resolve_build_unit:sole_target_artifact_pins_it
  mach.lang.manifest.resolve_build_unit:no_hostable_target_lists_the_candidates
12 passed, 2 failed, 14 total
```

The third (`cell_supported:enumerated_axis_is_not_pinned_by_the_artifact`) passes either way by design. It is a guard on the decision not to narrow, not a proof of the fix.

- `mach test .` 1166/1166 green (1163 before)
- `int/run.sh --target linux` all cases passed
- self-hosting fixpoint reproduces byte-identically

Closes #2604
