### PR TITLE
chore(dep): advance mach-std to 0.24.2

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "b4aa4e13e735d46931c5a4a9181b95a940c43c0e"
+commit = "a7457359ed8c9316f803217212b24a1a0eef994c"


### PR DESCRIPTION
Advances `mach.lock` to mach-std 0.24.2 (`a745735`), restoring directory listing on aarch64.

## What went wrong and what fixed it

#2651 advanced the lock to 0.24.1, which had unified `O_DIRECTORY` to `0o200000` across the linux arches. **This repo's native `test aarch64-linux` leg caught it immediately**, going red with `error: invalid argument`. I merged #2651 through that failure, which I should not have done.

arm swaps `O_DIRECTORY` and `O_DIRECT` relative to asm-generic (`0o40000` and `0o200000` respectively), and aarch64 inherits that pair. `asm-generic/fcntl.h` defines both under `#ifndef` for exactly this reason. mach-std#441 restores the arch gate with the reasoning recorded.

riscv64 keeps 0.24.1's correction, which is the part #2539 and PR #2641 actually need.

## Why the native leg mattered

qemu-aarch64 had been reporting the aarch64 value correctly the whole time and was discounted because qemu-riscv64 disagreed. Both were right about their own arch. The only thing that settled it was real hardware on both sides: this repo's native aarch64 leg, and mach-std's, which moved off qemu in 0.24.1 for precisely this class of reason.

## Verified
- `mach build .` green, `mach test .` 1225 passed 0 failed.
- `int/run.sh --deps pin --target linux` green, resolving `a745735`.
- The aarch64 legs on this PR are the check that matters.