### PR TITLE
diag(codegen): locate IR verifier failures at the offending instruction

### DIFF
--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -307,7 +307,7 @@ fun build_dispatch_executable(p: *driver.Project, unit: *plan.BuildUnit, obj_bas
     }
     var entry_ir: ir.Module = R.unwrap_ok[ir.Module, str](res_synth);
 
-    val res_opt: R.Result[bool, str] = pipeline.run(?entry_ir, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ctx.req.float_reassoc, ?p.s.interner);
+    val res_opt: R.Result[bool, str] = pipeline.run(?entry_ir, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ctx.req.float_reassoc, ?p.s.interner, ?p.s.sources);
     if (R.is_err[bool, str](res_opt)) {
         ir.dnit(?entry_ir);
         ret R.err[bool, outcome.Fail](outcome.internal(R.unwrap_err[bool, str](res_opt)));

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1198,7 +1198,7 @@ fun lower_raw(p: *project.Project, mid: session.ModuleId, home: *ir.ModuleHome, 
 fun lower_optimize(p: *project.Project, irmod: *ir.Module, main_id: intern.StrId) R.Result[bool, str] {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
 
-    val res_opt: R.Result[bool, str] = pipeline.run(irmod, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ctx.req.float_reassoc, ?p.s.interner);
+    val res_opt: R.Result[bool, str] = pipeline.run(irmod, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ctx.req.float_reassoc, ?p.s.interner, ?p.s.sources);
     if (R.is_err[bool, str](res_opt)) { ret res_opt; }
 
     if (main_id != intern.STR_NIL) { testrunner.neutralize_main(main_id, irmod); }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -19,12 +19,17 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use std.format;
+
 use mach.lang.intern;
+use mach.lang.query;
+use mach.lang.source;
 use semtype: mach.lang.type;
 use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
@@ -199,6 +204,102 @@ pub fun describe(check: VerifyCheck) str {
     if (check == VC_TYPE_AGREE)      { ret "type agreement: operand types violate the opcode's typing contract"; }
     if (check == VC_CALL_ARG_TYPE)   { ret "call argument typing: a call argument's type disagrees with the callee's declared parameter"; }
     ret "unknown verification check";
+}
+
+# the source location of the instruction a violation names, or loc_nil
+#
+# A function- or block-level violation carries INSTR_NIL and has no instruction to
+# read a location from; so does a violation whose instruction lowered from
+# compiler-synthesized IR the builder stamped no location onto.
+# ---
+# m: the module the violation was recorded against
+# v: the violation to locate
+# ret: the offending instruction's location, or loc_nil when there is none
+pub fun violation_loc(m: *ir.Module, v: *Violation) source.SrcLoc {
+    if (m == nil || v == nil)              { ret source.loc_nil(); }
+    if (v.function >= m.function_len)      { ret source.loc_nil(); }
+    val fn: *ir.Function = ?m.functions[v.function];
+    if (v.instr == id.INSTR_NIL)           { ret source.loc_nil(); }
+    if (v.instr::u32 >= fn.instr_len)      { ret source.loc_nil(); }
+    ret fn.instrs[v.instr].loc;
+}
+
+# render `<module>.<function>` for the function a violation fired in
+#
+# Falls back to a placeholder per component rather than dropping the qualifier, so
+# the shape of the name is the same whether or not the interner can resolve it.
+fun violation_scope(m: *ir.Module, v: *Violation, itn: *intern.Interner, alloc: *A.Allocator) str {
+    var mod: str = "<unknown module>";
+    val om: O.Option[str] = intern.lookup(itn, m.name);
+    if (O.is_some[str](om)) { mod = O.unwrap[str](om); }
+
+    # prefer the bare source name over the mangled linkage symbol: this message is
+    # read by a developer looking for a function in a file. the same fallback the
+    # dwarf producer uses, since `disp` is unset for a synthesized function.
+    var fname: str = "<unknown function>";
+    if (v.function < m.function_len) {
+        val fn: *ir.Function = ?m.functions[v.function];
+        var nm: intern.StrId = fn.disp;
+        if (nm == intern.STR_NIL) { nm = fn.name; }
+        val of: O.Option[str] = intern.lookup(itn, nm);
+        if (O.is_some[str](of)) { fname = O.unwrap[str](of); }
+    }
+
+    val rj: R.Result[str, str] = format.sprint(alloc, "{}.{}", mod, fname);
+    if (R.is_err[str, str](rj)) { ret fname; }
+    ret R.unwrap_ok[str, str](rj);
+}
+
+# render `<path>:<line>:<col>` for a location, or none when it names no loaded file
+fun violation_where(l: source.SrcLoc, srcmap: *source.SourceMap, alloc: *A.Allocator) O.Option[str] {
+    if (!source.loc_is_valid(l)) { ret O.none[str](); }
+    if (srcmap == nil)           { ret O.none[str](); }
+    val of: O.Option[*source.SourceFile] = source.get(srcmap, l.file);
+    if (O.is_none[*source.SourceFile](of)) { ret O.none[str](); }
+    val f: *source.SourceFile = O.unwrap[*source.SourceFile](of);
+
+    val p: source.Position = source.position(f, l.offset);
+    val rj: R.Result[str, str] = format.sprint(alloc, "{}:{}:{}", f.path, p.line, p.col);
+    if (R.is_err[str, str](rj)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](rj));
+}
+
+# format a violation as a located internal-compiler-error message
+#
+# A verifier failure is a compiler bug, so this is the message a developer bisects
+# with: it names the check, the module and function it fired in, and the source
+# location of the offending instruction. The location is what makes the message
+# greppable - without it every occurrence of a given check reads identically no
+# matter which function is at fault (#2538).
+#
+# A location is not always available: a function- or block-level check names no
+# instruction, and compiler-synthesized IR carries no source origin. That case says
+# so explicitly rather than silently degrading to a message that reads as though it
+# forgot, which is the outcome #2538 rules out.
+# ---
+# m:      the module the violation was recorded against
+# v:      the violation to format
+# itn:    interner resolving module and function names
+# srcmap: source map resolving a SrcLoc to path:line:col, or nil when unavailable
+# alloc:  allocator the returned message is built on
+# ret:    the formatted message (on `alloc`), or a static fallback on format failure
+pub fun describe_located(m: *ir.Module, v: *Violation, itn: *intern.Interner,
+                         srcmap: *source.SourceMap, alloc: *A.Allocator) str {
+    val what: str = describe(v.check);
+    if (m == nil || v == nil) { ret what; }
+
+    val scope: str = violation_scope(m, v, itn, alloc);
+    val where: O.Option[str] = violation_where(violation_loc(m, v), srcmap, alloc);
+
+    var rj: R.Result[str, str];
+    if (O.is_some[str](where)) {
+        rj = format.sprint(alloc, "{} (in {}, at {})", what, scope, O.unwrap[str](where));
+    }
+    or {
+        rj = format.sprint(alloc, "{} (in {}; no source location available for this check)", what, scope);
+    }
+    if (R.is_err[str, str](rj)) { ret what; }
+    ret R.unwrap_ok[str, str](rj);
 }
 
 # validates one function, recording violations into the report. extern functions
@@ -2236,4 +2337,119 @@ test "mach.lang.me.ir.verify.check_call_arg_types:vector_param_accepts_by_addres
     env.m.functions[0].instrs[cid].operands[1].ty = env.i64ty;
     if (t_count(?env, false, false, VC_CALL_ARG_TYPE) < 1) { ret 1; }
     ret 0;
+}
+
+# a verifier failure names the module, the function, and the source location of the
+# offending instruction (#2538)
+#
+# The spanless form this replaces ("constant typing: constant carries an
+# incompatible type" and nothing else) is identical no matter which function is at
+# fault, so it can only be localized by bisecting the module. Asserting each
+# component of the location separately is what keeps a future check from regressing
+# to that: dropping the srcmap lookup, the interner lookup, or the whole qualifier
+# each fails a different line here.
+test "mach.lang.me.ir.verify.describe_located:names_module_function_and_position" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    var itn: intern.Interner = intern.init(?env.alloc);
+    val res_db: R.Result[query.QueryDb, str] = query.init(?env.alloc);
+    if (R.is_err[query.QueryDb, str](res_db)) { ret 1; }
+    var db: query.QueryDb = R.unwrap_ok[query.QueryDb, str](res_db);
+    var smap: source.SourceMap = source.init(?env.alloc);
+
+    val res_fid: R.Result[source.FileId, str] = source.add(?smap, ?db, "./src/probe.mach", "ab\ncde\nf");
+    if (R.is_err[source.FileId, str](res_fid)) { ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_mod: R.Result[intern.StrId, str] = intern.intern(?itn, "probe.mod");
+    if (R.is_err[intern.StrId, str](res_mod)) { ret 1; }
+    env.m.name = R.unwrap_ok[intern.StrId, str](res_mod);
+
+    val res_fn: R.Result[intern.StrId, str] = intern.intern(?itn, "offender");
+    if (R.is_err[intern.StrId, str](res_fn)) { ret 1; }
+    env.m.functions[0].disp = R.unwrap_ok[intern.StrId, str](res_fn);
+
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+    builder.set_block(?env.bld, b0);
+
+    # offset 4 is 'd', the second character of the second line of the file above.
+    builder.set_loc(?env.bld, source.loc(fid, 4));
+    # a store whose destination operand is an integer rather than an address: an
+    # invariant violation the repr checks record against this instruction.
+    if (R.is_err[bool, str](builder.emit_store(?env.bld, t_ci(?env, 1), t_ci(?env, 0)))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))                            { ret 1; }
+
+    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, false, true);
+    if (R.is_err[VerifyReport, str](rr)) { ret 1; }
+    var rep: VerifyReport = R.unwrap_ok[VerifyReport, str](rr);
+    if (rep.len == 0) { dnit_report(?rep); ret 1; }
+
+    val msg: str = describe_located(?env.m, ?rep.violations[0], ?itn, ?smap, ?env.alloc);
+    dnit_report(?rep);
+
+    var code: i32 = 0;
+    # the check itself still names the invariant
+    if (!str_contains(msg, "type agreement"))         { code = 1; }
+    # the module and function it fired in
+    if (!str_contains(msg, "probe.mod.offender"))     { code = 1; }
+    # the file, and the line:col the byte offset resolves to
+    if (!str_contains(msg, "./src/probe.mach"))       { code = 1; }
+    if (!str_contains(msg, "2:2"))                    { code = 1; }
+    # and it does not claim a location is missing while carrying one
+    if (str_contains(msg, "no source location"))      { code = 1; }
+
+    source.dnit(?smap);
+    query.dnit(?db);
+    intern.dnit(?itn);
+    ret code;
+}
+
+# a violation with no instruction to locate says so, rather than degrading to a
+# message that reads as though it forgot (#2538)
+#
+# A function- or block-level check names no instruction, and a compiler-synthesized
+# instruction carries no source origin, so a spanless message is legitimately
+# reachable. The acceptance is that it is explicit about it: silence here is exactly
+# what made the original diagnostic unactionable.
+test "mach.lang.me.ir.verify.describe_located:spanless_says_so" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    var itn: intern.Interner = intern.init(?env.alloc);
+    var smap: source.SourceMap = source.init(?env.alloc);
+
+    val res_mod: R.Result[intern.StrId, str] = intern.intern(?itn, "probe.mod");
+    if (R.is_err[intern.StrId, str](res_mod)) { ret 1; }
+    env.m.name = R.unwrap_ok[intern.StrId, str](res_mod);
+
+    val res_fn: R.Result[intern.StrId, str] = intern.intern(?itn, "offender");
+    if (R.is_err[intern.StrId, str](res_fn)) { ret 1; }
+    env.m.functions[0].disp = R.unwrap_ok[intern.StrId, str](res_fn);
+
+    # a block-level violation: block 0 has no terminator, so the check records
+    # INSTR_NIL and there is no instruction whose loc could be read.
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+
+    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, false, false);
+    if (R.is_err[VerifyReport, str](rr)) { ret 1; }
+    var rep: VerifyReport = R.unwrap_ok[VerifyReport, str](rr);
+    if (rep.len == 0) { dnit_report(?rep); ret 1; }
+    if (rep.violations[0].instr != id.INSTR_NIL) { dnit_report(?rep); ret 1; }
+
+    val msg: str = describe_located(?env.m, ?rep.violations[0], ?itn, ?smap, ?env.alloc);
+    dnit_report(?rep);
+
+    var code: i32 = 0;
+    if (!str_contains(msg, "terminator presence"))                              { code = 1; }
+    # the scope is still named: a missing location does not cost the function name
+    if (!str_contains(msg, "probe.mod.offender"))                               { code = 1; }
+    # and the absence is stated, not implied by omission
+    if (!str_contains(msg, "no source location available for this check"))      { code = 1; }
+
+    source.dnit(?smap);
+    intern.dnit(?itn);
+    ret code;
 }

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -75,23 +75,31 @@ pub val OPT_RELEASE: OptLevel = 1;
 # float_reassoc: the resolved `[profile.X] float_reassoc` lever (#2160); when true the
 #               vectorizer may reassociate a float reduction into lane partials. false
 #               (the default) keeps every float reduction scalar and IEEE-strict
-# itn:          interner, consulted only on the require-error path to name the site
+# itn:          interner, naming the site on the require-error path and the module
+#               and function on a verifier failure
+# srcmap:       source map, resolving the offending instruction's SrcLoc to
+#               path:line:col on a verifier failure; nil when unavailable
 # ret:          ok(true) on a clean pipeline, or an internal-compiler-error / a
 #               require-mode build-error message
-pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool, vectorize_enabled: bool, simd_require: bool, float_reassoc: bool, itn: *intern.Interner) R.Result[bool, str] {
+pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool, vectorize_enabled: bool, simd_require: bool, float_reassoc: bool, itn: *intern.Interner, srcmap: *source.SourceMap) R.Result[bool, str] {
+    var vc: VerifyCtx;
+    vc.verify_ir = verify_ir;
+    vc.itn       = itn;
+    vc.srcmap    = srcmap;
+
     # entry verification sanity-checks the lowered input. reachability and
     # dominance are not enforced here: freshly-lowered IR still carries the
     # unreachable blocks the lowerer parks after terminators, which dce removes
     # below. the representation checks stay opt-in via verify_stage; the
     # always-on entry/exit runs keep repr=false until a clean self-host promotes
     # them.
-    val res_verify_in: R.Result[bool, str] = run_verify(m, false, false);
+    val res_verify_in: R.Result[bool, str] = run_verify(m, false, false, ?vc);
     if (R.is_err[bool, str](res_verify_in)) { ret res_verify_in; }
 
     # mem2reg always runs: code generation expects mostly-SSA input.
     val res_mem2reg: R.Result[bool, str] = mem2reg.run(m);
     if (R.is_err[bool, str](res_mem2reg)) { ret res_mem2reg; }
-    val res_verify_mem2reg: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+    val res_verify_mem2reg: R.Result[bool, str] = verify_stage(m, false, ?vc);
     if (R.is_err[bool, str](res_verify_mem2reg)) { ret res_verify_mem2reg; }
 
     # constfold always runs: with locals in SSA after mem2reg, constant operands
@@ -100,7 +108,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
     # it produces the exact runtime value, so it is correct at every level.
     val res_constfold: R.Result[bool, str] = constfold.run(m);
     if (R.is_err[bool, str](res_constfold)) { ret res_constfold; }
-    val res_verify_constfold: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+    val res_verify_constfold: R.Result[bool, str] = verify_stage(m, false, ?vc);
     if (R.is_err[bool, str](res_verify_constfold)) { ret res_verify_constfold; }
 
     # dce always runs: beyond cleaning dead values, its reachability sweep
@@ -109,7 +117,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
     # afterward, so reachability/dominance hold (full=true).
     val res_dce: R.Result[bool, str] = dce.run(m);
     if (R.is_err[bool, str](res_dce)) { ret res_dce; }
-    val res_verify_dce: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+    val res_verify_dce: R.Result[bool, str] = verify_stage(m, true, ?vc);
     if (R.is_err[bool, str](res_verify_dce)) { ret res_verify_dce; }
 
     if (level == OPT_RELEASE) {
@@ -119,7 +127,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # they are re-checked after the late dce below.
         val res_inline: R.Result[bool, str] = inline.run(m, tgt);
         if (R.is_err[bool, str](res_inline)) { ret res_inline; }
-        val res_verify_inline: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+        val res_verify_inline: R.Result[bool, str] = verify_stage(m, false, ?vc);
         if (R.is_err[bool, str](res_verify_inline)) { ret res_verify_inline; }
 
         # post-inline mem2reg: a caller alloca whose address escaped into a call
@@ -130,7 +138,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # escape analysis.
         val res_mem2reg2: R.Result[bool, str] = mem2reg.run(m);
         if (R.is_err[bool, str](res_mem2reg2)) { ret res_mem2reg2; }
-        val res_verify_mem2reg2: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+        val res_verify_mem2reg2: R.Result[bool, str] = verify_stage(m, false, ?vc);
         if (R.is_err[bool, str](res_verify_mem2reg2)) { ret res_verify_mem2reg2; }
 
         # post-inline constfold: inlining substitutes constant arguments into
@@ -139,7 +147,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # dce removes, so reachability is not yet enforced (full=false).
         val res_constfold2: R.Result[bool, str] = constfold.run(m);
         if (R.is_err[bool, str](res_constfold2)) { ret res_constfold2; }
-        val res_verify_constfold2: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+        val res_verify_constfold2: R.Result[bool, str] = verify_stage(m, false, ?vc);
         if (R.is_err[bool, str](res_verify_constfold2)) { ret res_verify_constfold2; }
 
         # a reachability sweep before the split stage. inlining a non-returning callee
@@ -149,7 +157,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # its block's predecessor multiset. the CFG is connected afterward (full=true).
         val res_dce_pre: R.Result[bool, str] = dce.run(m);
         if (R.is_err[bool, str](res_dce_pre)) { ret res_dce_pre; }
-        val res_verify_dce_pre: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+        val res_verify_dce_pre: R.Result[bool, str] = verify_stage(m, true, ?vc);
         if (R.is_err[bool, str](res_verify_dce_pre)) { ret res_verify_dce_pre; }
 
         # scalar replacement of aggregates (#2205): decompose every small record /
@@ -161,12 +169,12 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         val res_sroa: R.Result[bool, str] = sroa.run(m, tgt);
         if (R.is_err[bool, str](res_sroa)) { ret res_sroa; }
         if (R.unwrap_ok[bool, str](res_sroa)) {
-            val res_verify_sroa: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+            val res_verify_sroa: R.Result[bool, str] = verify_stage(m, true, ?vc);
             if (R.is_err[bool, str](res_verify_sroa)) { ret res_verify_sroa; }
 
             val res_mem2reg3: R.Result[bool, str] = mem2reg.run(m);
             if (R.is_err[bool, str](res_mem2reg3)) { ret res_mem2reg3; }
-            val res_verify_mem2reg3: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+            val res_verify_mem2reg3: R.Result[bool, str] = verify_stage(m, false, ?vc);
             if (R.is_err[bool, str](res_verify_mem2reg3)) { ret res_verify_mem2reg3; }
         }
 
@@ -175,7 +183,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # construction (integer-only where float semantics differ).
         val res_algebraic: R.Result[bool, str] = algebraic.run(m);
         if (R.is_err[bool, str](res_algebraic)) { ret res_algebraic; }
-        val res_verify_algebraic: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+        val res_verify_algebraic: R.Result[bool, str] = verify_stage(m, false, ?vc);
         if (R.is_err[bool, str](res_verify_algebraic)) { ret res_verify_algebraic; }
 
         # local CSE: within each block, share a redundant pure computation with
@@ -183,14 +191,14 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # arithmetic expressions across a call boundary, which this collapses.
         val res_cse: R.Result[bool, str] = cse.run(m);
         if (R.is_err[bool, str](res_cse)) { ret res_cse; }
-        val res_verify_cse: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+        val res_verify_cse: R.Result[bool, str] = verify_stage(m, false, ?vc);
         if (R.is_err[bool, str](res_verify_cse)) { ret res_verify_cse; }
 
         # second constfold: algebra/CSE expose constants (e.g. x*0 -> 0) and may
         # feed a constant condition to a branch; fold and simplify before dce.
         val res_constfold3: R.Result[bool, str] = constfold.run(m);
         if (R.is_err[bool, str](res_constfold3)) { ret res_constfold3; }
-        val res_verify_constfold3: R.Result[bool, str] = verify_stage(m, false, verify_ir);
+        val res_verify_constfold3: R.Result[bool, str] = verify_stage(m, false, ?vc);
         if (R.is_err[bool, str](res_verify_constfold3)) { ret res_verify_constfold3; }
 
         # late dce: sweep up now-dead calls, branches, and the instructions left
@@ -198,7 +206,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # (full=true).
         val res_dce2: R.Result[bool, str] = dce.run(m);
         if (R.is_err[bool, str](res_dce2)) { ret res_dce2; }
-        val res_verify_dce2: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+        val res_verify_dce2: R.Result[bool, str] = verify_stage(m, true, ?vc);
         if (R.is_err[bool, str](res_verify_dce2)) { ret res_verify_dce2; }
 
         # loop-invariant code motion (#2204): lift work that does not change across a
@@ -210,7 +218,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # touching the CFG, so reachability/dominance still hold (full=true).
         val res_licm: R.Result[bool, str] = licm.run(m, tgt);
         if (R.is_err[bool, str](res_licm)) { ret res_licm; }
-        val res_verify_licm: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+        val res_verify_licm: R.Result[bool, str] = verify_stage(m, true, ?vc);
         if (R.is_err[bool, str](res_verify_licm)) { ret res_verify_licm; }
 
         # element-wise loop vectorization (#2141): on a capable target, recognize
@@ -225,7 +233,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
             if (R.unwrap_ok[bool, str](res_vec)) {
                 val res_dce_vec: R.Result[bool, str] = dce.run(m);
                 if (R.is_err[bool, str](res_dce_vec)) { ret res_dce_vec; }
-                val res_verify_vec: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+                val res_verify_vec: R.Result[bool, str] = verify_stage(m, true, ?vc);
                 if (R.is_err[bool, str](res_verify_vec)) { ret res_verify_vec; }
             }
         }
@@ -240,7 +248,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
     val res_lanes: R.Result[bool, str] = scalarize.expand_lane_ops(m, tgt);
     if (R.is_err[bool, str](res_lanes)) { ret res_lanes; }
     if (!tgt.model.has_lane_ops && tgt.model.has_v128) {
-        val res_verify_lanes: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+        val res_verify_lanes: R.Result[bool, str] = verify_stage(m, true, ?vc);
         if (R.is_err[bool, str](res_verify_lanes)) { ret res_verify_lanes; }
     }
 
@@ -263,13 +271,13 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         } or {
             val res_scalarize: R.Result[bool, str] = scalarize.run(m, tgt);
             if (R.is_err[bool, str](res_scalarize)) { ret res_scalarize; }
-            val res_verify_scalarize: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+            val res_verify_scalarize: R.Result[bool, str] = verify_stage(m, true, ?vc);
             if (R.is_err[bool, str](res_verify_scalarize)) { ret res_verify_scalarize; }
         }
     }
 
     # exit verification: full invariant check before the backend takes over.
-    ret run_verify(m, true, false);
+    ret run_verify(m, true, false, ?vc);
 }
 
 # the `require`-posture enforcement (#2017): reject the first would-scalarize vector
@@ -325,34 +333,55 @@ fun vector_op_name(k: instruction.InstrKind) str {
     ret "operation";
 }
 
+# everything the verifier needs beyond the module itself: the --verify-ir gate and
+# the two tables a failure is localized through
+#
+# Bundled rather than passed positionally because every stage in `run` forwards the
+# same three values unchanged, and a verifier diagnostic that grows a new input
+# should not mean editing twenty call sites again.
+# ---
+# verify_ir: gate, run the verifier after every pass with representation checks on
+# itn:       interner resolving the module and function names in a failure message
+# srcmap:    source map resolving the offending instruction's SrcLoc to
+#            path:line:col, or nil when the caller has none
+rec VerifyCtx {
+    verify_ir: bool;
+    itn:       *intern.Interner;
+    srcmap:    *source.SourceMap;
+}
+
 # run the per-stage verifier when `verify_ir` is set, otherwise pass clean
 #
 # Threads the optional --verify-ir checks that run after each pass. These always
 # enable `repr`, since the aggregate-representation checks are exactly the opt-in
 # work `verify_ir` gates.
 # ---
-# m:         module to verify in place
-# full:      enforce reachability/dominance invariants (only valid after dce)
-# verify_ir: gate, run the verifier only when set
-# ret:       ok(true) when skipped or clean, or the verifier's err
-fun verify_stage(m: *ir.Module, full: bool, verify_ir: bool) R.Result[bool, str] {
-    if (verify_ir) {
-        ret run_verify(m, full, true);
+# m:    module to verify in place
+# full: enforce reachability/dominance invariants (only valid after dce)
+# vc:   the gate and the localization tables
+# ret:  ok(true) when skipped or clean, or the verifier's err
+fun verify_stage(m: *ir.Module, full: bool, vc: *VerifyCtx) R.Result[bool, str] {
+    if (vc.verify_ir) {
+        ret run_verify(m, full, true, vc);
     }
     ret R.ok[bool, str](true);
 }
 
 # run the verifier over `m`, mapping a non-empty report into an err
 #
-# A clean module yields ok(true). The err carries the description of the first
-# violated check. `full` enforces the post-dce reachability/dominance
-# invariants; `repr` enables the opt-in aggregate-representation checks.
+# A clean module yields ok(true). The err describes the first violated check and
+# localizes it to the module, function, and source location it fired in - a
+# verifier failure is a compiler bug, and without that location every occurrence of
+# a given check reads identically no matter which function is at fault (#2538).
+# `full` enforces the post-dce reachability/dominance invariants; `repr` enables the
+# opt-in aggregate-representation checks.
 # ---
 # m:    module to verify in place
 # full: enforce reachability/dominance invariants (only valid after dce)
 # repr: enable aggregate-representation checks
-# ret:  ok(true) on a clean module, or an err naming the first violated check
-fun run_verify(m: *ir.Module, full: bool, repr: bool) R.Result[bool, str] {
+# vc:   the localization tables the message is rendered through
+# ret:  ok(true) on a clean module, or an err naming and locating the first violation
+fun run_verify(m: *ir.Module, full: bool, repr: bool, vc: *VerifyCtx) R.Result[bool, str] {
     val res_report: R.Result[verify.VerifyReport, str] = verify.verify_module_ext(m, m.alloc, full, repr);
     if (R.is_err[verify.VerifyReport, str](res_report)) {
         ret R.err[bool, str](R.unwrap_err[verify.VerifyReport, str](res_report));
@@ -362,8 +391,9 @@ fun run_verify(m: *ir.Module, full: bool, repr: bool) R.Result[bool, str] {
         verify.dnit_report(?report);
         ret R.ok[bool, str](true);
     }
-    # internal compiler error: report the first violated invariant.
-    val msg: str = verify.describe(report.violations[0].check);
+    # internal compiler error: report the first violated invariant. the message is
+    # built on the module allocator, so the driver re-homes it before releasing it.
+    val msg: str = verify.describe_located(m, ?report.violations[0], vc.itn, vc.srcmap, m.alloc);
     verify.dnit_report(?report);
     ret R.err[bool, str](msg);
 }
@@ -677,7 +707,7 @@ test "mach.lang.me.pipeline.run:simd_require_gate" {
     or { if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](radd)))) { code = 1; } }
 
     # require + incapable + vector -> a precise error naming op, function, and arch
-    val e1: R.Result[bool, str] = run(?m, ?rv, OPT_DEBUG, false, true, true, false, ?itn);
+    val e1: R.Result[bool, str] = run(?m, ?rv, OPT_DEBUG, false, true, true, false, ?itn, nil);
     if (R.is_ok[bool, str](e1)) { code = 1; }
     or {
         val msg: str = R.unwrap_err[bool, str](e1);
@@ -701,7 +731,7 @@ test "mach.lang.me.pipeline.run:simd_require_gate" {
     if (R.is_err[id.BlockId, str](rb2)) { ir.dnit(?m2); intern.dnit(?itn); ret 1; }
     builder.set_block(?b2, R.unwrap_ok[id.BlockId, str](rb2));
     if (R.is_err[bool, str](builder.emit_ret_void(?b2))) { code = 1; }
-    if (R.is_err[bool, str](run(?m2, ?rv, OPT_DEBUG, false, true, true, false, ?itn))) { code = 1; }
+    if (R.is_err[bool, str](run(?m2, ?rv, OPT_DEBUG, false, true, true, false, ?itn, nil))) { code = 1; }
     ir.dnit(?m2);
 
     intern.dnit(?itn);


### PR DESCRIPTION
Closes #2538

## Which design

#2538 offered three candidates and preferred **(1) full per-instruction locations**, sequenced with the debug-info foundation, with (2) per-function locations as an interim.

**This is (1).** The issue's cost estimate was written against a compiler where "IR `Instruction`/`Value` carry no location and the builder `emit_*` API takes no span". That is no longer true: `instruction.Instruction` has a `loc: source.SrcLoc`, `builder` stamps it from a debug-location cursor (`set_loc` / `current_loc`), and `me/lower/{stmt,expr,decl}.mach` set that cursor from each AST node's span. `pipeline.mach` already carries a test asserting an instruction's `loc` survives mem2reg, constfold, and dce.

So the expensive half of (1) is already paid for, and the interim (2) would have been strictly worse for no saving. `verify.Violation` already recorded `function` + `instr`; the location was reachable the whole time and only the reporting site in `run_verify` was discarding it.

## What changed

- `me/ir/verify.mach`: `describe_located(m, v, itn, srcmap, alloc)` renders the check, the module and function, and the offending instruction's `path:line:col`. `violation_loc` reads the instruction's stamped location; `violation_scope` prefers `Function.disp` (the bare source name) over the mangled linkage symbol, matching the dwarf producer's fallback.
- `me/pipeline.mach`: `run` takes a `*source.SourceMap` alongside the interner. The `--verify-ir` gate and the two lookup tables travel together in a `VerifyCtx` rather than as three more positional parameters through twenty `verify_stage` call sites.
- `driver/passes.mach`, `build/testing.mach`: pass `?p.s.sources`.

The message is built on the module allocator, the same channel `pipeline.run`'s `simd = "require"` diagnostic uses, so `lower_stable_err` re-homes it before the arena is released.

### The last acceptance line

> the verifier should not be able to emit a spanless diagnostic silently

A spanless case is legitimately reachable: a function- or block-level check names no instruction, and compiler-synthesized IR carries no source origin. Those render `(in <module>.<function>; no source location available for this check)` — the scope is still named, and the absence is stated rather than implied by omission.

## Before / after

Against the #2523 repro (a record-returning function ending in a bare `for { }`):

```
before: error: constant typing: constant carries an incompatible type
after:  error: constant typing: constant carries an incompatible type (in case.main.f, at ./src/main.mach:3:1)
```

## Tests

Two regression tests in `me/ir/verify.mach`, both asserting each component of the location separately so that dropping the srcmap lookup, the interner lookup, or the qualifier as a whole each fails a different line:

- `describe_located:names_module_function_and_position` — deliberately invalid IR (a store whose destination operand is an integer, not an address) at a known file offset; asserts the check name, `probe.mod.offender`, `./src/probe.mach`, the resolved `2:2`, and that it does **not** claim a missing location while carrying one.
- `describe_located:spanless_says_so` — a block-level violation (block with no terminator, recorded as `INSTR_NIL`); asserts the scope survives and that the absence is stated explicitly.

Both construct invalid IR directly and have no dependency on #2523's typing bug, which is what the acceptance line about re-pointing the repro asks for — the assertion is durable rather than tied to one defect that is about to be fixed.

**Evidence both assertions fail before the fix.** With `describe_located` reverted to the old spanless `describe(v.check)` body and everything else unchanged:

```
mach.lang.me.ir.verify    19 ok     2 FAIL     26ms
  FAIL  mach.lang.me.ir.verify.describe_located:names_module_function_and_position
  FAIL  mach.lang.me.ir.verify.describe_located:spanless_says_so

19 passed, 2 failed, 21 total
```

With the fix restored: `21 passed, 0 failed`.

Full suite: `1165 passed, 0 failed` (1163 before, +2).