### PR TITLE
fix(driver): check every module under src, emit only the reachable ones

### DIFF
--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -376,7 +376,7 @@ fun collect_defined_globals(p: *driver.Project, img: *of.ObjectImage, member: *a
 # out_path: receives the owned archive path on success
 # ret:      ok(true) on success, or the failure as a Fail
 pub fun emit_static_archive(p: *driver.Project, unit: *plan.BuildUnit, images: *of.ObjectImage, paths: **u8, out_path: **u8) R.Result[bool, outcome.Fail] {
-    val len: u32 = p.topo_len;
+    val len: u32 = p.emit_len;
 
     val archive: str = unit.out_path;
     if (O.is_some[str](ensure_parents(p.alloc, archive))) {
@@ -494,9 +494,9 @@ pub fun link_executable(p: *driver.Project, paths: **u8, len: u32,
 # ---
 # p:      the project carrying the topo order and allocator
 # images: the per-module object images, indexed by module id
-# ret:    an owned topo-ordered image array (length `p.topo_len`), or an error
+# ret:    an owned topo-ordered image array (length `p.emit_len`), or an error
 fun gather_topo_images(p: *driver.Project, images: *of.ObjectImage) R.Result[*of.ObjectImage, str] {
-    val len: u32 = p.topo_len;
+    val len: u32 = p.emit_len;
     val res_ord: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.alloc, len::usize);
     if (R.is_err[*of.ObjectImage, str](res_ord)) { ret res_ord; }
     val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
@@ -530,8 +530,8 @@ pub fun link_flat_images(p: *driver.Project, images: *of.ObjectImage, exe_path: 
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, image_options);
-    A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
+        linker.link_images(p.s, ?p.target, ordered, p.emit_len, nil::*of.DynLib, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, image_options);
+    A.deallocate[of.ObjectImage](p.alloc, ordered, p.emit_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -568,9 +568,9 @@ pub fun link_mixed_images(p: *driver.Project, images: *of.ObjectImage,
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link_mixed(p.s, ?p.target, ordered, p.topo_len, ext_paths, ext_count,
+        linker.link_mixed(p.s, ?p.target, ordered, p.emit_len, ext_paths, ext_count,
                           dynlibs, dynlib_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie, image_options);
-    A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
+    A.deallocate[of.ObjectImage](p.alloc, ordered, p.emit_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }
@@ -1086,13 +1086,13 @@ test "mach.lang.build.emit.static_path_present:deduplicates_exact_paths" {
 # ret:       ok(true) on success, or the failure as a Fail
 pub fun write_objects(p: *driver.Project, images: *of.ObjectImage,
                       obj_base: *u8, paths_out: ***u8) R.Result[bool, outcome.Fail] {
-    val len: u32 = p.topo_len;
+    val len: u32 = p.emit_len;
     val res_paths: R.Result[**u8, str] = A.allocate[*u8](p.alloc, len::usize);
     if (R.is_err[**u8, str](res_paths)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
     val paths: **u8 = R.unwrap_ok[**u8, str](res_paths);
 
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val mid: session.ModuleId   = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
 

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -588,7 +588,7 @@ fun lower_phase(p: *driver.Project, st: *UnitState, rd: *outcome.Render) R.Resul
     # per-lane scalar sequences; the render seam owns the wording.
     var total: u32 = 0;
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val mid: session.ModuleId    = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
         total = total + m.ir_module.vector_ops_scalarized;
@@ -597,7 +597,7 @@ fun lower_phase(p: *driver.Project, st: *UnitState, rd: *outcome.Render) R.Resul
     if (total > 0) { outcome.render_note(rd, total); }
 
     i = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val mid: session.ModuleId    = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
         val irm: *ir.Module          = m.ir_module;
@@ -631,7 +631,7 @@ fun codegen_phase(p: *driver.Project, st: *UnitState) R.Result[bool, outcome.Fai
     if (R.is_err[bool, outcome.Fail](res_codegen)) { ret res_codegen; }
 
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val mid: session.ModuleId    = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
         val img: *of.ObjectImage     = m.object_image;
@@ -668,7 +668,7 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     # IR the objects are built from; the dirs are plan facts.
     if (ctx.req.emit_ir || ctx.req.emit_asm) {
         var i: u32 = 0;
-        for (i < p.topo_len) {
+        for (i < p.emit_len) {
             val mid: session.ModuleId    = p.topo[i];
             val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
             if (ctx.req.emit_ir) {
@@ -722,7 +722,7 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     if (objects) {
         val oc: R.Result[bool, outcome.Fail] = emit.write_objects(p, st.images, unit.obj_dir::*u8, ?st.obj_paths);
         if (R.is_err[bool, outcome.Fail](oc)) { ret oc; }
-        st.obj_len = p.topo_len;
+        st.obj_len = p.emit_len;
     }
 
     # the object tree is the delivery for an objects goal, and for an execute goal
@@ -731,7 +731,7 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     if (goal == request.GOAL_OBJECTS
         || (goal == request.GOAL_EXECUTE && plan.finished_modules(?p.target))) {
         st.out_path = unit.out_path::*u8;
-        readout.phase_end(ev, readout.PH_LINK, p.topo_len, "object", "objects");
+        readout.phase_end(ev, readout.PH_LINK, p.emit_len, "object", "objects");
         st.link_started = false;
     }
     ret R.ok[bool, outcome.Fail](true);
@@ -802,11 +802,11 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
 
     # record the link inputs into Q_LINK_CONFIG and consult Q_LINK: when no link
     # input changed and the prior artifact is present, reuse it instead of
-    # re-linking. the external link inputs are obj_paths[topo_len..obj_len)
-    # (obj_paths[0..topo_len) are the per-module objects Q_CODEGEN already
+    # re-linking. the external link inputs are obj_paths[emit_len..obj_len)
+    # (obj_paths[0..emit_len) are the per-module objects Q_CODEGEN already
     # tracks). a cold-cache CLI build always re-links (Q_LINK is a fresh entry).
-    val ext_from:  u32 = p.topo_len;
-    val ext_count: u32 = st.obj_len - p.topo_len;
+    val ext_from:  u32 = p.emit_len;
+    val ext_count: u32 = st.obj_len - p.emit_len;
     val loaded_r: R.Result[emit.LoadedImageOptions, outcome.Fail] =
         emit.load_image_options(p, linker.LINK_EXE, artifact::*u8);
     if (R.is_err[emit.LoadedImageOptions, outcome.Fail](loaded_r)) {
@@ -927,7 +927,9 @@ fun record_artifact(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, b
 # Reports the module count and total time, plus the linked binary's size when
 # the build produced one (an executable). A library / object-only build - and a
 # finished-module build, whose delivery is the module tree - has no single
-# binary, so the size segment is omitted.
+# binary, so the size segment is omitted. The count is the emitted set, not the
+# checked set: a module front-ended but not reachable from the entry contributes
+# nothing to the artifact this line names (#2539).
 fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress) {
     var out_str: str = "<output>";
     if (st.out_path != nil) { out_str = st.out_path::str; }
@@ -944,11 +946,11 @@ fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress)
             val fi: fs.Metadata = R.unwrap_ok[fs.Metadata, str](fi_r);
             var unit_s: str = "B";
             val mag: i64 = readout.size_split(fi.size, ?unit_s);
-            readout.summary(ev, out_str, p.module_len, mag, unit_s, true);
+            readout.summary(ev, out_str, p.emit_len, mag, unit_s, true);
             ret;
         }
     }
-    readout.summary(ev, out_str, p.module_len, 0, "B", false);
+    readout.summary(ev, out_str, p.emit_len, 0, "B", false);
 }
 
 # whether the parallel-codegen prelude should run for this build: the request
@@ -957,7 +959,7 @@ fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress)
 # type table (the layout oracle), so no two workers touch shared type state (#2101)
 fun pcg_enabled(p: *driver.Project) bool {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
-    ret ctx.req.jobs >= 1 && p.topo_len > 0;
+    ret ctx.req.jobs >= 1 && p.emit_len > 0;
 }
 
 # serialize the link-only build configuration into the Q_LINK_CONFIG input, keyed
@@ -1254,15 +1256,15 @@ fun pcg_worker_main(arg: *u8) {
 # p:   the active project (jobs resolved; DWARF decision settled per debug_info_of)
 # ret: true once every stale module is staged, or the first worker's codegen error
 fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
-    val topo_len: u32 = p.topo_len;
-    if (topo_len == 0) { ret R.ok[bool, str](true); }
+    val emit_len: u32 = p.emit_len;
+    if (emit_len == 0) { ret R.ok[bool, str](true); }
 
-    val rstale: R.Result[*u32, str] = A.allocate[u32](p.alloc, topo_len::usize);
+    val rstale: R.Result[*u32, str] = A.allocate[u32](p.alloc, emit_len::usize);
     if (R.is_err[*u32, str](rstale)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rstale)); }
     val stale: *u32 = R.unwrap_ok[*u32, str](rstale);
     var stale_len: u32 = 0;
     var ti: u32 = 0;
-    for (ti < topo_len) {
+    for (ti < emit_len) {
         if (!driver.codegen_reusable(p, p.topo[ti])) {
             stale[stale_len] = ti;
             stale_len = stale_len + 1;
@@ -1270,7 +1272,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
         ti = ti + 1;
     }
     if (stale_len <= 1) {
-        A.deallocate[u32](p.alloc, stale, topo_len::usize);
+        A.deallocate[u32](p.alloc, stale, emit_len::usize);
         ret R.ok[bool, str](true);
     }
 
@@ -1281,7 +1283,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
 
     val rslots: R.Result[*PcgSlot, str] = A.allocate[PcgSlot](p.alloc, stale_len::usize);
     if (R.is_err[*PcgSlot, str](rslots)) {
-        A.deallocate[u32](p.alloc, stale, topo_len::usize);
+        A.deallocate[u32](p.alloc, stale, emit_len::usize);
         ret R.err[bool, str](R.unwrap_err[*PcgSlot, str](rslots));
     }
     val slots: *PcgSlot = R.unwrap_ok[*PcgSlot, str](rslots);
@@ -1295,7 +1297,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     val rdbg: R.Result[codegen.DebugInfo, str] = driver.debug_info_of(p);
     if (R.is_err[codegen.DebugInfo, str](rdbg)) {
         A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
-        A.deallocate[u32](p.alloc, stale, topo_len::usize);
+        A.deallocate[u32](p.alloc, stale, emit_len::usize);
         ret R.err[bool, str](R.unwrap_err[codegen.DebugInfo, str](rdbg));
     }
     val dbg: codegen.DebugInfo = R.unwrap_ok[codegen.DebugInfo, str](rdbg);
@@ -1303,7 +1305,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     val rworkers: R.Result[*PcgWorker, str] = A.allocate[PcgWorker](p.alloc, nworkers::usize);
     if (R.is_err[*PcgWorker, str](rworkers)) {
         A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
-        A.deallocate[u32](p.alloc, stale, topo_len::usize);
+        A.deallocate[u32](p.alloc, stale, emit_len::usize);
         ret R.err[bool, str](R.unwrap_err[*PcgWorker, str](rworkers));
     }
     val workers: *PcgWorker = R.unwrap_ok[*PcgWorker, str](rworkers);
@@ -1316,7 +1318,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
             for (wj < wi) { pcg_worker_teardown(?workers[wj]); wj = wj + 1; }
             A.deallocate[PcgWorker](p.alloc, workers, nworkers::usize);
             A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
-            A.deallocate[u32](p.alloc, stale, topo_len::usize);
+            A.deallocate[u32](p.alloc, stale, emit_len::usize);
             ret R.err[bool, str](O.unwrap[str](io));
         }
         wi = wi + 1;
@@ -1346,7 +1348,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
             for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
             A.deallocate[PcgWorker](p.alloc, workers, nworkers::usize);
             A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
-            A.deallocate[u32](p.alloc, stale, topo_len::usize);
+            A.deallocate[u32](p.alloc, stale, emit_len::usize);
             ret R.err[bool, str](R.unwrap_err[*thread.Thread, str](rt));
         }
         threads = R.unwrap_ok[*thread.Thread, str](rt);
@@ -1376,7 +1378,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
             for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
             A.deallocate[PcgWorker](p.alloc, workers, nworkers::usize);
             A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
-            A.deallocate[u32](p.alloc, stale, topo_len::usize);
+            A.deallocate[u32](p.alloc, stale, emit_len::usize);
             ret R.err[bool, str](msg);
         }
         ei = ei + 1;
@@ -1388,7 +1390,7 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
     A.deallocate[PcgWorker](p.alloc, workers, nworkers::usize);
     A.deallocate[PcgSlot](p.alloc, slots, stale_len::usize);
-    A.deallocate[u32](p.alloc, stale, topo_len::usize);
+    A.deallocate[u32](p.alloc, stale, emit_len::usize);
     ret cr;
 }
 

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -207,7 +207,7 @@ pub fun link_dispatcher(p: *driver.Project, unit: *plan.BuildUnit, sc: *TestScop
 
     # the shared object set: the per-module paths (borrowed) copied into a
     # growable array the external inputs append to.
-    val len0: u32 = p.topo_len;
+    val len0: u32 = p.emit_len;
     val res_sh: R.Result[**u8, str] = A.allocate[*u8](p.alloc, len0::usize);
     if (R.is_err[**u8, str](res_sh)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
     var shared: **u8 = R.unwrap_ok[**u8, str](res_sh);
@@ -384,7 +384,7 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
     # archive is scanned, so the unrelated startup member stays unselected. the
     # ordinary build path reaches the same order by seeding the project's own
     # `main` image ahead of the external inputs (#2530, #2562).
-    val per_module: u32 = p.topo_len;
+    val per_module: u32 = p.emit_len;
     var i: u32 = 0;
     for (i < per_module) { paths[i] = shared[i]; i = i + 1; }
     paths[per_module] = entry_path;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -134,7 +134,7 @@ pub fun build_project(s: *session.Session, project_root: str, target_name: str) 
 # entries the build engine dispatches individually run here in sequence, so a
 # non-engine flow and an engine unit execute identical pieces.
 fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, for_union: bool, all_own_src: bool, run_steps: bool) R.Result[project.Project, outcome.Fail] {
-    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, for_union, all_own_src);
+    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, for_union, all_own_src, all_own_src);
     if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
 
@@ -185,11 +185,19 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
     sel.artifact     = req.artifact;
     sel.want_lib     = req.want_lib;
     sel.has_artifact = !str_empty(req.artifact);
-    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, false, request.test_goal(req.goal));
+    # every engine build front-ends the whole source tree, so `mach build` and
+    # `mach test` agree on whether the project compiles (#2539). `is_test` stays the
+    # narrower fact - it picks the link surface and the back-end work set.
+    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, false, request.test_goal(req.goal), true);
 }
 
 # the shared open: init + query binding + config synthesis + target entry
-fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, for_union: bool, all_own_src: bool) R.Result[project.Project, outcome.Fail] {
+#
+# `is_test` selects the `mach test` link surface (the union of every artifact's
+# libs); `all_own_src` loads every own-source module as a load root. They are
+# independent: a `mach build` loads the whole tree to check it while still linking
+# one artifact.
+fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, for_union: bool, is_test: bool, all_own_src: bool) R.Result[project.Project, outcome.Fail] {
     var p: project.Project;
     project.init_project(?p, s);
     p.events      = ev;
@@ -207,7 +215,7 @@ fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Sele
     # synthesis directly; a legacy entry reads the conventional <root>/mach.toml.
     var cfg_r: R.Result[bool, str];
     if (m != nil) {
-        cfg_r = dcfg.load_config_manifest(?p, project_root, m, sel, for_union, all_own_src);
+        cfg_r = dcfg.load_config_manifest(?p, project_root, m, sel, for_union, is_test);
     }
     or {
         val mp_r: R.Result[str, str] = load.join_path(s.alloc, project_root, manifest.MANIFEST_FILE);
@@ -216,7 +224,7 @@ fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Sele
             ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[str, str](mp_r)));
         }
         val manifest_path: str = R.unwrap_ok[str, str](mp_r);
-        cfg_r = dcfg.load_project_config(?p, project_root, manifest_path, sel, for_union, all_own_src);
+        cfg_r = dcfg.load_project_config(?p, project_root, manifest_path, sel, for_union, is_test);
         str_free(s.alloc, manifest_path);
     }
     if (R.is_err[bool, str](cfg_r)) {
@@ -349,16 +357,25 @@ pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
         ei = ei + 1;
     }
 
-    # test builds root collection at the whole source tree, not the entrypoint's
-    # import closure, so a `pub` module with no in-tree `use` consumer still has
-    # its tests collected (#1863). dfs_load dedups by FQN, so this only adds the
-    # modules the entry/union walks missed.
+    # the artifact closure is settled: everything loaded so far is what this build
+    # emits and links, and the whole-source sweep below only appends past it (#2539).
+    p.emit_len = p.topo_len;
+
+    # root the load at the whole source tree, not the entrypoint's import closure,
+    # so a `pub` module with no in-tree `use` consumer is still checked (#2539) and
+    # still has its tests collected (#1863). dfs_load dedups by FQN, so this only
+    # adds the modules the entry/union walks missed.
     if (p.all_own_src) {
         val allsrc_r: R.Result[bool, str] = union.load_all_own_src(p);
         if (R.is_err[bool, str](allsrc_r)) {
             ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](allsrc_r)));
         }
     }
+
+    # a test dispatcher links every module in the tree, so the back-end work set is
+    # the whole topo order rather than one artifact's closure.
+    if (passes.test_build(p)) { p.emit_len = p.topo_len; }
+
     readout.phase_end(p.events, readout.PH_LOAD, p.topo_len, "module", "modules");
 
     # the module table is stable past the load pass; publish every module's

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -640,7 +640,7 @@ pub fun codegen_reusable(p: *project.Project, mid: session.ModuleId) bool {
 # whether this build lowers the test variant (tests present, `main` neutralized) -
 # the request's goal, folded into the back-half query keys so it caches independently
 # from normal test-free IR (#1858, #2320)
-fun test_build(p: *project.Project) bool {
+pub fun test_build(p: *project.Project) bool {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     ret request.test_goal(ctx.req.goal);
 }
@@ -758,7 +758,7 @@ pub fun run_lower_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
     }
 
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val mid: session.ModuleId = p.topo[i];
         val r: R.Result[bool, str] = run_lower_one(p, mid);
         if (R.is_err[bool, str](r)) {
@@ -767,7 +767,7 @@ pub fun run_lower_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
         }
         i = i + 1;
     }
-    readout.phase_end(p.events, readout.PH_LOWER, p.topo_len, "module", "modules");
+    readout.phase_end(p.events, readout.PH_LOWER, p.emit_len, "module", "modules");
     ctx.p = nil;
     ret R.ok[bool, outcome.Fail](true);
 }
@@ -813,7 +813,7 @@ fun lower_prepare(p: *project.Project) R.Result[bool, outcome.Fail] {
     }
 
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val m: *project.ModuleEntry = ?p.modules[p.topo[i]::u32];
         val sf_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_LOWERED_SURFACE, m.stable_id::u64);
         if (R.is_err[*query.QueryEntry, str](sf_r)) {
@@ -1322,7 +1322,7 @@ fun ir_handle_decode(e: *query.QueryEntry) *ir.Module {
 # asked for at least one worker and there is at least one module
 fun lower_parallel_enabled(p: *project.Project) bool {
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
-    ret ctx.req.jobs >= 1 && p.topo_len > 0;
+    ret ctx.req.jobs >= 1 && p.emit_len > 0;
 }
 
 # one module's parallel-optimization slot, indexed by stale position
@@ -1413,16 +1413,16 @@ fun plw_worker_main(arg: *u8) {
 # p:   the active project (lower_prepare has settled the staleness verdicts)
 # ret: true once every stale module is staged, or the first error
 fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
-    val topo_len: u32 = p.topo_len;
-    if (topo_len == 0) { ret R.ok[bool, str](true); }
+    val emit_len: u32 = p.emit_len;
+    if (emit_len == 0) { ret R.ok[bool, str](true); }
 
-    val rslots: R.Result[*PlwSlot, str] = A.allocate[PlwSlot](p.alloc, topo_len::usize);
+    val rslots: R.Result[*PlwSlot, str] = A.allocate[PlwSlot](p.alloc, emit_len::usize);
     if (R.is_err[*PlwSlot, str](rslots)) { ret R.err[bool, str](R.unwrap_err[*PlwSlot, str](rslots)); }
     val slots: *PlwSlot = R.unwrap_ok[*PlwSlot, str](rslots);
 
     var slot_len: u32 = 0;
     var ti: u32 = 0;
-    for (ti < topo_len) {
+    for (ti < emit_len) {
         val mid: session.ModuleId = p.topo[ti];
         if (!lower_reusable(p, mid)) {
             slots[slot_len].mid = mid;
@@ -1433,7 +1433,7 @@ fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
         ti = ti + 1;
     }
     if (slot_len <= 1) {
-        A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+        A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
         ret R.ok[bool, str](true);
     }
 
@@ -1453,7 +1453,7 @@ fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
         val hr: R.Result[*ir.ModuleHome, str] = ir_home_new(p.s.alloc);
         if (R.is_err[*ir.ModuleHome, str](hr)) {
             lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
             ret R.err[bool, str](R.unwrap_err[*ir.ModuleHome, str](hr));
         }
         val home: *ir.ModuleHome = R.unwrap_ok[*ir.ModuleHome, str](hr);
@@ -1463,7 +1463,7 @@ fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
             val emsg: str = lower_stable_err(p, R.unwrap_err[*ir.Module, str](rr_raw));
             ir_release(p.s.alloc, home);
             lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
             ret R.err[bool, str](emsg);
         }
         m.staged_ir   = R.unwrap_ok[*ir.Module, str](rr_raw);
@@ -1480,7 +1480,7 @@ fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
     val nid: R.Result[intern.StrId, str] = neutralize_id(p, test_mode);
     if (R.is_err[intern.StrId, str](nid)) {
         lower_sweep_staged(p);
-        A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+        A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](nid));
     }
 
@@ -1500,7 +1500,7 @@ fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
         val rt: R.Result[*thread.Thread, str] = A.allocate[thread.Thread](p.alloc, extra::usize);
         if (R.is_err[*thread.Thread, str](rt)) {
             lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
             ret R.err[bool, str](R.unwrap_err[*thread.Thread, str](rt));
         }
         threads = R.unwrap_ok[*thread.Thread, str](rt);
@@ -1527,13 +1527,13 @@ fun run_lower_parallel(p: *project.Project) R.Result[bool, str] {
         if (slots[ei].err != nil) {
             val msg: str = lower_stable_err(p, slots[ei].err);
             lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
             ret R.err[bool, str](msg);
         }
         ei = ei + 1;
     }
 
-    A.deallocate[PlwSlot](p.alloc, slots, topo_len::usize);
+    A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
     ret R.ok[bool, str](true);
 }
 
@@ -1654,7 +1654,7 @@ pub fun run_codegen_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
     readout.phase_begin(p.events, readout.PH_CODEGEN);
 
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val mid: session.ModuleId = p.topo[i];
         val r: R.Result[bool, str] = run_codegen_one(p, mid);
         if (R.is_err[bool, str](r)) {
@@ -1663,7 +1663,7 @@ pub fun run_codegen_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
         }
         i = i + 1;
     }
-    readout.phase_end(p.events, readout.PH_CODEGEN, p.topo_len, "module", "modules");
+    readout.phase_end(p.events, readout.PH_CODEGEN, p.emit_len, "module", "modules");
     ctx.p = nil;
     ret R.ok[bool, outcome.Fail](true);
 }
@@ -1854,10 +1854,10 @@ pub fun q_link_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Resu
     val wc: R.Result[bool, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, str](rc));
     if (R.is_err[bool, str](wc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wc)); }
 
-    val wn: R.Result[bool, str] = dq.fp_u32(?fb, p.topo_len);
+    val wn: R.Result[bool, str] = dq.fp_u32(?fb, p.emit_len);
     if (R.is_err[bool, str](wn)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wn)); }
     var i: u32 = 0;
-    for (i < p.topo_len) {
+    for (i < p.emit_len) {
         val m: *project.ModuleEntry = ?p.modules[(p.topo[i])::u32];
         val rd: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_CODEGEN, m.stable_id::u64);
         if (R.is_err[query.Revision, str](rd)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rd)); }

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -336,8 +336,9 @@ pub rec TargetTuple {
 # load_status:       per-module DFS load state; cleared when build_project completes
 # load_cap:          allocated slots in load_status
 # topo:              module ids in dep-order (topo[0] has no deps within the graph)
-# topo_len:          number of entries in topo
+# topo_len:          number of entries in topo; the front-end work set
 # topo_cap:          allocated slots in topo
+# emit_len:          length of topo's leading back-end work set (see below)
 pub rec Project {
     s:            *session.Session;
     alloc:        *A.Allocator;
@@ -366,6 +367,18 @@ pub rec Project {
     topo:         *session.ModuleId;
     topo_len:     u32;
     topo_cap:     u32;
+
+    # the split between checking and emitting (#2539). `topo[0..topo_len)` is the
+    # front-end work set: resolve and sema walk all of it, so every module under
+    # `src` is checked wherever it sits in the tree. `topo[0..emit_len)` is the
+    # back-end work set: lower, codegen, emit and link walk only it, so a module no
+    # artifact entry reaches costs no object code and never enters the artifact.
+    #
+    # It is a leading prefix because the load phase walks the artifact closure first
+    # and records emit_len there; the whole-source sweep that follows only ever
+    # appends the modules that closure missed. A test build re-records emit_len after
+    # the sweep, since a test dispatcher does link every module.
+    emit_len:     u32;
 
     # the invocation's progress-event sink, installed by the engine for the
     # span of one build so the load walk and the passes narrate into it. nil
@@ -539,6 +552,7 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.topo          = nil;
     p.topo_len      = 0;
     p.topo_cap      = 0;
+    p.emit_len      = 0;
     p.events        = nil;
     p.all_own_src   = false;
     p.loading_orphans = false;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7716,6 +7716,102 @@ fun ut_stable_of(s: *session.Session, fqn: str) session.StableModuleId {
 # the session stays bounded (interner, SourceMap, and query-shard entry counts
 # do not grow). a third call after an edit recomputes exactly the edited
 # module's back half and re-links, proving the observables are live
+test "mach.lang.build.engine.execute:broken_unreferenced_module_fails_build" {
+    # #2539: a module under `src` that no artifact entry imports must still be
+    # checked. before this, `mach build` compiled only the entry's import closure, so
+    # a hard compile error in an unreferenced module left the build green while
+    # `mach test` - which roots its load at the whole tree - reported it. the two
+    # commands disagreed about whether the project compiled.
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [2]str; names[0] = "main.mach"; names[1] = "orphan.mach";
+    var texts: [2]str;
+    # main does NOT import orphan: nothing on the entry's path reaches it
+    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
+    texts[1] = "pub fun broken() i32 { ret no_such_function(); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, nil);
+    if (R.is_ok[outcome.BuildOutcome, outcome.Fail](r)) {
+        # the build reported success while a module in the tree does not compile
+        if (R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted" {
+    # the other half of #2539: widening the CHECK must not widen what is EMITTED. a
+    # valid module no artifact entry reaches is front-ended (it has a Q_SEMA entry)
+    # and never lowered or codegen'd (no Q_LOWER / Q_CODEGEN entry), so it costs no
+    # object code and does not enter the artifact.
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [3]str; names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "orphan.mach";
+    var texts: [3]str;
+    texts[0] = ut_cc3(?alloc, "use uniontest.a.fa;\n#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret fa(); }\n");
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun orphan_only() i32 { ret 7; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    if (!R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
+
+    val st_a:      session.StableModuleId = ut_stable_of(?s, "uniontest.a");
+    val st_orphan: session.StableModuleId = ut_stable_of(?s, "uniontest.orphan");
+    if (st_a == session.STABLE_MODULE_NIL || st_orphan == session.STABLE_MODULE_NIL) { bad = 1; }
+
+    # the reachable module is checked AND emitted
+    if (query.peek_revision(?s.queries, query.Q_SEMA,    st_a::u64) == 0) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_a::u64) == 0) { bad = 1; }
+
+    # the unreferenced one is checked but never reaches the back half
+    if (query.peek_revision(?s.queries, query.Q_SEMA,    st_orphan::u64) == 0) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_LOWER,   st_orphan::u64) != 0) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_orphan::u64) != 0) { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
 test "mach.lang.build.engine.execute_warm:unchanged_rebuild_reuses_and_stays_bounded" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }


### PR DESCRIPTION
Closes #2539

`mach build` compiled only the modules reachable from an artifact `entry`, so a module under `src` that nothing on that path imports was never checked. `mach test` roots its load at the whole source tree, so it did check it. The two commands disagreed about whether the project compiled, and a broken-but-unlinked module stayed green indefinitely.

This is issue design **(1)**: separate semantic checking from code generation, rather than widening what gets emitted.

## Shape

`Project.topo` becomes the front-end work set and `topo[0..emit_len)` the back-end one.

- resolve and sema walk `topo_len`, so every module under `src` is checked wherever it sits in the tree
- lower, codegen, emit and link walk `emit_len`, so reachability still governs code generation and linking

`emit_len` is a leading prefix rather than a separate list. The load phase walks the artifact closure first and records `emit_len` there, and the whole-source sweep that follows only ever appends the modules that closure missed. That keeps the existing `obj_paths[0..emit_len)` / `[emit_len..obj_len)` link-input arithmetic valid untouched. A test build re-records `emit_len` after the sweep, since a test dispatcher does link every module.

For a non-test build `emit_len` is exactly what `topo_len` was before this change, so nothing about codegen, linking, or the emitted object tree moves.

Two smaller consequences:

- `begin_build_impl` took one flag doing two jobs. `is_test` (which picks the `mach test` link surface) and `all_own_src` (which loads the whole tree) are now separate parameters, because a `mach build` wants the second without the first.
- the build summary line reports the emitted count rather than the loaded count, since it names the artifact those modules went into.

## Evidence

The issue's repro: a project with `src/broken.mach` containing a hard compile error that nothing imports.

Before, on the `origin/dev` compiler:

```
$ mach build .
build exit=0
$ mach test .
error: unresolved identifier `nope_this_does_not_exist`
 --> ./src/broken.mach:3:9
```

After:

```
$ mach build .
error: unresolved identifier `nope_this_does_not_exist`
 --> ./src/broken.mach:3:9
build exit=1
```

The other half, that reachability is still intact. Same module made valid, exporting `unreferenced_marker`:

```
$ mach build . && find out -name "*.o" | grep repro
out/linux-x86_64/debug/obj/repro/main.o
$ nm -a out/linux-x86_64/debug/bin/repro | grep -c unreferenced_marker
0
```

No `repro/broken.o` is emitted and the symbol is absent from the binary, while the module is still checked.

### New assertions demonstrated failing first

`broken_unreferenced_module_fails_build` and `unreferenced_module_checked_but_not_emitted`, with `begin_build` reverted to loading only the entry closure:

```
failures:
  mach.lang.build.engine.execute:broken_unreferenced_module_fails_build          (exit 1)
  mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted     (exit 1)
0 passed, 2 failed, 2 total
```

The second test also has to fail in the *other* direction, otherwise it would pass a change that simply emitted everything. With `emit_len` forced to `topo_len` unconditionally, so the tree is checked but reachability is lost:

```
failures:
  mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted     (exit 1)
1 passed, 1 failed, 2 total
```

It asserts through the query DB rather than the filesystem: the orphan module must have a `Q_SEMA` entry and must have no `Q_LOWER` or `Q_CODEGEN` entry.

## Build time

Cold `mach build .` on this repo, same source tree, `origin/dev` (9db96e47) vs patched, 5 runs each on a quiet machine:

| | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|
| before | 4848 | 4864 | 4829 | 4830 | 4822 |
| after | 4962 | 4938 | 4958 | 4968 | 4965 |

About **+130 ms on a 4.83 s cold build, 2.7 percent**. The phase breakdown shows where it lands:

```
before:  load 219 (479ms)  resolve 219 (257ms)  sema 219 (460ms)  lower 219 (2.7s)  codegen 219
after:   load 224 (514ms)  resolve 224 (274ms)  sema 224 (494ms)  lower 219 (2.7s)  codegen 219
```

Five more modules front-ended for +86 ms across load, resolve and sema; lower and codegen are untouched. That is the argument for design (1) holding: the cost is entirely in the cheap phase, and the expensive one does not move.

## On the unreachable-module warning

I did not include issue design (3). The five modules this repo front-ends but does not emit are:

```
mach.lang.be.codegen.vector_runtime
mach.lang.driver.tests
mach.lang.editor
mach.lang.me.lower.generic_layout_runtime
mach.lang.target.isa.tests
```

Every one is deliberately unlinked: test-only modules and the editor/LSP surface. A warning would fire five times on every build of this repo alone, which is exactly the noise the issue asked me to avoid. With errors now surfacing wherever they are, the warning no longer carries the signal it was proposed for. Happy to add it behind a flag if you want it.

## A riscv64 defect this uncovered

The `int linux-riscv64` leg went red on `regression/1852-rv64-self-host` with a bare `error: invalid argument`. It is a real bug, and it is one this change exists to expose: **the riscv64 build path had never opened a directory before**, because only the whole-source walk does that and `mach build` never ran it.

`error: invalid argument` is `errno` EINVAL rendered by `std.system.os.message`, not a compiler diagnostic.

Root cause is in mach-std, not here. `O_DIRECTORY` was arch-gated, and the riscv64 arm had been copied from the aarch64 arm:

| | O_DIRECTORY | O_DIRECT |
|---|---|---|
| asm-generic (x86_64, riscv64) | `0x10000` | `0x4000` |
| arm64 override | `0x4000` | `0x10000` |

aarch64 is the exception, not the rule: `arch/arm64/include/uapi/asm/fcntl.h` overrides asm-generic, while riscv has no `uapi/asm/fcntl.h` at all. So riscv64 was passing `O_DIRECT` where `O_DIRECTORY` belonged, and a directory rejects a direct-IO hint.

Isolated on riscv64 under qemu:

```
open(src, O_RDONLY)        -> 3     (a plain read-only open of a dir is fine)
open(src, 0x4000 literal)  -> -22   (EINVAL: that is O_DIRECT)
open(src, 0x10000 literal) -> 4     (that is O_DIRECTORY)
```

Fixed in **briar-systems/mach-std#437**. With that patch in the compiler's own std, the whole riscv64 leg is green: **94 cases pass, including 1852**, with the case manifests unmodified.

**Sequencing:** this PR needs no change. The fix only has to reach the compiler's own `dep.mach-std`, so once mach-std#437 ships in a release this goes green on its own. I would hold the merge until then rather than land a known-red leg.

I did not work around it here. Making the compiler avoid `O_DIRECTORY` would have hidden a real portability bug in the standard library.

## Status

- `mach test .`: 1227 passed, 0 failed
- linux integration suite: all cases passed
- linux-riscv64 integration suite: all 94 cases pass with mach-std#437 in the compiler's std; red without it
- self-host fixpoint: holds, stage2 and stage3 byte-identical
