### PR TITLE
docs(x64): correct two stale clauses in the float-immediate comment

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3212,9 +3212,10 @@ fun float_alu_opcode(op: mir.MirOpcode, w: u8) u16 {
 #     collides. x86-64 has no SSE immediate form, so a constant that is not already
 #     in memory costs this pair at every use. Routing them through a read-only
 #     constant pool instead - `mulsd xmm, [rip + .LCPI]` - was designed and
-#     measured in #2248 and deliberately NOT pursued: that issue was closed
-#     not-planned when the performance program ended, with the analysis left on it.
-#     #2662 tracks the live symptom, and holds the reopen decision.
+#     measured in #2248 and deliberately NOT pursued: the performance program it
+#     belonged to (#2199) COMPLETED its goals, and the pool was separately judged
+#     not worth reopening it for. #2248 is closed not-planned and holds the design,
+#     the measurement, and the reopen decision.
 # `w` is 4 (f32, MOVSS) or 8 (f64, MOVSD). a GP-register operand would mean a float
 # value the allocator placed in the wrong bank - rejected loudly rather than
 # mis-encoded


### PR DESCRIPTION
Follow-up to #2680. **Comment only, no behaviour change.** No `Closes` — neither correction has an issue.

Both clauses point a reader somewhere the work no longer lives, which is the defect #2680 existed to fix. One layer along each time.

## 1. "when the performance program ended"

True clause by clause, and it invites the wrong inference. **#2199 closed `COMPLETED`** — all eight children done, the Mach-vs-C gap measured from 3.99x to ~2.4x. The program *finished*; the pool was separately judged not worth reopening it for.

*Ended* reads as neglect. *Completed* reads as deliberate prioritisation. Someone deciding whether to pick the thread up is pointed in opposite directions by the two, and this comment is the durable artifact they will actually meet — the issue history is a click away and the code is in front of them.

## 2. "#2662 tracks the live symptom, and holds the reopen decision"

**This was true when I wrote it and is not now** — #2662 has since been closed `NOT_PLANNED`, with its answer recorded and the reopen question escalated. It is a consequence of that closure rather than an oversight in #2680; the sentence was accurate at merge time.

That is worth naming precisely, because it is the same failure mode one layer along: a reference that is *stale rather than absent*, so nothing errors and following it lands you on a closed issue you reasonably read as the live tracker. #2248 holds the design, the measurement and the reopen decision, so the comment names that.

Verified all three states rather than taking them from the conversation: #2199 `CLOSED/COMPLETED`, #2248 `CLOSED/NOT_PLANNED`, #2662 `CLOSED/NOT_PLANNED`. And `grep '#2662' src/` is now zero, so nothing else in the tree points at it.

## Checks

- `mach test .` — 1244 passed, 0 failed
- self-host fixpoint: `b == c`, byte-identical