### PR TITLE
feat(asm): let a raw encoding declare the registers it writes

### DIFF
--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -187,10 +187,91 @@ On aarch64 and riscv64 a statement must emit a whole number of instruction words
 `.byte 0x1f, 0x20, 0x03` is refused, because three bytes would misalign every
 instruction after it. x86-64 has no such constraint.
 
-A raw encoding is an instruction stream the parser cannot read, so the block's clobber
-set becomes **every register in every bank**, and an `#[oblivious]` function may not
-contain one at all — which is why a real mnemonic is always preferable where one
-exists.
+A raw encoding is an instruction stream the parser cannot read, so by default the
+block's clobber set becomes **every register in every bank**, and an `#[oblivious]`
+function may not contain one at all — which is why a real mnemonic is always preferable
+where one exists.
+
+## Declaring a raw encoding's effects
+
+That default is correct and expensive: with nothing held live across the statement, the
+allocator spills every value in a callee-saved register and the prologue saves every
+callee-saved register the function could reach. A raw encoding may instead state what it
+writes, with a `::` clause on the directive:
+
+```mach
+asm x86_64 {
+    mov dx, {port}
+    .byte 0xee :: writes()                 # out dx, al - reads dx and al, writes nothing
+    .byte 0x0f, 0x31 :: writes(rax, rdx)   # rdtsc - lands its result in EDX:EAX
+}
+
+asm aarch64 {
+    .word 0xd4000002 :: writes(x0, x1, x2, x3)   # hvc #0, returning per SMCCC
+}
+
+asm riscv64 {
+    .word 0xc0102573 :: writes(a0)               # csrr a0, time
+}
+```
+
+This is the same move the system-register surface above already makes. The named set is
+deliberately not exhaustive because any register is *also* nameable by its encoding;
+declared clobbers do for instructions what `s3_3_c14_c0_2` does for registers. The
+curated mnemonic table stays the ergonomic path, and the escape hatch stops being a
+cliff — an unmodeled instruction can be used at full codegen quality on the day it is
+needed.
+
+`writes()` with an empty list is a **declaration**, not an omission: it says the
+encoding writes no register. Leaving the clause off entirely is what keeps today's
+conservative default, so nothing written before this existed changes behaviour.
+
+Registers are named in the target's own vocabulary, in either bank:
+
+| target | general-purpose | float / vector |
+|---|---|---|
+| x86-64 | `rax`–`r15` | `xmm0`–`xmm15` |
+| aarch64 | `x0`–`x30`, `sp`, `xzr` | `v0`–`v31` |
+| riscv64 | `x0`–`x31`, psABI aliases (`a0`, `t0`, `sp`, …) | `f0`–`f31`, psABI aliases (`fa0`, `ft0`, …) |
+
+A width is not a register: `eax`, `w0` and `v2.4s` are refused, because `eax` and `rax`
+are one register whose bits the allocator tracks as a unit and accepting both spellings
+would suggest the clobber set told them apart.
+
+### What the compiler still guarantees, and what it does not
+
+A declaration moves part of the correctness burden from the compiler to you, and it is
+worth being precise about which part.
+
+**Still checked.** The clause is accounted for like every other byte of the statement,
+so a malformed one fails the build rather than being silently dropped — a mistyped
+`writes(` is an error, not a declaration that quietly said nothing. Every register named
+must resolve in this target's own name table, so a typo fails rather than declaring a
+smaller set than you wrote. An attribute that does not exist is refused by name.
+
+**Structurally bounded.** A clause may only follow a **data directive**. A modeled
+instruction's effects come from its mnemonic and cannot be overridden, so a declaration
+can only ever narrow the maximally conservative default, at exactly the statements where
+the compiler had no information at all. It can never contradict something the compiler
+derived, and a wrong one affects only the single statement carrying it.
+
+**Not checked, and it cannot be.** Whether the bytes write what the clause says. The
+compiler does not decode the payload — decoding it is what the mnemonic table *is*.
+**If you under-declare, you get a miscompile**: the allocator will keep a value in a
+register your encoding overwrites. This is the one place in the inline-asm surface where
+correctness rests on the author. Declare what the instruction's manual says it writes,
+including any implicit destination, and prefer a real mnemonic whenever one exists.
+
+**A declaration buys allocation quality, not verification.** An `#[oblivious]` function
+still refuses a data directive whether or not it is declared. A write set says which
+registers change; it says nothing about whether the encoding branches on a secret or
+divides in variable time, which is what that check exists to catch.
+
+`writes(...)` is the only attribute today. The clause is a space-separated list so more
+can be added, but an attribute is only added once it changes what the compiler does —
+`noreturn` is not here yet because control flow reaching past an `asm` block is a CFG
+fact the effect model does not touch, and a `barrier` attribute would be inert, since
+every `asm` block is already assumed to modify arbitrary memory.
 
 ## System registers (aarch64)
 
@@ -315,6 +396,9 @@ current level cannot reach traps at run time, as the architecture defines.
   function's clobber set.
 - **Memory clobber.** Every `asm` block is conservatively assumed to
   modify arbitrary memory.
+- **Raw encodings.** A data directive is a stream the parser cannot read, so
+  it clobbers every register in every bank unless it
+  [declares what it writes](#declaring-a-raw-encodings-effects).
 
 ## Multi-arch dispatch
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4990,7 +4990,56 @@ fun a64_grammar() iasm.Grammar {
     g.endian     = isa.ENDIAN_LITTLE;
     g.ct_class   = asm_ct_class;
     g.note_bytes = asm_note_bytes;
+    g.decl_reg   = a64_decl_reg;
     ret g;
+}
+
+# the register a declared clobber set names, in its bank (#2594)
+#
+# A superset of the operand lexer, which names no vector register: a declaration names
+# a register without placing it in an instruction, so it covers both files.
+#
+# `x0`-`x30` and `xzr` / `sp` at index 31 for the general-purpose file, `v0`-`v31` for
+# the vector file. The `w` spelling is deliberately absent: a declaration names a
+# REGISTER, and `w3` and `x3` are one register whose bits the allocator tracks as one
+# unit, so accepting both would suggest the mask distinguished them. `xzr` and `sp`
+# resolve because the operand lexer already spells them, and declaring either is
+# harmless - the allocator hands out neither.
+fun a64_decl_reg(name: str, bank: *u8, idx: *u32) bool {
+    var op: iasm.Operand = iasm.op_none();
+    if (a64_reg(name, ?op) && op.size == 8 && op.reg >= 0) {
+        @bank = iasm.ABANK_GP;
+        @idx  = op.reg::u32;
+        ret true;
+    }
+    var n: u32 = 0;
+    if (a64_vec_index(name, ?n)) {
+        @bank = iasm.ABANK_FP;
+        @idx  = n;
+        ret true;
+    }
+    ret false;
+}
+
+# the vector register index `v<N>` denotes, or false when the name is not one
+#
+# The arrangement suffix a vector OPERAND carries (`v2.4s`) is deliberately not
+# accepted: an arrangement says how an instruction reads the register's lanes, and a
+# declaration is about the register, which is written whole either way.
+fun a64_vec_index(name: str, out: *u32) bool {
+    val len: usize = str_len(name);
+    if (len < 2 || len > 3)       { ret false; }
+    if (name[0] != 'v'::char)     { ret false; }
+    var n: u32 = 0;
+    var i: usize = 1;
+    for (i < len) {
+        if (!iasm.is_digit(name[i])) { ret false; }
+        n = n * 10 + (name[i]::u32 - '0'::u32);
+        i = i + 1;
+    }
+    if (n > 31) { ret false; }
+    @out = n;
+    ret true;
 }
 
 # the `AsmClobbersFn` the arm64 ISA vtable exposes - the registers an inline-asm body
@@ -7593,6 +7642,97 @@ test "mach.lang.target.isa.arm64.encode:systems_mnemonics_clobbers" {
     asm_clobbers("hvc", ?gp, ?fp);
     if (gp != 0xFFFFFFFF) { bad = 1; }
 
+    ret bad;
+}
+
+# a raw encoding declares its write set through the target's own register names, and
+# reaches both banks (#2594)
+#
+# aarch64 is where the escape hatch is a wall rather than an inconvenience: every
+# instruction is one word, so a mnemonic the table lacks has no spelling at all short
+# of `.word`. That is what made `hvc` reachable before #2585 added it - and at the
+# price of the whole register file, which is exactly what a declaration pays down.
+test "mach.lang.target.isa.arm64.encode:declared_raw_encodings" {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var bad: i32 = 0;
+
+    # the `hvc #0` word this target spelled by hand before it was a mnemonic, now
+    # declaring the SMCCC result registers a PSCI call actually returns in.
+    asm_clobbers(".word 0xd4000002 :: writes(x0, x1, x2, x3)", ?gp, ?fp);
+    if (gp != 0xF) { bad = 1; }
+    if (fp != 0)   { bad = 1; }
+
+    # the same word undeclared is unchanged: every register in every bank.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd4000002", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    if (fp != 0xFFFFFFFF) { bad = 1; }
+
+    # an idle wait writes nothing at all.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd503207f :: writes()", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
+    # the vector bank, which no aarch64 inline-asm OPERAND in this grammar names.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd503201f :: writes(v7, v31)", ?gp, ?fp);
+    if (gp != 0)                                  { bad = 1; }
+    if (fp != ((1::u32 << 7) | (1::u32 << 31)))   { bad = 1; }
+
+    # x30 and the zero/stack register at index 31 are nameable, since a raw encoding
+    # can genuinely write the link register.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd503201f :: writes(x30)", ?gp, ?fp);
+    if (gp != (1::u32 << 30)) { bad = 1; }
+
+    # a WIDTH is not a register: `w0` and `x0` are one register whose bits the
+    # allocator tracks as a unit, so the narrow spelling is refused rather than
+    # accepted as if the mask told them apart.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd503201f :: writes(w0)", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    # an arrangement suffix is an instruction's reading of the lanes, not a register.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd503201f :: writes(v2.4s)", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    # and a name this target does not have refuses rather than declaring nothing.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xd503201f :: writes(x31)", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    # a clause cannot override a modeled instruction, so the derived facts stand.
+    gp = 0; fp = 0;
+    asm_clobbers("mov x0, x1 :: writes()", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    ret bad;
+}
+
+# a declaration changes the effect model and not one emitted byte
+test "mach.lang.target.isa.arm64.encode:declared_raw_encodings_emit_unchanged" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    a64_asm_text(?st, ?f, ?labels, ".word 0xd4000002 :: writes(x0)");  # 0
+    a64_asm_text(?st, ?f, ?labels, ".word 0xd4000002");                # 4
+    a64_asm_text(?st, ?f, ?labels, ".word 0xd503207f :: writes()");    # 8
+
+    if (read_word(?st.buf, 0) != 0xD4000002) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xD4000002) { bad = 1; }
+    if (read_word(?st.buf, 8) != 0xD503207F) { bad = 1; }
+    # three words and nothing else: the clause contributed no bytes of its own.
+    if (st.buf.len != 12) { bad = 1; }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
     ret bad;
 }
 

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -13,13 +13,15 @@
 #   SHARED (this module)          the statement cursor and its byte accounting, the
 #                                 mnemonic table walk, top-level operand splitting,
 #                                 numeric-local-label scope and resolution, `{name}`
-#                                 binding, the effect (clobber) fold, the block
-#                                 driver, and every diagnostic.
+#                                 binding, the effect-clause grammar, the effect
+#                                 (clobber) fold, the block driver, and every
+#                                 diagnostic.
 #   PER-ISA (the `Grammar`)       the mnemonic table (what each mnemonic denotes, its
 #                                 register-write facts, how many words it emits),
 #                                 the operand lexer (register names, `[base + i*s +
 #                                 d]` versus `d(base)` versus `[Xn, #d]`, relocation
-#                                 modifiers), and the emitter.
+#                                 modifiers), the declarable register names, and the
+#                                 emitter.
 #
 # TOTALITY IS CHECKED, NOT ASSUMED. Every byte of a body must be claimed by exactly
 # one parsed item, with only whitespace and statement separators between claims, or
@@ -47,6 +49,11 @@
 # Precision is earned per mnemonic, on that mnemonic's own table row, and never
 # credited by category - `opaque-and-slow` is safe, `modeled-and-wrong` is a
 # miscompile.
+#
+# THE ONE PLACE THAT DEFAULT MAY BE OVERRIDDEN is a data directive carrying an explicit
+# effect clause, `.byte 0xee :: writes()`, which is opt-in, attaches to nothing the
+# compiler can already read, and moves correctness onto the author for that statement
+# alone. See `CLAUSE_MARK` for what survives that trade and what does not (#2594).
 #
 # A `{name}` binding is the one operand every grammar reads the same way, so it is
 # stated here rather than three times (#2258): it denotes a frame slot, a frame slot
@@ -267,6 +274,65 @@ pub val AR_NONE:  u8 = 0;  # nothing: the instruction is self-contained
 pub val AR_SYM:   u8 = 1;  # a named symbol the linker resolves
 pub val AR_LOCAL: u8 = 2;  # a numeric local label within this block
 
+# the effect clause a raw encoding may carry: `.byte 0xee :: writes()`
+#
+# THE ESCAPE HATCH'S ESCAPE HATCH, and the reason it exists is the one the register
+# surface already argued (#2594). `doc/language/asm.md` says the named system-register
+# set is "deliberately not exhaustive" because any register is ALSO nameable by its
+# encoding, "which is what makes the surface complete rather than a list that always
+# lags the architecture". A data directive is that same numeric escape one level up:
+# it names an instruction the mnemonic table does not. What it could not do until now
+# is carry the fact the table would have carried, so it bought completeness at the
+# price of the whole register file - the allocator holds nothing live across a
+# `.byte`, which is measurable and which the curated table exists to avoid.
+#
+# THE PROPERTY THAT MAKES A DECLARATION SAFE TO ACCEPT IS THAT IT IS MONOTONE. A
+# clause attaches to a data directive and to nothing else. A modeled instruction's
+# facts come from its mnemonic row and cannot be overridden, so a declaration can only
+# ever NARROW the maximally-conservative default, applied at exactly the statements
+# where the compiler had no information at all. It can never contradict a fact the
+# compiler derived, and the blast radius of a wrong one is the single hand-written
+# statement that carries it.
+#
+# WHAT THE COMPILER STILL CHECKS, and what it cannot:
+#
+#   CHECKED  the clause is claimed like every other byte, so a malformed one refuses
+#            the block rather than being silently dropped - an author who mistypes
+#            `writes(` gets a build error, not a declaration that quietly said nothing.
+#   CHECKED  every register named resolves through the ISA's own name table, so a
+#            typo (`x32`, `raxx`) refuses rather than naming nothing.
+#   CHECKED  a grammar wiring no name table refuses every declaration, so a target
+#            gains the syntax only when it can validate it.
+#   CHECKED  `writes()` and an absent clause are DIFFERENT: the first declares the
+#            empty set, the second declares nothing and keeps the conservative default.
+#   UNCHECKED, AND IRREDUCIBLY SO: whether the bytes write what the clause says. The
+#            compiler does not decode the payload - that is what the mnemonic table is
+#            for, and a decoder here would be one. An author who under-declares gets a
+#            miscompile. This is the one place in the inline-asm surface where
+#            correctness rests on the author rather than on the compiler, and
+#            `doc/language/asm.md` says so where an author will read it.
+#
+# A DECLARATION BUYS ALLOCATION QUALITY, NOT VERIFICATION. `ct_scan` still refuses a
+# data directive inside an `#[oblivious]` function whether or not it is declared: a
+# write set says which registers change, and says nothing about whether the payload is
+# a secret-dependent branch or a variable-latency divide. Letting an author declare
+# past a security gate is #2288's failure exactly.
+#
+# WHY THERE IS NO `noreturn` YET, though `iretq` wants one (#2590). Control not
+# returning is a CFG fact: it would remove the block's fall-through edge, which is what
+# would make values live across the block dead instead. Nothing in the effect model
+# reaches liveness, so an attribute added here today would parse, validate, and change
+# nothing - a spelling that promises more than it does, which is worse than its
+# absence. The clause grammar is a space-separated attribute list precisely so it lands
+# as one more row when the CFG can act on it. A per-statement `barrier` is a different
+# story and will not be added: every `asm` block is already assumed to modify arbitrary
+# memory, so the attribute would be true and inert on the day it was written.
+pub val CLAUSE_MARK: str = "::";
+
+# the register banks a declared clobber can name
+pub val ABANK_GP: u8 = 0;  # the general-purpose file
+pub val ABANK_FP: u8 = 1;  # the float / vector file
+
 # one parsed inline-asm statement
 #
 # The unit both consumers read: the emitter turns it into bytes, the effect model
@@ -296,6 +362,9 @@ pub val AR_LOCAL: u8 = 2;  # a numeric local label within this block
 # ref_fwd:    true when an AR_LOCAL reference is forward (`<digits>f`)
 # bytes:      the raw byte payload (AI_BYTES)
 # byte_count: number of payload bytes
+# declared:   the statement carried a `::` effect clause (AI_BYTES only)
+# decl_gp:    the general-purpose registers that clause names
+# decl_fp:    the float / vector registers that clause names
 # src_off:    body offset of the statement text this item claims
 # src_len:    length of that text
 pub rec Item {
@@ -315,6 +384,9 @@ pub rec Item {
     ref_fwd:    bool;
     bytes:      [BYTES_MAX]u8;
     byte_count: usize;
+    declared:   bool;
+    decl_gp:    u32;
+    decl_fp:    u32;
     src_off:    usize;
     src_len:    usize;
 }
@@ -444,6 +516,30 @@ pub def CtClassFn: fun(u32, u16) ct.AsmClass;
 # start: `.text` offset of the payload's first byte
 pub def NoteBytesFn: fun(*encode.EncodeState, *u8, usize, usize) R.Result[bool, str];
 
+# resolve a register name a declared clobber set spells, to its bank and index
+#
+# The per-ISA half of the effect clause (#2594): the clause's SHAPE is one grammar on
+# every machine and lives in the shared parser, the register NAMES are the target's,
+# exactly the split the module header states.
+#
+# THIS IS NOT THE OPERAND LEXER AND MUST NOT BE IT. An operand lexer names only what an
+# operand may be, which on x86-64 excludes every vector register by design - the
+# comment on `x64_reg` says so, and widening it would give `xmm0` a `reg` id that
+# collides with RAX in the shared write fold. A declaration names a register in EITHER
+# bank without placing it in an instruction, so it is a strictly larger vocabulary and
+# gets its own resolver.
+#
+# EVERY REGISTER THE GRAMMAR'S `all_gp` / `all_fp` REACHES MUST BE NAMEABLE HERE, or
+# the escape hatch is incomplete in exactly the way it exists to fix: a raw encoding
+# writing a register with no spelling could not be declared, and would have to fall
+# back to the conservative default the clause is meant to avoid.
+# ---
+# name: the register name as written in the clause
+# bank: receives ABANK_GP or ABANK_FP
+# idx:  receives the within-bank register index, which is the bit position in the mask
+# ret:  true when the name resolves, false when this ISA spells no such register
+pub def DeclRegFn: fun(str, *u8, *u32) bool;
+
 # one target's inline-assembly grammar
 #
 # Everything the shared parser needs that is not the same on every machine. A target
@@ -469,6 +565,8 @@ pub def NoteBytesFn: fun(*encode.EncodeState, *u8, usize, usize) R.Result[bool, 
 # word:       the instruction word size in bytes, or 0 for a variable-length encoding
 # endian:     the byte order a data directive's values take
 # note_bytes: the assembly-printer notification for a directive payload
+# decl_reg:   the register-name resolver a declared clobber set reads, or nil to
+#             refuse every declaration on this target
 pub rec Grammar {
     isa:        str;
     unknown:    str;
@@ -487,6 +585,7 @@ pub rec Grammar {
     endian:     isa.Endian;
     ct_class:   CtClassFn;
     note_bytes: NoteBytesFn;
+    decl_reg:   DeclRegFn;
 }
 
 # an operand in the neutral state each lexer fills in
@@ -803,6 +902,9 @@ fun item_reset(item: *Item) {
     item.ref_num    = 0;
     item.ref_fwd    = false;
     item.byte_count = 0;
+    item.declared   = false;
+    item.decl_gp    = 0;
+    item.decl_fp    = 0;
     item.src_off    = 0;
     item.src_len    = 0;
     var i: usize = 0;
@@ -1028,10 +1130,18 @@ fun finish(c: *Cursor) R.Result[bool, str] {
 #
 # A data directive is resolved BEFORE the mnemonic table, so the family means the same
 # thing on every target and a mnemonic table cannot shadow it.
+#
+# An effect clause is split off FIRST, so everything below reads the statement proper
+# and no payload or operand splitter has to know the clause exists (#2594).
 fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, str] {
+    val cl: usize = clause_start(c.body, lo, hi);
+    var body_hi: usize = hi;
+    if (cl < hi) { body_hi = clause_body_end(c.body, lo, cl); }
+
     var num: u64 = 0;
-    val dlen: usize = label_def_span(c.body, lo, hi, ?num);
+    val dlen: usize = label_def_span(c.body, lo, body_hi, ?num);
     if (dlen > 0) {
+        if (cl < hi) { ret R.err[usize, str](clause_target_message(c, lo, hi)); }
         val cr: R.Result[bool, str] = claim(c, lo, dlen);
         if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
         item.kind    = AI_LABEL;
@@ -1039,8 +1149,21 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
         ret R.ok[usize, str](lo + dlen);
     }
 
-    val di: i32 = directive_lookup(c.g, c.body, lo, hi);
-    if (di >= 0) { ret parse_directive(c, lo, hi, ?c.g.data[di::usize], item); }
+    val di: i32 = directive_lookup(c.g, c.body, lo, body_hi);
+    if (di >= 0) {
+        val dr: R.Result[usize, str] = parse_directive(c, lo, body_hi, ?c.g.data[di::usize], item);
+        if (R.is_err[usize, str](dr)) { ret dr; }
+        if (cl >= hi) { ret R.ok[usize, str](body_hi); }
+        val kr: R.Result[bool, str] = parse_clause(c, cl, hi, item);
+        if (R.is_err[bool, str](kr)) { ret R.err[usize, str](R.unwrap_err[bool, str](kr)); }
+        ret R.ok[usize, str](hi);
+    }
+
+    # a modeled instruction's effects come from its mnemonic row, and letting a clause
+    # override them would be the one direction this feature must not go: it could
+    # UNDER-declare an instruction the compiler already reads correctly, turning a
+    # derived fact into an author's assertion for no gain (#2594).
+    if (cl < hi) { ret R.err[usize, str](clause_target_message(c, lo, hi)); }
 
     var s: Stmt;
     s.lo    = lo;
@@ -1076,6 +1199,193 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
     val pr: R.Result[bool, str] = c.g.parse(c, ?s, item);
     if (R.is_err[bool, str](pr)) { ret R.err[usize, str](R.unwrap_err[bool, str](pr)); }
     ret R.ok[usize, str](hi);
+}
+
+# the offset of the effect clause's `::` within `body[lo..hi)`, or `hi` when there is
+# none
+#
+# `::` cannot occur anywhere else in a statement: a payload value is an integer
+# literal, an operand is a register, a bracketed address, an immediate or a name, and
+# none of the three grammars spells a doubled colon. So a plain scan is exact rather
+# than a heuristic, and no depth tracking is needed.
+fun clause_start(body: str, lo: usize, hi: usize) usize {
+    var i: usize = lo;
+    for (i + 1 < hi) {
+        if (body[i] == ':'::char && body[i + 1] == ':'::char) { ret i; }
+        i = i + 1;
+    }
+    ret hi;
+}
+
+# the end of the statement proper: `cl` with its preceding whitespace trimmed off
+fun clause_body_end(body: str, lo: usize, cl: usize) usize {
+    var b: usize = cl;
+    for (b > lo && is_space(body[b - 1])) { b = b - 1; }
+    ret b;
+}
+
+# the diagnostic for an effect clause on a statement that may not carry one
+fun clause_target_message(c: *Cursor, lo: usize, hi: usize) str {
+    ret span_message(c,
+        "encode: inline-asm statement '", lo, hi,
+        "' carries an effect clause, which only a data directive may: a modeled instruction's effects come from its mnemonic",
+        "encode: an inline-asm effect clause may follow only a data directive, since a modeled instruction's effects come from its mnemonic");
+}
+
+# parse the effect clause spanning `body[lo..hi)`, claiming all of it
+#
+# The clause is claimed as ONE region rather than token by token, which is exactly what
+# it is: a single syntactic unit attached to the statement before it. The accounting
+# invariant is unchanged - every byte of the body is still claimed by exactly one item
+# - and this reader is total over the span, so no byte inside it goes unread either.
+# ---
+# c:    the cursor
+# lo:   body offset of the `::`
+# hi:   body offset just past the clause
+# item: receives the declared facts
+# ret:  ok(true), or the refusal naming what was wrong
+fun parse_clause(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[bool, str] {
+    # a target that wires no register-name resolver cannot validate a declaration, so
+    # it refuses one rather than accepting a set it could not check.
+    if (c.g.decl_reg == nil) {
+        ret R.err[bool, str](named_message(c.alloc, c.interner,
+            "encode: ", c.g.isa, " inline asm does not support effect clauses",
+            "encode: this target's inline asm does not support effect clauses"));
+    }
+
+    var i: usize = lo + 2;
+    var seen: u32 = 0;
+    for (i < hi) {
+        for (i < hi && is_space(c.body[i])) { i = i + 1; }
+        if (i >= hi) { cnt; }
+        val ar: R.Result[usize, str] = parse_attr(c, i, hi, item);
+        if (R.is_err[usize, str](ar)) { ret R.err[bool, str](R.unwrap_err[usize, str](ar)); }
+        i    = R.unwrap_ok[usize, str](ar);
+        seen = seen + 1;
+    }
+    if (seen == 0) {
+        ret R.err[bool, str](span_message(c,
+            "encode: inline-asm effect clause '", lo, hi, "' names no attribute",
+            "encode: an inline-asm effect clause names no attribute"));
+    }
+
+    item.declared = true;
+    ret claim(c, lo, hi - lo);
+}
+
+# parse one attribute starting at `lo`, returning the offset just past it
+#
+# `writes(<reg>, ...)` is the only attribute today and the grammar is a
+# space-separated LIST so that stays true by choice rather than by construction - see
+# the clause's design note for why `noreturn` is not here yet.
+fun parse_attr(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, str] {
+    var name_hi: usize = lo;
+    for (name_hi < hi && is_sym_char(c.body[name_hi])) { name_hi = name_hi + 1; }
+    if (name_hi == lo) {
+        ret R.err[usize, str](span_message(c,
+            "encode: inline-asm effect clause '", lo, hi, "' is malformed",
+            "encode: an inline-asm effect clause is malformed"));
+    }
+
+    if (!str_region_equals(c.body, lo, name_hi - lo, "writes")) {
+        ret R.err[usize, str](span_message(c,
+            "encode: unknown inline-asm effect attribute '", lo, name_hi,
+            "'; the only attribute is `writes(<registers>)`",
+            "encode: unknown inline-asm effect attribute; the only attribute is `writes(<registers>)`"));
+    }
+
+    if (name_hi >= hi || c.body[name_hi] != '('::char) {
+        ret R.err[usize, str](span_message(c,
+            "encode: inline-asm effect attribute '", lo, name_hi,
+            "' takes a parenthesized register list; write `writes()` to declare that the encoding writes none",
+            "encode: an inline-asm `writes` attribute takes a parenthesized register list; write `writes()` to declare that the encoding writes none"));
+    }
+
+    var close: usize = name_hi + 1;
+    var found: bool = false;
+    for (close < hi && !found) {
+        if (c.body[close] == ')'::char) { found = true; } or { close = close + 1; }
+    }
+    if (!found) {
+        ret R.err[usize, str](span_message(c,
+            "encode: inline-asm effect attribute '", lo, hi, "' has no closing ')'",
+            "encode: an inline-asm effect attribute has no closing ')'"));
+    }
+
+    val lr: R.Result[bool, str] = parse_reg_list(c, name_hi + 1, close, item);
+    if (R.is_err[bool, str](lr)) { ret R.err[usize, str](R.unwrap_err[bool, str](lr)); }
+    ret R.ok[usize, str](close + 1);
+}
+
+# fold the comma-separated register names in `body[lo..hi)` into the declared masks
+#
+# An empty list is a DECLARATION, not an omission: `writes()` says the encoding writes
+# no register, which is the whole point for an instruction like `out dx, al`. That is
+# why the presence of the clause and its contents are tracked separately - an absent
+# clause and an empty one must not be the same value (#2594).
+fun parse_reg_list(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[bool, str] {
+    var a: usize = lo;
+    for (a < hi && is_space(c.body[a])) { a = a + 1; }
+    if (a >= hi) { ret R.ok[bool, str](true); }
+
+    var start: usize = a;
+    var i: usize = a;
+    for (i <= hi) {
+        var sep: bool = false;
+        if (i == hi)                { sep = true; }
+        or (c.body[i] == ','::char) { sep = true; }
+
+        if (sep) {
+            var ta: usize = start;
+            var tb: usize = i;
+            for (ta < tb && is_space(c.body[ta])) { ta = ta + 1; }
+            for (tb > ta && is_space(c.body[tb - 1])) { tb = tb - 1; }
+            if (tb <= ta) {
+                ret R.err[bool, str](span_message(c,
+                    "encode: inline-asm effect clause '", lo, hi, "' names an empty register",
+                    "encode: an inline-asm effect clause names an empty register"));
+            }
+            val rr: R.Result[bool, str] = declare_reg(c, ta, tb, item);
+            if (R.is_err[bool, str](rr)) { ret rr; }
+            start = i + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# resolve one register name and set its bit in the declared mask
+#
+# A name this ISA does not spell REFUSES. That is the difference between a declaration
+# and a comment: a typo that resolved to nothing would silently declare a smaller set
+# than the author wrote, which is the miscompile this whole feature has to be careful
+# about (#2594).
+fun declare_reg(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[bool, str] {
+    var buf: [32]u8;
+    if (!copy_region(c.body, lo, hi, ?buf[0], 32)) {
+        ret R.err[bool, str](span_message(c,
+            "encode: inline-asm effect clause names '", lo, hi, "', which is not a register",
+            "encode: an inline-asm effect clause names something that is not a register"));
+    }
+
+    var bank: u8 = ABANK_GP;
+    var idx: u32 = 0;
+    if (!c.g.decl_reg((?buf[0])::str, ?bank, ?idx)) {
+        ret R.err[bool, str](span_message(c,
+            "encode: inline-asm effect clause names '", lo, hi, "', which is not a register on this target",
+            "encode: an inline-asm effect clause names something that is not a register on this target"));
+    }
+    # the masks are 32 bits wide, the same domain `mark_written` folds into, so a
+    # resolver handing back a wider index would silently declare nothing.
+    if (idx >= 32) {
+        ret R.err[bool, str](span_message(c,
+            "encode: inline-asm effect clause names '", lo, hi, "', whose register index the clobber mask cannot represent",
+            "encode: an inline-asm effect clause names a register the clobber mask cannot represent"));
+    }
+
+    if (bank == ABANK_FP) { item.decl_fp = item.decl_fp | (1::u32 << idx); }
+    or                    { item.decl_gp = item.decl_gp | (1::u32 << idx); }
+    ret R.ok[bool, str](true);
 }
 
 # parse one data-directive statement `body[lo..hi)`, returning the offset it consumed
@@ -1168,7 +1478,14 @@ fun bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, star
 # The whole effect model, and the same one on every target. An instruction writes
 # exactly the registers its mnemonic's facts name among its own operands, plus the
 # ones its form writes regardless. A raw byte payload is not an instruction the
-# parser read at all, so it reaches every register in every bank.
+# parser read at all, so it reaches every register in every bank UNLESS its statement
+# declared a set, in which case the declaration is the fact (#2594).
+#
+# THE UNDECLARED CASE IS UNCHANGED, deliberately: a `.byte` written before this
+# existed, or by an author who did not want to reason about it, keeps costing the whole
+# register file. A declaration is opt-in precisely because it moves the burden of being
+# right from the compiler onto the author, and nothing should acquire that burden by
+# being left alone.
 #
 # A `{name}` binding names a frame slot, never a register, so a statement carrying
 # one folds to the same set resolved or unresolved (#2258).
@@ -1180,6 +1497,11 @@ fun bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, star
 pub fun fold_clobbers(g: *Grammar, item: *Item, gp: *u32, fp: *u32) {
     if (item.kind == AI_LABEL) { ret; }
     if (item.kind == AI_BYTES) {
+        if (item.declared) {
+            @gp = @gp | item.decl_gp;
+            @fp = @fp | item.decl_fp;
+            ret;
+        }
         @gp = @gp | g.all_gp;
         @fp = @fp | g.all_fp;
         ret;
@@ -1868,8 +2190,16 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
     # consulted. that is what makes the raw-encoding escape (#2479) safe to widen: a
     # directive can never reach `g.ct_class`, so no spelling of it can be classified
     # constant-time by omission.
+    #
+    # A DECLARED WRITE SET DOES NOT CHANGE THIS AND MUST NOT (#2594). `item.declared`
+    # is deliberately not consulted here: a clause says which registers an encoding
+    # changes, which is what the ALLOCATOR needs, and says nothing about whether the
+    # payload branches on a secret or divides in variable time - the two things this
+    # walk exists to catch. Letting an author declare their way past a security gate is
+    # #2288's failure exactly, so a declaration buys allocation quality and never
+    # verification.
     if (item.kind == AI_BYTES) {
-        ret R.err[bool, str]("contains a data directive inside an #[oblivious] function; its payload can encode any instruction, so it cannot be verified constant-time");
+        ret R.err[bool, str]("contains a data directive inside an #[oblivious] function; its payload can encode any instruction, so it cannot be verified constant-time (a `writes(...)` declaration does not change this: it states which registers change, not whether the encoding is constant-time)");
     }
 
     val cls: ct.AsmClass = g.ct_class(item.code, item.flags);

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -75,8 +75,8 @@ use mach.lang.intern;
 use mach.lang.target.isa;
 use iasm: mach.lang.target.isa.asm;
 use mach.lang.target.isa.riscv64;
-use mach.lang.target.isa.riscv64.inst;
 use printer: mach.lang.target.isa.riscv64.printer;
+use mach.lang.target.isa.riscv64.inst;
 use mach.lang.target.of;
 use mach.lang.target.resolved;
 
@@ -4451,7 +4451,53 @@ fun rv_grammar() iasm.Grammar {
     g.endian     = isa.ENDIAN_LITTLE;
     g.ct_class   = asm_ct_class;
     g.note_bytes = asm_note_bytes;
+    g.decl_reg   = rv_decl_reg;
     ret g;
+}
+
+# the register a declared clobber set names, in its bank (#2594)
+#
+# A superset of the operand lexer, which reaches only the integer file: a declaration
+# names a register without placing it in an instruction, so it covers both. Both banks
+# accept the numeric spelling (`x5`, `f5`) and the psABI aliases (`t0`, `ft0`), which
+# is the same pairing the printer uses on each side.
+fun rv_decl_reg(name: str, bank: *u8, idx: *u32) bool {
+    val gp: i32 = asm_reg_index(name);
+    if (gp >= 0) {
+        @bank = iasm.ABANK_GP;
+        @idx  = gp::u32;
+        ret true;
+    }
+    val fp: i32 = asm_fp_reg_index(name);
+    if (fp >= 0) {
+        @bank = iasm.ABANK_FP;
+        @idx  = fp::u32;
+        ret true;
+    }
+    ret false;
+}
+
+# the float register index a RISC-V register token names, or -1 when it names none
+#
+# Accepts the numeric `fN` spelling and the psABI aliases the printer emits, resolved
+# through `printer.fp_name` so the two can never drift: a name that prints is a name
+# that parses, which is what keeps a `--emit-asm` artifact readable back in.
+fun asm_fp_reg_index(tok: str) i32 {
+    var i: u32 = 0;
+    for (i < 32) {
+        if (str_equals(tok, printer.fp_name(i))) { ret i::i32; }
+        i = i + 1;
+    }
+    if (tok[0] != 'f'::char || tok[1] == 0) { ret -1; }
+    var n: i32 = 0;
+    var k: usize = 1;
+    for (tok[k] != 0) {
+        if (tok[k] < '0'::char || tok[k] > '9'::char) { ret -1; }
+        n = n * 10 + (tok[k]::i32 - '0'::char::i32);
+        k = k + 1;
+    }
+    if (n >= 0 && n < 32) { ret n; }
+    ret -1;
 }
 
 # the `AsmClobbersFn` the RV64 ISA vtable exposes - the registers an inline-asm body
@@ -5571,6 +5617,65 @@ test "mach.lang.target.isa.riscv64.encode:asm_clobbers_data_directives_are_opaqu
     asm_clobbers("nop", ?gp, ?fp);
     if (gp != 0) { bad = 1; }
     if (fp != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# a raw encoding declares its write set through the psABI names, in both banks (#2594)
+#
+# RV64 is the target with the largest unreachable surface behind `.word`: the
+# privileged spec defines several hundred CSR addresses across three privilege levels
+# and the grammar's mnemonic table necessarily lags it. A declaration is what lets an
+# unmodeled instruction cost its own registers rather than all sixty-four.
+test "mach.lang.target.isa.riscv64.encode:declared_raw_encodings" {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var bad: i32 = 0;
+
+    # `csrr a0, time` - reads a counter into a0 and touches nothing else.
+    asm_clobbers(".word 0xc0102573 :: writes(a0)", ?gp, ?fp);
+    if (gp != (1::u32 << 10)) { bad = 1; }
+    if (fp != 0)              { bad = 1; }
+
+    # the same word undeclared stays opaque.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xc0102573", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    if (fp != 0xFFFFFFFF) { bad = 1; }
+
+    # both spellings of the same register resolve to the same bit, which is what makes
+    # a `--emit-asm` artifact readable back in as the declaration it describes.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0xc0102573 :: writes(x10)", ?gp, ?fp);
+    if (gp != (1::u32 << 10)) { bad = 1; }
+
+    # the float bank, which the RV64 operand lexer never reaches.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0x00000013 :: writes(ft2, fa0)", ?gp, ?fp);
+    if (gp != 0)                                    { bad = 1; }
+    if (fp != ((1::u32 << 2) | (1::u32 << 10)))     { bad = 1; }
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0x00000013 :: writes(f2)", ?gp, ?fp);
+    if (fp != (1::u32 << 2)) { bad = 1; }
+
+    # an empty declaration is a real statement: `fence` writes no register.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0x0ff0000f :: writes()", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
+    # a name this target does not have refuses rather than declaring a smaller set.
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0x00000013 :: writes(x32)", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    gp = 0; fp = 0;
+    asm_clobbers(".word 0x00000013 :: writes(a8)", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    # a clause cannot override a modeled instruction's derived facts.
+    gp = 0; fp = 0;
+    asm_clobbers("addi a0, a1, 1 :: writes()", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -6121,7 +6121,49 @@ fun x64_grammar() iasm.Grammar {
     g.endian     = isa.ENDIAN_LITTLE;
     g.ct_class   = asm_ct_class;
     g.note_bytes = asm_note_bytes;
+    g.decl_reg   = x64_decl_reg;
     ret g;
+}
+
+# the register a declared clobber set names, in its bank (#2594)
+#
+# A SUPERSET OF THE OPERAND LEXER, and it has to be. `x64_reg` names no vector register
+# on purpose - only a body the parser cannot read at all reaches the vector bank - and
+# widening it would give `xmm0` a `reg` id of 0, which the shared write fold reads as
+# RAX. A declaration names a register without placing it in an instruction, so the two
+# vocabularies are genuinely different and this one covers both files.
+#
+# The 64-bit spelling alone for the general-purpose file: a declaration names a
+# REGISTER, not an access width, and `eax` and `rax` are one register whose bits the
+# allocator tracks as one unit. Accepting both spellings would suggest the mask
+# distinguished them.
+fun x64_decl_reg(name: str, bank: *u8, idx: *u32) bool {
+    var op: iasm.Operand = iasm.op_none();
+    if (x64_reg(name, ?op) && op.size == 8 && op.reg >= 0) {
+        @bank = iasm.ABANK_GP;
+        @idx  = op.reg::u32;
+        ret true;
+    }
+    var n: i32 = 0;
+    if (x64_xmm_index(name, ?n)) {
+        @bank = iasm.ABANK_FP;
+        @idx  = n::u32;
+        ret true;
+    }
+    ret false;
+}
+
+# the XMM register index `name` denotes, or false when it names none
+#
+# Declaration-only, for the reason above: no x86-64 inline-asm OPERAND may name a
+# vector register, so this deliberately lives outside `x64_reg`.
+fun x64_xmm_index(name: str, out: *i32) bool {
+    var i: i32 = 0;
+    for (i < x64.FP_COUNT) {
+        if (str_equals(name, x64.fp_reg_name(i))) { @out = i; ret true; }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # the `AsmClobbersFn` the x86-64 ISA vtable exposes - the registers an inline-asm body
@@ -6765,6 +6807,185 @@ test "mach.lang.target.isa.x64.encode.x64_parse:body_to_inst" {
     val last: R.Result[bool, str] = iasm.next(?c, ?item);
     if (R.is_err[bool, str](last))    { ret 1; }
     if (R.unwrap_ok[bool, str](last)) { bad = 1; }
+    ret bad;
+}
+
+# a raw encoding that declares its write set costs that set, and an undeclared one
+# still costs the whole register file (#2594)
+#
+# The two halves are one test because the second is what makes the first safe to have.
+# `.byte` is the escape hatch that keeps the surface complete, and its price is that
+# the allocator holds nothing live across it. A declaration pays that price down to the
+# registers the encoding actually writes; leaving the declaration off must change
+# nothing at all, or every body written before this existed silently gets a new and
+# wrong effect model.
+test "mach.lang.target.isa.x64.encode.asm_clobbers:declared_raw_encodings" {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+    var bad: i32 = 0;
+
+    # `out dx, al` - reads DX and AL, writes no register at all. this is the case the
+    # feature exists for: an empty declaration is a real statement, not an omission.
+    asm_clobbers(".byte 0xee :: writes()", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
+    # THE SAME BYTES UNDECLARED ARE UNCHANGED, which is the no-regression half.
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0xee", ?gp, ?fp);
+    if (gp != X64_ALL_GP) { bad = 1; }
+    if (fp != X64_ALL_FP) { bad = 1; }
+
+    # `rdtsc` - lands its result in EDX:EAX, exactly what the modeled row declares.
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0x0f, 0x31 :: writes(rax, rdx)", ?gp, ?fp);
+    if (gp != 0x5) { bad = 1; }
+    if (fp != 0)   { bad = 1; }
+
+    # the vector bank is reachable, which no x86-64 inline-asm OPERAND is: a
+    # declaration names a register without placing it in an instruction.
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0x90 :: writes(xmm3)", ?gp, ?fp);
+    if (gp != 0)            { bad = 1; }
+    if (fp != (1::u32 << 3)) { bad = 1; }
+
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0x90 :: writes(rbx, xmm15)", ?gp, ?fp);
+    if (gp != (1::u32 << 3))  { bad = 1; }
+    if (fp != (1::u32 << 15)) { bad = 1; }
+
+    # a declaration is per STATEMENT: an undeclared directive beside a declared one
+    # still degrades the whole body, so the escape hatch cannot be half-applied by
+    # accident.
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0xee :: writes()\n.byte 0x90", ?gp, ?fp);
+    if (gp != X64_ALL_GP) { bad = 1; }
+    if (fp != X64_ALL_FP) { bad = 1; }
+
+    # a declared directive folds together with the modeled instructions around it.
+    gp = 0; fp = 0;
+    asm_clobbers("mov rdx, rcx\n.byte 0xee :: writes()", ?gp, ?fp);
+    if (gp != (1::u32 << 2)) { bad = 1; }
+    if (fp != 0)             { bad = 1; }
+
+    # whitespace around the clause is free, and `;` still separates statements.
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0xee   ::   writes( rax , rdx )", ?gp, ?fp);
+    if (gp != 0x5) { bad = 1; }
+    gp = 0; fp = 0;
+    asm_clobbers(".byte 0xee :: writes() ; .byte 0x90 :: writes(rcx)", ?gp, ?fp);
+    if (gp != (1::u32 << 1)) { bad = 1; }
+
+    ret bad;
+}
+
+# a declaration changes the effect model and nothing else: the same payload bytes are
+# emitted, and the clause is accounted for like every other byte of the statement
+test "mach.lang.target.isa.x64.encode.declared_raw_encodings:emit_and_accounting" {
+    var bad: i32 = 0;
+
+    # the payload is untouched by the clause.
+    var one: [1]u8;
+    one[0] = 0xEE;
+    if (!t_asm_bytes(".byte 0xee :: writes()", ?one[0], 1)) { bad = 1; }
+
+    var two: [2]u8;
+    two[0] = 0x0F; two[1] = 0x31;
+    if (!t_asm_bytes(".byte 0x0f, 0x31 :: writes(rax, rdx)", ?two[0], 2)) { bad = 1; }
+
+    # the item records the clause rather than the parse merely tolerating it.
+    var g: iasm.Grammar = x64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, ".byte 0xee :: writes(rax)", nil, nil, nil, nil);
+    var item: iasm.Item;
+    if (R.is_err[bool, str](iasm.next(?c, ?item))) { ret 1; }
+    if (item.kind != iasm.AI_BYTES)                { bad = 1; }
+    if (!item.declared)                            { bad = 1; }
+    if (item.decl_gp != 1)                         { bad = 1; }
+    if (item.decl_fp != 0)                         { bad = 1; }
+    if (item.byte_count != 1)                      { bad = 1; }
+
+    # the statement claims its clause too, so the body is exhausted with nothing left
+    # unaccounted - a clause that parsed but went unclaimed would fail here.
+    val last: R.Result[bool, str] = iasm.next(?c, ?item);
+    if (R.is_err[bool, str](last))    { ret 1; }
+    if (R.unwrap_ok[bool, str](last)) { bad = 1; }
+
+    # an UNDECLARED directive records no declaration, which is what the fold reads.
+    var c2: iasm.Cursor;
+    iasm.cursor_init(?c2, ?g, ".byte 0xee", nil, nil, nil, nil);
+    if (R.is_err[bool, str](iasm.next(?c2, ?item))) { ret 1; }
+    if (item.declared)                              { bad = 1; }
+
+    ret bad;
+}
+
+# every way of writing the clause wrong fails the build naming it, which is what
+# separates a declaration from a comment (#2594)
+#
+# The compiler cannot check that the bytes write what the clause says - that is the
+# irreducible cost of the escape hatch. Everything it CAN check it must, because each
+# of these, silently accepted, would declare a smaller set than the author wrote and
+# produce exactly the miscompile the feature has to avoid.
+test "mach.lang.target.isa.x64.encode.declared_raw_encodings:malformed_clauses_refused" {
+    var bad: i32 = 0;
+
+    # a register this target does not have. a typo that resolved to nothing would
+    # silently narrow the declared set.
+    if (!t_asm_refused(".byte 0x90 :: writes(nosuchreg)", "not a register on this target")) { bad = 1; }
+    if (!t_asm_refused(".byte 0x90 :: writes(r16)", "not a register on this target"))       { bad = 1; }
+    # a WIDTH is not a register: `eax` and `rax` are one register the allocator tracks
+    # as a unit, so accepting both spellings would suggest the mask told them apart.
+    if (!t_asm_refused(".byte 0x90 :: writes(eax)", "not a register on this target"))       { bad = 1; }
+
+    # a clause the parser cannot finish reading.
+    if (!t_asm_refused(".byte 0x90 :: writes(rax", "closing"))        { bad = 1; }
+    if (!t_asm_refused(".byte 0x90 :: writes", "parenthesized"))      { bad = 1; }
+    if (!t_asm_refused(".byte 0x90 ::", "names no attribute"))        { bad = 1; }
+    if (!t_asm_refused(".byte 0x90 :: writes(rax,)", "empty"))        { bad = 1; }
+    if (!t_asm_refused(".byte 0x90 :: writes(,rax)", "empty"))        { bad = 1; }
+
+    # an attribute that does not exist is named rather than ignored, so a reader
+    # learns what the surface is instead of getting a silent no-op.
+    if (!t_asm_refused(".byte 0x90 :: reads(rax)", "unknown"))        { bad = 1; }
+    # `noreturn` is deliberately not implemented yet, and refusing it by name is the
+    # honest state: an attribute that parsed and changed nothing would promise more
+    # than it does.
+    if (!t_asm_refused(".byte 0x90 :: noreturn", "unknown"))          { bad = 1; }
+
+    # A CLAUSE MAY NOT ATTACH TO A MODELED INSTRUCTION. This is the property that makes
+    # the whole feature monotone: a declaration can only narrow the maximally
+    # conservative default, never override a fact the compiler derived.
+    if (!t_asm_refused("mov rax, rbx :: writes()", "only a data directive")) { bad = 1; }
+    if (!t_asm_refused("nop :: writes()", "only a data directive"))          { bad = 1; }
+    if (!t_asm_refused("1: :: writes()", "only a data directive"))           { bad = 1; }
+
+    ret bad;
+}
+
+# a declared raw encoding is still refused inside an `#[oblivious]` function
+#
+# A write set says which registers change. It says nothing about whether the payload
+# branches on a secret or divides in variable time, which is what this walk exists to
+# catch, so a declaration must buy allocation quality and never verification. Letting
+# an author declare past a security gate is #2288's failure exactly.
+test "mach.lang.target.isa.x64.encode.asm_ct_scan:a_declaration_is_not_a_verification" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var bad: i32 = 0;
+
+    var names: [1]str;
+    names[0] = "secret";
+
+    val undeclared: R.Result[bool, str] = asm_ct_scan(".byte 0x90", ?names[0], 1, false, false, ?alloc);
+    if (!R.is_err[bool, str](undeclared)) { bad = 1; }
+
+    val declared: R.Result[bool, str] = asm_ct_scan(".byte 0x90 :: writes()", ?names[0], 1, false, false, ?alloc);
+    if (!R.is_err[bool, str](declared))   { bad = 1; }
+    # and the refusal says why a declaration did not help, rather than reading as a
+    # parse failure the author might try to fix by declaring harder.
+    if (!str_contains(R.unwrap_err[bool, str](declared), "writes(...)")) { bad = 1; }
+
     ret bad;
 }
 


### PR DESCRIPTION
Closes #2594

## The shape

A `::` clause on a data directive, and on nothing else:

```mach
asm x86_64 {
    mov dx, {port}
    .byte 0xee :: writes()                 # out dx, al
    .byte 0x0f, 0x31 :: writes(rax, rdx)   # rdtsc
}

asm aarch64 { .word 0xd4000002 :: writes(x0, x1, x2, x3) }   # hvc #0, per SMCCC
asm riscv64 { .word 0xc0102573 :: writes(a0) }               # csrr a0, time
```

I kept the issue's own spelling. `::` cannot occur anywhere else in a
statement, since a payload value is an integer literal and no operand in any
of the three grammars spells a doubled colon, so the scan is exact rather
than a heuristic. Registers are named in the target's own vocabulary and
reach **both banks**, which the operand lexers deliberately do not: x86-64's
`x64_reg` names no vector register on purpose, and widening it would give
`xmm0` a `reg` id of 0 that the shared write fold reads as RAX. A
declaration names a register without placing it in an instruction, so it is
a strictly larger vocabulary and gets its own per-ISA resolver hook.

`writes()` with an empty list is a declaration, not an omission. An absent
clause keeps today's behaviour byte for byte.

## The trust argument, which is the design

An author-supplied write set is untrusted, and under-declaring is a silent
miscompile. So the question is what survives the escape hatch.

**It is monotone, and that is the load-bearing property.** A clause may only
follow a data directive. A modeled instruction's effects come from its
mnemonic row and cannot be overridden, so a declaration can only ever
*narrow* the maximally conservative default, applied at exactly the
statements where the compiler had no information at all. It can never
contradict a fact the compiler derived, and the blast radius of a wrong one
is the single hand-written statement carrying it. `mov rax, rbx ::
writes()` is refused, not honoured.

**Still checked.** The clause is claimed like every other byte, so a
mistyped `writes(` fails the build instead of quietly declaring nothing.
Every register named must resolve in the ISA's own table, so a typo fails
rather than narrowing the set silently. A grammar wiring no resolver refuses
every declaration. An unknown attribute is refused by name. A width is not a
register: `eax`, `w0` and `v2.4s` are refused, because `eax` and `rax` are
one register the allocator tracks as a unit and accepting both spellings
would imply the mask told them apart.

**Not checked, irreducibly.** Whether the bytes write what the clause says.
Decoding the payload is what the mnemonic table *is*, and a decoder here
would be one. `doc/language/asm.md` says this in as many words, in bold,
where an author will read it.

**A declaration buys allocation quality, never verification.** `ct_scan`
still refuses a data directive inside `#[oblivious]` whether or not it is
declared, and `item.declared` is deliberately not consulted there. A write
set says which registers change and nothing about whether the payload
branches on a secret or divides in variable time. Letting an author declare
past a security gate is #2288's failure exactly. The refusal message now
says so, so nobody tries to fix it by declaring harder.

## `noreturn`, which I hit on `iretq` last week

Deliberately **not** added, and this is the honest answer rather than the
convenient one. Control not returning is a CFG fact: it would remove the
block's fall-through edge, which is what would make values live across the
block dead instead. Nothing in the effect model reaches liveness, so an
attribute added today would parse, validate, and change nothing — a
spelling that promises more than it does, which is worse than its absence
and is the repo's standing defect class in language form. The clause grammar
is a space-separated attribute list precisely so it lands as one row when
the CFG can act on it, and `:: noreturn` is refused by name today rather
than silently accepted.

A per-statement `barrier` will not be added at all: every `asm` block is
already assumed to modify arbitrary memory, so it would be true and inert on
the day it was written.

## The measurement

The issue quantifies the current cost at 368 bytes on bmos-mach, so here is
a number rather than a claim. One function, one raw-encoding site inside a
loop, five values live across it, release profile, `.text` of the module:

| target | undeclared | `:: writes()` | saved |
|---|---|---|---|
| x86-64 | 243 bytes | 166 bytes | 77 (31%) |
| aarch64 | 240 bytes | 156 bytes | 84 (35%) |
| riscv64 | 308 bytes | 184 bytes | 124 (40%) |

The mechanism is visible in the disassembly: undeclared, the prologue saves
all five callee-saved GP registers and every loop-carried value round-trips
through the frame (25 frame references, 56 instructions). Declared, the
prologue saves none and the loop keeps its values in registers (8 frame
references, 36 instructions). The emitted payload bytes are identical in
both.

## Tests

- Both halves of the contract on all three ISAs: a declared directive costs
  its declared set, and the same directive undeclared still costs the whole
  register file. The second is what makes the first safe to ship.
- Both register banks per target, including the ones no operand can name.
- Every malformed clause refused by message, not merely refused: an
  unresolvable register, a width spelling, a missing paren, a missing
  argument list, an empty clause, an empty register, an unknown attribute,
  `noreturn`, and a clause on an instruction or a label.
- Byte accounting: the clause contributes no emitted bytes, and the parse is
  exhausted with nothing unclaimed.
- `#[oblivious]` refuses a declared directive, and the refusal names why a
  declaration did not help.
- Mutation-tested, eight deliberate breaks: the declaration ignored, an
  unresolvable name accepted silently, the clause left unclaimed, a clause
  allowed on a modeled instruction, any attribute name accepted, a declared
  directive passed through the constant-time walk, the aarch64 width check
  dropped, and the riscv64 float resolver shifted by one. Each failed
  exactly the test that claims to cover it.

`mach test .` is 1193 green, the linux int suite passes, and the release
self-host reaches its byte-identical fixpoint.
