### PR TITLE
chore(dep): advance mach-std to 0.24.1

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "c52de19ac95bf050e68600b42c055ffef419aac6"
+commit = "b4aa4e13e735d46931c5a4a9181b95a940c43c0e"


### PR DESCRIPTION
Advances `mach.lock` from mach-std 0.24.0 (`c52de19`) to 0.24.1 (`b4aa4e1`).

## What it unblocks

briar-systems/mach-std#436: `O_DIRECTORY` was arch-gated to `0x4000` on aarch64 and riscv64, which is `O_DIRECT`. Opening a directory with it is refused `EINVAL`, so `fs.read_dir` could not list anything on either arch.

That is what blocks #2641 (#2539). Front-ending every module under `src` makes the compiler enumerate a source tree, and `regression/1852-rv64-self-host` is the only place a riscv64-hosted compiler runs. It failed with a bare `error: invalid argument`, which traced to:

```
openat(AT_FDCWD,"./src",O_RDONLY|O_DIRECT) = -1 errno=22 (Invalid argument)
```

## Also in 0.24.1

mach-std's aarch64 CI leg moved from qemu-user to a native `ubuntu-24.04-arm` runner. qemu's aarch64 and riscv64 targets disagree with each other about this very flag, so the leg deciding whether the syscall surface is correct was an emulator that is wrong about it. That change immediately found mach-std#439: `fs.read_dir` is broken on aarch64 even with the corrected constant, refused `EINVAL` on real hardware. It ships with an explicit gate naming the issue rather than silently.

Worth knowing for this repo: **mach's own `int` aarch64 leg is already native** and `run.sh`'s header explains why, citing #1885. mach-std had drifted from that and has now caught up.

## Verified
- `mach build .` green, `mach test .` 1225 passed 0 failed.
- `int/run.sh --deps pin --target linux` green, resolving `b4aa4e1`.
- The riscv64 half is settled by #2641's own leg, which is what this exists to unblock.