### PR TITLE
fix(diag): name the opcode, function and position in a backend refusal

### DIFF
--- a/int/surface/spirv-unsupported-names-opcode/case.conf
+++ b/int/surface/spirv-unsupported-names-opcode/case.conf
@@ -1,0 +1,12 @@
+# a SPIR-V refusal must say WHICH instruction it refused (#2656). Every unsupported
+# shape used to produce one sentence with no opcode, no function and no position,
+# so localizing one in a module of any size meant truncating the source until it
+# stopped failing - which is how the SPIR-V track spent the first hour of each of
+# its four changes.
+#
+# The observable is the diagnostic itself: the opcode name, the enclosing function,
+# and the source position of the offending instruction. Asserting only that the
+# build fails would pass against the bare message this case exists to rule out.
+run: build-fails
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
+++ b/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
@@ -1,0 +1,1 @@
+error: addressed memory is not yet supported by the SPIR-V target: a module-scope variable is reachable only when it carries a shader interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`), and only as a whole-variable read or write (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)

--- a/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
+++ b/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
@@ -1,1 +1,1 @@
-error: addressed memory is not yet supported by the SPIR-V target: a module-scope variable is reachable only when it carries a shader interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`), and only as a whole-variable read or write (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)
+error: a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)

--- a/int/surface/spirv-unsupported-names-opcode/mach.toml
+++ b/int/surface/spirv-unsupported-names-opcode/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-unsupported-names-opcode/src/main.mach
+++ b/int/surface/spirv-unsupported-names-opcode/src/main.mach
@@ -1,0 +1,23 @@
+# A local array indexed by a RUNTIME value forces the front end to materialize
+# storage that no optimization can promote away, which reaches the SPIR-V backend
+# as MIR_ALLOCA. The logical addressing model has no way to express it, so the
+# backend refuses - correctly. What this case pins is the SHAPE of that refusal,
+# not the refusal itself.
+#
+# The runtime index is load-bearing: with a constant one the release pipeline
+# promotes the array into registers and the refusal never fires, so the case would
+# assert the message in `debug` and assert nothing at all in `release`.
+#
+# `sum_pair` is deliberately not the entry: the message has to name the function
+# the instruction is in, and a single-function fixture could satisfy that by
+# naming any function at all.
+fun sum_pair(a: i32, b: i32) i32 {
+    var buf: [2]i32;
+    buf[0] = a;
+    buf[1] = b;
+    ret buf[a % 2] + buf[b % 2];
+}
+
+fun main() i32 {
+    ret sum_pair(1, 2);
+}

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -111,6 +111,7 @@ use std.types.size.usize;
 use std.types.string.str;
 
 use std.allocator.page;
+use std.format;
 
 use A: std.allocator;
 use R: std.types.result;
@@ -506,7 +507,7 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
     for (i < n) {
         val mi: *mir.MirInstr = ?b.instrs[i];
         if (instr_needs_legalize(f, mi, ?plan.mach)) {
-            val res_c: R.Result[u32, str] = expansion_count(plan, mi);
+            val res_c: R.Result[u32, str] = expansion_count(alloc, plan, mi);
             if (R.is_err[u32, str](res_c)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_c)); }
             total = total + R.unwrap_ok[u32, str](res_c);
             needs_expand = true;
@@ -599,19 +600,19 @@ fun free_source_operands(alloc: *A.Allocator, mi: *mir.MirInstr) {
 # plan: the function's lane assignment
 # mi:   the wide instruction
 # ret:  the exact piece count, or an error naming the unsupported wide op
-fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun expansion_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     val op: mir.MirOpcode = mi.opcode;
     val nl: u32 = wide_lane_count(plan, mi);
 
     # a memory access - an explicit load / store, or the move form the ABI placement
     # emits against a stack slot - costs one piece per lane plus the pointer's own
     # lanes when its base must be staged into the fixed address pair.
-    if (instr_is_memory(mi)) { ret memory_piece_count(plan, mi); }
+    if (instr_is_memory(mi)) { ret memory_piece_count(alloc, plan, mi); }
 
     if (op == mir.MIR_AND || op == mir.MIR_OR || op == mir.MIR_XOR || op == mir.MIR_NOT) {
         ret R.ok[u32, str](nl);
     }
-    if (is_shift(op)) { ret shift_piece_count(plan, mi); }
+    if (is_shift(op)) { ret shift_piece_count(alloc, plan, mi); }
     # a declassify is a move plus a compile-time barrier; it legalizes exactly like a
     # move (the barrier matters only on the pre-legalize lowered MIR the #1648 re-derive
     # reads). legalize runs before isel, so it sees the un-retagged MIR_DECLASSIFY (#1646).
@@ -641,9 +642,9 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
         # one move per (narrower) destination lane, copying the low source lanes.
         ret R.ok[u32, str](dst_lane_count(plan, mi));
     }
-    if (op == mir.MIR_MUL) { ret mul_piece_count(plan, mi); }
-    if (mir.is_cmp_opcode(op)) { ret cmp_piece_count(plan, mi); }
-    ret R.err[u32, str](unsupported_message(op, mi.width));
+    if (op == mir.MIR_MUL) { ret mul_piece_count(alloc, plan, mi); }
+    if (mir.is_cmp_opcode(op)) { ret cmp_piece_count(alloc, plan, mi); }
+    ret R.err[u32, str](unsupported_message(alloc, op, mi.width));
 }
 
 # the lane count of a wide instruction's destination (or its widest operand),
@@ -719,13 +720,13 @@ fun base_needs_staging(plan: *LanePlan, mem: *mir.MirOperand) bool {
 # plan: the function's lane assignment
 # mi:   the memory instruction
 # ret:  the exact piece count, or an error naming the unsupported shape
-fun memory_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
-    if (mi.operand_count != 2) { ret R.err[u32, str](unsupported_message(mi.opcode, mi.width)); }
+fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+    if (mi.operand_count != 2) { ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width)); }
     val mx: i32 = mem_operand_index(mi);
     val vx: u32 = 1 - mx::u32;
     var n: u32 = wide_lane_count(plan, mi);
     if (!operand_is_lane_ready(plan, ?mi.operands[vx], n)) {
-        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val mem: *mir.MirOperand = ?mi.operands[mx::u32];
     if (base_needs_staging(plan, mem)) {
@@ -756,7 +757,7 @@ fun memory_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
 # ret:    ok(true) on success, or an error naming an unsupported shape
 fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                   dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
-    val rc: R.Result[u32, str] = memory_piece_count(plan, mi);
+    val rc: R.Result[u32, str] = memory_piece_count(alloc, plan, mi);
     if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
 
     val mx:  u32 = mem_operand_index(mi)::u32;
@@ -859,7 +860,7 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     if (op == mir.MIR_TRUNC) {
         ret expand_trunc(alloc, plan, mi, dst, cursor);
     }
-    ret R.err[bool, str](unsupported_message(op, mi.width));
+    ret R.err[bool, str](unsupported_message(alloc, op, mi.width));
 }
 
 # emit one native-width piece into `dst[*cursor]`, copying the source's location
@@ -987,7 +988,7 @@ fun operands_are_lane_ready(plan: *LanePlan, mi: *mir.MirInstr, start: u32) bool
 fun expand_bitwise(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                    dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     if (mi.operand_count != 3 || !operands_are_lane_ready(plan, mi, 1)) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -1008,7 +1009,7 @@ fun expand_bitwise(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 fun expand_not(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     if (mi.operand_count != 2 || !operands_are_lane_ready(plan, mi, 1)) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -1040,7 +1041,7 @@ fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 2 || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl)) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val lw: u8  = plan.lane_width;
     var i: u32 = 0;
@@ -1068,7 +1069,7 @@ fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
                   dst: *mir.MirInstr, cursor: *u32, is_sub: bool) R.Result[bool, str] {
     if (mi.operand_count != 3 || !operands_are_lane_ready(plan, mi, 1) ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -1208,7 +1209,7 @@ fun expand_neg(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *m
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     if (mi.operand_count != 2 || !operands_are_lane_ready(plan, mi, 1) ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     # synthesize a three-operand subtract `dst = 0 - src` and drive the borrow chain.
     var sub: mir.MirInstr = @mi;
@@ -1356,10 +1357,10 @@ fun shift_stage_count(bits: u32) u32 {
 # plan: the function's lane assignment
 # mi:   the shift instruction
 # ret:  the exact piece count, or an error naming the unsupported shape
-fun shift_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun shift_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES) {
-        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     # the destination and the shifted value span every lane; the COUNT is read out of
     # its low lane alone, since the barrel needs only log2(width) of its bits.
@@ -1367,7 +1368,7 @@ fun shift_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
         !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[2], 1)) {
-        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
 
     val lb:   u32 = plan.lane_width::u32 * 8;
@@ -1558,7 +1559,7 @@ fun emit_sign_fill(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 # ret:    ok(true) on success, or an error naming the unsupported shape
 fun expand_shift(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                  dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
-    val rc: R.Result[u32, str] = shift_piece_count(plan, mi);
+    val rc: R.Result[u32, str] = shift_piece_count(alloc, plan, mi);
     if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
 
     val nl: u32 = wide_lane_count(plan, mi);
@@ -1742,12 +1743,12 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
 # plan: the function's lane assignment
 # mi:   the multiply instruction
 # ret:  the exact piece count, or an error naming the unsupported shape
-fun mul_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun mul_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES ||
         mi.operands[0].kind != mir.MIR_OP_VREG || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) || !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
-        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val lw:   u8  = plan.lane_width;
     val bits: u32 = nl * lw::u32 * 8;
@@ -1806,7 +1807,7 @@ fun mul_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
 # ret:    ok(true) on success, or an error naming the unsupported shape
 fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
-    val rc: R.Result[u32, str] = mul_piece_count(plan, mi);
+    val rc: R.Result[u32, str] = mul_piece_count(alloc, plan, mi);
     if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
 
     val nl: u32 = wide_lane_count(plan, mi);
@@ -2055,13 +2056,13 @@ fun emit_lane_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 # plan: the function's lane assignment
 # mi:   the comparison instruction
 # ret:  the exact piece count, or an error naming the unsupported shape
-fun cmp_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun cmp_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES ||
         !cmp_dest_is_native(plan, ?mi.operands[0]) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
-        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
 
     val op: mir.MirOpcode = mi.opcode;
@@ -2131,7 +2132,7 @@ fun cmp_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
 # ret:    ok(true) on success, or an error naming the unsupported shape
 fun expand_cmp(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
-    val rc: R.Result[u32, str] = cmp_piece_count(plan, mi);
+    val rc: R.Result[u32, str] = cmp_piece_count(alloc, plan, mi);
     if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
 
     if (cmp_is_equality(mi.opcode)) { ret expand_cmp_equality(alloc, plan, f, mi, dst, cursor); }
@@ -2268,7 +2269,7 @@ fun expand_zext(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                 dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     if (mi.operand_count != 2 ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val dl: u32 = dst_lane_count(plan, mi);
     val sl: u32 = src_lane_count(plan, mi);
@@ -2303,7 +2304,7 @@ fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *
                 dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     if (mi.operand_count != 2 ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val dl: u32 = dst_lane_count(plan, mi);
     val sl: u32 = src_lane_count(plan, mi);
@@ -2334,7 +2335,7 @@ fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *
 fun expand_trunc(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                  dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     if (mi.operand_count != 2) {
-        ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
+        ret R.err[bool, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val dl: u32 = dst_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -2362,14 +2363,28 @@ fun emit_bin(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.Mi
 
 # the diagnostic for a wide operation this pass does not legalize
 #
-# Names the numeric opcode and width so the failure is specific, mirroring the
-# vector path's loud unsupported-lane-op discipline. A static message (no
-# allocator) keeps the pass allocation-free on its error paths.
+# Names the operation family in prose, then the exact opcode and width. The
+# opcode spelling comes from `mir.opcode_name`, the shared seam #2656 added, so
+# this pass and the SPIR-V backend name an instruction the same way and a reader
+# who greps one finds the other.
+#
+# The family prose is kept because it says what is missing, which an opcode alone
+# does not: `MIR_SHL` is unsupported here only through certain operand shapes.
 # ---
+# alloc: allocator the message is built on
 # op:    the unsupported wide opcode
 # width: the operation width in bytes
-# ret:   the diagnostic string
-fun unsupported_message(op: mir.MirOpcode, width: u8) str {
+# ret:   the diagnostic string, or the family prose alone on format failure
+fun unsupported_message(alloc: *A.Allocator, op: mir.MirOpcode, width: u8) str {
+    val family: str = unsupported_family(op);
+    val rj: R.Result[str, str] =
+        format.sprint(alloc, "{} ({}, {} bytes wide)", family, mir.opcode_name(op), width);
+    if (R.is_err[str, str](rj)) { ret family; }
+    ret R.unwrap_ok[str, str](rj);
+}
+
+# the prose half of the refusal: which class of operation was not legalized
+fun unsupported_family(op: mir.MirOpcode) str {
     if (op == mir.MIR_DIV_S || op == mir.MIR_DIV_U) { ret "legalize: wide divide is unsupported on this target"; }
     if (op == mir.MIR_REM_S || op == mir.MIR_REM_U) { ret "legalize: wide remainder is unsupported on this target"; }
     if (is_shift(op)) {

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -20,14 +20,19 @@
 # (`isel`) replaces these generic opcodes with the concrete encoder opcodes
 # owned by the active ISA.
 
+use std.allocator.page;
+use std.format;
 use std.memory;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
+use std.types.string.str_equals;
 
 use A: std.allocator;
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.intern;
@@ -973,6 +978,171 @@ pub rec MirFunction {
     naked:          bool;
 }
 
+# the source spelling of a MIR opcode, for a diagnostic that has to say WHICH
+# instruction it is about
+#
+# Returns the constant's own name rather than a lowercase mnemonic, deliberately.
+# The reader of a backend refusal is usually the person about to implement the
+# missing arm, and `MIR_DIV_S` is the token they grep the compiler for; a mnemonic
+# reads marginally better in prose and is useless for that.
+#
+# Total over the opcode space, with a fallback for a value outside it, so no caller
+# has to guard. A new opcode that forgets to add its arm therefore degrades to the
+# fallback rather than reading as some other instruction.
+# ---
+# op:  the opcode
+# ret: the opcode's source spelling, or "<unknown MIR opcode>"
+pub fun opcode_name(op: MirOpcode) str {
+    if (op == MIR_ADD)          { ret "MIR_ADD"; }
+    if (op == MIR_SUB)          { ret "MIR_SUB"; }
+    if (op == MIR_MUL)          { ret "MIR_MUL"; }
+    if (op == MIR_DIV_S)        { ret "MIR_DIV_S"; }
+    if (op == MIR_DIV_U)        { ret "MIR_DIV_U"; }
+    if (op == MIR_REM_S)        { ret "MIR_REM_S"; }
+    if (op == MIR_REM_U)        { ret "MIR_REM_U"; }
+    if (op == MIR_NEG)          { ret "MIR_NEG"; }
+    if (op == MIR_AND)          { ret "MIR_AND"; }
+    if (op == MIR_OR)           { ret "MIR_OR"; }
+    if (op == MIR_XOR)          { ret "MIR_XOR"; }
+    if (op == MIR_SHL)          { ret "MIR_SHL"; }
+    if (op == MIR_SHR_S)        { ret "MIR_SHR_S"; }
+    if (op == MIR_SHR_U)        { ret "MIR_SHR_U"; }
+    if (op == MIR_NOT)          { ret "MIR_NOT"; }
+    if (op == MIR_CMP_EQ)       { ret "MIR_CMP_EQ"; }
+    if (op == MIR_CMP_NE)       { ret "MIR_CMP_NE"; }
+    if (op == MIR_CMP_LT_S)     { ret "MIR_CMP_LT_S"; }
+    if (op == MIR_CMP_LT_U)     { ret "MIR_CMP_LT_U"; }
+    if (op == MIR_CMP_LE_S)     { ret "MIR_CMP_LE_S"; }
+    if (op == MIR_CMP_LE_U)     { ret "MIR_CMP_LE_U"; }
+    if (op == MIR_TRUNC)        { ret "MIR_TRUNC"; }
+    if (op == MIR_SEXT)         { ret "MIR_SEXT"; }
+    if (op == MIR_ZEXT)         { ret "MIR_ZEXT"; }
+    if (op == MIR_FP_TRUNC)     { ret "MIR_FP_TRUNC"; }
+    if (op == MIR_FP_EXT)       { ret "MIR_FP_EXT"; }
+    if (op == MIR_FP_TO_SI)     { ret "MIR_FP_TO_SI"; }
+    if (op == MIR_FP_TO_UI)     { ret "MIR_FP_TO_UI"; }
+    if (op == MIR_SI_TO_FP)     { ret "MIR_SI_TO_FP"; }
+    if (op == MIR_UI_TO_FP)     { ret "MIR_UI_TO_FP"; }
+    if (op == MIR_BITCAST)      { ret "MIR_BITCAST"; }
+    if (op == MIR_ALLOCA)       { ret "MIR_ALLOCA"; }
+    if (op == MIR_LOAD)         { ret "MIR_LOAD"; }
+    if (op == MIR_STORE)        { ret "MIR_STORE"; }
+    if (op == MIR_GEP)          { ret "MIR_GEP"; }
+    if (op == MIR_EXTRACT)      { ret "MIR_EXTRACT"; }
+    if (op == MIR_INSERT)       { ret "MIR_INSERT"; }
+    if (op == MIR_PHI)          { ret "MIR_PHI"; }
+    if (op == MIR_CALL_IR)      { ret "MIR_CALL_IR"; }
+    if (op == MIR_BR)           { ret "MIR_BR"; }
+    if (op == MIR_CBR)          { ret "MIR_CBR"; }
+    if (op == MIR_RET)          { ret "MIR_RET"; }
+    if (op == MIR_UNREACHABLE)  { ret "MIR_UNREACHABLE"; }
+    if (op == MIR_ASM)          { ret "MIR_ASM"; }
+    if (op == MIR_MOV)          { ret "MIR_MOV"; }
+    if (op == MIR_ARG)          { ret "MIR_ARG"; }
+    if (op == MIR_CALL)         { ret "MIR_CALL"; }
+    if (op == MIR_CALL_RES)     { ret "MIR_CALL_RES"; }
+    if (op == MIR_DECLASSIFY)   { ret "MIR_DECLASSIFY"; }
+    if (op == MIR_VEC_EXTRACT)  { ret "MIR_VEC_EXTRACT"; }
+    if (op == MIR_VEC_INSERT)   { ret "MIR_VEC_INSERT"; }
+    if (op == MIR_SEL_ADD)      { ret "MIR_SEL_ADD"; }
+    if (op == MIR_SEL_SUB)      { ret "MIR_SEL_SUB"; }
+    if (op == MIR_SEL_MUL)      { ret "MIR_SEL_MUL"; }
+    if (op == MIR_SEL_AND)      { ret "MIR_SEL_AND"; }
+    if (op == MIR_SEL_OR)       { ret "MIR_SEL_OR"; }
+    if (op == MIR_SEL_XOR)      { ret "MIR_SEL_XOR"; }
+    if (op == MIR_SEL_SHL)      { ret "MIR_SEL_SHL"; }
+    if (op == MIR_SEL_SHR_U)    { ret "MIR_SEL_SHR_U"; }
+    if (op == MIR_SEL_SHR_S)    { ret "MIR_SEL_SHR_S"; }
+    if (op == MIR_SEL_DIV_S)    { ret "MIR_SEL_DIV_S"; }
+    if (op == MIR_SEL_DIV_U)    { ret "MIR_SEL_DIV_U"; }
+    if (op == MIR_SEL_REM_S)    { ret "MIR_SEL_REM_S"; }
+    if (op == MIR_SEL_REM_U)    { ret "MIR_SEL_REM_U"; }
+    if (op == MIR_SEL_CMP_EQ)   { ret "MIR_SEL_CMP_EQ"; }
+    if (op == MIR_SEL_CMP_NE)   { ret "MIR_SEL_CMP_NE"; }
+    if (op == MIR_SEL_CMP_LT_S) { ret "MIR_SEL_CMP_LT_S"; }
+    if (op == MIR_SEL_CMP_LT_U) { ret "MIR_SEL_CMP_LT_U"; }
+    if (op == MIR_SEL_CMP_LE_S) { ret "MIR_SEL_CMP_LE_S"; }
+    if (op == MIR_SEL_CMP_LE_U) { ret "MIR_SEL_CMP_LE_U"; }
+    if (op == MIR_SEL_CBR)      { ret "MIR_SEL_CBR"; }
+    if (op == MIR_SEL_CBR_EQ)   { ret "MIR_SEL_CBR_EQ"; }
+    if (op == MIR_SEL_CBR_NE)   { ret "MIR_SEL_CBR_NE"; }
+    if (op == MIR_SEL_CBR_LT_S) { ret "MIR_SEL_CBR_LT_S"; }
+    if (op == MIR_SEL_CBR_LT_U) { ret "MIR_SEL_CBR_LT_U"; }
+    if (op == MIR_SEL_CBR_LE_S) { ret "MIR_SEL_CBR_LE_S"; }
+    if (op == MIR_SEL_CBR_LE_U) { ret "MIR_SEL_CBR_LE_U"; }
+    if (op == MIR_FADD)         { ret "MIR_FADD"; }
+    if (op == MIR_FSUB)         { ret "MIR_FSUB"; }
+    if (op == MIR_FMUL)         { ret "MIR_FMUL"; }
+    if (op == MIR_FDIV)         { ret "MIR_FDIV"; }
+    if (op == MIR_FCMP)         { ret "MIR_FCMP"; }
+    if (op == MIR_FNEG)         { ret "MIR_FNEG"; }
+    ret "<unknown MIR opcode>";
+}
+
+# compose a backend's refusal of one instruction into a located, greppable message
+#
+# The shared spelling of a refusal, so a backend that cannot lower something says
+# which instruction, in which function, at which source position, rather than the
+# bare sentence that made localizing a bisection (#2656). The shape follows the one
+# #2538 settled on for the IR verifier: `<what> (<opcode> in <function>, at
+# <path>:<line>:<col>)`.
+#
+# The function is passed already resolved rather than as a `MirFunction`, because
+# what a function should be CALLED is the caller's knowledge: a MIR function
+# carries only its mangled link name, and a backend holding the IR beside it can
+# name the readable one. MIR owns the opcode and the location; it does not own the
+# vocabulary.
+#
+# A location is not always available - compiler-synthesized MIR carries no source
+# origin, and a caller may have no source map. That case says so rather than
+# silently dropping the clause, which is the outcome #2538 ruled out: a message
+# that quietly omits the position reads as though the position was never plumbed.
+# ---
+# alloc:   allocator the returned message is built on
+# srcmap:  source map resolving the instruction's SrcLoc, or nil when unavailable
+# fn_name: what to call the enclosing function
+# mi:      the instruction refused, or nil when the refusal names no instruction
+# what:    the backend's own sentence, used verbatim as the message head
+# ret:     the composed message (on `alloc`), or `what` unchanged on format failure
+pub fun instr_refusal(alloc: *A.Allocator, srcmap: *source.SourceMap,
+                      fn_name: str, mi: *MirInstr, what: str) str {
+    if (mi == nil) {
+        val fj: R.Result[str, str] = format.sprint(alloc, "{} (in {})", what, fn_name);
+        if (R.is_err[str, str](fj)) { ret what; }
+        ret R.unwrap_ok[str, str](fj);
+    }
+
+    val opc: str = opcode_name(mi.opcode);
+    val where: O.Option[str] = refusal_where(mi.loc, srcmap, alloc);
+
+    var rj: R.Result[str, str];
+    if (O.is_some[str](where)) {
+        rj = format.sprint(alloc, "{} ({} in {}, at {})", what, opc, fn_name,
+                           O.unwrap[str](where));
+    }
+    or {
+        rj = format.sprint(alloc, "{} ({} in {}; no source location on this instruction)",
+                           what, opc, fn_name);
+    }
+    if (R.is_err[str, str](rj)) { ret what; }
+    ret R.unwrap_ok[str, str](rj);
+}
+
+# render a SrcLoc as `path:line:col`, or none when it cannot be resolved
+fun refusal_where(l: source.SrcLoc, srcmap: *source.SourceMap,
+                  alloc: *A.Allocator) O.Option[str] {
+    if (!source.loc_is_valid(l)) { ret O.none[str](); }
+    if (srcmap == nil)           { ret O.none[str](); }
+    val of: O.Option[*source.SourceFile] = source.get(srcmap, l.file);
+    if (O.is_none[*source.SourceFile](of)) { ret O.none[str](); }
+    val f: *source.SourceFile = O.unwrap[*source.SourceFile](of);
+
+    val p: source.Position = source.position(f, l.offset);
+    val rj: R.Result[str, str] = format.sprint(alloc, "{}:{}:{}", f.path, p.line, p.col);
+    if (R.is_err[str, str](rj)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](rj));
+}
+
 # the per-source-module unit produced by `lower_ir`
 # ---
 # alloc:        allocator backing every owned array (mirrors the IR module's)
@@ -1473,5 +1643,101 @@ test "mach.lang.be.codegen.mir.instr_like:carries_every_field" {
     if (moved.operand_count != 3)  { ret 1; }
     if (moved.opcode != src.opcode)     { ret 1; }
     if (moved.vec_lane != src.vec_lane) { ret 1; }
+    ret 0;
+}
+
+# every opcode names itself, and the table is TOTAL over the opcode space
+#
+# A backend refusal that names the wrong instruction is worse than one that names
+# none, so the property under test is not "some names come back" but that no two
+# opcodes share a name and none falls through to the unknown fallback. A new
+# opcode added without an arm here is exactly the regression that produces a
+# refusal pointing at the wrong thing, and the sweep below is what catches it.
+#
+# The sweep walks the declared opcode VALUES rather than a dense range: the space
+# is deliberately sparse (the selected forms start at 0x1000), so a dense walk
+# would spend most of its time on values that are not opcodes at all.
+test "mach.lang.be.codegen.mir.opcode_name:total_and_distinct" {
+    var ops: [83]MirOpcode;
+    ops[0]  = MIR_ADD;         ops[1]  = MIR_SUB;         ops[2]  = MIR_MUL;
+    ops[3]  = MIR_DIV_S;       ops[4]  = MIR_DIV_U;       ops[5]  = MIR_REM_S;
+    ops[6]  = MIR_REM_U;       ops[7]  = MIR_NEG;         ops[8]  = MIR_AND;
+    ops[9]  = MIR_OR;          ops[10] = MIR_XOR;         ops[11] = MIR_SHL;
+    ops[12] = MIR_SHR_S;       ops[13] = MIR_SHR_U;       ops[14] = MIR_NOT;
+    ops[15] = MIR_CMP_EQ;      ops[16] = MIR_CMP_NE;      ops[17] = MIR_CMP_LT_S;
+    ops[18] = MIR_CMP_LT_U;    ops[19] = MIR_CMP_LE_S;    ops[20] = MIR_CMP_LE_U;
+    ops[21] = MIR_TRUNC;       ops[22] = MIR_SEXT;        ops[23] = MIR_ZEXT;
+    ops[24] = MIR_FP_TRUNC;    ops[25] = MIR_FP_EXT;      ops[26] = MIR_FP_TO_SI;
+    ops[27] = MIR_FP_TO_UI;    ops[28] = MIR_SI_TO_FP;    ops[29] = MIR_UI_TO_FP;
+    ops[30] = MIR_BITCAST;     ops[31] = MIR_ALLOCA;      ops[32] = MIR_LOAD;
+    ops[33] = MIR_STORE;       ops[34] = MIR_GEP;         ops[35] = MIR_EXTRACT;
+    ops[36] = MIR_INSERT;      ops[37] = MIR_PHI;         ops[38] = MIR_CALL_IR;
+    ops[39] = MIR_BR;          ops[40] = MIR_CBR;         ops[41] = MIR_RET;
+    ops[42] = MIR_UNREACHABLE; ops[43] = MIR_ASM;         ops[44] = MIR_MOV;
+    ops[45] = MIR_ARG;         ops[46] = MIR_CALL;        ops[47] = MIR_CALL_RES;
+    ops[48] = MIR_DECLASSIFY;  ops[49] = MIR_VEC_EXTRACT; ops[50] = MIR_VEC_INSERT;
+    ops[51] = MIR_SEL_ADD;     ops[52] = MIR_SEL_SUB;     ops[53] = MIR_SEL_MUL;
+    ops[54] = MIR_SEL_AND;     ops[55] = MIR_SEL_OR;      ops[56] = MIR_SEL_XOR;
+    ops[57] = MIR_SEL_SHL;     ops[58] = MIR_SEL_SHR_U;   ops[59] = MIR_SEL_SHR_S;
+    ops[60] = MIR_SEL_DIV_S;   ops[61] = MIR_SEL_DIV_U;   ops[62] = MIR_SEL_REM_S;
+    ops[63] = MIR_SEL_REM_U;   ops[64] = MIR_SEL_CMP_EQ;  ops[65] = MIR_SEL_CMP_NE;
+    ops[66] = MIR_SEL_CMP_LT_S; ops[67] = MIR_SEL_CMP_LT_U; ops[68] = MIR_SEL_CMP_LE_S;
+    ops[69] = MIR_SEL_CMP_LE_U; ops[70] = MIR_SEL_CBR;    ops[71] = MIR_SEL_CBR_EQ;
+    ops[72] = MIR_SEL_CBR_NE;  ops[73] = MIR_SEL_CBR_LT_S; ops[74] = MIR_SEL_CBR_LT_U;
+    ops[75] = MIR_SEL_CBR_LE_S; ops[76] = MIR_SEL_CBR_LE_U; ops[77] = MIR_FADD;
+    ops[78] = MIR_FSUB;        ops[79] = MIR_FMUL;        ops[80] = MIR_FDIV;
+    ops[81] = MIR_FCMP;        ops[82] = MIR_FNEG;
+
+    var i: usize = 0;
+    for (i < 83) {
+        val n: str = opcode_name(ops[i]);
+        # total: no declared opcode reaches the fallback
+        if (str_equals(n, "<unknown MIR opcode>")) { ret 1; }
+        # distinct: no two opcodes answer with the same name
+        var j: usize = 0;
+        for (j < i) {
+            if (str_equals(opcode_name(ops[j]), n)) { ret 1; }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+
+    # a spot check that the name is the SOURCE spelling, which is what makes it
+    # greppable - a mnemonic would satisfy total-and-distinct just as well
+    if (!str_equals(opcode_name(MIR_DIV_S), "MIR_DIV_S")) { ret 1; }
+    if (!str_equals(opcode_name(MIR_VEC_INSERT), "MIR_VEC_INSERT")) { ret 1; }
+
+    # and a value outside the space degrades rather than reading as an opcode
+    if (!str_equals(opcode_name(0xDEAD::MirOpcode), "<unknown MIR opcode>")) { ret 1; }
+    ret 0;
+}
+
+# a refusal names the opcode and the function, and says so explicitly when the
+# instruction carries no source origin
+#
+# The located form needs a source map to exercise, which a unit test has no
+# cheap way to build; the SPIR-V surface case covers that half end to end. What
+# is pinned here is the half a unit test can own: that the opcode and function
+# reach the message at all, and that a locationless instruction produces the
+# stated degradation rather than a message that silently drops the clause.
+test "mach.lang.be.codegen.mir.instr_refusal:names_opcode_and_function" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var mi: MirInstr = instr(MIR_ALLOCA, nil, 0, 0, 0);
+    val msg: str = instr_refusal(?alloc, nil::*source.SourceMap, "sum_pair", ?mi,
+                                 "addressed memory is not yet supported");
+    if (!str_contains(msg, "addressed memory is not yet supported")) { ret 1; }
+    if (!str_contains(msg, "MIR_ALLOCA"))  { ret 1; }
+    if (!str_contains(msg, "sum_pair"))    { ret 1; }
+    # a missing location is stated, not omitted
+    if (!str_contains(msg, "no source location on this instruction")) { ret 1; }
+
+    # with no instruction the refusal still names its function and claims no opcode
+    val fn_only: str = instr_refusal(?alloc, nil::*source.SourceMap, "sum_pair",
+                                     nil::*MirInstr, "more than 16 parameters");
+    if (!str_contains(fn_only, "more than 16 parameters")) { ret 1; }
+    if (!str_contains(fn_only, "sum_pair"))                { ret 1; }
+    if (str_contains(fn_only, "MIR_"))                     { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -55,6 +55,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.intern;
+use mach.lang.source;
 use mach.lang.target.resolved;
 use mach.lang.me.ir;
 use mach.lang.me.ir.type;
@@ -106,6 +107,16 @@ rec Emit {
     iface_len: u32;
     gslot:     *u32;
     iface_use: *u8;
+
+    # the refusal context: which function is being emitted and which instruction
+    # is being translated, so a refusal can say so without every site threading
+    # them (#2656). stamped at the two chokepoints below - function entry and
+    # instruction dispatch - the same way MIR stamps `loc` at `push_instr`, and
+    # read only by `unsupported`. `cur_instr` is cleared on entering a function so
+    # a whole-function refusal cannot inherit the previous function's last one.
+    srcmap:    *source.SourceMap;
+    cur_fn:    *mir.MirFunction;
+    cur_instr: *mir.MirInstr;
 }
 
 # the per-function value maps, sized to the function's vreg count
@@ -171,6 +182,7 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
     e.gvar_ids = nil; e.iface_ids = nil; e.iface_len = 0;
     e.gslot = nil; e.iface_use = nil;
+    e.srcmap = mirmod.srcmap; e.cur_fn = nil; e.cur_instr = nil;
 
     # a module is a shader module or a library module, never both, and which one is
     # settled before any function is emitted: the answer decides both the capability
@@ -644,6 +656,8 @@ fun emit_cap(e: *Emit, cap: u32) {
 # mf: the MIR function to emit
 # ret: true on success, or a precise error string
 fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
+    e.cur_fn = mf;
+    e.cur_instr = nil;
     val fix: u32 = ir_function_index(e.ir, mf.name);
     if (fix == IR_FN_NONE) {
         ret R.err[bool, str]("spirv.emit: no IR function matches a lowered MIR function");
@@ -944,6 +958,10 @@ fun emit_terminator(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32,
 
     val blk: *mir.MirBlock = ?mf.blocks[st.nodes[ix].block];
     val term: *mir.MirInstr = ?blk.instrs[blk.instr_count - 1];
+    # the terminator is the instruction any refusal below is about; without this
+    # stamp one would name the last BODY instruction instead, which is a wrong
+    # attribution rather than a missing one
+    e.cur_instr = term;
 
     if (term.opcode == mir.MIR_BR) {
         emit_merge(e, st, ix, labels);
@@ -1653,13 +1671,41 @@ fun by_class(lane_float: bool, int_op: u32, float_op: u32) u32 {
     ret int_op;
 }
 
-# raise a precise unsupported-feature diagnostic
+# raise a precise unsupported-feature diagnostic, located
+#
+# The backend's own sentence is composed with the opcode, the enclosing function
+# and the source position through the shared `mir.instr_refusal`, so a refusal
+# says WHICH instruction it is about. Before #2656 every one of these read
+# identically no matter what was at fault, which made localizing a bisection.
+#
+# The three context values are read off `Emit` rather than threaded through the
+# thirty call sites: a refusal names whatever the emitter was working on, and the
+# stamps are the only thing that has to be right.
 # ---
-# e:   the emission state
+# e:   the emission state, carrying the function / instruction being emitted
 # msg: the feature description
-# ret: an err result carrying the message
+# ret: an err result carrying the located message
 fun unsupported(e: *Emit, msg: str) R.Result[bool, str] {
-    ret R.err[bool, str](msg);
+    ret R.err[bool, str](mir.instr_refusal(e.alloc, e.srcmap, refusal_fn_name(e),
+                                           e.cur_instr, msg));
+}
+
+# what to call the function currently being emitted
+#
+# The MIR function carries only the mangled link name, which is unambiguous but
+# reads badly and does not match the source. The IR function beside it carries the
+# bare source name, so prefer that and fall back through the mangled name to a
+# stand-in, since this is only ever read by a diagnostic.
+fun refusal_fn_name(e: *Emit) str {
+    if (e.cur_fn == nil) { ret "<unknown function>"; }
+    val fix: u32 = ir_function_index(e.ir, e.cur_fn.name);
+    if (fix != IR_FN_NONE) {
+        val d: O.Option[str] = intern.lookup(e.interner, (?e.ir.functions[fix]).disp);
+        if (O.is_some[str](d)) { ret O.unwrap[str](d); }
+    }
+    val m: O.Option[str] = intern.lookup(e.interner, e.cur_fn.name);
+    if (O.is_some[str](m)) { ret O.unwrap[str](m); }
+    ret "<unresolved function name>";
 }
 
 # translate one MIR instruction into SPIR-V, using the value-variable model
@@ -1673,6 +1719,7 @@ fun unsupported(e: *Emit, msg: str) R.Result[bool, str] {
 # mi:           the instruction to translate
 # ret:          true on success, or a precise error string
 fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+    e.cur_instr = mi;
     val op: mir.MirOpcode = mi.opcode;
 
     # a VECTOR operation rides the integer-spelled shared opcode whatever its lanes


### PR DESCRIPTION
Closes #2656

## What

Every unsupported shape in the SPIR-V backend produced one sentence with no opcode, no function and no position. Localizing one meant truncating the source until it stopped failing.

Before:
```
error: addressed memory is not yet supported by the SPIR-V target: ...
```

After:
```
error: addressed memory is not yet supported by the SPIR-V target: ... (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)
```

## The seam

`mir.opcode_name(op) str` — the source spelling of a MIR opcode. Total over the space with a fallback, so no caller guards, and a new opcode that forgets its arm degrades to `<unknown MIR opcode>` rather than reading as some other instruction.

It returns the constant's own name (`MIR_DIV_S`) rather than a mnemonic, deliberately: the reader of a backend refusal is usually the person about to implement the missing arm, and that is the token they grep the compiler for. There was no existing MIR opcode-name table to reuse — the IR printer's is for IR opcodes, the ISA printers' are for machine opcodes — so this is new rather than duplicated.

`mir.instr_refusal(alloc, srcmap, fn_name, mi, what) str` composes `<what> (<opcode> in <function>, at <path>:<line>:<col>)`, the shape #2538 settled on for the IR verifier.

## On your two checks

**1. The location does reach here.** `MirInstr.loc` survives lowering to the backend, and `MirModule` already carries the `srcmap`, so the refusal names an exact position and not merely a function. Where a location is genuinely absent (synthesized MIR, or no source map) the message says `no source location on this instruction` rather than dropping the clause — the degradation #2538 ruled out, because a message that quietly omits the position reads as though it was never plumbed.

One layering choice worth flagging: `instr_refusal` takes the function name **already resolved** rather than a `MirFunction`. A MIR function carries only its mangled link name (`_M4case4mainN8sum_pair`), and the SPIR-V backend holding the IR beside it can resolve the readable `sum_pair`. MIR owns the opcode and the location; it does not own the vocabulary. The backend falls back mangled-name → stand-in, since this is only ever read by a diagnostic.

**2. The second caller is the mos6502 legalize pass.** Its `unsupported_message` claimed *in its own doc comment* to name the opcode and width, and named neither — `width` was entirely unused. It now says both through `mir.opcode_name`, so the two passes name an instruction identically and a reader who greps one finds the other. Its family prose is kept, because that says what is missing in a way an opcode alone does not: `MIR_SHL` is unsupported there only through certain operand shapes.

That needed an allocator threaded through five counting functions (`expansion_count`, `*_piece_count`), all of whose callers already had one, so it is mechanical. `legalize.run` also holds the `MirModule`, so it *could* carry a location too — I stopped short of that, since it is more plumbing than #2656 asks for.

## File ownership

Everything is in `mir.mach` (additive), `spirv/emit.mach`, and `legalize.mach`. **No edits in `mir/lower.mach`**, so no sequencing needed. I checked for open PRs touching any of the three before starting and found none.

The thirty SPIR-V refusal sites are unchanged: the emitter stamps the function and instruction it is working on onto `Emit` at its two chokepoints, the way MIR itself stamps `loc` at `push_instr`. The terminator path stamps too — without it a terminator refusal would name the last *body* instruction, which is a wrong attribution rather than a missing one, and worse than the bare message.

## Tests

- **`mir.opcode_name:total_and_distinct`** — sweeps all 83 declared opcodes and asserts none reaches the fallback and no two share a name. Naming the *wrong* instruction is worse than naming none, so totality-and-distinctness is the property, not "some names come back".
- **`mir.instr_refusal:names_opcode_and_function`** — the opcode and function reach the message, and a locationless instruction produces the stated degradation rather than a silently shortened message.
- **`int/surface/spirv-unsupported-names-opcode`** — the real diagnostic end to end.

The int fixture indexes its array with a **runtime** value on purpose. With a constant index the release pipeline promotes the array into registers and the refusal never fires, so the case asserted the message in `debug` and asserted nothing at all in `release`. I found that when the first blessing failed on the release leg.

### Demonstrated failing before the fix

The int case against a compiler built from `dev`:

```
@@ -1 +1 @@
-... (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)
+... and only as a whole-variable read or write
int: 2 failure(s) on linux
```

The unit test, with one arm deleted from the table the way a forgotten opcode would leave it:

```
failures:
  mach.lang.be.codegen.mir.opcode_name:total_and_distinct  ./src/lang/be/codegen/mir.mach:1659  (exit 1)
1229 passed, 1 failed, 1230 total
```

(My first attempt at that deletion silently didn't match on whitespace and the suite stayed green — which is the reason for demonstrating failure rather than assuming it.)

## Verification

- `mach test .` green (1230/1230)
- `int/run.sh --target linux` green (all cases)
- Self-host fixpoint holds: stage2 `cmp` stage3 identical