### PR TITLE
fix(spirv): name the real cause in each refusal; add array types and uniform block layout

### DIFF
--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -284,8 +284,13 @@ enumerates.
 ## Types
 
 Compiler-seeded primitives (the complete set): `u8 u16 u32 u64`,
-`i8 i16 i32 i64`, `f32 f64`, and the untyped pointer `ptr`. SIMD vector names
-(`f32x4` …) are a planned design and **do not resolve as types yet**.
+`i8 i16 i32 i64`, `f32 f64`, and the untyped pointer `ptr`.
+
+Ten 128-bit SIMD vector types are also seeded: `f32x4 f64x2`, `i8x16 i16x8
+i32x4 i64x2`, and `u8x16 u16x8 u32x4 u64x2` — a single `x`, no other shapes.
+Literals are full-arity (`f32x4{1.0, 2.0, 3.0, 4.0}`), lane access `v[i]` takes
+a comptime-constant index, and the operators apply lane-wise with a comparison
+producing a same-shape unsigned mask. See `doc/language/types.md`.
 
 ```mach
 *T                  # pointer          ?x address-of, @p dereference

--- a/int/surface/spirv-interface/src/main.mach
+++ b/int/surface/spirv-interface/src/main.mach
@@ -8,12 +8,13 @@
 # Block-decorated struct with explicit member offsets, and an entry point must name
 # its Input and Output variables.
 #
-# NOT here: reading a MEMBER of the uniform block (`camera.view`). The block itself
-# is declared correctly and the validator confirms it, but SPIR-V reaches a member
-# through an `OpAccessChain` naming the member's ordinal, and MIR has already
-# folded the member walk into a byte displacement by the time the back end sees it.
-# The backend refuses that read by name rather than guessing an ordinal back out of
-# an offset.
+# NOT here: reading a MEMBER of the uniform block (`camera.view`), and a scalar
+# `f32` interface variable. Both are refused by name, each under its own cause -
+# the member walk because SPIR-V reaches a member through an `OpAccessChain` naming
+# its ordinal and MIR has already folded that walk into a byte displacement, and the
+# scalar float because MIR materializes a float variable's address into a register
+# before touching it, losing the direct reference. An integer or vector interface
+# variable keeps the reference, which is why every varying here is one of those.
 
 #[input(0)] var in_position: f32x4;
 #[input(1)] var in_colour:   f32x4;
@@ -38,6 +39,32 @@ rec Material {
     albedo: f32x4;
 }
 #[uniform(1, 3)] var material: Material;
+
+# a block holding a matrix. mach has no matrix type by design - types.md puts one
+# in a library over vectors - so a mat4 is an array of four vectors, and the array
+# needs an `ArrayStride` decoration that an array outside an explicitly-laid-out
+# storage class must NOT carry. The stride and the member offsets come from the
+# compiler's own layout, so a host writing the block by `$offset_of` sees what the
+# shader reads.
+rec Transform {
+    model: [4]f32x4;
+    view:  [4]f32x4;
+    eye:   f32x4;
+}
+#[uniform(2, 0)] var transform: Transform;
+
+# a nested record inside a block: the inner struct carries member offsets like the
+# outer one, but only the OUTERMOST is decorated Block - that decoration marks the
+# descriptor's root, not every struct in it.
+rec Fog {
+    colour:  f32x4;
+    density: f32x4;
+}
+rec Scene {
+    fog:     Fog;
+    ambient: f32x4;
+}
+#[uniform(3, 1)] var scene: Scene;
 
 # a vertex stage reading a location-decorated input and writing BuiltIn Position -
 # the shape the interface issue names directly.

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -51,6 +51,7 @@ pub val OP_TYPE_BOOL:           u32 = 20;
 pub val OP_TYPE_INT:            u32 = 21;
 pub val OP_TYPE_FLOAT:          u32 = 22;
 pub val OP_TYPE_VECTOR:         u32 = 23;
+pub val OP_TYPE_ARRAY:          u32 = 28;
 pub val OP_TYPE_STRUCT:         u32 = 30;
 pub val OP_TYPE_POINTER:        u32 = 32;
 pub val OP_TYPE_FUNCTION:       u32 = 33;
@@ -183,13 +184,16 @@ pub val STORAGE_OUTPUT:  u32 = 3;
 # Block marks a record type as a uniform block's layout; Location numbers a
 # varying so consecutive stages match up; BuiltIn names a value the pipeline
 # supplies instead of a location; Binding and DescriptorSet address a descriptor;
-# Offset places a member within its block
+# Offset places a member within its block; ArrayStride is the byte step between an
+# array's elements, which every array in an explicitly-laid-out storage class must
+# carry and which an array anywhere else must NOT
 pub val DECOR_BLOCK:          u32 = 2;
 pub val DECOR_BUILTIN:        u32 = 11;
 pub val DECOR_LOCATION:       u32 = 30;
 pub val DECOR_BINDING:        u32 = 33;
 pub val DECOR_DESCRIPTOR_SET: u32 = 34;
 pub val DECOR_OFFSET:         u32 = 35;
+pub val DECOR_ARRAY_STRIDE:   u32 = 6;
 
 # BuiltIn decoration selectors. these are the SPIR-V values behind mach's
 # `#[builtin("...")]` names; the sparse numbering is the specification's, not a

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -388,23 +388,43 @@ fun uniform_block_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
         ret R.err[u32, str]("a `#[uniform(...)]` block must have between 1 and 16 fields");
     }
 
+    val sr: R.Result[u32, str] = laid_out_struct(e, id);
+    if (R.is_err[u32, str](sr)) { ret sr; }
+    val struct_id: u32 = R.unwrap_ok[u32, str](sr);
+
+    # only the OUTERMOST struct of a uniform is a Block; a nested one carries its
+    # member offsets but not the decoration, which marks the descriptor's root.
+    var bops: [2]u32;
+    bops[0] = struct_id; bops[1] = spirv.DECOR_BLOCK;
+    spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?bops[0], 2);
+    ret R.ok[u32, str](struct_id);
+}
+
+# build a struct type with an explicit layout: every member offset decorated, and
+# every aggregate member laid out the same way
+# ---
+# e:   the emission state
+# id:  the IR struct type
+# ret: the OpTypeStruct id, or a precise error string
+fun laid_out_struct(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
+    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
+    if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform block member has no IR type"); }
+    val t: *type.IrType = O.unwrap[*type.IrType](opt);
+    val n: u32 = t.data.struct_.field_count;
+    if (n == 0 || n > types.MAX_STRUCT_MEMBERS) {
+        ret R.err[u32, str]("a `#[uniform(...)]` block must have between 1 and 16 fields");
+    }
+
     var members: [16]u32;
     var i: u32 = 0;
     for (i < n) {
-        val mt: u32 = ir_value_spv_type(e, t.data.struct_.fields[i]);
-        if (mt == 0) {
-            ret R.err[u32, str](unsupported_ir_type(e, t.data.struct_.fields[i],
-                "unsupported uniform block member type in the SPIR-V target"));
-        }
-        members[i] = mt;
+        val mr: R.Result[u32, str] = laid_out_type(e, t.data.struct_.fields[i]);
+        if (R.is_err[u32, str](mr)) { ret mr; }
+        members[i] = R.unwrap_ok[u32, str](mr);
         i = i + 1;
     }
     val struct_id: u32 = types.type_struct(e.tt, ?members[0], n);
     if (struct_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block type"); }
-
-    var bops: [2]u32;
-    bops[0] = struct_id; bops[1] = spirv.DECOR_BLOCK;
-    spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?bops[0], 2);
 
     i = 0;
     for (i < n) {
@@ -415,6 +435,56 @@ fun uniform_block_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
         i = i + 1;
     }
     ret R.ok[u32, str](struct_id);
+}
+
+# the type of one uniform-block member, laid out explicitly
+#
+# A scalar or vector member is its ordinary type. An aggregate member needs its own
+# explicit layout: an array carries an `ArrayStride` and a nested struct carries its
+# member offsets. Both must be minted FRESH rather than shared with the interned
+# undecorated form, since the decoration is part of the type's identity here.
+#
+# The strides and offsets come from the compiler's own layout, so a host writing
+# the block by `$offset_of` sees what the shader reads. That also means a layout
+# rule Vulkan imposes and mach's layout does not satisfy is refused rather than
+# quietly repacked - repacking would move the members out from under the host.
+# ---
+# e:   the emission state
+# id:  the member's IR type
+# ret: the member type id, or a precise error string
+fun laid_out_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
+    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
+    if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform block member has no IR type"); }
+    val t: *type.IrType = O.unwrap[*type.IrType](opt);
+
+    if (t.kind == type.IRT_STRUCT) { ret laid_out_struct(e, id); }
+
+    if (t.kind == type.IRT_ARRAY) {
+        val er: R.Result[u32, str] = laid_out_type(e, t.data.array_.element);
+        if (R.is_err[u32, str](er)) { ret er; }
+        val elem_ty: u32 = R.unwrap_ok[u32, str](er);
+        val stride: u32 = type.byte_size(?e.ir.types, t.data.array_.element, e.tgt);
+        # a uniform block is laid out to std140-shaped rules, under which an array's
+        # stride is rounded up to 16. mach's layout packs at the element's natural
+        # size, so an array of anything narrower disagrees with what a Vulkan host
+        # would write, and there is no repacking that keeps both honest.
+        if ((stride % 16) != 0) {
+            ret R.err[u32, str]("an array inside a `#[uniform(...)]` block must have a 16-byte-aligned element in the SPIR-V target: a uniform block's array stride is rounded up to 16, which mach's own layout does not do, so the shader and the host would disagree about where the elements are. an array of a 128-bit vector (`[4]f32x4`) has the right stride already");
+        }
+        val arr_id: u32 = types.type_array(e.tt, elem_ty, t.data.array_.count, true);
+        if (arr_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block array type"); }
+        var aops: [3]u32;
+        aops[0] = arr_id; aops[1] = spirv.DECOR_ARRAY_STRIDE; aops[2] = stride;
+        spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?aops[0], 3);
+        ret R.ok[u32, str](arr_id);
+    }
+
+    val mt: u32 = ir_value_spv_type(e, id);
+    if (mt == 0) {
+        ret R.err[u32, str](unsupported_ir_type(e, id,
+            "unsupported uniform block member type in the SPIR-V target"));
+    }
+    ret R.ok[u32, str](mt);
 }
 
 # compute, per IR function, which interface variables it can reach
@@ -764,20 +834,107 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# whether a function materializes a vector by reading one out of addressed memory
+# what an address operand ultimately refers to
+#
+# Three different lowerings reach this back end as an address the milestone cannot
+# carry, and they need three different diagnostics, because each is fixed in a
+# different place. Telling them apart by the SHAPE of the instruction does not
+# work: an address materialization and a member walk are both `MIR_GEP` off a
+# symbol, and a member at offset 0 carries the same zero displacement an address
+# materialization does. What separates them is the ORIGIN of the address, so that
+# is what is resolved here and what every refusal below keys on.
+val ADDR_UNKNOWN: u8 = 0;  # not resolvable to a named origin
+val ADDR_GLOBAL:  u8 = 1;  # a module-scope global, index reported in out_ix
+val ADDR_ALLOCA:  u8 = 2;  # a function-local allocation
+
+# resolve an address operand to its origin, following one level of indirection
+#
+# A symbol operand names its global directly, whether or not it carries a member
+# displacement in `sym_off`. Anything reached through a register is resolved by
+# finding that register's defining instruction: MIR materializes an address into a
+# register with a `MIR_GEP`, and an allocation with a `MIR_ALLOCA`. One level is
+# all the lowerings in question produce; anything deeper is honestly unknown rather
+# than guessed at.
+# ---
+# e:      the emission state
+# mf:     the MIR function the operand belongs to
+# op:     the address operand
+# out_ix: receives the IR global index for ADDR_GLOBAL
+# ret:    one of ADDR_*
+fun address_origin(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand, out_ix: *u32) u8 {
+    @out_ix = 0;
+    if (op.kind == mir.MIR_OP_SYM) {
+        var i: u32 = 0;
+        for (i < e.ir.global_len) {
+            if (e.ir.globals[i].name == op.sym) { @out_ix = i; ret ADDR_GLOBAL; }
+            i = i + 1;
+        }
+        ret ADDR_UNKNOWN;
+    }
+    # a MEM operand's register base rides in `vreg`; a physical-register base leaves
+    # it nil. A frame-slot key shares the field, but no frame layout runs on this
+    # path, and a key naming no defining instruction resolves to UNKNOWN anyway.
+    var base: u32 = mir.MIR_VREG_NIL;
+    if (op.kind == mir.MIR_OP_VREG) { base = op.vreg; }
+    or (op.kind == mir.MIR_OP_MEM) { base = op.vreg; }
+    if (base == mir.MIR_VREG_NIL) { ret ADDR_UNKNOWN; }
+
+    val def: *mir.MirInstr = defining_instr(mf, base);
+    if (def == nil) { ret ADDR_UNKNOWN; }
+    if (def.opcode == mir.MIR_ALLOCA) { ret ADDR_ALLOCA; }
+    if (def.opcode == mir.MIR_GEP && def.operand_count >= 2
+        && def.operands[1].kind == mir.MIR_OP_SYM) {
+        ret address_origin(e, mf, ?def.operands[1], out_ix);
+    }
+    ret ADDR_UNKNOWN;
+}
+
+# the instruction defining a vreg in this function, or nil when none does
+# ---
+# mf:   the MIR function
+# vreg: the vreg to find the definition of
+# ret:  the defining instruction, or nil
+fun defining_instr(mf: *mir.MirFunction, vreg: u32) *mir.MirInstr {
+    var bi: u32 = 0;
+    for (bi < mf.block_count) {
+        val blk: *mir.MirBlock = ?mf.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mir.instr_defines_shape(mi) && mi.operand_count > 0
+                && mi.operands[0].kind == mir.MIR_OP_VREG && mi.operands[0].vreg == vreg) {
+                ret mi;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret nil;
+}
+
+# the address operand index of a load or store
+#
+# A load addresses through operand 1 and a store through operand 0, the shared
+# convention that operand 0 of a store is its memory destination.
+# ---
+# mi:  the instruction
+# ret: the operand index carrying the address
+fun address_operand_index(mi: *mir.MirInstr) u32 {
+    if (mi.opcode == mir.MIR_LOAD) { ret 1; }
+    ret 0;
+}
+
+# whether a function materializes a vector by reading one out of a local allocation
 #
 # The signature of the vector-literal / zero-init lowering: an `alloca [4]f32`
 # written lane by lane, then a whole-vector `load f32x4` off the same pointer. The
-# vector-tagged load is the identifying part, since the allocation itself is an
-# ordinary array and carries no lane descriptor.
-# ---
-# An access that names a shader interface variable directly is excluded: that is a
-# vector arriving from or leaving through the pipeline, not one built out of a
-# reinterpreted allocation, and it is exactly what the interface support exists for.
+# ALLOCA origin is the identifying part. A vector arriving from or leaving through
+# an interface variable reads the same way at the instruction level but originates
+# in a global, and reporting it as a literal sent readers to the wrong problem.
 # ---
 # e:   the emission state
 # mf:  the MIR function
-# ret: true when a vector-typed load or store reads addressed memory
+# ret: true when a vector-typed load or store reads a local allocation
 fun builds_vector_through_memory(e: *Emit, mf: *mir.MirFunction) bool {
     var bi: u32 = 0;
     for (bi < mf.block_count) {
@@ -788,10 +945,10 @@ fun builds_vector_through_memory(e: *Emit, mf: *mir.MirFunction) bool {
             if ((mi.opcode == mir.MIR_LOAD || mi.opcode == mir.MIR_STORE)
                 && mir.vec_lane_is_vector(mi.vec_lane)
                 && mi.operand_count == 2) {
-                # a load addresses through operand 1, a store through operand 0.
-                var addr: u32 = 0;
-                if (mi.opcode == mir.MIR_LOAD) { addr = 1; }
-                if (interface_target(e, ?mi.operands[addr]) == 0) { ret true; }
+                var gix: u32 = 0;
+                if (address_origin(e, mf, ?mi.operands[address_operand_index(mi)], ?gix) == ADDR_ALLOCA) {
+                    ret true;
+                }
             }
             ii = ii + 1;
         }
@@ -1435,6 +1592,11 @@ fun ir_value_spv_type(e: *Emit, id: type.IrTypeId) u32 {
         if (elem == 0) { ret 0; }
         ret types.type_vector(e.tt, elem, t.data.vector_.lanes);
     }
+    if (t.kind == type.IRT_ARRAY) {
+        val elem: u32 = ir_value_spv_type(e, t.data.array_.element);
+        if (elem == 0) { ret 0; }
+        ret types.type_array(e.tt, elem, t.data.array_.count, false);
+    }
     ret 0;
 }
 
@@ -1554,26 +1716,77 @@ fun unsupported_ir_type(e: *Emit, id: type.IrTypeId, fallback: str) str {
     ret fallback;
 }
 
-# the interface variable an address operand names, or 0 when it names something else
+# the interface variable an address operand names WHOLE, or 0 otherwise
 #
-# Only a direct symbol reference resolves: an interface variable is read and written
-# by name, and anything that computes an address off it is genuine addressed memory
-# the milestone does not carry.
+# Only a direct symbol reference with no member displacement resolves: that is the
+# one shape SPIR-V can name outright, as an OpLoad or OpStore on the variable's id.
+# A displacement means a member walk and a register base means an address was
+# computed, and neither is something this milestone carries.
 # ---
 # e:   the emission state
 # op:  the address operand
 # ret: the OpVariable id, or 0
 fun interface_target(e: *Emit, op: *mir.MirOperand) u32 {
-    if (op.kind != mir.MIR_OP_SYM) { ret 0; }
+    if (op.kind != mir.MIR_OP_SYM || op.sym_off != 0) { ret 0; }
     ret global_var_id(e, op.sym);
 }
 
-# the diagnostic for an addressed access that is not a plain interface variable read
-# or write
+# the diagnostic for an addressed access the milestone cannot carry, named by what
+# the address actually originates in
+#
+# Three lowerings land here and each is fixed somewhere different, so each says so.
+# A member walk into a uniform block needs the GEP to keep its index list; a scalar
+# float interface variable needs the float address materialization to stop being
+# unconditional; anything else is ordinary addressed memory this milestone does not
+# have. Reporting any of them under another's name sends a reader to the wrong
+# problem, which is exactly what the first version of this did.
 # ---
+# e:   the emission state
+# mf:  the MIR function
+# op:  the address operand
 # ret: the diagnostic text
-fun addressed_memory_refusal() str {
-    ret "addressed memory is not yet supported by the SPIR-V target: a module-scope variable is reachable only when it carries a shader interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`), and only as a whole-variable read or write";
+fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand) str {
+    var gix: u32 = 0;
+    if (address_origin(e, mf, op, ?gix) != ADDR_GLOBAL) {
+        ret "addressed memory is not yet supported by the SPIR-V target: a module-scope variable is reachable only when it carries a shader interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`), and only as a whole-variable read or write";
+    }
+    val g: *ir.Global = ?e.ir.globals[gix];
+    if (g.iface == ir.IFACE_NONE) {
+        ret "a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`)";
+    }
+    if (g.iface == ir.IFACE_UNIFORM) {
+        ret "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL, and MIR has already folded the member walk into a byte displacement, which the ordinal cannot be recovered from in general. the block itself is declared correctly, with its Block decoration and member offsets; only the member read is missing";
+    }
+    if (is_scalar_float_type(e, g.ty)) {
+        ret "a scalar `f32` / `f64` shader interface variable is not yet supported by the SPIR-V target: MIR materializes a FLOAT variable's address into a register before loading or storing it, which loses the direct reference SPIR-V needs, while an integer or vector variable keeps it. an `f32x4` or an `i32` interface variable of the same role works today";
+    }
+    if (is_aggregate_type(e, g.ty)) {
+        ret "indexing into an aggregate shader interface variable is not yet supported by the SPIR-V target: SPIR-V reaches an element through an OpAccessChain naming its ORDINAL, and MIR has already folded the walk into a byte displacement, which the ordinal cannot be recovered from in general. the variable itself is declared correctly; read or write it whole";
+    }
+    ret "this shader interface variable is reachable only as a whole-variable read or write in the SPIR-V target";
+}
+
+# whether an IR type is an aggregate reached by indexing
+# ---
+# e:   the emission state
+# id:  the IR type id
+# ret: true for an array or a struct
+fun is_aggregate_type(e: *Emit, id: type.IrTypeId) bool {
+    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
+    if (O.is_none[*type.IrType](opt)) { ret false; }
+    val k: type.IrTypeKind = O.unwrap[*type.IrType](opt).kind;
+    ret k == type.IRT_ARRAY || k == type.IRT_STRUCT;
+}
+
+# whether an IR type is a scalar float
+# ---
+# e:   the emission state
+# id:  the IR type id
+# ret: true for IRT_FLOAT
+fun is_scalar_float_type(e: *Emit, id: type.IrTypeId) bool {
+    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
+    if (O.is_none[*type.IrType](opt)) { ret false; }
+    ret O.unwrap[*type.IrType](opt).kind == type.IRT_FLOAT;
 }
 
 # emit an OpLoad of a shader interface variable
@@ -1583,12 +1796,12 @@ fun addressed_memory_refusal() str {
 # preg_val: the identity convention's nominal register file
 # mi:       the MIR_LOAD instruction ([dst, address])
 # ret:      true on success, or a precise error string
-fun emit_global_load(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
-        ret unsupported(e, addressed_memory_refusal());
+        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0]));
     }
     val var_id: u32 = interface_target(e, ?mi.operands[1]);
-    if (var_id == 0) { ret unsupported(e, addressed_memory_refusal()); }
+    if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1])); }
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n || vm.type_id[dst] == 0) {
         ret R.err[bool, str]("spirv.emit: interface load result vreg has no type");
@@ -1611,10 +1824,10 @@ fun emit_global_load(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R
 # preg_val: the identity convention's nominal register file
 # mi:       the MIR_STORE instruction ([address, value])
 # ret:      true on success, or a precise error string
-fun emit_global_store(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
-    if (mi.operand_count != 2) { ret unsupported(e, addressed_memory_refusal()); }
+fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count != 2) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
     val var_id: u32 = interface_target(e, ?mi.operands[0]);
-    if (var_id == 0) { ret unsupported(e, addressed_memory_refusal()); }
+    if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
     val value_ty: u32 = interface_value_type(e, ?mi.operands[0]);
     val value: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], value_ty);
     if (e.b.err || value == 0) { ret R.err[bool, str]("spirv.emit: unreadable value in an interface store"); }
@@ -1763,13 +1976,15 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # addressed memory the milestone supports, and it is supported because it is not
     # really addressing: an interface variable is named directly, so the access is an
     # OpLoad or OpStore on the variable's id with no address computed at all.
-    if (op == mir.MIR_LOAD)  { ret emit_global_load(e, vm, preg_val, mi); }
-    if (op == mir.MIR_STORE) { ret emit_global_store(e, vm, preg_val, mi); }
-    if (op == mir.MIR_GEP && mi.operand_count >= 2 && interface_target(e, ?mi.operands[1]) != 0) {
-        ret unsupported(e, "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL, and MIR has already folded the member walk into a byte displacement, which the ordinal cannot be recovered from in general. the block itself is declared correctly, with its Block decoration and member offsets; only the member read is missing. bind the whole block and read it as one value, or wait for the GEP to keep its index list");
+    if (op == mir.MIR_LOAD)  { ret emit_global_load(e, mf, vm, preg_val, mi); }
+    if (op == mir.MIR_STORE) { ret emit_global_store(e, mf, vm, preg_val, mi); }
+    # a GEP that survives to here computed an address, which the milestone carries
+    # in no form; the refusal names what the address originates in.
+    if (op == mir.MIR_GEP && mi.operand_count >= 2) {
+        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
     }
     if (op == mir.MIR_ALLOCA || op == mir.MIR_GEP) {
-        ret unsupported(e, addressed_memory_refusal());
+        ret unsupported(e, "a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live");
     }
 
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -86,6 +86,7 @@ val TAG_BOOL:  u8 = 2;  # OpTypeBool
 val TAG_VOID:  u8 = 3;  # OpTypeVoid
 val TAG_PTR:   u8 = 4;  # OpTypePointer, `a` = storage class, `b` = pointee id
 val TAG_VEC:   u8 = 5;  # OpTypeVector, `a` = component type id, `b` = component count
+val TAG_ARRAY: u8 = 6;  # OpTypeArray (no explicit layout), `a` = element type id, `b` = length
 
 # the largest component count a Shader module may give an OpTypeVector
 #
@@ -315,6 +316,37 @@ pub fun vector_shape(tt: *TypeTable, id: u32, out_count: *u32) u32 {
         i = i + 1;
     }
     ret 0;
+}
+
+# the id of the array type of `count` elements of `elem`, emitting it on first use
+#
+# SPIR-V takes an array's length as a CONSTANT id rather than a literal, so the
+# length is minted as a 32-bit integer constant first.
+#
+# `explicit_layout` decides whether the result is interned. An array inside a
+# uniform block must carry an `ArrayStride` decoration and an array outside one must
+# not, so the two cannot share an id - the same split, and for the same reason, as
+# a Block-decorated struct. A laid-out array is therefore minted fresh and its
+# caller decorates it; a plain array is interned like any other type.
+# ---
+# tt:              the table
+# elem:            the element type id
+# count:           the number of elements
+# explicit_layout: whether the result will carry an ArrayStride decoration
+# ret:             the OpTypeArray id, or 0 when the count is zero
+pub fun type_array(tt: *TypeTable, elem: u32, count: u32, explicit_layout: bool) u32 {
+    if (count == 0) { ret 0; }
+    if (!explicit_layout) {
+        val hit: u32 = scalar_find(tt, TAG_ARRAY, elem, count);
+        if (hit != 0) { ret hit; }
+    }
+    val len_id: u32 = const_int(tt, 32, count::i64);
+    val id: u32 = spirv.alloc_id(tt.b);
+    var ops: [3]u32;
+    ops[0] = id; ops[1] = elem; ops[2] = len_id;
+    spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_ARRAY, ?ops[0], 3);
+    if (!explicit_layout) { scalar_put(tt, TAG_ARRAY, elem, count, id); }
+    ret id;
 }
 
 # the id of the struct type over `members`, emitting it on first use
@@ -697,6 +729,38 @@ test "mach.lang.target.isa.spirv.types:vector_shapes_and_limit" {
     if (c1 == 0) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
     if (const_composite(?tt, v4f, ?p1[0], 4) != c1) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
     if (const_composite(?tt, v4f, ?p2[0], 4) == c1) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+
+    types_dnit(?tt);
+    spirv.builder_dnit(?b);
+    ret 0;
+}
+
+test "mach.lang.target.isa.spirv.types:array_layout_identity" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var b: spirv.Builder = spirv.builder_init(?alloc);
+    var tt: TypeTable = types_init(?b);
+
+    val v4f: u32 = type_vector(?tt, type_float(?tt, 32), 4);
+
+    # a plain array interns: the same shape asked for twice is one type.
+    val a1: u32 = type_array(?tt, v4f, 4, false);
+    if (a1 == 0) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+    if (type_array(?tt, v4f, 4, false) != a1) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+    # a different length is a different type.
+    if (type_array(?tt, v4f, 2, false) == a1) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+
+    # an explicitly-laid-out array must NOT share the interned id: it carries an
+    # ArrayStride decoration and the plain one must not, so one id cannot serve both.
+    val laid: u32 = type_array(?tt, v4f, 4, true);
+    if (laid == 0 || laid == a1) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+    # nor may two laid-out arrays share, since their strides may differ.
+    if (type_array(?tt, v4f, 4, true) == laid) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+    # and minting a laid-out array must not poison the interned cache.
+    if (type_array(?tt, v4f, 4, false) != a1) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
+
+    # a zero-length array is not a type SPIR-V has.
+    if (type_array(?tt, v4f, 0, false) != 0) { types_dnit(?tt); spirv.builder_dnit(?b); ret 1; }
 
     types_dnit(?tt);
     spirv.builder_dnit(?b);


### PR DESCRIPTION
D and E from the assessment, as two self-contained commits. F (GLSL.std.450) is untouched, as agreed — it needs the naming-surface decision first.

Neither item has an issue number. **D** (cross-wired refusals) was the SPIR-V track's own defect, reported in its shader-path assessment and fixed directly rather than filed first. **E** (`OpTypeArray` + `ArrayStride`) was likewise assigned from that assessment without an issue.

Deliberately **no `Closes` line**, since neither item has an issue to close. An earlier draft of this body guessed a number; it named an unrelated issue owned by another track, so it is gone rather than corrected in place — a wrong number reads as authoritative and would have cross-linked that issue from here.

Refs #2649 and #2655, whose refusals this makes legible without fixing either.

---

## Commit 1 — every refusal now names its own cause

**The defect.** Three lowerings reach this back end as an address it cannot carry, and each is fixed somewhere different. All three were reported under each other's names:

| you wrote | you were told | should have been told |
|---|---|---|
| `#[input(0)] var a: f32;` | *"reading a member of a `#[uniform(...)]` block"* | scalar float interface variable (#2655) |
| `cam.tint` where `tint: f32x4` | *"constructing a vector from a literal"* | uniform block member (#2649) |

Neither mentions a uniform or a literal respectively. A vague message wastes a minute; a confidently wrong one sends someone to the wrong issue.

**Why it happened, and why the fix is not a bigger `if`.** I classified by the *shape* of the instruction, which cannot work here:

- an address materialization and a member walk are **both** `MIR_GEP` off a symbol
- a member at offset 0 carries the **same zero displacement** an address materialization does
- the vector pre-scan ran first and claimed anything vector-shaped

What actually separates them is where the address **originates**. That is now resolved directly — one level through the `MIR_GEP` or `MIR_ALLOCA` that defined the address register — and every refusal keys on it. Six causes, each saying what it is and where it gets fixed: uniform block member; aggregate interface variable indexed (same root cause); scalar `f32`/`f64` interface variable; vector built through a local allocation; a plain global with no interface role, which a shader has no storage for at all; and ordinary addressed memory.

`interface_target` also now rejects a symbol carrying a member displacement instead of accepting it as a whole-variable reference — that was what let a member walk reach the whole-variable path to begin with.

**No behaviour change.** Every shape that compiled still compiles; every shape that was refused is still refused. Only the messages moved.

---

## Commit 2 — `OpTypeArray` and recursive uniform block layout

mach has no matrix type by design (types.md puts one in a library over vectors), so a mat4 is `[4]f32x4` — which means arrays are the gate on a uniform block carrying a transform.

```
OpDecorate %_arr_v4float_uint_4 ArrayStride 16
OpMemberDecorate %_struct_8 0 Offset 0
OpMemberDecorate %_struct_8 1 Offset 64
OpDecorate %_struct_8 Block
```

**The one real design point:** an array in an explicitly-laid-out storage class **must** carry `ArrayStride`, and an array outside one **must not**. So the two cannot share a type id. A laid-out array is minted fresh and decorated by its caller; a plain array is interned — the same split, for the same reason, as a Block-decorated struct. The type-table test pins both halves: minting a laid-out array must neither reuse the interned id nor poison the interned cache.

Block layout is now recursive: an array member gets its stride, a nested record gets its own member offsets, and **only the outermost struct is decorated `Block`**, since that marks the descriptor's root rather than every struct beneath it.

**Why `[4]f32` is refused rather than repacked.** A uniform block's array stride rounds up to 16; mach's layout packs at the element's natural size. Repacking to satisfy Vulkan would silently move the members out from under a host writing the block by `$offset_of`. Every offset and stride here comes from the compiler's own layout precisely so the two agree, so the mismatch is reported instead, naming the shape that already has the right stride.

---

## Checks

- `mach test .` — **1229 passed, 0 failed** (adds a type-table test for array layout identity)
- `int/run.sh --target linux` — full suite green; `spirv-interface` extended with a matrix-shaped block and a nested record, still validated against `vulkan1.3`
- self-host fixpoint: stage b == stage c, byte-identical

Also fixes the stale `.github/skills/mach/SKILL.md` claim that vector type names do not resolve yet, as you asked me to do in passing.

## Not done, deliberately

`f32x4` matrix members are now *declarable and bindable*, but reading one still needs #2649 — arrays alone do not deliver an MVP transform, exactly as flagged in the assessment. #2655 (scalar float interface variables) and #2640 are untouched middle-end work.

