### PR TITLE
fix(macho): frame static and dyld-loaded images identically

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -12,6 +12,11 @@
 #                 execution cannot observe (PE ASLR bit, macho PIE bit). dispatched
 #                 on the artifact's own magic, so it is independent of how the case
 #                 maps to a leg. no LLVM; reads little-endian fields (every runner is LE).
+#   macho-framing— walk a Mach-O executable's load commands and report how the image
+#                 is framed: the __PAGEZERO span, __TEXT's base, and the section
+#                 commands on every segment, plus which entry command it carries.
+#                 the static and dyld-loaded layouts must agree on all of it except
+#                 the entry command (#2599). no LLVM; od/dd reads only.
 #   macho-signed— structurally resolve the three x86_64 immediate-store displacements
 #                 and compare them with independent initialized-data markers, proving
 #                 SIGNED_1/_2/_4 each linked to its exact target without a mac runner.
@@ -219,8 +224,8 @@ field_macho() {
 
 # macho_segment_fields <file> <segname> — print a segment's
 # "vmaddr vmsize fileoff filesize" tuple from LC_SEGMENT_64, or fail when absent.
-# The executable writer emits section-header-less load segments, so the load
-# commands are the independent file-offset-to-VA map structural checks must use.
+# The load commands are the independent file-offset-to-VA map structural checks
+# must use; a section command's own offsets are derived from them.
 macho_segment_fields() {
     bin=$1
     want=$2
@@ -247,6 +252,72 @@ macho_segment_fields() {
     done
     echo "int: macho: segment '$want' not found" >&2
     return 2
+}
+
+# produce_macho_framing <runmode> <target> <binary>
+# Walk a Mach-O executable's load commands and report how the image is FRAMED: the
+# __PAGEZERO span, __TEXT's base, whether __PAGEZERO ends exactly where __TEXT
+# begins, then one line per LC_SEGMENT_64 naming its section commands, and finally
+# which entry command the image carries.
+#
+# The framing is what a static (LC_UNIXTHREAD) and a dyld-loaded (LC_MAIN) image
+# must have IN COMMON - the entry command is the only line that may differ between
+# the two goldens (#2599, where the non-PIE image was based a page below
+# DARWIN_BASE_ADDR, carried a __PAGEZERO one page short of 4 GiB, and emitted no
+# section commands at all, leaving `llvm-objdump -d` with nothing to disassemble).
+# Addresses other than the base are deliberately left out: they move with the
+# program's size, and the fact under test is the framing, not the layout.
+produce_macho_framing() {
+    bin=$3
+    magic=$(read_le_uint "$bin" 0 4)
+    [ "$magic" = "4277009103" ] || { echo "int: macho-framing: not a 64-bit mach-o (magic $magic)" >&2; return 2; }
+    ncmds=$(read_le_uint "$bin" 16 4)
+
+    pagezero_size=
+    text_vmaddr=
+    entry=none
+    segs=$(mktemp)
+    off=32
+    i=0
+    while [ "$i" -lt "$ncmds" ]; do
+        cmd=$(read_le_uint "$bin" "$off" 4)
+        cmdsize=$(read_le_uint "$bin" $((off + 4)) 4)
+        case "$cmd" in
+            25)   # LC_SEGMENT_64
+                name=$(dd if="$bin" bs=1 skip=$((off + 8)) count=16 2>/dev/null | tr '\0' '\n' | head -n 1)
+                vmaddr=$(read_le_uint "$bin" $((off + 24)) 8)
+                vmsize=$(read_le_uint "$bin" $((off + 32)) 8)
+                nsects=$(read_le_uint "$bin" $((off + 64)) 4)
+                [ "$name" = "__PAGEZERO" ] && pagezero_size=$vmsize
+                [ "$name" = "__TEXT" ] && text_vmaddr=$vmaddr
+                sects=
+                k=0
+                while [ "$k" -lt "$nsects" ]; do
+                    sh=$((off + 72 + k * 80))
+                    sname=$(dd if="$bin" bs=1 skip="$sh" count=16 2>/dev/null | tr '\0' '\n' | head -n 1)
+                    if [ -z "$sects" ]; then sects=$sname; else sects="$sects,$sname"; fi
+                    k=$((k + 1))
+                done
+                [ -n "$sects" ] || sects=-
+                printf 'seg %s nsects=%s sects=%s\n' "$name" "$nsects" "$sects" >>"$segs"
+                ;;
+            5)          entry=LC_UNIXTHREAD ;;   # LC_UNIXTHREAD
+            2147483688) entry=LC_MAIN ;;         # LC_MAIN (0x80000028)
+        esac
+        [ "$cmdsize" -ge 8 ] || { rm -f "$segs"; echo "int: macho-framing: zero-size load command" >&2; return 2; }
+        off=$((off + cmdsize))
+        i=$((i + 1))
+    done
+
+    [ -n "$pagezero_size" ] || { rm -f "$segs"; echo "int: macho-framing: no __PAGEZERO" >&2; return 2; }
+    [ -n "$text_vmaddr" ]   || { rm -f "$segs"; echo "int: macho-framing: no __TEXT" >&2; return 2; }
+
+    printf 'pagezero_vmsize=0x%x\n' "$pagezero_size"
+    printf 'text_vmaddr=0x%x\n' "$text_vmaddr"
+    printf 'pagezero_abuts_text=%s\n' "$(( pagezero_size == text_vmaddr ))"
+    cat "$segs"
+    rm -f "$segs"
+    printf 'entry=%s\n' "$entry"
 }
 
 # produce_macho_signed <runmode> <target> <binary>
@@ -1752,6 +1823,7 @@ produce() {
         field)       produce_field "$@" ;;
         macho-signed) produce_macho_signed "$@" ;;
         macho-got)   produce_macho_got "$@" ;;
+        macho-framing) produce_macho_framing "$@" ;;
         macho-abs-bind) produce_macho_abs_bind "$@" ;;
         pe-imports)  produce_pe_imports "$@" ;;
         pe-exceptions) produce_pe_exceptions "$@" ;;

--- a/int/surface/macho-framing-pie/case.conf
+++ b/int/surface/macho-framing-pie/case.conf
@@ -1,0 +1,8 @@
+# the dyld-loaded (LC_MAIN) darwin x86_64 layout's framing, the reference the
+# static twin macho-framing-static must match on the framing (#2599): the
+# __PAGEZERO span, __TEXT's base, and a section command on every mapped segment.
+# cross-built on the linux leg and read host-side.
+run: macho-framing
+targets: linux
+build-target: darwin-x86_64
+build-flags: --pie

--- a/int/surface/macho-framing-pie/expect.darwin-x86_64.txt
+++ b/int/surface/macho-framing-pie/expect.darwin-x86_64.txt
@@ -1,0 +1,10 @@
+pagezero_vmsize=0x100000000
+text_vmaddr=0x100000000
+pagezero_abuts_text=1
+seg __PAGEZERO nsects=0 sects=-
+seg __TEXT nsects=1 sects=__text
+seg __DATA nsects=1 sects=__data
+seg __RODATA nsects=1 sects=__const
+seg __DATA_CONST nsects=1 sects=__const
+seg __LINKEDIT nsects=0 sects=-
+entry=LC_MAIN

--- a/int/surface/macho-framing-pie/mach.toml
+++ b/int/surface/macho-framing-pie/mach.toml
@@ -1,0 +1,32 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/macho-framing-pie/src/main.mach
+++ b/int/surface/macho-framing-pie/src/main.mach
@@ -1,0 +1,15 @@
+# a minimal linked program for the macho-framing producer. the producer reads the
+# emitted image's load commands host-side and never executes it, so the body only
+# has to link, and it needs code, data, and read-only data so every mapped segment
+# the framing describes is actually present
+use std.runtime;
+use std.types.size.usize;
+
+val greeting: *u8 = "framing";
+var counter: usize = 0;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    counter = counter + greeting[0]::usize;
+    ret 0;
+}

--- a/int/surface/macho-framing-static/case.conf
+++ b/int/surface/macho-framing-static/case.conf
@@ -1,0 +1,14 @@
+# the static (LC_UNIXTHREAD) darwin x86_64 layout's framing: __PAGEZERO spans the
+# whole low 4 GiB, __TEXT is based at DARWIN_BASE_ADDR with the mach header inside
+# its first page, and every load segment carries its section commands (#2599).
+# cross-built on the linux leg and read host-side; no darwin runner is needed for
+# the framing, only for execution.
+#
+# its --pie twin is macho-framing-pie. the two goldens must agree on the framing -
+# the __PAGEZERO span, __TEXT's base, and a section command on every mapped segment.
+# they differ in the entry command, and in that only a dyld-loaded image has a
+# __DATA_CONST: that segment IS dyld's rebased-then-read-only mapping, and a static
+# image has no rebase stream, so its read-only content stays __RODATA.
+run: macho-framing
+targets: linux
+build-target: darwin-x86_64

--- a/int/surface/macho-framing-static/expect.darwin-x86_64.txt
+++ b/int/surface/macho-framing-static/expect.darwin-x86_64.txt
@@ -1,0 +1,9 @@
+pagezero_vmsize=0x100000000
+text_vmaddr=0x100000000
+pagezero_abuts_text=1
+seg __PAGEZERO nsects=0 sects=-
+seg __TEXT nsects=1 sects=__text
+seg __DATA nsects=1 sects=__data
+seg __RODATA nsects=2 sects=__const,__const
+seg __LINKEDIT nsects=0 sects=-
+entry=LC_UNIXTHREAD

--- a/int/surface/macho-framing-static/mach.toml
+++ b/int/surface/macho-framing-static/mach.toml
@@ -1,0 +1,32 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/macho-framing-static/src/main.mach
+++ b/int/surface/macho-framing-static/src/main.mach
@@ -1,0 +1,15 @@
+# a minimal linked program for the macho-framing producer. the producer reads the
+# emitted image's load commands host-side and never executes it, so the body only
+# has to link, and it needs code, data, and read-only data so every mapped segment
+# the framing describes is actually present
+use std.runtime;
+use std.types.size.usize;
+
+val greeting: *u8 = "framing";
+var counter: usize = 0;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    counter = counter + greeting[0]::usize;
+    ret 0;
+}

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3159,10 +3159,16 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
 # give each used merged section a base virtual address,
 # starting from the OS base and page-aligning each kind's start
 #
-# A PIE image reserves the first page above the base for the mach header + load
-# commands, so __TEXT (which maps the header at its start) begins exactly at the
-# base and __PAGEZERO spans [0, base) - the standard position-independent layout.
-# The writer asserts the header fits the one-page reservation.
+# An image whose header maps inside its first load segment reserves the first page
+# above the base for it, so that segment (which maps the header at its start)
+# begins exactly at the base - for Mach-O, __TEXT on the base with __PAGEZERO
+# spanning [0, base). The writer asserts the header fits the one-page reservation.
+#
+# Two independent things ask for the reservation and it is one page either way: a
+# position-independent image (PIE or shared) always reserves it, and so does any
+# format that maps its header inside the first segment (`of.header_in_first_segment`,
+# true for Mach-O), whose non-PIE layout would otherwise be framed a page below the
+# base (#2599).
 #
 # Each kind's start is aligned up to at least the OS page, so every merged segment
 # begins on a fresh page and thus owns its trailing (partial) page - no two segments
@@ -3172,13 +3178,13 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
 # ---
 # tgt:    active target - supplies the OS base address and page size
 # merged: the per-kind accumulators, whose vaddrs are assigned in place
-# pie:    true to reserve a one-page header gap above the base (PIE layout)
+# pie:    true when the image is position-independent (PIE or shared)
 fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection, pie: bool) {
     val base: u64 = os_base_addr(tgt);
     val page: u64 = os_page_size(tgt);
 
     var va: u64 = base;
-    if (pie) { va = base + page; }
+    if (pie || header_reserve_page(tgt)) { va = base + page; }
     var i: u32 = 0;
     for (i < MERGED_KIND_COUNT) {
         if (merged[i].used && is_loadable_kind(merged[i].kind)) {
@@ -5679,6 +5685,21 @@ fun merged_section_name(s: *session.Session, kind: of.SectionKind) intern.StrId 
 fun image_name(modules: *of.ObjectImage, module_count: u32) intern.StrId {
     if (module_count == 0) { ret intern.STR_NIL; }
     ret modules[0].name;
+}
+
+# whether the target's object format maps the image header inside the first load
+# segment, so the linker must leave a page above the base for it
+#
+# The reservation belongs to the format, not to position independence: Mach-O
+# frames __TEXT one header span below its first content byte in both the
+# LC_MAIN and LC_UNIXTHREAD layouts, so without the gap a non-PIE image is based
+# a page low and its __PAGEZERO is short by the same page (#2599)
+# ---
+# tgt: active target - supplies the object-format vtable
+# ret: true when a header page must be reserved above the image base
+fun header_reserve_page(tgt: *target.Target) bool {
+    if (tgt.of == nil) { ret false; }
+    ret tgt.of.header_in_first_segment;
 }
 
 # the base virtual address for the active target's executables. a per-target

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -839,6 +839,17 @@ val OF_ISA_MAX: u32 = 8;
 # import_address_prefix: object-symbol prefix denoting a reference to an import's
 #                 loader-filled address slot rather than to the export itself.
 #                 PE/COFF uses "__imp_"; formats without such symbol aliases use ""
+# header_in_first_segment: true when the format maps the image header + load
+#                 commands inside the first load segment at file offset 0, so the
+#                 segment's virtual address is fixed one header span BELOW its
+#                 first content byte (Mach-O: the Apple Silicon kernel admits a
+#                 signed image only when the header lies inside the mapped,
+#                 signed __TEXT). the linker must then reserve a page above the
+#                 image base for the header whether or not the image is
+#                 position-independent, otherwise the first segment - and with it
+#                 __PAGEZERO - lands a page below the base (#2599). false for a
+#                 format that maps its header outside any segment, or that
+#                 reserves the span itself inside the first section (PE)
 # executable_section_location: optional format-owned mapping from a linker load
 #                 segment to its enclosing final executable section. section-relative
 #                 relocations consult it before executable emission; nil means the
@@ -862,6 +873,7 @@ pub rec OfVTable {
     default_debug:       str;
     shared_input_ext:    str;
     import_address_prefix: str;
+    header_in_first_segment: bool;
     executable_section_location: ExecutableSectionLocationFn;
 }
 

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -4148,6 +4148,9 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.default_debug    = "";
     coff_vtable.shared_input_ext = ".dll";
     coff_vtable.import_address_prefix = "__imp_";
+    # the PE writer reserves its own header span inside the first section as
+    # prefix padding, so the linker leaves no gap above the image base.
+    coff_vtable.header_in_first_segment = false;
     coff_vtable.executable_section_location = pe_executable_section_location;
 
     # the COFF relocation mapping and writer cover x86-64 only today.

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1172,6 +1172,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     elf_vtable.default_debug    = "dwarf";
     elf_vtable.shared_input_ext = ".so";
     elf_vtable.import_address_prefix = "";
+    # the ELF header and program headers map at the image base ahead of the first
+    # section, inside the first PT_LOAD, with no page reserved above the base.
+    elf_vtable.header_in_first_segment = false;
     elf_vtable.executable_section_location = nil;
 
     # elf relocates and writes for every isa with an `elf_reloc_type` map.

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -245,8 +245,9 @@ val ARM_THREAD_STATE64_COUNT: u32 = 68;   # 34 u64 = 272 bytes
 val X86_RIP_STATE_OFFSET: usize = 128;
 val ARM_PC_STATE_OFFSET:  usize = 256;
 
-# default page size for the static executable layout; segment file offsets are
-# page-aligned to keep each segment's `fileoff` congruent with its `vmaddr`
+# the x86_64 darwin vm page. `macho_page_size` is the authority for a layout's
+# page (arm64 maps 16 KiB); this is the 4 KiB constant the parser tests frame
+# their fixtures with
 val EXEC_PAGE_SIZE: u64 = 4096;
 
 # embedded code-signing magics and the single code-directory sub-blob slot. all
@@ -1512,6 +1513,12 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     macho_vtable.default_debug    = "dwarf";
     macho_vtable.shared_input_ext = ".dylib";
     macho_vtable.import_address_prefix = "";
+    # both executable writers map the mach header + load commands at file offset 0
+    # inside __TEXT, so __TEXT is based one header span below the linker's first
+    # content byte. the linker reserves that page above the image base for every
+    # Mach-O image, position-independent or not, so __TEXT lands on the base and
+    # __PAGEZERO spans the whole low region below it (#2599).
+    macho_vtable.header_in_first_segment = true;
     macho_vtable.executable_section_location = nil;
 
     # Mach-O relocates and writes for the two Apple-silicon-era isas.
@@ -1860,6 +1867,9 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     val arch_id: u32 = isa_vt.id;
     val ct: R.Result[u32, str] = cpu_type_for(arch_id);
     if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
+    # the vm page darwin maps with on this architecture (16 KiB arm64, 4 KiB
+    # x86_64); every segment and file region below is aligned to it.
+    val exec_page: u64 = macho_page_size(arch_id);
 
     # non-allocated debug sections ride in a non-mapped __DWARF segment placed below
     # the code signature (so the ad-hoc signature's code_limit covers them). the
@@ -1875,30 +1885,33 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # rebased-then-read-only __DATA_CONST and the load segments collapse purely by
     # protection: the linker's rodata and rel.ro segments are one read-only Mach-O
     # segment, not two commands sharing a name.
-    val grp_count: u32 = seg_group_count(nil::*of.DynamicInfo, segs, seg_count);
-    # the Mach-O segments, a trailing __LINKEDIT (carrying the code signature),
-    # LC_UNIXTHREAD, LC_CODE_SIGNATURE, __PAGEZERO when the base is non-zero, and the
+    # the framing commands (__PAGEZERO + the load segments), a trailing __LINKEDIT
+    # (carrying the code signature), LC_UNIXTHREAD, LC_CODE_SIGNATURE, and the
     # __DWARF segment when debug sections are present.
-    var ncmds: u32 = grp_count + 3;
-    if (has_pagezero) { ncmds = ncmds + 1; }
-    if (have_dwarf)   { ncmds = ncmds + 1; }
+    var ncmds: u32 = frame_cmd_count(nil::*of.DynamicInfo, segs, seg_count, has_pagezero) + 3;
+    if (have_dwarf) { ncmds = ncmds + 1; }
 
     var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
     if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
     val thread_cmd_size: usize = 16 + thread_state;
 
-    var sizeofcmds: usize = grp_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size
+    var sizeofcmds: usize = frame_cmd_bytes(nil::*of.DynamicInfo, segs, seg_count, has_pagezero)
+                          + thread_cmd_size
                           + SEGMENT_CMD_64_SIZE + LINKEDIT_DATA_CMD_SIZE;   # __LINKEDIT + LC_CODE_SIGNATURE
-    if (has_pagezero) { sizeofcmds = sizeofcmds + SEGMENT_CMD_64_SIZE; }
     sizeofcmds = sizeofcmds + macho_dwarf_cmd_bytes(debug_count);
     val header_end: usize = MACH_HEADER_64_SIZE + sizeofcmds;
 
     # the mach header + load commands map into __TEXT's first hdr_span bytes: the
     # Apple Silicon kernel admits a signed image only when the header lies inside the
-    # signed, mapped __TEXT. the first linker segment must therefore sit at least
-    # hdr_span above the image base, leaving room for the header below it.
-    val hdr_span: usize = bin.align_up(header_end, EXEC_PAGE_SIZE::usize);
-    if (seg_count > 0 && segs[0].vaddr < hdr_span::u64) {
+    # signed, mapped __TEXT. the first linker segment must therefore sit strictly
+    # above hdr_span, leaving room for the header below it and a non-empty
+    # __PAGEZERO under that - the linker reserves exactly this page for every Mach-O
+    # image (`of.header_in_first_segment`), position-independent or not.
+    if (header_end > exec_page::usize) {
+        ret R.err[bool, str]("macho: exec header exceeds the one-page reservation");
+    }
+    val hdr_span: usize = exec_page::usize;
+    if (seg_count > 0 && segs[0].vaddr <= hdr_span::u64) {
         ret R.err[bool, str]("macho: exec base address too low to map the header");
     }
     var text_va:       u64 = 0;
@@ -1921,7 +1934,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     var total_size: usize = hdr_span;
     var li: u32 = 0;
     for (li < seg_count) {
-        total_size = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
+        total_size = bin.align_up(total_size, exec_page::usize);
         seg_offsets[li] = total_size;
         total_size = total_size + segs[li].filesz;
         li = li + 1;
@@ -1931,7 +1944,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     var hi_va: u64 = 0;
     li = 0;
     for (li < seg_count) {
-        val end: u64 = segs[li].vaddr + bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE);
+        val end: u64 = segs[li].vaddr + bin.align_up_u64(segs[li].memsz::u64, exec_page);
         if (end > hi_va) { hi_va = end; }
         li = li + 1;
     }
@@ -1960,11 +1973,11 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # page-aligned. codeLimit is the signature's file offset; the bytes between the
     # last content and it hash as zero.
     val ident_len:     usize = codesign_ident_len(name);
-    val linkedit_off:  usize = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
+    val linkedit_off:  usize = bin.align_up(total_size, exec_page::usize);
     val code_limit:    usize = linkedit_off;
     val sig_size:      usize = code_signature_size(ident_len, code_limit);
     val linkedit_size: usize = sig_size;
-    val linkedit_va:   u64 = bin.align_up_u64(hi_va, EXEC_PAGE_SIZE);
+    val linkedit_va:   u64 = bin.align_up_u64(hi_va, exec_page);
     total_size = linkedit_off + sig_size;
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
@@ -1984,71 +1997,12 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     bin.write_u32_le(buf, 24, MH_NOUNDEFS);
     bin.write_u32_le(buf, 28, 0);
 
-    var lc: usize = MACH_HEADER_64_SIZE;
-    if (pagezero_size > 0) {
-        bin.write_u32_le(buf, lc, LC_SEGMENT_64);
-        bin.write_u32_le(buf, lc + 4, SEGMENT_CMD_64_SIZE::u32);
-        write_fixed16(buf, lc + 8, "__PAGEZERO");
-        bin.write_u64_le(buf, lc + 24, 0);
-        bin.write_u64_le(buf, lc + 32, pagezero_size);
-        bin.write_u64_le(buf, lc + 40, 0);
-        bin.write_u64_le(buf, lc + 48, 0);
-        bin.write_u32_le(buf, lc + 56, 0);
-        bin.write_u32_le(buf, lc + 60, 0);
-        bin.write_u32_le(buf, lc + 64, 0);
-        bin.write_u32_le(buf, lc + 68, 0);
-        lc = lc + SEGMENT_CMD_64_SIZE;
-    }
-
-    li = 0;
-    for (li < seg_count) {
-        # the first segment is __TEXT: it maps the mach header + load commands ahead
-        # of the linker's text (fileoff 0, vmaddr text_va), so the signed header lies
-        # inside the mapped executable segment, and it shares no command. the rest are
-        # emitted one command per run of identically-mapped segments, so a segment name
-        # is never written twice.
-        val last: u32 = seg_group_last(nil::*of.DynamicInfo, segs, seg_count, li);
-        val prot: u32 = vm_prot_for(segs[li].flags);
-        var seg_vaddr:  u64 = segs[li].vaddr;
-        var seg_vmsize: u64 = bin.align_up_u64(segs[last].vaddr + segs[last].memsz::u64 - segs[li].vaddr,
-                                               EXEC_PAGE_SIZE);
-        var seg_foff:   u64 = seg_offsets[li]::u64;
-        var seg_fsz:    u64 = 0;
-        var m: u32 = li;
-        for (m <= last) {
-            if (segs[m].filesz > 0) { seg_fsz = (seg_offsets[m] + segs[m].filesz - seg_offsets[li])::u64; }
-            m = m + 1;
-        }
-        if (li == 0) {
-            seg_vaddr  = text_va;
-            seg_vmsize = bin.align_up_u64(hdr_span::u64 + segs[0].memsz::u64, EXEC_PAGE_SIZE);
-            seg_foff   = 0;
-            seg_fsz    = hdr_span::u64 + segs[0].filesz::u64;
-        }
-        bin.write_u32_le(buf, lc, LC_SEGMENT_64);
-        bin.write_u32_le(buf, lc + 4, SEGMENT_CMD_64_SIZE::u32);
-        # a static executable carries no loader-applied rebases, so no segment is
-        # dyld's rebased-then-read-only __DATA_CONST.
-        write_fixed16(buf, lc + 8, exec_segname(segs[li].flags, false));
-        bin.write_u64_le(buf, lc + 24, seg_vaddr);
-        bin.write_u64_le(buf, lc + 32, seg_vmsize);
-        bin.write_u64_le(buf, lc + 40, seg_foff);
-        bin.write_u64_le(buf, lc + 48, seg_fsz);
-        bin.write_u32_le(buf, lc + 56, prot);
-        bin.write_u32_le(buf, lc + 60, prot);
-        bin.write_u32_le(buf, lc + 64, 0);
-        bin.write_u32_le(buf, lc + 68, 0);
-        lc = lc + SEGMENT_CMD_64_SIZE;
-
-        m = li;
-        for (m <= last) {
-            if (segs[m].bytes != nil && segs[m].filesz > 0) {
-                memory.raw_copy((buf::usize + seg_offsets[m])::ptr, segs[m].bytes::ptr, segs[m].filesz);
-            }
-            m = m + 1;
-        }
-        li = last + 1;
-    }
+    # __PAGEZERO and the mapped load segments, framed exactly as the dyld-loaded
+    # path frames them; only the entry command below differs.
+    var lc: usize = write_frame_cmds(buf, MACH_HEADER_64_SIZE, nil::*of.DynamicInfo, segs,
+                                     seg_count, seg_offsets, pagezero_size, text_va,
+                                     hdr_span, exec_page);
+    write_segment_bytes(buf, segs, seg_count, seg_offsets);
 
     # the non-mapped __DWARF segment (debug sections) between the linker segments and
     # __LINKEDIT; its bytes sit below the code signature and hash into it.
@@ -2057,7 +2011,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
 
     # __LINKEDIT carries only the ad-hoc code signature.
     lc = write_segment_cmd(buf, lc, "__LINKEDIT", linkedit_va,
-                           bin.align_up_u64(linkedit_size::u64, EXEC_PAGE_SIZE),
+                           bin.align_up_u64(linkedit_size::u64, exec_page),
                            linkedit_off::u64, linkedit_size::u64,
                            VM_PROT_READ, VM_PROT_READ, 0);
 
@@ -2470,6 +2424,133 @@ fun write_section_64(buf: *u8, off: usize, sectname: str, segname: str, addr: u6
     bin.write_u32_le(buf, off + 72, 0);
     bin.write_u32_le(buf, off + 76, 0);
     ret off + SECTION_64_SIZE;
+}
+
+# the number of load commands the image framing emits: the optional __PAGEZERO
+# plus one LC_SEGMENT_64 per Mach-O segment the linker's load segments collapse into
+# ---
+# dyn:       the dynamic-link plan (nil for a static link)
+# segs:      the linker's load segments
+# seg_count: number of load segments
+# pagezero:  whether a __PAGEZERO command precedes them
+# ret:       the load-command count
+fun frame_cmd_count(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32, pagezero: bool) u32 {
+    var n: u32 = seg_group_count(dyn, segs, seg_count);
+    if (pagezero) { n = n + 1; }
+    ret n;
+}
+
+# the byte size of those commands - each segment command carries one section_64
+# per linker load segment it maps, so the section total is the load-segment count
+# ---
+# dyn:       the dynamic-link plan (nil for a static link)
+# segs:      the linker's load segments
+# seg_count: number of load segments
+# pagezero:  whether a __PAGEZERO command precedes them
+# ret:       the byte size of the framing commands
+fun frame_cmd_bytes(dyn: *of.DynamicInfo, segs: *of.LoadSegment, seg_count: u32, pagezero: bool) usize {
+    ret frame_cmd_count(dyn, segs, seg_count, pagezero)::usize * SEGMENT_CMD_64_SIZE
+        + seg_count::usize * SECTION_64_SIZE;
+}
+
+# write the image framing: __PAGEZERO, then the mapped load segments
+#
+# The framing is what an image IS to the loader, and it is identical for a static
+# LC_UNIXTHREAD image and a dyld-loaded LC_MAIN one - the entry command is the only
+# thing that distinguishes them (#2599). __PAGEZERO spans the whole unmapped low
+# region below the base. __TEXT carries the mach header + load commands at file
+# offset 0, so its vmaddr is `text_va`, one header span below the linker's first
+# content byte; it stands alone for that reason, since no other segment can begin
+# at file offset 0. The rest are emitted one command per run of identically-mapped
+# segments, so a segment name is never written twice, and every command carries one
+# section_64 per member so otool, lldb, and the dyld bind opcodes' segment index all
+# resolve against a real section table.
+# ---
+# buf:           the output buffer
+# lc:            byte offset to write the first command at
+# dyn:           the dynamic-link plan (nil for a static link)
+# segs:          the linker's load segments
+# seg_count:     number of load segments
+# seg_offsets:   each load segment's file offset
+# pagezero_size: the __PAGEZERO span; 0 leaves the command out
+# text_va:       __TEXT's virtual address (the image base)
+# hdr_span:      bytes reserved for the header + load commands at __TEXT's start
+# exec_page:     the target's vm page size
+# ret:           the byte offset just past the last command written
+fun write_frame_cmds(buf: *u8, lc: usize, dyn: *of.DynamicInfo, segs: *of.LoadSegment,
+                     seg_count: u32, seg_offsets: *usize, pagezero_size: u64, text_va: u64,
+                     hdr_span: usize, exec_page: u64) usize {
+    var off: usize = lc;
+    if (pagezero_size > 0) {
+        off = write_segment_cmd(buf, off, "__PAGEZERO", 0, pagezero_size, 0, 0, 0, 0, 0);
+    }
+    if (seg_count == 0) { ret off; }
+
+    val text_prot: u32 = seg_vm_prot(dyn, segs, 0);
+    var tsec: usize = write_segment_cmd(buf, off, "__TEXT", text_va,
+                          bin.align_up_u64(hdr_span::u64 + segs[0].memsz::u64, exec_page),
+                          0, hdr_span::u64 + segs[0].filesz::u64, text_prot, text_prot, 1);
+    if (seg_is_data_const(dyn, segs, 0)) { bin.write_u32_le(buf, off + 68, SG_READ_ONLY); }
+    write_section_64(buf, tsec, dyn_sectname(segs[0].flags, false), "__TEXT", segs[0].vaddr,
+                     segs[0].memsz::u64, seg_offsets[0]::u32, dyn_sect_flags(segs[0].flags, false));
+    off = tsec + SECTION_64_SIZE;
+
+    var li: u32 = 1;
+    for (li < seg_count) {
+        val last: u32 = seg_group_last(dyn, segs, seg_count, li);
+        # the loader rebases the absolute pointers a read-only segment holds, so
+        # __DATA_CONST maps read-write for dyld's fixups and is re-protected read-only
+        # afterward via SG_READ_ONLY; without it dyld cannot slide the slots. read-only
+        # content with no pointer to slide keeps neither, since a second SG_READ_ONLY
+        # makes the darwin kernel refuse the image (#2172).
+        val prot:  u32 = seg_vm_prot(dyn, segs, li);
+        val gname: str = exec_segname(segs[li].flags, seg_is_data_const(dyn, segs, li));
+        # the command spans its members: their file bytes are contiguous (each
+        # page-aligned in turn) and their addresses ascend, so the run's file size runs
+        # to the end of its last member holding bytes and its vm size to the last
+        # member's end.
+        var grp_fsz: u64 = 0;
+        var m: u32 = li;
+        for (m <= last) {
+            if (segs[m].filesz > 0) { grp_fsz = (seg_offsets[m] + segs[m].filesz - seg_offsets[li])::u64; }
+            m = m + 1;
+        }
+        val grp_vmsz: u64 = bin.align_up_u64(segs[last].vaddr + segs[last].memsz::u64 - segs[li].vaddr,
+                                             exec_page);
+
+        var lsec: usize = write_segment_cmd(buf, off, gname, segs[li].vaddr, grp_vmsz,
+                              seg_offsets[li]::u64, grp_fsz, prot, prot, last - li + 1);
+        if (seg_is_data_const(dyn, segs, li)) { bin.write_u32_le(buf, off + 68, SG_READ_ONLY); }
+        m = li;
+        for (m <= last) {
+            val zf: bool = segs[m].filesz == 0 && segs[m].memsz > 0;
+            var soff: u32 = seg_offsets[m]::u32;
+            if (zf) { soff = 0; }
+            write_section_64(buf, lsec, dyn_sectname(segs[m].flags, zf), gname,
+                             segs[m].vaddr, segs[m].memsz::u64, soff, dyn_sect_flags(segs[m].flags, zf));
+            lsec = lsec + SECTION_64_SIZE;
+            m = m + 1;
+        }
+        off = lsec;
+        li = last + 1;
+    }
+    ret off;
+}
+
+# copy every load segment's file bytes into its planned offset
+# ---
+# buf:         the output buffer
+# segs:        the linker's load segments
+# seg_count:   number of load segments
+# seg_offsets: each load segment's file offset
+fun write_segment_bytes(buf: *u8, segs: *of.LoadSegment, seg_count: u32, seg_offsets: *usize) {
+    var li: u32 = 0;
+    for (li < seg_count) {
+        if (segs[li].bytes != nil && segs[li].filesz > 0) {
+            memory.raw_copy((buf::usize + seg_offsets[li])::ptr, segs[li].bytes::ptr, segs[li].filesz);
+        }
+        li = li + 1;
+    }
 }
 
 # the two-level-namespace library ordinal for an import: the 1-based index
@@ -3291,10 +3372,9 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # the linker's load segments collapse into + (stubs, got when there are function
     # imports) + __LINKEDIT.
     val grp_count: u32 = seg_group_count(dyn, segs, seg_count);
-    var seg_cmds: u32 = grp_count + 1;              # Mach-O segments + __LINKEDIT
-    if (segs[0].vaddr > 0) { seg_cmds = seg_cmds + 1; }   # __PAGEZERO
-    if (nstub > 0)         { seg_cmds = seg_cmds + 1; }   # __STUBS
-    if (ngot > 0)          { seg_cmds = seg_cmds + 1; }   # __GOT
+    var seg_cmds: u32 = frame_cmd_count(dyn, segs, seg_count, segs[0].vaddr > 0) + 1;  # + __LINKEDIT
+    if (nstub > 0) { seg_cmds = seg_cmds + 1; }   # __STUBS
+    if (ngot > 0)  { seg_cmds = seg_cmds + 1; }   # __GOT
 
     var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
     if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
@@ -3346,16 +3426,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # a PIE image reserves exactly one page for the header so __TEXT maps at the OS
     # base (the linker reserved that page above the base when assigning vaddrs); a
     # non-PIE image maps the header below the linker's first segment, sized to fit.
-    if (pie) {
-        if (MACH_HEADER_64_SIZE + sizeofcmds > page) {
-            ret R.err[bool, str]("macho: dyn-exec PIE header exceeds the one-page reservation");
-        }
-        lay.hdr_span = page;
+    # the linker reserved exactly one page above the image base for the header, so
+    # the header span is that page for both layouts: growing it instead would push
+    # __TEXT (and __PAGEZERO with it) below the base (#2599).
+    if (MACH_HEADER_64_SIZE + sizeofcmds > page) {
+        ret R.err[bool, str]("macho: dyn-exec header exceeds the one-page reservation");
     }
-    or {
-        lay.hdr_span = bin.align_up(MACH_HEADER_64_SIZE + sizeofcmds, page);
-    }
-    if (segs[0].vaddr < lay.hdr_span::u64) {
+    lay.hdr_span = page;
+    if (segs[0].vaddr <= lay.hdr_span::u64) {
         ret R.err[bool, str]("macho: dyn-exec base address too low to map the header");
     }
     lay.text_va       = segs[0].vaddr - lay.hdr_span::u64;
@@ -3480,68 +3558,11 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     bin.write_u32_le(buf, 24, hdr_flags);
     bin.write_u32_le(buf, 28, 0);
 
-    var lc: usize = MACH_HEADER_64_SIZE;
-
-    # __PAGEZERO.
-    if (lay.pagezero_size > 0) {
-        lc = write_segment_cmd(buf, lc, "__PAGEZERO", 0, lay.pagezero_size, 0, 0, 0, 0, 0);
-    }
-
-    # __TEXT maps the mach header below the linker's first segment (its section starts
-    # at that segment's address, after the header). It stands alone for that reason -
-    # no other load segment can share a command that begins at file offset 0 - and
-    # goes through the same protection and flag rules as the rest, so a read-only,
-    # rebased first segment is flagged exactly like any other.
-    val text_prot: u32 = seg_vm_prot(dyn, segs, 0);
-    var tsec: usize = write_segment_cmd(buf, lc, "__TEXT", lay.text_va,
-                           bin.align_up_u64(lay.hdr_span::u64 + segs[0].memsz::u64, exec_page),
-                           0, lay.hdr_span::u64 + segs[0].filesz::u64, text_prot, text_prot, 1);
-    if (seg_is_data_const(dyn, segs, 0)) { bin.write_u32_le(buf, lc + 68, SG_READ_ONLY); }
-    write_section_64(buf, tsec, dyn_sectname(segs[0].flags, false), "__TEXT", segs[0].vaddr,
-                     segs[0].memsz::u64, seg_offsets[0]::u32, dyn_sect_flags(segs[0].flags, false));
-    lc = tsec + SECTION_64_SIZE;
-
-    # the remaining load segments, one Mach-O segment per run that maps identically:
-    # a run shares one command carrying one section per member, so a segment name is
-    # written once and every by-name lookup (otool, lldb, dsymutil) is unambiguous.
-    li = 1;
-    for (li < seg_count) {
-        val last: u32 = seg_group_last(dyn, segs, seg_count, li);
-        # the loader rebases the absolute pointers a read-only segment holds, so
-        # __DATA_CONST maps read-write for dyld's fixups and is re-protected read-only
-        # afterward via SG_READ_ONLY; without it dyld cannot slide the slots. read-only
-        # content with no pointer to slide keeps neither, since a second SG_READ_ONLY
-        # makes the darwin kernel refuse the image (#2172).
-        val prot: u32 = seg_vm_prot(dyn, segs, li);
-        val gname: str = exec_segname(segs[li].flags, seg_is_data_const(dyn, segs, li));
-        # the command spans its members: their file bytes are contiguous (each
-        # page-aligned in turn) and their addresses ascend, so the run's file size runs
-        # to the end of its last member holding bytes and its vm size to the last
-        # member's end.
-        var grp_fsz: u64 = 0;
-        var m: u32 = li;
-        for (m <= last) {
-            if (segs[m].filesz > 0) { grp_fsz = (seg_offsets[m] + segs[m].filesz - seg_offsets[li])::u64; }
-            m = m + 1;
-        }
-        val grp_vmsz: u64 = bin.align_up_u64(segs[last].vaddr + segs[last].memsz::u64 - segs[li].vaddr, exec_page);
-
-        var lsec: usize = write_segment_cmd(buf, lc, gname, segs[li].vaddr, grp_vmsz,
-                               seg_offsets[li]::u64, grp_fsz, prot, prot, last - li + 1);
-        if (seg_is_data_const(dyn, segs, li)) { bin.write_u32_le(buf, lc + 68, SG_READ_ONLY); }
-        m = li;
-        for (m <= last) {
-            val zf: bool = segs[m].filesz == 0 && segs[m].memsz > 0;
-            var soff: u32 = seg_offsets[m]::u32;
-            if (zf) { soff = 0; }
-            write_section_64(buf, lsec, dyn_sectname(segs[m].flags, zf), gname,
-                             segs[m].vaddr, segs[m].memsz::u64, soff, dyn_sect_flags(segs[m].flags, zf));
-            lsec = lsec + SECTION_64_SIZE;
-            m = m + 1;
-        }
-        lc = lsec;
-        li = last + 1;
-    }
+    # __PAGEZERO and the mapped load segments, framed exactly as the static path
+    # frames them; only the entry command below differs.
+    var lc: usize = write_frame_cmds(buf, MACH_HEADER_64_SIZE, dyn, segs, seg_count,
+                                     seg_offsets, lay.pagezero_size, lay.text_va,
+                                     lay.hdr_span, exec_page);
 
     # synthesized stub (R+X) and got (R+W) segments, each with one section so the
     # llvm/otool readers resolve the bind opcodes' segment index and address. they
@@ -5719,6 +5740,144 @@ fun t_emit_dyn(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTabl
     ret rb;
 }
 
+# the framing facts of an emitted image: __PAGEZERO's span, __TEXT's address, and
+# each mapped segment's section count and first section name, in load-command order
+# ---
+# buf:      the emitted image
+# names:    out, one segment name per LC_SEGMENT_64
+# nsects:   out, that segment's section count
+# sect0:    out, the offset of its first section_64 entry (0 when it has none)
+# cap:      capacity of the three arrays
+# ret:      the number of segments recorded, or cap when it overflows
+fun t_frame_segs(buf: *u8, names: *usize, nsects: *u32, sect0: *usize, cap: u32) u32 {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var n:   u32 = 0;
+    var c:   u32 = 0;
+    for (c < ncmds && n < cap) {
+        if (bin.read_u32_le(buf, off) == LC_SEGMENT_64) {
+            names[n]  = off + 8;
+            nsects[n] = bin.read_u32_le(buf, off + 64);
+            sect0[n]  = 0;
+            if (nsects[n] > 0) { sect0[n] = off + SEGMENT_CMD_64_SIZE; }
+            n = n + 1;
+        }
+        off = off + bin.read_u32_le(buf, off + 4)::usize;
+        c = c + 1;
+    }
+    ret n;
+}
+
+# whether two 16-byte fixed-width name fields hold the same name
+fun t_fixed16_same(buf_a: *u8, off_a: usize, buf_b: *u8, off_b: usize) bool {
+    var i: usize = 0;
+    for (i < 16) {
+        if (buf_a[off_a + i] != buf_b[off_b + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# the static (LC_UNIXTHREAD) and dyld-loaded (LC_MAIN) writers frame one image
+# identically: __PAGEZERO spans the whole low region below the base, __TEXT is based
+# exactly at it with the mach header inside its first page, and every mapped segment
+# carries its section commands. Only the entry command may differ (#2599).
+#
+# The bug this pins was invisible to a per-writer test: emit_exec derived __TEXT from
+# `segs[0].vaddr - hdr_span` on a base the linker had not reserved a header page
+# above, so the whole image slid one page down (__PAGEZERO 4 GiB - 4 KiB, __TEXT at
+# DARWIN_BASE_ADDR - 0x1000) and its load segments carried nsects 0, leaving every
+# Mach-O tool with nothing describing where a section began. Comparing the two
+# writers against each other is what makes it a defect rather than a convention
+fun ts_exec_frames_like_dyn() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var bytes: [48]u8;
+    var k: usize = 0;
+    for (k < 48) { bytes[k] = 0x90; k = k + 1; }
+
+    # the linker reserves one page above the image base for the header on every
+    # Mach-O image (`of.header_in_first_segment`), so the first segment starts there.
+    val base: u64 = 0x100000000;
+    val pg:   u64 = macho_page_size(isa.ARCH_X86_64);
+    val first: u64 = base + pg;
+    var segs: [3]of.LoadSegment;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;   segs[1].bytes = ?bytes[16];
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].flags = of.SEG_FLAG_READ;                       segs[2].bytes = ?bytes[32];
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_frame");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 3,
+                                            pg, base, first,
+                                            nil::*of.ExecFunction, 0, nil::*of.Section, 0,
+                                            nil::*of.Section, 0,
+                                            fs.temp_path(?tf)::*u8, "machoframe"::*u8,
+                                            of.image_options_default(of.SUBSYSTEM_CONSOLE));
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    val stat: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    var dyn: of.DynamicInfo;
+    dyn.interp = intern.STR_NIL;
+    dyn.pie = true;
+    val dr: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 3, ?dyn, first);
+    if (R.is_err[Vector[u8], str](dr)) { ret 1; }
+    val dynb: Vector[u8] = R.unwrap_ok[Vector[u8], str](dr);
+
+    # __PAGEZERO spans the whole low region and __TEXT is based exactly at the image
+    # base, in both layouts.
+    val spz: usize = t_find_seg(stat.data, "__PAGEZERO");
+    val dpz: usize = t_find_seg(dynb.data, "__PAGEZERO");
+    if (spz == 0 || dpz == 0)                                { ret 1; }
+    if (bin.read_u64_le(stat.data, spz + 32) != base)        { ret 1; }
+    if (bin.read_u64_le(dynb.data, dpz + 32) != base)        { ret 1; }
+    val stx: usize = t_find_seg(stat.data, "__TEXT");
+    val dtx: usize = t_find_seg(dynb.data, "__TEXT");
+    if (stx == 0 || dtx == 0)                                { ret 1; }
+    if (bin.read_u64_le(stat.data, stx + 24) != base)        { ret 1; }
+    if (bin.read_u64_le(dynb.data, dtx + 24) != base)        { ret 1; }
+    # the header lies inside __TEXT's first page: the segment maps from file offset 0
+    # and its section starts one page above its own address.
+    if (bin.read_u64_le(stat.data, stx + 40) != 0)           { ret 1; }
+    if (bin.read_u64_le(stat.data, stx + SEGMENT_CMD_64_SIZE + 32) != first) { ret 1; }
+
+    # the mapped segments agree name for name, section count for section count, and
+    # first-section name for first-section name.
+    var snames: [8]usize; var snsects: [8]u32; var ssect0: [8]usize;
+    var dnames: [8]usize; var dnsects: [8]u32; var dsect0: [8]usize;
+    val sn: u32 = t_frame_segs(stat.data, ?snames[0], ?snsects[0], ?ssect0[0], 8);
+    val dn: u32 = t_frame_segs(dynb.data, ?dnames[0], ?dnsects[0], ?dsect0[0], 8);
+    if (sn != dn || sn < 4)                                  { ret 1; }
+    var i: u32 = 0;
+    for (i < sn) {
+        if (!t_fixed16_same(stat.data, snames[i], dynb.data, dnames[i]))       { ret 1; }
+        if (snsects[i] != dnsects[i])                                          { ret 1; }
+        if (snsects[i] > 0
+            && !t_fixed16_same(stat.data, ssect0[i], dynb.data, dsect0[i]))    { ret 1; }
+        i = i + 1;
+    }
+    # and every mapped segment really carries sections - the defect reported nsects 0
+    # on all three while __PAGEZERO and __LINKEDIT legitimately carry none.
+    if (snsects[1] == 0 || snsects[2] == 0 || snsects[3] == 0) { ret 1; }
+
+    # the entry command is the one thing that differs.
+    if (t_find_lc(stat.data, LC_UNIXTHREAD) == 0)           { ret 1; }
+    if (t_find_lc(dynb.data, LC_MAIN) == 0)                 { ret 1; }
+    if (t_find_lc(stat.data, LC_MAIN) != 0)                 { ret 1; }
+    if (t_find_lc(dynb.data, LC_UNIXTHREAD) != 0)           { ret 1; }
+    ret 0;
+}
+
 # the Mach-O segment table a PIE link with distinct rodata and rel.ro segments must
 # produce: exactly one segment is SG_READ_ONLY - the one the rebase stream writes
 # into, which is also the only one that may be named __DATA_CONST - while un-rebased
@@ -6158,6 +6317,7 @@ test "mach.lang.target.of.macho:dyn_exec" {
     if (ts_dyn_exec_relro_segments(isa.ARCH_AARCH64) != 0) { ret 1; }
     if (ts_dyn_exec_split_data_const() != 0)               { ret 1; }
     if (ts_exec_merges_read_only() != 0)                   { ret 1; }
+    if (ts_exec_frames_like_dyn() != 0)                    { ret 1; }
     if (ts_import_address_fixup_validation() != 0)         { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -264,6 +264,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.default_debug    = "";
     raw_vtable.shared_input_ext = "";
     raw_vtable.import_address_prefix = "";
+    # a flat image is pure content: the loader jumps at the base, no header maps.
+    raw_vtable.header_in_first_segment = false;
     raw_vtable.executable_section_location = nil;
 
     # a flat image carries no machine relocation types, so it is isa-agnostic and

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -116,6 +116,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     spv_vtable.default_debug       = "";
     spv_vtable.shared_input_ext    = "";
     spv_vtable.import_address_prefix = "";
+    # a SPIR-V module is not a loaded image; it has no header span to reserve.
+    spv_vtable.header_in_first_segment = false;
     spv_vtable.executable_section_location = nil;
 
     # only the SPIR-V ISA's whole-module emitter produces the `.spirv` section this


### PR DESCRIPTION
Closes #2599

## Cause

Both Mach-O executable writers derive `__TEXT` from `segs[0].vaddr - hdr_span`, because the mach header maps at file offset 0 inside `__TEXT`. That only lands `__TEXT` on the image base if the linker left a page above the base for the header, and `assign_section_vaddrs` reserved it **only for a position-independent image**. So the non-PIE layout slid a page down: `__TEXT` at `DARWIN_BASE_ADDR - 0x1000`, `__PAGEZERO` sized from it and short by the same page. Separately, `emit_exec` wrote `nsects 0` on every load segment while `emit_dyn_exec` wrote one section per segment.

The reservation is a property of the object format, not of position independence. It is now declared by the format: `of.header_in_first_segment` (true for Mach-O, false for ELF, PE, raw, and SPIR-V, each with a comment saying why), and the linker reserves the page when the image is position-independent **or** the format maps its header inside the first segment.

With the base agreed between the two layouts, the framing itself is shared: `write_frame_cmds` emits `__PAGEZERO` and every load segment with its section commands, and both writers call it. `frame_cmd_count` / `frame_cmd_bytes` size it. The two images now differ only in the entry command, which is what the issue asked for — no non-PIE special case exists anywhere.

Two adjacent things the unification surfaced, both fixed here because leaving them would reintroduce the same defect from the other side:

- `emit_exec` framed with a fixed 4 KiB `EXEC_PAGE_SIZE` while `emit_dyn_exec` used the target's own vm page (16 KiB on arm64). It now uses `macho_page_size` too. No effect on x86_64.
- Both writers grew `hdr_span` past a page when the load commands did not fit, which would push `__TEXT` below the base again. Both now assert the header fits the one-page reservation the linker made.

## Verified structurally on linux

Cross-built darwin-x86_64 both ways, `llvm-otool -l`:

```
                     before (non-PIE)            after (non-PIE)      --pie (unchanged)
__PAGEZERO vmsize    0xfffff000                  0x100000000          0x100000000
__TEXT vmaddr        0xfffff000                  0x100000000          0x100000000
__TEXT  nsects       0                           1  (__text)          1  (__text)
__DATA  nsects       0                           1  (__data)          1  (__data)
__RODATA nsects      0                           2  (__const)         1  (__const)
```

`llvm-objdump -d` produced nothing at all for the non-PIE image before and disassembles `__TEXT,__text` from `0x100001000` now. darwin-aarch64 (always PIE) is unchanged and still framed at `0x100000000` with 16 KiB pages.

One deliberate difference remains between the goldens beyond the entry command: only the dyld-loaded image has a `__DATA_CONST`. That segment **is** dyld's rebased-then-read-only mapping, and a static image has no rebase stream, so its read-only content correctly stays `__RODATA`.

## Tests

New int cases `surface/macho-framing-static` and `surface/macho-framing-pie` cross-build the same program for darwin-x86_64 with and without `--pie` on the linux leg and run a new `macho-framing` producer over the load commands (od/dd only, no LLVM). Per the fixture rule, the static case **fails against the current writer**:

```
FAIL surface/macho-framing-static [linux/debug] (diff)
    -pagezero_vmsize=0x100000000
    -text_vmaddr=0x100000000
    +pagezero_vmsize=0xfffff000
    +text_vmaddr=0xfffff000
     seg __PAGEZERO nsects=0 sects=-
    -seg __TEXT nsects=1 sects=__text
    -seg __DATA nsects=1 sects=__data
    -seg __RODATA nsects=2 sects=__const,__const
    +seg __TEXT nsects=0 sects=-
    +seg __DATA nsects=0 sects=-
    +seg __RODATA nsects=0 sects=-
     seg __LINKEDIT nsects=0 sects=-
     entry=LC_UNIXTHREAD
```

The `--pie` case passes against both writers, which is the point: it is the reference layout, and it now guards against a regression in it.

Unit test `ts_exec_frames_like_dyn` emits one segment set through both writers and compares the framing directly: `__PAGEZERO` span, `__TEXT` base, `__TEXT` fileoff 0 with its section one page above its own address, then segment names, section counts, and first-section names index by index, and finally that the entry command is the only difference. Both defects were injected as mutations to confirm it is not vacuous — basing static `__TEXT` a page low, and writing `nsects 0` on the static path — and each was caught.

## What needs the darwin CI leg

Everything above is structural, read on linux. The issue's acceptance also requires **both layouts to execute correctly on a real darwin x86_64 runner**, which settles the "likely-unloadable" question the issue raised. I cannot run a Mach-O image here. That needs the `macos-15-intel` leg.

## Green here

- `mach test .`: 1163 passed, 0 failed.
- `int/run.sh --target linux`: all cases passed.
- `int/lib/check-target-matrix.sh`: 305 case x leg pairs OK.
- Self-host fixpoint: stage2 and stage3 byte-identical.