### PR TITLE
feat(spirv): storage buffers, and refuse the uvec3 built-ins

### DIFF
--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -43,7 +43,8 @@ A decorator is written as an attribute:
 #[input(n)]          # shader interface input at location n (global only)
 #[output(n)]         # shader interface output at location n (global only)
 #[builtin("name")]   # pipeline built-in variable (global only)
-#[uniform(set, bnd)] # descriptor-bound uniform block (global only)
+#[uniform(set, bnd)] # descriptor-bound uniform block, read-only (global only)
+#[storage(set, bnd)] # descriptor-bound storage buffer, read-write (global only)
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -412,7 +413,7 @@ stage takes the single-invocation default `(1, 1, 1)`; the dimensions are always
 declared in the emitted module, since a compute stage that does not state its
 workgroup size is not one a consumer can dispatch.
 
-### `input(n)` / `output(n)` / `builtin(str)` / `uniform(set, binding)` — shader interface
+### `input(n)` / `output(n)` / `builtin(str)` / `uniform(set, binding)` / `storage(set, binding)` — shader interface
 
 A pipeline stage does not receive its inputs or return its results through a call.
 It reads and writes **module-scope variables** that the pipeline binds, and these
@@ -427,6 +428,9 @@ are mutually exclusive.
 
 rec Camera { view: f32x4; proj: f32x4; }
 #[uniform(0, 0)] var camera: Camera;
+
+rec Particles { pos: [64]f32x4; }
+#[storage(0, 1)] var particles: Particles;
 ```
 
 `input` and `output` number a **varying** with a location, which is how one
@@ -458,6 +462,21 @@ its `Block` decoration and an explicit byte offset on every member, taken from t
 same layout the rest of the compiler uses, so what the shader reads is what the
 host wrote. Wrap a single value in a one-field record.
 
+`storage` binds a **read-write** buffer by descriptor set and binding, where
+`uniform` binds a read-only one. Both must be a `rec` for the same reason, and both
+are emitted as a `Block`-decorated struct with an explicit offset on every member.
+
+They differ in one place: their **layout rules**. A uniform block follows
+std140-shaped rules, under which an array's stride is rounded up to 16 — which
+mach's own layout does not do, so an array of anything narrower than 16 bytes is
+refused rather than silently repacked. A storage buffer follows std430-shaped
+rules, which use the element's natural stride, and that *is* mach's layout, so
+`[8]f32` is fine in a `storage` block and rejected in a `uniform` one.
+
+A compute stage's data path is `storage`: Vulkan forbids the `Output` storage class
+in a compute execution model, so a compute shader reads and writes buffers rather
+than varyings.
+
 As with `#[stage(...)]`, these are accepted on every target and acted on only by a
 target that forms pipeline stages. On `spirv` each becomes an `OpVariable` in the
 matching storage class, carrying the matching decoration, and the Input and Output
@@ -483,6 +502,7 @@ variables are named in every entry point's interface list.
 | `output`    |  no   |    no     |      yes      |      no       |
 | `builtin`   |  no   |    no     |      yes      |      no       |
 | `uniform`   |  no   |    no     |      yes      |      no       |
+| `storage`   |  no   |    no     |      yes      |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).

--- a/int/surface/spirv-storage/case.conf
+++ b/int/surface/spirv-storage/case.conf
@@ -1,0 +1,8 @@
+# descriptor-bound storage buffers through the spirv back half, validated host-side
+# against the VULKAN environment. the environment carries the whole point here: a
+# StorageBuffer variable's mandatory Block layout and the std430 array-stride rules
+# that separate it from a uniform block are Vulkan rules, and the universal
+# environment applies none of them.
+run: spirv-val-vulkan
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-storage/expect.spirv.txt
+++ b/int/surface/spirv-storage/expect.spirv.txt
@@ -1,0 +1,1 @@
+modules=1 validator=clean env=vulkan1.3

--- a/int/surface/spirv-storage/mach.toml
+++ b/int/surface/spirv-storage/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-storage/src/main.mach
+++ b/int/surface/spirv-storage/src/main.mach
@@ -1,0 +1,88 @@
+# SPIR-V storage-buffer fixture: a compute stage's data path
+#
+# Vulkan forbids the `Output` storage class in a compute execution model, so the
+# varyings the spirv-interface case is built on are unavailable to `GLCompute`
+# entirely. A compute shader's data travels through descriptor-bound storage
+# buffers instead, and this case declares them.
+#
+# The observable is `spirv-val --target-env vulkan1.3`. That matters more here than
+# anywhere else in the spirv set, because the rules being exercised are Vulkan's:
+# a StorageBuffer variable must be a Block-decorated struct with an explicit offset
+# on every member, and its arrays follow std430-shaped stride rules rather than the
+# std140-shaped ones a uniform block follows.
+#
+# THE LAYOUT DIFFERENCE IS THE POINT of the narrow-element members below. A uniform
+# block rounds an array's stride up to 16 and mach packs at the element's natural
+# size, so `[8]f32` in a uniform is refused rather than repacked - repacking would
+# move the members out from under a host writing the block by `$offset_of`. A
+# storage buffer's std430 stride IS the natural size, so the same shape is legal
+# here. Both halves of that are checked: this case declares the shapes a uniform
+# block cannot carry, and the spirv-interface case keeps the uniform-side refusal.
+#
+# NOT here: reading or writing any of these buffers. A block member is reached
+# through an `OpAccessChain` naming its ordinal, and MIR folds the member walk into
+# a byte displacement before the back end sees it, so the member access is refused
+# by name. The buffers are declared, laid out and bound correctly - which the
+# validator confirms - and become readable when the ordinal survives lowering.
+#
+# Also not here: the three compute built-ins. `global_invocation`,
+# `local_invocation` and `workgroup_id` are three-component unsigned vectors by the
+# specification and every mach vector is exactly 128 bits, so they cannot be typed
+# and the back end refuses them by name rather than emitting an invalid module.
+
+# a buffer of 128-bit elements, the shape a uniform block could also carry.
+rec Particles {
+    position: [64]f32x4;
+    velocity: [64]f32x4;
+    count:    i32;
+}
+#[storage(0, 0)] var particles: Particles;
+
+# narrow-element arrays, legal under std430 and refused under std140. these are the
+# members that make this case a check on the layout posture rather than a repeat of
+# the uniform one.
+rec Samples {
+    weights: [8]f32;
+    indices: [16]i32;
+    scale:   f32x4;
+}
+#[storage(0, 1)] var samples: Samples;
+
+# a nested record inside a buffer: the inner struct carries its own member offsets
+# and only the outermost is decorated Block, as in a uniform block.
+rec Bounds {
+    lo: f32x4;
+    hi: f32x4;
+}
+rec Scene {
+    bounds:  Bounds;
+    gravity: f32x4;
+}
+#[storage(1, 0)] var scene: Scene;
+
+# a uniform and a storage buffer in one module, so the two storage classes and
+# their two layout postures are emitted side by side.
+rec Config {
+    steps: f32x4;
+}
+#[uniform(2, 0)] var config: Config;
+
+#[stage("compute")] #[workgroup(64, 1, 1)]
+fun simulate() { }
+
+#[stage("compute")] #[workgroup(8, 8, 1)]
+fun reduce() { }
+
+# a graphics stage in the same module: a storage buffer is not compute-only, and a
+# vertex stage may carry one alongside its varyings.
+#[input(0)]            var in_position: f32x4;
+#[builtin("position")] var position:    f32x4;
+
+#[stage("vertex")]
+fun vertex_main() {
+    position = in_position;
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -1436,8 +1436,9 @@ fun validate_iface_target(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.De
     if (has_decorator(sc, d, "output"))  { roles = roles + 1; }
     if (has_decorator(sc, d, "builtin")) { roles = roles + 1; }
     if (has_decorator(sc, d, "uniform")) { roles = roles + 1; }
+    if (has_decorator(sc, d, "storage")) { roles = roles + 1; }
     if (roles > 1) {
-        context.report(sc, dec.name, "a shader interface variable carries exactly one role; `input`, `output`, `builtin`, and `uniform` are mutually exclusive");
+        context.report(sc, dec.name, "a shader interface variable carries exactly one role; `input`, `output`, `builtin`, `uniform`, and `storage` are mutually exclusive");
     }
 }
 
@@ -1685,16 +1686,16 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         validate_builtin_value(sc, dec);
         ret;
     }
-    if (decorator_named(sc, dec, "uniform")) {
+    if (decorator_named(sc, dec, "uniform") || decorator_named(sc, dec, "storage")) {
         if (dec.args_len != 2) {
-            context.report(sc, dec.name, "`uniform` decorator takes two arguments: the descriptor set and the binding");
+            context.report(sc, dec.name, "`uniform` / `storage` decorator takes two arguments: the descriptor set and the binding");
         }
         or {
             var ui: u32 = 0;
             for (ui < 2) {
                 val ueid: id.ExprId = sc.a.expr_ids[dec.args_start + ui];
                 if (!type.is_integer(?sc.s.types, decorator_arg_type(sc, ueid))) {
-                    context.report(sc, dec.name, "`uniform` descriptor set and binding must be integer comptime expressions");
+                    context.report(sc, dec.name, "`uniform` / `storage` descriptor set and binding must be integer comptime expressions");
                     ui = 2; cnt;
                 }
                 ui = ui + 1;
@@ -1723,7 +1724,7 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
     # agreement - is checked by the pre-type-resolution pass that has to read the
     # file anyway (#2507). Re-checking any of it here would report it twice.
     if (decorator_named(sc, dec, "embed")) { ret; }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform");
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -89,7 +89,8 @@ pub val STAGE_FRAGMENT: u8 = 2;
 pub val STAGE_COMPUTE:  u8 = 3;
 
 # the shader interface role of a global, from an `#[input(...)]`, `#[output(...)]`,
-# `#[builtin("...")]`, or `#[uniform(set, binding)]` decorator. IFACE_NONE is every
+# `#[builtin("...")]`, `#[uniform(set, binding)]`, or `#[storage(set, binding)]`
+# decorator. IFACE_NONE is every
 # ordinary global. a target that forms pipeline stages turns a roled global into an
 # interface variable in the matching storage class; every other target ignores the
 # role and emits the global normally
@@ -97,12 +98,13 @@ pub val STAGE_COMPUTE:  u8 = 3;
 # the two payload words mean different things per role, which is what keeps one
 # pair of fields serving every role rather than a field per decoration: a location
 # for IFACE_INPUT / IFACE_OUTPUT, a BUILTIN_* selector for IFACE_BUILTIN, and a
-# descriptor set plus binding for IFACE_UNIFORM
+# descriptor set plus binding for IFACE_UNIFORM and IFACE_STORAGE
 pub val IFACE_NONE:    u8 = 0;
 pub val IFACE_INPUT:   u8 = 1;
 pub val IFACE_OUTPUT:  u8 = 2;
 pub val IFACE_BUILTIN: u8 = 3;
 pub val IFACE_UNIFORM: u8 = 4;
+pub val IFACE_STORAGE: u8 = 5;
 
 # the built-in variables `#[builtin("...")]` accepts. each names a value the
 # pipeline supplies or consumes rather than one a location carries, and each has a

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1321,6 +1321,12 @@ fun fill_iface_role(ctx: *context.LowerContext, d: *decl.Decl, g: *ir.Global) {
         g.iface   = ir.IFACE_UNIFORM;
         g.iface_a = decorator_uint(ctx, d, "uniform", 0, 0);
         g.iface_b = decorator_uint(ctx, d, "uniform", 1, 0);
+        ret;
+    }
+    if (decl_has_decorator(ctx, d, "storage")) {
+        g.iface   = ir.IFACE_STORAGE;
+        g.iface_a = decorator_uint(ctx, d, "storage", 0, 0);
+        g.iface_b = decorator_uint(ctx, d, "storage", 1, 0);
     }
 }
 

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -180,6 +180,12 @@ pub val STORAGE_INPUT:   u32 = 1;
 pub val STORAGE_UNIFORM: u32 = 2;
 pub val STORAGE_OUTPUT:  u32 = 3;
 
+# storage class of a read-write descriptor-bound buffer. this is the SPIR-V 1.3
+# spelling; the older one put the same thing in `Uniform` under a `BufferBlock`
+# decoration, which a 1.6 module does not use. a compute stage's data path is this
+# class, since Vulkan forbids `Output` in a compute execution model
+pub val STORAGE_STORAGE_BUFFER: u32 = 12;
+
 # decoration operands of OpDecorate / OpMemberDecorate for the shader interface.
 # Block marks a record type as a uniform block's layout; Location numbers a
 # varying so consecutive stages match up; BuiltIn names a value the pipeline

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -282,14 +282,14 @@ fun emit_dnit(e: *Emit, n: u32) {
 # declare one global OpVariable per interface-roled global, with its decorations
 #
 # A shader stage does not receive its inputs or hand back its outputs through a
-# call: it reads and writes module-scope variables in the Input, Output, and
-# Uniform storage classes, and the pipeline binds them by the decorations attached
-# here. So a mach global carrying `#[input(N)]`, `#[output(N)]`, `#[builtin("...")]`,
-# or `#[uniform(set, binding)]` becomes one of those variables rather than an
-# ordinary data symbol.
+# call: it reads and writes module-scope variables in the Input, Output, Uniform,
+# and StorageBuffer storage classes, and the pipeline binds them by the decorations
+# attached here. So a mach global carrying `#[input(N)]`, `#[output(N)]`,
+# `#[builtin("...")]`, `#[uniform(set, binding)]`, or `#[storage(set, binding)]`
+# becomes one of those variables rather than an ordinary data symbol.
 #
-# The Input and Output variables are also collected into the entry-point interface
-# list, which every OpEntryPoint must name in full.
+# Every variable declared here is a candidate for an entry point's interface list;
+# which ones a given entry point actually names is decided later by reachability.
 # ---
 # e:   the emission state
 # ret: true on success, or a precise error string
@@ -316,17 +316,27 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
         val g: *ir.Global = ?e.ir.globals[i];
         if (g.iface == ir.IFACE_NONE) { i = i + 1; cnt; }
 
+        # a built-in whose specified type mach cannot spell is refused here rather
+        # than emitted mistyped: the module would be invalid and the failure would
+        # surface from a validator instead of from the declaration that caused it.
+        if (g.iface == ir.IFACE_BUILTIN) {
+            val br: str = unspellable_builtin(g.iface_a);
+            if (br != nil) { ret unsupported(e, br); }
+        }
+
         var storage: u32 = spirv.STORAGE_INPUT;
         if (g.iface == ir.IFACE_OUTPUT)      { storage = spirv.STORAGE_OUTPUT; }
         or (g.iface == ir.IFACE_UNIFORM)     { storage = spirv.STORAGE_UNIFORM; }
+        or (g.iface == ir.IFACE_STORAGE)     { storage = spirv.STORAGE_STORAGE_BUFFER; }
         or (g.iface == ir.IFACE_BUILTIN)     { storage = builtin_storage(g.iface_a); }
 
         var value_ty: u32 = 0;
-        if (g.iface == ir.IFACE_UNIFORM) {
-            # a Uniform variable must be a Block-decorated struct: Vulkan rejects a
-            # bare scalar or vector in that storage class outright, so the mach type
-            # has to be a record and the block layout is emitted with it.
-            val ur: R.Result[u32, str] = uniform_block_type(e, g.ty);
+        if (g.iface == ir.IFACE_UNIFORM || g.iface == ir.IFACE_STORAGE) {
+            # a descriptor-bound variable must be a Block-decorated struct: Vulkan
+            # rejects a bare scalar or vector in either class outright, so the mach
+            # type has to be a record and the block layout is emitted with it. The two
+            # differ in their LAYOUT rules, which `block_type` takes as its posture.
+            val ur: R.Result[u32, str] = block_type(e, g.ty, g.iface == ir.IFACE_STORAGE);
             if (R.is_err[u32, str](ur)) { ret R.err[bool, str](R.unwrap_err[u32, str](ur)); }
             value_ty = R.unwrap_ok[u32, str](ur);
         }
@@ -348,17 +358,18 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
         if (g.iface == ir.IFACE_BUILTIN) {
             decorate(e, var_id, spirv.DECOR_BUILTIN, builtin_selector(g.iface_a));
         }
-        if (g.iface == ir.IFACE_UNIFORM) {
+        if (g.iface == ir.IFACE_UNIFORM || g.iface == ir.IFACE_STORAGE) {
             decorate(e, var_id, spirv.DECOR_DESCRIPTOR_SET, g.iface_a);
             decorate(e, var_id, spirv.DECOR_BINDING, g.iface_b);
         }
-        # only the per-invocation classes are entry-point interface; a descriptor is
-        # reached through its binding, not through the interface list.
-        if (g.iface != ir.IFACE_UNIFORM) {
-            e.iface_ids[e.iface_len] = var_id;
-            e.gslot[i] = e.iface_len + 1;
-            e.iface_len = e.iface_len + 1;
-        }
+        # EVERY global an entry point statically uses belongs in its interface list,
+        # of any storage class. That is a SPIR-V 1.4 change from the 1.3 rule of
+        # Input and Output only, and this module declares 1.6. A descriptor that no
+        # stage reads is still left out, since the list names what is USED - which
+        # the per-function reachability pass decides, not this loop.
+        e.iface_ids[e.iface_len] = var_id;
+        e.gslot[i] = e.iface_len + 1;
+        e.iface_len = e.iface_len + 1;
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -376,7 +387,7 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
 # e:   the emission state
 # id:  the IR type of the uniform global
 # ret: the OpTypeStruct id, or a precise error string
-fun uniform_block_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
+fun block_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
     val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
     if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform global has no IR type"); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
@@ -385,10 +396,10 @@ fun uniform_block_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
     }
     val n: u32 = t.data.struct_.field_count;
     if (n == 0 || n > types.MAX_STRUCT_MEMBERS) {
-        ret R.err[u32, str]("a `#[uniform(...)]` block must have between 1 and 16 fields");
+        ret R.err[u32, str]("a `#[uniform(...)]` / `#[storage(...)]` block must have between 1 and 16 fields");
     }
 
-    val sr: R.Result[u32, str] = laid_out_struct(e, id);
+    val sr: R.Result[u32, str] = laid_out_struct(e, id, relaxed_stride);
     if (R.is_err[u32, str](sr)) { ret sr; }
     val struct_id: u32 = R.unwrap_ok[u32, str](sr);
 
@@ -406,19 +417,19 @@ fun uniform_block_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
 # e:   the emission state
 # id:  the IR struct type
 # ret: the OpTypeStruct id, or a precise error string
-fun laid_out_struct(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
+fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
     val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
     if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform block member has no IR type"); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
     val n: u32 = t.data.struct_.field_count;
     if (n == 0 || n > types.MAX_STRUCT_MEMBERS) {
-        ret R.err[u32, str]("a `#[uniform(...)]` block must have between 1 and 16 fields");
+        ret R.err[u32, str]("a `#[uniform(...)]` / `#[storage(...)]` block must have between 1 and 16 fields");
     }
 
     var members: [16]u32;
     var i: u32 = 0;
     for (i < n) {
-        val mr: R.Result[u32, str] = laid_out_type(e, t.data.struct_.fields[i]);
+        val mr: R.Result[u32, str] = laid_out_type(e, t.data.struct_.fields[i], relaxed_stride);
         if (R.is_err[u32, str](mr)) { ret mr; }
         members[i] = R.unwrap_ok[u32, str](mr);
         i = i + 1;
@@ -452,24 +463,28 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
 # e:   the emission state
 # id:  the member's IR type
 # ret: the member type id, or a precise error string
-fun laid_out_type(e: *Emit, id: type.IrTypeId) R.Result[u32, str] {
+fun laid_out_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
     val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
     if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform block member has no IR type"); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
 
-    if (t.kind == type.IRT_STRUCT) { ret laid_out_struct(e, id); }
+    if (t.kind == type.IRT_STRUCT) { ret laid_out_struct(e, id, relaxed_stride); }
 
     if (t.kind == type.IRT_ARRAY) {
-        val er: R.Result[u32, str] = laid_out_type(e, t.data.array_.element);
+        val er: R.Result[u32, str] = laid_out_type(e, t.data.array_.element, relaxed_stride);
         if (R.is_err[u32, str](er)) { ret er; }
         val elem_ty: u32 = R.unwrap_ok[u32, str](er);
         val stride: u32 = type.byte_size(?e.ir.types, t.data.array_.element, e.tgt);
-        # a uniform block is laid out to std140-shaped rules, under which an array's
-        # stride is rounded up to 16. mach's layout packs at the element's natural
-        # size, so an array of anything narrower disagrees with what a Vulkan host
-        # would write, and there is no repacking that keeps both honest.
-        if ((stride % 16) != 0) {
-            ret R.err[u32, str]("an array inside a `#[uniform(...)]` block must have a 16-byte-aligned element in the SPIR-V target: a uniform block's array stride is rounded up to 16, which mach's own layout does not do, so the shader and the host would disagree about where the elements are. an array of a 128-bit vector (`[4]f32x4`) has the right stride already");
+        # the two block classes differ here, and only here. A UNIFORM block is laid
+        # out to std140-shaped rules, under which an array's stride is rounded up to
+        # 16; mach packs at the element's natural size, so an array of anything
+        # narrower disagrees with what a Vulkan host would write and is refused
+        # rather than repacked - repacking would move the members out from under the
+        # host. A STORAGE buffer is laid out to std430-shaped rules, which use the
+        # element's natural stride, and that is exactly mach's own layout, so every
+        # element width a uniform block has to turn away is legal there.
+        if (!relaxed_stride && (stride % 16) != 0) {
+            ret R.err[u32, str]("an array inside a `#[uniform(...)]` block must have a 16-byte-aligned element in the SPIR-V target: a uniform block's array stride is rounded up to 16, which mach's own layout does not do, so the shader and the host would disagree about where the elements are. an array of a 128-bit vector (`[4]f32x4`) has the right stride already, and a `#[storage(...)]` buffer accepts any element width");
         }
         val arr_id: u32 = types.type_array(e.tt, elem_ty, t.data.array_.count, true);
         if (arr_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block array type"); }
@@ -618,6 +633,25 @@ fun decorate(e: *Emit, target: u32, decor: u32, operand: u32) {
     spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?ops[0], 3);
 }
 
+# the refusal for a built-in whose specified type mach has no way to write, or nil
+#
+# `GlobalInvocationId`, `LocalInvocationId` and `WorkgroupId` are `uvec3` by the
+# specification, and the requirement is on the VARIABLE's type rather than on how it
+# is read, so widening is not available the way it is for a varying: a `u32x4`
+# decorated with one of these is an invalid module, not a wasteful one. Every mach
+# vector is exactly 128 bits, so `u32x4` exists and `u32x3` cannot. These are refused
+# by name because no correct program can be written against them, which is a
+# different thing from a built-in a user merely typed wrongly - that one has a right
+# answer and the validator names it.
+# ---
+# which: the ir.BUILTIN_* value
+# ret:   the diagnostic, or nil when the built-in is spellable
+fun unspellable_builtin(which: u32) str {
+    if (which != ir.BUILTIN_GLOBAL_INVOCATION && which != ir.BUILTIN_LOCAL_INVOCATION
+        && which != ir.BUILTIN_WORKGROUP_ID) { ret nil; }
+    ret "this compute built-in cannot be typed in mach yet: SPIR-V specifies `global_invocation`, `local_invocation` and `workgroup_id` as three-component unsigned vectors, and every mach vector is exactly 128 bits, so `u32x4` exists and `u32x3` does not. a variable of any other type decorated with one of these is an invalid module rather than a wasteful one, so it is refused instead of emitted. the other built-ins, and `#[storage(...)]` buffers, are available to a compute stage";
+}
+
 # the SPIR-V BuiltIn selector for one of mach's built-in names
 # ---
 # which: the ir.BUILTIN_* value
@@ -761,7 +795,7 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
     # Reaching it instruction by instruction would report the `alloca` that opens the
     # sequence, which is the least informative part of it.
     if (builds_vector_through_memory(e, mf)) {
-        ret unsupported(e, "constructing a vector from a literal or an uninitialized local is not yet supported by the SPIR-V target: the front end materializes one as an array allocation written lane by lane and read back as a whole vector, and reinterpreting an allocation through its pointer is not expressible under the logical addressing model. derive the vector from an existing vector value instead - lane assignment onto a parameter, or arithmetic");
+        ret unsupported(e, "constructing a vector from a literal or an uninitialized local is not yet supported by the SPIR-V target: the value is built in an ADDRESSABLE LOCAL and read back out, and this milestone emits no local allocations at all. a literal additionally writes its lanes through per-lane indices, which MIR folds into byte displacements the lane ordinal cannot be recovered from. derive the vector from an existing vector value instead - lane assignment onto a parameter, or arithmetic");
     }
 
     # the structured shape of the body, or a refusal naming the construct.
@@ -926,11 +960,17 @@ fun address_operand_index(mi: *mir.MirInstr) u32 {
 
 # whether a function materializes a vector by reading one out of a local allocation
 #
-# The signature of the vector-literal / zero-init lowering: an `alloca [4]f32`
-# written lane by lane, then a whole-vector `load f32x4` off the same pointer. The
-# ALLOCA origin is the identifying part. A vector arriving from or leaving through
-# an interface variable reads the same way at the instruction level but originates
-# in a global, and reporting it as a literal sent readers to the wrong problem.
+# The signature of the vector-literal / zero-init lowering: an `alloca f32x4`
+# written lane by lane or zeroed, then a whole-vector `load f32x4` off the same
+# pointer. The ALLOCA origin is the identifying part. A vector arriving from or
+# leaving through an interface variable reads the same way at the instruction level
+# but originates in a global, and reporting it as a literal sent readers to the
+# wrong problem.
+#
+# The allocation used to be an `[4]f32` reinterpreted as a vector through its
+# pointer, which no SPIR-V back end could have accepted. That is fixed upstream: it
+# is now allocated at the vector's own type, so what remains is only that this
+# milestone emits no local allocations.
 # ---
 # e:   the emission state
 # mf:  the MIR function


### PR DESCRIPTION
Refs #2658 — **not** `Closes`. One of its two acceptance items is half met; see below.

## What landed

**`#[storage(set, binding)]`** — deliberately the same shape as `#[uniform(set, binding)]` rather than a new spelling. Both bind a `rec` by descriptor set and binding, both emit a `Block`-decorated struct with an explicit offset on every member, and the pair reads as one surface where read-only versus read-write is the only difference the author states.

```
OpDecorate %_arr_v4float_uint_4 ArrayStride 16
OpMemberDecorate %_struct_8 0 Offset 0
OpMemberDecorate %_struct_8 1 Offset 64
OpDecorate %_struct_8 Block
OpDecorate %10 DescriptorSet 0
OpDecorate %10 Binding 0
%10 = OpVariable %_ptr_StorageBuffer__struct_8 StorageBuffer
```

**The uvec3 built-ins are refused**, not mistyped. They were accepted by the decorator and emitted at whatever type the variable had, producing a module the validator rejects outright:

```
error: [VUID-GlobalInvocationId-GlobalInvocationId-04238] According to the Vulkan
spec BuiltIn GlobalInvocationId variable needs to be a 3-component 32-bit int vector
```

Only those three are refused. A built-in a user merely typed wrongly has a right answer and the validator names it; these three have no correct spelling in mach at all, which is a different category.

## The layout difference, checked rather than assumed

You said to check whether a storage buffer's rules match a uniform block's. **They do not, and the difference is load-bearing.**

| | uniform block | storage buffer |
|---|---|---|
| rules | std140-shaped | std430-shaped |
| array stride | rounded up to 16 | element's natural size |
| `[8]f32` member | **refused** | **legal** |

mach's own layout is the natural one, so the shapes a uniform block has to turn away are exactly the ones a storage buffer accepts. Verified against `spirv-val --target-env vulkan1.3` both ways rather than read off the spec. The uniform-side refusal stands for the reason it always did — repacking would move members out from under a host writing the block by `$offset_of` — and its message now points at `#[storage(...)]` as the alternative. The layout walk takes the posture as a parameter rather than growing a second copy.

## A latent bug this surfaced

**Entry-point interface lists now include every storage class**, not Input and Output alone. That is a SPIR-V 1.4 change from the 1.3 rule, and this module declares 1.6. It was invisible until now only because no descriptor could ever be *statically used* — a variable that is not used need not be listed. The moment #2649 lands and a uniform or storage buffer is actually read, the old behaviour would have produced invalid modules. The per-function reachability pass still decides which variables an entry point names, so an unused descriptor stays out.

## Acceptance: item 2 met, item 1 half met

> A compute shader can declare a storage buffer, **read from it and write to it**, and passes `spirv-val --target-env vulkan1.3`.

Declaring, laying out and binding: **done**, Vulkan-clean. Reading and writing: **blocked on #2649**, and it is the same wall as uniform member reads — a block member is reached through an `OpAccessChain` naming its ordinal, and MIR folds the member walk into a byte displacement first. Refused by name.

> The three `uvec3` built-ins are either spellable or refused with a diagnostic saying why.

**Done.**

So a storage buffer is currently declarable and bindable but not readable — the same half-state uniforms are in, for the same reason. Worth saying plainly rather than letting the PR title imply a working compute path.

## Also in here

The vector-literal refusal had **gone stale** and I corrected it. It said the value was materialized as an array allocation reinterpreted through its pointer; #2661 fixed that upstream, so the allocation is now at the vector's own type. What actually remains is that this milestone emits no local allocations, plus the per-lane indices a literal writes through. A confidently wrong diagnostic is worse than a vague one, and this one had started pointing at a solved problem.

## Checks

- `mach test .` — 1233 passed, 0 failed
- `int/run.sh --target linux` — full suite green; new `int/surface/spirv-storage` on `vulkan1.3`
- self-host fixpoint: b == c, byte-identical