### PR TITLE
fix(mir): gate the float address materialization on flat addressing

### DIFF
--- a/int/surface/spirv-interface/src/main.mach
+++ b/int/surface/spirv-interface/src/main.mach
@@ -8,13 +8,20 @@
 # Block-decorated struct with explicit member offsets, and an entry point must name
 # its Input and Output variables.
 #
-# NOT here: reading a MEMBER of the uniform block (`camera.view`), and a scalar
-# `f32` interface variable. Both are refused by name, each under its own cause -
-# the member walk because SPIR-V reaches a member through an `OpAccessChain` naming
-# its ordinal and MIR has already folded that walk into a byte displacement, and the
-# scalar float because MIR materializes a float variable's address into a register
-# before touching it, losing the direct reference. An integer or vector interface
-# variable keeps the reference, which is why every varying here is one of those.
+# NOT here: reading a MEMBER of the uniform block (`camera.view`). It is refused by
+# name, because SPIR-V reaches a member through an `OpAccessChain` naming its
+# ordinal and MIR has already folded that walk into a byte displacement (#2649).
+#
+# A scalar `f32` interface variable IS here, in both directions, and it is the
+# #2655 pin. It used to be refused alongside the member walk: MIR materialized a
+# FLOAT variable's address into a register before loading or storing it, which is a
+# repair for x86-64 recording no relocation on a float MEM operand's symbol, and it
+# was applied on every target. That destroyed the direct reference SPIR-V needs, so
+# half the scalar interface surface was dead while an `i32` or an `f32x4` of the
+# same role worked, from identical IR. The materialization is now gated on
+# `MachineModel.flat_addressing`. Keeping a scalar float varying in BOTH directions
+# is what makes a regression visible: a store-only or load-only case would pass
+# with one of the two sites still ungated.
 
 #[input(0)] var in_position: f32x4;
 #[input(1)] var in_colour:   f32x4;
@@ -23,6 +30,13 @@
 #[builtin("vertex_index")] var vertex_index: i32;
 
 #[output(0)] var vary_colour: f32x4;
+
+# the #2655 pin: SCALAR float varyings, written by a vertex stage and read by a
+# fragment stage. f64 is deliberately absent - a Vulkan shader interface variable
+# may not be 64-bit without the Float64 capability, which this module does not
+# declare, so f32 is the whole of the scalar float interface surface here.
+#[output(1)] var vary_alpha: f32;
+#[input(2)]  var in_alpha:   f32;
 
 # a uniform block: a `rec` bound at descriptor set 0, binding 0. it is emitted with
 # its Block decoration and a byte offset on every member.
@@ -81,6 +95,8 @@ fun vertex_main() {
 fun vertex_shaded() {
     position    = in_position + in_colour;
     vary_colour = in_colour * in_colour;
+    # a scalar float STORE to an interface variable
+    vary_alpha  = 0.5;
 }
 
 # a fragment stage reading a varying and writing a colour output. its interface
@@ -88,6 +104,9 @@ fun vertex_shaded() {
 #[stage("fragment")]
 fun fragment_main() {
     vary_colour = in_colour - in_position;
+    # a scalar float LOAD from an interface variable, feeding arithmetic and a
+    # store back out, so the value is genuinely carried rather than dead
+    vary_alpha  = in_alpha * 2.0;
 }
 
 # a compute stage carrying NO interface variables, which is what makes its entry

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2277,6 +2277,13 @@ fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instru
 # float load addresses `[base]` rather than an unrelocated `[rip+sym]` that would
 # read the wrong address. An integer load keeps the symbol operand: its generic
 # encoding records the relocation directly.
+#
+# That is a FLAT-ADDRESSING repair and is gated on it (#2655). Under a logical
+# addressing model there is no `[rip+sym]` to leave unrelocated and no address to
+# materialize: a variable IS its pointer, at one pointee type, and rewriting the
+# operand to `[base + 0]` only destroys the direct reference the target reaches it
+# through. Applying it there made a scalar float interface variable unencodable in
+# either direction while an integer or vector one worked, from identical IR.
 # ---
 # ctx:  the per-function lowering context
 # mb:   the destination MIR block
@@ -2292,7 +2299,7 @@ fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
         ret R.err[bool, str]("mir.lower_ir: load defines no result vreg");
     }
     var mem: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[0]);
-    if (mem.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.ty)) {
+    if (ctx.tgt.model.flat_addressing && mem.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.ty)) {
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = lctx.addr_to_vreg(ctx, mb, mem, ?base);
         if (R.is_err[bool, str](ar)) { ret R.err[bool, str](R.unwrap_err[bool, str](ar)); }
@@ -2355,9 +2362,10 @@ fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     # destination MEM. a global symbol destination must therefore be LEA-materialized
     # into a GP base vreg first (so the store addresses `[base]`), mirroring the
     # float-load path; an integer store keeps the symbol destination and relocates
-    # through the generic encoding.
+    # through the generic encoding. gated on flat addressing for the same reason the
+    # load is (#2655).
     var dest: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[1]);
-    if (dest.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.operands[0].ty)) {
+    if (ctx.tgt.model.flat_addressing && dest.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.operands[0].ty)) {
         var dbase: u32 = mir.MIR_VREG_NIL;
         val dr: R.Result[bool, str] = lctx.addr_to_vreg(ctx, mb, dest, ?dbase);
         if (R.is_err[bool, str](dr)) { ret R.err[bool, str](R.unwrap_err[bool, str](dr)); }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -330,6 +330,27 @@ pub rec MachineModel {
     # rv64 MUL, and SPIR-V's OpIMul), so the gate is dead everywhere but mos6502.
     has_mul: bool;
 
+    # whether the ISA addresses memory as a FLAT space of bytes reached from a base
+    # (#2655). true on every machine target: an address there is an integer, any two
+    # objects sit in one numbered space, and a pointer may be re-read at whatever type
+    # the instruction wants. false under a LOGICAL addressing model (SPIR-V), where a
+    # pointer names one object at exactly one pointee type, offsets are not arithmetic,
+    # and a member is reached structurally by ordinal rather than by byte.
+    #
+    # The distinction is what makes a byte-oriented transformation legal, not merely
+    # cheap. MIR lowering carries several: a float variable's address is
+    # LEA-materialized into a register before it is touched, because x86-64 records no
+    # relocation for a float MEM operand's symbol; an aggregate member walk folds into a
+    # byte displacement. Each is right for a flat target and destroys the structure a
+    # logical one cannot rebuild - an offset does not determine an ordinal, since unions
+    # overlap, nested aggregates share offsets with their first members, and padding
+    # belongs to no member.
+    #
+    # Gate the transformation, not the target: `if (flat_addressing)` keeps every
+    # machine target's output identical byte for byte and leaves the structural form
+    # standing where it is the only expressible one.
+    flat_addressing: bool;
+
     # the second constant-time capability fact (#1646): true when the ISA shifts by a
     # variable count in constant time (a barrel shifter), so a secret shift COUNT is
     # permitted; false gates a shift by a secret count as a variable-latency leak (an

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -250,6 +250,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.ct_trust_mul  = false;
     arm64_model.has_var_shift = true;        # LSLV / LSRV / ASRV read the count from a register (#2217)
     arm64_model.has_mul = true;              # MUL (#2344)
+    arm64_model.flat_addressing = true;      # a byte-addressed linear space (#2655)
     arm64_model.ct_trust_var_shift = true;   # aarch64 variable shift is constant-time (#1646)
 
     arm64_model.reg_classes     = ?arm64_classes[0];

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -130,6 +130,7 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no hardware multiply at any width (#2344): be.codegen.legalize owns every
     # MIR_MUL, native-width included, and expands it into a double-and-add sequence.
     mos6502_model.has_mul = false;
+    mos6502_model.flat_addressing = true;   # a 16-bit byte address space (#2655)
 
     mos6502_model.reg_classes     = ?mos6502_classes[0];
     mos6502_model.reg_class_len   = 1;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -293,6 +293,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_model.ct_trust_mul = false;
     riscv64_model.has_var_shift = true;        # SLL / SRL / SRA read the count from a register (#2217)
     riscv64_model.has_mul = true;              # MUL, the M extension (#2344)
+    riscv64_model.flat_addressing = true;      # a byte-addressed linear space (#2655)
     riscv64_model.ct_trust_var_shift = true;   # rv64 SLL/SRL variable shift is constant-time (#1646)
 
     riscv64_model.reg_classes     = ?riscv64_classes[0];

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -103,6 +103,9 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     spirv_model.ct_trust_mul           = false;
     spirv_model.has_var_shift          = true;
     spirv_model.has_mul                = true;   # OpIMul (#2344)
+    # the logical addressing model: a pointer names one object at one pointee type,
+    # there is no pointer arithmetic and no pointer bitcast (#2655)
+    spirv_model.flat_addressing        = false;
     spirv_model.ct_trust_var_shift     = false;
 
     # the whole-module contract is the entire SPIR-V back half, and it is the whole

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -296,6 +296,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.ct_trust_mul    = false;
     x64_model.has_var_shift = true;        # SHL/SHR/SAR by CL is a single instruction (#2217)
     x64_model.has_mul = true;              # IMUL (#2344)
+    x64_model.flat_addressing = true;      # a byte-addressed linear space (#2655)
     x64_model.ct_trust_var_shift = true;   # SHL/SHR by CL is single-instruction constant-time (#1646)
 
     x64_model.reg_classes     = ?x64_classes[0];


### PR DESCRIPTION
Closes #2655.

## Cause

`lower_load` and `lower_store` LEA-materialize a symbol address into a GP vreg when the value is float, then rewrite the operand to `[base + 0]`. That repairs a real x86-64 constraint — the encoder dispatches a float move on operand class and records no relocation for a float MEM operand's symbol, so an unrelocated `[rip+sym]` would read the wrong address.

It was applied on every target. Under a logical addressing model there is nothing to repair: a variable **is** its pointer, at exactly one pointee type, and rewriting the operand to a register base only destroys the direct reference SPIR-V reaches it through. That is why a scalar `f32` interface variable failed in both directions while an `i32` and an `f32x4` of the same role worked, from identical IR.

## Fix

Adds `MachineModel.flat_addressing` — true on x86-64, aarch64, riscv64 and mos6502, false on SPIR-V — and gates both sites on it.

**On the "one machine-model fact rather than three conditionals" question:** the fact is the right shape, but #2649 and #2655 are one *decision* and two *changes*. #2655 is two five-line conditionals. #2649 additionally needs MIR to **carry** the gep index list, which is a representation change to `MirInstr`. So this lands the fact in a form #2649 consumes without reshaping, rather than bundling a representation change into a conditional. `flat_addressing` is documented at the declaration as the axis, naming both sites, so the next one is a drop-in.

#2640 is not part of this family at all: it is in the AST-to-IR lowering, where the structure was never built, so there is nothing to gate.

## Native output unchanged, proven not asserted

This is the acceptance item that matters, since x86 genuinely needs the materialization. Float globals stored and loaded in both directions plus float constants and mixed float/int work, whole `.s` compared byte for byte:

| target | debug | release |
|---|---|---|
| x86_64 | **IDENTICAL** (81 instrs) | **IDENTICAL** (92) |
| aarch64 | **IDENTICAL** (87) | **IDENTICAL** (112) |
| riscv64 | **IDENTICAL** (108) | **IDENTICAL** (122) |

Not "no diff in the region I changed" — `cmp` over the entire emitted assembly, six builds.

## SPIR-V

A scalar `f32` varying now works in both directions and the module passes `spirv-val --target-env vulkan1.3`. The emitted store is direct, with no intermediate address:

```
OpDecorate %18 Location 1
...
OpStore %18 %float_0_5
```

## Tests

Extended `int/surface/spirv-interface` with scalar `f32` varyings in **both** directions — a store-only or load-only case would pass with one of the two sites still ungated. `f64` is deliberately absent: a Vulkan interface variable may not be 64-bit without the `Float64` capability, which this module does not declare.

**Evidence it fails first**, same case against the baseline compiler at the branch point:
```
FAIL surface/spirv-interface [linux/debug] (build)
    error: a scalar `f32` / `f64` shader interface variable is not yet supported by the SPIR-V target...
FAIL surface/spirv-interface [linux/release] (build)
int: 2 failure(s) on linux
```

I also updated that fixture's header, which documented this limitation as a standing fact and was now false. The `#2649` half of the note is untouched and still accurate.

## For the SPIR-V track

Two things in `spirv/emit.mach`, which I did not edit:

1. The refusal `unsupported(...)` for a scalar float interface variable no longer fires for this case, but is **still reachable** for a float access to a non-interface target, so it is not dead. Its message text is now stale though — it says "MIR materializes a FLOAT variable's address into a register", which is no longer true on that target. Worth rewording to describe what it still catches.
2. `builds_vector_through_memory` and the #2640 refusal are unaffected.

## Found in passing, not fixed here

**A module-scope vector global fails to encode on aarch64**, on `dev` at the branch point and unrelated to this change:
```
var gvec: f32x4;
fun vecs(v: f32x4) f32x4 { gvec = v; ret gvec; }
```
→ `error: encode: expected a memory operand`

x86_64 and riscv64 both accept it. I hit it building the native-unchanged comparison and excluded it to get the aarch64 numbers above. Worth its own issue.

## Status

- `mach test .` — 1233 passed, 0 failed
- `int/run.sh --target linux` — all cases passed, including all five spirv cases
- release self-host fixpoint, three generations — R2 and R3 byte-identical