### PR TITLE
fix(link): exempt mutually exclusive comptime arms from the attribution conflict

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -261,7 +261,9 @@ decorator's, is an error naming both claimants rather than a silent
 order-dependent win. The same holds between two `#[library]` decorators: two
 `ext` declarations resolving to one link name under different libraries are an
 error naming both declarations, so no attribution is decided by module load
-order. Repeating an identical claim is accepted, which is what an
+order. Declarations under different arms of one `$if` chain are exempt: no target
+selects both arms, so they never both apply. Repeating an identical claim is
+accepted, which is what an
 `export = true` entry reaching a consumer through both the cascade and its own
 manifest does, and what two modules declaring the same binding under the same
 library do.

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -165,6 +165,9 @@ ext fun WSAStartup(ver: u16, data: *u8) i32;
   table names never depends on module load order. Two declarations naming the
   *same* library are accepted: they name one provider, which is what a shared
   binding declared in two modules does.
+- Declarations under **different arms of one `$if` chain** are exempt, because no
+  target selects both arms, so they never both apply. A target-conditional
+  attribution is written the obvious way and is not a conflict.
 
 `library` composes with `symbol`: the rename sets the imported symbol's name,
 `library` sets the dependency it is imported from. On one decl the import is emitted

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11815,3 +11815,79 @@ test "mach.lang.driver:fallthrough_return_is_well_typed" {
     session.dnit(?s);
     ret bad;
 }
+
+# two `#[library]` decorators under DIFFERENT arms of one `$if` chain are not a
+# conflict: no target selects both arms, so they never both apply. The conflict
+# check must not read mutually exclusive declarations as a contradiction (#2529),
+# and it decides that from the source alone - this pass runs before sema, so the
+# conditions are not foldable here and are deliberately never evaluated
+test "mach.lang.driver:exclusive_comptime_arms_are_not_a_conflict" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\nfun main() i32 { a.call(); ret 0; }\n";
+    texts[1] = "$if ($mach.build.os == $mach.os.windows) {\n    #[library(\"kernel32\")]\n    ext fun ct_probe();\n}\n$or {\n    #[library(\"c\")]\n    ext fun ct_probe();\n}\n\npub fun call() { ct_probe(); }\n";
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_build(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        # an attribution is still registered; which arm's it is remains the
+        # pre-existing walk-order answer this change deliberately leaves alone
+        val sym: R.Result[intern.StrId, str] = intern.intern(?s.interner, "ct_probe");
+        if (R.is_err[intern.StrId, str](sym)) { bad = 1; }
+        or (!O.is_some[intern.StrId](
+                session.import_library(?s, R.unwrap_ok[intern.StrId, str](sym)))) { bad = 1; }
+        project.dnit_project(?p);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# the exclusion rule is not a blanket amnesty for anything near a `$if`: a second
+# module contradicting the chain's attribution shares no arm with it, so that is
+# still a conflict and still names both
+test "mach.lang.driver:comptime_arm_does_not_mask_cross_module_conflict" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a;\nuse uniontest.b;\nfun main() i32 { a.call(); b.call(); ret 0; }\n";
+    # both arms name kernel32, so the chain itself is unambiguous
+    texts[1] = "$if ($mach.build.os == $mach.os.windows) {\n    #[library(\"kernel32\")]\n    ext fun cx_probe();\n}\n$or {\n    #[library(\"kernel32\")]\n    ext fun cx_probe();\n}\n\npub fun call() { cx_probe(); }\n";
+    texts[2] = "#[library(\"user32\")]\next fun cx_probe();\npub fun call() { cx_probe(); }\n";
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_build(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p);
+        bad = 1;
+    }
+    or {
+        val msg: str = R.unwrap_err[project.Project, outcome.Fail](pr).message;
+        if (!ut_str_contains(msg, "import 'cx_probe'")) { bad = 1; }
+        if (!ut_str_contains(msg, "'kernel32'"))        { bad = 1; }
+        if (!ut_str_contains(msg, "'user32'"))          { bad = 1; }
+        if (!ut_str_contains(msg, "uniontest.a"))       { bad = 1; }
+        if (!ut_str_contains(msg, "uniontest.b"))       { bad = 1; }
+    }
+
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -405,6 +405,53 @@ rec ImportAttribution {
     module: intern.StrId;
     decl:   intern.StrId;
     lib:    intern.StrId;
+    arms:   *ArmStep;
+    arm_len: u32;
+}
+
+# one step of a declaration's comptime-arm path: the `$if` chain it sits under and
+# which arm of that chain
+# ---
+# cif: DeclId of the enclosing DECL_KIND_COMPTIME_IF
+# arm: index of the branch within that chain
+rec ArmStep {
+    cif: u32;
+    arm: u32;
+}
+
+# one arm path the walk allocated, held so it can be released in bulk
+# ---
+# data: the path array
+# len:  its element count
+rec OwnedPath {
+    data: *ArmStep;
+    len:  u32;
+}
+
+# whether two declarations can never both apply: some `$if` chain encloses both and
+# puts them in DIFFERENT arms, which no target selects together
+#
+# This is a property of the source, decided without evaluating any condition -
+# deliberately, because this pass runs before sema and a declaration-scope
+# condition is not always foldable here (a `$size_of` in one is sema's diagnostic
+# to report, not this pass's).
+# ---
+# a:  first declaration's arm path
+# an: its length
+# b:  second declaration's arm path
+# bn: its length
+# ret: true when the two are mutually exclusive
+fun arms_exclusive(a: *ArmStep, an: u32, b: *ArmStep, bn: u32) bool {
+    var i: u32 = 0;
+    for (i < an) {
+        var j: u32 = 0;
+        for (j < bn) {
+            if (a[i].cif == b[j].cif && a[i].arm != b[j].arm) { ret true; }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # project the per-decl `#[library(...)]` attributions
@@ -422,6 +469,9 @@ rec ImportAttribution {
 pub fun register_import_libraries(p: *project.Project) R.Result[bool, str] {
     var attrs: map.Map[intern.StrId, ImportAttribution] =
         map.init[intern.StrId, ImportAttribution](p.alloc, map.hash_u32, map.eq_u32);
+    # every arm path the walk builds, kept alive for the whole registration (a
+    # stored attribution borrows one) and released together at the end
+    var paths: vector.Vector[OwnedPath] = vector.init[OwnedPath](p.alloc);
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *project.ModuleEntry = ?p.modules[i];
@@ -438,16 +488,29 @@ pub fun register_import_libraries(p: *project.Project) R.Result[bool, str] {
                 source = O.unwrap[*src.SourceFile](src_opt).text;
             }
             val r: R.Result[bool, str] = bind_import_libraries(p, i::session.ModuleId,
-                source, ?attrs, mod_node.decls_start, mod_node.decls_len);
+                source, ?attrs, ?paths, nil::*ArmStep, 0,
+                mod_node.decls_start, mod_node.decls_len);
             if (R.is_err[bool, str](r)) {
+                free_arm_paths(p, ?paths);
                 map.dnit[intern.StrId, ImportAttribution](?attrs);
                 ret r;
             }
         }
         i = i + 1;
     }
+    free_arm_paths(p, ?paths);
     map.dnit[intern.StrId, ImportAttribution](?attrs);
     ret R.ok[bool, str](true);
+}
+
+# release every arm path the registration walk allocated
+fun free_arm_paths(p: *project.Project, paths: *vector.Vector[OwnedPath]) {
+    var i: usize = 0;
+    for (i < paths.len) {
+        A.deallocate[ArmStep](p.alloc, paths.data[i].data, paths.data[i].len::usize);
+        i = i + 1;
+    }
+    vector.dnit[OwnedPath](paths);
 }
 
 # walk a decl list (recursing into comptime-if branch
@@ -459,6 +522,8 @@ pub fun register_import_libraries(p: *project.Project) R.Result[bool, str] {
 # across the whole walk so a contradicting second one is refused by name
 fun bind_import_libraries(p: *project.Project, mid: session.ModuleId, source: str,
                           attrs: *map.Map[intern.StrId, ImportAttribution],
+                          paths: *vector.Vector[OwnedPath],
+                          path: *ArmStep, path_len: u32,
                           start: u32, len: u32) R.Result[bool, str] {
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     var i: u32 = 0;
@@ -481,18 +546,28 @@ fun bind_import_libraries(p: *project.Project, mid: session.ModuleId, source: st
                         ret R.err[bool, str]("internal: ext decl carries a #[library] attribution but no link name");
                     }
                     val r: R.Result[bool, str] = bind_one_import_library(p, mid, source,
-                        attrs, d, O.unwrap[intern.StrId](name_opt),
+                        attrs, path, path_len, d, O.unwrap[intern.StrId](name_opt),
                         O.unwrap[intern.StrId](lib_opt));
                     if (R.is_err[bool, str](r)) { ret r; }
                 }
             }
             or (d.kind == decl.DECL_KIND_COMPTIME_IF) {
+                # every arm is walked, as `scan_export_directives` walks them: the
+                # conditions are not foldable in this pass, which runs before sema.
+                # each arm extends the path so a declaration under one arm is known
+                # never to coexist with a declaration under a sibling arm
                 val ci: *decl.DeclComptimeIf = ?d.data.comptime_if;
                 var bi: u32 = 0;
                 for (bi < ci.branches_len) {
                     val br: *decl.ComptimeBranch = ?m.a.comptime_branches[ci.branches_start + bi];
+                    val pr: R.Result[*ArmStep, str] =
+                        push_arm(p, paths, path, path_len, did::u32, bi);
+                    if (R.is_err[*ArmStep, str](pr)) {
+                        ret R.err[bool, str](R.unwrap_err[*ArmStep, str](pr));
+                    }
                     val rb: R.Result[bool, str] = bind_import_libraries(p, mid, source, attrs,
-                                                                       br.body_start, br.body_len);
+                        paths, R.unwrap_ok[*ArmStep, str](pr), path_len + 1,
+                        br.body_start, br.body_len);
                     if (R.is_err[bool, str](rb)) { ret rb; }
                     bi = bi + 1;
                 }
@@ -520,25 +595,74 @@ fun bind_import_libraries(p: *project.Project, mid: session.ModuleId, source: st
 # ret:    ok(true) once recorded, or the conflict as a user-facing string
 fun bind_one_import_library(p: *project.Project, mid: session.ModuleId, source: str,
                             attrs: *map.Map[intern.StrId, ImportAttribution],
+                            path: *ArmStep, path_len: u32,
                             d: *decl.Decl, name: intern.StrId,
                             lib: intern.StrId) R.Result[bool, str] {
     var here: ImportAttribution;
-    here.module = session.module_fqn(p.s, mid);
-    here.decl   = attribution_decl_name(p, source, d);
-    here.lib    = lib;
+    here.module  = session.module_fqn(p.s, mid);
+    here.decl    = attribution_decl_name(p, source, d);
+    here.lib     = lib;
+    here.arms    = path;
+    here.arm_len = path_len;
 
     val prev: R.Result[*ImportAttribution, str] =
         map.get[intern.StrId, ImportAttribution](attrs, ?name);
     if (R.is_ok[*ImportAttribution, str](prev)) {
         val had: *ImportAttribution = R.unwrap_ok[*ImportAttribution, str](prev);
         if (had.lib == lib) { ret R.ok[bool, str](true); }
-        ret R.err[bool, str](attribution_conflict_message(p, name, had, ?here));
+        # two declarations under different arms of one `$if` chain never both
+        # apply, so they are not a conflict to report. WHICH of them the link
+        # then sees is a separate, pre-existing defect: this pass runs before the
+        # target selects an arm, so the last arm walked still wins. That is
+        # unchanged here on purpose - repairing it means projecting attributions
+        # after arm selection, which is a pass-ordering change well beyond #2529.
+        if (!arms_exclusive(had.arms, had.arm_len, path, path_len)) {
+            ret R.err[bool, str](attribution_conflict_message(p, name, had, ?here));
+        }
     }
 
     val ins: R.Result[bool, str] =
         map.insert[intern.StrId, ImportAttribution](attrs, name, here);
     if (R.is_err[bool, str](ins)) { ret ins; }
     ret session.register_import_library(p.s, name, lib);
+}
+
+# extend an arm path by one step, returning the new owned array
+#
+# The parent path is copied rather than shared: a sibling arm extends the same
+# parent, so the two must not alias one buffer. `paths` takes ownership, keeping
+# every array alive for the whole registration (stored attributions borrow them)
+# and releasing them together at the end.
+# ---
+# p:        the project (allocator)
+# paths:    the registration's owned-path list
+# path:     the parent path, or nil at module scope
+# path_len: the parent path's length
+# cif:      DeclId of the `$if` chain being entered
+# arm:      index of the arm being entered
+# ret:      the extended path, or an allocation error
+fun push_arm(p: *project.Project, paths: *vector.Vector[OwnedPath],
+             path: *ArmStep, path_len: u32, cif: u32, arm: u32) R.Result[*ArmStep, str] {
+    val ar: R.Result[*ArmStep, str] = A.allocate[ArmStep](p.alloc, (path_len + 1)::usize);
+    if (R.is_err[*ArmStep, str](ar)) { ret ar; }
+    val buf: *ArmStep = R.unwrap_ok[*ArmStep, str](ar);
+    var i: u32 = 0;
+    for (i < path_len) {
+        buf[i] = path[i];
+        i = i + 1;
+    }
+    buf[path_len].cif = cif;
+    buf[path_len].arm = arm;
+
+    var owned: OwnedPath;
+    owned.data = buf;
+    owned.len  = path_len + 1;
+    val pr: R.Result[usize, str] = vector.push[OwnedPath](paths, owned);
+    if (R.is_err[usize, str](pr)) {
+        A.deallocate[ArmStep](p.alloc, buf, (path_len + 1)::usize);
+        ret R.err[*ArmStep, str](R.unwrap_err[usize, str](pr));
+    }
+    ret R.ok[*ArmStep, str](buf);
 }
 
 # the bare source identifier of an `ext` declaration, or STR_NIL when it cannot be

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -398,14 +398,16 @@ fun register_module_export_names(p: *project.Project, mid: session.ModuleId) R.R
 # the declaration one `#[library(...)]` attribution came from, so a second,
 # contradicting attribution of the same link name can name both
 # ---
-# module: declaring module's FQN
-# decl:   declaration's bare source identifier
-# lib:    the library it pinned the import to
+# module:  declaring module's FQN
+# decl:    declaration's bare source identifier
+# lib:     the library it pinned the import to
+# arms:    the comptime-arm path the declaration sits under (nil at module scope)
+# arm_len: that path's length
 rec ImportAttribution {
-    module: intern.StrId;
-    decl:   intern.StrId;
-    lib:    intern.StrId;
-    arms:   *ArmStep;
+    module:  intern.StrId;
+    decl:    intern.StrId;
+    lib:     intern.StrId;
+    arms:    *ArmStep;
     arm_len: u32;
 }
 


### PR DESCRIPTION
Fixes a regression **currently live on `dev`**, introduced by #2618 (my own PR).

## What happened

#2618 was merged at `f72fdc2f`. I pushed three correction commits after that point, so they were never picked up. `dev` therefore carries the version of the `#[library]` conflict check that rejects a legitimate and expected pattern: a target-conditional attribution.

```mach
$if ($mach.build.os == $mach.os.windows) {
    #[library("kernel32")]
    ext fun Sleep(ms: u32);
}
$or {
    #[library("c")]
    ext fun Sleep(ms: u32);
}
```

Against `dev` today:

```
error: import 'Sleep' is attributed to library 'kernel32' by declaration 'Sleep' in module 'ctif.a' and to library 'c' by declaration 'Sleep' in module 'ctif.a'; a symbol may name only one providing library
```

The arms are mutually exclusive, so calling them a contradiction asserts something untrue. This PR is those three commits, cherry-picked onto current `dev`.

## The fix

Each declaration carries the comptime-arm path it sits under, and a conflict is reported only between declarations that no `$if` chain separates.

The rule is decided from the source alone, never by evaluating a condition. I did try evaluating them — descending only into the selected arm, as lowering does — and it is the wrong place: this pass runs before sema, so `mach.lang.driver:layout_intrinsic_remaining_positions` began failing, because a `$size_of` in a declaration-scope `$if` condition is sema's diagnostic to report and evaluating here front-ran it.

## A separate pre-existing defect, deliberately not fixed here

Independently of #2529 and of this PR, a target-conditional attribution binds to the **wrong arm**. The projection runs before a target selects an arm, so the last arm walked wins. With this PR applied, building the fixture above for windows gives:

```
error: import 'Sleep' pinned to library 'c' not among the link's dependencies
```

`c` is the `$or` arm, the one windows does not take. That is `dev`'s behaviour from before #2529 and is left exactly as it was; repairing it means projecting attributions after arm selection, which is a pass-ordering change. It deserves its own issue.

## Tests

- `mach.lang.driver:exclusive_comptime_arms_are_not_a_conflict` — the chain above builds clean and still registers an attribution.
- `mach.lang.driver:comptime_arm_does_not_mask_cross_module_conflict` — a second module contradicting the chain shares no arm with it, so that is still a conflict naming both. This is what stops the exemption becoming a blanket amnesty for anything near a `$if`.

### Demonstrated failing before the fix

With `arms_exclusive` removed so every meeting reports:

```
  FAIL  mach.lang.driver:exclusive_comptime_arms_are_not_a_conflict  ./src/lang/driver/tests.mach:11574  (exit 1)
1189 passed, 1 failed, 1190 total
```

And the end-to-end shape, against `dev` as it stands, is the diagnostic quoted at the top of this PR.

## Verification

- `mach test .` green (1199/1199)
- `int/run.sh --target linux` green (all cases)
- Self-host fixpoint holds: stage2 `cmp` stage3 identical
- The real cross-module conflict still errors naming both declarations