### PR TITLE
fix(lower): allocate vector storage at the vector's own type

### DIFF
--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2557,6 +2557,14 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
             if (ct.kind == ir_type.IRT_ARRAY) {
                 stride = ir_type.byte_size(ctx.types, ct.data.array_.element, ctx.tgt)::u64;
                 cur_ty = ct.data.array_.element;
+            } or (ct.kind == ir_type.IRT_VECTOR) {
+                # a vector indexes by LANE, at the element's stride: its storage is
+                # exactly `lanes` elements end to end, the same walk an array of the
+                # element type takes. Vector storage is allocated at the vector's own
+                # type rather than reshaped to `[lanes]elem` (#2640), so this is the
+                # level a lane address descends through.
+                stride = ir_type.byte_size(ctx.types, ct.data.vector_.element, ctx.tgt)::u64;
+                cur_ty = ct.data.vector_.element;
             } or (ct.kind == ir_type.IRT_STRUCT || ct.kind == ir_type.IRT_UNION) {
                 is_struct = true;
             } or {

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1196,11 +1196,14 @@ fun ut_vector_local_wellformed(p: *project.Project) i32 {
                     var ix: u32 = 0;
                     for (ix < blk.instr_count) {
                         val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
+                        # the zero fill is a SIZED memzero of the local's own storage,
+                        # and that storage is now the vector type itself rather than an
+                        # `[lanes]elem` reshape of it (#2640). the shape is not what
+                        # #2043 is about; the constant check below is.
                         if (ins.kind == instruction.OP_MEMZERO) {
                             seen_memzero = true;
-                            if (ir_type.is_vector(?m.types, ins.aux_ty)) { bad = true; }
+                            if (!ir_type.is_vector(?m.types, ins.aux_ty)) { bad = true; }
                         }
-                        if (ins.kind == instruction.OP_GEP && ir_type.is_vector(?m.types, ins.aux_ty)) { bad = true; }
                         var oi: u32 = 0;
                         for (oi < ins.operand_count) {
                             if (ins.operands[oi].kind == value.VAL_CONST_INT
@@ -1221,11 +1224,92 @@ fun ut_vector_local_wellformed(p: *project.Project) i32 {
     ret 0;
 }
 
-# an uninitialized vector local default-initializes to all-zero lanes through the
-# aggregate memzero over its array-shaped storage, on all three targets' pipelines
-# -- never the scalar zero_const that produced a vector-typed constant the verifier
-# rejected (#2043). the program reads a lane no write touched, so the memzero must
-# stay live; it holds no vector operator, so it lowers clean on every target
+# no vector value is loaded out of an allocation of a different type (#2640)
+#
+# The defect this pins is a TYPE LIE, not an inefficiency: a vector literal and an
+# uninitialized vector local allocated `[lanes]elem` and then read the slot back with
+# a whole-vector load, so the allocation was reinterpreted through its pointer. A
+# target under a logical addressing model gives a pointer exactly one pointee type
+# and has no pointer bitcast, so it cannot encode that at all -- and on every target
+# it under-aligned the storage, since the reshaped array carried the ELEMENT's
+# alignment (4 for f32) where the vector declares 16.
+#
+# The assertion is the property rather than the mechanism: every vector-typed load
+# whose address is an alloca must load that alloca's own type. It stays true of any
+# later lowering that removes the memory entirely, which the round trip still here is
+# a separate change to fix.
+# ---
+# p:   the lowered project
+# ret: 0 when no vector load reinterprets its allocation, 1 otherwise
+fun ut_vector_load_matches_alloca(p: *project.Project) i32 {
+    var mi: u32 = 0;
+    for (mi < p.module_len) {
+        val me: *project.ModuleEntry = ?p.modules[mi];
+        if (me.ir_module == nil) { mi = mi + 1; cnt; }
+        val m: *ir.Module = me.ir_module;
+        var fi: u32 = 0;
+        for (fi < m.function_len) {
+            val fn: *ir.Function = ?m.functions[fi];
+            var ii: u32 = 0;
+            for (ii < fn.instr_len) {
+                val ins: *instruction.Instruction = ?fn.instrs[ii];
+                if (ins.kind == instruction.OP_LOAD && ir_type.is_vector(?m.types, ins.ty)
+                    && ins.operand_count >= 1 && ins.operands[0].kind == value.VAL_INSTR) {
+                    val did: ir.InstructionId = ins.operands[0].data.instr;
+                    if (did != ir.INSTR_NIL && did::u32 < fn.instr_len) {
+                        val def: *instruction.Instruction = ?fn.instrs[did];
+                        if (def.kind == instruction.OP_ALLOCA && def.aux_ty != ins.ty) { ret 1; }
+                    }
+                }
+                ii = ii + 1;
+            }
+            fi = fi + 1;
+        }
+        mi = mi + 1;
+    }
+    ret 0;
+}
+
+# a vector literal and an uninitialized vector local allocate storage of the
+# vector's own type (#2640)
+#
+# Checked on linux-arm64 ONLY, and that is the point rather than a shortcut. It is
+# the target that declares `has_lane_ops`, so `scalarize.expand_lane_ops` returns
+# early and vectors survive lowering intact -- the same path a logical-addressing
+# target takes. Every other target runs the scalar expansion, which DELIBERATELY
+# represents a vector as `[lanes]elem` in memory because it has no vector register
+# class at all. Asserting there would be asserting against that pass's whole job.
+test "mach.lang.driver:vector_storage_is_not_reinterpreted" {
+    val src: str = "fun mk(o: *f32x4, d: f32) { val k: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; var z: f32x4; val b: f32x4 = f32x4{d, d, d, d}; @o = k + z + b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { mk(argv:~*f32x4, 1.0); ret 0; }\n";
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, src, "linux-arm64");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (ut_vector_load_matches_alloca(?p) != 0) { bad = 1; }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# an uninitialized vector local default-initializes to all-zero lanes through a
+# sized memzero of storage carrying the VECTOR's own type, on all three targets'
+# pipelines -- never the scalar zero_const that produced a vector-typed constant the
+# verifier rejected (#2043). the program reads a lane no write touched, so the
+# memzero must stay live; it holds no vector operator, so it lowers clean on every
+# target
+#
+# The invariant #2043 needs is the constant check: no VAL_CONST_INT operand may
+# carry a vector type. The storage SHAPE is a separate decision, and it changed with
+# #2640 -- the local is allocated at the vector type instead of being reshaped to
+# `[lanes]elem` and read back through its pointer, which is a reinterpretation a
+# logical-addressing target cannot express. So the memzero is now asserted to be
+# over the vector rather than away from it, and a lane gep into vector storage is no
+# longer a failure.
 test "mach.lang.driver:vector_local_default_init" {
     val src: str = "fun f(o: *i32) { var v: i32x4; @o = v[2]; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(argv:~*i32); ret 0; }\n";
     var targets: [3]str;

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3186,11 +3186,14 @@ fun lower_array_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R
 
 # lower a full-arity vector literal `f32x4{a, b, c, d}` (#1965)
 #
-# A vector is register-class, so it cannot be addressed lane-wise like an
-# aggregate; the lanes are assembled through array-shaped backing storage (same
-# 16-byte layout) and loaded back as the vector value. The resulting IRT_VECTOR
-# value flows to the target-generic isel guard until a backend wires real
-# construction.
+# The lanes are assembled through backing storage of the vector's OWN type and
+# loaded back as the vector value. Allocating `[lanes]elem` instead would have the
+# same 16-byte layout, but it makes the load a reinterpretation of the allocation
+# through its pointer: the slot is an array and the load reads a vector. A target
+# under a logical addressing model gives a pointer exactly one pointee type and has
+# no pointer bitcast, so it cannot express that at all (#2640). The lane gep and the
+# whole-vector load of a vector-typed slot are the same shape lane assignment onto a
+# `var` already lowers to, so nothing downstream is new.
 # ---
 # ctx: per-module lowering context
 # eid: the vector-literal expression (supplies the vector type)
@@ -3207,19 +3210,11 @@ fun lower_vector_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) 
     if (O.is_none[*ir_type.IrType](opt_vt)) { ret R.err[value.Value, str]("lower: vector literal type is not an IR vector"); }
     val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_vt);
     if (vt.kind != ir_type.IRT_VECTOR) { ret R.err[value.Value, str]("lower: vector literal type is not an IR vector"); }
-    val elem_ir: ir_type.IrTypeId = vt.data.vector_.element;
-    val lanes:   u32              = vt.data.vector_.lanes;
-
-    # array-shaped backing storage; a `[lanes]elem` alloca has the vector's layout.
-    val res_arr_ir: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?ctx.m.types, elem_ir, lanes);
-    if (R.is_err[ir_type.IrTypeId, str](res_arr_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_arr_ir)); }
-    val arr_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_arr_ir);
-
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
     val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
 
-    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, arr_ir, value.const_int(1, xty));
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, vec_ir, value.const_int(1, xty));
     if (R.is_err[value.Value, str](res_slot)) { ret res_slot; }
     val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
 
@@ -3236,7 +3231,7 @@ fun lower_vector_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) 
         var idx: [2]value.Value;
         idx[0] = value.const_int(0, xty);
         idx[1] = value.const_int(i::u64, xty);
-        val res_gep: R.Result[value.Value, str] = builder.emit_gep(?ctx.builder, slot, arr_ir, ?idx[0], 2);
+        val res_gep: R.Result[value.Value, str] = builder.emit_gep(?ctx.builder, slot, vec_ir, ?idx[0], 2);
         if (R.is_err[value.Value, str](res_gep)) { ret res_gep; }
         val res_store: R.Result[bool, str] = builder.emit_store(?ctx.builder, R.unwrap_ok[value.Value, str](res_elem), R.unwrap_ok[value.Value, str](res_gep));
         if (R.is_err[bool, str](res_store)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_store)); }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -442,22 +442,14 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
     }
     val slot_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_slot_ty);
 
-    # a vector local is backed by array-shaped storage (`[lanes]elem`, the same
-    # 16-byte layout the literal and lane-access paths use): a register-class
-    # IRT_VECTOR is not address-typed, so it can be neither default-initialized
-    # through the aggregate memzero path nor lane-addressed by a gep. the array
-    # shape makes vector storage consistent with every other vector storage site
-    # (#1965/#2043). `slot_ty` stays the vector for the source-level debug type.
-    var storage_ty: ir_type.IrTypeId = slot_ty;
-    if (ir_type.is_vector(?ctx.m.types, slot_ty)) {
-        val opt_vt: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, slot_ty);
-        if (O.is_some[*ir_type.IrType](opt_vt)) {
-            val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_vt);
-            val res_arr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?ctx.m.types, vt.data.vector_.element, vt.data.vector_.lanes);
-            if (R.is_err[ir_type.IrTypeId, str](res_arr)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_arr)); }
-            storage_ty = R.unwrap_ok[ir_type.IrTypeId, str](res_arr);
-        }
-    }
+    # a vector local is backed by storage of its OWN type. Shaping it as
+    # `[lanes]elem` has the same 16-byte layout, but it makes every whole-vector
+    # load a reinterpretation of the allocation through its pointer, which a
+    # logical-addressing target cannot express at all (#2640). Default-init and
+    # lane addressing both work on the vector slot directly: the zero fill is the
+    # sized memzero below, and a lane gep of a vector-typed slot is the shape lane
+    # assignment already lowers to.
+    val storage_ty: ir_type.IrTypeId = slot_ty;
 
     val res_count_ty: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
     if (R.is_err[ir_type.IrTypeId, str](res_count_ty)) {
@@ -496,9 +488,11 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
         if (context.type_is_secret(ctx, context.decl_type_of(ctx, did))) { builder.mark_last_secret(?ctx.builder); }
         birth_val = init;
     }
-    or (ir_type.is_aggregate(?ctx.m.types, storage_ty)) {
-        # a vector's array-shaped storage is an aggregate, so a default-initialized
-        # vector local zero-fills here -- all-zero bytes is +0.0 / 0 on every lane.
+    or (ir_type.is_aggregate(?ctx.m.types, storage_ty) || ir_type.is_vector(?ctx.m.types, storage_ty)) {
+        # a vector zero-fills here alongside the aggregates -- all-zero bytes is
+        # +0.0 / 0 on every lane, which is the all-zero-lane default types.md
+        # documents. it is a sized fill of the slot either way, so the vector needs
+        # no array shape to reach it.
         val res_mz: R.Result[bool, str] = builder.emit_memzero(?ctx.builder, slot, storage_ty);
         if (R.is_err[bool, str](res_mz)) { ret res_mz; }
         # a default-zeroed SECRET aggregate is a zeroizing write into secret storage:


### PR DESCRIPTION
Refs #2640 — deliberately **not** `Closes`. This removes the reinterpret, which is the defect in the title. It does not remove the memory round trip, and the reason is below.

## What was wrong

Both sites backed a vector with `alloca [lanes]elem` and read it back with a whole-vector load. Right layout, wrong type: the load reinterprets the allocation through its pointer.

Two consequences, and only one of them is in the issue:

1. A logical-addressing target gives a pointer exactly one pointee type and has no pointer bitcast, so it cannot encode this at all.
2. **The reshaped array carried the element's alignment.** `types.md` declares every vector's `$align_of` to be 16; an `[4]f32` slot is 4-byte aligned. Vector locals were under-aligned on **every** target, native ones included. That was not in the issue and I did not go looking for it — it fell out of the before/after diff.

## What changed

Both sites allocate the vector type. MIR's gep walk gains the vector level, striding by the element exactly as an array of the element does. The default zero fill moves to a branch admitting vectors alongside aggregates — a sized fill of the slot either way, and all-zero bytes is the all-zero-lane default `types.md` documents.

Nothing downstream is new: a lane gep and whole-vector load of a vector-typed slot is the shape lane assignment onto a `var` already lowered to.

## Native effect, measured not asserted

Same source, both compilers, debug and release, whole `.s` diffed:

| | before | after |
|---|---|---|
| `konst()` (constant literal) | 16 | 16 |
| `zeroed()` (uninit local) | 10 | 10 |

**Instruction counts identical.** The only diff in the entire file is the frame slot moving from `rbp-20` to `rbp-32`, plus the frame growing to hold it — which is the alignment fix, not a cost. Every other byte is unchanged.

## What this does NOT do, and why

**The stack round trip is still there.** `konst()` is still 16 instructions for a compile-time constant. I want to be plain that this PR does not deliver the native half of #2640's value, and that the remaining work is not more of the same:

- Removing the memory needs an `OP_VEC_INSERT` chain, which needs a **seed** — a zero or constant vector as an SSA value. There is none: `VAL_CONST_AGG` appears only as a global initializer, and `const_type_ok` rejects `VAL_CONST_INT` stamped with a vector type, so a zero vector cannot currently be named at all.
- Even with a seed, an insert chain does not help x86-64. Only **arm64 and spirv** declare `has_lane_ops`; baseline SSE2 has no general lane write, so `scalarize.expand_lane_ops` rewrites the chain straight back to a stack round trip. I verified this against the existing `r[1] = x` path, which already goes through `OP_VEC_INSERT` and still emits store, lane store, reload.
- The constant case wants a rodata load, and **x86-64 has no constant pool**. `x64/encode.mach:3212` says so: "x86-64 has no SSE immediate form, so this pair is unavoidable until the constants live in a pool (#2248)". #2248 is closed and its symptom is live — I measured the same `movabs`/`movq` pair three times per iteration in `rec_particle` while working #2315.

**SPIR-V is not unblocked by this alone.** The shape is now legal, but `builds_vector_through_memory` refuses any function-local vector load/store, and the emitter has no path for a Function-storage vector variable with per-lane `OpAccessChain`. Getting SPIR-V to accept construction wants the insert chain (it keeps `has_lane_ops`, so the chain survives to `OpCompositeConstruct`/`OpCompositeInsert`), which loops back to the seed. I did not touch `spirv/emit.mach`.

## Tests

`mach.lang.driver:vector_storage_is_not_reinterpreted` — asserts every vector-typed load whose address is an alloca loads that alloca's own type. It pins the **property**, not the mechanism, so it stays true of any later lowering that removes the memory entirely.

Checked on `linux-arm64` only, and that is the point rather than a shortcut: it declares `has_lane_ops`, so `expand_lane_ops` returns early and vectors survive intact — the same path a logical-addressing target takes. Every other target runs the scalar expansion, which *deliberately* represents a vector as `[lanes]elem` because it has no vector register class. Asserting there would be asserting against that pass's job. I found this by writing the broader assertion first and watching it fail.

**Evidence it fails first.** With only the literal lowering reverted to the array reshape:
```
mach.lang.driver.tests   187 ok   1 FAIL
  FAIL  mach.lang.driver:vector_storage_is_not_reinterpreted
1228 passed, 1 failed, 1229 total
```

I also had to **update** `vector_local_default_init`, which asserted the memzero's `aux_ty` was *not* a vector and no gep carried one. Those pinned the array-shaping mechanism, not the invariant. The invariant #2043 actually needs is the third check in that scan — no `VAL_CONST_INT` operand carrying a vector type — and it is untouched and still passing. The memzero assertion is now inverted to pin the new contract rather than deleted.

## Status

- `mach test .` — 1229 passed, 0 failed
- `int/run.sh --target linux` — all cases passed
- release self-host fixpoint, three generations — R2 and R3 byte-identical