### PR TITLE
feat(mir): keep a GEP's index list on a logical-addressing target

### DIFF
--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2537,6 +2537,15 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
         ret R.err[bool, str]("mir.lower_ir: gep with indices is missing its source pointee type");
     }
 
+    # a logical-addressing target reaches a member by ORDINAL, not by byte, so the
+    # walk is kept rather than folded (#2649). the fold below is a byte-space
+    # transformation and is not merely slower there, it is unrecoverable: an offset
+    # does not determine an ordinal, because unions overlap, a nested aggregate
+    # shares an offset with its first member, and padding belongs to no member.
+    if (!ctx.tgt.model.flat_addressing) {
+        ret lower_gep_structural(ctx, mb, inst, dst, base);
+    }
+
     # walk the indices, accumulating a constant displacement and at most one
     # scaled runtime index. a struct level needs a constant field ordinal.
     var disp:      i64 = 0;
@@ -2625,6 +2634,52 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     ops[1] = R.unwrap_ok[mir.MirOperand, str](mem);
     # the GEP selects to a LEA computing a pointer-sized effective address.
     var mi: mir.MirInstr = mir.instr(mir.MIR_GEP, ops, 2,
+                                     ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
+    ret lctx.push_instr(ctx, mb, mi);
+}
+
+# lower an OP_GEP structurally, keeping its index list, for a logical-addressing
+# target (#2649)
+#
+# The flat form above folds the whole walk into `[base + index*scale + disp]`,
+# because on a byte-addressed machine that IS the address. Under a logical
+# addressing model a pointer names one object at one pointee type and a member is
+# reached by its ORDINAL, so the walk has to survive lowering: the emitter builds an
+# `OpAccessChain` from exactly these indices.
+#
+# THE OPERAND LAYOUT IS THE CONTRACT. A structural GEP is
+# `[dst, base, idx0, idx1, ...]` - `operand_count > 2` - where the indices are the
+# IR GEP's own index operands in order, unchanged and unscaled, following the
+# standard getelementptr model (index 0 strides over the source pointee type, each
+# later index descends one level). A flat GEP stays `[dst, mem]` at
+# `operand_count == 2`, so a consumer distinguishes the two by the count alone and
+# every machine target's lowering is bit-for-bit what it was.
+#
+# The source pointee type is NOT carried here. It is recoverable at the consumer
+# from what the base names - a global's declared type, or the allocated type of the
+# `MIR_ALLOCA` a local base defines - and duplicating it into the operand list would
+# be a second source of truth for a fact the base already fixes.
+# ---
+# ctx:  the per-function lowering context
+# mb:   the destination MIR block
+# inst: the IR OP_GEP instruction
+# dst:  the destination vreg
+# base: the lowered base operand
+# ret:  true on success, or a lowering / allocation error
+fun lower_gep_structural(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
+                         dst: u32, base: mir.MirOperand) R.Result[bool, str] {
+    val n: usize = (inst.operand_count + 1)::usize;
+    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, n);
+    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](r)); }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    ops[0] = mir.op_vreg(dst);
+    ops[1] = base;
+    var k: u32 = 1;
+    for (k < inst.operand_count) {
+        ops[(k + 1)::usize] = lctx.lower_value(ctx, inst.operands[k]);
+        k = k + 1;
+    }
+    var mi: mir.MirInstr = mir.instr(mir.MIR_GEP, ops, inst.operand_count + 1,
                                      ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     ret lctx.push_instr(ctx, mb, mi);
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -30,6 +30,8 @@ use R: std.types.result;
 use ctime: std.chrono.time;
 
 use mach.lang.be.codegen;
+use mir: mach.lang.be.codegen.mir;
+use mirlower: mach.lang.be.codegen.mir.lower;
 use mach.lang.be.obj;
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
@@ -1000,7 +1002,7 @@ fun ut_vec_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name
     names[0] = "main.mach";
     var texts: [1]str;
     texts[0] = src;
-    val root_r: R.Result[str, str] = ut_scaffold(alloc, ?names[0], ?texts[0], 1);
+    val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_manifest_spirv(), ?names[0], ?texts[0], 1);
     if (R.is_err[str, str](root_r)) { ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[str, str](root_r))); }
     val root: str = R.unwrap_ok[str, str](root_r);
     val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
@@ -1392,6 +1394,95 @@ test "mach.lang.driver:vector_storage_is_not_reinterpreted" {
     project.dnit_project(?p);
     session.dnit(?s);
     ret bad;
+}
+
+# a manifest declaring the spirv target alongside linux, for a test that must lower
+# the SAME source both ways. kept separate from `ut_manifest` so adding a target
+# here cannot perturb the ~180 tests that share that fixture
+fun ut_manifest_spirv() str {
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64\"\n\n[target.spirv]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# the widest MIR_GEP operand count in a lowered module, or 0 when there is no gep
+# ---
+# mm:  the lowered MIR module
+# ret: the largest `operand_count` seen on a MIR_GEP
+fun ut_max_gep_operands(mm: *mir.MirModule) u32 {
+    var best: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < mm.function_len) {
+        val mf: *mir.MirFunction = ?mm.functions[fi];
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                val mi: *mir.MirInstr = ?blk.instrs[ii];
+                if (mi.opcode == mir.MIR_GEP && mi.operand_count > best) { best = mi.operand_count; }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+    ret best;
+}
+
+# lower `src` for `tname` all the way to MIR and report the widest MIR_GEP
+# ---
+# alloc: allocator for the session and the MIR arena
+# src:   the module source
+# tname: the target to lower for
+# ret:   the widest MIR_GEP operand count, or -1 on any failure
+fun ut_gep_shape(alloc: *A.Allocator, src: str, tname: str) i64 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, alloc, src, tname);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var out: i64 = -1;
+    var mi: u32 = 0;
+    for (mi < p.module_len) {
+        val me: *project.ModuleEntry = ?p.modules[mi];
+        if (me.ir_module == nil) { mi = mi + 1; cnt; }
+        val mr: R.Result[mir.MirModule, str] = mirlower.lower_ir(?p.target, me.ir_module, alloc, ?s.interner, ?s.sources);
+        if (R.is_err[mir.MirModule, str](mr)) { mi = mi + 1; cnt; }
+        var mm: mir.MirModule = R.unwrap_ok[mir.MirModule, str](mr);
+        val w: u32 = ut_max_gep_operands(?mm);
+        if (w::i64 > out) { out = w::i64; }
+        mi = mi + 1;
+    }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret out;
+}
+
+# a MIR_GEP keeps its index list on a logical-addressing target and folds to a
+# byte displacement on a flat one (#2649)
+#
+# THE OPERAND COUNT IS THE CONTRACT the SPIR-V emitter reads to tell the two apart.
+# A flat GEP is `[dst, mem]` at exactly 2; a structural one is
+# `[dst, base, idx0, ...]` at more than 2. A member walk `g.x.a` carries two IR
+# indices, so it must reach 4 on spirv and stay at 2 on every machine target.
+#
+# Asserting the count on BOTH sides is what makes this a regression test rather
+# than a feature test: gating the fold the wrong way round, or dropping the gate
+# entirely, moves one of the two numbers.
+test "mach.lang.driver:gep_index_list_survives_on_logical_addressing" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val src: str = "rec Inner { a: i64; b: i64; }\nrec Outer { x: Inner; y: i64; }\n#[uniform(0, 0)] var g: Outer;\n#[output(0)] var o: i32;\n#[stage(\"vertex\")]\nfun vs() { o = g.x.a::i32; }\nfun main() i32 { ret 0; }\n";
+
+    # spirv keeps the walk: base plus two indices, past the flat form's 2.
+    if (ut_gep_shape(?alloc, src, "spirv") <= 2) { ret 1; }
+
+    # every flat target folds it away and stays at exactly 2.
+    val nsrc: str = "rec Inner { a: i64; b: i64; }\nrec Outer { x: Inner; y: i64; }\nvar g: Outer;\nfun rd() i64 { ret g.x.a; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret rd()::i32; }\n";
+    if (ut_gep_shape(?alloc, nsrc, "linux")         != 2) { ret 1; }
+    if (ut_gep_shape(?alloc, nsrc, "linux-arm64")   != 2) { ret 1; }
+    if (ut_gep_shape(?alloc, nsrc, "linux-riscv64") != 2) { ret 1; }
+    ret 0;
 }
 
 # an uninitialized vector local default-initializes to all-zero lanes through a

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -1813,13 +1813,13 @@ fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand
         ret "a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`)";
     }
     if (g.iface == ir.IFACE_UNIFORM) {
-        ret "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL, and MIR has already folded the member walk into a byte displacement, which the ordinal cannot be recovered from in general. the block itself is declared correctly, with its Block decoration and member offsets; only the member read is missing";
+        ret "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the block itself is declared correctly, with its Block decoration and member offsets";
     }
     if (is_scalar_float_type(e, g.ty)) {
         ret "a scalar `f32` / `f64` shader interface variable is not yet supported by the SPIR-V target: MIR materializes a FLOAT variable's address into a register before loading or storing it, which loses the direct reference SPIR-V needs, while an integer or vector variable keeps it. an `f32x4` or an `i32` interface variable of the same role works today";
     }
     if (is_aggregate_type(e, g.ty)) {
-        ret "indexing into an aggregate shader interface variable is not yet supported by the SPIR-V target: SPIR-V reaches an element through an OpAccessChain naming its ORDINAL, and MIR has already folded the walk into a byte displacement, which the ordinal cannot be recovered from in general. the variable itself is declared correctly; read or write it whole";
+        ret "indexing into an aggregate shader interface variable is not yet supported by the SPIR-V target: SPIR-V reaches an element through an OpAccessChain naming its ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the variable itself is declared correctly; read or write it whole";
     }
     ret "this shader interface variable is reachable only as a whole-variable read or write in the SPIR-V target";
 }


### PR DESCRIPTION
Refs #2649 — deliberately **not** `Closes`. This is the enabling half; building the access chain is backend work, detailed below.

## Cause

MIR folded an aggregate member walk into a byte displacement before the back end saw it: `gep ptr @camera, 0, 1` arrived as `disp=16` and nothing else. On a byte-addressed machine that *is* the address. SPIR-V reaches a member through `OpAccessChain` naming its **ordinal**, and an offset does not determine one — unions overlap, a nested aggregate shares an offset with its first member, and padding belongs to no member. Inverting it would be guessing dressed as arithmetic, wrong exactly where it matters.

## Fix

`lower_gep` branches on `flat_addressing`. Flat targets take the identical path. A logical target takes `lower_gep_structural`, which emits the walk unchanged.

**The operand layout is the contract**, and it is what the emitter reads to tell the two forms apart:

| form | operands | count |
|---|---|---|
| flat | `[dst, mem]` | exactly 2 |
| structural | `[dst, base, idx0, idx1, ...]` | more than 2 |

The source pointee type is deliberately **not** carried. It is recoverable at the consumer from what the base names — a global's declared type, or the allocated type of the `MIR_ALLOCA` a local base defines — and duplicating it would be a second source of truth for a fact the base already fixes.

This is the second consumer of `flat_addressing` (#2655) and it needed no reshaping, which was the point of landing that as an axis rather than as a conditional.

## Flat-target output unchanged, proven not asserted

The strongest form available: **the entire 8.2 MB compiler binary, built from identical source by each compiler, is byte-identical.** That is every gep in the compiler's own body.

Plus gep-heavy source — nested records, arrays with runtime indices, a union, pointer-parameter walks, reads and writes:

| target | debug | release |
|---|---|---|
| x86_64 | identical (72 instrs) | identical (74) |
| aarch64 | identical (82) | identical (95) |
| riscv64 | identical (101) | identical (100) |

## No silent miscompile in the interim

Worth stating because it was the real risk of landing the enabling half alone. A member read addresses through the GEP's **vreg**, not a symbol, so `interface_target` never resolved it as a whole-variable access and cannot start to now. Verified directly: `camera.view` still refuses by name after this change rather than emitting a whole-block load.

I corrected the two refusal messages that named the fold as the cause, since that is no longer true on that target and they would now send a reader to the wrong problem — the same failure mode their own comment warns about.

## Tests

`mach.lang.driver:gep_index_list_survives_on_logical_addressing` lowers a member walk **all the way to MIR** and asserts the operand count on both sides: more than 2 on spirv, exactly 2 on x86_64, aarch64 and riscv64. Asserting both sides is what makes it a regression test rather than a feature test.

**Mutation evidence — both directions of the gate are load-bearing:**

| mutation | result |
|---|---|
| drop the gate (never keep the list) | 1233 passed, **1 failed** |
| invert the gate (keep it on flat targets too) | 1233 passed, **1 failed** |

I added `ut_manifest_spirv` rather than adding a spirv target to `ut_manifest`, so a new target here cannot perturb the ~180 tests sharing that fixture.

## What the SPIR-V backend needs (not done here)

`addressed_memory_refusal` now names it precisely. Concretely: on `MIR_GEP` with `operand_count > 2`, map the base symbol to its variable id, map operands 2 onward to constant ids, walk the base's IR type with those ordinals to get the member type, intern a pointer to it in the right storage class, and emit `OpAccessChain`. The subsequent load or store then addresses the chain result.

Per #2665's finding this unblocks three consumers: uniform block member reads, storage buffer member access, and — after #2661 removed the type-punned allocation — the per-lane geps that are all that remains of #2640's vector literal blocker.

**On the seed question:** this does **not** make a vector nameable as an SSA value. It is about addressing, not constants. `VAL_CONST_AGG` is still global-initializer-only and `const_type_ok` still rejects `VAL_CONST_INT` with a vector type, so the insert-chain seed remains blocked independently, and #2662 still gates the native constant case.

## Status

- `mach test .` — 1239 passed, 0 failed
- `int/run.sh --target linux` — all cases passed, all five spirv cases included
- release self-host fixpoint, three generations — R2 and R3 byte-identical