### PR TITLE
fix(lower): materialize a :~ that crosses the value/address classes

### DIFF
--- a/int/regression/2670-bitcast-value-address/case.conf
+++ b/int/regression/2670-bitcast-value-address/case.conf
@@ -1,0 +1,22 @@
+# a `:~` between a VALUE (scalar or vector) and an AGGREGATE (array / record) is a
+# representation change, not a retag: an aggregate is carried by its storage address
+# and a scalar or vector by value. Both directions were miscompiled (#2670).
+#
+# aggregate -> value handed back the storage ADDRESS as the scalar, which did not
+# fault: it was a silent wrong answer that also leaked a stack address into ordinary
+# integer data. value -> aggregate produced an aggregate-typed value that the store
+# then dereferenced as a pointer, which segfaulted only when the bytes happened not
+# to form a mapped address.
+#
+# Both directions must be covered. A case testing only the crashing one would leave
+# the silent disclosure live, which is the more serious of the two.
+#
+# The observable is the reinterpreted bytes printed in hex, not an exit code: the
+# values are chosen so a wrong answer cannot coincide with a right one. A stack
+# address shares no digits with 0102030405060708, and it also varies per run, so the
+# broken behaviour cannot produce a stable golden at all.
+#
+# every leg: the defect was present on all three, including riscv64, whose
+# scalarizer spared only the vector row.
+run: exec
+targets: linux linux-arm64 linux-riscv64

--- a/int/regression/2670-bitcast-value-address/expect.txt
+++ b/int/regression/2670-bitcast-value-address/expect.txt
@@ -1,0 +1,5 @@
+arr->u64 102030405060708
+u64->arr 8 7 2 1
+roundtrip 1122334455667788
+vec->arr ab ab
+vec->vec cdcdcdcd cdcdcdcd

--- a/int/regression/2670-bitcast-value-address/mach.toml
+++ b/int/regression/2670-bitcast-value-address/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2670-bitcast-value-address/src/main.mach
+++ b/int/regression/2670-bitcast-value-address/src/main.mach
@@ -1,0 +1,41 @@
+# `:~` across the value / address representation classes, both directions (#2670)
+
+use std.runtime;
+use p: std.print;
+use std.simd.shuffle.splat_u8x16;
+
+# aggregate -> value: the array's BYTES, never its storage address
+fun arr_to_u64(a: [8]u8) u64 { ret a:~u64; }
+
+# value -> aggregate: the integer's bytes given storage
+fun u64_to_arr(x: u64) [8]u8 { ret x:~[8]u8; }
+
+# the same crossing with a vector on the value side
+fun vec_to_arr(v: u8x16) [16]u8 { ret v:~[16]u8; }
+
+# within one class: a pure retag, which must be unaffected
+fun vec_to_vec(v: u8x16) u32x4 { ret v:~u32x4; }
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    # a distinctive pattern: every byte differs, so a byte-order or width error
+    # shows, and no stack address shares these digits
+    var a: [8]u8;
+    a[0] = 0x08; a[1] = 0x07; a[2] = 0x06; a[3] = 0x05;
+    a[4] = 0x04; a[5] = 0x03; a[6] = 0x02; a[7] = 0x01;
+    p.printlnf("arr->u64 {:x}", arr_to_u64(a));
+
+    val b: [8]u8 = u64_to_arr(0x0102030405060708);
+    p.printlnf("u64->arr {:x} {:x} {:x} {:x}", b[0]::i64, b[1]::i64, b[6]::i64, b[7]::i64);
+
+    # round trip: the bytes must survive both crossings unchanged
+    p.printlnf("roundtrip {:x}", arr_to_u64(u64_to_arr(0x1122334455667788)));
+
+    val c: [16]u8 = vec_to_arr(splat_u8x16(0xAB));
+    p.printlnf("vec->arr {:x} {:x}", c[0]::i64, c[15]::i64);
+
+    val w: u32x4 = vec_to_vec(splat_u8x16(0xCD));
+    p.printlnf("vec->vec {:x} {:x}", w[0]::i64, w[3]::i64);
+
+    ret 0;
+}

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -100,6 +100,17 @@ pub val VC_TYPE_AGREE:      VerifyCheck = 13;
 # shipping
 pub val VC_CALL_ARG_TYPE:   VerifyCheck = 14;
 
+# a bitcast may not cross the value / address representation classes. An aggregate
+# (struct / union / array) is carried by its storage ADDRESS; a scalar or vector is
+# carried by VALUE. A bitcast between the two classes is a representation change,
+# not the retag the opcode means, and neither end of it is expressible: from an
+# aggregate it hands back the storage address as the scalar, and into an aggregate
+# it produces an aggregate-typed value every consumer then dereferences as a
+# pointer. `:~` lowering materializes the crossing with a load or a store instead
+# (#2670). Always on: the shape is individually coherent at both ends and only wrong
+# in combination, which review does not catch and only an invariant does
+pub val VC_BITCAST_CLASS:   VerifyCheck = 15;
+
 # one invariant failure, located as precisely as the failing check allows
 # ---
 # function: index into Module.functions
@@ -199,6 +210,7 @@ pub fun describe(check: VerifyCheck) str {
     if (check == VC_DOMINANCE)       { ret "dominance: operand definition does not dominate its use"; }
     if (check == VC_REACHABILITY)    { ret "reachability: block is unreachable"; }
     if (check == VC_AGG_ADDRESS)     { ret "aggregate representation: aggregate-typed operand is not address-producing"; }
+    if (check == VC_BITCAST_CLASS)   { ret "bitcast crosses the value / address representation classes without materializing it"; }
     if (check == VC_TYPE_RESOLVE)    { ret "type resolution: operand or aux type does not resolve"; }
     if (check == VC_DANGLING_ID)     { ret "dangling id: a block list names an out-of-range instruction id"; }
     if (check == VC_TYPE_AGREE)      { ret "type agreement: operand types violate the opcode's typing contract"; }
@@ -642,6 +654,8 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
     # declared IRT_FN signature. now that generic instances carry real signatures,
     # this makes the #2035 defect class (a by-value aggregate arg mis-typed to a
     # pointer) structurally impossible to ship.
+    val res_bc: R.Result[bool, str] = check_bitcast_class(m, ins, fi, bid, iid, r);
+    if (R.is_err[bool, str](res_bc)) { ret res_bc; }
     val res_call: R.Result[bool, str] = check_call_arg_types(m, ins, fi, bid, iid, r);
     if (R.is_err[bool, str](res_call)) { ret res_call; }
     ret R.ok[bool, str](true);
@@ -771,6 +785,33 @@ fun check_type_agree(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid:
 # iid: the instruction id (located on a violation)
 # r:   the report to record into
 # ret: true on completion, or an allocation error
+# VC_BITCAST_CLASS: a bitcast's operand and result must sit on the same side of the
+# value / address divide
+#
+# `is_aggregate` is the single classifier the lowerer and the back end already share,
+# so this asks exactly the question they both answer. A crossing is a representation
+# change the opcode cannot express, and it shipped in both directions before #2670:
+# `[8]u8 :~ i64` evaluated to the array's stack address, and `i64 :~ [8]u8` emitted a
+# copy from whatever the integer's bytes looked like as a pointer. Neither faulted
+# reliably, so the first was a silent wrong answer.
+#
+# A sentinel-typed operand is not classified: an unresolvable id is VC_TYPE_RESOLVE's
+# to report, and reading it here would double-report one defect.
+# ---
+# m:   the module (type table)
+# ins: the instruction to check
+# ret: ok(true) once checked, or an allocation error from `push`
+fun check_bitcast_class(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport) R.Result[bool, str] {
+    if (ins.kind != instruction.OP_BITCAST) { ret R.ok[bool, str](true); }
+    if (ins.operand_count < 1)              { ret R.ok[bool, str](true); }
+    val src: type.IrTypeId = (?ins.operands[0]).ty;
+    if (src == type.IRT_NIL || ins.ty == type.IRT_NIL) { ret R.ok[bool, str](true); }
+    if (type.is_aggregate(?m.types, src) == type.is_aggregate(?m.types, ins.ty)) {
+        ret R.ok[bool, str](true);
+    }
+    ret push(r, fi, bid, iid, VC_BITCAST_CLASS);
+}
+
 fun check_call_arg_types(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport) R.Result[bool, str] {
     if (ins.kind != instruction.OP_CALL) { ret R.ok[bool, str](true); }
     if (ins.operand_count == 0)          { ret R.ok[bool, str](true); }
@@ -1996,6 +2037,94 @@ test "mach.lang.me.ir.verify.check_pred_consistency:wrong_member" {
     # block 3's preds are {1, 2}; rewrite to {1, 1} - same length, wrong members.
     env.m.functions[0].blocks[3].preds[1] = 1::id.BlockId;
     if (t_count(?env, false, false, VC_PRED_CONSISTENT) < 1) { ret 1; }
+    ret 0;
+}
+
+# a bitcast from a scalar VALUE into an aggregate is rejected, always on
+#
+# The shape #2670 shipped: `i64 :~ [8]u8` lowered to a bitcast whose result was
+# aggregate-typed but whose operand was a register-resident value, and every
+# consumer then treated the result as the aggregate's address. Checked with repr
+# OFF as well as on, because this is the invariant that stops the defect class from
+# returning and an opt-in tripwire would not have caught the original.
+test "mach.lang.me.ir.verify.check_bitcast_class:value_into_aggregate" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    val ar_r: R.Result[type.IrTypeId, str] = type.intern_array(?env.m.types, env.i64ty, 1);
+    if (R.is_err[type.IrTypeId, str](ar_r)) { ret 1; }
+    val arrty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ar_r);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+
+    # bitcast an i64 constant into the array type: a value crossing into an address
+    val bc: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, t_ci(?env, 7), arrty);
+    if (R.is_err[value.Value, str](bc)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_count(?env, false, false, VC_BITCAST_CLASS) < 1) { ret 1; }
+    if (t_count(?env, false, true,  VC_BITCAST_CLASS) < 1) { ret 1; }
+    ret 0;
+}
+
+# and the mirror: a bitcast from an aggregate ADDRESS out to a scalar
+#
+# `[8]u8 :~ i64` is the direction that did not fault. It evaluated to the array's
+# stack address, so it is the one a test must cover or the silent form stays live.
+test "mach.lang.me.ir.verify.check_bitcast_class:aggregate_into_value" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    val ar_r: R.Result[type.IrTypeId, str] = type.intern_array(?env.m.types, env.i64ty, 1);
+    if (R.is_err[type.IrTypeId, str](ar_r)) { ret 1; }
+    val arrty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ar_r);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+
+    val slot_r: R.Result[value.Value, str] = builder.emit_alloca(?env.bld, arrty, t_ci(?env, 1));
+    if (R.is_err[value.Value, str](slot_r)) { ret 1; }
+    val agg: value.Value = value.retype(R.unwrap_ok[value.Value, str](slot_r), arrty);
+
+    val bc: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, agg, env.i64ty);
+    if (R.is_err[value.Value, str](bc)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_count(?env, false, false, VC_BITCAST_CLASS) < 1) { ret 1; }
+    ret 0;
+}
+
+# a bitcast WITHIN one class is the retag the opcode means and must not be flagged,
+# or the check would reject every pointer retype and signedness flip in the tree
+test "mach.lang.me.ir.verify.check_bitcast_class:same_class_accepted" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    val ar_r: R.Result[type.IrTypeId, str] = type.intern_array(?env.m.types, env.i64ty, 1);
+    if (R.is_err[type.IrTypeId, str](ar_r)) { ret 1; }
+    val arrty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ar_r);
+    val ar2_r: R.Result[type.IrTypeId, str] = type.intern_array(?env.m.types, env.i64ty, 1);
+    if (R.is_err[type.IrTypeId, str](ar2_r)) { ret 1; }
+    val arrty2: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ar2_r);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+
+    # value -> value
+    val v1: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, t_ci(?env, 7), env.i64ty);
+    if (R.is_err[value.Value, str](v1)) { ret 1; }
+
+    # aggregate -> aggregate, both carried by address
+    val slot_r: R.Result[value.Value, str] = builder.emit_alloca(?env.bld, arrty, t_ci(?env, 1));
+    if (R.is_err[value.Value, str](slot_r)) { ret 1; }
+    val agg: value.Value = value.retype(R.unwrap_ok[value.Value, str](slot_r), arrty);
+    val v2: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, agg, arrty2);
+    if (R.is_err[value.Value, str](v2)) { ret 1; }
+
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_count(?env, false, false, VC_BITCAST_CLASS) != 0) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3066,7 +3066,7 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
     if (R.is_err[ir_type.IrTypeId, str](res_dst)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_dst)); }
     val dst: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_dst);
 
-    if (e.data.cast.reinterpret) { ret builder.emit_bitcast(?ctx.builder, v, dst); }
+    if (e.data.cast.reinterpret) { ret lower_reinterpret(ctx, v, from_ty, dst); }
 
     val from_float:  bool = is_float_type(ctx, from_ty);
     val to_float:    bool = is_float_type(ctx, to_ty);
@@ -3095,6 +3095,68 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
         ret builder.emit_zext(?ctx.builder, v, dst);
     }
     ret builder.emit_bitcast(?ctx.builder, v, dst);
+}
+
+# lower a `:~` bit reinterpret, materializing a crossing of the value/address classes
+#
+# The IR carries two representations. An AGGREGATE's rvalue IS its storage address,
+# tagged with the aggregate type; a scalar or vector rvalue is the value itself. A
+# `:~` between the two classes therefore changes representation, not just the type
+# tag, and a bare bitcast silently reinterprets one as the other (#2670):
+#
+#   aggregate -> value  handed the slot's ADDRESS back as the scalar, so
+#                       `a:~i64` over a `[8]u8` evaluated to a stack address
+#   value -> aggregate  produced an aggregate-typed SSA value from a register,
+#                       which every consumer then dereferenced as a pointer, so
+#                       `x:~[8]u8` copied from whatever the bytes looked like as
+#                       an address
+#
+# Both were wrong on every target and neither faulted reliably, which is what made
+# the first direction a silent wrong answer rather than a crash.
+#
+# Within one class nothing is materialized: aggregate-to-aggregate is a
+# pointer-to-pointer retag and value-to-value is the genuine bit reinterpret, which
+# is what the bitcast opcode means. Sema has already proven the two types are the
+# same size, so the store and the load below move exactly the operand's bytes.
+# ---
+# ctx:     per-module lowering context
+# v:       the already-lowered operand
+# from_ty: the operand's semantic type, for its IR representation class
+# dst:     the destination IR type
+# ret:     the reinterpreted value in the destination's representation, or an error
+fun lower_reinterpret(ctx: *context.LowerContext, v: value.Value, from_ty: type.TypeId, dst: ir_type.IrTypeId) R.Result[value.Value, str] {
+    val res_src: R.Result[ir_type.IrTypeId, str] = context.lower_type(ctx, from_ty);
+    if (R.is_err[ir_type.IrTypeId, str](res_src)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_src)); }
+    val src: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_src);
+
+    val src_agg: bool = is_aggregate_ir(ctx, src);
+    val dst_agg: bool = is_aggregate_ir(ctx, dst);
+    if (src_agg == dst_agg) { ret builder.emit_bitcast(?ctx.builder, v, dst); }
+
+    if (src_agg) {
+        # `v` is the aggregate's storage address; read the destination out of it.
+        # the address is retyped to the pointer type first so the load's operand is
+        # a pointer rather than a value still tagged with the aggregate.
+        val res_ptr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?ctx.m.types);
+        if (R.is_err[ir_type.IrTypeId, str](res_ptr)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ptr)); }
+        ret builder.emit_load(?ctx.builder, value.retype(v, R.unwrap_ok[ir_type.IrTypeId, str](res_ptr)), dst);
+    }
+
+    # value -> aggregate: give the bytes storage, since the aggregate's rvalue is an
+    # address. the slot is typed by the DESTINATION so the frame reserves the
+    # aggregate's own size and alignment.
+    val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
+    if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
+    val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
+
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, dst, value.const_int(1, xty));
+    if (R.is_err[value.Value, str](res_slot)) { ret res_slot; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
+
+    val res_store: R.Result[bool, str] = builder.emit_store(?ctx.builder, v, slot);
+    if (R.is_err[bool, str](res_store)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_store)); }
+
+    ret R.ok[value.Value, str](value.retype(slot, dst));
 }
 
 # lower a `:^` secret-qualifier strip cast to an explicit declassify barrier (#1646)


### PR DESCRIPTION
Closes #2670

## What was wrong

The IR carries two representations. An **aggregate**'s rvalue *is* its storage address, tagged with the aggregate type; a **scalar or vector** rvalue is the value itself. `lower_cast` emitted a bare bitcast for every `:~`, so a reinterpret between the two classes changed the type tag without changing the representation. Both directions were miscompiled, on every target and both profiles.

```
aggregate -> value    `a:~i64` over a [8]u8 evaluated to the array's own STACK ADDRESS
value -> aggregate    `x:~[8]u8` produced an aggregate-typed value from a register,
                      which the store then dereferenced as a pointer
```

The first direction does not fault. It is a silent wrong answer that also puts a stack address into ordinary integer data. The second faults only when the operand's bytes do not happen to form a mapped address.

## The fix

`lower_reinterpret` materializes the crossing: a **load** out of the operand when the source is an aggregate, an **alloca plus a store** when the destination is. Within one class nothing is materialized, because aggregate-to-aggregate is a pointer retag and value-to-value is the genuine reinterpret the opcode means.

This is issue design (1) plus the verifier half of (2). It sits in `me/lower/expr.mach` at the producer rather than in the backend, so the bad shape never enters the IR at all — which is what lets the invariant be asserted rather than worked around downstream. **`be/codegen/mir/lower.mach` is untouched.**

## VC_BITCAST_CLASS

A new IR verifier invariant: a bitcast's operand and result must sit on the same side of the value/address divide. **Always on**, not behind the `repr` gate, because this shape is individually coherent at both ends and wrong only in combination — exactly what review misses and only an invariant catches.

It is not vacuous in either direction. With the lowering fix reverted and the check kept, it fires with a located diagnostic:

```
error: bitcast crosses the value / address representation classes without materializing it
(in bc.main.main, at ./src/main.mach:5:20)
```

And with the same-class exemption removed so it over-fires, the compiler cannot build `std` at all:

```
error: bitcast crosses the value / address representation classes ...
(in std.types.char.char_digit_val, at ./dep/mach-std/src/types/char.mach:110:14)
```

The compiler and mach-std both self-host under `--verify-ir` with it on, so nothing else in either tree produces the crossing.

## Native output proven unchanged

Not asserted — measured. The compiler's own source is built with the **old** and the **new** compiler and the results compared:

| target | result |
|---|---|
| `x86_64-linux` | **byte-identical** (5,545,984 bytes) |
| `aarch64-linux` | **byte-identical** (5,177,344 bytes) |
| `riscv64-linux` | **byte-identical** (5,304,944 bytes) |

And mach-std's entire object corpus, `sha256` over every `.o` in path order:

```
base linux-x86_64: c8b83dc129af8330e5ac8a4ee645c2b3e2da201341278bb2cb3d5c4a9168733a
fix  linux-x86_64: c8b83dc129af8330e5ac8a4ee645c2b3e2da201341278bb2cb3d5c4a9168733a
base linux-arm64:  dc910f32f05be6745d595ed70c8e8250e2fe8460e63c0df0f3555e9a7a10fe7a
fix  linux-arm64:  dc910f32f05be6745d595ed70c8e8250e2fe8460e63c0df0f3555e9a7a10fe7a
```

This is a meaningful comparison rather than a vacuous one: the compiler's own `:~` uses are vector-to-vector (`src/lang/be/codegen/vector_runtime.mach`), so the corpus does exercise `:~`, down the path this change leaves alone.

## Evidence

Both directions, independently, so neither masks the other:

```
                       before                          after
aggregate -> value     x86_64=1   arm64=1   riscv64=1  0  0  0
value -> aggregate     x86_64=139 arm64=139 riscv64=139 0  0  0
vector -> array        x86_64=139 arm64=139 riscv64=0   0  0  0
vector -> vector       x86_64=0   arm64=0   riscv64=0   0  0  0   (control)
```

`1` is the wrong value, `139` is SIGSEGV. The riscv64 `0` in the vector row is the incidental one the issue explains: scalarization had already put the vector in a slot there.

### `int/regression/2670-bitcast-value-address`

Runs both directions plus a round trip on all three legs and diffs stdout. The golden is hand-checkable:

```
arr->u64 102030405060708
u64->arr 8 7 2 1
roundtrip 1122334455667788
vec->arr ab ab
vec->vec cdcdcdcd cdcdcdcd
```

Against the base compiler it fails on **all three legs**, and the harness output shows the defect directly rather than only a failure:

```
FAIL regression/2670-bitcast-value-address [linux/debug]         (producer exit 139)
    arr->u64 7ffd7472f078        <- a stack address, where 102030405060708 was expected
FAIL regression/2670-bitcast-value-address [linux-riscv64/debug] (producer exit 139)
    arr->u64 7ff79bffea88
FAIL regression/2670-bitcast-value-address [linux-arm64/debug]   (producer exit 139)
    arr->u64 7ff69bffeb08
```

The values are chosen so a wrong answer cannot coincide with a right one: a stack address shares no digits with `0102030405060708` and varies per run, so the broken behaviour cannot produce a stable golden at all.

### New assertions, each demonstrated failing first

With `check_bitcast_class` stubbed to `ok`:

```
failures:
  mach.lang.me.ir.verify.check_bitcast_class:value_into_aggregate
  mach.lang.me.ir.verify.check_bitcast_class:aggregate_into_value
1 passed, 2 failed, 3 total
```

The one that keeps passing is `same_class_accepted`, the negative control; its teeth are shown by the over-firing run above, which breaks the build on `std`.

## Status

- `mach test .`: 1242 passed, 0 failed
- self-host fixpoint: holds, stage2 and stage3 byte-identical
- self-host under `--verify-ir` with the new invariant: clean
- int `linux`: all cases passed
- int `linux-riscv64` (qemu): all cases passed
- int `linux-arm64` (qemu): 4 pre-existing failures, `surface/c-variadic` and `surface/narrow-stack-args`, **identical on the base compiler** under the same run-mode. That leg is `native` in CI per `targets.conf`, and `int/run.sh`'s header is explicit that a forced-qemu arm64 run is not CI-equivalent. Nothing in this change touches them.

## Follow-up ordering

#2672 (the `:~` size check reading every `rec` and `uni` as 0 bytes) should land **after** this. Fixing it first would enable records straight into the miscompilation this PR removes. Once both are in, #2670's table is worth growing record rows.
