### PR TITLE
fix(linker): leave absolute-offset DWARF out of the link

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -52,6 +52,9 @@ use format: std.format;
 
 use mach.lang.be.obj;
 use enc: mach.lang.be.codegen.encode;
+use mach.lang.diagnostic;
+use mach.lang.fe.token;
+use src: mach.lang.source;
 use mach.lang.intern;
 use mach.lang.session;
 use mach.lang.target;
@@ -653,6 +656,18 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     val dn_r: R.Result[bool, str] = discover_debug_names(alloc, modules, module_count, ?debug_names, ?debug_count);
     if (R.is_err[bool, str](dn_r)) { ret R.err[bool, str](R.unwrap_err[bool, str](dn_r)); }
 
+    # report every object whose debug info the merge is leaving out, before any pass
+    # acts on it, so the drop is stated once per object rather than inferred from an
+    # output that turns out to carry less debug info than the inputs did (#2540). the
+    # drop applies to every mode that concatenates debug sections, which is all of
+    # them: a relocatable output shifts the same offsets an executable does, it just
+    # defers the damage to whoever links it next.
+    var dm: u32 = 0;
+    for (dm < module_count) {
+        if (!module_debug_is_linkable(modules, dm)) { warn_debug_dropped(s, modules[dm].name); }
+        dm = dm + 1;
+    }
+
     # build the deduped .debug_str table before section accumulation: the merged
     # .debug_str content is this buffer and its length sizes the merged slot. only the
     # in-place-patched modes (executable, shared object) dedup; a relocatable output
@@ -1061,7 +1076,7 @@ fun read_objects(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
                                     ?state, ?modules, ?count, ?cap);
         }
         or {
-            input_r = parse_loose(alloc, ?s.interner, tgt, buf.data, buf.len, ?modules, ?count, ?cap);
+            input_r = parse_loose(alloc, ?s.interner, tgt, path, buf.data, buf.len, ?modules, ?count, ?cap);
             if (R.is_ok[bool, str](input_r)) {
                 val accepted: *of.ObjectImage = modules;
                 input_r = archive_note_image(
@@ -1337,13 +1352,21 @@ fun grow_modules(alloc: *A.Allocator, modules: **of.ObjectImage, count: *u32, ca
 # count:   in/out - current image count
 # cap:     in/out - current backing capacity
 # ret:     ok(true) on success, or an error string
-fun parse_loose(alloc: *A.Allocator, itn: *intern.Interner, tgt: *target.Target, buf: *u8, buf_len: usize,
+fun parse_loose(alloc: *A.Allocator, itn: *intern.Interner, tgt: *target.Target,
+                path: str, buf: *u8, buf_len: usize,
                 modules: **of.ObjectImage, count: *u32, cap: *u32) R.Result[bool, str] {
     val gr: R.Result[u32, str] = grow_modules(alloc, modules, count, cap);
     if (R.is_err[u32, str](gr)) { ret R.err[bool, str](R.unwrap_err[u32, str](gr)); }
     val ix: u32 = R.unwrap_ok[u32, str](gr);
     val arr: *of.ObjectImage = @modules;
-    ret tgt.of.parse_object(alloc, itn, buf, buf_len, ?arr[ix]);
+    val pr: R.Result[bool, str] = tgt.of.parse_object(alloc, itn, buf, buf_len, ?arr[ix]);
+    if (R.is_err[bool, str](pr)) { ret pr; }
+    # name the image after the file it came from. only the COFF parser recovers a name
+    # of its own, so without this every diagnostic that names the offending object
+    # degrades to its nameless form for a loose input.
+    val nr: R.Result[intern.StrId, str] = intern.intern(itn, path);
+    if (R.is_ok[intern.StrId, str](nr)) { arr[ix].name = R.unwrap_ok[intern.StrId, str](nr); }
+    ret pr;
 }
 
 # select the needed members of one `ar` archive
@@ -2460,6 +2483,92 @@ fun init_merged(merged: *MergedSection, debug_names: *intern.StrId, debug_count:
 # out_names:    out - the distinct debug names (nil when count is 0), freed by caller
 # out_count:    out - number of distinct debug names
 # ret:          ok(true) on success, or an allocation error
+# whether module `m`'s debug sections may be concatenated with another contributor's
+#
+# a DWARF unit's cross-section references are section-relative: the unit header's
+# `debug_abbrev_offset`, `DW_AT_stmt_list` into `.debug_line`, every `DW_FORM_strp`
+# into `.debug_str`. Concatenating the section behind another contributor shifts all
+# of them at once, so they are still correct afterwards only if the producer expressed
+# them as relocations the linker re-resolves.
+#
+# mach does: each is an RK_ABS32 against a per-module anchor symbol at offset 0 of the
+# target debug section. So does a C toolchain targeting ELF, whose `.debug_info`
+# carries relocations into `.debug_str`, `.debug_line` and `.debug_abbrev`. A C
+# toolchain targeting Mach-O does NOT: clang's `__debug_info` relocates only to
+# `__text` / `__const` / `__bss` and leaves the abbrev offset, `stmt_list` and every
+# strp as plain integers, because ld64 never merges `__DWARF` into an executable at
+# all - it records an N_OSO debug map and leaves the DWARF in the object for dsymutil
+# to gather later (#2540).
+#
+# So the question is not which format or which producer, but whether this module's
+# DWARF references itself through relocations at all. A unit header always carries an
+# abbrev offset, so a module with a non-empty `.debug_info` and no debug-to-debug
+# relocation is expressing that reference absolutely and its DWARF cannot survive the
+# merge.
+#
+# `.debug_info` specifically, not any debug section, because the argument above is
+# about a DWARF unit header. CodeView carries its cross-references as type indices in
+# `.debug$S` / `.debug$T` rather than as section-relative offsets, so a foreign PE
+# object has no `.debug_info`, is linkable, and keeps the merge behaviour
+# surface/pe-foreign-codeview pins. The Mach-O parser normalizes `__debug_info` to the
+# ELF-canonical spelling, so one name covers both formats.
+# ---
+# modules: the input image array
+# m:       index of the module to classify
+# ret:     true when the module's debug sections may join the merge
+fun module_debug_is_linkable(modules: *of.ObjectImage, m: u32) bool {
+    var has_debug: bool = false;
+    var sc: u32 = 0;
+    for (sc < modules[m].section_count) {
+        val sec: *of.Section = ?modules[m].sections[sc];
+        if (sec.kind == of.SK_DEBUG && sec.len > 0) {
+            val nm: O.Option[str] = intern.lookup(modules[m].interner, sec.name);
+            if (O.is_some[str](nm) && str_equals(O.unwrap[str](nm), ".debug_info")) {
+                has_debug = true;
+            }
+        }
+        sc = sc + 1;
+    }
+    if (!has_debug) { ret true; }
+
+    var ri: u32 = 0;
+    for (ri < modules[m].reloc_count) {
+        val r: *of.Relocation = ?modules[m].relocations[ri];
+        if (r.section >= modules[m].section_count
+            || modules[m].sections[r.section].kind != of.SK_DEBUG
+            || r.sym >= modules[m].symbol_count) { ri = ri + 1; cnt; }
+        val tsec: u32 = modules[m].symbols[r.sym].section;
+        if (tsec != of.SECTION_EXTERNAL && tsec < modules[m].section_count
+            && tsec != r.section && modules[m].sections[tsec].kind == of.SK_DEBUG) {
+            ret true;
+        }
+        ri = ri + 1;
+    }
+    ret false;
+}
+
+# file a `warning:` naming an object whose debug info the link is leaving out, so the
+# drop is reported rather than silent. carries no source span, like the driver's other
+# spanless warnings, and renders message-only
+# ---
+# s:    shared session holding the interner, allocator and diagnostic sink
+# name: interned name of the object whose debug info is dropped
+fun warn_debug_dropped(s: *session.Session, name: intern.StrId) {
+    val nm: O.Option[str] = intern.lookup(?s.interner, name);
+    var on: str = "?";
+    if (O.is_some[str](nm)) { on = O.unwrap[str](nm); }
+    val res: R.Result[str, str] = format.sprint(s.alloc,
+        "debug info in '{}' uses unrelocated cross-section offsets and cannot be merged; it is left out of the link",
+        on);
+    if (R.is_err[str, str](res)) { ret; }
+    val buf: str = R.unwrap_ok[str, str](res);
+    var span: token.Span;
+    span.offset = 0;
+    span.len    = 0;
+    diagnostic.warning(?s.diags, 0xFFFFFFFF::src.FileId, span, buf);
+    str_free(s.alloc, buf);
+}
+
 fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_count: u32,
                          out_names: **intern.StrId, out_count: *u32) R.Result[bool, str] {
     @out_names = nil;
@@ -2542,6 +2651,9 @@ fun build_str_merge(s: *session.Session, modules: *of.ObjectImage, module_count:
 
     var m: u32 = 0;
     for (m < module_count) {
+        # a module whose debug info the link leaves out contributes no strings either,
+        # or the deduped table would carry names nothing in the output references.
+        if (!module_debug_is_linkable(modules, m)) { m = m + 1; cnt; }
         var sc: u32 = 0;
         for (sc < modules[m].section_count) {
             val sec: *of.Section = ?modules[m].sections[sc];
@@ -3379,6 +3491,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
     var flat: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
+        val debug_linkable: bool = module_debug_is_linkable(modules, m);
         var sc: u32 = 0;
         for (sc < modules[m].section_count) {
             val sec: *of.Section = ?modules[m].sections[sc];
@@ -3409,6 +3522,22 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                 # .debug_str is string-merge deduped: its merged content is the pre-built
                 # deduped buffer, so no module contributes bytes here (#1708).
                 if (strm.active && sec.name == strm.name) { str_slot = true; }
+            }
+
+            # a module whose cross-section debug references are absolute cannot be
+            # concatenated behind another contributor: shifting the section invalidates
+            # every one of them, and the .debug_abbrev dedup below would substitute a
+            # different producer's table for its own outright. its debug sections take a
+            # placement so the flat index stays aligned, contribute no bytes, and do not
+            # mark the slot used - a name only this module carried therefore yields no
+            # output section at all (#2540).
+            if (sec.kind == of.SK_DEBUG && !debug_linkable) {
+                placements[flat].merged_index = ki;
+                placements[flat].offset       = 0;
+                placements[flat].vaddr        = 0;
+                flat = flat + 1;
+                sc = sc + 1;
+                cnt;
             }
 
             if (str_slot) {
@@ -3878,12 +4007,17 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
     # output sections (skip BSS, which has no on-disk content).
     var m: u32 = 0;
     for (m < module_count) {
+        val debug_linkable: bool = module_debug_is_linkable(modules, m);
         var sc: u32 = 0;
         for (sc < modules[m].section_count) {
             val src: *of.Section = ?modules[m].sections[sc];
             if (src.kind == of.SK_BSS || src.bytes == nil || src.len == 0) { sc = sc + 1; cnt; }
             # the deduped .debug_str was written once above; skip every per-module copy.
             if (strm.active && src.kind == of.SK_DEBUG && src.name == strm.name) { sc = sc + 1; cnt; }
+            # left out of the link (#2540): accumulate_sections gave this a zero-length
+            # placement at offset 0, so copying it would overwrite another contributor's
+            # bytes at the front of the shared slot.
+            if (src.kind == of.SK_DEBUG && !debug_linkable) { sc = sc + 1; cnt; }
 
             val flat: u32 = sec_base[m] + sc;
             val ki: u32 = placements[flat].merged_index;
@@ -4209,12 +4343,21 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         scx = scx + 1;
     }
 
+    # a module whose debug info the link leaves out (#2540) has no merged bytes for a
+    # debug-section relocation to patch: its placement is a zero-length share of
+    # another contributor's slot, so applying one would scribble on that contributor.
+    val debug_linkable: bool = module_debug_is_linkable(modules, m);
+
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
         val r: *of.Relocation = ?modules[m].relocations[ri];
         if (arch == nil || arch.reloc == nil || arch.reloc.reloc_traits == nil
             || arch.reloc.apply_reloc == nil) {
             ret R.err[bool, str](unsupported_message(s, r.kind));
+        }
+        if (!debug_linkable && r.section < modules[m].section_count
+            && modules[m].sections[r.section].kind == of.SK_DEBUG) {
+            ri = ri + 1; cnt;
         }
         # a corrupt object can name an out-of-range section, or an offset past the
         # end of its own section (which would wrap the u32 patch cursor and scribble
@@ -6153,6 +6296,7 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
                      sym_base: *u32, sym_out: *u32) R.Result[bool, str] {
     var m: u32 = 0;
     for (m < module_count) {
+        val debug_linkable: bool = module_debug_is_linkable(modules, m);
         var ri: u32 = 0;
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
@@ -6161,6 +6305,10 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
             if (r.section >= modules[m].section_count) {
                 ret R.err[bool, str]("linker: relocation names an out-of-range section");
             }
+            # the debug sections this relocation lives in contributed no bytes (#2540),
+            # so there is nothing in the carried object for it to name.
+            if (!debug_linkable
+                && modules[m].sections[r.section].kind == of.SK_DEBUG) { ri = ri + 1; cnt; }
             if (r.offset > modules[m].sections[r.section].len) {
                 ret R.err[bool, str]("linker: relocation offset is past the end of its section");
             }
@@ -6840,6 +6988,214 @@ fun lt_marker_live_value(bytes: *u8, len: usize, marker: u8, value: *u64) bool {
     ret false;
 }
 
+# whether an eight-byte repeated marker appears anywhere in a test artifact
+# ---
+# bytes:  the artifact
+# len:    its length
+# marker: the byte the eight-byte run repeats
+# ret:    true when such a run is present
+# whether a hand-built fixture module would be treated as a mach object by the debug
+# merge, i.e. whether its DWARF references itself through relocations
+#
+# every mach module that emits `.debug_info` emits, unconditionally, an RK_ABS32
+# `DW_AT_stmt_list` against a per-module `.debug_line` anchor - `attach_debug_sections`
+# adds it on the way out with no flag guarding it - plus one strp relocation per
+# `.debug_str` reference. A `.debug_info` whose only relocations reach `.text` is not a
+# shape mach can produce; it is the clang Mach-O shape, and the merge leaves it out
+# (#2540).
+#
+# A fixture standing in for a mach object therefore has to carry that shape, or its
+# debug sections are dropped, its relocations are never patched, and every assertion
+# downstream of them passes vacuously or fails for an unrelated-looking reason. Callers
+# assert this before linking so that regression is named where it happens rather than
+# surfacing as unreadable markers.
+# ---
+# modules: the fixture's image array
+# m:       index of the module standing in for a mach object
+# ret:     true when the merge will keep its debug sections
+fun lt_is_mach_shaped(modules: *of.ObjectImage, m: u32) bool {
+    ret module_debug_is_linkable(modules, m);
+}
+
+fun lt_marker_present(bytes: *u8, len: usize, marker: u8) bool {
+    var at: usize = 0;
+    for (at + 8 <= len) {
+        var i: usize = 0;
+        for (i < 8 && bytes[at + i] == marker) { i = i + 1; }
+        if (i == 8) { ret true; }
+        at = at + 1;
+    }
+    ret false;
+}
+
+# link a self-relocating contributor against one whose debug info uses absolute
+# cross-section offsets, and report which of the two reached the output
+#
+# module 0 stands in for a mach object: its `.debug_info` names its `.debug_line`
+# through a relocation against a per-module anchor, the way every cross-section
+# reference mach emits is expressed. module 1 stands in for a clang Mach-O object:
+# its `.debug_info` relocates only into `.text` and leaves its abbrev offset,
+# stmt_list and strp fields as plain integers. Concatenating module 1 behind module 0
+# shifts every one of those and nothing remaps them, and the `.debug_abbrev` dedup
+# substitutes module 0's table for module 1's outright (#2540).
+# ---
+# s:   session
+# tgt: the target whose writer and parser the objects round-trip through
+# out_self:    out - module 0's debug bytes reached the output
+# out_foreign: out - module 1's debug bytes reached the output
+# ret: true when the fixture built and linked
+fun lt_foreign_dwarf_link(s: *session.Session, tgt: *target.Target,
+                          out_self: *bool, out_foreign: *bool) bool {
+    val alloc: *A.Allocator = s.alloc;
+    val text:   intern.StrId = lt_name(s, ".text");
+    val info:   intern.StrId = lt_name(s, ".debug_info");
+    val line:   intern.StrId = lt_name(s, ".debug_line");
+    val entry:  intern.StrId = lt_name(s, tgt.os.entry_symbol);
+    val ffn:    intern.StrId = lt_name(s, "foreign_fn");
+    val lanchor: intern.StrId = lt_name(s, "selfrel.debug_line");
+    if (text == intern.STR_NIL || info == intern.STR_NIL || line == intern.STR_NIL
+        || entry == intern.STR_NIL || ffn == intern.STR_NIL || lanchor == intern.STR_NIL) {
+        ret false;
+    }
+
+    var self_text:    [16]u8;
+    var foreign_text: [16]u8;
+    var self_info:    [24]u8;
+    var foreign_info: [24]u8;
+    var self_line:    [8]u8;
+    var foreign_line: [8]u8;
+    var i: u32 = 0;
+    for (i < 16) { self_text[i] = (0x10 + i)::u8; foreign_text[i] = (0x30 + i)::u8; i = i + 1; }
+    i = 0;
+    for (i < 24) { self_info[i] = 0; foreign_info[i] = 0; i = i + 1; }
+    i = 0;
+    for (i < 8) {
+        self_info[i] = 0xAA; foreign_info[i] = 0xBB;
+        self_line[i] = 0x5A; foreign_line[i] = 0x5B;
+        i = i + 1;
+    }
+
+    var self_secs: [3]of.Section;
+    self_secs[0].name = text; self_secs[0].kind = of.SK_TEXT;
+    self_secs[0].bytes = ?self_text[0]; self_secs[0].len = 16; self_secs[0].align = 16;
+    self_secs[1].name = info; self_secs[1].kind = of.SK_DEBUG;
+    self_secs[1].bytes = ?self_info[0]; self_secs[1].len = 24; self_secs[1].align = 1;
+    self_secs[2].name = line; self_secs[2].kind = of.SK_DEBUG;
+    self_secs[2].bytes = ?self_line[0]; self_secs[2].len = 8; self_secs[2].align = 1;
+
+    var foreign_secs: [3]of.Section;
+    foreign_secs[0].name = text; foreign_secs[0].kind = of.SK_TEXT;
+    foreign_secs[0].bytes = ?foreign_text[0]; foreign_secs[0].len = 16; foreign_secs[0].align = 16;
+    foreign_secs[1].name = info; foreign_secs[1].kind = of.SK_DEBUG;
+    foreign_secs[1].bytes = ?foreign_info[0]; foreign_secs[1].len = 24; foreign_secs[1].align = 1;
+    foreign_secs[2].name = line; foreign_secs[2].kind = of.SK_DEBUG;
+    foreign_secs[2].bytes = ?foreign_line[0]; foreign_secs[2].len = 8; foreign_secs[2].align = 1;
+
+    val fn_flags: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    var self_syms: [2]of.Symbol;
+    self_syms[0].name = entry; self_syms[0].section = 0;
+    self_syms[0].offset = 0; self_syms[0].size = 16; self_syms[0].flags = fn_flags;
+    self_syms[1].name = lanchor; self_syms[1].section = 2;
+    self_syms[1].offset = 0; self_syms[1].size = 0; self_syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL;
+
+    var foreign_syms: [1]of.Symbol;
+    foreign_syms[0].name = ffn; foreign_syms[0].section = 0;
+    foreign_syms[0].offset = 0; foreign_syms[0].size = 16; foreign_syms[0].flags = fn_flags;
+
+    # module 0 relocates a code address AND its cross-debug stmt_list reference.
+    var self_relocs: [2]of.Relocation;
+    self_relocs[0].section = 1; self_relocs[0].offset = 8;
+    self_relocs[0].kind = of.RK_ABS64; self_relocs[0].sym = 0; self_relocs[0].addend = 0;
+    self_relocs[1].section = 1; self_relocs[1].offset = 16;
+    self_relocs[1].kind = of.RK_ABS32; self_relocs[1].sym = 1; self_relocs[1].addend = 0;
+
+    # module 1 relocates only into .text, exactly as clang's Mach-O __debug_info does.
+    var foreign_relocs: [1]of.Relocation;
+    foreign_relocs[0].section = 1; foreign_relocs[0].offset = 8;
+    foreign_relocs[0].kind = of.RK_ABS64; foreign_relocs[0].sym = 0; foreign_relocs[0].addend = 0;
+
+    var modules: [2]of.ObjectImage;
+    modules[0] = lt_image(s, lt_name(s, "selfrel.o"), ?self_secs[0], 3,
+                          ?self_syms[0], 2, ?self_relocs[0], 2);
+    modules[1] = lt_image(s, lt_name(s, "foreign.o"), ?foreign_secs[0], 3,
+                          ?foreign_syms[0], 1, ?foreign_relocs[0], 1);
+
+    val atf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "foreign_dwarf_self");
+    if (R.is_err[fs.TempFile, str](atf_r)) { ret false; }
+    var atf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](atf_r);
+    val btf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "foreign_dwarf_foreign");
+    if (R.is_err[fs.TempFile, str](btf_r)) { fs.temp_close_and_remove(?atf); ret false; }
+    var btf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](btf_r);
+    val etf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "foreign_dwarf_exe");
+    if (R.is_err[fs.TempFile, str](etf_r)) {
+        fs.temp_close_and_remove(?atf); fs.temp_close_and_remove(?btf); ret false;
+    }
+    var etf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](etf_r);
+    val apath: str = fs.temp_path(?atf);
+    val bpath: str = fs.temp_path(?btf);
+    val epath: str = fs.temp_path(?etf);
+
+    var ok: bool = true;
+    if (R.is_err[bool, str](tgt.of.emit_object(tgt.isa, ?modules[0], apath::*u8))) { ok = false; }
+    if (ok && R.is_err[bool, str](tgt.of.emit_object(tgt.isa, ?modules[1], bpath::*u8))) { ok = false; }
+    if (ok) {
+        var paths: [2]*u8;
+        paths[0] = apath::*u8; paths[1] = bpath::*u8;
+        val lr: R.Result[bool, str] = link(s, tgt, ?paths[0], 2,
+            nil::*of.DynLib, 0, epath::*u8, "foreign_dwarf"::*u8,
+            LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        if (R.is_err[bool, str](lr)) { ok = false; }
+    }
+    if (ok) {
+        val rr: R.Result[Vector[u8], str] = fs.read_bytes(alloc, epath);
+        if (R.is_err[Vector[u8], str](rr)) { ok = false; }
+        or {
+            var out: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+            @out_self    = lt_marker_present(out.data, out.len, 0xAA);
+            @out_foreign = lt_marker_present(out.data, out.len, 0xBB);
+            vector.dnit[u8](?out);
+        }
+    }
+
+    fs.temp_close_and_remove(?atf);
+    fs.temp_close_and_remove(?btf);
+    fs.temp_close_and_remove(?etf);
+    ret ok;
+}
+
+# a contributor whose debug info uses absolute cross-section offsets is left out of
+# the link, and one whose references are relocations is kept. dropping BOTH would
+# satisfy "no invalid debug info" while destroying every darwin -g build, so the
+# kept side is asserted as hard as the dropped one
+test "mach.lang.be.linker.debug_merge:foreign_dwarf_left_out" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val er: R.Result[target.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    val mr: R.Result[target.Target, str] = target.select(?reg, "x86_64", "darwin", "sysv64");
+    if (R.is_err[target.Target, str](er) || R.is_err[target.Target, str](mr)) { ret 1; }
+    var elf_tgt: target.Target = R.unwrap_ok[target.Target, str](er);
+    var macho_tgt: target.Target = R.unwrap_ok[target.Target, str](mr);
+
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var code: i32 = 0;
+    var elf_self: bool = false;
+    var elf_foreign: bool = true;
+    var macho_self: bool = false;
+    var macho_foreign: bool = true;
+    if (!lt_foreign_dwarf_link(?s, ?elf_tgt, ?elf_self, ?elf_foreign))       { code = 1; }
+    if (!lt_foreign_dwarf_link(?s, ?macho_tgt, ?macho_self, ?macho_foreign)) { code = 1; }
+    session.dnit(?s);
+
+    if (!elf_self   || elf_foreign)   { code = 1; }
+    if (!macho_self || macho_foreign) { code = 1; }
+    ret code;
+}
+
 # whether an eight-byte repeated marker is immediately followed by the DWARF
 # tombstone address anywhere in a test artifact
 fun lt_marker_tombstoned(bytes: *u8, len: usize, marker: u8) bool {
@@ -6881,13 +7237,13 @@ fun lt_parsed_weak_dwarf_target(s: *session.Session, tgt: *target.Target) bool {
 
     var winner_text: [16]u8;
     var loser_text: [8]u8;
-    var winner_debug: [4][32]u8;
-    var loser_debug: [4][32]u8;
+    var winner_debug: [4][40]u8;
+    var loser_debug: [4][40]u8;
     var d: u32 = 0;
     for (d < 4) {
         if (debug_names[d] == intern.STR_NIL) { ret false; }
         var i: u32 = 0;
-        for (i < 32) {
+        for (i < 40) {
             winner_debug[d][i] = 0;
             loser_debug[d][i] = 0;
             i = i + 1;
@@ -6914,27 +7270,41 @@ fun lt_parsed_weak_dwarf_target(s: *session.Session, tgt: *target.Target) bool {
     for (d < 4) {
         winner_secs[d + 1].name = debug_names[d]; winner_secs[d + 1].kind = of.SK_DEBUG;
         winner_secs[d + 1].bytes = ?winner_debug[d][0];
-        winner_secs[d + 1].len = 32; winner_secs[d + 1].align = 1;
+        winner_secs[d + 1].len = 40; winner_secs[d + 1].align = 1;
         loser_secs[d + 1].name = debug_names[d]; loser_secs[d + 1].kind = of.SK_DEBUG;
         loser_secs[d + 1].bytes = ?loser_debug[d][0];
-        loser_secs[d + 1].len = 32; loser_secs[d + 1].align = 1;
+        loser_secs[d + 1].len = 40; loser_secs[d + 1].align = 1;
         d = d + 1;
     }
 
     val weak_flags: u32 =
         of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
-    var winner_syms: [2]of.Symbol;
+    # the per-module `.debug_line` anchor every mach object carries, and the
+    # `DW_AT_stmt_list` reference to it. a producer that relocates its cross-section
+    # debug references this way is the one whose debug info survives the merge, so a
+    # fixture standing in for a mach object has to carry the shape (#2540).
+    val wline: intern.StrId = lt_name(s, "parsed_weak.w.debug_line");
+    val lline: intern.StrId = lt_name(s, "parsed_weak.l.debug_line");
+    if (wline == intern.STR_NIL || lline == intern.STR_NIL) { ret false; }
+
+    var winner_syms: [3]of.Symbol;
     winner_syms[0].name = dup; winner_syms[0].section = 0;
     winner_syms[0].offset = 0; winner_syms[0].size = 8; winner_syms[0].flags = weak_flags;
     winner_syms[1].name = entry; winner_syms[1].section = 0;
     winner_syms[1].offset = 8; winner_syms[1].size = 8;
     winner_syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
-    var loser_syms: [1]of.Symbol;
+    winner_syms[2].name = wline; winner_syms[2].section = 2;
+    winner_syms[2].offset = 0; winner_syms[2].size = 0;
+    winner_syms[2].flags = of.SYM_OBJ_FLAG_GLOBAL;
+    var loser_syms: [2]of.Symbol;
     loser_syms[0].name = dup; loser_syms[0].section = 0;
     loser_syms[0].offset = 0; loser_syms[0].size = 8; loser_syms[0].flags = weak_flags;
+    loser_syms[1].name = lline; loser_syms[1].section = 2;
+    loser_syms[1].offset = 0; loser_syms[1].size = 0;
+    loser_syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL;
 
-    var winner_relocs: [8]of.Relocation;
-    var loser_relocs: [8]of.Relocation;
+    var winner_relocs: [9]of.Relocation;
+    var loser_relocs: [9]of.Relocation;
     d = 0;
     for (d < 4) {
         winner_relocs[d].section = d + 1; winner_relocs[d].offset = 8;
@@ -6951,12 +7321,22 @@ fun lt_parsed_weak_dwarf_target(s: *session.Session, tgt: *target.Target) bool {
         loser_relocs[4 + d].addend = 4;
         d = d + 1;
     }
+    winner_relocs[8].section = 1; winner_relocs[8].offset = 32;
+    winner_relocs[8].kind = of.RK_ABS32; winner_relocs[8].sym = 2;
+    winner_relocs[8].addend = 0;
+    loser_relocs[8].section = 1; loser_relocs[8].offset = 32;
+    loser_relocs[8].kind = of.RK_ABS32; loser_relocs[8].sym = 1;
+    loser_relocs[8].addend = 0;
 
     var modules: [2]of.ObjectImage;
     modules[0] = lt_image(s, lt_name(s, "parsed-winner"), ?winner_secs[0], 5,
-                          ?winner_syms[0], 2, ?winner_relocs[0], 8);
+                          ?winner_syms[0], 3, ?winner_relocs[0], 9);
     modules[1] = lt_image(s, lt_name(s, "parsed-loser"), ?loser_secs[0], 5,
-                          ?loser_syms[0], 1, ?loser_relocs[0], 8);
+                          ?loser_syms[0], 2, ?loser_relocs[0], 9);
+
+    # both modules stand in for mach objects; if either stopped being mach-shaped the
+    # merge would drop its DWARF and every tombstone assertion below would be vacuous.
+    if (!lt_is_mach_shaped(?modules[0], 0) || !lt_is_mach_shaped(?modules[0], 1)) { ret false; }
 
     val wtf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "weak_dwarf_winner");
     if (R.is_err[fs.TempFile, str](wtf_r)) { ret false; }
@@ -7079,17 +7459,21 @@ test "mach.lang.be.linker.patch_relocations:parsed_weak_dwarf_tombstones" {
 # ret: 0 refused with the expected diagnostic, 1 linked and wrote the stale address,
 #      2 linked without writing a stale address, 3 refused for another reason,
 #      4 the fixture itself could not be built, 5 linked but the atom plan discarded
-#      nothing, so the fixture no longer exercises the case at all
+#      nothing, so the fixture no longer exercises the case at all, 6 the stand-in
+#      module stopped being mach-shaped so its DWARF would be left out of the merge
 fun lt_dwarf_addend_crossing(s: *session.Session, tgt: *target.Target) i32 {
     val alloc: *A.Allocator = s.alloc;
     val text:   intern.StrId = lt_name(s, ".text");
     val info:   intern.StrId = lt_name(s, ".debug_info");
+    val line:   intern.StrId = lt_name(s, ".debug_line");
     val dup:    intern.StrId = lt_name(s, "crossing_weak");
     val anchor: intern.StrId = lt_name(s, "crossing_anchor");
     val tail:   intern.StrId = lt_name(s, "crossing_tail");
+    val lanchor: intern.StrId = lt_name(s, "crossing.debug_line");
     val entry:  intern.StrId = lt_name(s, tgt.os.entry_symbol);
-    if (text == intern.STR_NIL || info == intern.STR_NIL || dup == intern.STR_NIL
-        || anchor == intern.STR_NIL || tail == intern.STR_NIL || entry == intern.STR_NIL) {
+    if (text == intern.STR_NIL || info == intern.STR_NIL || line == intern.STR_NIL
+        || dup == intern.STR_NIL || anchor == intern.STR_NIL || tail == intern.STR_NIL
+        || lanchor == intern.STR_NIL || entry == intern.STR_NIL) {
         ret 4;
     }
 
@@ -7103,24 +7487,34 @@ fun lt_dwarf_addend_crossing(s: *session.Session, tgt: *target.Target) i32 {
     # three marker/address pairs: the crossing address, then `anchor` and `tail` with
     # addend 0, which give the test the live bases to measure the crossing one against
     # and let it confirm the atom plan actually discarded the body in between.
-    var cross_info: [48]u8;
+    var cross_info: [56]u8;
     i = 0;
-    for (i < 48) { cross_info[i] = 0; i = i + 1; }
+    for (i < 56) { cross_info[i] = 0; i = i + 1; }
     i = 0;
     for (i < 8) {
         cross_info[i] = 0xC1; cross_info[16 + i] = 0xC2; cross_info[32 + i] = 0xC3;
         i = i + 1;
     }
+    var cross_line: [8]u8;
+    i = 0;
+    for (i < 8) { cross_line[i] = 0x5C; i = i + 1; }
 
     var win_secs: [1]of.Section;
     win_secs[0].name = text; win_secs[0].kind = of.SK_TEXT;
     win_secs[0].bytes = ?win_text[0]; win_secs[0].len = 32; win_secs[0].align = 16;
 
-    var cross_secs: [2]of.Section;
+    # the `.debug_line` anchor and the `DW_AT_stmt_list` reference to it that every
+    # mach object carries. without them this module's DWARF uses only absolute
+    # cross-section offsets, and the merge leaves it out entirely (#2540) - which is
+    # correct for a clang Mach-O object and wrong for a fixture standing in for a mach
+    # one, whose whole point is that its debug addresses reach the output.
+    var cross_secs: [3]of.Section;
     cross_secs[0].name = text; cross_secs[0].kind = of.SK_TEXT;
     cross_secs[0].bytes = ?cross_text[0]; cross_secs[0].len = 48; cross_secs[0].align = 16;
     cross_secs[1].name = info; cross_secs[1].kind = of.SK_DEBUG;
-    cross_secs[1].bytes = ?cross_info[0]; cross_secs[1].len = 48; cross_secs[1].align = 1;
+    cross_secs[1].bytes = ?cross_info[0]; cross_secs[1].len = 56; cross_secs[1].align = 1;
+    cross_secs[2].name = line; cross_secs[2].kind = of.SK_DEBUG;
+    cross_secs[2].bytes = ?cross_line[0]; cross_secs[2].len = 8; cross_secs[2].align = 1;
 
     val weak_flags: u32 =
         of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
@@ -7132,15 +7526,17 @@ fun lt_dwarf_addend_crossing(s: *session.Session, tgt: *target.Target) i32 {
     win_syms[1].name = entry; win_syms[1].section = 0;
     win_syms[1].offset = 16; win_syms[1].size = 16; win_syms[1].flags = fn_flags;
 
-    var cross_syms: [3]of.Symbol;
+    var cross_syms: [4]of.Symbol;
     cross_syms[0].name = anchor; cross_syms[0].section = 0;
     cross_syms[0].offset = 0; cross_syms[0].size = 16; cross_syms[0].flags = fn_flags;
     cross_syms[1].name = dup; cross_syms[1].section = 0;
     cross_syms[1].offset = 16; cross_syms[1].size = 16; cross_syms[1].flags = weak_flags;
     cross_syms[2].name = tail; cross_syms[2].section = 0;
     cross_syms[2].offset = 32; cross_syms[2].size = 16; cross_syms[2].flags = fn_flags;
+    cross_syms[3].name = lanchor; cross_syms[3].section = 2;
+    cross_syms[3].offset = 0; cross_syms[3].size = 0; cross_syms[3].flags = of.SYM_OBJ_FLAG_GLOBAL;
 
-    var cross_relocs: [3]of.Relocation;
+    var cross_relocs: [4]of.Relocation;
     cross_relocs[0].section = 1; cross_relocs[0].offset = 8;
     cross_relocs[0].kind = of.RK_ABS64; cross_relocs[0].sym = 0;
     cross_relocs[0].addend = 32;
@@ -7150,12 +7546,21 @@ fun lt_dwarf_addend_crossing(s: *session.Session, tgt: *target.Target) i32 {
     cross_relocs[2].section = 1; cross_relocs[2].offset = 40;
     cross_relocs[2].kind = of.RK_ABS64; cross_relocs[2].sym = 2;
     cross_relocs[2].addend = 0;
+    cross_relocs[3].section = 1; cross_relocs[3].offset = 48;
+    cross_relocs[3].kind = of.RK_ABS32; cross_relocs[3].sym = 3;
+    cross_relocs[3].addend = 0;
 
     var modules: [2]of.ObjectImage;
     modules[0] = lt_image(s, lt_name(s, "crossing-winner"), ?win_secs[0], 1,
                           ?win_syms[0], 2, nil::*of.Relocation, 0);
-    modules[1] = lt_image(s, lt_name(s, "crossing-loser"), ?cross_secs[0], 2,
-                          ?cross_syms[0], 3, ?cross_relocs[0], 3);
+    modules[1] = lt_image(s, lt_name(s, "crossing-loser"), ?cross_secs[0], 3,
+                          ?cross_syms[0], 4, ?cross_relocs[0], 4);
+
+    # module 1 stands in for a mach object. if it stopped being mach-shaped the merge
+    # would leave its DWARF out, the crossing relocation would never be patched, and
+    # the check under test would never run - reported here rather than surfacing later
+    # as markers that cannot be read back.
+    if (!lt_is_mach_shaped(?modules[0], 1)) { ret 6; }
 
     val wtf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "cross_dwarf_winner");
     if (R.is_err[fs.TempFile, str](wtf_r)) { ret 4; }


### PR DESCRIPTION
Closes #2540

**Replaces #2637**, which GitHub closed by accident and will not let me reopen. Same branch, same work, rebased forward. See "Why this is a new PR" at the bottom — the cause is worth knowing because it can happen again.

Design **(1)** from the issue, as preferred. I went in expecting to weigh it against (2) and the evidence made it one-sided.

## What the merge was doing

Reproduced exactly as the issue states it, with clang 22.1.8 cross-compiling the stub to `x86_64-apple-macos11` and a `debug = true` darwin-x86_64 build. `llvm-objdump -r` confirms the cause: `__debug_info` relocates only to `__text`, `__const` and `__bss`. The abbrev offset, `stmt_list` and every strp are plain integers.

The damage is worse than the shifted offsets the issue names. `accumulate_sections` **dedups `.debug_abbrev`** — a later contributor shares the first one's table at offset 0 and adds no bytes (#1708). Correct for mach, where every module's table is byte-identical. For a foreign unit it does not shift the abbrev table, it *substitutes a different producer's table*, which is what `invalid abbreviation 115 ..., valid abbreviations are 1-15` in the repro is. There is no offset arithmetic that repairs that, which is most of why (2) is the wrong shape: the linker would first have to stop deduping abbrev, then parse and rewrite each unit, then track format versions.

## The rule

The linker now asks whether a module's DWARF references itself through relocations, and leaves the debug sections of one that does not out of the merge.

Keyed on the property, not on the format or the producer. Demonstrated directly: the **same C source, same clang, same `-g`**, compiled once for ELF and once for Mach-O. The ELF object relocates its cross-section references (12 into `.debug_str`, 2 into `.debug_line`, 1 into `.debug_abbrev`) and its DWARF still reaches the output — 9 `shim.c` references and 4 function DIEs, unchanged from before this PR. The Mach-O object does not, and is left out. Nothing in the rule names either format.

**Scoped to a module carrying a non-empty `.debug_info`**, because the argument above is about a DWARF unit header always having an abbrev offset. That scoping is not a detail I anticipated — the first cut applied to any debug section and broke `surface/pe-foreign-codeview`, which links a foreign PE object and asserts its CodeView survives. CodeView carries cross-references as type indices in `.debug$S` / `.debug$T` rather than as section-relative offsets, so it is a different question and a foreign PE object is now untouched. The int suite caught that, not me.

## The fixtures were not representative, and now say so

The rule dropped the DWARF of two hand-built test fixtures that stand in for mach objects, which silently defanged the assertions built on them.

That is the rule being right and the fixtures being wrong. `attach_debug_sections` emits an RK_ABS32 `DW_AT_stmt_list` against a per-module `.debug_line` anchor **unconditionally**, for every module that emits `.debug_info` at all, plus one strp relocation per `.debug_str` reference. A `.debug_info` whose only relocations reach `.text` is not a shape mach can produce — it is precisely the clang Mach-O shape the predicate exists to catch. Both fixtures had exactly that shape and were mislabelled as mach objects.

So both now carry the anchor and the relocation, **and both assert `lt_is_mach_shaped` before linking**. Making them merely satisfy the predicate would leave the next hand-built DWARF fixture free to trip the same trap; the assertion makes the requirement explicit and checked. `dwarf_addend_crossing` gets a dedicated exit code 6 for it, so the failure names itself:

```
# fixture reverted to its non-representative shape, guard in place
FAIL patch_relocations:dwarf_addend_crossing_refused (exit 6)   # "stopped being mach-shaped"
# same revert, guard removed
FAIL patch_relocations:dwarf_addend_crossing_refused (exit 4)   # "markers could not be read"
```

## Scope note: this does not make foreign ELF `-g` correct

The rule keeps foreign ELF objects in the merge, which is right — their references are relocated and the linker re-resolves them. But that link still fails `llvm-dwarfdump --verify`, from a **separate defect this PR does not touch**: the `.debug_abbrev` dedup assumes every contributor's table is byte-identical, true within mach and false across producers. A clang ELF unit's correctly relocated abbrev offset therefore resolves to mach's table — relocating the reference does not save you when the thing it points at was replaced.

Measured A/B on the same fixture, pre-PR compiler versus this branch:

```
old: shim.c refs=9 fnDIEs=4   DW_AT_stmt_list out of bounds x11, Invalid DW_FORM x33
new: shim.c refs=9 fnDIEs=4   DW_AT_stmt_list out of bounds x11, Invalid DW_FORM x33
```

Identical: this change neither fixes nor worsens it. Flagged so the PR is not read as claiming the foreign ELF path is sound. Fix sketch is in my report for a follow-up issue.

## Evidence

Before, on the issue's darwin repro:

```
error: DW_AT_stmt_list offset out of bounds occurred 12 time(s).
error: Invalid DIE offset occurred 8 time(s).
error: Invalid DW_FORM attribute occurred 48 time(s).
Errors detected.
```

After:

```
warning: debug info in 'shim.o' uses unrelocated cross-section offsets and cannot be merged; it is left out of the link
...
No errors.
```

mach's own `__debug_*` sections are all still present; the foreign object's `__apple_names` / `__apple_types` / `__apple_namespac` / `__apple_objc` are gone with its DWARF.

## Regression

`debug_merge:foreign_dwarf_left_out` links a self-relocating contributor against an absolute-offset one through both the ELF and Mach-O writer and parser, and checks which reached the output by marker bytes. It needs no clang on the runner, so it cannot silently skip.

**It asserts the kept side as hard as the dropped side**, because dropping *everything* would satisfy "no invalid debug info" while destroying every darwin `-g` build:

| mutation | result |
|---|---|
| predicate always true (pre-fix behaviour) | `FAIL foreign_dwarf_left_out` — 1 failed |
| predicate always false (drop everything) | that plus `FAIL parsed_weak_dwarf_tombstones` and `FAIL dwarf_addend_crossing_refused` — 3 failed |
| #2634's check removed | `FAIL dwarf_addend_crossing_refused` (exit 1, the stale address written) |
| none | 1226 passed, 0 failed |

`surface/debuginfo` and `surface/pe-foreign-codeview` both pass, the end-to-end statements that mach's own DWARF and foreign CodeView are untouched.

## Also in this change

`parse_loose` now names an image after its input path. Only the COFF parser recovered a name of its own, so the new warning said `'?'` — as does every existing diagnostic naming an offending object, for any loose input.

The `std.format` alias conflict from the #2634 merge is resolved to `dev`'s `format:` spelling as requested. For the record, `linker.mach` declares `format: *of.OfVTable` in four signatures and the module alias is shadowed inside every one of them — but it fails loudly (`error: no such field 'sprint' on type OfVTable`), not silently, so it is a papercut rather than a hazard and does not belong here.

## Why this is a new PR

Commit `14e3dad1` (`fix(macho): preserve the section type dyld dispatches on`, merged as #2643 from `fix/2637-macho-mod-init-section-type`) carries `Closes #2637` in its body, meant for an issue. GitHub issues and pull requests share one number namespace, and #2637 was **this pull request**, so merging that work closed it. A closed PR does not track pushes, which is why the head SHA sat frozen while the branch moved. GitHub then refuses to reopen it: `state cannot be changed. The fix/2540-foreign-dwarf branch was force-pushed or recreated.`

Two things worth checking on that: whichever issue `14e3dad1` actually meant to close is still open, and a `Closes #N` whose N lands on a PR will silently close it again.

## Not in this change

The `N_OSO` debug map, and therefore any route to recovering the dropped DWARF. It only has value with a `dsymutil` equivalent to consume it, and mach ships none, so emitting a debug map nothing reads would be speculative structure.

## Status

Rebased onto `9db96e47`, which includes two later changes to `linker.mach` (`key section-group identity on loader-visible flags only`, and the #2532 step-collision work). Both auto-merged; the whole battery was re-run on this base.

- `mach test .` — 1226 passed, 0 failed
- `int/run.sh --target linux` — all cases passed
- self-host fixpoint — `cmp b c` identical