### PR TITLE
fix(spirv): drop the dead scalar-float refusal, and cover the built-in path

### DIFF
--- a/int/surface/spirv-interface/src/main.mach
+++ b/int/surface/spirv-interface/src/main.mach
@@ -29,6 +29,13 @@
 #[builtin("position")]     var position:     f32x4;
 #[builtin("vertex_index")] var vertex_index: i32;
 
+# a scalar float BUILT-IN, which is a different path from the scalar float varying
+# above: a built-in derives its storage class from the built-in itself rather than
+# from an `#[input]` / `#[output]` marker, so it reaches the interface declaration
+# through separate code. It was unreachable for the same #2655 reason and is the
+# only spellable scalar-float built-in, so nothing else covers that path.
+#[builtin("point_size")]   var point_size:   f32;
+
 #[output(0)] var vary_colour: f32x4;
 
 # the #2655 pin: SCALAR float varyings, written by a vertex stage and read by a
@@ -85,6 +92,7 @@ rec Scene {
 #[stage("vertex")]
 fun vertex_main() {
     position    = in_position;
+    point_size  = 1.0;
     vary_colour = in_colour;
 }
 

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -1792,12 +1792,17 @@ fun interface_target(e: *Emit, op: *mir.MirOperand) u32 {
 # the diagnostic for an addressed access the milestone cannot carry, named by what
 # the address actually originates in
 #
-# Three lowerings land here and each is fixed somewhere different, so each says so.
-# A member walk into a uniform block needs the GEP to keep its index list; a scalar
-# float interface variable needs the float address materialization to stop being
-# unconditional; anything else is ordinary addressed memory this milestone does not
-# have. Reporting any of them under another's name sends a reader to the wrong
-# problem, which is exactly what the first version of this did.
+# Several lowerings land here and each is fixed somewhere different, so each says
+# so. A member walk into a uniform block, and an index into any other aggregate,
+# need this emitter to build an access chain from the ordinals MIR now keeps;
+# anything else is ordinary addressed memory this milestone does not have.
+# Reporting any of them under another's name sends a reader to the wrong problem,
+# which is exactly what the first version of this did.
+#
+# A scalar `f32` / `f64` interface variable used to have an arm here, because the
+# float address materialization was applied on every target and destroyed the
+# direct symbol reference. #2655 gated that on `MachineModel.flat_addressing`, so
+# those shapes reach the whole-variable path and never arrive here at all.
 # ---
 # e:   the emission state
 # mf:  the MIR function
@@ -1815,9 +1820,6 @@ fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand
     if (g.iface == ir.IFACE_UNIFORM) {
         ret "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the block itself is declared correctly, with its Block decoration and member offsets";
     }
-    if (is_scalar_float_type(e, g.ty)) {
-        ret "a scalar `f32` / `f64` shader interface variable is not yet supported by the SPIR-V target: MIR materializes a FLOAT variable's address into a register before loading or storing it, which loses the direct reference SPIR-V needs, while an integer or vector variable keeps it. an `f32x4` or an `i32` interface variable of the same role works today";
-    }
     if (is_aggregate_type(e, g.ty)) {
         ret "indexing into an aggregate shader interface variable is not yet supported by the SPIR-V target: SPIR-V reaches an element through an OpAccessChain naming its ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the variable itself is declared correctly; read or write it whole";
     }
@@ -1834,17 +1836,6 @@ fun is_aggregate_type(e: *Emit, id: type.IrTypeId) bool {
     if (O.is_none[*type.IrType](opt)) { ret false; }
     val k: type.IrTypeKind = O.unwrap[*type.IrType](opt).kind;
     ret k == type.IRT_ARRAY || k == type.IRT_STRUCT;
-}
-
-# whether an IR type is a scalar float
-# ---
-# e:   the emission state
-# id:  the IR type id
-# ret: true for IRT_FLOAT
-fun is_scalar_float_type(e: *Emit, id: type.IrTypeId) bool {
-    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
-    if (O.is_none[*type.IrType](opt)) { ret false; }
-    ret O.unwrap[*type.IrType](opt).kind == type.IRT_FLOAT;
 }
 
 # emit an OpLoad of a shader interface variable


### PR DESCRIPTION
No `Closes` line and no issue: this is dead code left behind by #2655 landing, spotted while reviewing #2671.

## What was dead

`addressed_memory_refusal` had an arm for a scalar `f32` / `f64` interface variable, saying MIR materializes a float variable's address into a register and destroys the direct symbol reference SPIR-V needs. **That was true and is not any more.** #2655 gated the materialization on `MachineModel.flat_addressing`, so on this target a scalar float global keeps its symbol operand, reaches the whole-variable path, and never arrives at the refusal.

So the arm cannot fire, and its text describes a solved problem. Both are removed, along with the `is_scalar_float_type` helper that fed only it, and the docstring no longer lists it as one of the causes.

## Demonstrated, not asserted

Every shape the arm guarded, built for `spirv` and checked with `spirv-val --target-env vulkan1.3`:

```
COMPILES+VALID | f32 input, read
COMPILES+VALID | f32 output, write
COMPILES+VALID | f32 in and out, arithmetic
COMPILES+VALID | f64 in and out
COMPILES+VALID | f32 BuiltIn point_size
```

## The gap that last line closes

The #2655 work pinned a scalar float **varying** in both directions, which was the right call — a store-only or load-only case would pass with one of the two sites still ungated.

But a **built-in** is a different path: it derives its storage class from the built-in itself rather than from an `#[input]` / `#[output]` marker, so it reaches the interface declaration through separate code that nothing exercised. `point_size` is the only spellable scalar-float built-in — the three `uvec3` compute ones cannot be typed at all — so it is the only way to cover that path, and it was unreachable for the same #2655 reason.

`spirv-interface` now writes it, and the emitted module carries:

```
OpEntryPoint Vertex %1 "vertex_main" %9 %10 %gl_Position %gl_PointSize %18
OpDecorate %gl_PointSize BuiltIn PointSize
%gl_PointSize = OpVariable %_ptr_Output_float Output
```

Named in the entry point's interface list, which is the part that would have regressed silently.

## Checks

- `mach test .` — 1239 passed, 0 failed
- `int/run.sh --target linux` — full suite green
- self-host fixpoint: `b == c`, byte-identical

## Not in scope

#2668 (this emitter consuming the ordinals #2671 now keeps) is still blocked, and on two things rather than one: the access-chain construction itself, and #2673 for the pointee type on a local base.