### PR TITLE
fix(dwarf): reserve line-table file slot 0 for the CU primary source

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -1448,12 +1448,14 @@ elf_seg_identical() {
 # produce_debuginfo <runmode> <target> <nog_binary> <g_binary>
 # the binary-inspection producer for the debuginfo case kind (#2039): asserts, purely
 # host-side over the artifacts run.sh built with and without `-g`, that (1) the
-# standard structural validator accepts the whole `-g` image, (2) `-g` is loadable-
-# byte additive, and (3) duplicate generic, comptime-value, and pack instances retain
+# standard structural validator accepts the whole `-g` image, (1b) a real consumer
+# (addr2line, i.e. libbfd) decodes the line table without a diagnostic and resolves the
+# entry point to a name, (2) `-g` is loadable-byte additive, and (3) duplicate generic,
+# comptime-value, and pack instances retain
 # one live, symbolizable DIE while each discarded copy carries DWARF's dead-code address,
 # has no line-table sequence at the winner, and has no location list at the winner.
 # the facts are ISA-independent, so the golden is shared. requires llvm-dwarfdump,
-# llvm-symbolizer, and readelf on the leg; a missing validator is a hard error.
+# llvm-symbolizer, readelf, and addr2line on the leg; a missing tool is a hard error.
 produce_debuginfo() {
     nog=$3
     g=$4
@@ -1466,11 +1468,36 @@ produce_debuginfo() {
     command -v readelf >/dev/null 2>&1 || {
         echo "int: debuginfo: readelf not found (install 'binutils')" >&2; return 2
     }
+    command -v addr2line >/dev/null 2>&1 || {
+        echo "int: debuginfo: addr2line not found (install 'binutils')" >&2; return 2
+    }
 
     if "$dd_tool" --verify "$g" >/dev/null 2>&1; then
         echo "dwarfdump_verify=clean"
     else
         echo "dwarfdump_verify=errors"
+    fi
+
+    # CONSUMER-SIDE DECODE (#2582). --verify above checks structural and reference
+    # integrity; it does NOT check that the line program decodes against the file table
+    # the way a consumer reads it, so it accepted a .debug_line that binutils rejected
+    # outright ("mangled line number section (bad file number)") on every CU. addr2line
+    # is the cheapest standard consumer of that decode - the same libbfd path perf, gdb,
+    # and most crash symbolizers reach - so its stderr is the observable, verbatim when
+    # non-empty so a regression names itself in the diff rather than reading `errors`.
+    # the entry point is the address because every leg's image has one at a known place.
+    entry=$(readelf -hW "$g" 2>/dev/null | awk '/Entry point address:/{print $NF}')
+    a2l_err=$(addr2line -f -e "$g" "$entry" 2>&1 >/dev/null | sed -n '1p')
+    a2l_fn=$(addr2line -f -e "$g" "$entry" 2>/dev/null | sed -n '1p')
+    if [ -n "$a2l_err" ]; then
+        echo "addr2line_stderr=$a2l_err"
+    else
+        echo "addr2line_stderr=clean"
+    fi
+    if [ -n "$a2l_fn" ] && [ "$a2l_fn" != "??" ]; then
+        echo "addr2line_entry=resolved"
+    else
+        echo "addr2line_entry=unresolved"
     fi
 
     if elf_seg_identical "$g" "$nog"; then

--- a/int/surface/debuginfo/case.conf
+++ b/int/surface/debuginfo/case.conf
@@ -1,6 +1,7 @@
 # binary-inspection case: builds the fixture with and without `-g` and asserts, over
-# the artifacts, that llvm-dwarfdump --verify accepts the multi-TU `-g` image and that
-# `-g` perturbs no loadable segment (byte-additivity). the two facts are ISA-independent,
+# the artifacts, that llvm-dwarfdump --verify accepts the multi-TU `-g` image, that a
+# real consumer (addr2line) decodes its line table without a diagnostic, and that
+# `-g` perturbs no loadable segment (byte-additivity). the facts are ISA-independent,
 # so the golden is shared and the case runs on each ELF leg for that leg's own target,
 # covering x86_64 / aarch64 / riscv64. windows (CodeView) and darwin (Mach-O) debug info
 # have distinct validators and are out of scope here.

--- a/int/surface/debuginfo/expect.txt
+++ b/int/surface/debuginfo/expect.txt
@@ -1,4 +1,6 @@
 dwarfdump_verify=clean
+addr2line_stderr=clean
+addr2line_entry=resolved
 g_additive=yes
 weak_ident_dies=live:1,dead:1
 weak_ident_symbol=ident

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -337,7 +337,7 @@ fun resolve(itn: *intern.Interner, id: intern.StrId) str {
 # disp:      readable source name for DW_AT_name, or STR_NIL to fall back to `name`
 # disp_off:  byte offset of the DW_AT_name string within `.debug_str`
 # external:  true when the symbol has global linkage (DW_AT_external)
-# decl_file: 0-based DWARF file index of the function's first row, or 0
+# decl_file: DWARF file slot of the function's first row, or 0 (the primary file)
 # decl_line: 1-based source line of the function's first row, or 0
 # ret_ty:    index into the type table for the return type, or -1 when the return is
 #            void or an unresolved type (no DW_AT_type)
@@ -474,7 +474,7 @@ rec LocRange {
 # func_idx:    index of the enclosing DwFunc (subprogram) in the subs array
 # callee:      inlined callee's symbol name (DW_AT_abstract_origin target)
 # origin_off:  `.debug_info` offset of the callee's abstract-instance subprogram DIE
-# call_file:   1-based DWARF file index of the call site (DW_AT_call_file)
+# call_file:   DWARF file slot of the call site (DW_AT_call_file)
 # call_line:   1-based source line of the call site (DW_AT_call_line)
 # parent:      enclosing instance's 1-based site id within the same function (0 = directly
 #              under the subprogram), for nested inlines
@@ -1025,31 +1025,51 @@ fun frame_base_omit_reg(tgt: *target.Target) i32 {
 val MAX_FILES: u32 = 256;
 
 # a compile unit's source-file table, mapping the encoder rows' `source.FileId`s to
-# 0-based DWARF file indices in first-seen order
+# DWARF file slots in first-seen order.
+#
+# the emitted table reserves slot 0 for the CU's primary source file (DWARF 5 §6.2.4
+# requires it to match the CU DIE's DW_AT_name) and lists the interned ids from slot 1
+# up, so `ids[i]` is DWARF slot `i + 1`. slot 1 must exist whenever the line program
+# has any row: DWARF 5 §6.2.2 gives the state machine's `file` register an initial
+# value of 1, and a consumer materializes that register at the start of every sequence
+# before any DW_LNS_set_file is seen. reserving slot 0 also keeps `DW_AT_decl_file` /
+# `DW_AT_call_file` 0 meaningful (the primary file) when a location cannot be recovered.
 # ---
-# ids:   the distinct FileIds, in first-seen order (dwarf index = array index)
-# count: number of files
+# ids:   the distinct FileIds, in first-seen order (dwarf slot = array index + 1)
+# count: number of interned files (the emitted table holds one more)
 rec FileTable {
     ids:   [256]source.FileId;
     count: u32;
 }
 
-# find or append `id` in the file table, returning its 0-based DWARF file index, or
-# -1 when the table is full
+# find or append `id` in the file table, returning its DWARF file slot, or -1 when the
+# table is full
 # ---
 # ft: the file table to search / grow
 # id: the FileId to intern into the table
-# ret: the 0-based dwarf file index, or -1 on overflow
+# ret: the dwarf file slot (1-based), or -1 on overflow
 fun file_index(ft: *FileTable, id: source.FileId) i32 {
-    var i: u32 = 0;
-    for (i < ft.count) {
-        if (ft.ids[i] == id) { ret i::i32; }
-        i = i + 1;
-    }
+    val hit: i32 = file_slot(ft, id);
+    if (hit >= 0) { ret hit; }
     if (ft.count >= MAX_FILES) { ret -1; }
     ft.ids[ft.count] = id;
     ft.count = ft.count + 1;
-    ret (ft.count - 1)::i32;
+    ret ft.count::i32;
+}
+
+# look `id` up in the file table without growing it, for the emission passes that run
+# after the line header has committed the table's size
+# ---
+# ft: the file table to search
+# id: the FileId to look up
+# ret: the dwarf file slot (1-based), or -1 when `id` is not interned
+fun file_slot(ft: *FileTable, id: source.FileId) i32 {
+    var i: u32 = 0;
+    for (i < ft.count) {
+        if (ft.ids[i] == id) { ret (i + 1)::i32; }
+        i = i + 1;
+    }
+    ret -1;
 }
 
 # copy a byte buffer's contents into a fresh image-owned, exactly-sized allocation
@@ -2274,11 +2294,12 @@ fun emit_row(b: *enc.ByteBuf, addr_delta: u32, line_delta: i32) {
 # text_sec:     the `.text` section index (rows outside it are ignored)
 # address_size: target pointer width in bytes
 # comp_dir:     the compilation directory (line-header directory 0)
-# ft:           the built file table (line-header file entries)
+# name:         the CU's primary source path (DW_AT_name), emitted as file slot 0
+# ft:           the built file table (line-header file entries), read only here
 # b:            out - the line-program bytes
 # addr_off:     out - per-function byte offset of the set_address address field
 fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow, row_count: u32,
-               text_sec: u32, address_size: u8, comp_dir: str, ft: *FileTable,
+               text_sec: u32, address_size: u8, comp_dir: str, name: str, ft: *FileTable,
                b: *enc.ByteBuf, addr_off: *u32) {
     val len_pos: usize = b.len;
     enc.emit_u32(b, 0);              # unit_length (backpatched)
@@ -2307,11 +2328,15 @@ fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.Line
     uleb(b, 1);
     emit_cstr(b, comp_dir);
 
-    # file table: two format fields (path/string, dir_index/udata), one entry per file.
+    # file table: two format fields (path/string, dir_index/udata). slot 0 is the CU's
+    # primary source file (matching DW_AT_name), then one entry per interned file, so
+    # the state machine's initial `file` register of 1 always names a declared entry.
     enc.emit_byte(b, 2);
     uleb(b, DW_LNCT_path::u64);            uleb(b, DW_FORM_string::u64);
     uleb(b, DW_LNCT_directory_index::u64); uleb(b, 0x0F::u64);  # DW_FORM_udata
-    uleb(b, ft.count::u64);
+    uleb(b, (ft.count + 1)::u64);
+    emit_cstr(b, name);
+    uleb(b, 0);
     var fi: u32 = 0;
     for (fi < ft.count) {
         emit_cstr(b, file_path(s, ft.ids[fi]));
@@ -2381,27 +2406,29 @@ fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.Line
     bin.write_u32_le(b.data, len_pos, (b.len - ul_end)::u32);
 }
 
-# a resolved (dwarf file index, 1-based line) for a source location
+# a resolved (dwarf file slot, 1-based line) for a source location
 # ---
-# file: 0-based dwarf file index
+# file: dwarf file slot (0 is the CU's primary source file)
 # line: 1-based source line
 rec PosLine {
     file: u32;
     line: i32;
 }
 
-# resolve a source location to its dwarf file index and 1-based line, defaulting to
-# (0, 1) when the file or position cannot be recovered
+# resolve a source location to its dwarf file slot and 1-based line, defaulting to
+# (0, 1) - the CU's primary file, first line - when the file or position cannot be
+# recovered. lookup only: the table is grown by the pre-pass that runs before the line
+# header commits its size, never by an emission pass reading it back
 # ---
 # s:   session, for the source map
 # loc: the source location to resolve
 # ft:  the file table (already populated with this loc's file)
-# ret: the (file index, line) pair
+# ret: the (file slot, line) pair
 fun pos_of(s: *session.Session, loc: source.SrcLoc, ft: *FileTable) PosLine {
     var out: PosLine;
     out.file = 0;
     out.line = 1;
-    val fx: i32 = file_index(ft, loc.file);
+    val fx: i32 = file_slot(ft, loc.file);
     if (fx >= 0) { out.file = fx::u32; }
     val fo: O.Option[*source.SourceFile] = source.get(?s.sources, loc.file);
     if (O.is_some[*source.SourceFile](fo)) {
@@ -2656,7 +2683,8 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, mir
         fi0 = fi0 + 1;
     }
 
-    # pre-populate the file table so the line header lists every file it references.
+    # pre-populate the file table so the line header lists every file it references;
+    # every later pass only reads it back, so no slot can appear after the header.
     var ft: FileTable;
     ft.count = 0;
     var r: u32 = 0;
@@ -2858,7 +2886,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, mir
     val type_fixups: *TypeFixup = R.unwrap_ok[*TypeFixup, str](rfx);
 
     build_abbrev(?b_abbrev);
-    build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, ?ft, ?b_line, addr_off);
+    build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, name, ?ft, ?b_line, addr_off);
     # loclists / rnglists before info: they stamp each variable's `loclist_off` and each
     # instance's `rnglist_off`, which build_info patches into the sec_offset fields.
     if (has_loclists) {
@@ -3097,8 +3125,7 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
                 di.call_line = pl.line::u32;
             }
             or {
-                # no call-site location: attribute to the enclosing function's file rather
-                # than file index 0, which is out of range when the file table is empty.
+                # no call-site location: attribute to the enclosing function's file.
                 di.call_file = funcs[i].decl_file;
                 di.call_line = funcs[i].decl_line;
             }
@@ -4401,7 +4428,7 @@ test "mach.lang.be.codegen.dwarf.build_line:prologue_end_and_entry_row" {
     var ft: FileTable; ft.count = 0;
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     var addr_off: [1]u32; addr_off[0] = 0;
-    build_line(?s, ?fn, 1, ?row, 1, 0, 8, "/", ?ft, ?b, ?addr_off[0]);
+    build_line(?s, ?fn, 1, ?row, 1, 0, 8, "/", "/", ?ft, ?b, ?addr_off[0]);
 
     # exactly one DW_LNS_set_prologue_end for the one function. scan the program past the
     # DW_LNE_set_address address field (addr_off records its start) so no header u32 length
@@ -4410,6 +4437,53 @@ test "mach.lang.be.codegen.dwarf.build_line:prologue_end_and_entry_row" {
     var i: usize = (addr_off[0] + 8)::usize;
     for (i < b.len) { if (b.data[i] == DW_LNS_set_prologue_end) { pe = pe + 1; } i = i + 1; }
     if (pe != 1) { code = 1; }
+
+    enc.buf_dnit(?b);
+    session.dnit(?s);
+    ret code;
+}
+
+# DWARF 5 §6.2.2 gives the line state machine's `file` register an initial value of 1,
+# which a consumer materializes at the start of every sequence before any
+# DW_LNS_set_file. the emitted file table must therefore always declare a slot 1, so
+# build_line reserves slot 0 for the CU's primary source and lists the interned files
+# from 1 up (binutils' addr2line rejected the whole section otherwise, #2582)
+test "mach.lang.be.codegen.dwarf.build_line:file_table_declares_slot_one" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var code: i32 = 0;
+
+    var fn: DwFunc;
+    fn.name = intern.STR_NIL; fn.offset = 0; fn.size = 16; fn.weak = false;
+    fn.disp = intern.STR_NIL; fn.disp_off = 0; fn.external = false;
+    fn.decl_file = 0; fn.decl_line = 1; fn.ret_ty = -1; fn.var_start = 0; fn.var_count = 0;
+
+    # one interned source file, as a single-file compile unit has.
+    var ft: FileTable; ft.count = 0;
+    if (file_index(?ft, 7::source.FileId) != 1) { code = 1; }
+    if (file_slot(?ft, 7::source.FileId) != 1) { code = 1; }
+    if (file_slot(?ft, 9::source.FileId) != -1) { code = 1; }
+
+    var row: enc.LineRow;
+    row.text_offset = 8; row.sec = 0; row.loc.file = 7::source.FileId; row.loc.offset = 0;
+
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    var addr_off: [1]u32; addr_off[0] = 0;
+    build_line(?s, ?fn, 1, ?row, 1, 0, 8, "/", "/", ?ft, ?b, ?addr_off[0]);
+
+    # walk to the file-entry count: 30 fixed header bytes, then the directory table
+    # (format count, one two-byte format pair, entry count, the one-byte comp_dir plus
+    # its NUL), then the file format count and its two two-byte pairs.
+    val fc: usize = 30 + 1 + 2 + 1 + 2 + 1 + 4;
+    if (b.data[fc] != 2) { code = 1; }
+    if (b.data[fc - 1] != 0x0F) { code = 1; }
+
+    # and the row names slot 1, not slot 0.
+    var sf: usize = (addr_off[0] + 8)::usize;
+    if (b.data[sf] != DW_LNS_set_file || b.data[sf + 1] != 1) { code = 1; }
 
     enc.buf_dnit(?b);
     session.dnit(?s);


### PR DESCRIPTION
Closes #2582

## Root cause

DWARF 5 §6.2.2 gives the line state machine's `file` register an initial value of **1**, which a consumer materializes at the start of every sequence, before any `DW_LNS_set_file` is seen. `build_line` (`src/lang/be/codegen/dwarf.mach`) interned the CU's files from slot **0** up, so a single-file compile unit declared exactly one entry and no slot 1 existed. binutils' `concat_filename` is reached unconditionally per sequence via

```c
      if (table->num_files)
	{
	  /* PR 30783: Always start with a file index of 1, even
	     for DWARF-5.  */
	  filename = concat_filename (table, 1);
	}
```

and rejects the section with `mangled line number section (bad file number)`. Every `DW_LNS_set_file` we emitted was in range, which is why `llvm-dwarfdump --verify` and `--debug-line` both saw nothing wrong.

## The fix

Slot 0 now holds the CU's primary source file (DWARF 5 §6.2.4 requires it to match the CU DIE's `DW_AT_name`, which it now does by construction) and the interned files are listed from slot 1 up. That is the shape gcc and clang both emit, and it makes `DW_AT_decl_file` / `DW_AT_call_file` 0 mean "the primary file" rather than being out of range on an empty table — the hazard the `gather_inlines` fallback comment already named.

A second, latent hole in the same encoder: `pos_of` called `file_index`, which **appends**. The pre-pass that sizes the table skips rows whose loc is `FILE_NIL`, but `build_line`'s program loop did not, so such a row could add an entry *after* the header had already written the count. `pos_of` now uses a non-mutating `file_slot` and resolves an uninterned file to the primary slot; only the pre-pass and the call-site interning grow the table, both before the header commits.

## Verification, and why the old check missed this

`int/surface/debuginfo` runs `llvm-dwarfdump --verify` and nothing else. `--verify` checks structural and reference integrity, not that the line program decodes against the file table the way a consumer reads it, so it was green on a binary `addr2line` rejected outright.

The case now also runs `addr2line` over the image's entry point and takes its stderr as the observable, verbatim when non-empty so a regression names itself in the diff. Against the **pre-fix** compiler:

```
 dwarfdump_verify=clean
-addr2line_stderr=clean
+addr2line_stderr=addr2line: DWARF error: mangled line number section (bad file number)
 addr2line_entry=resolved
 g_additive=yes
```

`FAIL surface/debuginfo [linux/debug]` and `[linux/release]` — the two facts disagreeing in one diff is the gap itself. Against the fixed compiler both profiles pass.

A unit test, `build_line:file_table_declares_slot_one`, pins the invariant directly: the emitted header declares `ft.count + 1` entries and the row names slot 1.

## Evidence

Reproduction exactly as the issue states it, a release `-g` self-build:

```
$ addr2line -f -e mach.g 0x400de9        # before
addr2line: DWARF error: mangled line number section (bad file number)
...(118 times)...
unwrap
./././dep/mach-std/src/types/option.mach:54

$ addr2line -f -e mach.g 0x400de9        # after
unwrap
./././dep/mach-std/src/types/option.mach:54
```

`llvm-dwarfdump --verify` stays clean on the same binary.

## Status

- `mach test .` — 1168 passed, 0 failed (1167 on `dev`, +1 new)
- `int/run.sh --target linux` — all cases passed
- self-host fixpoint — `cmp b c` identical