### PR TITLE
feat(mir): keep an alloca's type and a whole-object zero for a logical target

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -417,6 +417,17 @@ pub val MIR_FCMP: MirOpcode = 0x1118;
 # width (4 for f32, 8 for f64) selects the f32 vs f64 sign-bit mask
 pub val MIR_FNEG: MirOpcode = 0x111B;
 
+# zero an entire object at a memory operand; operands [dst_mem, size_imm] (#2669).
+#
+# A whole-object operation rather than the byte-chunked store run it used to lower
+# to. A flat-addressing target never sees one - `lower_memzero` still expands it
+# into sized stores there, exactly as before - so this reaches only a target that
+# declares storage structurally, where a run of byte stores spanning object
+# boundaries is not expressible at all. Recovering the whole-object intent from
+# such a run would mean pattern-matching a chunking strategy, which breaks silently
+# on partial zeroing, interleaved stores, or a change of chunk widths.
+pub val MIR_MEMZERO: MirOpcode = 0x111C;
+
 # a bit reinterpret (`:~`) is a plain MIR_BITCAST in every direction. a same-bank
 # reinterpret (GP<->GP or XMM<->XMM) is a register copy; a `:~` between a float and
 # an equal-size integer crosses the GP and XMM banks. both select to a plain MOV:
@@ -885,13 +896,28 @@ pub val SLOT_SPILL:  MirSlotKind = 1;
 # offset: negative byte offset from the frame pointer (assigned by frame.run)
 # size:   slot size in bytes
 # align:  slot alignment in bytes
+# ty:     the IR type id the slot was allocated AT, or IR_TYPE_NIL when unknown
+#         (#2673). `size` and `align` are measured FROM this type and answer every
+#         flat-addressing question, so this is inert on a machine target. A
+#         logical-addressing target cannot use them at all: it declares storage as a
+#         typed `OpVariable`, and a byte count does not name a type. Keeping the id
+#         the measurement came from is what makes a base's pointee type recoverable
+#         at the consumer, which is the contract `lower_gep_structural` states.
+#         Stored as a raw id rather than the `ir_type.IrTypeId` alias so the backend
+#         MIR record takes no dependency on the middle end's type module.
 pub rec MirSlot {
     value:  u32;
     kind:   MirSlotKind;
     offset: i64;
     size:   u32;
     align:  u32;
+    ty:     u32;
 }
+
+# the `MirSlot.ty` sentinel for a slot whose allocated type is not known: a spill
+# slot, or an alloca lowered before the type was carried. Mirrors ir_type.IRT_NIL
+# without importing it
+pub val SLOT_TY_NIL: u32 = 0xFFFFFFFF;
 
 # a function's stack layout, populated by frame.run after register allocation
 # ---

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -972,12 +972,12 @@ pub fun copy_aggregate(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperan
 # size:     the allocation size in bytes (0 falls back to its alignment)
 # align:    the allocation alignment in bytes (0 falls back to 1)
 # ret:      true on success, or an allocation error
-pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) R.Result[bool, str] {
+pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32, ty: u32) R.Result[bool, str] {
     var al: u32 = align;
     if (al == 0) { al = 1; }
     var sz: u32 = size::u32;
     if (sz == 0) { sz = al; }
-    ret frame_slot_add(ctx, value_id, mir.SLOT_ALLOCA, sz, al);
+    ret frame_slot_add(ctx, value_id, mir.SLOT_ALLOCA, sz, al, ty);
 }
 
 # append a mir.SLOT_SPILL frame slot for a register-passed aggregate parameter,
@@ -995,7 +995,7 @@ pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) R.
 pub fun add_spill_slot(ctx: *LowerCtx, value_id: u32, size: u64) R.Result[bool, str] {
     var padded: u64 = (size + 7) & ~7::u64;
     if (padded == 0) { padded = 8; }
-    ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, padded::u32, 8);
+    ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, padded::u32, 8, mir.SLOT_TY_NIL);
 }
 
 # back an aggregate call's result vreg with a caller-owned stack region and
@@ -1143,7 +1143,7 @@ pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: 
     if (al == 0) { al = 1; }
     var sz: u32 = ((size + 7) & ~7::u64)::u32;
     if (sz == 0) { sz = al; }
-    ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, sz, al);
+    ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, sz, al, mir.SLOT_TY_NIL);
 }
 
 # append a frame slot of the given kind, size, and alignment, growing the slot
@@ -1159,7 +1159,7 @@ pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: 
 # size:     the slot size in bytes
 # align:    the slot alignment in bytes
 # ret:      true on success, or an allocation error
-fun frame_slot_add(ctx: *LowerCtx, value_id: u32, kind: mir.MirSlotKind, size: u32, align: u32) R.Result[bool, str] {
+fun frame_slot_add(ctx: *LowerCtx, value_id: u32, kind: mir.MirSlotKind, size: u32, align: u32, ty: u32) R.Result[bool, str] {
     val f: *mir.MirFunction = ctx.f;
     val frame: *mir.MirFrame = ?f.frame;
     if (frame.slot_count >= frame.slot_cap) {
@@ -1176,6 +1176,7 @@ fun frame_slot_add(ctx: *LowerCtx, value_id: u32, kind: mir.MirSlotKind, size: u
     frame.slots[si].offset = 0;
     frame.slots[si].size   = size;
     frame.slots[si].align  = align;
+    frame.slots[si].ty     = ty;
     frame.slot_count = frame.slot_count + 1;
     ret R.ok[bool, str](true);
 }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2175,7 +2175,7 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     if (R.is_err[u32, str](skr)) { ret R.err[bool, str](R.unwrap_err[u32, str](skr)); }
     val sk: u32 = R.unwrap_ok[u32, str](skr);
 
-    val ar: R.Result[bool, str] = lctx.add_alloca_slot(ctx, sk, total, elem_align);
+    val ar: R.Result[bool, str] = lctx.add_alloca_slot(ctx, sk, total, elem_align, inst.aux_ty::u32);
     if (R.is_err[bool, str](ar)) { ret ar; }
 
     # record the slot-key vreg under this alloca's instruction id so an
@@ -2457,6 +2457,25 @@ fun lower_memzero(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
         ret R.err[bool, str]("mir.lower_ir: memzero is missing its pointee type");
     }
     val size: u32 = ir_type.byte_size(ctx.types, inst.aux_ty, ctx.tgt);
+
+    # a logical-addressing target keeps the whole-object form (#2669). The chunked
+    # store run below is a byte-space expansion: its stores are sized for the
+    # machine, not for the object, so an 8-byte chunk over a `f32x4` spans two lanes
+    # and there is no structural access that names it. Recovering the intent from
+    # such a run afterwards would mean pattern-matching the chunking strategy, which
+    # breaks silently on partial zeroing, an interleaved store, or a change of chunk
+    # widths - so the intent is kept rather than reconstructed.
+    if (!ctx.tgt.model.flat_addressing) {
+        val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](r)); }
+        val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+        ops[0] = agg_pointer_mem(ctx, inst.operands[0], 0);
+        ops[1] = mir.op_imm(size::i64);
+        var mi: mir.MirInstr = mir.instr(mir.MIR_MEMZERO, ops, 2,
+                                         ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
+        ret lctx.push_instr(ctx, mb, mi);
+    }
+
     var off: i64 = 0;
     for (off::u32 < size) {
         val remaining: u32 = size - off::u32;
@@ -2656,9 +2675,14 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
 # every machine target's lowering is bit-for-bit what it was.
 #
 # The source pointee type is NOT carried here. It is recoverable at the consumer
-# from what the base names - a global's declared type, or the allocated type of the
-# `MIR_ALLOCA` a local base defines - and duplicating it into the operand list would
-# be a second source of truth for a fact the base already fixes.
+# from what the base names - a global's declared type, or the `MirSlot.ty` of the
+# frame slot a local base's `MIR_ALLOCA` defines - and duplicating it into the
+# operand list would be a second source of truth for a fact the base already fixes.
+#
+# That was only half true when this was written: the global path held, but
+# `lower_alloca` measured `aux_ty` into a size and an align and then discarded the
+# id, so a local base fixed nothing (#2673). `MirSlot` carries the id now, which is
+# what makes the sentence above true of both kinds of base rather than one.
 # ---
 # ctx:  the per-function lowering context
 # mb:   the destination MIR block

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1458,6 +1458,104 @@ fun ut_gep_shape(alloc: *A.Allocator, src: str, tname: str) i64 {
     ret out;
 }
 
+# counts, over a lowered MIR module: MIR_MEMZERO instructions, and alloca frame
+# slots whose allocated type survived
+# ---
+# mm:        the lowered MIR module
+# out_slots: receives the number of SLOT_ALLOCA slots carrying a real type id
+# ret:       the number of MIR_MEMZERO instructions
+fun ut_memzero_and_typed_slots(mm: *mir.MirModule, out_slots: *u32) u32 {
+    var mz: u32 = 0;
+    var ts: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < mm.function_len) {
+        val mf: *mir.MirFunction = ?mm.functions[fi];
+        var si: u32 = 0;
+        for (si < mf.frame.slot_count) {
+            val sl: *mir.MirSlot = ?mf.frame.slots[si];
+            if (sl.kind == mir.SLOT_ALLOCA && sl.ty != mir.SLOT_TY_NIL) { ts = ts + 1; }
+            si = si + 1;
+        }
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                if (blk.instrs[ii].opcode == mir.MIR_MEMZERO) { mz = mz + 1; }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+    @out_slots = ts;
+    ret mz;
+}
+
+# lower `src` for `tname` to MIR and report (memzero count, typed-alloca-slot count)
+fun ut_memzero_shape(alloc: *A.Allocator, src: str, tname: str, out_slots: *u32) i64 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, alloc, src, tname);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var out: i64 = -1;
+    var slots: u32 = 0;
+    var mi: u32 = 0;
+    for (mi < p.module_len) {
+        val me: *project.ModuleEntry = ?p.modules[mi];
+        if (me.ir_module == nil) { mi = mi + 1; cnt; }
+        val mr: R.Result[mir.MirModule, str] = mirlower.lower_ir(?p.target, me.ir_module, alloc, ?s.interner, ?s.sources);
+        if (R.is_err[mir.MirModule, str](mr)) { mi = mi + 1; cnt; }
+        var mm: mir.MirModule = R.unwrap_ok[mir.MirModule, str](mr);
+        var sc: u32 = 0;
+        val n: u32 = ut_memzero_and_typed_slots(?mm, ?sc);
+        if (out < 0) { out = 0; }
+        out = out + n::i64;
+        slots = slots + sc;
+        mi = mi + 1;
+    }
+    @out_slots = slots;
+    ret out;
+}
+
+# an alloca keeps the type it was allocated at, and a whole-object zero survives to
+# a logical-addressing target while a flat one still gets the byte-chunked stores
+# (#2673, #2669)
+#
+# The two are one contract read from two ends. A flat target answers every question
+# from the slot's SIZE, so it keeps the store run and the type id is inert. A
+# logical target cannot use a byte count at all - it declares storage as a typed
+# `OpVariable` - so it needs the type AND the unexpanded zero, and neither is
+# recoverable once thrown away: a run of 8-byte stores over an `f32x4` spans two
+# lanes per store, and no structural access names that.
+#
+# ASSERTING BOTH SIDES is what makes this a regression test. Dropping either gate
+# moves one of the two numbers, and gating the wrong way round moves both.
+test "mach.lang.driver:alloca_type_and_memzero_survive_on_logical_addressing" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val src: str = "rec Pair { a: i64; b: i64; }\n#[output(0)] var o: i32;\n#[stage(\"vertex\")]\nfun vs() { var p: Pair; var v: f32x4; o = p.a::i32; }\nfun main() i32 { ret 0; }\n";
+    val nsrc: str = "rec Pair { a: i64; b: i64; }\nfun rd() i64 { var p: Pair; var q: Pair; ret p.a + q.b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret rd()::i32; }\n";
+
+    # spirv: the whole-object zero survives, and the allocas kept their types.
+    var sv: u32 = 0;
+    if (ut_memzero_shape(?alloc, src, "spirv", ?sv) < 1) { ret 1; }
+    if (sv < 1) { ret 1; }
+
+    # every flat target: no MIR_MEMZERO at all - the store run is still the lowering
+    # there - while the slots carry their type regardless, since it is inert not absent.
+    var fv: u32 = 0;
+    if (ut_memzero_shape(?alloc, nsrc, "linux", ?fv)         != 0) { ret 1; }
+    if (fv < 1) { ret 1; }
+    if (ut_memzero_shape(?alloc, nsrc, "linux-arm64", ?fv)   != 0) { ret 1; }
+    if (fv < 1) { ret 1; }
+    if (ut_memzero_shape(?alloc, nsrc, "linux-riscv64", ?fv) != 0) { ret 1; }
+    if (fv < 1) { ret 1; }
+    ret 0;
+}
+
 # a MIR_GEP keeps its index list on a logical-addressing target and folds to a
 # byte displacement on a flat one (#2649)
 #


### PR DESCRIPTION
Closes #2673. Closes #2669.

## Why these are one change, not two

You asked for the argument in the body, and I verified it rather than assuming it.

#2669's end state is `OpVariable %_ptr_Function_v4float Function %null` — which needs the variable's **type** to construct the null constant. `build_vmaps` in the SPIR-V emitter types a vreg from *"its definition's width and register class"*, so a vreg defined by `MIR_ALLOCA` has no semantic type available. The type it needs is exactly what #2673 restores.

So #2669's acceptance is unreachable without #2673. They are the same erasure read from two ends: **a size does not name a type, and a store run does not name an object.** Landing #2673 alone would also mean shipping a representation with no consumer to prove it works.

## What changed

**#2673** — `MirSlot` gains `ty`, the IR type id the slot was allocated at. `size` and `align` are measured *from* that type and answer every flat-addressing question, so the id is inert on a machine target. It is stored as a raw `u32` with a `SLOT_TY_NIL` sentinel so the backend MIR record takes no dependency on the middle end's type module.

**#2669** — `lower_memzero` gates on `flat_addressing`. A flat target emits the byte-chunked store run exactly as before. A logical one emits `MIR_MEMZERO [dst, size]`.

Both are the third and fourth consumers of `flat_addressing`, again with no reshaping of it.

**And I corrected the #2671 doc comment**, which is the thing that has to be right whether or not the fix lands with it. It claimed the pointee type was recoverable from *"a global's declared type, or the allocated type of the `MIR_ALLOCA` a local base defines"*. The global half held; the alloca half did not, because the id was discarded. The comment now says `MirSlot.ty` and records that it was only half true when written. **That was my error in #2671** — I asserted a two-sided claim having checked one side.

## Why not reconstruct instead

Both erasures are irreversible, which is what rules out the cheap fixes:

- A byte count does not determine a type.
- Recognising a run of zero stores as a whole-object zero is pattern-matching a chunking strategy. It breaks silently on partial zeroing, an interleaved store, or a change of chunk widths — and silent lane misplacement is the failure mode this family keeps producing. The issue names this as the tempting wrong fix and there is none of it here.

The 8-byte chunk point is worth stating concretely: over an `f32x4` each chunk spans **two lanes**, so unlike #2649 — where an ordinal existed and was folded away — there is no structural access that names these stores at all.

## Native output unchanged, proven not asserted

**The entire 8.2 MB compiler binary, built from identical source by each compiler, is byte-identical.** That is every alloca and every memzero in the compiler's own body.

Plus memzero- and alloca-heavy source — records at several sizes and paddings, a union, a vector, sub-word arrays, an aggregate copy:

| target | debug | release |
|---|---|---|
| x86_64 | identical (195 instrs) | identical (151) |
| aarch64 | identical (195) | identical (150) |
| riscv64 | identical (251) | identical (206) |

## Tests

`mach.lang.driver:alloca_type_and_memzero_survive_on_logical_addressing` lowers to MIR and asserts both sides: spirv gets `MIR_MEMZERO` and typed alloca slots; every flat target gets **zero** `MIR_MEMZERO` and still has typed slots, since the id is inert rather than absent.

**All three guards are mutation-tested and load-bearing:**

| mutation | result |
|---|---|
| drop the memzero gate (always expand) | **1 failed** |
| invert the memzero gate (never expand) | **1 failed** |
| discard the alloca type again | **1 failed** |

## For the SPIR-V track

Both halves are now available and neither needs anything further from the middle end:

- a local base's pointee type is `MirSlot.ty` on the frame slot keyed by the alloca's vreg — which is what makes #2649's `lower_gep_structural` ordinals interpretable for a local base, and so unblocks #2640's per-lane geps
- a whole-object zero arrives as `MIR_MEMZERO [dst_mem, size_imm]`, and with the slot's type in hand it becomes `OpVariable %ptr Function %null` with no stores at all — better output than the two stores a machine target emits

## Status

- `mach test .` — 1245 passed, 0 failed
- `int/run.sh --target linux` — all cases passed
- release self-host fixpoint, three generations — R2 and R3 byte-identical