### PR TITLE
fix(link): attribute #[library] from the compiled set, not every loaded module

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11830,6 +11830,170 @@ fun ut_attr_probe(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
     ret R.ok[str, outcome.Fail](out);
 }
 
+# ut_attr_probe over the whole-source loader, so the fixture's orphan modules are
+# LOADED without being COMPILED - the state #2539 made routine and #2657 scoped
+# attribution against
+#
+# `build_project_test` sets all_own_src (every module under src becomes a load
+# root) while the internal default request keeps GOAL_EXECUTE, so `emit_len` stays
+# at the artifact's closure. That combination is what makes loaded-but-not-compiled
+# reachable from a test; plain `build_project` never loads an orphan at all, and a
+# real `mach test` compiles every module it loads.
+fun ut_attr_probe_allsrc(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str,
+                         n: u32, target_name: str, sym: str) R.Result[str, outcome.Fail] {
+    val root_r: R.Result[str, str] = ut_scaffold(alloc, names, texts, n);
+    if (R.is_err[str, str](root_r)) {
+        ret R.err[str, outcome.Fail](outcome.user(R.unwrap_err[str, str](root_r)));
+    }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) {
+        fs.remove_all(alloc, root);
+        ret R.err[str, outcome.Fail](outcome.user(R.unwrap_err[bool, str](rr)));
+    }
+
+    var sel: manifest.Selection;
+    sel.target = target_name; sel.profile = ""; sel.artifact = "";
+    sel.want_lib = false; sel.has_artifact = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(s, root, ?sel);
+    fs.remove_all(alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        ret R.err[str, outcome.Fail](R.unwrap_err[project.Project, outcome.Fail](pr));
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    # the fixture is only meaningful while some loaded module is not compiled; a
+    # probe where the two sets coincide would pass whatever the pass walked. this
+    # compares against module_len rather than topo_len so it holds for both kinds of
+    # exclusion: a plain orphan sits in topo past emit_len, while a target-gated one
+    # is kept out of topo altogether and only module_len still counts it
+    if (p.emit_len >= p.module_len) {
+        project.dnit_project(?p);
+        ret R.err[str, outcome.Fail](outcome.user("fixture loaded no uncompiled module"));
+    }
+
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](se)) {
+        project.dnit_project(?p);
+        ret R.err[str, outcome.Fail](R.unwrap_err[bool, outcome.Fail](se));
+    }
+    val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+    if (R.is_err[bool, outcome.Fail](le)) {
+        project.dnit_project(?p);
+        ret R.err[str, outcome.Fail](R.unwrap_err[bool, outcome.Fail](le));
+    }
+
+    var out: str = "";
+    val sid: R.Result[intern.StrId, str] = intern.intern(?s.interner, sym);
+    if (R.is_ok[intern.StrId, str](sid)) {
+        val got: O.Option[intern.StrId] =
+            session.import_library(s, R.unwrap_ok[intern.StrId, str](sid));
+        if (O.is_some[intern.StrId](got)) {
+            val nm: O.Option[str] = intern.lookup(?s.interner, O.unwrap[intern.StrId](got));
+            if (O.is_some[str](nm)) { out = O.unwrap[str](nm); }
+        }
+    }
+    project.dnit_project(?p);
+    ret R.ok[str, outcome.Fail](out);
+}
+
+# an attribution from a module no artifact compiles must not be projected at all
+# (#2657)
+#
+# This is the direct form of the decision: attribution follows the COMPILED set.
+# The orphan here carries the only `#[library]` in the tree, so a pass that walked
+# every loaded module reports 'user32' and a pass scoped to `emit_len` reports
+# nothing. Asserting the absence rather than a conflict is what separates "the
+# attribution is not projected" from "the conflict check stopped looking".
+test "mach.lang.driver:uncompiled_module_attribution_not_projected" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str; names[0] = "main.mach"; names[1] = "orphan.mach";
+    var texts: [2]str;
+    # main imports nothing, so orphan is loaded as a src root and never compiled
+    texts[0] = "fun main() i32 { ret 0; }\n";
+    texts[1] = "#[library(\"user32\")]\next fun Sleep(ms: u32);\npub fun call() { Sleep(0); }\n";
+
+    var bad: i32 = 0;
+    val pr: R.Result[str, outcome.Fail] =
+        ut_attr_probe_allsrc(?s, ?alloc, ?names[0], ?texts[0], 2, "linux", "Sleep");
+    if (R.is_err[str, outcome.Fail](pr)) { bad = 1; }
+    or {
+        val got: str = R.unwrap_ok[str, outcome.Fail](pr);
+        if (!str_equals(got, "")) { bad = 1; }
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# when a compiled and an uncompiled module disagree, the compiled one wins outright
+# rather than the pair being a conflict (#2657)
+#
+# Before scoping, this was a hard error: a module nothing links could break a build
+# by naming a library. The assertion is the surviving attribution, not merely that
+# the build succeeded, so a fix that dropped both would fail here.
+test "mach.lang.driver:compiled_module_wins_over_uncompiled_attribution" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str; names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "orphan.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a;\nfun main() i32 { a.call(); ret 0; }\n";
+    texts[1] = "#[library(\"kernel32\")]\next fun Sleep(ms: u32);\npub fun call() { Sleep(0); }\n";
+    texts[2] = "#[library(\"user32\")]\next fun Sleep(ms: u32);\npub fun call() { Sleep(0); }\n";
+
+    var bad: i32 = 0;
+    val pr: R.Result[str, outcome.Fail] =
+        ut_attr_probe_allsrc(?s, ?alloc, ?names[0], ?texts[0], 3, "linux", "Sleep");
+    if (R.is_err[str, outcome.Fail](pr)) { bad = 1; }
+    or {
+        val got: str = R.unwrap_ok[str, outcome.Fail](pr);
+        if (!str_equals(got, "kernel32")) { bad = 1; }
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# a module the build excluded as target-gated must not attribute either (#2657)
+#
+# Its own top-level `$error` guard fired, so the driver already keeps it out of
+# topo and no other pass touches it. Attribution was the one pass that still read
+# it, which made an excluded module able to fail the build.
+test "mach.lang.driver:target_gated_module_does_not_attribute" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str; names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "gated.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a;\nfun main() i32 { a.call(); ret 0; }\n";
+    texts[1] = "#[library(\"kernel32\")]\next fun Sleep(ms: u32);\npub fun call() { Sleep(0); }\n";
+    texts[2] = "$if ($mach.build.os != $mach.os.darwin) {\n    $error(\"uniontest.gated: darwin only\");\n}\n\n#[library(\"user32\")]\next fun Sleep(ms: u32);\npub fun call() { Sleep(0); }\n";
+
+    var bad: i32 = 0;
+    val pr: R.Result[str, outcome.Fail] =
+        ut_attr_probe_allsrc(?s, ?alloc, ?names[0], ?texts[0], 3, "linux", "Sleep");
+    if (R.is_err[str, outcome.Fail](pr)) { bad = 1; }
+    or {
+        val got: str = R.unwrap_ok[str, outcome.Fail](pr);
+        if (!str_equals(got, "kernel32")) { bad = 1; }
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 # two `ext` declarations pinning one link name to different libraries must be a
 # hard error naming both, not a silent load-order win (#2529). the session's
 # attribution map overwrites on a repeated key, so before the check which library

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -426,12 +426,29 @@ rec ImportAttribution {
 # paths (#2510) - the session map overwrites on a repeated key, so without this
 # the emitted import table would depend on module load order (#2529). an
 # identical repeat is accepted, exactly as a repeated manifest claim is.
+#
+# Only the COMPILED set attributes: `topo[0..emit_len)`, not every loaded module
+# (#2657). An attribution is a link fact - it routes a symbol to a providing
+# library - and a module this build does not compile contributes no symbol for it
+# to route. Walking the loaded set instead let a module nothing links pin an
+# import, and conflict with one that does. This is #2639's rule at module
+# granularity: that fix established that only the comptime arm the target SELECTS
+# may attribute, and a module outside the artifact's closure is unselected for the
+# same reason. It also excludes a target-gated module, which the build had already
+# excluded from every other pass by keeping it out of topo.
+#
+# The cost is that the same source can attribute differently depending on which
+# artifact is selected. That is already true across targets by #2639 and is the
+# intended reading: an attribution describes a link, and the link is what varies.
+# Consistency of the DECLARATION is not lost either - a conflict between two
+# modules that are compiled together is still a hard error.
 pub fun register_import_libraries(p: *project.Project) R.Result[bool, str] {
     var attrs: map.Map[intern.StrId, ImportAttribution] =
         map.init[intern.StrId, ImportAttribution](p.alloc, map.hash_u32, map.eq_u32);
-    var i: u32 = 0;
-    for (i < p.module_len) {
-        val m: *project.ModuleEntry = ?p.modules[i];
+    var ti: u32 = 0;
+    for (ti < p.emit_len) {
+        val mid: session.ModuleId = p.topo[ti];
+        val m: *project.ModuleEntry = ?p.modules[mid::u32];
         val m_opt: O.Option[*module.Module] = ast.get_module(m.a, m.a.root_module);
         if (O.is_some[*module.Module](m_opt)) {
             val mod_node: *module.Module = O.unwrap[*module.Module](m_opt);
@@ -444,14 +461,14 @@ pub fun register_import_libraries(p: *project.Project) R.Result[bool, str] {
             if (O.is_some[*src.SourceFile](src_opt)) {
                 source = O.unwrap[*src.SourceFile](src_opt).text;
             }
-            val r: R.Result[bool, str] = bind_import_libraries(p, i::session.ModuleId,
+            val r: R.Result[bool, str] = bind_import_libraries(p, mid,
                 source, ?attrs, mod_node.decls_start, mod_node.decls_len);
             if (R.is_err[bool, str](r)) {
                 map.dnit[intern.StrId, ImportAttribution](?attrs);
                 ret r;
             }
         }
-        i = i + 1;
+        ti = ti + 1;
     }
     map.dnit[intern.StrId, ImportAttribution](?attrs);
     ret R.ok[bool, str](true);


### PR DESCRIPTION
Closes #2657

## The decision

**Attribution follows the compiled set: `topo[0..emit_len)`.**

An attribution is a *link* fact. `#[library("kernel32")]` says how to route a symbol to a providing library, and a module this build does not compile contributes no symbol for it to route. Walking the loaded set let a module nothing links pin an import, and conflict with one that does.

This is #2639's rule applied at module granularity. That fix established that only the comptime arm the target *selects* may attribute; a module outside the artifact's closure is unselected for the same reason. Keeping the loaded set would have meant fixing the within-module case and leaving the across-module case broken, which #2539 had just made common rather than rare.

### The argument against, and why it loses

The case for the loaded set is that an attribution is a property of the declaration, so narrowing means one source can attribute differently depending on which artifact is selected.

That is true, and it is the intended reading rather than a cost to avoid. It is already true across targets by #2639: the same source attributes to `kernel32` on windows and `c` on linux. An attribution describes a link, and the link is the thing that varies. What would be alarming is the *declaration's* consistency changing, and that is preserved: two modules compiled together that disagree are still a hard error, so #2529's conflict detection and #2630's exclusive-arm exemption both hold unchanged.

The stability the counter-argument wants is also not on offer from the status quo. The loaded set already varies with artifact selection, because a dependency's modules are loaded only when reachable. So the choice was never "stable versus varying", only "varies for a principled reason or an incidental one".

### What settled it

A module the build had **already excluded** still broke the build:

```mach
$if ($mach.build.arch != $mach.arch.aarch64) {
    $error("att.orphan: requires aarch64");
}
#[library("m")]
ext fun abs(v: i32) i32;
```

```
$ mach build .
error: import 'abs' is attributed to library 'c' by declaration 'abs' in module 'att.main'
and to library 'm' by declaration 'abs' in module 'att.orphan'; a symbol may name only one
providing library
```

That module is target-gated. Its own guard fired, and the driver deliberately keeps it out of `topo` so that "resolve / sema / lower / codegen all walk topo, so the module is never touched". Attribution was the one pass still reading it. There is no reading of the decision under which that is correct.

### Walking the wider set was never load-bearing

Worth recording, because it means nothing was lost. An uncompiled module's import is never referenced by any emitted object, so its attribution reached neither the import table nor the "pinned to library X not among the link's dependencies" validation. I checked both on ELF and PE:

```
# only attribution in the tree lives in an uncompiled module, naming an undeclared library
$ mach build .                    -> exit 0   (before and after)
$ mach build . --target windows   -> exit 0   (before and after)
```

Its sole observable effect was to fail a build through the conflict check.

## Evidence

Repro, with a compiled `att.main` pinning `abs` to `c` and an unreferenced `att.orphan` pinning it to `m`:

```
before:  error: import 'abs' is attributed to ... a symbol may name only one providing library
after:   exit 0, and only att/main.o is emitted
```

Two *compiled* modules disagreeing still errors, so this is a narrowing rather than a removal:

```
$ mach build .        # entry now imports att.other
error: import 'abs' is attributed to library 'm' by declaration 'abs' in module 'att.other'
and to library 'c' by declaration 'abs' in module 'att.main'; ...
```

### New assertions, each demonstrated failing first

Against the unfixed pass (restored to walk `p.module_len`):

```
failures:
  mach.lang.driver:uncompiled_module_attribution_not_projected
  mach.lang.driver:compiled_module_wins_over_uncompiled_attribution
  mach.lang.driver:target_gated_module_does_not_attribute
7 passed, 3 failed, 10 total
```

The first is the load-bearing one: the orphan carries the *only* `#[library]` in the tree, so the probe reports `user32` before and nothing after. Asserting the absence rather than a conflict is what separates "the attribution is not projected" from "the conflict check stopped looking". The second asserts the surviving attribution is `kernel32` rather than merely that the build succeeded, so a fix that dropped both attributions would fail it.

### On reaching the loaded-but-not-compiled state from a test

`build_project` never loads an orphan, and a real `mach test` compiles every module it loads, so neither reaches the state. The new probe uses `build_project_test`, which sets `all_own_src` while the internal default request keeps `GOAL_EXECUTE`, leaving `emit_len` at the artifact's closure. The probe asserts `emit_len < module_len` up front and fails the fixture otherwise, so a test that stopped exercising the split would say so instead of passing vacuously. It compares against `module_len` rather than `topo_len` deliberately: a plain orphan sits in `topo` past `emit_len`, while a target-gated one is kept out of `topo` altogether.

## Status

- `mach test .`: 1231 passed, 0 failed
- linux integration suite: all cases passed
- self-host fixpoint: holds, stage2 and stage3 byte-identical
