### PR TITLE
feat(spirv): OpEntryPoint and execution models via #[stage(...)]

### DIFF
--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -38,6 +38,8 @@ A decorator is written as an attribute:
 #[scalar]            # opt out of auto-vectorization (no arguments)
 #[naked]             # no prologue or epilogue; body as written (no arguments)
 #[embed("path")]     # compile-time file embedding (val only)
+#[stage("name")]     # GPU pipeline stage; makes the function an entry point
+#[workgroup(x,y,z)]  # compute workgroup dimensions (with #[stage("compute")])
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -346,6 +348,66 @@ val SECTOR: [512]u8;      # length pinned; a size change fails the build
   [manifest.md](../manifest.md#stepname--build-steps) for the equivalent
   guarantee on `[step]` `in` entries.
 
+### `stage(str)` — GPU pipeline stage
+
+Marks a function as the entry point of a graphics or compute pipeline stage. The
+argument names the stage and the set is closed:
+
+| Value        | Stage                     |
+|--------------|---------------------------|
+| `"vertex"`   | vertex shader             |
+| `"fragment"` | fragment (pixel) shader   |
+| `"compute"`  | compute shader            |
+
+An unrecognized value is a compile error, not a module that quietly forms no
+stage.
+
+```mach
+#[stage("vertex")]
+fun vertex_main() { }
+
+#[stage("fragment")]
+fun fragment_main() { }
+```
+
+A staged function **takes no parameters and returns nothing**. A pipeline stage
+does not have a caller: its inputs arrive through input interface variables and
+its results leave through output ones, so there is no argument list or return
+value to carry them. A staged function with either is rejected.
+
+The decorator is accepted on every target, because which target a module is built
+for is not a property of its source. Only a target that has pipeline stages acts
+on it: on `spirv` a staged function becomes an `OpEntryPoint` with the matching
+execution model, and on a machine target the stage is ignored and the function is
+compiled normally.
+
+A module that declares any stage is a **shader module**, and that changes the whole
+artifact rather than just the one function. A shader module carries entry points
+and no external linkage at all; a module with no stage is a **library module**,
+which publishes each function as a linkage export so a consumer can find it. The
+two are exclusive — a Vulkan consumer refuses a module carrying linkage — so
+adding the first `#[stage(...)]` to a module stops it exporting its functions.
+
+The entry point's name, as a pipeline-creation call looks it up, is the function's
+**bare source name** (`vertex_main` above), not a mangled linker symbol. A shader
+module has no linker symbols to mangle.
+
+### `workgroup(x, y, z)` — compute workgroup dimensions
+
+Sizes the workgroup of a `#[stage("compute")]` function. The three arguments are
+comptime integers giving the x, y and z dimensions.
+
+```mach
+#[stage("compute")] #[workgroup(64, 1, 1)]
+fun compute_main() { }
+```
+
+It requires a stage on the same function — without one it would silently mean
+nothing — and it applies only to the compute stage. When it is omitted, a compute
+stage takes the single-invocation default `(1, 1, 1)`; the dimensions are always
+declared in the emitted module, since a compute stage that does not state its
+workgroup size is not one a consumer can dispatch.
+
 ## Applicability
 
 | Directive   | `fun` | `ext fun` | `val` / `var` | `rec` / `uni` |
@@ -360,6 +422,8 @@ val SECTOR: [512]u8;      # length pinned; a size change fails the build
 | `scalar`    |  yes  |    no     |      no       |      no       |
 | `naked`     |  yes  |    no     |      no       |      no       |
 | `embed`     |  no   |    no     |      yes      |      no       |
+| `stage`     |  yes  |    no     |      no       |      no       |
+| `workgroup` |  yes  |    no     |      no       |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).
@@ -375,4 +439,5 @@ The set is closed. New directives require a compiler change.
 - [asm.md](asm.md) — inline `asm`, the only body a `naked` function may have
 - [val-var.md](val-var.md) — `val` / `var` bindings, and the `embed` exemption to `val`'s initializer requirement
 - [grammar.md](grammar.md#types) — the `[_]` inferred array length `embed` introduces
+- [types.md](types.md) — the SIMD vector types a shader stage computes over
 - [../manifest.md](../manifest.md) — the `vectorize` profile key `scalar` opts out of, and content-fingerprinted build inputs (`embed`, `[step]` `in`)

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -61,7 +61,10 @@
 #                 requires llvm-dwarfdump, llvm-symbolizer, and readelf; it runs only
 #                 on the ELF debug-info legs, which install them.
 #   spirv-val   — validate every `.spv` module a finished-module target delivered
-#                 with the Khronos validator (spirv-tools). the target links
+#                 with the Khronos validator (spirv-tools), in its universal
+#                 environment. `spirv-val-vulkan` is the same check under the
+#                 stricter Vulkan environment, for a module carrying entry points.
+#                 the target links
 #                 nothing, so there is no binary to run and the module tree is the
 #                 artifact; the external validator is what makes this a validity
 #                 check rather than a round-trip through mach's own reader.
@@ -1448,19 +1451,52 @@ produce_built() {
 # the observable is the module count plus the verdict, so a build that silently
 # stopped emitting fails on the count rather than passing vacuously.
 produce_spirv_val() {
-    out_dir=$(dirname "$3")
+    spirv_val_env "$3" ''
+}
+
+# produce_spirv_val_vulkan <runmode> <target> <binary>
+# as produce_spirv_val, but validates against the VULKAN environment rather than
+# the universal one. the two are different contracts and a module cannot satisfy
+# both: a library module declares the Linkage capability so a consumer can find its
+# exported functions, and Vulkan forbids that capability outright; a shader module
+# carries entry points and no linkage at all. so a case picks the environment its
+# module is actually meant for, and the stricter Vulkan rules — the fragment
+# stage's mandatory origin, the compute stage's mandatory workgroup size — are
+# genuinely checked rather than skipped by validating everything universally.
+produce_spirv_val_vulkan() {
+    spirv_val_env "$3" vulkan1.3
+}
+
+# spirv_val_env <binary> <target-env>
+# shared body: glob the case's output root (a finished-module target has no linked
+# binary, so the delivery is the module tree) and run spirv-val over each `.spv`.
+# an EXTERNAL validator is the point — mach reading back its own bytes proves
+# self-consistency, not validity. the observable is the module count plus the
+# verdict, so a build that silently stopped emitting fails on the count rather than
+# passing vacuously.
+spirv_val_env() {
+    out_dir=$(dirname "$1")
+    env_arg=$2
     if ! command -v spirv-val >/dev/null 2>&1; then
         echo "int: spirv-val: the validator is not installed (spirv-tools)" >&2
         return 2
     fi
     n=0
     for m in $(find "$out_dir" -name '*.spv' | sort); do
-        spirv-val "$m" || return 1
+        if [ -n "$env_arg" ]; then
+            spirv-val --target-env "$env_arg" "$m" || return 1
+        else
+            spirv-val "$m" || return 1
+        fi
         n=$((n + 1))
     done
     if [ "$n" -eq 0 ]; then
         echo "int: spirv-val: the build delivered no .spv module" >&2
         return 2
+    fi
+    if [ -n "$env_arg" ]; then
+        printf 'modules=%d validator=clean env=%s\n' "$n" "$env_arg"
+        return 0
     fi
     printf 'modules=%d validator=clean\n' "$n"
 }
@@ -1962,6 +1998,7 @@ produce() {
         built)       produce_built "$@" ;;
         debuginfo)   produce_debuginfo "$@" ;;
         spirv-val)   produce_spirv_val "$@" ;;
+        spirv-val-vulkan) produce_spirv_val_vulkan "$@" ;;
         vector-emit) produce_vector_emit "$@" ;;
         vector-lanes) produce_vector_lanes "$@" ;;
         frame-elision) produce_frame_elision "$@" ;;

--- a/int/surface/spirv-entrypoint/case.conf
+++ b/int/surface/spirv-entrypoint/case.conf
@@ -1,0 +1,9 @@
+# pipeline entry points through the spirv back half, validated host-side against
+# the VULKAN environment rather than the universal one. that is the point of this
+# case: a module carrying entry points must satisfy the rules an actual Vulkan
+# consumer applies - no Linkage capability, a fragment stage's framebuffer origin
+# declared, a compute stage's workgroup size declared - and the universal
+# environment checks none of them.
+run: spirv-val-vulkan
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-entrypoint/expect.spirv.txt
+++ b/int/surface/spirv-entrypoint/expect.spirv.txt
@@ -1,0 +1,1 @@
+modules=1 validator=clean env=vulkan1.3

--- a/int/surface/spirv-entrypoint/mach.toml
+++ b/int/surface/spirv-entrypoint/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-entrypoint/src/main.mach
+++ b/int/surface/spirv-entrypoint/src/main.mach
@@ -1,0 +1,70 @@
+# SPIR-V entry-point fixture: a module that forms real pipeline stages
+#
+# The sibling spirv-module, spirv-float and spirv-vector cases build LIBRARY
+# modules: they declare the Linkage capability and publish each function as an
+# export, which is right for compiled mach code a consumer links against, and which
+# a Vulkan consumer rejects outright. This case builds the other kind. A function
+# carrying `#[stage(...)]` becomes an `OpEntryPoint`, the module drops Linkage
+# entirely, and the observable is `spirv-val --target-env vulkan1.3` - the rules an
+# actual pipeline applies.
+#
+# What the Vulkan environment checks here that the universal one does not: that the
+# module declares no Linkage capability, that a fragment stage fixes its
+# framebuffer origin, and that a compute stage declares a workgroup size. The back
+# end emits the latter two with the stage rather than leaving them to the author,
+# because a stage without them is not a stage a consumer can use.
+#
+# Entry points carry an EMPTY interface list here, which is valid: a stage that
+# reads and writes no interface variables has none to name. The interface-variable
+# work fills that list in.
+
+#[stage("vertex")]
+fun vertex_main() { }
+
+#[stage("fragment")]
+fun fragment_main() { }
+
+#[stage("compute")] #[workgroup(64, 1, 1)]
+fun compute_main() { }
+
+# a compute stage with no `#[workgroup(...)]` takes the single-invocation default,
+# so it still carries the LocalSize mode Vulkan requires.
+#[stage("compute")]
+fun compute_default() { }
+
+# a stage with a real body: the structured control flow and the scalar and float
+# work the other cases cover, reached through an entry point rather than an export.
+# an entry function returns nothing, so the work lands in a called function.
+fun mix(a: f32, b: f32) f32 {
+    if (a < b) { ret b - a; }
+    ret a - b;
+}
+
+fun ramp(n: i32) f32 {
+    var acc: f32 = 0.0;
+    var i: i32 = 0;
+    for (i < n) {
+        acc = acc + 0.25;
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# a called function inside a shader module is an ordinary OpFunction: it is NOT
+# published under a linkage export, since the module declares no Linkage.
+#[stage("vertex")]
+fun vertex_work() {
+    val t: f32 = mix(ramp(4), 2.0);
+    sink(t);
+}
+
+# a call the entry point's work reaches, so the computation is not dead. Until
+# output interface variables exist there is nowhere for a stage's result to go, so
+# this stands in for that consumer.
+fun sink(v: f32) f32 {
+    ret v * 2.0;
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -1416,6 +1416,29 @@ fun require_string_arg(sc: *context.SemaContext, dec: *decl.Decorator, count_msg
     }
 }
 
+# report unless a `#[stage(...)]` argument names one of the accepted stages
+#
+# The value set is closed on purpose. A stage that does not resolve to an execution
+# model would otherwise build a module that forms no pipeline stage at all, and the
+# failure would surface as a consumer rejecting the artifact rather than as a
+# compile error on the line that caused it.
+# ---
+# sc:  the context
+# dec: the `stage` decorator, already known to carry one string argument
+fun validate_stage_value(sc: *context.SemaContext, dec: *decl.Decorator) {
+    if (dec.args_len != 1) { ret; }
+    val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
+    if (O.is_none[*expr.Expr](opt_arg)) { ret; }
+    val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+    if (arg.kind != expr.EXPR_KIND_LIT_STR || arg.span.len < 2::usize) { ret; }
+    val off: usize = arg.span.offset + 1::usize;
+    val len: usize = arg.span.len - 2::usize;
+    if (str_region_equals(sc.source, off, len, "vertex"))   { ret; }
+    if (str_region_equals(sc.source, off, len, "fragment")) { ret; }
+    if (str_region_equals(sc.source, off, len, "compute"))  { ret; }
+    context.report(sc, arg.span, "unknown pipeline stage; `stage` accepts \"vertex\", \"fragment\", or \"compute\"");
+}
+
 # whether `kind` is a valid `align` target: a global binding or a rec/uni nominal
 #
 # A `def` alias is excluded - it is transparent (no layout of its own, emits no
@@ -1548,6 +1571,48 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         }
         ret;
     }
+    # `#[stage("...")]` names the pipeline stage a function is the entry point of.
+    # The value set is closed and checked here, so a typo is a compile error rather
+    # than a module that builds and forms no stage. Only a target that HAS pipeline
+    # stages acts on it; the decorator is legal everywhere, since which target a
+    # module is built for is not a property of the source.
+    if (decorator_named(sc, dec, "stage")) {
+        require_string_arg(sc, dec,
+            "`stage` decorator takes one string argument",
+            "`stage` decorator argument must be a string literal");
+        if (d.kind != decl.DECL_KIND_FUN) {
+            context.report(sc, dec.name, "`stage` decorator applies only to functions");
+            ret;
+        }
+        validate_stage_value(sc, dec);
+        ret;
+    }
+    # `#[workgroup(x, y, z)]` sizes a compute stage's workgroup. Meaningless without
+    # a compute stage, so requiring one here keeps it from reading as a silent no-op.
+    if (decorator_named(sc, dec, "workgroup")) {
+        if (dec.args_len != 3) {
+            context.report(sc, dec.name, "`workgroup` decorator takes three arguments: the x, y, and z workgroup dimensions");
+        }
+        or {
+            var wi: u32 = 0;
+            for (wi < 3) {
+                val aeid: id.ExprId = sc.a.expr_ids[dec.args_start + wi];
+                if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, aeid))) {
+                    context.report(sc, dec.name, "`workgroup` decorator dimensions must be integer comptime expressions");
+                    wi = 3; cnt;
+                }
+                wi = wi + 1;
+            }
+        }
+        if (d.kind != decl.DECL_KIND_FUN) {
+            context.report(sc, dec.name, "`workgroup` decorator applies only to functions");
+            ret;
+        }
+        if (!has_decorator(sc, d, "stage")) {
+            context.report(sc, dec.name, "`workgroup` decorator requires a `#[stage(\"compute\")]` on the same function; it sizes a compute stage's workgroup and means nothing without one");
+        }
+        ret;
+    }
     if (decorator_named(sc, dec, "scalar")) {
         if (dec.args_len != 0) {
             context.report(sc, dec.name, "`scalar` decorator takes no arguments");
@@ -1568,7 +1633,7 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
     # agreement - is checked by the pre-type-resolution pass that has to read the
     # file anyway (#2507). Re-checking any of it here would report it twice.
     if (decorator_named(sc, dec, "embed")) { ret; }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed");
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -78,6 +78,16 @@ pub val FN_FLAG_NOINLINE: u32 = 0x100;
 # the link register, the stack alignment and the return
 pub val FN_FLAG_NAKED: u32 = 0x200;
 
+# pipeline stage of a function, from a `#[stage("...")]` decorator. STAGE_NONE is
+# every ordinary function; the rest name the shader stage a SPIR-V entry point is
+# formed for. this is the axis new execution models are added along - a tessellation
+# or ray-tracing stage is one value here, one row in the decorator's accepted table,
+# and one row in the back end's model mapping, with nothing else to change
+pub val STAGE_NONE:     u8 = 0;
+pub val STAGE_VERTEX:   u8 = 1;
+pub val STAGE_FRAGMENT: u8 = 2;
+pub val STAGE_COMPUTE:  u8 = 3;
+
 # one `{name}` local binding referenced by an inline-asm body: the interned
 # source name and the alloca instruction that owns the local's stack slot. the
 # back end resolves the alloca to a frame offset and substitutes `[rbp+off]`
@@ -256,6 +266,16 @@ pub rec Block {
 #              reported as `file:line` by `mach test`; 0 for every non-test function
 # section:     object section name from a `#[section("...")]` decorator, or STR_NIL
 #              for the default `.text`; the back end places the encoded bytes there
+# stage:       pipeline stage from a `#[stage("...")]` decorator (one of STAGE_*),
+#              STAGE_NONE for an ordinary function. a target that forms pipeline
+#              stages (spirv) turns a staged function into an entry point; every
+#              other target ignores it, since the decorator names a GPU concept no
+#              machine target has
+# wg_x:        workgroup x dimension from a `#[workgroup(x, y, z)]` decorator, read
+#              only for STAGE_COMPUTE; 1 when the decorator is absent, which with
+#              its siblings is the single-invocation workgroup
+# wg_y:        workgroup y dimension; 1 when the decorator is absent
+# wg_z:        workgroup z dimension; 1 when the decorator is absent
 # disp:        bare source name of the function. inert debug metadata like `loc`
 #              (#1689): the machine-code path never reads it; only the `-g` DWARF
 #              producer does, for a readable DW_AT_name instead of the mangled linkage
@@ -298,6 +318,10 @@ pub rec Function {
     label:       intern.StrId;
     line:        u32;
     section:     intern.StrId;
+    stage:       u8;
+    wg_x:        u32;
+    wg_y:        u32;
+    wg_z:        u32;
     disp:        intern.StrId;
     ret_sem:     semtype.TypeId;
 
@@ -691,6 +715,10 @@ pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId
     f.label       = intern.STR_NIL;
     f.line        = 0;
     f.section     = intern.STR_NIL;
+    f.stage       = STAGE_NONE;
+    f.wg_x        = 1;
+    f.wg_y        = 1;
+    f.wg_z        = 1;
     f.disp        = intern.STR_NIL;
     f.ret_sem     = semtype.TYPE_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](alloc, map.hash_u32, map.eq_u32);

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -150,6 +150,11 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
     val fn_index: u32 = R.unwrap_ok[u32, str](res_idx);
 
     ctx.m.functions[fn_index].section = decl_section_of(ctx, d);
+    # the pipeline stage a `#[stage("...")]` names, for a target that forms stages.
+    ctx.m.functions[fn_index].stage = decl_stage_of(ctx, d);
+    ctx.m.functions[fn_index].wg_x  = decl_workgroup_dim(ctx, d, 0);
+    ctx.m.functions[fn_index].wg_y  = decl_workgroup_dim(ctx, d, 1);
+    ctx.m.functions[fn_index].wg_z  = decl_workgroup_dim(ctx, d, 2);
 
     # a declared `ext fun` is a genuine foreign C import (a strict subset of the
     # FN_FLAG_EXTERN this function also carries): its calls marshal their arguments to
@@ -1280,6 +1285,51 @@ fun decl_has_decorator(ctx: *context.LowerContext, d: *decl.Decl, name: str) boo
 # ctx: the context
 # d:   the Decl to inspect
 # ret: the interned section name, or STR_NIL
+# the pipeline stage a `#[stage("...")]` decorator names, or STAGE_NONE
+#
+# Sema has already closed the value set, so an unrecognized spelling cannot reach
+# here; STAGE_NONE covers the decorator being absent.
+# ---
+# ctx: the context
+# d:   the function's Decl
+# ret: one of ir.STAGE_*
+fun decl_stage_of(ctx: *context.LowerContext, d: *decl.Decl) u8 {
+    val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "stage", 0);
+    if (O.is_none[id.ExprId](opt_arg)) { ret ir.STAGE_NONE; }
+    val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.a, O.unwrap[id.ExprId](opt_arg));
+    if (O.is_none[*aexpr.Expr](opt_val)) { ret ir.STAGE_NONE; }
+    val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+    if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret ir.STAGE_NONE; }
+    val src: str = context.module_source(ctx);
+    val off: usize = ve.span.offset + 1::usize;
+    val len: usize = ve.span.len - 2::usize;
+    if (str_region_equals(src, off, len, "vertex"))   { ret ir.STAGE_VERTEX; }
+    if (str_region_equals(src, off, len, "fragment")) { ret ir.STAGE_FRAGMENT; }
+    if (str_region_equals(src, off, len, "compute"))  { ret ir.STAGE_COMPUTE; }
+    ret ir.STAGE_NONE;
+}
+
+# one workgroup dimension from a `#[workgroup(x, y, z)]` decorator, or 1 when the
+# decorator is absent or the dimension does not fold
+# ---
+# ctx: the context
+# d:   the function's Decl
+# ord: which dimension (0 = x, 1 = y, 2 = z)
+# ret: the dimension, defaulting to 1
+fun decl_workgroup_dim(ctx: *context.LowerContext, d: *decl.Decl, ord: u32) u32 {
+    val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "workgroup", ord);
+    if (O.is_none[id.ExprId](opt_arg)) { ret 1; }
+    val res_u64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_u64)) { ret 1; }
+    val u64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_u64);
+    val res_fold: R.Result[value.Value, str] = fold_global_init(ctx, O.unwrap[id.ExprId](opt_arg), u64t, intern.STR_NIL);
+    if (R.is_err[value.Value, str](res_fold)) { ret 1; }
+    val v: value.Value = R.unwrap_ok[value.Value, str](res_fold);
+    if (v.kind != value.VAL_CONST_INT) { ret 1; }
+    if (v.data.int_lit == 0 || v.data.int_lit > 0xFFFFFFFF) { ret 1; }
+    ret v.data.int_lit::u32;
+}
+
 fun decl_section_of(ctx: *context.LowerContext, d: *decl.Decl) intern.StrId {
     val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "section", 0);
     if (O.is_none[id.ExprId](opt_arg)) { ret intern.STR_NIL; }

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -43,6 +43,8 @@ pub val SPV_GENERATOR: u32 = 0;
 # count (`inst_word`)
 pub val OP_NAME:                u32 = 5;
 pub val OP_MEMORY_MODEL:        u32 = 14;
+pub val OP_ENTRY_POINT:         u32 = 15;
+pub val OP_EXECUTION_MODE:      u32 = 16;
 pub val OP_CAPABILITY:          u32 = 17;
 pub val OP_TYPE_VOID:           u32 = 19;
 pub val OP_TYPE_BOOL:           u32 = 20;
@@ -138,6 +140,21 @@ pub val NEED_INT64:   u32 = 0x04;
 pub val NEED_FLOAT16: u32 = 0x08;
 pub val NEED_FLOAT64: u32 = 0x10;
 
+# execution model operand of OpEntryPoint: which pipeline stage the entry function
+# is. these are the three mach's `#[stage(...)]` decorator spells; SPIR-V defines
+# more (tessellation, geometry, and the ray-tracing models), and each is a value
+# here plus a row in the decorator's table when it is wanted
+pub val EXEC_MODEL_VERTEX:    u32 = 0;
+pub val EXEC_MODEL_FRAGMENT:  u32 = 4;
+pub val EXEC_MODEL_GLCOMPUTE: u32 = 5;
+
+# execution mode operand of OpExecutionMode: OriginUpperLeft fixes a fragment
+# stage's framebuffer origin, and Vulkan requires exactly this one (OriginLowerLeft
+# is the GL convention and is not permitted); LocalSize declares a compute stage's
+# workgroup dimensions, which every Vulkan compute entry point must carry
+pub val EXEC_MODE_ORIGIN_UPPER_LEFT: u32 = 7;
+pub val EXEC_MODE_LOCAL_SIZE:        u32 = 17;
+
 # addressing model operand of OpMemoryModel: Logical (no physical pointers - the
 # only model a Shader/Linkage module without the Addresses capability may use)
 pub val ADDRESSING_LOGICAL: u32 = 0;
@@ -181,6 +198,8 @@ pub val SELECTION_CONTROL_NONE: u32 = 0;
 # next_id:      the next id to hand out; equals the id bound at serialize time
 # caps:         OpCapability instructions
 # memory_model: the single OpMemoryModel instruction
+# entry_points: OpEntryPoint instructions
+# exec_modes:   OpExecutionMode instructions
 # decorations:  OpDecorate / OpName instructions
 # types_consts: OpType* / OpConstant* / global OpTypePointer instructions
 # functions:    OpFunction ... OpFunctionEnd bodies, in emission order
@@ -191,6 +210,8 @@ pub rec Builder {
     next_id:      u32;
     caps:         Vec;
     memory_model: Vec;
+    entry_points: Vec;
+    exec_modes:   Vec;
     decorations:  Vec;
     types_consts: Vec;
     functions:    Vec;
@@ -277,6 +298,8 @@ pub fun builder_init(alloc: *A.Allocator) Builder {
     b.next_id      = 1;
     b.caps         = vec_init();
     b.memory_model = vec_init();
+    b.entry_points = vec_init();
+    b.exec_modes   = vec_init();
     b.decorations  = vec_init();
     b.types_consts = vec_init();
     b.functions    = vec_init();
@@ -291,6 +314,8 @@ pub fun builder_init(alloc: *A.Allocator) Builder {
 pub fun builder_dnit(b: *Builder) {
     vec_dnit(b, ?b.caps);
     vec_dnit(b, ?b.memory_model);
+    vec_dnit(b, ?b.entry_points);
+    vec_dnit(b, ?b.exec_modes);
     vec_dnit(b, ?b.decorations);
     vec_dnit(b, ?b.types_consts);
     vec_dnit(b, ?b.functions);
@@ -374,7 +399,8 @@ pub fun pack_string(s: str, out: *u32) u32 {
 #
 # The word bound is the current `next_id` (one past the highest id handed out).
 # Sections are emitted in SPIR-V's required order: capabilities, memory model,
-# decorations, types / constants, then function bodies. Every word is serialized
+# entry points, execution modes, decorations, types / constants, then function
+# bodies. Every word is serialized
 # little-endian. The returned buffer is allocated from the builder's allocator and
 # owned by the caller.
 # ---
@@ -384,7 +410,8 @@ pub fun pack_string(s: str, out: *u32) u32 {
 pub fun serialize(b: *Builder, out_len: *u32) R.Result[*u8, str] {
     if (b.err) { ret R.err[*u8, str]("spirv: module builder hit an allocation error"); }
 
-    val total_words: u32 = 5 + b.caps.len + b.memory_model.len + b.decorations.len
+    val total_words: u32 = 5 + b.caps.len + b.memory_model.len + b.entry_points.len
+                         + b.exec_modes.len + b.decorations.len
                          + b.types_consts.len + b.functions.len;
     val total_bytes: u32 = total_words * 4;
 
@@ -401,6 +428,8 @@ pub fun serialize(b: *Builder, out_len: *u32) R.Result[*u8, str] {
 
     pos = put_section(buf, pos, ?b.caps);
     pos = put_section(buf, pos, ?b.memory_model);
+    pos = put_section(buf, pos, ?b.entry_points);
+    pos = put_section(buf, pos, ?b.exec_modes);
     pos = put_section(buf, pos, ?b.decorations);
     pos = put_section(buf, pos, ?b.types_consts);
     pos = put_section(buf, pos, ?b.functions);

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -78,6 +78,9 @@ use mach.lang.target.isa.spirv.types;
 # fn_ids:   SPIR-V id per IR function index, allocated before any body is emitted
 #           so a call can name a callee defined later in the module (0 for a
 #           function with no body)
+# has_entry: whether any function in the module declares a pipeline stage, which
+#           decides whether this is a shader module (entry points, no Linkage) or a
+#           library module (Linkage exports, no entry point)
 rec Emit {
     alloc:    *A.Allocator;
     interner: *intern.Interner;
@@ -86,6 +89,7 @@ rec Emit {
     b:        *spirv.Builder;
     tt:       *types.TypeTable;
     fn_ids:   *u32;
+    has_entry: bool;
 }
 
 # the per-function value maps, sized to the function's vreg count
@@ -149,6 +153,17 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     var e: Emit;
     e.alloc = mirmod.alloc; e.interner = mirmod.interner;
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
+
+    # a module is a shader module or a library module, never both, and which one is
+    # settled before any function is emitted: the answer decides both the capability
+    # set and whether each function is published under a linkage export.
+    e.has_entry = false;
+    var si: u32 = 0;
+    for (si < irmod.function_len) {
+        if (irmod.functions[si].stage != ir.STAGE_NONE
+            && (irmod.functions[si].flags & ir.FN_FLAG_EXTERN) == 0) { e.has_entry = true; }
+        si = si + 1;
+    }
 
     # every defined function gets its id before any body is emitted, so a call can
     # name a callee that appears later in the module (or itself).
@@ -219,7 +234,13 @@ fun emit_dnit(e: *Emit, n: u32) {
 # e: the emission state
 fun emit_preamble(e: *Emit) {
     emit_cap(e, spirv.CAP_SHADER);
-    emit_cap(e, spirv.CAP_LINKAGE);
+    # Linkage is what lets a module with no entry point publish its functions to a
+    # consumer, and it is the RIGHT thing for a compiled mach library. It is also
+    # forbidden in a module meant for a Vulkan pipeline: a shader module is complete
+    # in itself and declares no external linkage, and spirv-val rejects the
+    # capability outright under a Vulkan environment. So the two are exclusive, and
+    # the presence of an entry point is what decides which module this is.
+    if (!e.has_entry) { emit_cap(e, spirv.CAP_LINKAGE); }
     val need: u32 = e.b.caps_needed;
     if ((need & spirv.NEED_INT8) != 0)    { emit_cap(e, spirv.CAP_INT8); }
     if ((need & spirv.NEED_INT16) != 0)   { emit_cap(e, spirv.CAP_INT16); }
@@ -282,11 +303,19 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
 
     val fn_id: u32 = e.fn_ids[fix];
 
-    # export decoration: OpDecorate <fn> LinkageAttributes "<name>" Export.
     val name_opt: O.Option[str] = intern.lookup(e.interner, mf.name);
     if (O.is_none[str](name_opt)) { ret R.err[bool, str]("spirv.emit: function name not interned"); }
     val fn_name: str = O.unwrap[str](name_opt);
-    emit_linkage_export(e, fn_id, fn_name);
+
+    # a staged function becomes an entry point; in a library module every function is
+    # published under a linkage export instead. The two are exclusive: SPIR-V forbids
+    # decorating an entry point with LinkageAttributes, and a Vulkan module may not
+    # declare the Linkage capability at all.
+    if (irfn.stage != ir.STAGE_NONE) {
+        val er: R.Result[bool, str] = emit_entry_point(e, irfn, fn_id, entry_name(e, irfn, fn_name), returns_void);
+        if (R.is_err[bool, str](er)) { ret er; }
+    }
+    or (!e.has_entry) { emit_linkage_export(e, fn_id, fn_name); }
 
     # a vector materialized through memory is refused up front, under its own name.
     # Reaching it instruction by instruction would report the `alloca` that opens the
@@ -603,6 +632,88 @@ fun read_condition(e: *Emit, vm: *VMaps, preg_val: *Regs, op: *mir.MirOperand) u
     ops[0] = types.type_bool(e.tt); ops[1] = result; ops[2] = raw; ops[3] = zero;
     spirv.inst(e.b, ?e.b.functions, opcode, ?ops[0], 4);
     ret result;
+}
+
+# the name a consumer looks an entry point up by: the function's BARE source name
+#
+# Not the mangled linkage name the rest of the back end uses. An entry point name is
+# a lookup key passed to a pipeline-creation call, not a linker symbol - and a
+# shader module declares no Linkage capability at all, so the mangled name has
+# nothing to refer to inside one. Falls back to the linkage name only for a
+# synthesized function carrying no source spelling, which cannot currently declare a
+# stage anyway.
+# ---
+# e:       the emission state
+# irfn:    the IR function
+# linkage: the mangled linkage name, the fallback
+# ret:     the entry point name
+fun entry_name(e: *Emit, irfn: *ir.Function, linkage: str) str {
+    if (irfn.disp == intern.STR_NIL) { ret linkage; }
+    val opt: O.Option[str] = intern.lookup(e.interner, irfn.disp);
+    if (O.is_none[str](opt)) { ret linkage; }
+    ret O.unwrap[str](opt);
+}
+
+# emit the OpEntryPoint, and the execution modes the stage requires
+#
+# SPIR-V constrains an entry function's signature hard: it takes no parameters and
+# returns void, because a pipeline stage's inputs and outputs travel through
+# interface VARIABLES rather than through a call. That is checked here rather than
+# left to the validator, so a mach signature that cannot be a stage is reported
+# against the function that declared the stage.
+#
+# The interface operand list names every Input and Output variable the entry point
+# statically uses. It is empty until interface variables exist, which is valid: an
+# entry point that reads and writes nothing has nothing to list.
+#
+# Two execution modes are not optional under Vulkan and are emitted with the stage
+# rather than left to the author: a fragment stage must fix its framebuffer origin,
+# and a compute stage must declare its workgroup size.
+# ---
+# e:            the emission state
+# irfn:         the IR function (its stage and workgroup dimensions)
+# fn_id:        the function's SPIR-V id
+# name:         the entry point's name, as a consumer will look it up
+# returns_void: whether the function returns void
+# ret:          true on success, or a precise error string
+fun emit_entry_point(e: *Emit, irfn: *ir.Function, fn_id: u32, name: str,
+                     returns_void: bool) R.Result[bool, str] {
+    if (!returns_void) {
+        ret unsupported(e, "a function declaring a `#[stage(...)]` must return nothing: a pipeline stage's results leave through its output interface variables, not through a return value");
+    }
+    if (irfn.param_count != 0) {
+        ret unsupported(e, "a function declaring a `#[stage(...)]` must take no parameters: a pipeline stage's inputs arrive through its input interface variables, not as arguments");
+    }
+
+    var model: u32 = spirv.EXEC_MODEL_VERTEX;
+    if (irfn.stage == ir.STAGE_FRAGMENT) { model = spirv.EXEC_MODEL_FRAGMENT; }
+    or (irfn.stage == ir.STAGE_COMPUTE)  { model = spirv.EXEC_MODEL_GLCOMPUTE; }
+
+    # OpEntryPoint <model> <fn> "<name>" <interface...>; the interface list is empty
+    # until interface variables land.
+    val sw: u32 = spirv.string_words(name);
+    val total: u32 = 2 + sw;
+    val ra: R.Result[*u32, str] = A.allocate[u32](e.alloc, total::usize);
+    if (R.is_err[*u32, str](ra)) { ret R.err[bool, str](R.unwrap_err[*u32, str](ra)); }
+    val ops: *u32 = R.unwrap_ok[*u32, str](ra);
+    ops[0] = model;
+    ops[1] = fn_id;
+    spirv.pack_string(name, ?ops[2]);
+    spirv.inst(e.b, ?e.b.entry_points, spirv.OP_ENTRY_POINT, ops, total);
+    A.deallocate[u32](e.alloc, ops, total::usize);
+
+    if (irfn.stage == ir.STAGE_FRAGMENT) {
+        var fm: [2]u32;
+        fm[0] = fn_id; fm[1] = spirv.EXEC_MODE_ORIGIN_UPPER_LEFT;
+        spirv.inst(e.b, ?e.b.exec_modes, spirv.OP_EXECUTION_MODE, ?fm[0], 2);
+    }
+    if (irfn.stage == ir.STAGE_COMPUTE) {
+        var cm: [5]u32;
+        cm[0] = fn_id; cm[1] = spirv.EXEC_MODE_LOCAL_SIZE;
+        cm[2] = irfn.wg_x; cm[3] = irfn.wg_y; cm[4] = irfn.wg_z;
+        spirv.inst(e.b, ?e.b.exec_modes, spirv.OP_EXECUTION_MODE, ?cm[0], 5);
+    }
+    ret R.ok[bool, str](true);
 }
 
 # emit the LinkageAttributes Export decoration for a function


### PR DESCRIPTION
Closes #2570

Stacked on #2638 → #2631. Merge those first, in that order.

## The declaration surface

The issue left the channel open between the attribute and decorator channels and asked for one to be picked and documented. **The decorator channel**, since that is where codegen directives live now:

```mach
#[stage("vertex")]
fun vertex_main() { }

#[stage("compute")] #[workgroup(64, 1, 1)]
fun compute_main() { }
```

One directive with a closed, sema-checked value set (`"vertex"` / `"fragment"` / `"compute"`) rather than a decorator per stage. Execution models are the obvious axis this grows along, and adding tessellation, geometry, or a ray-tracing model is now **one constant, one row in the accepted table, one row in the model mapping** — no new decorator, no new plumbing. An unrecognized value is a compile error rather than a module that quietly forms no stage.

Documented in `doc/language/decorators.md`: both directives get a section, the grammar block, and the applicability table.

## A staged function's signature

It takes **no parameters and returns nothing**, checked in the backend and reported against the function that declared the stage. A pipeline stage has no caller — its inputs arrive through input interface variables and its results leave through output ones, so there is no argument list or return value to carry them. Leaving this to `spirv-val` would report it as a type mismatch on a generated id.

## The consequence that reaches furthest

**A module is now a shader module or a library module, never both.**

A library module (no stage anywhere) declares the `Linkage` capability and publishes each function as a `LinkageAttributes` export. That is right for compiled mach code a consumer links against, and it is what the backend has always emitted. **Vulkan forbids that capability outright:**

```
error: Capability Linkage is not allowed by Vulkan 1.3 specification
  OpCapability Linkage
```

So the presence of any entry point drops `Linkage` and every linkage export with it. Both kinds are valid SPIR-V; they answer to different consumers. Adding the first `#[stage(...)]` to a module therefore stops it exporting its functions — a real behavioural cliff, so it is called out in the decorator docs.

**Entry point names are the bare source name**, not the mangled linkage name. `OpEntryPoint Vertex %1 "vertex_main"`, not `"_M4case4mainN11vertex_main"`. It is a lookup key a pipeline-creation call passes, and a shader module has no linker symbols to mangle.

## Execution modes are emitted, not delegated

A fragment stage without a framebuffer origin and a compute stage without a workgroup size are not stages a consumer can use, so the backend emits both with the stage:

```
OpEntryPoint Vertex %1 "vs"
OpEntryPoint Fragment %2 "fs"
OpEntryPoint GLCompute %3 "cs"
OpExecutionMode %2 OriginUpperLeft
OpExecutionMode %3 LocalSize 64 1 1
```

`OriginUpperLeft` is the only origin Vulkan permits. `#[workgroup(...)]` is optional and defaults to the single-invocation `(1, 1, 1)`, but the mode is always emitted.

## Validation — this is where the issue's acceptance actually bites

`spirv-val` is available here. **The universal environment checks none of the rules above** — not the Linkage prohibition, not the mandatory origin, not the mandatory workgroup size. Validating a shader module universally would have passed while a real Vulkan consumer refused it, which is exactly this repo's recurring defect shape.

So the int harness grows a **`spirv-val-vulkan`** producer, and `int/surface/spirv-entrypoint` is validated against `--target-env vulkan1.3`. The existing three spirv cases stay on the universal environment, correctly: they are library modules and *cannot* satisfy Vulkan, by design.

The issue's second acceptance item — "entry-point interface rules (Input/Output variable lists on `OpEntryPoint`) are emitted correctly" — is met as far as it can be here: the interface list is **empty**, which is valid for a stage that reads and writes no interface variables. #2571 fills it in, and that is the coordination the issue anticipated.

## Files outside the SPIR-V backend

Flagging explicitly, since the track is otherwise backend-local. A declaration surface cannot live in the backend, so this touches three shared files, all additively:

- `src/lang/fe/sema.mach` — validate the two directives
- `src/lang/me/ir.mach` — `stage` / `wg_x` / `wg_y` / `wg_z` on `ir.Function`
- `src/lang/me/lower/decl.mach` — read them off the decorators

None is on the owned-elsewhere list for this session, but a reviewer should confirm no collision.

## Checks

- `mach test .` — 1198 passed, 0 failed
- `int/run.sh --target linux` — full suite green
- self-host fixpoint: stage b == stage c, byte-identical