### PR TITLE
fix(codegen): well-typed return on a function's fall-through edge

### DIFF
--- a/int/regression/2523-unreachable-fallthrough-return/expect.txt
+++ b/int/regression/2523-unreachable-fallthrough-return/expect.txt
@@ -1,0 +1,12 @@
+rec_loop.a=7
+rec_loop.b=5
+f64_loop=3ff8000000000000
+u64_loop=1
+ptr_loop.nil=1
+rec_brk.a=9
+rec_fall.a=0
+rec_fall.b=0
+f64_fall=0
+arr_fall.0=0
+arr_fall.1=0
+u64_fall=0

--- a/int/regression/2523-unreachable-fallthrough-return/mach.toml
+++ b/int/regression/2523-unreachable-fallthrough-return/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2523-unreachable-fallthrough-return/src/main.mach
+++ b/int/regression/2523-unreachable-fallthrough-return/src/main.mach
@@ -1,0 +1,100 @@
+# regression pin for #2523: a function whose fall-through edge needs no value
+#
+# A body ending in a bare `for { }` leaves the lowering cursor on the loop's exit
+# block, which no `brk` ever branches to. Lowering used to close that block with a
+# synthesized `ret const_int(0, T)` - a SCALAR zero stamped with the function's
+# return type. That is accidentally well-typed for an integer or a pointer and
+# ill-typed for a record or an `f64`, so exactly those two return types were
+# rejected at IR verification with a spanless constant-type error (#2523, the same
+# class as #2043's scalar `zero_const` where the type needed `memzero`).
+#
+# TWO INDEPENDENT SHAPES ARE PINNED HERE, because two separate defects produced the
+# one symptom and either could regress alone:
+#
+#   1. UNREACHABLE fall-through (the `_loop` functions). The synthesized value was
+#      never the bug's cause - the edge cannot be taken at all, so there should be
+#      no value. These now close with `unreachable`.
+#   2. REACHABLE fall-through (the `_fall` functions). A non-void function may run
+#      off the end of its body; sema does not reject it. That edge IS taken, so it
+#      needs a real zero of the return type - a float constant for an `f64`, zeroed
+#      storage for an aggregate.
+#
+# The integer and pointer returns are pinned alongside because they compiled BEFORE
+# the fix: they are what a repair of the aggregate path could silently break.
+#
+# Every observable is a VALUE, not merely a successful compile. The original defect
+# was a hard compile error, so a case that only asserted "it builds" would pass on a
+# fix that returned garbage; the `_fall` shapes in particular assert the zero is
+# actually zero rather than whatever the stack happened to hold.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec P { a: u64; b: u64; }
+
+# --- shape 1: unreachable fall-through, exits only through a `ret` in a bare loop
+
+fun rec_loop() P {
+    var p: P;
+    for {
+        p.a = 7;
+        p.b = 5;
+        ret p;
+    }
+}
+
+fun f64_loop() f64 {
+    var i: i64 = 0;
+    for {
+        i = i + 1;
+        ret 1.5;
+    }
+}
+
+# compiled before the fix: pinned so the repair cannot regress them
+fun u64_loop() u64 { var i: u64 = 0; for { i = i + 1; ret i; } }
+fun ptr_loop() *u8 { var i: u64 = 0; for { i = i + 1; ret nil; } }
+
+# the loop given an exit, so the fall-through is reached the ordinary way. this
+# compiled before the fix too - the issue names it as the distinguishing case
+fun rec_brk() P { var p: P; for { p.a = 9; brk; } ret p; }
+
+# --- shape 2: reachable fall-through, no `ret` on the path at all
+
+fun rec_fall() P { var p: P; p.a = 1; }
+fun f64_fall() f64 { var i: i64 = 0; i = i + 1; }
+fun arr_fall() [2]u64 { var i: i64 = 0; i = i + 1; }
+fun u64_fall() u64 { var i: u64 = 0; i = i + 1; }
+
+fun b64(f: f64) u64 { ret f:~u64; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    val r: P = rec_loop();
+    p.printlnf("rec_loop.a={}", r.a);
+    p.printlnf("rec_loop.b={}", r.b);
+    p.printlnf("f64_loop={:x}", b64(f64_loop()));
+    p.printlnf("u64_loop={}", u64_loop());
+
+    var pnil: i64 = 0;
+    if (ptr_loop() == nil) { pnil = 1; }
+    p.printlnf("ptr_loop.nil={}", pnil);
+
+    val rb: P = rec_brk();
+    p.printlnf("rec_brk.a={}", rb.a);
+
+    # the reachable fall-through returns a genuine zero of the return type: an
+    # aggregate's is zeroed storage, a float's is +0.0 (bit pattern, since `== 0.0`
+    # would also accept -0.0), an integer's is 0
+    val rf: P = rec_fall();
+    p.printlnf("rec_fall.a={}", rf.a);
+    p.printlnf("rec_fall.b={}", rf.b);
+    p.printlnf("f64_fall={:x}", b64(f64_fall()));
+    val af: [2]u64 = arr_fall();
+    p.printlnf("arr_fall.0={}", af[0]);
+    p.printlnf("arr_fall.1={}", af[1]);
+    p.printlnf("u64_fall={}", u64_fall());
+
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11333,3 +11333,153 @@ test "mach.lang.driver:embed_buffer_is_stable_across_warm_rebuilds" {
     session.dnit(?s);
     ret bad;
 }
+
+# scan a lowered module for the #2523 ill-formed shape: an OP_RET whose value
+# operand is a scalar constant stamped with an aggregate or float type
+#
+# That is precisely what the old fall-through synthesis produced - a
+# `const_int(0, T)` for whatever T the function declared - and it is what the IR
+# verifier's constant-typing check rejects. Probing for the shape rather than for
+# a particular terminator keeps the assertion true of either repair: not
+# synthesizing on an unreachable edge, or materializing the placeholder through
+# the type's own zero-init path.
+# ---
+# m:   the lowered module
+# ret: 0 when no such ret exists, 1 when one is found
+fun ut_probe_bad_zero_ret(m: *ir.Module) i32 {
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        var ii: u32 = 0;
+        for (ii < fn.instr_len) {
+            val inst: *instruction.Instruction = ?fn.instrs[ii];
+            if (inst.kind == instruction.OP_RET && inst.operand_count > 0) {
+                val op: value.Value = inst.operands[0];
+                if (op.kind == value.VAL_CONST_INT) {
+                    if (ir_type.is_aggregate(?m.types, op.ty))     { ret 1; }
+                    if (ir_type.is_float_scalar(?m.types, op.ty))  { ret 1; }
+                }
+            }
+            ii = ii + 1;
+        }
+        fi = fi + 1;
+    }
+    ret 0;
+}
+
+# count the OP_RETs in `m` returning an aggregate by address (a non-constant
+# aggregate-typed operand), so a clean `ut_probe_bad_zero_ret` cannot pass
+# vacuously on a module where the aggregate returns went missing entirely
+# ---
+# m:   the lowered module
+# ret: the number of such rets
+fun ut_agg_address_rets(m: *ir.Module) u32 {
+    var n: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        var ii: u32 = 0;
+        for (ii < fn.instr_len) {
+            val inst: *instruction.Instruction = ?fn.instrs[ii];
+            if (inst.kind == instruction.OP_RET && inst.operand_count > 0) {
+                val op: value.Value = inst.operands[0];
+                if (!value.is_constant(op) && ir_type.is_aggregate(?m.types, op.ty)) { n = n + 1; }
+            }
+            ii = ii + 1;
+        }
+        fi = fi + 1;
+    }
+    ret n;
+}
+
+# count the OP_RETs in the instruction pool of the function whose bare source name
+# is `want`
+#
+# Reads the POOL, not the block lists, so an instruction stranded in a block `dce`
+# later dropped is still counted. That is deliberate: the synthesized fall-through
+# return this pins sits in an unreachable block, which `dce` removes, so a
+# block-list walk would report the same count whether or not lowering emitted it.
+# ---
+# m:    the lowered module
+# itn:  interner resolving the display name
+# want: the bare source name of the function to inspect
+# ret:  the number of OP_RETs in that function, or -1 when it is not found
+fun ut_fn_ret_count(m: *ir.Module, itn: *intern.Interner, want: str) i64 {
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        val nm: O.Option[str] = intern.lookup(itn, fn.disp);
+        if (O.is_some[str](nm) && str_equals(O.unwrap[str](nm), want)) {
+            var n: i64 = 0;
+            var ii: u32 = 0;
+            for (ii < fn.instr_len) {
+                if (fn.instrs[ii].kind == instruction.OP_RET) { n = n + 1; }
+                ii = ii + 1;
+            }
+            ret n;
+        }
+        fi = fi + 1;
+    }
+    ret -1;
+}
+
+# a record- or f64-returning function whose fall-through edge carries no value
+# lowers to well-typed IR (#2523)
+#
+# Two distinct edges are covered, because two defects produced the one symptom.
+# `rec_loop` / `f64_loop` end in a bare `for { }`, so the cursor is parked on the
+# loop's exit - a block no `brk` branches to, which must close with `unreachable`
+# rather than a fabricated return value. `rec_fall` / `f64_fall` run off the end of
+# a reachable body, so that edge IS taken and needs a genuine zero of the return
+# type: zeroed storage for the aggregate, a float constant for the f64.
+#
+# Both used to lower to `ret const_int(0, T)`, which is accidentally well-typed for
+# an integer or pointer return and rejected by the IR verifier for an aggregate or
+# a float - so `run_lower_pass` itself failed here before the fix, and the probes
+# below pin the shape so a future regression cannot reintroduce it more quietly.
+# `u64_loop` is present because it compiled before the fix and is what a repair of
+# the aggregate path could break.
+test "mach.lang.driver:fallthrough_return_is_well_typed" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "rec P { a: u64; b: u64; }\nfun rec_loop() P { var p: P; for { p.a = 1; ret p; } }\nfun f64_loop() f64 { var i: i64 = 0; for { i = i + 1; ret 1.5; } }\nfun u64_loop() u64 { var i: u64 = 0; for { i = i + 1; ret i; } }\nfun rec_fall() P { var p: P; p.a = 1; }\nfun f64_fall() f64 { var i: i64 = 0; i = i + 1; }\nfun main() i32 { var a: P = rec_loop(); var b: P = rec_fall(); ret (a.a + b.a + u64_loop())::i32; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    if (R.is_err[bool, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    # this is the pre-fix failure: the IR verifier rejected the synthesized
+    # constant, so lowering never completed at all.
+    if (R.is_err[bool, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    # starts failed and clears only once the module is found and probed, so a
+    # missing module can never pass vacuously.
+    var bad: i32 = 1;
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid != session.MODULE_NIL) {
+        val m: *project.ModuleEntry = ?p.modules[mid::u32];
+        if (m.ir_module != nil) {
+            bad = ut_probe_bad_zero_ret(m.ir_module);
+            # and the aggregate returns are still there, by address: without this a
+            # module that lost them entirely would satisfy the probe above.
+            if (ut_agg_address_rets(m.ir_module) == 0) { bad = 1; }
+            # the unreachable fall-through carries NO return: `rec_loop`'s only ret
+            # is the user's own `ret p` inside the loop. synthesizing a second one
+            # for an edge that cannot be taken is well-typed once the placeholder
+            # goes through the zero-init path, so nothing above would catch it.
+            if (ut_fn_ret_count(m.ir_module, ?s.interner, "rec_loop") != 1) { bad = 1; }
+        }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -973,22 +973,51 @@ fun lower_params(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, fn_i
 # whose every incoming arm already returned) is unreachable: it is given an
 # `unreachable` terminator so the IR is structurally well-formed, and `dce`
 # then drops it.
+#
+# The cursor itself can be parked on such a block - a body ending in a bare
+# `for { }` leaves it on the loop exit, which no `brk` ever branches to - and
+# that block needs the same `unreachable`, not a fabricated return value. Falling
+# through to `terminate_orphan_blocks` is what gives it one (#2523).
 # ---
 # ctx:    the context
 # ret_ir: the function's IR return type
 # ret:    true on success, or an error
 fun close_function(ctx: *context.LowerContext, ret_ir: ir_type.IrTypeId) R.Result[bool, str] {
-    if (!context.block_terminated(ctx)) {
+    if (!context.block_terminated(ctx) && !cursor_block_unreachable(ctx)) {
         val res_term: R.Result[bool, str] = emit_default_terminator(ctx, ret_ir);
         if (R.is_err[bool, str](res_term)) { ret res_term; }
     }
     ret terminate_orphan_blocks(ctx);
 }
 
+# whether the block the cursor is parked on can never be entered
+#
+# Every control-flow edge is recorded on its target's `preds` when the source
+# block's terminator is emitted, and the body is fully lowered by the time
+# `close_function` runs, so a non-entry block with no predecessors at this point
+# has none and can gain none - `terminate_orphan_blocks` only adds `unreachable`,
+# which creates no edges. The entry block is reachable by definition and has no
+# preds, so it is excluded explicitly rather than by the pred count.
+# ---
+# ctx: the context
+# ret: true when the cursor's block is provably unreachable
+fun cursor_block_unreachable(ctx: *context.LowerContext) bool {
+    if (ctx.builder.fn == nil) { ret false; }
+    val fn: *ir.Function = ctx.builder.fn;
+    val b: ir.BlockId = ctx.builder.block;
+    if (b == ir.BLOCK_NIL)   { ret false; }
+    if (b >= fn.block_count) { ret false; }
+    if (b == 0)              { ret false; }
+    ret fn.blocks[b].pred_count == 0;
+}
+
 # emit the function's default fall-through terminator into the current block
 #
 # `unreachable` for a noreturn function, a void return for a void function,
-# otherwise a zero return of the declared type.
+# otherwise a zero return of the declared type. Reached only for a fall-through
+# that is actually reachable: `close_function` routes an unreachable cursor block
+# to `unreachable` instead, so this never fabricates a value for an edge that
+# cannot be taken.
 # ---
 # ctx:    the context
 # ret_ir: the function's IR return type
@@ -1003,7 +1032,48 @@ fun emit_default_terminator(ctx: *context.LowerContext, ret_ir: ir_type.IrTypeId
     if (context.is_void_ir(ctx, ret_ir)) {
         ret builder.emit_ret_void(?ctx.builder);
     }
-    ret builder.emit_ret(?ctx.builder, value.const_int(0, ret_ir));
+
+    val res_zero: R.Result[value.Value, str] = default_return_value(ctx, ret_ir);
+    if (R.is_err[value.Value, str](res_zero)) {
+        ret R.err[bool, str](R.unwrap_err[value.Value, str](res_zero));
+    }
+    ret builder.emit_ret(?ctx.builder, R.unwrap_ok[value.Value, str](res_zero));
+}
+
+# materialise the zero placeholder a reachable fall-through returns
+#
+# The placeholder must go through the return type's own zero-init path, not a
+# scalar `const_int(0)`: a float's zero is a float constant, and an aggregate
+# flows by address, so its zero is zeroed stack storage rather than any constant
+# at all. A scalar zero stamped with an aggregate or float type is exactly the
+# ill-typed constant the IR verifier rejects (#2523, the same class as #2043).
+# ---
+# ctx:    the context
+# ret_ir: the function's IR return type (neither void nor noreturn)
+# ret:    a well-typed zero of `ret_ir`, or an allocation error
+fun default_return_value(ctx: *context.LowerContext, ret_ir: ir_type.IrTypeId) R.Result[value.Value, str] {
+    if (ir_type.is_float_scalar(?ctx.m.types, ret_ir)) {
+        ret R.ok[value.Value, str](value.const_float(0.0, ret_ir));
+    }
+    if (!ir_type.is_aggregate(?ctx.m.types, ret_ir)) {
+        ret R.ok[value.Value, str](value.const_int(0, ret_ir));
+    }
+
+    val res_count_ty: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_count_ty)) {
+        ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_count_ty));
+    }
+    val count_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_count_ty);
+
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, ret_ir, value.const_int(1, count_ty));
+    if (R.is_err[value.Value, str](res_slot)) { ret res_slot; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
+
+    val res_mz: R.Result[bool, str] = builder.emit_memzero(?ctx.builder, slot, ret_ir);
+    if (R.is_err[bool, str](res_mz)) {
+        ret R.err[value.Value, str](R.unwrap_err[bool, str](res_mz));
+    }
+    ret R.ok[value.Value, str](slot);
 }
 
 # give every still-unterminated block in the current function an `unreachable`


### PR DESCRIPTION
Closes #2523

## Root cause

Lowering closed a function's fall-through edge with `ret const_int(0, T)` — a **scalar** zero stamped with whatever type the function declared. That is accidentally well-typed for an integer or a pointer and ill-typed for an aggregate or a float, which is exactly the split the issue observed. Same class as #2043, where a scalar `zero_const` stood in for a type that needed `memzero`.

The issue offered two fixes and preferred not synthesizing on a provably unreachable edge. Investigating showed **two independent defects producing the one symptom**, and the preferred fix only addresses one of them, so both are fixed:

**1. The unreachable edge (`me/lower/decl.mach`, `close_function`).** A body ending in a bare `for { }` leaves the lowering cursor on the loop's exit block, which no `brk` ever branches to. That edge cannot be taken, so it needs no value at all. `close_function` now leaves a provably unreachable cursor block to `terminate_orphan_blocks`, which closes it with `unreachable`. The existing doc comment on `close_function` already described this as the intended treatment of such blocks — the cursor's own block was simply the case it did not cover.

Reachability is proven, not guessed: every control-flow edge is recorded on its target's `preds` when the source block's terminator is emitted, the body is fully lowered by the time `close_function` runs, and `terminate_orphan_blocks` only adds `unreachable`, which creates no edges. So a non-entry block with no predecessors at that point has none and can gain none. The entry block is excluded explicitly rather than by pred count.

**2. The reachable edge (`default_return_value`).** Sema does **not** require a non-void function to return on every path, so a body can simply run off the end and that edge is genuinely taken. Fix 1 alone leaves those broken — `fun f() P { var p: P; }` and `fun g() f64 { var i: i64 = 0; }` still fail IR verification. The placeholder now goes through the return type's own zero-init path: a float constant for a float, alloca + memzero for an aggregate (which flows by address, so its zero is zeroed storage rather than any constant), the existing scalar zero otherwise.

## Verified shapes

All four from the issue, plus the reachable fall-through that fix 1 does not reach. Pre-fix column is `dev` + #2538's located diagnostic (PR #2615):

| shape | pre-fix | post-fix |
|---|---|---|
| record return, bare `for { }` | `constant typing: ... (in case.main.f, at ./src/main.mach:2:1)` | OK |
| `f64` return, bare `for { }` | `constant typing: ... (in case.main.g, at ./src/main.mach:1:1)` | OK |
| `u64` return, bare `for { }` | OK | OK |
| `*u8` return, bare `for { }` | OK | OK |
| record return, `for` with `brk` | OK | OK |
| record return, reachable fall-through | `constant typing: ...` | OK |
| `f64` return, reachable fall-through | `constant typing: ...` | OK |
| `[4]u64` return, reachable fall-through | `constant typing: ...` | OK |

## Tests

**`int/regression/2523-unreachable-fallthrough-return`** — an exec case covering all four shapes from the issue plus the reachable fall-through ones. Every observable is a **value**, not a successful compile: the original defect was a hard compile error, so a case asserting only "it builds" would pass on a fix that returned garbage. As the repro caveat in the issue notes, the module must be reachable from the artifact entry, so `main` consumes every function.

**`mach.lang.driver:fallthrough_return_is_well_typed`** — probes the lowered IR for the ill-formed shape itself (an `OP_RET` whose operand is a scalar constant stamped with an aggregate or float type), so the assertion holds under either repair rather than pinning one implementation. Two anti-vacuity guards: the aggregate returns must still be present by address, and `rec_loop` must carry exactly one `OP_RET` (the user's own).

### Evidence each assertion fails before its fix

**Both halves reverted** — the driver test fails:
```
FAIL  mach.lang.driver:fallthrough_return_is_well_typed
165 passed, 1 failed, 166 total
```

**Only the unreachable-edge half reverted** — the `ret`-count assertion is what catches it. This was checked deliberately: with the placeholder-typing half intact the synthesized dead return is well-typed, so nothing else in the test notices, and an earlier version of this test passed in this configuration. The assertion was added because of that.
```
FAIL  mach.lang.driver:fallthrough_return_is_well_typed
165 passed, 1 failed, 166 total
```

**Int case against the pre-fix compiler:**
```
FAIL regression/2523-unreachable-fallthrough-return [linux/debug] (build)
    error: constant typing: constant carries an incompatible type (in case.main.rec_loop, at ./src/main.mach:38:1)
```

**The `memzero` specifically** — dropping it while leaving the alloca in place still compiles and still passes at `-O2`, and the debug leg catches it returning stack garbage. This is what proves the zero-value assertions verify something rather than reporting:
```
-rec_fall.a=0        +rec_fall.a=1
-rec_fall.b=0        +rec_fall.b=11
-arr_fall.0=0        +arr_fall.0=1
-arr_fall.1=0        +arr_fall.1=4265186
```

## Status

- `mach test .` — 1168 passed, 0 failed
- `int/run.sh --target linux` — all cases passed
- self-host fixpoint — stage2 and stage3 byte-identical