### PR TITLE
abi: Apple arm64 gives a fixed stack argument its natural size

### DIFF
--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -85,6 +85,16 @@ The fixed parameters always follow the target's ordinary calling convention. The
 A tail argument keeps its *form* on every target: a record too large to pass by
 value is still passed by reference, and only the hidden pointer's location moves.
 
+The *fixed* parameters diverge on Apple arm64 too, on a separate axis: a fixed
+argument that lands on the stack there takes its **natural size and alignment**,
+where AAPCS64 rounds every stack argument up to an 8-byte slot. Past the eight GP
+registers, `(…, int i, short j, long long k)` occupies `[sp+0]`, `[sp+4]`, `[sp+8]`
+on `darwin-aarch64` and `[sp+0]`, `[sp+8]`, `[sp+16]` on `linux-arm64`. Mach applies
+each target's own rule, so nothing in a declaration has to say which one is in force.
+Note only that Apple's two rules genuinely differ from each other: the variadic tail
+in the table above keeps its 8-byte minimum on the very target where a fixed argument
+does not.
+
 Apple arm64 is the reason this form exists. The obvious workaround — declaring the
 call at its fixed arity, `ext fun open(path: *u8, flags: i32, mode: u32) i32` —
 works on Linux and on x86-64 and is **silently wrong** there: the fixed-arity

--- a/int/surface/narrow-stack-args/case.conf
+++ b/int/surface/narrow-stack-args/case.conf
@@ -1,0 +1,21 @@
+# Fixed arguments that overflow the register file with a tail narrower than eight
+# bytes, called against a C object the RUNNER'S own toolchain built, so each callee
+# reads its stack arguments where the platform's real ABI puts them rather than where
+# mach's model does. This is the case that fails on darwin-aarch64 without #2598:
+# Apple's arm64 ABI gives a stack-passed fixed argument its natural size and alignment,
+# so a caller applying the AAPCS64 eight-byte slot writes four of the five tail
+# arguments into offsets belonging to a different argument - a wrong VALUE, which only
+# executing against real clang output can catch.
+#
+# Runs natively on the two macOS legs (the arm64 one is the divergence, the Intel one
+# the SysV control) and on both linux legs (linux-arm64 is the same AAPCS64 vtable
+# WITHOUT the divergence, so the two arm64 legs cross-check each other).
+#
+# exempt linux-riscv64: the leg runs the mach binary under qemu-user, but the case's
+# C half is built by the runner's native `cc`, which produces an x86-64 object no
+# riscv64 link can consume. A riscv64 cross-toolchain is not part of the leg.
+#
+# exempt windows: a `[step]` command does not run on the windows leg (#2578), so the
+# C object is never produced there. Re-enable this leg once that lands.
+run: exec
+exempt: linux-riscv64 windows

--- a/int/surface/narrow-stack-args/expect.txt
+++ b/int/surface/narrow-stack-args/expect.txt
@@ -1,0 +1,4 @@
+narrow n=12 regs=1 4 7
+narrow tail=9 10 11 12 13
+float n=11 regs=10 80
+float tail=95 105 115

--- a/int/surface/narrow-stack-args/mach.toml
+++ b/int/surface/narrow-stack-args/mach.toml
@@ -1,0 +1,71 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "cc -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/narrow-stack-args/probe.c
+++ b/int/surface/narrow-stack-args/probe.c
@@ -1,0 +1,51 @@
+/* the C half of the narrow-stack-args surface case (mach #2598).
+ *
+ * Compiled by the RUNNER'S OWN C toolchain, so each callee reads its stack arguments
+ * at the offsets the platform's real ABI puts them at rather than mach's model of it.
+ * That is the whole point: Apple's arm64 ABI gives a stack-passed FIXED argument its
+ * natural size and alignment, while the AAPCS64 base standard rounds every one up to
+ * an eight-byte slot, so a caller using the wrong rule writes each argument into a
+ * live offset belonging to a DIFFERENT argument. The result is a wrong VALUE here, not
+ * a link error or a crash.
+ *
+ * Both entry points take `out` first so it consumes the first GP argument register:
+ * the fillers that follow exhaust the register file exactly, and every argument after
+ * them is stack-passed. Each argument is written to `out` for the mach caller to
+ * print, so a misplaced one is visible individually rather than folded into a sum. */
+
+/* eight GP registers consumed (out + seven fillers), then a narrow tail.
+ *
+ * Apple arm64 places the tail at [sp+0] (int), [sp+4] (short), [sp+6] (signed char),
+ * [sp+8] (int, realigned to 4), [sp+16] (long long, realigned to 8) - 24 bytes total.
+ * AAPCS64 places it at 0, 8, 16, 24, 32 - 40 bytes. Every offset past the first
+ * differs, so a caller on the wrong rule gets four wrong values out of five. */
+long long narrow_tail(long long *out, long long a, long long b, long long c,
+                      long long d, long long e, long long f, long long g,
+                      int i, short j, signed char k, int l, long long m) {
+    out[0] = a; out[1] = b; out[2] = c; out[3] = d;
+    out[4] = e; out[5] = f; out[6] = g;
+    out[7]  = (long long)i;
+    out[8]  = (long long)j;
+    out[9]  = (long long)k;
+    out[10] = (long long)l;
+    out[11] = m;
+    return 12;
+}
+
+/* the same divergence on the FP side: eight doubles exhaust V0-V7, then a narrow tail.
+ *
+ * Apple arm64 places it at [sp+0] (float), [sp+4] (float), [sp+8] (double); AAPCS64 at
+ * 0, 8, 16. Each value is scaled by 10 and truncated so the observable is exact integer
+ * text on every target. */
+long long float_tail(long long *out, double a, double b, double c, double d,
+                     double e, double f, double g, double h,
+                     float i, float j, double k) {
+    out[0] = (long long)(a * 10.0); out[1] = (long long)(b * 10.0);
+    out[2] = (long long)(c * 10.0); out[3] = (long long)(d * 10.0);
+    out[4] = (long long)(e * 10.0); out[5] = (long long)(f * 10.0);
+    out[6] = (long long)(g * 10.0); out[7] = (long long)(h * 10.0);
+    out[8]  = (long long)((double)i * 10.0);
+    out[9]  = (long long)((double)j * 10.0);
+    out[10] = (long long)(k * 10.0);
+    return 11;
+}

--- a/int/surface/narrow-stack-args/src/main.mach
+++ b/int/surface/narrow-stack-args/src/main.mach
@@ -1,0 +1,51 @@
+# narrow fixed stack-argument surface case (mach #2598)
+#
+# Calls two real clang/gcc-built C functions whose fixed arguments overflow the
+# register file with a tail narrower than eight bytes, and asserts every argument
+# round-trips. The C half reads each stack argument at the offset the RUNNER'S own ABI
+# puts it at, so a mismatch between mach's placement rule and the platform's is a wrong
+# VALUE printed here - the failure shape Apple arm64 produces, where a stack-passed
+# fixed argument takes its natural size and the AAPCS64 base standard's eight-byte slot
+# puts every argument after the first at an offset the callee does not read.
+#
+# The observable is target-independent on purpose: the same golden must hold on
+# darwin-aarch64 (natural size, tail at 0/4/6/8/16), linux-arm64 (the SAME AAPCS64
+# vtable WITHOUT the divergence, tail at 0/8/16/24/32), and both SysV legs. A leg that
+# disagrees with the others is the bug.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# eight GP registers consumed by `out` plus the seven fillers, then a five-argument
+# narrow tail that is entirely stack-passed.
+ext fun narrow_tail(out: *i64, a: i64, b: i64, c: i64,
+                    d: i64, e: i64, f: i64, g: i64,
+                    i: i32, j: i16, k: i8, l: i32, m: i64) i64;
+
+# eight V registers consumed by the doubles, then a narrow FP tail; `out` rides x0.
+ext fun float_tail(out: *i64, a: f64, b: f64, c: f64, d: f64,
+                   e: f64, f: f64, g: f64, h: f64,
+                   i: f32, j: f32, k: f64) i64;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var out: [12]i64;
+
+    # the register-borne arguments are the control: they are placed identically under
+    # both rules, so a leg that gets these right and the tail wrong has exactly the
+    # stack-granularity bug and nothing else.
+    val n1: i64 = narrow_tail(?out[0], 1, 2, 3, 4, 5, 6, 7,
+                              9::i32, 10::i16, 11::i8, 12::i32, 13::i64);
+    p.printlnf("narrow n={} regs={} {} {}", n1, out[0], out[3], out[6]);
+    p.printlnf("narrow tail={} {} {} {} {}", out[7], out[8], out[9], out[10], out[11]);
+
+    var fo: [11]i64;
+    val n2: i64 = float_tail(?fo[0], 1.0::f64, 2.0::f64, 3.0::f64, 4.0::f64,
+                             5.0::f64, 6.0::f64, 7.0::f64, 8.0::f64,
+                             9.5::f32, 10.5::f32, 11.5::f64);
+    p.printlnf("float n={} regs={} {}", n2, fo[0], fo[7]);
+    p.printlnf("float tail={} {} {}", fo[8], fo[9], fo[10]);
+
+    ret 0;
+}

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -508,18 +508,59 @@ fun round_up_i64(value: i64, align: u64) i64 {
 # regardless of the aggregate's alignment. On x86 every stack argument is
 # <=8-aligned, so this is always eight and the round-up is identity; AAPCS64 honors
 # a 16-byte-aligned by-value argument.
+#
+# `natural` drops the eight-byte clamp for a by-value slot, leaving the value's own
+# alignment: the Apple arm64 rule for a FIXED argument, where a `u32` is 4-aligned and
+# a `u8` 1-aligned rather than both being 8-aligned (#2598). A by-reference spill is
+# unaffected either way - the pointer it holds is genuinely 8 bytes and 8-aligned.
 # ---
-# class: the slot's classification (CLASS_STACK, CLASS_STACK_BYREF, or CLASS_VEC_STACK_BYREF)
-# align: the value's natural alignment in bytes
-# ret:   the slot's stack alignment in bytes
-fun stack_arg_align(class: abi.ParamClass, align: u64) u64 {
+# class:   the slot's classification (CLASS_STACK, CLASS_STACK_BYREF, or CLASS_VEC_STACK_BYREF)
+# align:   the value's natural alignment in bytes
+# natural: whether this argument's slot takes the value's natural alignment with no minimum
+# ret:     the slot's stack alignment in bytes
+fun stack_arg_align(class: abi.ParamClass, align: u64, natural: bool) u64 {
     # both by-reference stack spills carry only an 8-byte pointer, so they round to 8
     # regardless of the referent's alignment (CLASS_VEC_STACK_BYREF's referent is the
     # spilled vector temp, aligned at its own frame slot, not this outgoing pointer slot).
     if (class == abi.CLASS_STACK_BYREF)     { ret 8; }
     if (class == abi.CLASS_VEC_STACK_BYREF) { ret 8; }
+    if (natural)                            { ret align; }
     if (align < 8)                          { ret 8; }
     ret align;
+}
+
+# the outgoing stack bytes one by-value stack argument consumes
+#
+# The convention's rule is an eight-byte-granular slot (`context.stack_slot_bytes`): a
+# value narrower than the machine word still consumes a whole slot. `natural` selects
+# the Apple arm64 FIXED-argument rule instead, where the argument consumes exactly its
+# own size and the next one packs against it, so two `i32`s land at [sp+0] and [sp+4].
+#
+# It is asked per ARGUMENT rather than read off the target, because Apple runs both
+# rules at once: a variadic tail argument keeps the eight-byte slot on the very target
+# where a fixed one does not, so the caller passes which rule this argument is under.
+# ---
+# size:    the argument's value size in bytes (from its ABI ParamSlot)
+# natural: whether this argument's slot takes its natural size with no minimum
+# ret:     the outgoing stack bytes the argument consumes
+fun stack_arg_bytes(size: u64, natural: bool) i64 {
+    if (natural) { ret size::i64; }
+    ret context.stack_slot_bytes(size);
+}
+
+# whether one argument's outgoing stack slot takes its natural size and alignment
+#
+# The single statement of Apple arm64's two-rule split (#2598, #2575): a FIXED argument
+# takes its natural size there, and the variadic tail keeps the eight-byte minimum the
+# calling convention gives it. Every other platform answers false for both. The target
+# fact is resolved once from the (os, isa) pair by `target.select`, so this names no os.
+# ---
+# tgt:      the resolved target
+# variadic: whether the argument sits in the call's variadic tail
+# ret:      true when the slot takes the value's natural size and alignment
+fun natural_stack_slot(tgt: *target.Target, variadic: bool) bool {
+    if (variadic) { ret false; }
+    ret tgt.fixed_args_natural_size;
 }
 
 # rewrite a variadic-tail placement into its stack form, for a platform that passes
@@ -539,8 +580,10 @@ fun stack_arg_align(class: abi.ParamClass, align: u64) u64 {
 # register-borne placement -- a scalar, a register pair, an HFA's V-register run, a
 # register-plus-stack split -- becomes one by-value stack slot of the value's own size.
 # A placement the classifier already put on the stack is returned untouched. The slot's
-# natural alignment and eight-byte-minimum granularity come from the shared
-# `stack_arg_align` / `stack_slot_bytes` walk, which is already the Apple rule.
+# alignment and eight-byte-minimum granularity come from the shared `stack_arg_align` /
+# `stack_arg_bytes` walk under `natural = false`, which is already the Apple rule for a
+# variadic tail argument -- and is why Apple's natural-size FIXED rule (#2598) is a
+# separate fact and never applies here.
 # ---
 # slot: the placement the convention classifier returned for a tail argument
 # ret:  the same value's stack placement
@@ -633,6 +676,10 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     if (wants_agg) { ret_agg = agg_layout(ctx, ret_type, ret_aggr); }
     out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_vec, ret_hm, ret_he, ret_agg);
 
+    # every parameter this walk places is a fixed one, so the fixed rule governs all of
+    # them; the variadic tail is placed by `lower_call` under the other one.
+    val fixed_natural: bool = natural_stack_slot(ctx.tgt, false);
+
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
     # outgoing stack arguments start above the ABI's caller shadow space (win64's
@@ -699,10 +746,13 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         # GP/SSE aggregate consumes one of each). a by-value stack slot is first
         # rounded up to the value's alignment (identity on x86, where every stack
         # argument is <=8-aligned; honors a 16-aligned AAPCS64 by-value argument).
+        # every parameter here is FIXED, so a platform that gives a fixed stack argument
+        # its natural size (Apple arm64) packs it against its neighbour rather than
+        # rounding both the alignment and the footprint up to eight.
         if (is_stack_slot_class(slot.class)) {
-            stack_off   = round_up_i64(stack_off, stack_arg_align(slot.class, pal));
+            stack_off   = round_up_i64(stack_off, stack_arg_align(slot.class, pal, fixed_natural));
             slot.offset = stack_off;
-            stack_off   = stack_off + context.stack_slot_bytes(slot.size);
+            stack_off   = stack_off + stack_arg_bytes(slot.size, fixed_natural);
         } or {
             advance_arg_cursors(?slot, ?gp_used, ?fp_used);
             # a register-plus-stack split also reserves an outgoing stack slot for its
@@ -976,8 +1026,10 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
             # a register-plus-stack split's tail stack chunk is eight-byte-granular.
+            # the tail is never under the natural-size rule: Apple arm64 keeps the
+            # eight-byte minimum here even though a fixed argument there does not (#2598).
             if (is_stack_slot_class(slot.class)) {
-                stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal));
+                stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal, false));
             } or (slot_has_stack_piece(?slot)) {
                 stack_off = round_up_i64(stack_off, 8);
             }
@@ -993,7 +1045,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         }
         val argop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](aor);
 
-        val er: R.Result[bool, str] = emit_arg_slot(ctx, mb, slot, argop, soff, aag, asz);
+        val er: R.Result[bool, str] = emit_arg_slot(ctx, mb, slot, argop, soff, aag, asz,
+                                                    natural_stack_slot(ctx.tgt, pidx >= layout.param_count));
         if (R.is_err[bool, str](er)) {
             sig_layout_free(ctx, ?layout);
             ret er;
@@ -1036,7 +1089,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         # advances each assigned register's bank; a stack slot advances the offset.
         if (pidx >= layout.param_count) {
             if (is_stack_slot_class(slot.class)) {
-                stack_off = stack_off + context.stack_slot_bytes(slot.size);
+                stack_off = stack_off + stack_arg_bytes(slot.size, false);
             } or {
                 advance_arg_cursors(?slot, ?gp_used, ?fp_used);
                 # a split tail also consumes its stack chunk's outgoing slot.
@@ -1243,9 +1296,12 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
 # stack_off: the slot's outgoing stack base (a STACK slot, or a split's stack chunk)
 # is_aggr:   whether the argument is an aggregate flowing by address
 # size:      the argument's byte size (the copy length for a by-value aggregate)
+# natural:   whether the outgoing slot is exactly the value's size, so a narrow scalar
+#            must be stored at its own width or it overwrites the argument packed
+#            against it (the Apple arm64 fixed rule)
 # ret:       ok(true) on success, or a loud error
 fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
-                  stack_off: i64, is_aggr: bool, size: u64) R.Result[bool, str] {
+                  stack_off: i64, is_aggr: bool, size: u64, natural: bool) R.Result[bool, str] {
     # a register-resident value marshalled by reference (a 128-bit vector at a win64 `ext`
     # boundary, #2058): unlike an aggregate or a scalarized rv64 vector -- already
     # memory-resident, its argop a storage pointer -- the value is in a register, so the
@@ -1286,7 +1342,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         # is the scalar's own width when that exceeds the machine word (the read twin
         # in `emit_param_slot`), so an 8-bit target passes all of a wide argument.
         ret context.emit_store_to_w(ctx, mb, mir.op_mem_preg(sp, stack_off), argop,
-                                    scalar_mem_move_width(ctx.tgt.model.gpr_width, size));
+                                    scalar_mem_move_width(ctx.tgt.model.gpr_width, size, natural));
     }
     if (slot.class == abi.CLASS_BYREF) {
         # the aggregate is passed by hidden pointer; move its address into the
@@ -1419,11 +1475,17 @@ fun scalar_reg_move_width(gpr_width: u32, size: u64) u8 {
 # preserved exactly. The one rule it adds is the same: a scalar wider than the machine
 # word is accessed at its own size, so an 8-bit target reads all four bytes of a `u32`
 # stack parameter instead of its low byte.
+#
+# `natural` accesses the scalar at exactly its own width instead. That is not an
+# optimization: under Apple arm64's natural-size FIXED rule the next argument packs
+# against this one, so a machine-word store into a 4-byte slot would overwrite it.
 # ---
 # gpr_width: the target's machine word in bytes
 # size:      the scalar's byte size
+# natural:   whether this argument's slot is exactly its own size
 # ret:       the access width in bytes
-fun scalar_mem_move_width(gpr_width: u32, size: u64) u8 {
+fun scalar_mem_move_width(gpr_width: u32, size: u64, natural: bool) u8 {
+    if (natural)               { ret size::u8; }
     if (size > gpr_width::u64) { ret size::u8; }
     ret gpr_width::u8;
 }
@@ -1615,8 +1677,12 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         # pointer, addressed through the physical frame pointer at the running offset.
         # the read is the scalar's own width when that exceeds the machine word, so an
         # 8-bit target loads all of a wide parameter rather than its low byte.
+        # the read twin of `emit_arg_slot`'s store: a declared parameter is always a
+        # fixed one, so a platform that sizes a fixed stack slot naturally reads exactly
+        # the parameter's own bytes and not the neighbouring argument's.
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off),
-                               scalar_mem_move_width(ctx.tgt.model.gpr_width, size));
+                               scalar_mem_move_width(ctx.tgt.model.gpr_width, size,
+                                                     natural_stack_slot(ctx.tgt, false)));
     }
     if (slot.class == abi.CLASS_BYREF) {
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32), ptr_move_width(ctx));
@@ -1837,9 +1903,9 @@ test "mach.lang.be.codegen.mir.abi:scalar_move_widths" {
     if (scalar_reg_move_width(8, 2) != 8) { ret 1; }
     if (scalar_reg_move_width(8, 4) != 4) { ret 1; }
     if (scalar_reg_move_width(8, 8) != 8) { ret 1; }
-    if (scalar_mem_move_width(8, 1) != 8) { ret 1; }
-    if (scalar_mem_move_width(8, 4) != 8) { ret 1; }
-    if (scalar_mem_move_width(8, 8) != 8) { ret 1; }
+    if (scalar_mem_move_width(8, 1, false) != 8) { ret 1; }
+    if (scalar_mem_move_width(8, 4, false) != 8) { ret 1; }
+    if (scalar_mem_move_width(8, 8, false) != 8) { ret 1; }
 
     # a 1-byte machine word: every wider scalar carries its own size, so the width
     # legalizer downstream sees the whole value rather than its low byte.
@@ -1847,10 +1913,10 @@ test "mach.lang.be.codegen.mir.abi:scalar_move_widths" {
     if (scalar_reg_move_width(1, 2) != 2) { ret 1; }
     if (scalar_reg_move_width(1, 4) != 4) { ret 1; }
     if (scalar_reg_move_width(1, 8) != 8) { ret 1; }
-    if (scalar_mem_move_width(1, 1) != 1) { ret 1; }
-    if (scalar_mem_move_width(1, 2) != 2) { ret 1; }
-    if (scalar_mem_move_width(1, 4) != 4) { ret 1; }
-    if (scalar_mem_move_width(1, 8) != 8) { ret 1; }
+    if (scalar_mem_move_width(1, 1, false) != 1) { ret 1; }
+    if (scalar_mem_move_width(1, 2, false) != 2) { ret 1; }
+    if (scalar_mem_move_width(1, 4, false) != 4) { ret 1; }
+    if (scalar_mem_move_width(1, 8, false) != 8) { ret 1; }
     ret 0;
 }
 
@@ -1877,10 +1943,78 @@ test "mach.lang.be.codegen.mir.abi:stack_arg_alignment" {
     if (round_up_i64(24, 16) != 32) { ret 1; }
     # a by-reference spill holds an 8-byte pointer, so it rounds to 8 regardless of
     # the aggregate's natural alignment.
-    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16) != 8) { ret 1; }
+    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16, false) != 8) { ret 1; }
     # a by-value slot honors the value's alignment, clamped to the 8-byte minimum.
-    if (stack_arg_align(abi.CLASS_STACK, 16) != 16) { ret 1; }
-    if (stack_arg_align(abi.CLASS_STACK, 4) != 8)   { ret 1; }
+    if (stack_arg_align(abi.CLASS_STACK, 16, false) != 16) { ret 1; }
+    if (stack_arg_align(abi.CLASS_STACK, 4, false) != 8)   { ret 1; }
+    ret 0;
+}
+
+# APPLE ARM64'S FIXED STACK ARGUMENT TAKES ITS NATURAL SIZE AND ALIGNMENT (#2598).
+#
+# The base standard's 8-byte minimum is what puts a narrow argument at an offset an
+# Apple-built callee does not read: three trailing i32s land at 0/4/8 there and at
+# 0/8/16 under AAPCS64. Both the alignment and the footprint have to drop the minimum
+# together - keeping either one alone still misplaces the third argument - so both are
+# asserted against the exact offsets clang emits for the issue's repro.
+test "mach.lang.be.codegen.mir.abi:natural_stack_args_pack_a_narrow_argument" {
+    # alignment: the value's own, with no clamp. a u8 argument is 1-aligned here and
+    # 8-aligned under the base rule.
+    if (stack_arg_align(abi.CLASS_STACK, 4, true) != 4) { ret 1; }
+    if (stack_arg_align(abi.CLASS_STACK, 1, true) != 1) { ret 1; }
+    # a 16-aligned by-value aggregate is 16-aligned under BOTH rules: natural size is
+    # not "no alignment", it is the value's own.
+    if (stack_arg_align(abi.CLASS_STACK, 16, true) != 16) { ret 1; }
+    # a by-reference spill is exempt under both: the pointer it holds really is 8/8.
+    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16, true) != 8) { ret 1; }
+
+    # footprint: exactly the value's size, so the next argument packs against it.
+    if (stack_arg_bytes(4, true) != 4) { ret 1; }
+    if (stack_arg_bytes(1, true) != 1) { ret 1; }
+    if (stack_arg_bytes(8, true) != 8) { ret 1; }
+    # and the convention's rule is untouched where it applies.
+    if (stack_arg_bytes(4, false) != 8) { ret 1; }
+    if (stack_arg_bytes(1, false) != 8) { ret 1; }
+
+    # the access width follows the slot: a machine-word store into a 4-byte slot would
+    # write over the argument packed at the next offset.
+    if (scalar_mem_move_width(8, 4, true) != 4) { ret 1; }
+    if (scalar_mem_move_width(8, 1, true) != 1) { ret 1; }
+    if (scalar_mem_move_width(8, 8, true) != 8) { ret 1; }
+
+    # the issue's repro, walked end to end: three i32s past the eight GP registers.
+    # 0/4/8 is clang's Apple-arm64 output; 0/8/16 is what mach emitted before the fix
+    # and what linux-arm64 must keep emitting.
+    var off:  i64 = 0;
+    var boff: i64 = 0;
+    var n:    u32 = 0;
+    for (n < 3) {
+        off = round_up_i64(off, stack_arg_align(abi.CLASS_STACK, 4, true));
+        boff = round_up_i64(boff, stack_arg_align(abi.CLASS_STACK, 4, false));
+        if (n == 0 && (off != 0 || boff != 0))   { ret 1; }
+        if (n == 1 && (off != 4 || boff != 8))   { ret 1; }
+        if (n == 2 && (off != 8 || boff != 16))  { ret 1; }
+        off  = off + stack_arg_bytes(4, true);
+        boff = boff + stack_arg_bytes(4, false);
+        n = n + 1;
+    }
+    if (off != 12 || boff != 24) { ret 1; }
+    ret 0;
+}
+
+# the two Apple arm64 rules are separate: a FIXED argument takes its natural size, and
+# the variadic tail keeps the convention's eight-byte minimum. `natural_stack_slot` is
+# the single place that says so, so a tail argument answers false even on the target
+# that answers true for a fixed one
+test "mach.lang.be.codegen.mir.abi.natural_stack_slot:fixed_diverges_variadic_does_not" {
+    var tgt: target.Target;
+    tgt.fixed_args_natural_size = true;
+    if (!natural_stack_slot(?tgt, false)) { ret 1; }
+    if (natural_stack_slot(?tgt, true))   { ret 1; }
+    # every other target: neither half diverges.
+    tgt.fixed_args_natural_size = false;
+    if (natural_stack_slot(?tgt, false)) { ret 1; }
+    if (natural_stack_slot(?tgt, true))  { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -319,6 +319,13 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     # answer, resolved once here for the call lowering to read.
     t.variadic_args_on_stack = os.variadic_stack_for(os_vt, arch_vt.id);
 
+    # the platform FIXED stack-argument granularity rule for THIS (os, isa) pair, on the
+    # same axis and for the same reason: Apple arm64 gives a stack-passed fixed argument
+    # its natural size where the AAPCS64 vtable darwin and linux share rounds it up to
+    # eight bytes. resolved beside the variadic fact, never merged with it - Apple keeps
+    # the eight-byte minimum for its variadic tail.
+    t.fixed_args_natural_size = os.natural_stack_args_for(os_vt, arch_vt.id);
+
     # derive the legacy identity ids from the resolved vtables; the ~89 id-readers
     # and the comptime tag space keep reading these unchanged.
     t.os_id   = t.os.id;
@@ -772,6 +779,45 @@ test "mach.lang.target.select:c_variadic_stack_is_per_os_and_isa" {
     val lx: R.Result[resolved.Target, str] = select(?reg, "x86_64", "linux", "sysv64");
     if (R.is_err[resolved.Target, str](lx))                                     { ret 1; }
     if (R.unwrap_ok[resolved.Target, str](lx).variadic_args_on_stack)           { ret 1; }
+
+    ret 0;
+}
+
+# THE FIXED STACK-ARGUMENT SIZE RULE IS RESOLVED PER (OS, ISA) TOO, AND IS A SEPARATE
+# FACT FROM THE VARIADIC ONE (#2598).
+#
+# Apple arm64 gives a stack-passed FIXED argument its natural size and alignment; the
+# AAPCS64 base standard rounds every one up to eight bytes. Same axis as the variadic
+# rule above and same reason it cannot live on either vtable alone, so the same four
+# cells are asserted: getting one wrong places an argument at an offset the callee does
+# not read, a wrong VALUE rather than a link error.
+test "mach.lang.target.select:fixed_stack_arg_size_is_per_os_and_isa" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    # darwin + aarch64: the divergence.
+    val da: R.Result[resolved.Target, str] = select(?reg, "aarch64", "darwin", "aapcs64");
+    if (R.is_err[resolved.Target, str](da))                                      { ret 1; }
+    if (!R.unwrap_ok[resolved.Target, str](da).fixed_args_natural_size)          { ret 1; }
+
+    # linux + aarch64: the SAME convention vtable, WITHOUT it.
+    val la: R.Result[resolved.Target, str] = select(?reg, "aarch64", "linux", "aapcs64");
+    if (R.is_err[resolved.Target, str](la))                                      { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](la).fixed_args_natural_size)           { ret 1; }
+
+    # darwin + x86_64: the SAME os, WITHOUT it - SysV's eight-byte slot is unchanged.
+    val dx: R.Result[resolved.Target, str] = select(?reg, "x86_64", "darwin", "sysv64");
+    if (R.is_err[resolved.Target, str](dx))                                      { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](dx).fixed_args_natural_size)           { ret 1; }
+
+    # linux + x86_64: neither.
+    val lx: R.Result[resolved.Target, str] = select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[resolved.Target, str](lx))                                      { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](lx).fixed_args_natural_size)           { ret 1; }
+
+    # and the two facts are independent: darwin-aarch64 carries BOTH, and carrying both
+    # is what makes the fixed and variadic rules differ from each other there.
+    if (!R.unwrap_ok[resolved.Target, str](da).variadic_args_on_stack)           { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -127,6 +127,27 @@ pub def NativeAbiFn: fun(u32) str;
 # ret:   true when the whole variadic tail is stack-passed on that architecture
 pub def VariadicStackFn: fun(u32) bool;
 
+# a per-os stack-argument granularity policy for FIXED arguments, parameterized by
+# architecture id
+#
+# Returns true when this platform gives each stack-passed FIXED argument its natural
+# size and natural alignment, with no minimum. Apple's arm64 ABI does exactly that, a
+# documented divergence from the AAPCS64 base standard, which rounds every stack
+# argument up to an eight-byte slot: a pair of `int`s past the register file lands at
+# `[sp+0]` and `[sp+4]` under Apple's rule and at `[sp+0]` and `[sp+8]` under the base
+# standard. Like `VariadicStackFn` this is a PLATFORM fact rather than a convention
+# fact - darwin and linux compose the very same "aapcs64" vtable, and darwin's own
+# x86_64 keeps SysV's eight-byte slot - so it is declared here, per architecture, and
+# resolved onto the target rather than branched on anywhere.
+#
+# It governs FIXED arguments ONLY. Apple genuinely runs two rules at once: the
+# variadic tail keeps the eight-byte minimum even where a fixed argument does not, so
+# the two policies are siblings and never collapse into one.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   true when a fixed stack argument takes its natural size there
+pub def NaturalStackArgsFn: fun(u32) bool;
+
 # the operating-system runtime-dispatch interface
 #
 # Exactly one of these exists per OS; the driver and linker read the entry
@@ -202,6 +223,12 @@ pub def VariadicStackFn: fun(u32) bool;
 #                 follows its calling convention's ordinary variadic rule everywhere
 #                 (every platform but Apple arm64); `target.select` resolves it once
 #                 onto `Target.variadic_args_on_stack`, which the call lowering reads
+# natural_stack_args: per-architecture FIXED stack-argument granularity policy, or nil
+#                 when the OS follows its calling convention's ordinary slot rule
+#                 everywhere (every platform but Apple arm64); `target.select` resolves
+#                 it once onto `Target.fixed_args_natural_size`. Sibling of
+#                 `variadic_stack` and deliberately separate from it: Apple's fixed and
+#                 variadic rules differ from each other
 pub rec OsVTable {
     id:                  u32;
     name:                str;
@@ -224,6 +251,7 @@ pub rec OsVTable {
     page_size_for:       PageSizeFn;
     native_abi:          NativeAbiFn;
     variadic_stack:      VariadicStackFn;
+    natural_stack_args:  NaturalStackArgsFn;
 }
 
 # maximum number of OS implementations an OsRegistry holds
@@ -414,6 +442,22 @@ pub fun variadic_stack_for(vt: *OsVTable, arch_id: u32) bool {
     ret vt.variadic_stack(arch_id);
 }
 
+# whether operating system `vt` gives a FIXED stack-passed argument its natural size
+# and alignment on architecture `arch_id`
+#
+# The nil-safe reader over the vtable's `natural_stack_args` policy: a nil policy (every
+# OS but darwin) yields false, the calling convention's ordinary eight-byte slot rule.
+# `target.select` calls this once per resolved target and the backend reads the answer
+# off the target, so no argument-lowering path names an OS.
+# ---
+# vt:      the os vtable to read
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     true when a fixed stack argument takes its natural size there
+pub fun natural_stack_args_for(vt: *OsVTable, arch_id: u32) bool {
+    if (vt.natural_stack_args == nil) { ret false; }
+    ret vt.natural_stack_args(arch_id);
+}
+
 # stub variadic-placement policy for the variadic_stack_for test: covers arch id 1
 fun variadic_stack_stub(arch_id: u32) bool {
     ret arch_id == 1;
@@ -428,6 +472,23 @@ test "mach.lang.target.os.variadic_stack_for:reads_policy_and_is_nil_safe" {
     vt.variadic_stack = variadic_stack_stub;
     if (!variadic_stack_for(?vt, 1)) { ret 1; }
     if (variadic_stack_for(?vt, 2))  { ret 1; }
+    ret 0;
+}
+
+# stub natural-stack-argument policy for the natural_stack_args_for test: arch id 1 only
+fun natural_stack_args_stub(arch_id: u32) bool {
+    ret arch_id == 1;
+}
+
+# natural_stack_args_for is nil-safe (a nil policy yields the convention's eight-byte
+# slot rule) and otherwise reads the vtable's policy per architecture
+test "mach.lang.target.os.natural_stack_args_for:reads_policy_and_is_nil_safe" {
+    var vt: OsVTable;
+    vt.natural_stack_args = nil;
+    if (natural_stack_args_for(?vt, 1)) { ret 1; }
+    vt.natural_stack_args = natural_stack_args_stub;
+    if (!natural_stack_args_for(?vt, 1)) { ret 1; }
+    if (natural_stack_args_for(?vt, 2))  { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -76,6 +76,27 @@ fun darwin_variadic_stack(arch_id: u32) bool {
     ret arch_id == isa.ARCH_AARCH64;
 }
 
+# whether Darwin gives a FIXED stack-passed argument its natural size, per architecture
+#
+# TRUE ON ARM64. Apple's arm64 ABI gives each stack-passed fixed argument its natural
+# size and natural alignment, with no minimum, where the AAPCS64 base standard rounds
+# every one up to an eight-byte slot. Three trailing `i32`s past the eight GP argument
+# registers land at [sp+0], [sp+4], [sp+8] here and at [sp+0], [sp+8], [sp+16] on
+# linux-arm64: same convention vtable, different platform rule. Getting it wrong is a
+# silent wrong value at the callee, not a link error (#2598).
+#
+# FALSE ON X86_64. Darwin adopts SysV there unchanged, and SysV gives every stack
+# argument a full eight-byte slot.
+#
+# This is NOT the variadic rule: Apple stacks the variadic tail with the eight-byte
+# minimum intact, which is `darwin_variadic_stack`'s separate concern.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     true on arm64, false elsewhere
+fun darwin_natural_stack_args(arch_id: u32) bool {
+    ret arch_id == isa.ARCH_AARCH64;
+}
+
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime
 var darwin_vtable: os.OsVTable;
@@ -132,6 +153,10 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     # Apple arm64 stacks the whole C variadic tail; every other platform mach
     # targets follows its convention's ordinary rule and leaves this nil.
     darwin_vtable.variadic_stack = darwin_variadic_stack;
+    # Apple arm64 also gives a FIXED stack argument its natural size rather than the
+    # AAPCS64 eight-byte slot; a separate rule from the variadic one above, which keeps
+    # the eight-byte minimum.
+    darwin_vtable.natural_stack_args = darwin_natural_stack_args;
 
     os.register(reg, ?darwin_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -89,6 +89,9 @@ pub fun register_freestanding(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform variadic divergence: the selected convention's ordinary
     # register-then-stack rule governs a variadic argument as it does a named one.
     freestanding_vtable.variadic_stack = nil;
+    # no platform stack-granularity divergence either: a stack argument takes the
+    # convention's slot.
+    freestanding_vtable.natural_stack_args = nil;
 
     os.register(reg, ?freestanding_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -119,6 +119,9 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform variadic divergence: the selected convention's ordinary
     # register-then-stack rule governs a variadic argument as it does a named one.
     linux_vtable.variadic_stack = nil;
+    # no platform stack-granularity divergence either: a stack argument takes the
+    # convention's slot (AAPCS64's eight-byte one on arm64, not Apple's natural size).
+    linux_vtable.natural_stack_args = nil;
 
     os.register(reg, ?linux_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -110,6 +110,9 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform variadic divergence: the selected convention's ordinary
     # register-then-stack rule governs a variadic argument as it does a named one.
     windows_vtable.variadic_stack = nil;
+    # no platform stack-granularity divergence either: win64 gives every stack argument
+    # a full eight-byte slot.
+    windows_vtable.natural_stack_args = nil;
 
     os.register(reg, ?windows_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -61,6 +61,14 @@ use mach.lang.target.os;
 #           "aapcs64" convention, and darwin's own x86_64 keeps SysV's ordinary rule.
 #           Held as a resolved scalar so the call lowering reads a target fact rather
 #           than branching on an os or convention id
+# fixed_args_natural_size: true when this platform gives each stack-passed FIXED
+#           argument its natural size and natural alignment, with no minimum, rather
+#           than the eight-byte slot the calling convention would round it up to (Apple
+#           arm64, and only there). Resolved the same way and for the same reason as
+#           `variadic_args_on_stack`, from the os vtable's per-architecture
+#           `natural_stack_args` policy. The two are SIBLINGS, not one fact: Apple runs
+#           both rules at once, so a variadic tail argument keeps the eight-byte minimum
+#           on a target where a fixed one does not
 pub rec Target {
     os_id:    u32;
     arch_id:  u32;
@@ -75,4 +83,5 @@ pub rec Target {
     model:    isa.MachineModel;
     base:     u64;
     variadic_args_on_stack: bool;
+    fixed_args_natural_size: bool;
 }


### PR DESCRIPTION
Closes #2598

Apple's arm64 ABI gives each stack-passed **fixed** argument its natural size and
alignment. The AAPCS64 base standard rounds every stack argument up to an 8-byte slot.
Mach applied the AAPCS64 rule on every aarch64 target including darwin, so a
`darwin-aarch64` call whose stack arguments were narrower than 8 bytes placed them at
offsets the callee does not read: a silent wrong value, no link error and no crash.

## The shape of the fix

The rule is resolved exactly the way #2575 resolved `Target.variadic_args_on_stack`,
because it diverges on the same axis and for the same reason. `os.OsVTable` gains a
`natural_stack_args` policy per architecture (darwin returns true on aarch64, every
other OS leaves it nil), and `target.select` resolves it once from the `(os, isa)` pair
onto `Target.fixed_args_natural_size`. No lowering path names an OS.

The stack-argument walk was 8-byte granular in three places, not one: the slot
alignment (`stack_arg_align`), the slot footprint (`context.stack_slot_bytes`, now
behind `stack_arg_bytes`), and the memory access width (`scalar_mem_move_width`). All
three had to move together. Leaving the width alone would have had a machine-word store
into a 4-byte slot overwrite the argument packed against it, which is why the fix
reaches the store and load sites and not only the offset cursor.

`natural_stack_slot(tgt, variadic)` is the single place that states Apple's two-rule
split. `classify_signature` places only fixed parameters and asks for the fixed rule;
`lower_call`'s tail arm passes `false` explicitly. **The variadic tail keeps its 8-byte
minimum on both targets**, as #2598 requires.

## Evidence: the issue's repro, before and after

`mach build . --target darwin-aarch64 --emit-asm` on the issue's exact source
(`many(1..8, 9::i32, 10::i32, 11::i32)`):

| | before | after | `clang -O1 --target=arm64-apple-macos11` |
|---|---|---|---|
| `i` | `str x17, [sp]` | `str w17, [sp]` | `[sp+0]` |
| `j` | `str x17, [sp, #0x8]` | `str w17, [sp, #0x4]` | `[sp+4]` |
| `k` | `str x17, [sp, #0x10]` | `str w17, [sp, #0x8]` | `[sp+8]` |

The outgoing region shrank from `sub sp, sp, #0x20` to `#0x10` to match.

`linux-arm64` is **byte-identical** before and after, on this repro and on the entire
`int/surface/c-variadic` program (about 16k lines of emitted `darwin-aarch64` assembly
across the case and all of `std`, diffed clean against a compiler built from `dev`).
That diff is also the proof the **variadic path is unchanged**: the c-variadic fixture
compiles to the same bytes for `darwin-aarch64` after the fix.

## Evidence: the new case fails before the fix

`int/surface/narrow-stack-args` links a clang-built C object with two >8-argument,
narrow-tailed **fixed** signatures and asserts every value round-trips. Emitted stack
stores for `narrow_tail(out, 1..7, 9::i32, 10::i16, 11::i8, 12::i32, 13::i64)`:

| | `dev` compiler | this branch | clang, Apple arm64 | clang, aarch64-linux |
|---|---|---|---|---|
| `i: i32` | `str x17, [sp]` | `str w17, [sp]` | `[sp+0]` | `[sp+0]` |
| `j: i16` | `str x17, [sp, #0x8]` | `strh w17, [sp, #0x4]` | `[sp+4]` | `[sp+8]` |
| `k: i8` | `str x17, [sp, #0x10]` | `strb w17, [sp, #0x6]` | `[sp+6]` | `[sp+16]` |
| `l: i32` | `str x17, [sp, #0x18]` | `str w17, [sp, #0x8]` | `[sp+8]` | `[sp+24]` |
| `m: i64` | `str x8, [sp, #0x20]` | `str x8, [sp, #0x10]` | `[sp+16]` | `[sp+32]` |

and for `float_tail(..., 9.5::f32, 10.5::f32, 11.5::f64)`, `dev` emits `str d16, [sp]` /
`str d17, [sp, #0x8]` / `str d18, [sp, #0x10]` against clang's `[sp+0]`, `[sp+4]`,
`[sp+8]`; this branch emits `str s16, [sp]` / `str s17, [sp, #0x4]` / `str d18, [sp, #0x8]`.

So against the `dev` compiler the clang-built callee reads four of the five integer tail
values and two of the three float ones out of bytes a different argument was written
into. The `linux-arm64` column is unchanged by this branch and matches
`clang --target=aarch64-linux-gnu` exactly.

## What is structural and what needs CI

**Settled here (linux host).** The emitted offsets and store widths above for both
arm64 targets, `linux-arm64` byte-identity, the `darwin-aarch64` variadic-path
byte-identity, `mach test .` (1167 passed, 0 failed, up from 1163 with 4 new tests), the
full `int/run.sh --target linux` suite green including the new case, and the self-host
fixpoint (`a` -> `b` -> `c`, `b == c`).

**Only CI can settle it.** The *executing* half of `narrow-stack-args` on
`darwin-aarch64`. A linux host cannot run a darwin-aarch64 binary, so the round-trip
assertion itself is proven by the `macos-15` leg, which is `main`-cadence per
`int/targets.conf`. The same applies to `linux-arm64` execution of the new case: the
case's C half is built by the runner's native `cc`, so it cannot be cross-linked here.
The offsets above are the structural evidence standing in for both until those legs run.
