### PR TITLE
chore(dep): advance mach-std to 0.24.0

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "231fe98577e80ebb2df715dc51193d3030ae5905"
+commit = "c52de19ac95bf050e68600b42c055ffef419aac6"


### PR DESCRIPTION
Advances `mach.lock` from mach-std 0.23.0 (`231fe98`) to 0.24.0 (`c52de19`).

## What it picks up

briar-systems/mach-std#435. Four OS-layer defects, all the same shape: a public docstring described one behaviour and at least one backend did another.

- `os.rename` on windows now replaces an existing destination (mach-std#414). This is the one mach cares about directly: #2475's link temp-file-and-rename carries a remove-then-retry fallback purely to work around it. That fallback can now be reconsidered on its own merits, and is deliberately left alone here so this stays a dependency bump.
- `os.getcwd` honours the caller's buffer capacity on darwin (mach-std#409), returns one contract across all three backends (mach-std#432), and no longer reports success on windows for a call that wrote nothing (mach-std#433).

## Why now rather than at release time

Since #2592 the root `mach.lock` is what `--deps pin` resolves the release gate against, so this file is no longer only the compiler's own dependency: it is also the statement of which mach-std a tag is cut against. Advancing it deliberately, as its own reviewable change, is the workflow that issue asked for.

## Verified

- `mach build .` green, `mach test .` 1186 passed 0 failed.
- `int/run.sh --target linux` green (float, resolving `c52de19`).
- `int/run.sh --deps pin --target linux` green, resolving `c52de19` from this lock, which is the gate's own path.
- Self-host fixpoint reproduces byte-identically.