### PR TITLE
docs(mir): the MIR_BITCAST contract only classifies values, not aggregates

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -417,13 +417,28 @@ pub val MIR_FCMP: MirOpcode = 0x1118;
 # width (4 for f32, 8 for f64) selects the f32 vs f64 sign-bit mask
 pub val MIR_FNEG: MirOpcode = 0x111B;
 
-# a bit reinterpret (`:~`) is a plain MIR_BITCAST in every direction. a same-bank
+# a bit reinterpret (`:~`) BETWEEN TWO VALUES is a plain MIR_BITCAST. a same-bank
 # reinterpret (GP<->GP or XMM<->XMM) is a register copy; a `:~` between a float and
 # an equal-size integer crosses the GP and XMM banks. both select to a plain MOV:
 # the encoder dispatches the move family on operand register CLASS - a same-bank XMM
 # pair emits MOVSS / MOVSD, a register-register GP<->XMM pair emits MOVD / MOVQ, and
 # a spilled side is moved through memory at byte width - so no dedicated cross opcode
 # is needed and the bank can never be lost across register allocation.
+#
+# The bank reasoning above only classifies VALUES, so it says nothing about a `:~`
+# whose other side is an AGGREGATE: a struct / union / array is carried by its
+# storage ADDRESS, not in a register of either bank. Such a cast changes
+# representation rather than bank, and no MOV expresses it. This comment used to
+# claim a bitcast was a plain MIR_BITCAST "in every direction", which asserted the
+# property that does not hold and is presumably why the gap survived: reaching MIR
+# at all, the aggregate side was read as a pointer, so `[8]u8 :~ i64` produced the
+# array's stack address and `i64 :~ [8]u8` copied from the integer's bytes as if
+# they were one (#2670).
+#
+# The crossing is therefore materialized in `me/lower/expr.mach`'s `lower_reinterpret`
+# - a load out of the aggregate, or an alloca plus a store into it - so a bitcast
+# reaching here has values on both sides by construction. `VC_BITCAST_CLASS` in the
+# IR verifier holds that invariant, always on.
 
 # float-comparison condition codes carried on a MIR_FCMP. a UCOMISD sets CF/ZF/PF
 # (an UNORDERED result sets all three), so the float compare maps to UNSIGNED


### PR DESCRIPTION
Follow-up to #2676, which fixed #2670. Comment only, no code change.

## What

The `MIR_BITCAST` contract at `src/lang/be/codegen/mir.mach` claimed a `:~` was a plain `MIR_BITCAST` **"in every direction"**. That is exactly the property #2670 disproved, written down as the design.

Its reasoning is entirely about **register banks** — GP versus XMM, which side a MOV selects, how a spilled operand moves through memory. That analysis is correct and it classifies **values**. It says nothing about a side that is carried by its storage **address** instead, and an aggregate always is. So the sentence was true of every case the comment actually analysed and false of the one it did not, which is presumably how the gap survived: the documentation asserted the invariant that caused the bug.

## The change

Keep the bank reasoning, which is right, and record three things it does not cover:

- the argument classifies values, so it does not reach a `:~` whose other side is a struct / union / array
- such a cast changes representation rather than bank, and no MOV expresses it, which is why reaching MIR at all meant the aggregate side was read as a pointer
- the crossing is materialized upstream in `me/lower/expr.mach`'s `lower_reinterpret`, and `VC_BITCAST_CLASS` holds that invariant in the IR verifier, so a bitcast arriving here has values on both sides by construction

The one-line comment on the `MIR_BITCAST` declaration itself already said "reinterpret a **value's** bits", which is accurate, so it is unchanged.

## Why separately

#2676 merged while this was being written. Rather than push onto a merged branch and have the commit silently go nowhere, it lands as its own PR.

## Status

Comment-only, so nothing observable moves, and that is measured rather than assumed:

- the compiler binary built by the pre-change and post-change compilers is byte-identical
- self-host fixpoint holds, stage2 and stage3 byte-identical
- `mach test .`: 1242 passed, 0 failed
