### PR TITLE
perf(sroa): carry a Result's union payload into registers

### DIFF
--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -13,6 +13,14 @@
 # of field slots, so the address merge becomes a merge of the slots' contents, and
 # the mem2reg run that follows turns those slots into the scalar phis.
 #
+# A union field is the one member that does not decompose: its members share storage,
+# so per-member slots would break the reinterpretation a union exists to express. It
+# becomes ONE slot instead, whenever every member is a scalar covering the whole cell
+# (`union_leaf_ty`) -- then every store writes all of it and every load reads all of
+# it, so the bits one member reads are exactly the bits another wrote, and a member
+# access naming a different type than the cell's is a plain bit reinterpret. This is
+# what carries `Result[T, E]`, whose payload is an anonymous `uni`, into registers.
+#
 # ESCAPE CONDITION (the whole legality argument). A candidate is an OP_ALLOCA of a
 # struct / array type (never a union: its fields overlap) with a constant count of
 # one, or an OP_PHI of that same type, whose whole type tree splits to scalars.
@@ -21,7 +29,9 @@
 #   - the base of an OP_GEP whose first two indices are the constants `0, k` with
 #     `k` a valid field ordinal, and whose own result is used only as a load
 #     pointer, a store pointer, or the base of a further gep that stays inside the
-#     field (a constant zero first index over the field's own type);
+#     field (a constant zero first index over the field's own type -- or, over a
+#     union field, a gep naming one of its members, which resolves to the cell's own
+#     address and is retargeted onto the cell's slot);
 #   - an OP_MEMZERO of the whole slot (alloca candidates only);
 #   - the pointer of a whole-aggregate OP_STORE (a copy into the slot) whose stored
 #     value is an address of the same aggregate type;
@@ -121,6 +131,9 @@ val MAX_ROUNDS: u32 = MAX_DEPTH + 1;
 # cand_of:    instruction id -> candidate index, or NONE_U32
 # gep_of:     instruction id -> the candidate index a field gep addresses, or NONE_U32
 # gep_field:  instruction id -> the field ordinal a field gep selects
+# uni_gep:    instruction id -> whether the gep names a member of a split union field
+#             rather than the field itself; it carries the field's own ordinal in
+#             gep_field, since every union member sits at the cell's own address
 # erase:      instruction id -> whether the rewrite superseded the instruction
 # cand_id:    per-candidate defining instruction id
 # cand_ty:    per-candidate aggregate type
@@ -155,6 +168,7 @@ rec State {
     cand_of:     *u32;
     gep_of:      *u32;
     gep_field:   *u32;
+    uni_gep:     *bool;
     erase:       *bool;
 
     cand_id:     *id.InstructionId;
@@ -233,6 +247,7 @@ fun split_function(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) R.Resul
 
     link_phi_partitions(?st);
     classify_references(?st);
+    mark_union_member_geps(?st);
     classify_gep_uses(?st);
     check_partitions(?st);
     propagate_escapes(?st);
@@ -314,6 +329,10 @@ fun state_alloc(st: *State) R.Result[bool, str] {
     if (R.is_err[*u32, str](r_gf)) { ret R.err[bool, str](R.unwrap_err[*u32, str](r_gf)); }
     st.gep_field = R.unwrap_ok[*u32, str](r_gf);
 
+    val r_ug: R.Result[*bool, str] = A.allocate[bool](st.alloc, n::usize);
+    if (R.is_err[*bool, str](r_ug)) { ret R.err[bool, str](R.unwrap_err[*bool, str](r_ug)); }
+    st.uni_gep = R.unwrap_ok[*bool, str](r_ug);
+
     val r_er: R.Result[*bool, str] = A.allocate[bool](st.alloc, n::usize);
     if (R.is_err[*bool, str](r_er)) { ret R.err[bool, str](R.unwrap_err[*bool, str](r_er)); }
     st.erase = R.unwrap_ok[*bool, str](r_er);
@@ -324,6 +343,7 @@ fun state_alloc(st: *State) R.Result[bool, str] {
         st.cand_of[i]     = NONE_U32;
         st.gep_of[i]      = NONE_U32;
         st.gep_field[i]   = 0;
+        st.uni_gep[i]     = false;
         st.erase[i]       = false;
         i = i + 1;
     }
@@ -391,6 +411,7 @@ fun state_dnit(st: *State) {
     if (st.cand_of != nil)     { A.deallocate[u32](st.alloc, st.cand_of, n::usize); }
     if (st.gep_of != nil)      { A.deallocate[u32](st.alloc, st.gep_of, n::usize); }
     if (st.gep_field != nil)   { A.deallocate[u32](st.alloc, st.gep_field, n::usize); }
+    if (st.uni_gep != nil)     { A.deallocate[bool](st.alloc, st.uni_gep, n::usize); }
     if (st.erase != nil)       { A.deallocate[bool](st.alloc, st.erase, n::usize); }
 
     val c: u32 = st.cand_cap;
@@ -515,10 +536,98 @@ fun splittable_at(st: *State, ty: ir_type.IrTypeId, depth: u32) bool {
     var k: u32 = 0;
     for (k < nf) {
         val ft: ir_type.IrTypeId = agg_field_type(st, ty, k);
-        if (!scalar_field(st, ft) && !splittable_at(st, ft, depth + 1)) { ret false; }
+        if (!scalar_field(st, ft) && union_leaf_ty(st, ft) == ir_type.IRT_NIL
+            && !splittable_at(st, ft, depth + 1)) { ret false; }
         k = k + 1;
     }
     ret true;
+}
+
+# the scalar storage type a union field's single slot is held in, or IRT_NIL when the
+# union must stay in memory
+#
+# A union cannot be split the way a struct is -- its members share storage, and
+# per-member slots would break the reinterpretation a union exists to express. It can
+# still become ONE slot, provided every member covers the whole cell: when each member
+# is a scalar whose byte size is the union's own, every store writes all of it and
+# every load reads all of it, so the bits a later member reads are exactly the bits an
+# earlier one wrote, and no byte survives a store that a whole-cell store would miss.
+# A member narrower than the union is refused for exactly that reason: writing it
+# would have to preserve the bytes it does not cover, which one whole-cell store
+# cannot express.
+#
+# The storage type is one of the members rather than a synthesized integer -- the
+# first integer member, else the first pointer member, else member 0 -- so the cell
+# stays in the general-purpose bank whenever any member already is, and at least one
+# member always accesses it with no reinterpret at all. `uni{ptr, ptr}` needs none;
+# `uni{i64, ptr}` (a `Result[i64, str]` payload) needs one only on the pointer side.
+# ---
+# st: state (for the module's type table and target)
+# ty: the field type to classify
+# ret: the storage type of the union's slot, or IRT_NIL when it is not a leaf
+fun union_leaf_ty(st: *State, ty: ir_type.IrTypeId) ir_type.IrTypeId {
+    val opt: O.Option[*ir_type.IrType] = ir_type.get(?st.m.types, ty);
+    if (O.is_none[*ir_type.IrType](opt)) { ret ir_type.IRT_NIL; }
+    val t: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt);
+    if (t.kind != ir_type.IRT_UNION) { ret ir_type.IRT_NIL; }
+
+    val size: u32 = ir_type.byte_size(?st.m.types, ty, st.tgt);
+    var pick: ir_type.IrTypeId = ir_type.IRT_NIL;
+    var rank: u32 = 3;
+    var k: u32 = 0;
+    for (k < t.data.struct_.field_count) {
+        val mt: ir_type.IrTypeId = t.data.struct_.fields[k];
+        if (!scalar_field(st, mt))                                     { ret ir_type.IRT_NIL; }
+        if (ir_type.byte_size(?st.m.types, mt, st.tgt) != size)        { ret ir_type.IRT_NIL; }
+        if (storage_rank(st, mt) < rank) { pick = mt; rank = storage_rank(st, mt); }
+        k = k + 1;
+    }
+    ret pick;
+}
+
+# the preference order `union_leaf_ty` picks a union's storage type by: an integer
+# first, then a pointer, then anything else
+# ---
+# st: state (for the module's type table)
+# ft: the member type to rank
+# ret: 0 for an integer, 1 for a pointer, 2 otherwise
+fun storage_rank(st: *State, ft: ir_type.IrTypeId) u32 {
+    val opt: O.Option[*ir_type.IrType] = ir_type.get(?st.m.types, ft);
+    if (O.is_none[*ir_type.IrType](opt)) { ret 2; }
+    val k: ir_type.IrTypeKind = O.unwrap[*ir_type.IrType](opt).kind;
+    if (k == ir_type.IRT_INT) { ret 0; }
+    if (k == ir_type.IRT_PTR) { ret 1; }
+    ret 2;
+}
+
+# the member count of a union type, or 0 when `ty` is not one
+# ---
+# st: state (for the module's type table)
+# ty: the type to measure
+# ret: the union's member count
+fun union_member_count(st: *State, ty: ir_type.IrTypeId) u32 {
+    val opt: O.Option[*ir_type.IrType] = ir_type.get(?st.m.types, ty);
+    if (O.is_none[*ir_type.IrType](opt)) { ret 0; }
+    val t: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt);
+    if (t.kind != ir_type.IRT_UNION) { ret 0; }
+    ret t.data.struct_.field_count;
+}
+
+# the type field `k`'s own slot is allocated at, and every whole-field zero fill and
+# copy moves it in
+#
+# A struct or array field's slot holds the field type itself; a union field's slot
+# holds the one scalar `union_leaf_ty` chose to stand in for the whole cell.
+# ---
+# st: state (for the module's type table and target)
+# ty: the aggregate type being split
+# k:  the field ordinal
+# ret: the slot's type
+fun slot_ty(st: *State, ty: ir_type.IrTypeId, k: u32) ir_type.IrTypeId {
+    val ft: ir_type.IrTypeId = agg_field_type(st, ty, k);
+    val ut: ir_type.IrTypeId = union_leaf_ty(st, ft);
+    if (ut != ir_type.IRT_NIL) { ret ut; }
+    ret ft;
 }
 
 # whether a field type is a scalar a slot can hold in a register
@@ -725,6 +834,12 @@ fun classify_one(st: *State, c: u32, iid: id.InstructionId, inst: *instruction.I
         if (inst.operands[2].kind != value.VAL_CONST_INT)    { ret false; }
         val k: u64 = inst.operands[2].data.int_lit;
         if (k >= st.cand_nf[c]::u64)                         { ret false; }
+        # a union field is one cell, not a tree: a walk continuing past it within the
+        # same gep addresses part of the cell, which one whole-cell slot cannot stand
+        # in for. its members are named by a chained gep instead, which
+        # `mark_union_member_geps` resolves onto the cell's own address
+        if (inst.operand_count > 3
+            && union_leaf_ty(st, agg_field_type(st, st.cand_ty[c], k::u32)) != ir_type.IRT_NIL) { ret false; }
         st.gep_of[iid::u32]    = c;
         st.gep_field[iid::u32] = k::u32;
         ret true;
@@ -756,6 +871,52 @@ fun classify_one(st: *State, c: u32, iid: id.InstructionId, inst: *instruction.I
         ret find_root(st, pc) == find_root(st, c);
     }
     ret false;
+}
+
+# tag every gep that names a member of a split union field
+#
+# `classify_references` has already tagged the direct field geps, so a union member gep
+# is exactly a three-index gep based on one of those whose field is a union leaf. Every
+# member of a union starts at the cell's own address, so the member gep resolves to the
+# same address as the field gep it is chained onto: it carries the same candidate and
+# the same field ordinal, is retargeted onto the same slot, and only the load or store
+# on the far side has to reinterpret the cell's bits as the member's type.
+#
+# This runs as its own sweep rather than inside `classify_gep_uses`, which validates a
+# gep's uses when it reaches the *using* instruction -- a use at a lower pool id than
+# the member gep it reads would be walked past before the tag existed.
+# ---
+# st: state whose gep_of / gep_field / uni_gep are written for each member gep
+fun mark_union_member_geps(st: *State) {
+    val fn: *ir.Function = st.fn;
+    var i: u32 = 0;
+    for (i < st.pool_len) {
+        if (st.instr_block[i] == id.BLOCK_NIL) { i = i + 1; cnt; }
+        if (st.gep_of[i] != NONE_U32)          { i = i + 1; cnt; }
+        val inst: *instruction.Instruction = ?fn.instrs[i];
+        if (inst.kind != instruction.OP_GEP || inst.operand_count != 3) { i = i + 1; cnt; }
+
+        val base: value.Value = inst.operands[0];
+        if (base.kind != value.VAL_INSTR)               { i = i + 1; cnt; }
+        if (base.data.instr::u32 >= st.pool_len)        { i = i + 1; cnt; }
+        val bid: u32 = base.data.instr::u32;
+        if (st.gep_of[bid] == NONE_U32 || st.uni_gep[bid]) { i = i + 1; cnt; }
+
+        val c: u32 = st.gep_of[bid];
+        val k: u32 = st.gep_field[bid];
+        val ft: ir_type.IrTypeId = agg_field_type(st, st.cand_ty[c], k);
+        if (union_leaf_ty(st, ft) == ir_type.IRT_NIL)    { i = i + 1; cnt; }
+        if (inst.aux_ty != ft)                           { i = i + 1; cnt; }
+        if (inst.operands[1].kind != value.VAL_CONST_INT) { i = i + 1; cnt; }
+        if (inst.operands[1].data.int_lit != 0)           { i = i + 1; cnt; }
+        if (inst.operands[2].kind != value.VAL_CONST_INT) { i = i + 1; cnt; }
+        if (inst.operands[2].data.int_lit >= union_member_count(st, ft)::u64) { i = i + 1; cnt; }
+
+        st.gep_of[i]    = c;
+        st.gep_field[i] = k;
+        st.uni_gep[i]   = true;
+        i = i + 1;
+    }
 }
 
 # mark every candidate bound by an OP_ASM's `{name}` list as escaped
@@ -806,7 +967,7 @@ fun classify_gep_uses(st: *State) {
                     taint(st, g, op.secret);
                     taint(st, g, inst.secret);
                     note_home(st, g, st.instr_block[i]);
-                    if (!gep_use_ok(st, g, op.data.instr, inst, o)) { st.cand_out[g] = true; }
+                    if (!gep_use_ok(st, g, op.data.instr, i::id.InstructionId, inst, o)) { st.cand_out[g] = true; }
                 }
             }
             o = o + 1;
@@ -816,19 +977,54 @@ fun classify_gep_uses(st: *State) {
 }
 
 # whether one use of a field gep keeps its owner splittable
+#
+# A gep addressing a union field -- the field gep itself, or a chained gep naming one
+# of its members, which is the same address -- is stricter: the cell's slot holds one
+# register-sized scalar, so an access must cover all of it. There is no partial form of
+# a whole-cell store, and a narrower load would read bytes the slot does not model.
 # ---
 # st:   state
 # c:    the candidate the gep addresses
 # gid:  the field gep's instruction id
+# uid:  the using instruction's id
 # inst: the using instruction
 # o:    the operand slot naming the gep
 # ret:  true when the use is a plain dereference, or a further descent that stays
 #       inside the field
-fun gep_use_ok(st: *State, c: u32, gid: id.InstructionId, inst: *instruction.Instruction, o: u32) bool {
-    if (inst.kind == instruction.OP_LOAD  && o == 0) { ret true; }
-    if (inst.kind == instruction.OP_GEP   && o == 0) { ret gep_stays_in_field(st, c, gid, inst); }
-    if (inst.kind == instruction.OP_STORE && o == 1) { ret st.cand_phi[c] == false; }
+fun gep_use_ok(st: *State, c: u32, gid: id.InstructionId, uid: id.InstructionId, inst: *instruction.Instruction, o: u32) bool {
+    val cell: bool = union_leaf_ty(st, agg_field_type(st, st.cand_ty[c], st.gep_field[gid::u32])) != ir_type.IRT_NIL;
+    if (inst.kind == instruction.OP_LOAD && o == 0) {
+        if (cell) { ret union_access_full(st, c, gid, inst.ty); }
+        ret true;
+    }
+    if (inst.kind == instruction.OP_STORE && o == 1) {
+        if (st.cand_phi[c]) { ret false; }
+        if (cell) { ret union_access_full(st, c, gid, inst.operands[0].ty); }
+        ret true;
+    }
+    if (inst.kind == instruction.OP_GEP && o == 0) {
+        # a member gep already stands at the cell; nothing descends past it
+        if (st.uni_gep[gid::u32]) { ret false; }
+        ret gep_stays_in_field(st, c, gid, uid, inst);
+    }
     ret false;
+}
+
+# whether an access through a union member gep covers the whole cell
+#
+# The cell's slot holds one scalar, so a load or store naming a member must be a scalar
+# of the cell's own byte size -- then the reinterpret between it and the slot's storage
+# type is a plain bit cast, and no byte of the cell escapes the transfer.
+# ---
+# st:  state
+# c:   the candidate the member gep addresses
+# gid: the member gep's instruction id
+# at:  the access type (a load's result type, or a store's value type)
+# ret: true when the access is a full-cell scalar
+fun union_access_full(st: *State, c: u32, gid: id.InstructionId, at: ir_type.IrTypeId) bool {
+    if (!scalar_field(st, at)) { ret false; }
+    val ft: ir_type.IrTypeId = agg_field_type(st, st.cand_ty[c], st.gep_field[gid::u32]);
+    ret ir_type.byte_size(?st.m.types, at, st.tgt) == ir_type.byte_size(?st.m.types, ft, st.tgt);
 }
 
 # whether a gep chained onto a field gep still addresses only that field
@@ -843,13 +1039,20 @@ fun gep_use_ok(st: *State, c: u32, gid: id.InstructionId, inst: *instruction.Ins
 # st:   state
 # c:    the candidate the field gep addresses
 # gid:  the field gep's instruction id
+# uid:  the chained gep's instruction id
 # inst: the chained gep
 # ret:  true when the chained gep stays inside the field
-fun gep_stays_in_field(st: *State, c: u32, gid: id.InstructionId, inst: *instruction.Instruction) bool {
+fun gep_stays_in_field(st: *State, c: u32, gid: id.InstructionId, uid: id.InstructionId, inst: *instruction.Instruction) bool {
+    val ft: ir_type.IrTypeId = agg_field_type(st, st.cand_ty[c], st.gep_field[gid::u32]);
+    # a union field is one cell rather than a tree to descend: `mark_union_member_geps`
+    # tagged the geps that name a member, all of which resolve to the cell's own
+    # address. any other gep addresses part of the cell, which one slot cannot stand in
+    # for
+    if (union_leaf_ty(st, ft) != ir_type.IRT_NIL)     { ret st.uni_gep[uid::u32]; }
     if (inst.operand_count < 2)                       { ret false; }
     if (inst.operands[1].kind != value.VAL_CONST_INT) { ret false; }
     if (inst.operands[1].data.int_lit != 0)           { ret false; }
-    ret inst.aux_ty == agg_field_type(st, st.cand_ty[c], st.gep_field[gid::u32]);
+    ret inst.aux_ty == ft;
 }
 
 # enforce the two rules that let one shared slot set stand in for the several
@@ -1241,6 +1444,28 @@ fun emit_load(st: *State, cur: *Cursor, ptr: value.Value, ty: ir_type.IrTypeId, 
     ret R.ok[value.Value, str](v);
 }
 
+# emit `bitcast to, v`, reinterpreting a union cell's bits as a member's type or the
+# other way round
+# ---
+# st:     state
+# cur:    the insertion point
+# v:      the value to reinterpret
+# to:     the type to reinterpret it as
+# secret: the taint to stamp
+# ret:    the reinterpreted value, or an allocation error
+fun emit_bitcast(st: *State, cur: *Cursor, v: value.Value, to: ir_type.IrTypeId, secret: bool) R.Result[value.Value, str] {
+    val r: R.Result[*value.Value, str] = A.allocate[value.Value](st.alloc, 1::usize);
+    if (R.is_err[*value.Value, str](r)) { ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](r)); }
+    val ops: *value.Value = R.unwrap_ok[*value.Value, str](r);
+    ops[0] = v;
+    val tainted: bool = secret || v.secret;
+    val ri: R.Result[id.InstructionId, str] = emit(st, cur, instruction.OP_BITCAST, to, ops, 1, ir_type.IRT_NIL, tainted);
+    if (R.is_err[id.InstructionId, str](ri)) { ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](ri)); }
+    var out: value.Value = value.instr(R.unwrap_ok[id.InstructionId, str](ri), to);
+    out.secret = tainted;
+    ret R.ok[value.Value, str](out);
+}
+
 # emit `memzero ptr` over a nested aggregate field
 # ---
 # st:     state
@@ -1303,7 +1528,7 @@ fun emit_field_slots(st: *State) R.Result[bool, str] {
         cur.loc = st.fn.instrs[st.cand_id[c]::u32].loc;
         var k: u32 = 0;
         for (k < st.cand_nf[c]) {
-            val ft: ir_type.IrTypeId = agg_field_type(st, st.cand_ty[c], k);
+            val ft: ir_type.IrTypeId = slot_ty(st, st.cand_ty[c], k);
             val r: R.Result[value.Value, str] = emit_slot(st, ?cur, ft, partition_secret(st, c));
             if (R.is_err[value.Value, str](r)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r)); }
             st.slots[st.cand_slot[c] + k] = R.unwrap_ok[value.Value, str](r);
@@ -1486,6 +1711,16 @@ fun rewrite_instr(st: *State, rw: *mutate.Rewrite, bid: id.BlockId, iid: id.Inst
     val g: u32 = st.gep_of[iid::u32];
     if (g != NONE_U32 && st.cand_out[g] == false) { ret retarget_gep(st, rw, iid, g); }
 
+    if (inst.kind == instruction.OP_LOAD && inst.operand_count >= 1) {
+        val ug: u32 = union_access_at(st, inst.operands[0]);
+        if (ug != NONE_U32) { ret reinterpret_load(st, rw, ?cur, iid, inst, ug); }
+    }
+
+    if (inst.kind == instruction.OP_STORE && inst.operand_count >= 2) {
+        val ug: u32 = union_access_at(st, inst.operands[1]);
+        if (ug != NONE_U32) { ret reinterpret_store(st, ?cur, iid, inst, ug); }
+    }
+
     if (inst.kind == instruction.OP_MEMZERO && inst.operand_count >= 1) {
         val c: u32 = candidate_at(st, inst.operands[0]);
         if (c != NONE_U32 && st.cand_out[c] == false) {
@@ -1502,6 +1737,84 @@ fun rewrite_instr(st: *State, rw: *mutate.Rewrite, bid: id.BlockId, iid: id.Inst
             ret expand_copy(st, ?cur, dc, inst.operands[0], inst.secret);
         }
     }
+    ret R.ok[bool, str](true);
+}
+
+# the gep addressing a split union cell that a value names, or NONE_U32
+#
+# Both the field gep and a chained member gep resolve to the cell's own address, so
+# either one puts the access on the reinterpreting path.
+# ---
+# st: state
+# v:  the address operand to resolve
+# ret: the gep's instruction id, or NONE_U32
+fun union_access_at(st: *State, v: value.Value) u32 {
+    if (v.kind != value.VAL_INSTR)        { ret NONE_U32; }
+    if (v.data.instr::u32 >= st.pool_len) { ret NONE_U32; }
+    val gid: u32 = v.data.instr::u32;
+    val c: u32 = st.gep_of[gid];
+    if (c == NONE_U32 || st.cand_out[c])  { ret NONE_U32; }
+    if (union_leaf_ty(st, agg_field_type(st, st.cand_ty[c], st.gep_field[gid])) == ir_type.IRT_NIL) { ret NONE_U32; }
+    ret gid;
+}
+
+# read a union cell's slot and reinterpret it as the member the load names
+#
+# The load already had its pointer retargeted onto the cell's slot, so when the member
+# it names is the slot's own storage type there is nothing left to do. Otherwise the
+# cell is read at its storage type and bit-cast to the member's, and the original load
+# is superseded by the cast.
+# ---
+# st:   state
+# rw:   rewrite map collecting the substitution
+# cur:  the insertion point
+# iid:  the load's instruction id
+# inst: the load
+# gid:  the member gep it reads through
+# ret:  ok(true) once rewritten, or the first error
+fun reinterpret_load(st: *State, rw: *mutate.Rewrite, cur: *Cursor, iid: id.InstructionId,
+                     inst: *instruction.Instruction, gid: u32) R.Result[bool, str] {
+    val c: u32 = st.gep_of[gid];
+    val sty: ir_type.IrTypeId = slot_ty(st, st.cand_ty[c], st.gep_field[gid]);
+    if (inst.ty == sty) { ret R.ok[bool, str](true); }
+
+    val slot: value.Value = st.slots[st.cand_slot[c] + st.gep_field[gid]];
+    val tainted: bool = inst.secret || st.cand_secret[c];
+    val r_load: R.Result[value.Value, str] = emit_load(st, cur, slot, sty, tainted);
+    if (R.is_err[value.Value, str](r_load)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_load)); }
+    val r_cast: R.Result[value.Value, str] = emit_bitcast(st, cur, R.unwrap_ok[value.Value, str](r_load), inst.ty, tainted);
+    if (R.is_err[value.Value, str](r_cast)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_cast)); }
+
+    mutate.replace_value(rw, iid, R.unwrap_ok[value.Value, str](r_cast));
+    st.erase[iid::u32] = true;
+    ret R.ok[bool, str](true);
+}
+
+# reinterpret a stored member as the union cell's storage type and write the whole cell
+#
+# Every member covers the whole cell (`union_leaf_ty`), so the reinterpreted store
+# writes exactly the bytes the member's store did.
+# ---
+# st:   state
+# cur:  the insertion point
+# iid:  the store's instruction id
+# inst: the store
+# gid:  the member gep it writes through
+# ret:  ok(true) once rewritten, or the first error
+fun reinterpret_store(st: *State, cur: *Cursor, iid: id.InstructionId,
+                      inst: *instruction.Instruction, gid: u32) R.Result[bool, str] {
+    val c: u32 = st.gep_of[gid];
+    val sty: ir_type.IrTypeId = slot_ty(st, st.cand_ty[c], st.gep_field[gid]);
+    val v: value.Value = inst.operands[0];
+    if (v.ty == sty) { ret R.ok[bool, str](true); }
+
+    val slot: value.Value = st.slots[st.cand_slot[c] + st.gep_field[gid]];
+    val tainted: bool = inst.secret || v.secret || st.cand_secret[c];
+    val r_cast: R.Result[value.Value, str] = emit_bitcast(st, cur, v, sty, tainted);
+    if (R.is_err[value.Value, str](r_cast)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_cast)); }
+    val r_store: R.Result[bool, str] = emit_store(st, cur, R.unwrap_ok[value.Value, str](r_cast), slot, tainted);
+    if (R.is_err[bool, str](r_store)) { ret r_store; }
+    st.erase[iid::u32] = true;
     ret R.ok[bool, str](true);
 }
 
@@ -1565,7 +1878,7 @@ fun expand_memzero(st: *State, cur: *Cursor, c: u32, secret: bool) R.Result[bool
     val tainted: bool = secret || st.cand_secret[c];
     var k: u32 = 0;
     for (k < st.cand_nf[c]) {
-        val ft: ir_type.IrTypeId = agg_field_type(st, st.cand_ty[c], k);
+        val ft: ir_type.IrTypeId = slot_ty(st, st.cand_ty[c], k);
         val slot: value.Value = st.slots[st.cand_slot[c] + k];
         if (ir_type.is_aggregate(?st.m.types, ft)) {
             val r: R.Result[bool, str] = emit_memzero(st, cur, slot, ft, tainted);
@@ -1605,7 +1918,7 @@ fun expand_copy(st: *State, cur: *Cursor, dst: u32, src: value.Value, secret: bo
             from = R.unwrap_ok[value.Value, str](r);
         }
         val res: R.Result[bool, str] = copy_field(st, cur, st.slots[st.cand_slot[dst] + k],
-                                                  from, agg_field_type(st, st.cand_ty[dst], k), tainted);
+                                                  from, slot_ty(st, st.cand_ty[dst], k), tainted);
         if (R.is_err[bool, str](res)) { ret res; }
         k = k + 1;
     }

--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -2704,9 +2704,422 @@ test "mach.lang.me.transform.sroa.run:splits_an_aggregate_phi_partition" {
     ret code;
 }
 
-# a union is never split -- its fields share storage, so per-field slots would break
-# the reinterpretation it exists to express -- and neither is an array past the field
-# bound, which keeps the pass on small records rather than buffers
+# intern `{i8, uni{...}}`, the tagged-payload record shape `Result[T, E]` lowers to
+# (test helper)
+# ---
+# m:   the module owning the type table
+# a:   the union's first member type
+# b:   the union's second member type
+# out: receives the record type
+# ret: 0 on success, 1 on failure
+fun ut_tagged(m: *ir.Module, a: ir_type.IrTypeId, b: ir_type.IrTypeId, out: *ir_type.IrTypeId) i32 {
+    var members: [2]ir_type.IrTypeId;
+    members[0] = a;
+    members[1] = b;
+    val ru: R.Result[ir_type.IrTypeId, str] = ir_type.intern_union(?m.types, ?members[0], 2, 0);
+    if (R.is_err[ir_type.IrTypeId, str](ru)) { ret 1; }
+
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ret 1; }
+    var fields: [2]ir_type.IrTypeId;
+    fields[0] = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+    fields[1] = R.unwrap_ok[ir_type.IrTypeId, str](ru);
+    val rs: R.Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?m.types, ?fields[0], 2, 0);
+    if (R.is_err[ir_type.IrTypeId, str](rs)) { ret 1; }
+    @out = R.unwrap_ok[ir_type.IrTypeId, str](rs);
+    ret 0;
+}
+
+# emit `gep (gep base, 0, 1), 0, k`: the address of member `k` of the union payload of
+# a `ut_tagged` record (test helper)
+# ---
+# b:    the construction cursor
+# m:    the module owning the type table
+# base: the record's address
+# ty:   the record type
+# k:    the union member ordinal
+# ret:  the member's address, or an error
+fun ut_member_gep(b: *builder.Builder, m: *ir.Module, base: value.Value, ty: ir_type.IrTypeId, k: u64) R.Result[value.Value, str] {
+    val gf: R.Result[value.Value, str] = ut_gep(b, m, base, ty, 1);
+    if (R.is_err[value.Value, str](gf)) { ret gf; }
+    ret ut_gep(b, m, R.unwrap_ok[value.Value, str](gf), ut_field_type(m, ty, 1), k);
+}
+
+# open a fresh function whose entry block holds `s = alloca ty; memzero s`, leaving the
+# cursor there for the caller to append the body under test (test helper)
+# ---
+# m:    the module to add the function to
+# b:    the construction cursor, positioned on the new function's entry block
+# ty:   the record type of the local
+# slot: receives the local's slot pointer
+# ret:  the new function's index, or NONE_U32 on failure
+fun ut_open_local(m: *ir.Module, b: *builder.Builder, ty: ir_type.IrTypeId, slot: *value.Value) u32 {
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ret NONE_U32; }
+
+    val rf: R.Result[u32, str] = ir.function_add(m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ret NONE_U32; }
+    val ix: u32 = R.unwrap_ok[u32, str](rf);
+
+    builder.set_function(b, ?m.functions[ix]);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(b);
+    if (R.is_err[id.BlockId, str](rb)) { ret NONE_U32; }
+    builder.set_block(b, R.unwrap_ok[id.BlockId, str](rb));
+
+    val ra: R.Result[value.Value, str] = builder.emit_alloca(b, ty, value.const_int(1, R.unwrap_ok[ir_type.IrTypeId, str](r64)));
+    if (R.is_err[value.Value, str](ra)) { ret NONE_U32; }
+    @slot = R.unwrap_ok[value.Value, str](ra);
+    if (R.is_err[bool, str](builder.emit_memzero(b, @slot, ty))) { ret NONE_U32; }
+    ret ix;
+}
+
+# the instruction a value names, or nil when it names something else (test helper)
+# ---
+# fn: the function owning the pool
+# v:  the value to resolve
+# ret: the defining instruction, or nil
+fun ut_def(fn: *ir.Function, v: value.Value) *instruction.Instruction {
+    if (v.kind != value.VAL_INSTR)     { ret nil; }
+    if (v.data.instr >= fn.instr_len)  { ret nil; }
+    ret ?fn.instrs[v.data.instr::u32];
+}
+
+# a `Result`-shaped record -- a tag beside an anonymous union payload -- reaches
+# registers: the union is one cell rather than per-member slots, so the record splits
+# into a tag slot and a cell slot and mem2reg promotes both. Nothing stays in memory and
+# the payload read back IS the stored parameter
+#
+# Refusing the union field in `splittable_at` leaves 1 alloca and 1 memzero, and so does
+# dropping `mark_union_member_geps` (the member gep then reads as a descent into the
+# field, which no whole-cell slot can stand in for): either way this test fails
+test "mach.lang.me.transform.sroa.run:splits_a_tagged_union_payload_into_registers" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r64);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(?m, i64t, ptrt, ?rec) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    var b: builder.Builder = builder.init(?m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[ix];
+
+    val gt: R.Result[value.Value, str] = ut_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](gt)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.const_int(1, i8t), R.unwrap_ok[value.Value, str](gt)))) { code = 1; }
+
+    val gp: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](gp)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.param(0, i64t), R.unwrap_ok[value.Value, str](gp)))) { code = 1; }
+
+    val hp: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](hp)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](hp), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    if (ut_count(fn, instruction.OP_ALLOCA) != 1) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))              { code = 1; }
+    or { if (!R.unwrap_ok[bool, str](rs))     { code = 1; } }
+    if (R.is_err[bool, str](mem2reg.run(?m))) { code = 1; }
+    if (R.is_err[bool, str](dce.run(?m)))     { code = 1; }
+
+    if (ut_count(fn, instruction.OP_ALLOCA)  != 0) { code = 1; }
+    if (ut_count(fn, instruction.OP_MEMZERO) != 0) { code = 1; }
+    if (ut_count(fn, instruction.OP_LOAD)    != 0) { code = 1; }
+    if (ut_count(fn, instruction.OP_STORE)   != 0) { code = 1; }
+    val rv: value.Value = ut_ret_value(fn);
+    if (rv.kind != value.VAL_PARAM) { code = 1; }
+    if (rv.data.param_ix != 0)      { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# a member read at a type other than the cell's storage comes back through a bit
+# reinterpret, so the value is the stored bits rather than a converted number: the cell
+# of `uni{i64, ptr}` is its i64 member, so the pointer written into it is bit-cast in
+# and the i64 read out is the cast itself
+#
+# Dropping the reinterpret in `reinterpret_store` returns the pointer parameter under an
+# i64 use, which is the ill-typed operand the verifier's VC_TYPE_AGREE catches; this
+# test names the cast directly, so it fails either way
+test "mach.lang.me.transform.sroa.run:reinterprets_a_member_of_another_type" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r64);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(?m, i64t, ptrt, ?rec) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    var b: builder.Builder = builder.init(?m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[ix];
+
+    val gp: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 1);
+    if (R.is_err[value.Value, str](gp)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.param(0, ptrt), R.unwrap_ok[value.Value, str](gp)))) { code = 1; }
+
+    val hp: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](hp)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](hp), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))              { code = 1; }
+    if (R.is_err[bool, str](mem2reg.run(?m))) { code = 1; }
+    if (R.is_err[bool, str](dce.run(?m)))     { code = 1; }
+
+    if (ut_count(fn, instruction.OP_ALLOCA) != 0) { code = 1; }
+    val cast: *instruction.Instruction = ut_def(fn, ut_ret_value(fn));
+    if (cast == nil) { code = 1; }
+    or {
+        if (cast.kind != instruction.OP_BITCAST)        { code = 1; }
+        if (cast.ty != i64t)                            { code = 1; }
+        if (cast.operand_count != 1)                    { code = 1; }
+        or {
+            if (cast.operands[0].kind != value.VAL_PARAM) { code = 1; }
+            if (cast.operands[0].data.param_ix != 0)      { code = 1; }
+        }
+    }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# writing a member narrower than the cell leaves the bytes it does not cover exactly as
+# they were: an `i8` member of an eight-byte cell is widened and merged into the cell
+# under a mask, so a subsequent whole-cell read sees the earlier value in its upper
+# seven bytes and the narrow member in its lowest
+#
+# Storing the widened value straight into the cell -- the obvious simplification --
+# clears those seven bytes, and the returned value is then the zext rather than the or;
+# this test names the mask and the merge, so either shortcut fails it
+test "mach.lang.me.transform.sroa.run:a_narrow_member_preserves_its_cell" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r64);
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(?m, i64t, i8t, ?rec) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    var b: builder.Builder = builder.init(?m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[ix];
+
+    val gw: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](gw)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.param(0, i64t), R.unwrap_ok[value.Value, str](gw)))) { code = 1; }
+
+    val gn: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 1);
+    if (R.is_err[value.Value, str](gn)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.param(1, i8t), R.unwrap_ok[value.Value, str](gn)))) { code = 1; }
+
+    val hw: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](hw)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](hw), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))              { code = 1; }
+    if (R.is_err[bool, str](mem2reg.run(?m))) { code = 1; }
+    if (R.is_err[bool, str](dce.run(?m)))     { code = 1; }
+
+    if (ut_count(fn, instruction.OP_ALLOCA) != 0) { code = 1; }
+
+    # ret = or(and(p0, 0xFFFFFFFFFFFFFF00), zext(p1))
+    val merge: *instruction.Instruction = ut_def(fn, ut_ret_value(fn));
+    if (merge == nil) { code = 1; ir.dnit(?m); ret code; }
+    if (merge.kind != instruction.OP_OR || merge.operand_count != 2) { code = 1; ir.dnit(?m); ret code; }
+
+    val keep: *instruction.Instruction = ut_def(fn, merge.operands[0]);
+    if (keep == nil) { code = 1; }
+    or {
+        if (keep.kind != instruction.OP_AND || keep.operand_count != 2)      { code = 1; }
+        or {
+            if (keep.operands[0].kind != value.VAL_PARAM)                    { code = 1; }
+            if (keep.operands[0].data.param_ix != 0)                         { code = 1; }
+            if (keep.operands[1].kind != value.VAL_CONST_INT)                { code = 1; }
+            or { if (keep.operands[1].data.int_lit != 0xFFFFFFFFFFFFFF00)    { code = 1; } }
+        }
+    }
+
+    val wide: *instruction.Instruction = ut_def(fn, merge.operands[1]);
+    if (wide == nil) { code = 1; }
+    or {
+        if (wide.kind != instruction.OP_ZEXT || wide.ty != i64t)  { code = 1; }
+        or {
+            if (wide.operands[0].kind != value.VAL_PARAM)         { code = 1; }
+            if (wide.operands[0].data.param_ix != 1)              { code = 1; }
+        }
+    }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# an access narrower than a cell whose storage is not an integer keeps the record whole:
+# `uni{ptr, ptr}` holds its cell in a pointer, and there is no masking form that could
+# merge a byte into one
+#
+# Admitting it (dropping the storage-is-the-cell-integer condition in
+# `union_access_ok`) splits the record and the alloca disappears, failing this test
+test "mach.lang.me.transform.sroa.run:declines_a_narrow_access_to_a_pointer_cell" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(?m, ptrt, ptrt, ?rec) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    var b: builder.Builder = builder.init(?m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[ix];
+
+    val gp: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](gp)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](gp), i8t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))         { code = 1; }
+    or { if (R.unwrap_ok[bool, str](rs)) { code = 1; } }
+    if (ut_count(fn, instruction.OP_ALLOCA) != 1) { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# a gep that reaches a union member and keeps walking keeps the record whole: the cell
+# is one scalar slot, and an index past its start addresses part of it
+#
+# Accepting the longer walk (dropping the union condition in `classify_one`) retargets
+# the gep onto the cell's slot, which then has a gep for a base and never promotes; the
+# alloca survives either way, but this test pins the decline at the classification so
+# the pass does not silently produce a slot it cannot promote
+test "mach.lang.me.transform.sroa.run:declines_a_gep_walking_past_a_union_field" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r64);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(?m, i64t, ptrt, ?rec) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    var b: builder.Builder = builder.init(?m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[ix];
+
+    # `gep s, 0, 1, 0`: the field walk continues into the union within one gep
+    var idx: [3]value.Value;
+    idx[0] = value.const_int(0, i64t);
+    idx[1] = value.const_int(1, i64t);
+    idx[2] = value.const_int(0, i64t);
+    val gd: R.Result[value.Value, str] = builder.emit_gep(?b, slot, rec, ?idx[0], 3);
+    if (R.is_err[value.Value, str](gd)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](gd), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))         { code = 1; }
+    or { if (R.unwrap_ok[bool, str](rs)) { code = 1; } }
+    if (ut_count(fn, instruction.OP_ALLOCA) != 1) { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# a bare union local is never split -- with no field it could give a slot of its own,
+# there is nothing to decompose -- and neither is an array past the field bound, which
+# keeps the pass on small records rather than buffers
 test "mach.lang.me.transform.sroa.run:declines_a_union_and_an_oversized_array" {
     var alloc: A.Allocator;
     page.make(?alloc);

--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -626,16 +626,22 @@ fun union_leaf_ty(st: *State, ty: ir_type.IrTypeId) ir_type.IrTypeId {
     var k: u32 = 0;
     for (k < t.data.struct_.field_count) {
         val mt: ir_type.IrTypeId = t.data.struct_.fields[k];
-        if (!scalar_field(st, mt))                              { ret ir_type.IRT_NIL; }
-        val ms: u32 = ir_type.byte_size(?st.m.types, mt, st.tgt);
-        if (ms > size)                                          { ret ir_type.IRT_NIL; }
-        if (ms < size) { narrow = true; }
+        if (!scalar_field(st, mt)) { ret ir_type.IRT_NIL; }
+        # a union's size is its widest member rounded up to its alignment, so a member
+        # is never wider than the cell and `<` versus `==` covers every case
+        if (ir_type.byte_size(?st.m.types, mt, st.tgt) < size) { narrow = true; }
         or {
             if (storage_rank(st, mt) < rank) { pick = mt; rank = storage_rank(st, mt); }
         }
         k = k + 1;
     }
     if (!narrow) { ret pick; }
+    # UNREACHABLE TODAY, AND NOT DEAD. Every registered isa declares ENDIAN_LITTLE, so no
+    # build reaches this and deleting it changes no test -- but the narrow form rests on
+    # it: a member at offset zero is the cell integer's low bits only under that byte
+    # order, and the mask, the widening and the truncation all read it that way. A
+    # big-endian isa would need the member's bits shifted into place instead, and without
+    # this condition it would silently get the little-endian formula.
     if (st.tgt.model.endianness != isa.ENDIAN_LITTLE) { ret ir_type.IRT_NIL; }
     ret int_of_bytes(st, size);
 }
@@ -1057,11 +1063,7 @@ fun gep_use_ok(st: *State, c: u32, gid: id.InstructionId, uid: id.InstructionId,
         if (cell) { ret union_access_ok(st, c, gid, inst.operands[0].ty); }
         ret true;
     }
-    if (inst.kind == instruction.OP_GEP && o == 0) {
-        # a member gep already stands at the cell; nothing descends past it
-        if (st.uni_gep[gid::u32]) { ret false; }
-        ret gep_stays_in_field(st, c, gid, uid, inst);
-    }
+    if (inst.kind == instruction.OP_GEP && o == 0) { ret gep_stays_in_field(st, c, gid, uid, inst); }
     ret false;
 }
 
@@ -1110,7 +1112,8 @@ fun gep_stays_in_field(st: *State, c: u32, gid: id.InstructionId, uid: id.Instru
     # a union field is one cell rather than a tree to descend: `mark_union_member_geps`
     # tagged the geps that name a member, all of which resolve to the cell's own
     # address. any other gep addresses part of the cell, which one slot cannot stand in
-    # for
+    # for -- including a gep chained onto a member gep, which is never tagged because
+    # tagging refuses a member gep for a base
     if (union_leaf_ty(st, ft) != ir_type.IRT_NIL)     { ret st.uni_gep[uid::u32]; }
     if (inst.operand_count < 2)                       { ret false; }
     if (inst.operands[1].kind != value.VAL_CONST_INT) { ret false; }
@@ -3062,13 +3065,173 @@ test "mach.lang.me.transform.sroa.run:declines_a_narrow_access_to_a_pointer_cell
     ret code;
 }
 
-# a gep that reaches a union member and keeps walking keeps the record whole: the cell
-# is one scalar slot, and an index past its start addresses part of it
+# build `{i8, uni{a, b}}`, open a local of it, and append one load through a member gep
+# plus a return of it (test helper)
 #
-# Accepting the longer walk (dropping the union condition in `classify_one`) retargets
-# the gep onto the cell's slot, which then has a gep for a base and never promotes; the
-# alloca survives either way, but this test pins the decline at the classification so
-# the pass does not silently produce a slot it cannot promote
+# The decline cases differ only in the union's members, the member ordinal and the access
+# type, so they share this body and check the same thing: the record stayed whole.
+# ---
+# m:      the module to build in
+# a:      the union's first member type
+# b:      the union's second member type
+# member: the member ordinal the gep names
+# at:     the type the load reads the member at
+# ret:    the function's index, or NONE_U32 on failure
+fun ut_tagged_probe(m: *ir.Module, a: ir_type.IrTypeId, b: ir_type.IrTypeId, member: u64, at: ir_type.IrTypeId) u32 {
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(m, a, b, ?rec) != 0) { ret NONE_U32; }
+
+    var bl: builder.Builder = builder.init(m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(m, ?bl, rec, ?slot);
+    if (ix == NONE_U32) { ret NONE_U32; }
+
+    val g: R.Result[value.Value, str] = ut_member_gep(?bl, m, slot, rec, member);
+    if (R.is_err[value.Value, str](g)) { ret NONE_U32; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bl, R.unwrap_ok[value.Value, str](g), at);
+    if (R.is_err[value.Value, str](rl)) { ret NONE_U32; }
+    if (R.is_err[bool, str](builder.emit_ret(?bl, R.unwrap_ok[value.Value, str](rl)))) { ret NONE_U32; }
+    ret ix;
+}
+
+# four shapes no union cell can hold, each of which must leave its record in memory: an
+# access wider than the cell, an access that is itself an aggregate (which in this IR is
+# an address rather than a value, so there is nothing to reinterpret), a member ordinal
+# past the union's end, and a member that is itself an aggregate
+#
+# Each is a distinct condition, and dropping any one of them splits the record whose case
+# it covers -- the record's alloca is then replaced by its slots, so the count under test
+# moves off 1 and this fails
+test "mach.lang.me.transform.sroa.run:declines_four_shapes_no_cell_can_hold" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val r64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](r64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r64);
+    val r32: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](r32)) { ir.dnit(?m); ret 1; }
+    val i32t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r32);
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    var pair_fields: [2]ir_type.IrTypeId;
+    pair_fields[0] = i32t;
+    pair_fields[1] = i32t;
+    val rpair: R.Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?m.types, ?pair_fields[0], 2, 0);
+    if (R.is_err[ir_type.IrTypeId, str](rpair)) { ir.dnit(?m); ret 1; }
+    val pair: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rpair);
+
+    # an eight-byte read of a one-byte cell
+    val f_wide: u32 = ut_tagged_probe(?m, i8t, i8t, 0, i64t);
+    if (f_wide == NONE_U32) { ir.dnit(?m); ret 1; }
+    # a read of the cell at an aggregate type, which names an address here, not a value
+    val f_read: u32 = ut_tagged_probe(?m, i64t, i64t, 0, pair);
+    if (f_read == NONE_U32) { ir.dnit(?m); ret 1; }
+    # a member ordinal past a two-member union
+    val f_ord: u32 = ut_tagged_probe(?m, i64t, i64t, 2, i64t);
+    if (f_ord == NONE_U32) { ir.dnit(?m); ret 1; }
+    # a member that is itself a record, which no scalar slot can hold
+    val f_agg: u32 = ut_tagged_probe(?m, pair, i64t, 1, i64t);
+    if (f_agg == NONE_U32) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))         { code = 1; }
+    or { if (R.unwrap_ok[bool, str](rs)) { code = 1; } }
+
+    if (ut_count(?m.functions[f_wide], instruction.OP_ALLOCA) != 1) { code = 1; }
+    if (ut_count(?m.functions[f_read], instruction.OP_ALLOCA) != 1) { code = 1; }
+    if (ut_count(?m.functions[f_ord],  instruction.OP_ALLOCA) != 1) { code = 1; }
+    if (ut_count(?m.functions[f_agg],  instruction.OP_ALLOCA) != 1) { code = 1; }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# reading a narrow member back is the truncation matching the widening its store used, so
+# the value that comes out is the member's own bits rather than the whole cell's
+#
+# Built over `{i8, uni{i8, ptr}}`, the exact shape `Result[bool, str]` lowers to and the
+# one the compiler is written on. Its narrow member comes FIRST, so a storage type picked
+# member-by-member without noticing the narrowing would land on the `i8` and give an
+# eight-byte cell a one-byte slot -- with no truncation left to name, since the member
+# would then already be the storage type
+#
+# Reinterpreting instead of truncating would be a bit cast between two different widths;
+# this test names the truncation, so dropping either it or the narrowing check fails here
+test "mach.lang.me.transform.sroa.run:reads_a_narrow_member_by_truncation" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var reg: target.TargetRegistry;
+    var tgt: resolved.Target;
+    if (ut_target(?reg, ?tgt) != 0) { ret 1; }
+
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    var rec: ir_type.IrTypeId;
+    if (ut_tagged(?m, i8t, ptrt, ?rec) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    var b: builder.Builder = builder.init(?m);
+    var slot: value.Value;
+    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[ix];
+
+    val gn: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](gn)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?b, value.param(0, i8t), R.unwrap_ok[value.Value, str](gn)))) { code = 1; }
+
+    val hn: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot, rec, 0);
+    if (R.is_err[value.Value, str](hn)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](hn), i8t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
+
+    val rs: R.Result[bool, str] = run(?m, ?tgt);
+    if (R.is_err[bool, str](rs))              { code = 1; }
+    if (R.is_err[bool, str](mem2reg.run(?m))) { code = 1; }
+    if (R.is_err[bool, str](dce.run(?m)))     { code = 1; }
+
+    if (ut_count(fn, instruction.OP_ALLOCA) != 0) { code = 1; }
+    val narrow: *instruction.Instruction = ut_def(fn, ut_ret_value(fn));
+    if (narrow == nil) { code = 1; }
+    or {
+        if (narrow.kind != instruction.OP_TRUNC) { code = 1; }
+        if (narrow.ty != i8t)                    { code = 1; }
+    }
+
+    ir.dnit(?m);
+    ret code;
+}
+
+# a gep that reaches a union field and keeps walking keeps the record whole: within the
+# field gep itself, chained onto a member gep, or walking some other aggregate from the
+# field's address. Only a gep naming a member of the union itself resolves to the cell,
+# and the third case is the one that says why -- an ordinal of another type lands
+# somewhere the cell's slot is not
+#
+# Accepting any of the three retargets the gep onto the cell's slot: the first two lose
+# only promotion, the third lands at the wrong address. All three split the record and
+# replace its alloca with two slots, so the count moves off 1 and this fails
 test "mach.lang.me.transform.sroa.run:declines_a_gep_walking_past_a_union_field" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -3092,12 +3255,13 @@ test "mach.lang.me.transform.sroa.run:declines_a_gep_walking_past_a_union_field"
 
     var code: i32 = 0;
     var b: builder.Builder = builder.init(?m);
-    var slot: value.Value;
-    val ix: u32 = ut_open_local(?m, ?b, rec, ?slot);
-    if (ix == NONE_U32) { ir.dnit(?m); ret 1; }
-    val fn: *ir.Function = ?m.functions[ix];
 
-    # `gep s, 0, 1, 0`: the field walk continues into the union within one gep
+    # `gep s, 0, 1, 0`: the walk continues into the union within one gep
+    var slot: value.Value;
+    val ix_one: u32 = ut_open_local(?m, ?b, rec, ?slot);
+    if (ix_one == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn_one: *ir.Function = ?m.functions[ix_one];
+
     var idx: [3]value.Value;
     idx[0] = value.const_int(0, i64t);
     idx[1] = value.const_int(1, i64t);
@@ -3108,10 +3272,48 @@ test "mach.lang.me.transform.sroa.run:declines_a_gep_walking_past_a_union_field"
     if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
     if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl)))) { code = 1; }
 
+    # and one chained onto a member gep, which tagging refuses to reach past
+    var slot2: value.Value;
+    val ix_two: u32 = ut_open_local(?m, ?b, rec, ?slot2);
+    if (ix_two == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn_two: *ir.Function = ?m.functions[ix_two];
+
+    val gm: R.Result[value.Value, str] = ut_member_gep(?b, ?m, slot2, rec, 0);
+    if (R.is_err[value.Value, str](gm)) { ir.dnit(?m); ret 1; }
+    val gp: R.Result[value.Value, str] = ut_gep(?b, ?m, R.unwrap_ok[value.Value, str](gm), i64t, 0);
+    if (R.is_err[value.Value, str](gp)) { ir.dnit(?m); ret 1; }
+    val rl2: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](gp), i64t);
+    if (R.is_err[value.Value, str](rl2)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl2)))) { code = 1; }
+
+    # and one that walks a DIFFERENT aggregate from the union field's address: its second
+    # index is an ordinal of that type, so it lands somewhere the cell's slot is not
+    var struct_fields: [2]ir_type.IrTypeId;
+    struct_fields[0] = i64t;
+    struct_fields[1] = i64t;
+    val rother: R.Result[ir_type.IrTypeId, str] = ir_type.intern_struct(?m.types, ?struct_fields[0], 2, 0);
+    if (R.is_err[ir_type.IrTypeId, str](rother)) { ir.dnit(?m); ret 1; }
+    val other: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rother);
+
+    var slot3: value.Value;
+    val ix_three: u32 = ut_open_local(?m, ?b, rec, ?slot3);
+    if (ix_three == NONE_U32) { ir.dnit(?m); ret 1; }
+    val fn_three: *ir.Function = ?m.functions[ix_three];
+
+    val gf: R.Result[value.Value, str] = ut_gep(?b, ?m, slot3, rec, 1);
+    if (R.is_err[value.Value, str](gf)) { ir.dnit(?m); ret 1; }
+    val go: R.Result[value.Value, str] = ut_gep(?b, ?m, R.unwrap_ok[value.Value, str](gf), other, 1);
+    if (R.is_err[value.Value, str](go)) { ir.dnit(?m); ret 1; }
+    val rl3: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](go), i64t);
+    if (R.is_err[value.Value, str](rl3)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](rl3)))) { code = 1; }
+
     val rs: R.Result[bool, str] = run(?m, ?tgt);
     if (R.is_err[bool, str](rs))         { code = 1; }
     or { if (R.unwrap_ok[bool, str](rs)) { code = 1; } }
-    if (ut_count(fn, instruction.OP_ALLOCA) != 1) { code = 1; }
+    if (ut_count(fn_one, instruction.OP_ALLOCA)   != 1) { code = 1; }
+    if (ut_count(fn_two, instruction.OP_ALLOCA)   != 1) { code = 1; }
+    if (ut_count(fn_three, instruction.OP_ALLOCA) != 1) { code = 1; }
 
     ir.dnit(?m);
     ret code;

--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -94,6 +94,7 @@ use mach.lang.me.pass.dce;
 use mach.lang.me.pass.mem2reg;
 use mach.lang.source;
 use mach.lang.target;
+use isa: mach.lang.target.isa;
 use mach.lang.target.resolved;
 
 # sentinel for an unset entry in a u32 index map
@@ -157,6 +158,10 @@ val MAX_ROUNDS: u32 = MAX_DEPTH + 1;
 # ptr_ty:     the untyped IR pointer an alloca and a gep produce
 # void_ty:    the void a store and a memzero carry
 # i64_ty:     the type the synthesized index and count constants ride in
+# int_ty:     interned integers of 1, 2, 4 and 8 bytes indexed by log2 of the byte
+#             width, or IRT_NIL where the width did not intern; the storage type of a
+#             union cell some member covers only part of, and the intermediate a
+#             narrow member's value is widened through
 rec State {
     alloc: *A.Allocator;
     m:     *ir.Module;
@@ -194,13 +199,17 @@ rec State {
     ptr_ty:  ir_type.IrTypeId;
     void_ty: ir_type.IrTypeId;
     i64_ty:  ir_type.IrTypeId;
+    int_ty:  [4]ir_type.IrTypeId;
 }
 
 # run scalar replacement over every defined function in `m`
 #
-# Repeats per function until no further candidate splits, so a nested record peels
-# one level per round: splitting `{i8, {i64, ptr}}` yields an `i8` slot mem2reg can
-# promote and a `{i64, ptr}` slot the next round splits again.
+# Repeats per function until no further candidate splits. A round both peels one level
+# of nesting -- splitting `{i8, {i64, ptr}}` yields an `i8` slot mem2reg can promote and
+# a `{i64, ptr}` slot the next round splits again -- and frees candidates the previous
+# round's rewrite unblocked: the source of a whole-aggregate copy is only reachable by
+# field gep once that copy has been expanded, so it first becomes splittable a round
+# after its destination did.
 # ---
 # m:   module to transform in place
 # tgt: target, consulted for aggregate byte sizes
@@ -240,6 +249,12 @@ fun split_function(m: *ir.Module, fn: *ir.Function, tgt: *target.Target) R.Resul
     val res_maps: R.Result[bool, str] = state_alloc(?st);
     if (R.is_err[bool, str](res_maps)) { state_dnit(?st); ret res_maps; }
     if (st.pool_len == 0) { state_dnit(?st); ret R.ok[bool, str](false); }
+
+    # the integer widths a union cell's storage and its narrow members ride in are
+    # interned up front: classification decides splittability from them, and it runs
+    # before the rewrite that would otherwise be the first to need a type
+    val res_ints: R.Result[bool, str] = intern_int_widths(?st);
+    if (R.is_err[bool, str](res_ints)) { state_dnit(?st); ret res_ints; }
 
     map_instr_blocks(?st);
     collect_candidates(?st);
@@ -303,6 +318,36 @@ fun state_init(st: *State, m: *ir.Module, fn: *ir.Function, tgt: *target.Target)
     st.ptr_ty  = ir_type.IRT_NIL;
     st.void_ty = ir_type.IRT_NIL;
     st.i64_ty  = ir_type.IRT_NIL;
+    var w: u32 = 0;
+    for (w < 4) { st.int_ty[w] = ir_type.IRT_NIL; w = w + 1; }
+}
+
+# intern the 1-, 2-, 4- and 8-byte integers into `int_ty`
+# ---
+# st:  state whose int_ty table is filled
+# ret: ok(true) once interned, or the first error
+fun intern_int_widths(st: *State) R.Result[bool, str] {
+    var w: u32 = 0;
+    for (w < 4) {
+        val r: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?st.m.types, 8 << w);
+        if (R.is_err[ir_type.IrTypeId, str](r)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](r)); }
+        st.int_ty[w] = R.unwrap_ok[ir_type.IrTypeId, str](r);
+        w = w + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the interned integer of `bytes` bytes, or IRT_NIL when that is not a scalar width
+# ---
+# st:    state with int_ty filled
+# bytes: the byte width to name
+# ret:   the integer type, or IRT_NIL
+fun int_of_bytes(st: *State, bytes: u32) ir_type.IrTypeId {
+    if (bytes == 1) { ret st.int_ty[0]; }
+    if (bytes == 2) { ret st.int_ty[1]; }
+    if (bytes == 4) { ret st.int_ty[2]; }
+    if (bytes == 8) { ret st.int_ty[3]; }
+    ret ir_type.IRT_NIL;
 }
 
 # allocate and clear every instruction- and candidate-indexed map
@@ -548,21 +593,24 @@ fun splittable_at(st: *State, ty: ir_type.IrTypeId, depth: u32) bool {
 #
 # A union cannot be split the way a struct is -- its members share storage, and
 # per-member slots would break the reinterpretation a union exists to express. It can
-# still become ONE slot, provided every member covers the whole cell: when each member
-# is a scalar whose byte size is the union's own, every store writes all of it and
-# every load reads all of it, so the bits a later member reads are exactly the bits an
-# earlier one wrote, and no byte survives a store that a whole-cell store would miss.
-# A member narrower than the union is refused for exactly that reason: writing it
-# would have to preserve the bytes it does not cover, which one whole-cell store
-# cannot express.
+# still become ONE slot, provided every member is a scalar the cell can be read and
+# written whole through.
 #
-# The storage type is one of the members rather than a synthesized integer -- the
-# first integer member, else the first pointer member, else member 0 -- so the cell
+# When every member is exactly the cell's width, the slot's storage type is one of the
+# members -- the first integer, else the first pointer, else member 0 -- so the cell
 # stays in the general-purpose bank whenever any member already is, and at least one
-# member always accesses it with no reinterpret at all. `uni{ptr, ptr}` needs none;
+# member accesses it with no reinterpret at all. `uni{ptr, ptr}` needs none;
 # `uni{i64, ptr}` (a `Result[i64, str]` payload) needs one only on the pointer side.
+#
+# A member narrower than the cell (`uni{i8, ptr}`, a `Result[bool, str]` payload) is
+# admitted too, and then the storage type is the whole cell's integer: a narrow store
+# has to leave the bytes it does not cover as they were, which only an integer cell can
+# express -- read, clear the member's bits, or the widened value back in. That is why
+# the narrow form needs a little-endian target: it identifies the member at offset zero
+# with the cell integer's LOW bits, which is a byte-order fact rather than a layout one.
+# Every registered target is little-endian today, so this condition never declines.
 # ---
-# st: state (for the module's type table and target)
+# st: state (for the module's type table, target and interned integers)
 # ty: the field type to classify
 # ret: the storage type of the union's slot, or IRT_NIL when it is not a leaf
 fun union_leaf_ty(st: *State, ty: ir_type.IrTypeId) ir_type.IrTypeId {
@@ -574,15 +622,22 @@ fun union_leaf_ty(st: *State, ty: ir_type.IrTypeId) ir_type.IrTypeId {
     val size: u32 = ir_type.byte_size(?st.m.types, ty, st.tgt);
     var pick: ir_type.IrTypeId = ir_type.IRT_NIL;
     var rank: u32 = 3;
+    var narrow: bool = false;
     var k: u32 = 0;
     for (k < t.data.struct_.field_count) {
         val mt: ir_type.IrTypeId = t.data.struct_.fields[k];
-        if (!scalar_field(st, mt))                                     { ret ir_type.IRT_NIL; }
-        if (ir_type.byte_size(?st.m.types, mt, st.tgt) != size)        { ret ir_type.IRT_NIL; }
-        if (storage_rank(st, mt) < rank) { pick = mt; rank = storage_rank(st, mt); }
+        if (!scalar_field(st, mt))                              { ret ir_type.IRT_NIL; }
+        val ms: u32 = ir_type.byte_size(?st.m.types, mt, st.tgt);
+        if (ms > size)                                          { ret ir_type.IRT_NIL; }
+        if (ms < size) { narrow = true; }
+        or {
+            if (storage_rank(st, mt) < rank) { pick = mt; rank = storage_rank(st, mt); }
+        }
         k = k + 1;
     }
-    ret pick;
+    if (!narrow) { ret pick; }
+    if (st.tgt.model.endianness != isa.ENDIAN_LITTLE) { ret ir_type.IRT_NIL; }
+    ret int_of_bytes(st, size);
 }
 
 # the preference order `union_leaf_ty` picks a union's storage type by: an integer
@@ -994,12 +1049,12 @@ fun classify_gep_uses(st: *State) {
 fun gep_use_ok(st: *State, c: u32, gid: id.InstructionId, uid: id.InstructionId, inst: *instruction.Instruction, o: u32) bool {
     val cell: bool = union_leaf_ty(st, agg_field_type(st, st.cand_ty[c], st.gep_field[gid::u32])) != ir_type.IRT_NIL;
     if (inst.kind == instruction.OP_LOAD && o == 0) {
-        if (cell) { ret union_access_full(st, c, gid, inst.ty); }
+        if (cell) { ret union_access_ok(st, c, gid, inst.ty); }
         ret true;
     }
     if (inst.kind == instruction.OP_STORE && o == 1) {
         if (st.cand_phi[c]) { ret false; }
-        if (cell) { ret union_access_full(st, c, gid, inst.operands[0].ty); }
+        if (cell) { ret union_access_ok(st, c, gid, inst.operands[0].ty); }
         ret true;
     }
     if (inst.kind == instruction.OP_GEP && o == 0) {
@@ -1010,21 +1065,29 @@ fun gep_use_ok(st: *State, c: u32, gid: id.InstructionId, uid: id.InstructionId,
     ret false;
 }
 
-# whether an access through a union member gep covers the whole cell
+# whether an access through a gep addressing a union cell is one the slot can carry
 #
-# The cell's slot holds one scalar, so a load or store naming a member must be a scalar
-# of the cell's own byte size -- then the reinterpret between it and the slot's storage
-# type is a plain bit cast, and no byte of the cell escapes the transfer.
+# The slot holds one scalar, so the access must be a scalar too, and no wider than the
+# cell. A full-width access transfers through a bit cast; a narrower one needs the
+# cell's own integer to mask and widen through, which `union_leaf_ty` guarantees is the
+# storage type whenever the union has a narrow member -- but an access narrower than
+# every member (loading an `i8` out of a `uni{i64, ptr}`) can still land on a cell whose
+# storage is a member's type, and that has no masking form.
 # ---
 # st:  state
-# c:   the candidate the member gep addresses
-# gid: the member gep's instruction id
+# c:   the candidate the gep addresses
+# gid: the gep's instruction id
 # at:  the access type (a load's result type, or a store's value type)
-# ret: true when the access is a full-cell scalar
-fun union_access_full(st: *State, c: u32, gid: id.InstructionId, at: ir_type.IrTypeId) bool {
+# ret: true when the slot can carry the access
+fun union_access_ok(st: *State, c: u32, gid: id.InstructionId, at: ir_type.IrTypeId) bool {
     if (!scalar_field(st, at)) { ret false; }
     val ft: ir_type.IrTypeId = agg_field_type(st, st.cand_ty[c], st.gep_field[gid::u32]);
-    ret ir_type.byte_size(?st.m.types, at, st.tgt) == ir_type.byte_size(?st.m.types, ft, st.tgt);
+    val cell: u32 = ir_type.byte_size(?st.m.types, ft, st.tgt);
+    val acc: u32  = ir_type.byte_size(?st.m.types, at, st.tgt);
+    if (acc > cell) { ret false; }
+    if (acc == cell) { ret true; }
+    if (union_leaf_ty(st, ft) != int_of_bytes(st, cell)) { ret false; }
+    ret int_of_bytes(st, acc) != ir_type.IRT_NIL;
 }
 
 # whether a gep chained onto a field gep still addresses only that field
@@ -1466,6 +1529,53 @@ fun emit_bitcast(st: *State, cur: *Cursor, v: value.Value, to: ir_type.IrTypeId,
     ret R.ok[value.Value, str](out);
 }
 
+# emit a one-operand conversion (`trunc` / `zext`) narrowing or widening `v` to `to`
+# ---
+# st:     state
+# cur:    the insertion point
+# kind:   OP_TRUNC or OP_ZEXT
+# v:      the value to convert
+# to:     the integer type to convert it to
+# secret: the taint to stamp
+# ret:    the converted value, or an allocation error
+fun emit_convert(st: *State, cur: *Cursor, kind: instruction.InstrKind, v: value.Value,
+                 to: ir_type.IrTypeId, secret: bool) R.Result[value.Value, str] {
+    val r: R.Result[*value.Value, str] = A.allocate[value.Value](st.alloc, 1::usize);
+    if (R.is_err[*value.Value, str](r)) { ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](r)); }
+    val ops: *value.Value = R.unwrap_ok[*value.Value, str](r);
+    ops[0] = v;
+    val tainted: bool = secret || v.secret;
+    val ri: R.Result[id.InstructionId, str] = emit(st, cur, kind, to, ops, 1, ir_type.IRT_NIL, tainted);
+    if (R.is_err[id.InstructionId, str](ri)) { ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](ri)); }
+    var out: value.Value = value.instr(R.unwrap_ok[id.InstructionId, str](ri), to);
+    out.secret = tainted;
+    ret R.ok[value.Value, str](out);
+}
+
+# emit a two-operand integer op (`and` / `or`) over `a` and `b`
+# ---
+# st:     state
+# cur:    the insertion point
+# kind:   OP_AND or OP_OR
+# a:      the left operand, whose type the result takes
+# b:      the right operand
+# secret: the taint to stamp
+# ret:    the resulting value, or an allocation error
+fun emit_binary(st: *State, cur: *Cursor, kind: instruction.InstrKind, a: value.Value,
+                b: value.Value, secret: bool) R.Result[value.Value, str] {
+    val r: R.Result[*value.Value, str] = A.allocate[value.Value](st.alloc, 2::usize);
+    if (R.is_err[*value.Value, str](r)) { ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](r)); }
+    val ops: *value.Value = R.unwrap_ok[*value.Value, str](r);
+    ops[0] = a;
+    ops[1] = b;
+    val tainted: bool = secret || a.secret || b.secret;
+    val ri: R.Result[id.InstructionId, str] = emit(st, cur, kind, a.ty, ops, 2, ir_type.IRT_NIL, tainted);
+    if (R.is_err[id.InstructionId, str](ri)) { ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](ri)); }
+    var out: value.Value = value.instr(R.unwrap_ok[id.InstructionId, str](ri), a.ty);
+    out.secret = tainted;
+    ret R.ok[value.Value, str](out);
+}
+
 # emit `memzero ptr` over a nested aggregate field
 # ---
 # st:     state
@@ -1762,15 +1872,16 @@ fun union_access_at(st: *State, v: value.Value) u32 {
 #
 # The load already had its pointer retargeted onto the cell's slot, so when the member
 # it names is the slot's own storage type there is nothing left to do. Otherwise the
-# cell is read at its storage type and bit-cast to the member's, and the original load
-# is superseded by the cast.
+# cell is read whole and narrowed to the access: a `trunc` first when the member is
+# narrower (its bits are the cell integer's low ones), then a bit cast when the result
+# is not already the access type. The original load is superseded by the result.
 # ---
 # st:   state
 # rw:   rewrite map collecting the substitution
 # cur:  the insertion point
 # iid:  the load's instruction id
 # inst: the load
-# gid:  the member gep it reads through
+# gid:  the gep it reads through
 # ret:  ok(true) once rewritten, or the first error
 fun reinterpret_load(st: *State, rw: *mutate.Rewrite, cur: *Cursor, iid: id.InstructionId,
                      inst: *instruction.Instruction, gid: u32) R.Result[bool, str] {
@@ -1782,24 +1893,40 @@ fun reinterpret_load(st: *State, rw: *mutate.Rewrite, cur: *Cursor, iid: id.Inst
     val tainted: bool = inst.secret || st.cand_secret[c];
     val r_load: R.Result[value.Value, str] = emit_load(st, cur, slot, sty, tainted);
     if (R.is_err[value.Value, str](r_load)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_load)); }
-    val r_cast: R.Result[value.Value, str] = emit_bitcast(st, cur, R.unwrap_ok[value.Value, str](r_load), inst.ty, tainted);
-    if (R.is_err[value.Value, str](r_cast)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_cast)); }
+    var cur_v: value.Value = R.unwrap_ok[value.Value, str](r_load);
 
-    mutate.replace_value(rw, iid, R.unwrap_ok[value.Value, str](r_cast));
+    val acc: u32 = ir_type.byte_size(?st.m.types, inst.ty, st.tgt);
+    if (acc < ir_type.byte_size(?st.m.types, sty, st.tgt)) {
+        val r_tr: R.Result[value.Value, str] = emit_convert(st, cur, instruction.OP_TRUNC, cur_v,
+                                                            int_of_bytes(st, acc), tainted);
+        if (R.is_err[value.Value, str](r_tr)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_tr)); }
+        cur_v = R.unwrap_ok[value.Value, str](r_tr);
+    }
+    if (cur_v.ty != inst.ty) {
+        val r_cast: R.Result[value.Value, str] = emit_bitcast(st, cur, cur_v, inst.ty, tainted);
+        if (R.is_err[value.Value, str](r_cast)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_cast)); }
+        cur_v = R.unwrap_ok[value.Value, str](r_cast);
+    }
+
+    mutate.replace_value(rw, iid, cur_v);
     st.erase[iid::u32] = true;
     ret R.ok[bool, str](true);
 }
 
-# reinterpret a stored member as the union cell's storage type and write the whole cell
+# write a stored member back through the union cell's slot
 #
-# Every member covers the whole cell (`union_leaf_ty`), so the reinterpreted store
-# writes exactly the bytes the member's store did.
+# A member the width of the cell is bit-cast and stored whole. A narrower one must leave
+# the bytes it does not cover exactly as they were -- the very thing the memory form did
+# for free -- so it is widened into the cell integer and merged in: read the cell, clear
+# the member's bits, or the widened value back. In the shape this exists for, the cell
+# was zero-filled a moment earlier, and the later simplification passes fold the read,
+# the mask and the merge away, leaving only the widening.
 # ---
 # st:   state
 # cur:  the insertion point
 # iid:  the store's instruction id
 # inst: the store
-# gid:  the member gep it writes through
+# gid:  the gep it writes through
 # ret:  ok(true) once rewritten, or the first error
 fun reinterpret_store(st: *State, cur: *Cursor, iid: id.InstructionId,
                       inst: *instruction.Instruction, gid: u32) R.Result[bool, str] {
@@ -1810,9 +1937,38 @@ fun reinterpret_store(st: *State, cur: *Cursor, iid: id.InstructionId,
 
     val slot: value.Value = st.slots[st.cand_slot[c] + st.gep_field[gid]];
     val tainted: bool = inst.secret || v.secret || st.cand_secret[c];
-    val r_cast: R.Result[value.Value, str] = emit_bitcast(st, cur, v, sty, tainted);
-    if (R.is_err[value.Value, str](r_cast)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_cast)); }
-    val r_store: R.Result[bool, str] = emit_store(st, cur, R.unwrap_ok[value.Value, str](r_cast), slot, tainted);
+    val acc: u32 = ir_type.byte_size(?st.m.types, v.ty, st.tgt);
+    val cell: u32 = ir_type.byte_size(?st.m.types, sty, st.tgt);
+
+    var cur_v: value.Value = v;
+    if (acc < cell) {
+        if (cur_v.ty != int_of_bytes(st, acc)) {
+            val r_ci: R.Result[value.Value, str] = emit_bitcast(st, cur, cur_v, int_of_bytes(st, acc), tainted);
+            if (R.is_err[value.Value, str](r_ci)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_ci)); }
+            cur_v = R.unwrap_ok[value.Value, str](r_ci);
+        }
+        val r_z: R.Result[value.Value, str] = emit_convert(st, cur, instruction.OP_ZEXT, cur_v, sty, tainted);
+        if (R.is_err[value.Value, str](r_z)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_z)); }
+        cur_v = R.unwrap_ok[value.Value, str](r_z);
+
+        val r_old: R.Result[value.Value, str] = emit_load(st, cur, slot, sty, tainted);
+        if (R.is_err[value.Value, str](r_old)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_old)); }
+        val keep: value.Value = value.const_int(~((1::u64 << (acc * 8)) - 1), sty);
+        val r_and: R.Result[value.Value, str] = emit_binary(st, cur, instruction.OP_AND,
+                                                            R.unwrap_ok[value.Value, str](r_old), keep, tainted);
+        if (R.is_err[value.Value, str](r_and)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_and)); }
+        val r_or: R.Result[value.Value, str] = emit_binary(st, cur, instruction.OP_OR,
+                                                           R.unwrap_ok[value.Value, str](r_and), cur_v, tainted);
+        if (R.is_err[value.Value, str](r_or)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_or)); }
+        cur_v = R.unwrap_ok[value.Value, str](r_or);
+    }
+    or {
+        val r_cast: R.Result[value.Value, str] = emit_bitcast(st, cur, cur_v, sty, tainted);
+        if (R.is_err[value.Value, str](r_cast)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r_cast)); }
+        cur_v = R.unwrap_ok[value.Value, str](r_cast);
+    }
+
+    val r_store: R.Result[bool, str] = emit_store(st, cur, cur_v, slot, tainted);
     if (R.is_err[bool, str](r_store)) { ret r_store; }
     st.erase[iid::u32] = true;
     ret R.ok[bool, str](true);


### PR DESCRIPTION
Closes #2315.

Recovers the work from the closed PR #2324, rebased across 670 commits of `dev`, re-verified from scratch, and measured on the current tree. #2324 was closed for programme priority, not for a defect. **Three of its four commits existed only in a local checkout**; they are pushed now so they cannot be lost again.

I re-derived the diagnosis rather than taking the prior write-up at face value, and it still holds on current `dev`.

## Root cause

SROA never saw `Result` at all. `splittable_at` requires the whole type tree to reduce to scalars, `Result[T, E]` lowers to `{i8, uni{T, E}}`, and `agg_field_count` returns 0 for `IRT_UNION` by design. So the candidate is refused at the type test on line 513, **before escape analysis ever runs**. This is not an inlining gap: the call is inlined already, and a probe with the identical control-flow shape over a plain two-field `rec` splits today.

## Fix

A union field becomes **one** slot, not one per member. Every member resolves to the same cell, so the variants still alias byte for byte and the reinterpretation a union exists to express is preserved exactly. This is why it does not reintroduce what #2239 fixed: re-admitting the *shape* is not re-admitting the *layout*, and splitting into per-member slots is exactly what is **not** done here.

The storage type is picked from the members (first integer, else first pointer, else member 0), so at least one member accesses it with no cast and any other is a plain `bitcast`. A member narrower than the cell is read-modify-written through the cell's own integer, precisely so the bytes it does not cover survive.

## The bar, item by item

**1. The `Result` temp does not reach memory.** Confirmed from `k_result_chain`'s disassembly. Before, per iteration: a stack slot, a 16-byte zero fill, a tag store, a payload store, and a reload. After, the discriminant lives in `cl` and the payload in `r15` across the branch, with no slot, no `memzero` and no reload:

```
.13:                          .8:
  mov rcx, 1                    mov rcx, 0
  mov r15, rax                  mov r15, r12
```

**2. `result_chain` re-measured — the number: 19.52x → 2.50x vs `cc -O3`** (754.46 us → 96.70 us), `--rounds 5 --reps 7`, both compilers run back to back on the same machine. The kernel goes from 93 instructions to 61, against C's 19.

Load-independent whole-suite retired instructions, two runs each with a spread of ~300 out of 10.9 G: **10,887,573,088 → 9,419,554,030, −13.5%**. A per-function asm diff shows only three functions changed **anywhere** in the benchmark, so the entire −1.468 G is this kernel:

| function | before | after |
|---|---|---|
| `k_result_chain` | 93 | 61 |
| `std.types.result.is_err[i64,*u8]` | 19 | 15 |
| `std.types.result.unwrap_ok[i64,*u8]` | 25 | 20 |

Group geomeans vs `cc -O3`: general codegen **2.28x → 1.82x**, whole suite **2.32x → 2.08x**.

**It is not at parity, and I am not presenting it as fixed.** 61 against C's 19 leaves a real gap, and it is a *different* gap: `is_err` materializes a boolean and then tests it (`cmp cl,0` / `sete al` / `movzx rax,al` / `test al,al` / `jne`, where `cmp` / `jne` would do), and the tag is compared a second time inside the inlined `unwrap_ok` panic guard. Neither is aggregate traffic. Details in "New issues" below.

**3. `rec_particle` does NOT share the cause — answered from its disassembly.** Its emitted code is **byte-identical** before and after this change, which settles it directly rather than by argument. Its 43-instruction loop body breaks down as:

| | count | |
|---|---|---|
| real float arithmetic | 12 | the actual work |
| real loads from the record | 6 | the actual work |
| dead reg-reg float copies | 9 | #2203 / #2237 |
| loop-invariant f32 constant rematerialized (3x/iter) | 6 | #2204 |
| `lea` for a constant field displacement, not folded into the load | 6 | isel |
| index strength reduction | 3 | |

Only 18 of 43 are real work. Note the issue recorded `rec_particle` at 8.10x / 81 instructions; on current `dev` it is 4.03x / 53, so it has already improved a lot from other work.

**4. Checksums bit-identical.** All 19 kernels report `=` in both the before and after runs.

## Correctness

The change is release-only (SROA runs inside the `OPT_RELEASE` arm), so a debug build never exercises it. Everything below therefore runs through the **release-built self-hosted compiler**, which has this SROA applied to its own extremely `Result`-heavy code — the strongest available test:

- `mach test .` — 1205 passed, 0 failed
- `mach-std` — 764 passed, 0 failed (pin `c52de19`)
- `int/run.sh --target linux` — all cases passed
- Release self-host fixpoint, three generations — R2 and R3 byte-identical

On secrecy, which the prior write-up explicitly left unconfirmed: #2225's rule (a union's variants must agree on secrecy) is still enforced at sema on current `dev`, and within the pass `partition_secret` joins the taint over the whole partition, so a `^T` member cannot be laundered public. That is strictly more conservative than per-member slots would be. `preserves_a_secret_field` passes. This is reasoning plus a test, not a full constant-time audit.

## Cost, stated plainly

Release compile of identical source: **300.603 G → 315.977 G instructions, +5.11%**. Output: **8,900,608 → 8,056,832 bytes, −9.48%**. Roughly 5% slower release builds for 9.5% smaller and materially faster output. Not free.

## Tests

15 sroa cases, 10 of them new for the union cell. I mutation-tested the guards myself rather than relying on the prior claim; each mutation is caught by exactly one case:

| mutation | result |
|---|---|
| drop the narrow-member refusal | 14 passed, **1 failed** |
| allow an access wider than the cell | 14 passed, **1 failed** |
| allow a non-scalar union member | 14 passed, **1 failed** |

The little-endian condition on the narrow form cannot be mutation-tested, since no registered isa can reach it; it carries its rationale at the guard instead.