### PR TITLE
feat(spirv): shader interface variables and descriptors

### DIFF
--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -40,6 +40,10 @@ A decorator is written as an attribute:
 #[embed("path")]     # compile-time file embedding (val only)
 #[stage("name")]     # GPU pipeline stage; makes the function an entry point
 #[workgroup(x,y,z)]  # compute workgroup dimensions (with #[stage("compute")])
+#[input(n)]          # shader interface input at location n (global only)
+#[output(n)]         # shader interface output at location n (global only)
+#[builtin("name")]   # pipeline built-in variable (global only)
+#[uniform(set, bnd)] # descriptor-bound uniform block (global only)
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -408,6 +412,57 @@ stage takes the single-invocation default `(1, 1, 1)`; the dimensions are always
 declared in the emitted module, since a compute stage that does not state its
 workgroup size is not one a consumer can dispatch.
 
+### `input(n)` / `output(n)` / `builtin(str)` / `uniform(set, binding)` — shader interface
+
+A pipeline stage does not receive its inputs or return its results through a call.
+It reads and writes **module-scope variables** that the pipeline binds, and these
+four directives say which kind each variable is. They apply only to module-level
+`val` / `var` bindings, and a variable carries **exactly one** of them — the four
+are mutually exclusive.
+
+```mach
+#[input(0)]            var in_position: f32x4;
+#[output(0)]           var out_colour:  f32x4;
+#[builtin("position")] var position:    f32x4;
+
+rec Camera { view: f32x4; proj: f32x4; }
+#[uniform(0, 0)] var camera: Camera;
+```
+
+`input` and `output` number a **varying** with a location, which is how one
+stage's outputs line up with the next stage's inputs: the producer's
+`#[output(0)]` feeds the consumer's `#[input(0)]`.
+
+`builtin` names a value the pipeline supplies or consumes instead of one a
+location carries. The accepted set is closed:
+
+| Value                 | Meaning                        | Direction |
+|-----------------------|--------------------------------|-----------|
+| `"position"`          | clip-space vertex position     | written   |
+| `"point_size"`        | rasterized point size          | written   |
+| `"vertex_index"`      | index of the current vertex    | read      |
+| `"instance_index"`    | index of the current instance  | read      |
+| `"frag_coord"`        | fragment window coordinate     | read      |
+| `"global_invocation"` | compute global invocation id   | read      |
+| `"local_invocation"`  | compute local invocation id    | read      |
+| `"workgroup_id"`      | compute workgroup id           | read      |
+
+The direction is a property of the built-in, not something you restate — a stage
+writes its position and reads what the pipeline hands it — so there is no
+input/output marker to pair with `builtin`, and none that could disagree with it.
+
+`uniform` binds a read-only block by descriptor set and binding. Its type **must
+be a `rec`**: a uniform is a block with a host-visible layout, and a bare scalar
+or vector has no block layout for a pipeline to bind. The record is emitted with
+its `Block` decoration and an explicit byte offset on every member, taken from the
+same layout the rest of the compiler uses, so what the shader reads is what the
+host wrote. Wrap a single value in a one-field record.
+
+As with `#[stage(...)]`, these are accepted on every target and acted on only by a
+target that forms pipeline stages. On `spirv` each becomes an `OpVariable` in the
+matching storage class, carrying the matching decoration, and the Input and Output
+variables are named in every entry point's interface list.
+
 ## Applicability
 
 | Directive   | `fun` | `ext fun` | `val` / `var` | `rec` / `uni` |
@@ -424,6 +479,10 @@ workgroup size is not one a consumer can dispatch.
 | `embed`     |  no   |    no     |      yes      |      no       |
 | `stage`     |  yes  |    no     |      no       |      no       |
 | `workgroup` |  yes  |    no     |      no       |      no       |
+| `input`     |  no   |    no     |      yes      |      no       |
+| `output`    |  no   |    no     |      yes      |      no       |
+| `builtin`   |  no   |    no     |      yes      |      no       |
+| `uniform`   |  no   |    no     |      yes      |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).

--- a/int/surface/spirv-interface/case.conf
+++ b/int/surface/spirv-interface/case.conf
@@ -1,0 +1,8 @@
+# shader interface variables through the spirv back half, validated host-side
+# against the VULKAN environment. the environment matters here more than anywhere
+# else in the spirv set: the interface rules this case exists to check - a Uniform
+# variable's mandatory Block layout, an entry point's interface list - are Vulkan
+# rules the universal environment does not apply.
+run: spirv-val-vulkan
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-interface/expect.spirv.txt
+++ b/int/surface/spirv-interface/expect.spirv.txt
@@ -1,0 +1,1 @@
+modules=1 validator=clean env=vulkan1.3

--- a/int/surface/spirv-interface/mach.toml
+++ b/int/surface/spirv-interface/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-interface/src/main.mach
+++ b/int/surface/spirv-interface/src/main.mach
@@ -1,0 +1,80 @@
+# SPIR-V interface-variable fixture: stages that talk to a pipeline
+#
+# The spirv-entrypoint case forms stages that communicate with nothing, and their
+# `OpEntryPoint` interface lists are empty. Here the stages have a real interface:
+# location-numbered varyings, built-ins, and a descriptor-bound uniform block. The
+# observable is `spirv-val --target-env vulkan1.3`, which is the only environment
+# that checks the rules this case is about - a Uniform variable must be a
+# Block-decorated struct with explicit member offsets, and an entry point must name
+# its Input and Output variables.
+#
+# NOT here: reading a MEMBER of the uniform block (`camera.view`). The block itself
+# is declared correctly and the validator confirms it, but SPIR-V reaches a member
+# through an `OpAccessChain` naming the member's ordinal, and MIR has already
+# folded the member walk into a byte displacement by the time the back end sees it.
+# The backend refuses that read by name rather than guessing an ordinal back out of
+# an offset.
+
+#[input(0)] var in_position: f32x4;
+#[input(1)] var in_colour:   f32x4;
+
+#[builtin("position")]     var position:     f32x4;
+#[builtin("vertex_index")] var vertex_index: i32;
+
+#[output(0)] var vary_colour: f32x4;
+
+# a uniform block: a `rec` bound at descriptor set 0, binding 0. it is emitted with
+# its Block decoration and a byte offset on every member.
+rec Camera {
+    view: f32x4;
+    proj: f32x4;
+    tint: f32x4;
+}
+#[uniform(0, 0)] var camera: Camera;
+
+# a second block at another binding, so the descriptor decorations are shown to
+# vary rather than being constant-folded into one pair everywhere.
+rec Material {
+    albedo: f32x4;
+}
+#[uniform(1, 3)] var material: Material;
+
+# a vertex stage reading a location-decorated input and writing BuiltIn Position -
+# the shape the interface issue names directly.
+#[stage("vertex")]
+fun vertex_main() {
+    position    = in_position;
+    vary_colour = in_colour;
+}
+
+# a second vertex stage doing arithmetic between the interface reads and writes, so
+# the interface variables feed real computation rather than being copied straight
+# through.
+#[stage("vertex")]
+fun vertex_shaded() {
+    position    = in_position + in_colour;
+    vary_colour = in_colour * in_colour;
+}
+
+# a fragment stage reading a varying and writing a colour output. its interface
+# variables are the same module-scope set, which every entry point names.
+#[stage("fragment")]
+fun fragment_main() {
+    vary_colour = in_colour - in_position;
+}
+
+# a compute stage carrying NO interface variables, which is what makes its entry
+# point's interface list empty while its neighbours' are not - the check that the
+# lists are per stage rather than one module-wide set.
+#
+# A compute stage cannot use these variables at all: Vulkan forbids the Output
+# storage class in a compute execution model, and a compute stage's data travels
+# through storage buffers, which are a later increment. Writing `vary_colour` here
+# produces a module the validator rejects with exactly that rule, which is how this
+# comment came to be written.
+#[stage("compute")] #[workgroup(8, 8, 1)]
+fun compute_main() { }
+
+fun main() i32 {
+    ret 0;
+}

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -1416,6 +1416,54 @@ fun require_string_arg(sc: *context.SemaContext, dec: *decl.Decorator, count_msg
     }
 }
 
+# report unless an interface-role decorator sits on a global binding and is the
+# only role that global carries
+#
+# A pipeline stage communicates through variables in distinct storage classes, so a
+# variable is an input, an output, a built-in, or a uniform - never two at once,
+# and never a local, which has no storage the pipeline can reach.
+# ---
+# sc:  the context
+# d:   the decorated decl
+# dec: the interface-role decorator
+fun validate_iface_target(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    if (!is_global_binding(d.kind)) {
+        context.report(sc, dec.name, "shader interface decorators apply only to module-level `val` / `var` bindings");
+        ret;
+    }
+    var roles: u32 = 0;
+    if (has_decorator(sc, d, "input"))   { roles = roles + 1; }
+    if (has_decorator(sc, d, "output"))  { roles = roles + 1; }
+    if (has_decorator(sc, d, "builtin")) { roles = roles + 1; }
+    if (has_decorator(sc, d, "uniform")) { roles = roles + 1; }
+    if (roles > 1) {
+        context.report(sc, dec.name, "a shader interface variable carries exactly one role; `input`, `output`, `builtin`, and `uniform` are mutually exclusive");
+    }
+}
+
+# report unless a `#[builtin(...)]` argument names one of the accepted built-ins
+# ---
+# sc:  the context
+# dec: the `builtin` decorator, already known to carry one string argument
+fun validate_builtin_value(sc: *context.SemaContext, dec: *decl.Decorator) {
+    if (dec.args_len != 1) { ret; }
+    val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
+    if (O.is_none[*expr.Expr](opt_arg)) { ret; }
+    val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+    if (arg.kind != expr.EXPR_KIND_LIT_STR || arg.span.len < 2::usize) { ret; }
+    val off: usize = arg.span.offset + 1::usize;
+    val len: usize = arg.span.len - 2::usize;
+    if (str_region_equals(sc.source, off, len, "position"))          { ret; }
+    if (str_region_equals(sc.source, off, len, "vertex_index"))      { ret; }
+    if (str_region_equals(sc.source, off, len, "instance_index"))    { ret; }
+    if (str_region_equals(sc.source, off, len, "frag_coord"))        { ret; }
+    if (str_region_equals(sc.source, off, len, "point_size"))        { ret; }
+    if (str_region_equals(sc.source, off, len, "global_invocation")) { ret; }
+    if (str_region_equals(sc.source, off, len, "local_invocation"))  { ret; }
+    if (str_region_equals(sc.source, off, len, "workgroup_id"))      { ret; }
+    context.report(sc, arg.span, "unknown built-in; `builtin` accepts \"position\", \"vertex_index\", \"instance_index\", \"frag_coord\", \"point_size\", \"global_invocation\", \"local_invocation\", or \"workgroup_id\"");
+}
+
 # report unless a `#[stage(...)]` argument names one of the accepted stages
 #
 # The value set is closed on purpose. A stage that does not resolve to an execution
@@ -1613,6 +1661,48 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         }
         ret;
     }
+    # the four shader interface roles. each puts a global in a storage class a
+    # pipeline stage communicates through, so they are mutually exclusive: a variable
+    # is an input, an output, a built-in, or a uniform, never two of those.
+    if (decorator_named(sc, dec, "input") || decorator_named(sc, dec, "output")) {
+        if (dec.args_len != 1) {
+            context.report(sc, dec.name, "`input` / `output` decorator takes one argument: the interface location");
+        }
+        or {
+            val leid: id.ExprId = sc.a.expr_ids[dec.args_start];
+            if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, leid))) {
+                context.report(sc, dec.name, "`input` / `output` location must be an integer comptime expression");
+            }
+        }
+        validate_iface_target(sc, d, dec);
+        ret;
+    }
+    if (decorator_named(sc, dec, "builtin")) {
+        require_string_arg(sc, dec,
+            "`builtin` decorator takes one string argument",
+            "`builtin` decorator argument must be a string literal");
+        validate_iface_target(sc, d, dec);
+        validate_builtin_value(sc, dec);
+        ret;
+    }
+    if (decorator_named(sc, dec, "uniform")) {
+        if (dec.args_len != 2) {
+            context.report(sc, dec.name, "`uniform` decorator takes two arguments: the descriptor set and the binding");
+        }
+        or {
+            var ui: u32 = 0;
+            for (ui < 2) {
+                val ueid: id.ExprId = sc.a.expr_ids[dec.args_start + ui];
+                if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, ueid))) {
+                    context.report(sc, dec.name, "`uniform` descriptor set and binding must be integer comptime expressions");
+                    ui = 2; cnt;
+                }
+                ui = ui + 1;
+            }
+        }
+        validate_iface_target(sc, d, dec);
+        ret;
+    }
     if (decorator_named(sc, dec, "scalar")) {
         if (dec.args_len != 0) {
             context.report(sc, dec.name, "`scalar` decorator takes no arguments");
@@ -1633,7 +1723,7 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
     # agreement - is checked by the pre-type-resolution pass that has to read the
     # file anyway (#2507). Re-checking any of it here would report it twice.
     if (decorator_named(sc, dec, "embed")) { ret; }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup");
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -88,6 +88,38 @@ pub val STAGE_VERTEX:   u8 = 1;
 pub val STAGE_FRAGMENT: u8 = 2;
 pub val STAGE_COMPUTE:  u8 = 3;
 
+# the shader interface role of a global, from an `#[input(...)]`, `#[output(...)]`,
+# `#[builtin("...")]`, or `#[uniform(set, binding)]` decorator. IFACE_NONE is every
+# ordinary global. a target that forms pipeline stages turns a roled global into an
+# interface variable in the matching storage class; every other target ignores the
+# role and emits the global normally
+#
+# the two payload words mean different things per role, which is what keeps one
+# pair of fields serving every role rather than a field per decoration: a location
+# for IFACE_INPUT / IFACE_OUTPUT, a BUILTIN_* selector for IFACE_BUILTIN, and a
+# descriptor set plus binding for IFACE_UNIFORM
+pub val IFACE_NONE:    u8 = 0;
+pub val IFACE_INPUT:   u8 = 1;
+pub val IFACE_OUTPUT:  u8 = 2;
+pub val IFACE_BUILTIN: u8 = 3;
+pub val IFACE_UNIFORM: u8 = 4;
+
+# the built-in variables `#[builtin("...")]` accepts. each names a value the
+# pipeline supplies or consumes rather than one a location carries, and each has a
+# fixed direction the back end derives rather than the author restating: a vertex
+# stage WRITES its position and READS its indices, a fragment stage READS its
+# fragment coordinate, and a compute stage READS its invocation ids. this is the
+# axis new built-ins are added along - one value, one row in the accepted table,
+# one row in the back end's selector and direction mapping
+pub val BUILTIN_POSITION:            u32 = 0;
+pub val BUILTIN_VERTEX_INDEX:        u32 = 1;
+pub val BUILTIN_INSTANCE_INDEX:      u32 = 2;
+pub val BUILTIN_FRAG_COORD:          u32 = 3;
+pub val BUILTIN_POINT_SIZE:          u32 = 4;
+pub val BUILTIN_GLOBAL_INVOCATION:   u32 = 5;
+pub val BUILTIN_LOCAL_INVOCATION:    u32 = 6;
+pub val BUILTIN_WORKGROUP_ID:        u32 = 7;
+
 # one `{name}` local binding referenced by an inline-asm body: the interned
 # source name and the alloca instruction that owns the local's stack slot. the
 # back end resolves the alloca to a frame offset and substitutes `[rbp+off]`
@@ -371,6 +403,12 @@ pub rec Function {
 #            (lowering validates the folded value)
 # section:   object section name from a `#[section("...")]` decorator, or STR_NIL for
 #            the back end's default (.data / .rodata / .bss by mutability and init)
+# iface:     shader interface role from an `#[input]` / `#[output]` / `#[builtin]` /
+#            `#[uniform]` decorator (one of IFACE_*), IFACE_NONE for an ordinary
+#            global
+# iface_a:   first role payload: the location for IFACE_INPUT / IFACE_OUTPUT, the
+#            BUILTIN_* selector for IFACE_BUILTIN, the descriptor set for IFACE_UNIFORM
+# iface_b:   second role payload: the binding for IFACE_UNIFORM, unused otherwise
 pub rec Global {
     name:      intern.StrId;
     ty:        type.IrTypeId;
@@ -386,6 +424,9 @@ pub rec Global {
     is_embed:  bool;
     align:     u32;
     section:   intern.StrId;
+    iface:     u8;
+    iface_a:   u32;
+    iface_b:   u32;
 }
 
 # the private allocation channel one IR module owns
@@ -1646,6 +1687,9 @@ test "mach.lang.me.ir.dnit:frees_by_capacity_not_count" {
     gl.is_embed  = false;
     gl.align     = 0;
     gl.section   = intern.STR_NIL;
+    gl.iface     = IFACE_NONE;
+    gl.iface_a   = 0;
+    gl.iface_b   = 0;
     m.globals[0] = gl;
     m.global_len = 1;
 

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -445,6 +445,9 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
         gx.is_embed  = false;
         gx.align     = R.unwrap_ok[u32, str](res_align);
         gx.section   = intern.STR_NIL;
+        gx.iface     = ir.IFACE_NONE;
+        gx.iface_a   = 0;
+        gx.iface_b   = 0;
         val res_ext: R.Result[u32, str] = append_global(ctx, gx);
         if (R.is_err[u32, str](res_ext)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_ext)); }
         ret R.ok[bool, str](true);
@@ -462,6 +465,11 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
     g.is_embed  = is_embed;
     g.align     = R.unwrap_ok[u32, str](res_align);
     g.section   = decl_section_of(ctx, d);
+    # the shader interface role, for a target that forms pipeline stages.
+    g.iface     = ir.IFACE_NONE;
+    g.iface_a   = 0;
+    g.iface_b   = 0;
+    fill_iface_role(ctx, d, ?g);
 
     val res_idx: R.Result[u32, str] = append_global(ctx, g);
     if (R.is_err[u32, str](res_idx)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_idx)); }
@@ -1285,6 +1293,87 @@ fun decl_has_decorator(ctx: *context.LowerContext, d: *decl.Decl, name: str) boo
 # ctx: the context
 # d:   the Decl to inspect
 # ret: the interned section name, or STR_NIL
+# fill a global's shader interface role from its decorators
+#
+# Sema has already closed each value set and rejected a global carrying two roles,
+# so the first match wins outright rather than needing a conflict check here.
+# ---
+# ctx: the context
+# d:   the global's Decl
+# g:   the global being built
+fun fill_iface_role(ctx: *context.LowerContext, d: *decl.Decl, g: *ir.Global) {
+    if (decl_has_decorator(ctx, d, "input")) {
+        g.iface   = ir.IFACE_INPUT;
+        g.iface_a = decorator_uint(ctx, d, "input", 0, 0);
+        ret;
+    }
+    if (decl_has_decorator(ctx, d, "output")) {
+        g.iface   = ir.IFACE_OUTPUT;
+        g.iface_a = decorator_uint(ctx, d, "output", 0, 0);
+        ret;
+    }
+    if (decl_has_decorator(ctx, d, "builtin")) {
+        g.iface   = ir.IFACE_BUILTIN;
+        g.iface_a = decl_builtin_of(ctx, d);
+        ret;
+    }
+    if (decl_has_decorator(ctx, d, "uniform")) {
+        g.iface   = ir.IFACE_UNIFORM;
+        g.iface_a = decorator_uint(ctx, d, "uniform", 0, 0);
+        g.iface_b = decorator_uint(ctx, d, "uniform", 1, 0);
+    }
+}
+
+# the BUILTIN_* selector a `#[builtin("...")]` decorator names
+#
+# Sema has closed the set, so an unrecognized spelling cannot reach here.
+# ---
+# ctx: the context
+# d:   the global's Decl
+# ret: one of ir.BUILTIN_*
+fun decl_builtin_of(ctx: *context.LowerContext, d: *decl.Decl) u32 {
+    val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "builtin", 0);
+    if (O.is_none[id.ExprId](opt_arg)) { ret ir.BUILTIN_POSITION; }
+    val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.a, O.unwrap[id.ExprId](opt_arg));
+    if (O.is_none[*aexpr.Expr](opt_val)) { ret ir.BUILTIN_POSITION; }
+    val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+    if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret ir.BUILTIN_POSITION; }
+    val src: str = context.module_source(ctx);
+    val off: usize = ve.span.offset + 1::usize;
+    val len: usize = ve.span.len - 2::usize;
+    if (str_region_equals(src, off, len, "position"))          { ret ir.BUILTIN_POSITION; }
+    if (str_region_equals(src, off, len, "vertex_index"))      { ret ir.BUILTIN_VERTEX_INDEX; }
+    if (str_region_equals(src, off, len, "instance_index"))    { ret ir.BUILTIN_INSTANCE_INDEX; }
+    if (str_region_equals(src, off, len, "frag_coord"))        { ret ir.BUILTIN_FRAG_COORD; }
+    if (str_region_equals(src, off, len, "point_size"))        { ret ir.BUILTIN_POINT_SIZE; }
+    if (str_region_equals(src, off, len, "global_invocation")) { ret ir.BUILTIN_GLOBAL_INVOCATION; }
+    if (str_region_equals(src, off, len, "local_invocation"))  { ret ir.BUILTIN_LOCAL_INVOCATION; }
+    if (str_region_equals(src, off, len, "workgroup_id"))      { ret ir.BUILTIN_WORKGROUP_ID; }
+    ret ir.BUILTIN_POSITION;
+}
+
+# one unsigned integer argument of a decorator, folded, with a fallback
+# ---
+# ctx: the context
+# d:   the decorated Decl
+# name: the directive name
+# ord: which argument
+# dflt: the value to use when the argument is absent or does not fold
+# ret: the folded value
+fun decorator_uint(ctx: *context.LowerContext, d: *decl.Decl, name: str, ord: u32, dflt: u32) u32 {
+    val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, name, ord);
+    if (O.is_none[id.ExprId](opt_arg)) { ret dflt; }
+    val res_u64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_u64)) { ret dflt; }
+    val u64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_u64);
+    val res_fold: R.Result[value.Value, str] = fold_global_init(ctx, O.unwrap[id.ExprId](opt_arg), u64t, intern.STR_NIL);
+    if (R.is_err[value.Value, str](res_fold)) { ret dflt; }
+    val v: value.Value = R.unwrap_ok[value.Value, str](res_fold);
+    if (v.kind != value.VAL_CONST_INT) { ret dflt; }
+    if (v.data.int_lit > 0xFFFFFFFF) { ret dflt; }
+    ret v.data.int_lit::u32;
+}
+
 # the pipeline stage a `#[stage("...")]` decorator names, or STAGE_NONE
 #
 # Sema has already closed the value set, so an unrecognized spelling cannot reach

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -51,6 +51,7 @@ pub val OP_TYPE_BOOL:           u32 = 20;
 pub val OP_TYPE_INT:            u32 = 21;
 pub val OP_TYPE_FLOAT:          u32 = 22;
 pub val OP_TYPE_VECTOR:         u32 = 23;
+pub val OP_TYPE_STRUCT:         u32 = 30;
 pub val OP_TYPE_POINTER:        u32 = 32;
 pub val OP_TYPE_FUNCTION:       u32 = 33;
 pub val OP_CONSTANT_TRUE:       u32 = 41;
@@ -64,7 +65,9 @@ pub val OP_FUNCTION_CALL:       u32 = 57;
 pub val OP_VARIABLE:            u32 = 59;
 pub val OP_LOAD:                u32 = 61;
 pub val OP_STORE:               u32 = 62;
+pub val OP_ACCESS_CHAIN:        u32 = 65;
 pub val OP_DECORATE:            u32 = 71;
+pub val OP_MEMBER_DECORATE:     u32 = 72;
 pub val OP_VECTOR_SHUFFLE:      u32 = 79;
 pub val OP_COMPOSITE_EXTRACT:   u32 = 81;
 pub val OP_COMPOSITE_INSERT:    u32 = 82;
@@ -167,6 +170,38 @@ pub val MEMORY_GLSL450: u32 = 1;
 # automatic storage local to one function invocation - the class every MIR vreg's
 # backing variable lives in)
 pub val STORAGE_FUNCTION: u32 = 7;
+
+# the storage classes a shader interface variable lives in. Input and Output are
+# the per-invocation interface a stage reads from and writes to (a vertex
+# attribute, a varying, a built-in); Uniform is the descriptor-bound read-only
+# block a pipeline supplies to every invocation
+pub val STORAGE_INPUT:   u32 = 1;
+pub val STORAGE_UNIFORM: u32 = 2;
+pub val STORAGE_OUTPUT:  u32 = 3;
+
+# decoration operands of OpDecorate / OpMemberDecorate for the shader interface.
+# Block marks a record type as a uniform block's layout; Location numbers a
+# varying so consecutive stages match up; BuiltIn names a value the pipeline
+# supplies instead of a location; Binding and DescriptorSet address a descriptor;
+# Offset places a member within its block
+pub val DECOR_BLOCK:          u32 = 2;
+pub val DECOR_BUILTIN:        u32 = 11;
+pub val DECOR_LOCATION:       u32 = 30;
+pub val DECOR_BINDING:        u32 = 33;
+pub val DECOR_DESCRIPTOR_SET: u32 = 34;
+pub val DECOR_OFFSET:         u32 = 35;
+
+# BuiltIn decoration selectors. these are the SPIR-V values behind mach's
+# `#[builtin("...")]` names; the sparse numbering is the specification's, not a
+# compression of it
+pub val BUILTIN_POSITION:              u32 = 0;
+pub val BUILTIN_POINT_SIZE:            u32 = 1;
+pub val BUILTIN_FRAG_COORD:            u32 = 15;
+pub val BUILTIN_WORKGROUP_ID:          u32 = 26;
+pub val BUILTIN_LOCAL_INVOCATION_ID:   u32 = 27;
+pub val BUILTIN_GLOBAL_INVOCATION_ID:  u32 = 28;
+pub val BUILTIN_VERTEX_INDEX:          u32 = 42;
+pub val BUILTIN_INSTANCE_INDEX:        u32 = 43;
 
 # decoration operand of OpDecorate: LinkageAttributes (names an exported / imported
 # symbol and its linkage), the decoration that publishes a function under the

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -81,15 +81,31 @@ use mach.lang.target.isa.spirv.types;
 # has_entry: whether any function in the module declares a pipeline stage, which
 #           decides whether this is a shader module (entry points, no Linkage) or a
 #           library module (Linkage exports, no entry point)
+# gvar_ids: SPIR-V OpVariable id per IR global index, allocated before any body is
+#           emitted so a load or store can name a variable declared later (0 for a
+#           global carrying no interface role)
+# iface_ids: the Input / Output variable ids, in declaration order; an entry point
+#           lists the subset of these it can reach
+# iface_len: how many of `iface_ids` are live
+# gslot:    per IR global index, one more than its slot in `iface_ids`, or 0 when
+#           the global is not entry-point interface
+# iface_use: an (IR function) x (interface slot) matrix, 1 where that function can
+#           reach that variable, transitively through its calls. an entry point
+#           lists exactly its own row
 rec Emit {
-    alloc:    *A.Allocator;
-    interner: *intern.Interner;
-    tgt:      *resolved.Target;
-    ir:       *ir.Module;
-    b:        *spirv.Builder;
-    tt:       *types.TypeTable;
-    fn_ids:   *u32;
+    alloc:     *A.Allocator;
+    interner:  *intern.Interner;
+    tgt:       *resolved.Target;
+    ir:        *ir.Module;
+    b:         *spirv.Builder;
+    tt:        *types.TypeTable;
+    fn_ids:    *u32;
     has_entry: bool;
+    gvar_ids:  *u32;
+    iface_ids: *u32;
+    iface_len: u32;
+    gslot:     *u32;
+    iface_use: *u8;
 }
 
 # the per-function value maps, sized to the function's vreg count
@@ -153,6 +169,8 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     var e: Emit;
     e.alloc = mirmod.alloc; e.interner = mirmod.interner;
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
+    e.gvar_ids = nil; e.iface_ids = nil; e.iface_len = 0;
+    e.gslot = nil; e.iface_use = nil;
 
     # a module is a shader module or a library module, never both, and which one is
     # settled before any function is emitted: the answer decides both the capability
@@ -183,6 +201,25 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
             }
             ii = ii + 1;
         }
+    }
+
+    # interface variables are declared before any body, both because a SPIR-V global
+    # must precede the functions that use it and because every entry point has to
+    # name the same interface list.
+    val gr: R.Result[bool, str] = declare_interface(?e);
+    if (R.is_err[bool, str](gr)) {
+        emit_dnit(?e, irmod.function_len);
+        types.types_dnit(?tt);
+        spirv.builder_dnit(?b);
+        ret gr;
+    }
+
+    val ur: R.Result[bool, str] = build_iface_uses(?e, mirmod);
+    if (R.is_err[bool, str](ur)) {
+        emit_dnit(?e, irmod.function_len);
+        types.types_dnit(?tt);
+        spirv.builder_dnit(?b);
+        ret ur;
     }
 
     var fi: u32 = 0;
@@ -223,6 +260,339 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
 fun emit_dnit(e: *Emit, n: u32) {
     if (e.fn_ids != nil && n > 0) { A.deallocate[u32](e.alloc, e.fn_ids, n::usize); }
     e.fn_ids = nil;
+    if (e.gvar_ids != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.gvar_ids, e.ir.global_len::usize);
+    }
+    e.gvar_ids = nil;
+    if (e.iface_ids != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.iface_ids, e.ir.global_len::usize);
+    }
+    e.iface_ids = nil;
+    if (e.gslot != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.gslot, e.ir.global_len::usize);
+    }
+    e.gslot = nil;
+    if (e.iface_use != nil && n > 0 && e.iface_len > 0) {
+        A.deallocate[u8](e.alloc, e.iface_use, (n * e.iface_len)::usize);
+    }
+    e.iface_use = nil;
+    e.iface_len = 0;
+}
+
+# declare one global OpVariable per interface-roled global, with its decorations
+#
+# A shader stage does not receive its inputs or hand back its outputs through a
+# call: it reads and writes module-scope variables in the Input, Output, and
+# Uniform storage classes, and the pipeline binds them by the decorations attached
+# here. So a mach global carrying `#[input(N)]`, `#[output(N)]`, `#[builtin("...")]`,
+# or `#[uniform(set, binding)]` becomes one of those variables rather than an
+# ordinary data symbol.
+#
+# The Input and Output variables are also collected into the entry-point interface
+# list, which every OpEntryPoint must name in full.
+# ---
+# e:   the emission state
+# ret: true on success, or a precise error string
+fun declare_interface(e: *Emit) R.Result[bool, str] {
+    val n: u32 = e.ir.global_len;
+    if (n == 0) { ret R.ok[bool, str](true); }
+
+    val rg: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rg)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rg)); }
+    e.gvar_ids = R.unwrap_ok[*u32, str](rg);
+    val ri: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](ri)) { ret R.err[bool, str](R.unwrap_err[*u32, str](ri)); }
+    e.iface_ids = R.unwrap_ok[*u32, str](ri);
+
+    val rs: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rs)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rs)); }
+    e.gslot = R.unwrap_ok[*u32, str](rs);
+
+    var i: u32 = 0;
+    for (i < n) { e.gvar_ids[i] = 0; e.iface_ids[i] = 0; e.gslot[i] = 0; i = i + 1; }
+
+    i = 0;
+    for (i < n) {
+        val g: *ir.Global = ?e.ir.globals[i];
+        if (g.iface == ir.IFACE_NONE) { i = i + 1; cnt; }
+
+        var storage: u32 = spirv.STORAGE_INPUT;
+        if (g.iface == ir.IFACE_OUTPUT)      { storage = spirv.STORAGE_OUTPUT; }
+        or (g.iface == ir.IFACE_UNIFORM)     { storage = spirv.STORAGE_UNIFORM; }
+        or (g.iface == ir.IFACE_BUILTIN)     { storage = builtin_storage(g.iface_a); }
+
+        var value_ty: u32 = 0;
+        if (g.iface == ir.IFACE_UNIFORM) {
+            # a Uniform variable must be a Block-decorated struct: Vulkan rejects a
+            # bare scalar or vector in that storage class outright, so the mach type
+            # has to be a record and the block layout is emitted with it.
+            val ur: R.Result[u32, str] = uniform_block_type(e, g.ty);
+            if (R.is_err[u32, str](ur)) { ret R.err[bool, str](R.unwrap_err[u32, str](ur)); }
+            value_ty = R.unwrap_ok[u32, str](ur);
+        }
+        or { value_ty = ir_value_spv_type(e, g.ty); }
+        if (value_ty == 0) {
+            ret unsupported(e, unsupported_ir_type(e, g.ty,
+                "unsupported shader interface variable type in the SPIR-V target"));
+        }
+        val ptr_ty: u32 = types.type_ptr(e.tt, storage, value_ty);
+        val var_id: u32 = spirv.alloc_id(e.b);
+        var vop: [3]u32;
+        vop[0] = ptr_ty; vop[1] = var_id; vop[2] = storage;
+        spirv.inst(e.b, ?e.b.types_consts, spirv.OP_VARIABLE, ?vop[0], 3);
+        e.gvar_ids[i] = var_id;
+
+        if (g.iface == ir.IFACE_INPUT || g.iface == ir.IFACE_OUTPUT) {
+            decorate(e, var_id, spirv.DECOR_LOCATION, g.iface_a);
+        }
+        if (g.iface == ir.IFACE_BUILTIN) {
+            decorate(e, var_id, spirv.DECOR_BUILTIN, builtin_selector(g.iface_a));
+        }
+        if (g.iface == ir.IFACE_UNIFORM) {
+            decorate(e, var_id, spirv.DECOR_DESCRIPTOR_SET, g.iface_a);
+            decorate(e, var_id, spirv.DECOR_BINDING, g.iface_b);
+        }
+        # only the per-invocation classes are entry-point interface; a descriptor is
+        # reached through its binding, not through the interface list.
+        if (g.iface != ir.IFACE_UNIFORM) {
+            e.iface_ids[e.iface_len] = var_id;
+            e.gslot[i] = e.iface_len + 1;
+            e.iface_len = e.iface_len + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# build the Block-decorated struct type behind a uniform variable
+#
+# A Uniform variable's type is not the mach record directly: it is an
+# `OpTypeStruct` carrying a `Block` decoration and an explicit `Offset` on every
+# member. Vulkan requires all three - a bare scalar or vector in Uniform storage is
+# rejected, and a block whose members carry no offsets has no defined layout for a
+# host to write into. The offsets come from the same layout the rest of the
+# compiler uses, so what the shader reads is what the host wrote.
+# ---
+# e:   the emission state
+# id:  the IR type of the uniform global
+# ret: the OpTypeStruct id, or a precise error string
+fun uniform_block_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
+    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
+    if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform global has no IR type"); }
+    val t: *type.IrType = O.unwrap[*type.IrType](opt);
+    if (t.kind != type.IRT_STRUCT) {
+        ret R.err[u32, str]("a `#[uniform(...)]` variable must be a `rec`: a uniform is a descriptor-bound BLOCK with a host-visible layout, and a bare scalar or vector has no block layout for a pipeline to bind. wrap the value in a record with one field");
+    }
+    val n: u32 = t.data.struct_.field_count;
+    if (n == 0 || n > types.MAX_STRUCT_MEMBERS) {
+        ret R.err[u32, str]("a `#[uniform(...)]` block must have between 1 and 16 fields");
+    }
+
+    var members: [16]u32;
+    var i: u32 = 0;
+    for (i < n) {
+        val mt: u32 = ir_value_spv_type(e, t.data.struct_.fields[i]);
+        if (mt == 0) {
+            ret R.err[u32, str](unsupported_ir_type(e, t.data.struct_.fields[i],
+                "unsupported uniform block member type in the SPIR-V target"));
+        }
+        members[i] = mt;
+        i = i + 1;
+    }
+    val struct_id: u32 = types.type_struct(e.tt, ?members[0], n);
+    if (struct_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block type"); }
+
+    var bops: [2]u32;
+    bops[0] = struct_id; bops[1] = spirv.DECOR_BLOCK;
+    spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?bops[0], 2);
+
+    i = 0;
+    for (i < n) {
+        var mops: [4]u32;
+        mops[0] = struct_id; mops[1] = i; mops[2] = spirv.DECOR_OFFSET;
+        mops[3] = type.byte_offset(?e.ir.types, id, i, e.tgt);
+        spirv.inst(e.b, ?e.b.decorations, spirv.OP_MEMBER_DECORATE, ?mops[0], 4);
+        i = i + 1;
+    }
+    ret R.ok[u32, str](struct_id);
+}
+
+# compute, per IR function, which interface variables it can reach
+#
+# An entry point's interface list must name the Input and Output variables THAT
+# entry point uses, not every one the module declares. Listing them all is legal
+# SPIR-V from 1.4 on, but it makes each stage inherit every other stage's
+# variables, and Vulkan's rules are per stage: an integer Input on a fragment entry
+# point needs a Flat decoration, so a vertex stage's `vertex_index` dragged into a
+# fragment stage's list makes that fragment stage invalid. The variable is not
+# really the fragment stage's at all, so the fix is to stop claiming it.
+#
+# Reachability is transitive: a stage that calls a helper touching an interface
+# variable uses that variable. The closure is a fixpoint over direct calls, which
+# terminates because the matrix only ever gains entries.
+# ---
+# e:      the emission state
+# mirmod: the lowered MIR module
+# ret:    true on success, or an allocation error
+fun build_iface_uses(e: *Emit, mirmod: *mir.MirModule) R.Result[bool, str] {
+    if (e.iface_len == 0 || e.ir.function_len == 0) { ret R.ok[bool, str](true); }
+    val cells: u32 = e.ir.function_len * e.iface_len;
+    val ru: R.Result[*u8, str] = A.allocate[u8](e.alloc, cells::usize);
+    if (R.is_err[*u8, str](ru)) { ret R.err[bool, str](R.unwrap_err[*u8, str](ru)); }
+    e.iface_use = R.unwrap_ok[*u8, str](ru);
+    var c: u32 = 0;
+    for (c < cells) { e.iface_use[c] = 0; c = c + 1; }
+
+    # direct uses: any symbol operand naming an interface variable.
+    var fi: u32 = 0;
+    for (fi < mirmod.function_len) {
+        val mf: *mir.MirFunction = ?mirmod.functions[fi];
+        val fx: u32 = ir_function_index(e.ir, mf.name);
+        if (fx == IR_FN_NONE) { fi = fi + 1; cnt; }
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                val mi: *mir.MirInstr = ?blk.instrs[ii];
+                var oi: u32 = 0;
+                for (oi < mi.operand_count) {
+                    if (mi.operands[oi].kind == mir.MIR_OP_SYM) {
+                        val slot: u32 = iface_slot_of(e, mi.operands[oi].sym);
+                        if (slot != 0) { e.iface_use[fx * e.iface_len + slot - 1] = 1; }
+                    }
+                    oi = oi + 1;
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+
+    # transitive closure over direct calls.
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        fi = 0;
+        for (fi < mirmod.function_len) {
+            val mf: *mir.MirFunction = ?mirmod.functions[fi];
+            val fx: u32 = ir_function_index(e.ir, mf.name);
+            if (fx == IR_FN_NONE) { fi = fi + 1; cnt; }
+            var bi: u32 = 0;
+            for (bi < mf.block_count) {
+                val blk: *mir.MirBlock = ?mf.blocks[bi];
+                var ii: u32 = 0;
+                for (ii < blk.instr_count) {
+                    val mi: *mir.MirInstr = ?blk.instrs[ii];
+                    if (mi.opcode == mir.MIR_CALL && mi.operand_count >= 1
+                        && mi.operands[0].kind == mir.MIR_OP_SYM) {
+                        val cx: u32 = ir_function_index(e.ir, mi.operands[0].sym);
+                        if (cx != IR_FN_NONE) {
+                            var s: u32 = 0;
+                            for (s < e.iface_len) {
+                                if (e.iface_use[cx * e.iface_len + s] != 0
+                                    && e.iface_use[fx * e.iface_len + s] == 0) {
+                                    e.iface_use[fx * e.iface_len + s] = 1;
+                                    changed = true;
+                                }
+                                s = s + 1;
+                            }
+                        }
+                    }
+                    ii = ii + 1;
+                }
+                bi = bi + 1;
+            }
+            fi = fi + 1;
+        }
+    }
+    ret R.ok[bool, str](true);
+}
+
+# whether an IR function can reach the interface variable in `slot`
+# ---
+# e:    the emission state
+# fn_ix: the IR function index
+# slot: the interface slot
+# ret:  true when the function uses that variable
+fun uses_iface(e: *Emit, fn_ix: u32, slot: u32) bool {
+    if (e.iface_use == nil || fn_ix >= e.ir.function_len || slot >= e.iface_len) { ret false; }
+    ret e.iface_use[fn_ix * e.iface_len + slot] != 0;
+}
+
+# one more than an interface variable's slot for an interned global name, or 0
+# ---
+# e:    the emission state
+# name: the global's interned name
+# ret:  slot + 1, or 0 when the name is not entry-point interface
+fun iface_slot_of(e: *Emit, name: intern.StrId) u32 {
+    if (e.gslot == nil) { ret 0; }
+    var i: u32 = 0;
+    for (i < e.ir.global_len) {
+        if (e.ir.globals[i].name == name) { ret e.gslot[i]; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# emit a one-operand OpDecorate
+# ---
+# e:      the emission state
+# target: the id being decorated
+# decor:  the decoration
+# operand: the decoration's single literal operand
+fun decorate(e: *Emit, target: u32, decor: u32, operand: u32) {
+    var ops: [3]u32;
+    ops[0] = target; ops[1] = decor; ops[2] = operand;
+    spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?ops[0], 3);
+}
+
+# the SPIR-V BuiltIn selector for one of mach's built-in names
+# ---
+# which: the ir.BUILTIN_* value
+# ret:   the SPIR-V BuiltIn decoration operand
+fun builtin_selector(which: u32) u32 {
+    if (which == ir.BUILTIN_VERTEX_INDEX)      { ret spirv.BUILTIN_VERTEX_INDEX; }
+    if (which == ir.BUILTIN_INSTANCE_INDEX)    { ret spirv.BUILTIN_INSTANCE_INDEX; }
+    if (which == ir.BUILTIN_FRAG_COORD)        { ret spirv.BUILTIN_FRAG_COORD; }
+    if (which == ir.BUILTIN_POINT_SIZE)        { ret spirv.BUILTIN_POINT_SIZE; }
+    if (which == ir.BUILTIN_GLOBAL_INVOCATION) { ret spirv.BUILTIN_GLOBAL_INVOCATION_ID; }
+    if (which == ir.BUILTIN_LOCAL_INVOCATION)  { ret spirv.BUILTIN_LOCAL_INVOCATION_ID; }
+    if (which == ir.BUILTIN_WORKGROUP_ID)      { ret spirv.BUILTIN_WORKGROUP_ID; }
+    ret spirv.BUILTIN_POSITION;
+}
+
+# the storage class a built-in lives in
+#
+# A built-in's direction is a property of the built-in, not something the author
+# restates: a stage WRITES its position and point size and READS everything the
+# pipeline hands it. Deriving it here is what keeps `#[builtin("...")]` a single
+# directive rather than one that must be paired with an input/output marker that
+# could disagree with it.
+# ---
+# which: the ir.BUILTIN_* value
+# ret:   spirv.STORAGE_INPUT or spirv.STORAGE_OUTPUT
+fun builtin_storage(which: u32) u32 {
+    if (which == ir.BUILTIN_POSITION || which == ir.BUILTIN_POINT_SIZE) {
+        ret spirv.STORAGE_OUTPUT;
+    }
+    ret spirv.STORAGE_INPUT;
+}
+
+# the SPIR-V variable id backing an IR global, or 0 when it has no interface role
+# ---
+# e:    the emission state
+# name: the global's interned name
+# ret:  the OpVariable id, or 0
+fun global_var_id(e: *Emit, name: intern.StrId) u32 {
+    if (e.gvar_ids == nil) { ret 0; }
+    var i: u32 = 0;
+    for (i < e.ir.global_len) {
+        if (e.ir.globals[i].name == name) { ret e.gvar_ids[i]; }
+        i = i + 1;
+    }
+    ret 0;
 }
 
 # emit the module preamble: capabilities and the memory model
@@ -312,7 +682,7 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
     # decorating an entry point with LinkageAttributes, and a Vulkan module may not
     # declare the Linkage capability at all.
     if (irfn.stage != ir.STAGE_NONE) {
-        val er: R.Result[bool, str] = emit_entry_point(e, irfn, fn_id, entry_name(e, irfn, fn_name), returns_void);
+        val er: R.Result[bool, str] = emit_entry_point(e, irfn, fix, fn_id, entry_name(e, irfn, fn_name), returns_void);
         if (R.is_err[bool, str](er)) { ret er; }
     }
     or (!e.has_entry) { emit_linkage_export(e, fn_id, fn_name); }
@@ -320,7 +690,7 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
     # a vector materialized through memory is refused up front, under its own name.
     # Reaching it instruction by instruction would report the `alloca` that opens the
     # sequence, which is the least informative part of it.
-    if (builds_vector_through_memory(mf)) {
+    if (builds_vector_through_memory(e, mf)) {
         ret unsupported(e, "constructing a vector from a literal or an uninitialized local is not yet supported by the SPIR-V target: the front end materializes one as an array allocation written lane by lane and read back as a whole vector, and reinterpreting an allocation through its pointer is not expressible under the logical addressing model. derive the vector from an existing vector value instead - lane assignment onto a parameter, or arithmetic");
     }
 
@@ -401,9 +771,14 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
 # vector-tagged load is the identifying part, since the allocation itself is an
 # ordinary array and carries no lane descriptor.
 # ---
+# An access that names a shader interface variable directly is excluded: that is a
+# vector arriving from or leaving through the pipeline, not one built out of a
+# reinterpreted allocation, and it is exactly what the interface support exists for.
+# ---
+# e:   the emission state
 # mf:  the MIR function
 # ret: true when a vector-typed load or store reads addressed memory
-fun builds_vector_through_memory(mf: *mir.MirFunction) bool {
+fun builds_vector_through_memory(e: *Emit, mf: *mir.MirFunction) bool {
     var bi: u32 = 0;
     for (bi < mf.block_count) {
         val blk: *mir.MirBlock = ?mf.blocks[bi];
@@ -411,7 +786,13 @@ fun builds_vector_through_memory(mf: *mir.MirFunction) bool {
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
             if ((mi.opcode == mir.MIR_LOAD || mi.opcode == mir.MIR_STORE)
-                && mir.vec_lane_is_vector(mi.vec_lane)) { ret true; }
+                && mir.vec_lane_is_vector(mi.vec_lane)
+                && mi.operand_count == 2) {
+                # a load addresses through operand 1, a store through operand 0.
+                var addr: u32 = 0;
+                if (mi.opcode == mir.MIR_LOAD) { addr = 1; }
+                if (interface_target(e, ?mi.operands[addr]) == 0) { ret true; }
+            }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -672,11 +1053,12 @@ fun entry_name(e: *Emit, irfn: *ir.Function, linkage: str) str {
 # ---
 # e:            the emission state
 # irfn:         the IR function (its stage and workgroup dimensions)
+# fn_ix:        the function's IR index, which selects its interface-use row
 # fn_id:        the function's SPIR-V id
 # name:         the entry point's name, as a consumer will look it up
 # returns_void: whether the function returns void
 # ret:          true on success, or a precise error string
-fun emit_entry_point(e: *Emit, irfn: *ir.Function, fn_id: u32, name: str,
+fun emit_entry_point(e: *Emit, irfn: *ir.Function, fn_ix: u32, fn_id: u32, name: str,
                      returns_void: bool) R.Result[bool, str] {
     if (!returns_void) {
         ret unsupported(e, "a function declaring a `#[stage(...)]` must return nothing: a pipeline stage's results leave through its output interface variables, not through a return value");
@@ -689,16 +1071,31 @@ fun emit_entry_point(e: *Emit, irfn: *ir.Function, fn_id: u32, name: str,
     if (irfn.stage == ir.STAGE_FRAGMENT) { model = spirv.EXEC_MODEL_FRAGMENT; }
     or (irfn.stage == ir.STAGE_COMPUTE)  { model = spirv.EXEC_MODEL_GLCOMPUTE; }
 
-    # OpEntryPoint <model> <fn> "<name>" <interface...>; the interface list is empty
-    # until interface variables land.
+    # OpEntryPoint <model> <fn> "<name>" <interface...>. The interface names every
+    # Input and Output variable the entry point can reach. Listing the module's whole
+    # set rather than the subset one stage touches is permitted from SPIR-V 1.4 on and
+    # is what a module targeting 1.6 wants: the alternative is a reachability walk
+    # whose only effect would be to shorten a list a consumer does not read for size.
     val sw: u32 = spirv.string_words(name);
-    val total: u32 = 2 + sw;
+    var used: u32 = 0;
+    var si: u32 = 0;
+    for (si < e.iface_len) {
+        if (uses_iface(e, fn_ix, si)) { used = used + 1; }
+        si = si + 1;
+    }
+    val total: u32 = 2 + sw + used;
     val ra: R.Result[*u32, str] = A.allocate[u32](e.alloc, total::usize);
     if (R.is_err[*u32, str](ra)) { ret R.err[bool, str](R.unwrap_err[*u32, str](ra)); }
     val ops: *u32 = R.unwrap_ok[*u32, str](ra);
     ops[0] = model;
     ops[1] = fn_id;
     spirv.pack_string(name, ?ops[2]);
+    var ii: u32 = 0;
+    si = 0;
+    for (si < e.iface_len) {
+        if (uses_iface(e, fn_ix, si)) { ops[2 + sw + ii] = e.iface_ids[si]; ii = ii + 1; }
+        si = si + 1;
+    }
     spirv.inst(e.b, ?e.b.entry_points, spirv.OP_ENTRY_POINT, ops, total);
     A.deallocate[u32](e.alloc, ops, total::usize);
 
@@ -1157,6 +1554,94 @@ fun unsupported_ir_type(e: *Emit, id: type.IrTypeId, fallback: str) str {
     ret fallback;
 }
 
+# the interface variable an address operand names, or 0 when it names something else
+#
+# Only a direct symbol reference resolves: an interface variable is read and written
+# by name, and anything that computes an address off it is genuine addressed memory
+# the milestone does not carry.
+# ---
+# e:   the emission state
+# op:  the address operand
+# ret: the OpVariable id, or 0
+fun interface_target(e: *Emit, op: *mir.MirOperand) u32 {
+    if (op.kind != mir.MIR_OP_SYM) { ret 0; }
+    ret global_var_id(e, op.sym);
+}
+
+# the diagnostic for an addressed access that is not a plain interface variable read
+# or write
+# ---
+# ret: the diagnostic text
+fun addressed_memory_refusal() str {
+    ret "addressed memory is not yet supported by the SPIR-V target: a module-scope variable is reachable only when it carries a shader interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`), and only as a whole-variable read or write";
+}
+
+# emit an OpLoad of a shader interface variable
+# ---
+# e:        the emission state
+# vm:       the per-vreg value maps
+# preg_val: the identity convention's nominal register file
+# mi:       the MIR_LOAD instruction ([dst, address])
+# ret:      true on success, or a precise error string
+fun emit_global_load(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
+        ret unsupported(e, addressed_memory_refusal());
+    }
+    val var_id: u32 = interface_target(e, ?mi.operands[1]);
+    if (var_id == 0) { ret unsupported(e, addressed_memory_refusal()); }
+    val dst: u32 = mi.operands[0].vreg;
+    if (dst >= vm.n || vm.type_id[dst] == 0) {
+        ret R.err[bool, str]("spirv.emit: interface load result vreg has no type");
+    }
+    val result: u32 = spirv.alloc_id(e.b);
+    var ops: [3]u32;
+    ops[0] = vm.type_id[dst]; ops[1] = result; ops[2] = var_id;
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_LOAD, ?ops[0], 3);
+    ret store_vreg(e, vm, dst, result);
+}
+
+# emit an OpStore into a shader interface variable
+#
+# The stored value is typed by the VARIABLE, not by the store's width: the ABI
+# emits a move at the machine word, and an immediate stored into an f32x4 output
+# has to be minted at the output's type or the module is ill-typed.
+# ---
+# e:        the emission state
+# vm:       the per-vreg value maps
+# preg_val: the identity convention's nominal register file
+# mi:       the MIR_STORE instruction ([address, value])
+# ret:      true on success, or a precise error string
+fun emit_global_store(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count != 2) { ret unsupported(e, addressed_memory_refusal()); }
+    val var_id: u32 = interface_target(e, ?mi.operands[0]);
+    if (var_id == 0) { ret unsupported(e, addressed_memory_refusal()); }
+    val value_ty: u32 = interface_value_type(e, ?mi.operands[0]);
+    val value: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], value_ty);
+    if (e.b.err || value == 0) { ret R.err[bool, str]("spirv.emit: unreadable value in an interface store"); }
+    var ops: [2]u32;
+    ops[0] = var_id; ops[1] = value;
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_STORE, ?ops[0], 2);
+    ret R.ok[bool, str](true);
+}
+
+# the SPIR-V type of the value an interface variable holds, or 0 when the operand
+# does not name one
+# ---
+# e:   the emission state
+# op:  the address operand
+# ret: the value type id, or 0
+fun interface_value_type(e: *Emit, op: *mir.MirOperand) u32 {
+    if (op.kind != mir.MIR_OP_SYM) { ret 0; }
+    var i: u32 = 0;
+    for (i < e.ir.global_len) {
+        if (e.ir.globals[i].name == op.sym && e.ir.globals[i].iface != ir.IFACE_NONE) {
+            ret ir_value_spv_type(e, e.ir.globals[i].ty);
+        }
+        i = i + 1;
+    }
+    ret 0;
+}
+
 # select the integer or float form of a class-polymorphic opcode
 # ---
 # lane_float: whether the operation's lanes are float
@@ -1274,8 +1759,17 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # the liveness marker pairing the call with its result move: nothing to emit.
     if (op == mir.MIR_CALL_RES) { ret R.ok[bool, str](true); }
 
-    if (op == mir.MIR_ALLOCA || op == mir.MIR_LOAD || op == mir.MIR_STORE || op == mir.MIR_GEP) {
-        ret unsupported(e, "addressed memory is not yet supported by the SPIR-V target");
+    # a whole-variable read or write of a shader interface variable. This is the ONLY
+    # addressed memory the milestone supports, and it is supported because it is not
+    # really addressing: an interface variable is named directly, so the access is an
+    # OpLoad or OpStore on the variable's id with no address computed at all.
+    if (op == mir.MIR_LOAD)  { ret emit_global_load(e, vm, preg_val, mi); }
+    if (op == mir.MIR_STORE) { ret emit_global_store(e, vm, preg_val, mi); }
+    if (op == mir.MIR_GEP && mi.operand_count >= 2 && interface_target(e, ?mi.operands[1]) != 0) {
+        ret unsupported(e, "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL, and MIR has already folded the member walk into a byte displacement, which the ordinal cannot be recovered from in general. the block itself is declared correctly, with its Block decoration and member offsets; only the member read is missing. bind the whole block and read it as one value, or wait for the GEP to keep its index list");
+    }
+    if (op == mir.MIR_ALLOCA || op == mir.MIR_GEP) {
+        ret unsupported(e, addressed_memory_refusal());
     }
 
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -97,6 +97,10 @@ val TAG_VEC:   u8 = 5;  # OpTypeVector, `a` = component type id, `b` = component
 # name rather than emitting a type no consumer accepts.
 pub val MAX_VECTOR_COMPONENTS: u32 = 4;
 
+# the largest member count a uniform block may carry in this milestone, bounded by
+# the fixed operand buffer `type_struct` assembles into
+pub val MAX_STRUCT_MEMBERS: u32 = 16;
+
 # a memoized composite constant: its result type id and the borrowed-then-copied
 # component id list
 # ---
@@ -311,6 +315,29 @@ pub fun vector_shape(tt: *TypeTable, id: u32, out_count: *u32) u32 {
         i = i + 1;
     }
     ret 0;
+}
+
+# the id of the struct type over `members`, emitting it on first use
+#
+# Not memoized. A struct type here is a uniform BLOCK, and a block carries
+# decorations - Block on the type, an Offset on every member - so two blocks with
+# the same member types are still distinct types whenever their layouts differ.
+# Interning on the member list alone would silently merge them and attach one
+# block's offsets to the other.
+# ---
+# tt:      the table
+# members: the member type ids
+# n:       number of members
+# ret:     the OpTypeStruct id, or 0 when the member count is out of range
+pub fun type_struct(tt: *TypeTable, members: *u32, n: u32) u32 {
+    if (n == 0 || n > MAX_STRUCT_MEMBERS) { ret 0; }
+    val id: u32 = spirv.alloc_id(tt.b);
+    var ops: [17]u32;
+    ops[0] = id;
+    var i: u32 = 0;
+    for (i < n) { ops[1 + i] = members[i]; i = i + 1; }
+    spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_STRUCT, ?ops[0], n + 1);
+    ret id;
 }
 
 # the id of the pointer type `storage`-class to `pointee`, emitting it on first use


### PR DESCRIPTION
Refs #2571 — deliberately **not** `Closes`. One acceptance item is half-met; see below.

Stacked on #2642 → #2638 → #2631. Merge in that order.

## The surface

Four directives, on module-level bindings, mutually exclusive, continuing the channel `#[stage(...)]` established:

```mach
#[input(0)]            var in_position: f32x4;
#[output(0)]           var vary_colour: f32x4;
#[builtin("position")] var position:    f32x4;

rec Camera { view: f32x4; proj: f32x4; }
#[uniform(0, 0)] var camera: Camera;
```

A built-in's **direction is derived, not restated** — a stage writes its position and point size and reads everything the pipeline hands it. That keeps `builtin` one directive rather than one that must be paired with an input/output marker that could contradict it. Eight built-ins accepted, closed set, sema-checked.

A uniform's type **must be a `rec`**. Vulkan rejects a bare scalar or vector in Uniform storage, so the record becomes an `OpTypeStruct` with `Block` and an explicit `Offset` on every member, taken from the same layout the rest of the compiler uses — what the shader reads is what the host wrote.

Documented in `doc/language/decorators.md` alongside `#[stage]`.

## The bug I shipped first, and why it matters

My first version listed **every** interface variable in **every** entry point. That is legal SPIR-V from 1.4 on, and it is wrong:

```
error: [VUID-StandaloneSpirv-Flat-04744] Fragment OpEntryPoint operand 15 with Input
interfaces with integer or float type must have a Flat decoration
  %gl_VertexIndex = OpVariable %_ptr_Input_uint Input
```

Vulkan's rules are **per stage**. A vertex stage's integer `vertex_index`, dragged into a fragment stage's interface list, makes that fragment stage invalid — for a variable it never touches. The fix is not to add a `Flat` decoration; it is to stop claiming the variable. Interface lists are now computed per entry point as a **fixpoint over the call graph**, so a stage names what it can actually reach:

```
OpEntryPoint Vertex   %1 "vertex_main"   %9 %10 %gl_Position %16
OpEntryPoint Vertex   %2 "vertex_shaded" %9 %10 %gl_Position %16
OpEntryPoint Fragment %3 "fragment_main" %9 %10 %16
OpEntryPoint GLCompute %4 "compute_main"
```

The fragment stage no longer claims `gl_Position`, the compute stage claims nothing, and `gl_VertexIndex` — declared but unused — appears in none. **The universal validator environment reports none of this**, which is the whole argument for the `spirv-val-vulkan` producer added in #2642.

## Acceptance: half met, and I am not closing the issue on it

> A vertex shader reading a Location-decorated input and writing `BuiltIn Position`, **plus a fragment shader reading a uniform block member**, compile and pass `spirv-val`.

- Vertex reading a Location input and writing BuiltIn Position: **done**, Vulkan-clean.
- Fragment reading a uniform block **member**: **not done.** The block declares correctly — `Block`, per-member `Offset`, `DescriptorSet`, `Binding`, all validator-confirmed — but the member *read* is refused.

The reason is structural and the same shape as the vector-literal blocker in #2638. SPIR-V reaches a member through an `OpAccessChain` naming the member's **ordinal**. MIR has already folded the member walk into a **byte displacement** by the time the back end sees it:

```
%0 = gep ptr @camera, 0: i64, 1: i64     ->   MIR_GEP with disp = 16
%1 = load f32x4 %0
```

An ordinal cannot be recovered from a displacement in general — unions overlap, and nested aggregates share offsets. Inverting the layout function would be guessing dressed as arithmetic, so the backend refuses by name instead and says what would fix it: **the GEP needs to keep its index list** for a logical-addressing target, rather than collapsing to a displacement during MIR lowering. That is a middle-end change this branch does not make.

So a uniform block is currently declarable and bindable but not readable member-wise. That is a real half-state and I would rather it be visible in the issue than papered over — hence `Refs`. **The repo owner should decide** whether #2571 stays open for the member read or a middle-end issue is split out.

## Two more findings for the shader push

1. **Compute stages cannot use Input/Output at all.** Vulkan forbids the Output storage class in `GLCompute`; compute data travels through storage buffers, which no issue in this batch covers. My int case originally wrote an output from a compute stage and the validator caught it.

2. **Several SPIR-V built-ins are 3-component and mach cannot type them.** `GlobalInvocationId`, `LocalInvocationId` and `WorkgroupId` are `uvec3`. Every mach vector is exactly 128 bits, so there is no `u32x3` — only `u32x4`. The three compute built-ins are accepted by the decorator but cannot currently be given a correct type. Worth an issue.

## Files outside the SPIR-V backend

Same three as #2642, extended: `src/lang/fe/sema.mach`, `src/lang/me/ir.mach` (`iface` / `iface_a` / `iface_b` on `ir.Global`), `src/lang/me/lower/decl.mach`. All additive.

## Checks

- `mach test .` — 1198 passed, 0 failed
- `int/run.sh --target linux` — full suite green; new `int/surface/spirv-interface` validated against `vulkan1.3`
- self-host fixpoint: stage b == stage c, byte-identical