### PR TITLE
docs(x64): stop citing a closed issue as pending work

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3209,8 +3209,12 @@ fun float_alu_opcode(op: mir.MirOpcode, w: u8) u16 {
 #   - an immediate (a float CONSTANT, whose raw bit pattern `lower_value` carried):
 #     the bit pattern is materialized into the R11 GP scratch (MOVABS) and moved
 #     into `xmm` with MOVQ - R11 is reserved from GP allocation, so no live value
-#     collides. x86-64 has no SSE immediate form, so this pair is unavoidable until
-#     the constants live in a pool (#2248).
+#     collides. x86-64 has no SSE immediate form, so a constant that is not already
+#     in memory costs this pair at every use. Routing them through a read-only
+#     constant pool instead - `mulsd xmm, [rip + .LCPI]` - was designed and
+#     measured in #2248 and deliberately NOT pursued: that issue was closed
+#     not-planned when the performance program ended, with the analysis left on it.
+#     #2662 tracks the live symptom, and holds the reopen decision.
 # `w` is 4 (f32, MOVSS) or 8 (f64, MOVSD). a GP-register operand would mean a float
 # value the allocator placed in the wrong bank - rejected loudly rather than
 # mis-encoded


### PR DESCRIPTION
Refs #2662. **Comment only, no behaviour change** — this is the uncontroversial half of that issue's acceptance. The pool itself I am recommending against building; reasoning below.

## The comment

`emit_float_load` said the MOVABS/MOVQ pair "is unavoidable until the constants live in a pool (#2248)". #2248 is closed, so it points a reader at a resolved issue as though the work were queued.

It is not queued. **#2248 was closed `NOT_PLANNED`** when the performance program ended, with its measurements and a complete design left on it and the note *"Reopen if the perf program restarts."* The mechanism the comment describes is unchanged and still correct; what it now records is that the pool was designed and declined rather than pending, and it points at #2662, which holds the reopen decision.

## Measured, not asserted

#2662 asks for instruction counts. The symptom is entirely live and matches #2248's original measurement exactly. A five-term Horner loop, x86-64 release, `-O2`:

```
2c: movabs $0x4004000000000000,%r11    ;; \
36: movq   %r11,%xmm2                  ;; / pair 1
3f: movabs $0x400a000000000000,%r11
49: movq   %r11,%xmm15
5f: movabs $0x3fc0000000000000,%r11
69: movq   %r11,%xmm15
7f: movabs $0x401e000000000000,%r11
89: movq   %r11,%xmm15
9f: movabs $0x3ffc000000000000,%r11
a9: movq   %r11,%xmm15
```

**5 pairs = 10 instructions per iteration, out of 31 in the loop body — 32%.** #2248 measured the same 5 pairs / 10 instructions on the same shape, so nothing has moved.

(Measured on object files. The linked image strips section headers, so `objdump -d` yields nothing there — worth knowing for anyone repeating this.)

## Why I am not building the pool

Not because it is the wrong shape. #2248 establishes it is the right one, with measurements, a five-step plan, and the observation that the encoder side is already done — the moment isel hands it a `MIR_OP_SYM` it emits `mulsd xmm, [rip + .LCPI]`.

**The blocker is that the closure was a scope decision at the owner's level**, not a technical one, and it has not been reversed. Building it would be overriding that decision rather than implementing a plan.

**But the premise has genuinely changed since**, which is the part worth escalating rather than deciding:

#2248 was closed on the grounds that the remaining perf items were "single-digit or narrow-shape wins". The pool now has a **non-performance** consumer. PR #2661, the first stage of #2640, says so directly:

> The constant case wants a rodata load, and **x86-64 has no constant pool**. `x64/encode.mach:3212` says so.

And #2640's own acceptance requires "a native target's emitted code for a constant vector literal is checked before and after, since removing the round trip there is the other half of the value" — which needs the pool. #2640 is open and is not a performance issue.

So "the perf program ended" no longer covers the whole case. That is a fact the owner did not have when closing, and whether it reopens #2248 is theirs to weigh, not mine.

## Checks

- `mach test .` — 1239 passed, 0 failed
- self-host fixpoint: `b == c`, byte-identical