### PR TITLE
feat(spirv): build OpAccessChain from the structural GEP's ordinals

### DIFF
--- a/int/surface/spirv-interface/src/main.mach
+++ b/int/surface/spirv-interface/src/main.mach
@@ -8,9 +8,11 @@
 # Block-decorated struct with explicit member offsets, and an entry point must name
 # its Input and Output variables.
 #
-# NOT here: reading a MEMBER of the uniform block (`camera.view`). It is refused by
-# name, because SPIR-V reaches a member through an `OpAccessChain` naming its
-# ordinal and MIR has already folded that walk into a byte displacement (#2649).
+# Reading a MEMBER of the uniform block IS here now (#2649): MIR keeps the GEP's
+# index list on a logical-addressing target, so the walk reaches the back end as
+# ordinals and becomes an `OpAccessChain`. `transform.model[2]` is the nested case -
+# a struct member that is an array, indexed - which lowers to two chained GEPs and
+# is what a flat `camera.view` would not exercise.
 #
 # A scalar `f32` interface variable IS here, in both directions, and it is the
 # #2655 pin. It used to be refused alongside the member walk: MIR materialized a
@@ -93,7 +95,7 @@ rec Scene {
 fun vertex_main() {
     position    = in_position;
     point_size  = 1.0;
-    vary_colour = in_colour;
+    vary_colour = in_colour + camera.tint + transform.model[2];
 }
 
 # a second vertex stage doing arithmetic between the interface reads and writes, so

--- a/int/surface/spirv-storage/src/main.mach
+++ b/int/surface/spirv-storage/src/main.mach
@@ -19,11 +19,16 @@
 # here. Both halves of that are checked: this case declares the shapes a uniform
 # block cannot carry, and the spirv-interface case keeps the uniform-side refusal.
 #
-# NOT here: reading or writing any of these buffers. A block member is reached
-# through an `OpAccessChain` naming its ordinal, and MIR folds the member walk into
-# a byte displacement before the back end sees it, so the member access is refused
-# by name. The buffers are declared, laid out and bound correctly - which the
-# validator confirms - and become readable when the ordinal survives lowering.
+# Reading and writing these buffers IS here now. MIR keeps a GEP's index list on a
+# logical-addressing target (#2649), so a member walk reaches the back end as
+# ordinals and becomes an `OpAccessChain`. A compute stage can therefore read its
+# input buffer and write its output one, which is what #2658 said no compute shader
+# could do.
+#
+# The nested cases matter more than the flat ones: `out.rows[i]` lowers to TWO
+# chained GEPs, the second based on the first's result, so the emitter has to accept
+# a pointer as an access chain's base rather than only the variable. A flat
+# `buf.member` would pass without exercising that at all.
 #
 # Also not here: the three compute built-ins. `global_invocation`,
 # `local_invocation` and `workgroup_id` are three-component unsigned vectors by the
@@ -67,8 +72,25 @@ rec Config {
 }
 #[uniform(2, 0)] var config: Config;
 
+# a read-write buffer the compute stage moves data through. `rows` is an array
+# member, so writing `rows[i]` exercises the CHAINED access-chain path - two GEPs,
+# the second based on the first's result - rather than a single flat member walk,
+# which is the case a flat `buf.member` would leave untested.
+rec Scratch {
+    acc:  f32x4;
+    rows: [4]f32x4;
+}
+#[storage(3, 0)] var scratch: Scratch;
+
+# a compute stage that actually moves data: reads one storage buffer, writes
+# another, and indexes an array member on the way. This is the shape #2658 named as
+# impossible - a stage that can be dispatched and can read or write nothing.
 #[stage("compute")] #[workgroup(64, 1, 1)]
-fun simulate() { }
+fun simulate() {
+    scratch.acc = particles.velocity[0] + particles.velocity[1];
+    scratch.rows[0] = particles.position[0];
+    scratch.rows[3] = scratch.acc * scratch.acc;
+}
 
 #[stage("compute")] #[workgroup(8, 8, 1)]
 fun reduce() { }

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -82,6 +82,10 @@ use mach.lang.target.isa.spirv.types;
 # has_entry: whether any function in the module declares a pipeline stage, which
 #           decides whether this is a shader module (entry points, no Linkage) or a
 #           library module (Linkage exports, no entry point)
+# gtype_ids: the SPIR-V VALUE type each interface variable was declared with, and
+#           gstorage its storage class. An access chain's result is a pointer to a
+#           member of that exact type, and a laid-out block's array members are not
+#           interned, so the declared id has to be remembered rather than rebuilt.
 # gvar_ids: SPIR-V OpVariable id per IR global index, allocated before any body is
 #           emitted so a load or store can name a variable declared later (0 for a
 #           global carrying no interface role)
@@ -103,6 +107,8 @@ rec Emit {
     fn_ids:    *u32;
     has_entry: bool;
     gvar_ids:  *u32;
+    gtype_ids: *u32;
+    gstorage:  *u32;
     iface_ids: *u32;
     iface_len: u32;
     gslot:     *u32;
@@ -125,11 +131,18 @@ rec Emit {
 # type_id: SPIR-V element type id per vreg (0 when the vreg has no determined type)
 # var_id:  SPIR-V OpVariable id per vreg (0 when the vreg needs no variable)
 # is_bool: whether the vreg holds a boolean (defined by a comparison)
+# chain_id: for a vreg defined by an access chain, the resulting POINTER id, and
+#          chain_ty the type it points at. Such a vreg holds an address rather than
+#          a value, so it gets no backing variable and is never loaded as one; the
+#          load or store that consumes it addresses through the chain instead
 # n:       number of vregs
 rec VMaps {
     type_id: *u32;
     var_id:  *u32;
     is_bool: *bool;
+    chain_id: *u32;
+    chain_ty: *u32;
+    chain_sc: *u32;
     n:       u32;
 }
 
@@ -180,7 +193,7 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     var e: Emit;
     e.alloc = mirmod.alloc; e.interner = mirmod.interner;
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
-    e.gvar_ids = nil; e.iface_ids = nil; e.iface_len = 0;
+    e.gvar_ids = nil; e.gtype_ids = nil; e.gstorage = nil; e.iface_ids = nil; e.iface_len = 0;
     e.gslot = nil; e.iface_use = nil;
     e.srcmap = mirmod.srcmap; e.cur_fn = nil; e.cur_instr = nil;
 
@@ -284,6 +297,14 @@ fun emit_dnit(e: *Emit, n: u32) {
         A.deallocate[u32](e.alloc, e.gslot, e.ir.global_len::usize);
     }
     e.gslot = nil;
+    if (e.gtype_ids != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.gtype_ids, e.ir.global_len::usize);
+    }
+    e.gtype_ids = nil;
+    if (e.gstorage != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.gstorage, e.ir.global_len::usize);
+    }
+    e.gstorage = nil;
     if (e.iface_use != nil && n > 0 && e.iface_len > 0) {
         A.deallocate[u8](e.alloc, e.iface_use, (n * e.iface_len)::usize);
     }
@@ -319,9 +340,15 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
     val rs: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
     if (R.is_err[*u32, str](rs)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rs)); }
     e.gslot = R.unwrap_ok[*u32, str](rs);
+    val rt: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rt)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rt)); }
+    e.gtype_ids = R.unwrap_ok[*u32, str](rt);
+    val rc: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rc)); }
+    e.gstorage = R.unwrap_ok[*u32, str](rc);
 
     var i: u32 = 0;
-    for (i < n) { e.gvar_ids[i] = 0; e.iface_ids[i] = 0; e.gslot[i] = 0; i = i + 1; }
+    for (i < n) { e.gvar_ids[i] = 0; e.iface_ids[i] = 0; e.gslot[i] = 0; e.gtype_ids[i] = 0; e.gstorage[i] = 0; i = i + 1; }
 
     i = 0;
     for (i < n) {
@@ -362,7 +389,9 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
         var vop: [3]u32;
         vop[0] = ptr_ty; vop[1] = var_id; vop[2] = storage;
         spirv.inst(e.b, ?e.b.types_consts, spirv.OP_VARIABLE, ?vop[0], 3);
-        e.gvar_ids[i] = var_id;
+        e.gvar_ids[i]  = var_id;
+        e.gtype_ids[i] = value_ty;
+        e.gstorage[i]  = storage;
 
         if (g.iface == ir.IFACE_INPUT || g.iface == ir.IFACE_OUTPUT) {
             decorate(e, var_id, spirv.DECOR_LOCATION, g.iface_a);
@@ -1371,6 +1400,9 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     out.type_id = nil;
     out.var_id  = nil;
     out.is_bool = nil;
+    out.chain_id = nil;
+    out.chain_ty = nil;
+    out.chain_sc = nil;
     if (n == 0) { ret R.ok[bool, str](true); }
 
     val rt: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
@@ -1382,9 +1414,18 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     val rb: R.Result[*bool, str] = A.allocate[bool](e.alloc, n::usize);
     if (R.is_err[*bool, str](rb)) { ret R.err[bool, str](R.unwrap_err[*bool, str](rb)); }
     out.is_bool = R.unwrap_ok[*bool, str](rb);
+    val rch: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rch)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rch)); }
+    out.chain_id = R.unwrap_ok[*u32, str](rch);
+    val rct: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rct)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rct)); }
+    out.chain_ty = R.unwrap_ok[*u32, str](rct);
+    val rcs: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rcs)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rcs)); }
+    out.chain_sc = R.unwrap_ok[*u32, str](rcs);
 
     var i: u32 = 0;
-    for (i < n) { out.type_id[i] = 0; out.var_id[i] = 0; out.is_bool[i] = false; i = i + 1; }
+    for (i < n) { out.type_id[i] = 0; out.var_id[i] = 0; out.is_bool[i] = false; out.chain_id[i] = 0; out.chain_ty[i] = 0; out.chain_sc[i] = 0; i = i + 1; }
 
     # a vreg fed from a nominal register is typed by the DECLARATION behind that
     # register, never by the move: the ABI pre-coloring is emitted at the machine
@@ -1474,6 +1515,10 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
+            # a structural GEP defines an ADDRESS. It gets no element type and no
+            # backing variable: the access chain it becomes is consumed directly by
+            # the load or store that follows, never loaded as a value.
+            if (mi.opcode == mir.MIR_GEP) { ii = ii + 1; cnt; }
             if (mir.instr_defines_shape(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
                 val v: u32 = mi.operands[0].vreg;
                 if (v < out.n && out.type_id[v] == 0 && !(skip_copies && is_reg_copy(mi))) {
@@ -1555,7 +1600,11 @@ fun vmaps_dnit(e: *Emit, vm: *VMaps) {
     if (vm.type_id != nil) { A.deallocate[u32](e.alloc, vm.type_id, vm.n::usize); }
     if (vm.var_id != nil)  { A.deallocate[u32](e.alloc, vm.var_id, vm.n::usize); }
     if (vm.is_bool != nil) { A.deallocate[bool](e.alloc, vm.is_bool, vm.n::usize); }
-    vm.type_id = nil; vm.var_id = nil; vm.is_bool = nil; vm.n = 0;
+    if (vm.chain_id != nil) { A.deallocate[u32](e.alloc, vm.chain_id, vm.n::usize); }
+    if (vm.chain_ty != nil) { A.deallocate[u32](e.alloc, vm.chain_ty, vm.n::usize); }
+    if (vm.chain_sc != nil) { A.deallocate[u32](e.alloc, vm.chain_sc, vm.n::usize); }
+    vm.type_id = nil; vm.var_id = nil; vm.is_bool = nil;
+    vm.chain_id = nil; vm.chain_ty = nil; vm.chain_sc = nil; vm.n = 0;
 }
 
 # the SPIR-V scalar type of one lane of a lane descriptor, or 0 when unmappable
@@ -1792,12 +1841,15 @@ fun interface_target(e: *Emit, op: *mir.MirOperand) u32 {
 # the diagnostic for an addressed access the milestone cannot carry, named by what
 # the address actually originates in
 #
-# Several lowerings land here and each is fixed somewhere different, so each says
-# so. A member walk into a uniform block, and an index into any other aggregate,
-# need this emitter to build an access chain from the ordinals MIR now keeps;
-# anything else is ordinary addressed memory this milestone does not have.
-# Reporting any of them under another's name sends a reader to the wrong problem,
-# which is exactly what the first version of this did.
+# Each lowering that lands here is fixed somewhere different, so each says so, and
+# reporting one under another's name sends a reader to the wrong problem - which is
+# what the first version of this did, twice.
+#
+# A member walk no longer arrives at all: MIR keeps the GEP's index list on this
+# target (#2649) and the emitter builds an `OpAccessChain` from it, so reading and
+# writing a block member is supported. What is left here is a whole-AGGREGATE copy,
+# which lowers to a byte copy rather than a value load or store, and addressed
+# memory with no interface variable behind it.
 #
 # A scalar `f32` / `f64` interface variable used to have an arm here, because the
 # float address materialization was applied on every target and destroyed the
@@ -1817,11 +1869,8 @@ fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand
     if (g.iface == ir.IFACE_NONE) {
         ret "a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`)";
     }
-    if (g.iface == ir.IFACE_UNIFORM) {
-        ret "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the block itself is declared correctly, with its Block decoration and member offsets";
-    }
     if (is_aggregate_type(e, g.ty)) {
-        ret "indexing into an aggregate shader interface variable is not yet supported by the SPIR-V target: SPIR-V reaches an element through an OpAccessChain naming its ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the variable itself is declared correctly; read or write it whole";
+        ret "copying a whole record or array to or from a shader interface variable is not supported by the SPIR-V target: an aggregate assignment lowers to a byte copy, which addresses the object rather than loading or storing a value of it. reading and writing its MEMBERS individually is supported, and is what a shader wants anyway - a whole-block copy would move the descriptor's contents rather than the values in it";
     }
     ret "this shader interface variable is reachable only as a whole-variable read or write in the SPIR-V target";
 }
@@ -1849,7 +1898,9 @@ fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0]));
     }
-    val var_id: u32 = interface_target(e, ?mi.operands[1]);
+    var chain_ty: u32 = 0;
+    var var_id: u32 = chain_target(vm, ?mi.operands[1], ?chain_ty);
+    if (var_id == 0) { var_id = interface_target(e, ?mi.operands[1]); }
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1])); }
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n || vm.type_id[dst] == 0) {
@@ -1875,9 +1926,14 @@ fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs
 # ret:      true on success, or a precise error string
 fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count != 2) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
-    val var_id: u32 = interface_target(e, ?mi.operands[0]);
+    var chain_ty: u32 = 0;
+    var var_id: u32 = chain_target(vm, ?mi.operands[0], ?chain_ty);
+    var value_ty: u32 = chain_ty;
+    if (var_id == 0) {
+        var_id = interface_target(e, ?mi.operands[0]);
+        value_ty = interface_value_type(e, ?mi.operands[0]);
+    }
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
-    val value_ty: u32 = interface_value_type(e, ?mi.operands[0]);
     val value: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], value_ty);
     if (e.b.err || value == 0) { ret R.err[bool, str]("spirv.emit: unreadable value in an interface store"); }
     var ops: [2]u32;
@@ -1902,6 +1958,147 @@ fun interface_value_type(e: *Emit, op: *mir.MirOperand) u32 {
         i = i + 1;
     }
     ret 0;
+}
+
+# emit an OpAccessChain for a structural GEP into a shader interface variable
+#
+# MIR now keeps a GEP's index list on this target rather than folding it to a byte
+# displacement, which is what makes this expressible at all: SPIR-V reaches a member
+# by its ORDINAL and an offset does not determine one.
+#
+# THE LEADING INDEX IS DROPPED, and that is not a detail. A getelementptr's first
+# index strides over the source pointee type without descending into it - `gep %p, 0,
+# 1` is "the 0th object, then member 1" - while an OpAccessChain's base pointer
+# already names the object, so it takes only the descending indices. A NONZERO
+# leading index is pointer arithmetic across whole objects, which the logical model
+# has no form for; it is refused rather than dropped, because dropping it would
+# silently read the wrong object.
+#
+# The result is a pointer, recorded on the destination vreg rather than stored into
+# a backing variable, and the load or store that consumes it addresses through it.
+# ---
+# e:        the emission state
+# mf:       the MIR function
+# vm:       the per-vreg value maps
+# preg_val: the identity convention's nominal register file
+# mi:       the MIR_GEP instruction ([dst, base, idx...])
+# ret:      true on success, or a precise error string
+fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs,
+                      mi: *mir.MirInstr) R.Result[bool, str] {
+    # a two-operand GEP is the FLAT form, an address materialization with no index
+    # list; nothing on this target should produce one.
+    if (mi.operand_count < 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
+        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
+    }
+    # the base is either the interface variable itself or a chain already built off
+    # it: `m.mvp[2]` lowers to two GEPs, the second based on the first's result, and
+    # an OpAccessChain's base may be any pointer.
+    var base_id: u32 = 0;
+    var base_ty: u32 = 0;
+    var base_sc: u32 = 0;
+    var prior_ty: u32 = 0;
+    val prior: u32 = chain_target(vm, ?mi.operands[1], ?prior_ty);
+    if (prior != 0) {
+        base_id = prior;
+        base_ty = prior_ty;
+        base_sc = chain_storage(vm, ?mi.operands[1]);
+    }
+    or {
+        var gix: u32 = 0;
+        if (address_origin(e, mf, ?mi.operands[1], ?gix) != ADDR_GLOBAL) {
+            ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
+        }
+        val g: *ir.Global = ?e.ir.globals[gix];
+        if (g.iface == ir.IFACE_NONE || e.gvar_ids[gix] == 0) {
+            ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
+        }
+        base_id = e.gvar_ids[gix];
+        base_ty = e.gtype_ids[gix];
+        base_sc = e.gstorage[gix];
+    }
+
+    # index 0 strides over whole objects; only 0 names this one.
+    if (mi.operands[2].kind != mir.MIR_OP_IMM || mi.operands[2].imm != 0) {
+        ret unsupported(e, "pointer arithmetic across whole objects is not supported by the SPIR-V target: a logical pointer names one object, so a getelementptr's leading index may only be 0");
+    }
+
+    val dst: u32 = mi.operands[0].vreg;
+    if (dst >= vm.n) { ret R.err[bool, str]("spirv.emit: access chain result vreg out of range"); }
+
+    val count: u32 = mi.operand_count - 3;
+    if (count == 0 || count > 8) {
+        ret unsupported(e, "an access chain of more than 8 levels is not supported by the SPIR-V target");
+    }
+
+    var idx: [8]u32;
+    var cur: u32 = base_ty;
+    var k: u32 = 0;
+    for (k < count) {
+        val opnd: *mir.MirOperand = ?mi.operands[3 + k];
+        if (opnd.kind == mir.MIR_OP_IMM) {
+            if (opnd.imm < 0) { ret unsupported(e, "a negative index is not supported by the SPIR-V target"); }
+            cur = types.composite_member(e.tt, cur, opnd.imm::u32);
+            idx[k] = types.const_int(e.tt, 32, opnd.imm);
+        }
+        or {
+            # a runtime index is legal into an array, whose element type does not
+            # depend on it, and never into a struct, whose member type does.
+            val elem: u32 = types.composite_member(e.tt, cur, 0);
+            var lanes: u32 = 0;
+            if (elem == 0 || types.vector_shape(e.tt, cur, ?lanes) != 0) {
+                ret unsupported(e, "a runtime index into a record or vector is not supported by the SPIR-V target: SPIR-V takes a struct member and a vector lane by a constant ordinal, since the type reached depends on which one it is");
+            }
+            idx[k] = read_operand(e, vm, preg_val, opnd, types.type_int(e.tt, 32));
+            cur = elem;
+        }
+        if (cur == 0 || idx[k] == 0) {
+            ret unsupported(e, "an index reaches past the end of its aggregate in the SPIR-V target");
+        }
+        k = k + 1;
+    }
+    if (e.b.err) { ret R.err[bool, str]("spirv.emit: unreadable index in an access chain"); }
+
+    val ptr_ty: u32 = types.type_ptr(e.tt, base_sc, cur);
+    val result: u32 = spirv.alloc_id(e.b);
+    var ops: [11]u32;
+    ops[0] = ptr_ty; ops[1] = result; ops[2] = base_id;
+    k = 0;
+    for (k < count) { ops[3 + k] = idx[k]; k = k + 1; }
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_ACCESS_CHAIN, ?ops[0], count + 3);
+
+    vm.chain_id[dst] = result;
+    vm.chain_ty[dst] = cur;
+    vm.chain_sc[dst] = base_sc;
+    ret R.ok[bool, str](true);
+}
+
+# the access chain an address operand resolves to, or 0 when it is not one
+# ---
+# vm:      the per-vreg value maps
+# op:      the address operand
+# out_ty:  receives the type the chain points at
+# ret:     the pointer id, or 0
+fun chain_target(vm: *VMaps, op: *mir.MirOperand, out_ty: *u32) u32 {
+    @out_ty = 0;
+    var v: u32 = mir.MIR_VREG_NIL;
+    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg; }
+    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg; }
+    if (v == mir.MIR_VREG_NIL || v >= vm.n) { ret 0; }
+    @out_ty = vm.chain_ty[v];
+    ret vm.chain_id[v];
+}
+
+# the storage class of the access chain an address operand resolves to
+# ---
+# vm: the per-vreg value maps
+# op: the address operand
+# ret: the storage class, or 0
+fun chain_storage(vm: *VMaps, op: *mir.MirOperand) u32 {
+    var v: u32 = mir.MIR_VREG_NIL;
+    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg; }
+    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg; }
+    if (v == mir.MIR_VREG_NIL || v >= vm.n) { ret 0; }
+    ret vm.chain_sc[v];
 }
 
 # select the integer or float form of a class-polymorphic opcode
@@ -2058,9 +2255,7 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     if (op == mir.MIR_STORE) { ret emit_global_store(e, mf, vm, preg_val, mi); }
     # a GEP that survives to here computed an address, which the milestone carries
     # in no form; the refusal names what the address originates in.
-    if (op == mir.MIR_GEP && mi.operand_count >= 2) {
-        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
-    }
+    if (op == mir.MIR_GEP) { ret emit_access_chain(e, mf, vm, preg_val, mi); }
     if (op == mir.MIR_ALLOCA || op == mir.MIR_GEP) {
         ret unsupported(e, "a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live");
     }

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -116,6 +116,24 @@ rec CompositeKey {
     id:         u32;
 }
 
+# the member types of one composite (struct or array) this table minted
+#
+# A composite's own instruction names its members, but nothing reads instructions
+# back, and an `OpAccessChain` result type is the member type at an index - so the
+# shape has to be recoverable from the id. This is the composite analogue of
+# `vector_shape`. It matters most for an explicitly-laid-out array or struct, which
+# is deliberately NOT interned (its decorations are part of its identity), so it
+# cannot be rebuilt by asking for the same shape again.
+# ---
+# id:      the composite type id
+# members: owned copy of the member type ids; for an array, one entry, the element
+# count:   number of members, or 0 for an array (whose index is unbounded)
+rec ShapeKey {
+    id:      u32;
+    members: *u32;
+    count:   u32;
+}
+
 # the per-module type / constant memoization table
 #
 # Threads the builder so a cache miss can allocate an id and emit the defining
@@ -127,12 +145,14 @@ rec CompositeKey {
 # consts:  memoized scalar constants
 # fns:     memoized function types
 # comps:   memoized composite (vector) constants
+# shapes:  member types of every struct / array minted, for walking an access chain
 pub rec TypeTable {
     b:       *spirv.Builder;
     scalars: Vector[ScalarKey];
     consts:  Vector[ConstKey];
     fns:     Vector[FnKey];
     comps:   Vector[CompositeKey];
+    shapes:  Vector[ShapeKey];
 }
 
 # construct an empty type table over a builder
@@ -146,6 +166,7 @@ pub fun types_init(b: *spirv.Builder) TypeTable {
     tt.consts  = vector.init[ConstKey](b.alloc);
     tt.fns     = vector.init[FnKey](b.alloc);
     tt.comps   = vector.init[CompositeKey](b.alloc);
+    tt.shapes  = vector.init[ShapeKey](b.alloc);
     ret tt;
 }
 
@@ -172,7 +193,68 @@ pub fun types_dnit(tt: *TypeTable) {
     vector.dnit[ScalarKey](?tt.scalars);
     vector.dnit[ConstKey](?tt.consts);
     vector.dnit[FnKey](?tt.fns);
+    var si: usize = 0;
+    for (si < tt.shapes.len) {
+        val sk: *ShapeKey = ?tt.shapes.data[si];
+        if (sk.members != nil) {
+            var n: u32 = sk.count;
+            if (n == 0) { n = 1; }
+            A.deallocate[u32](tt.b.alloc, sk.members, n::usize);
+        }
+        si = si + 1;
+    }
     vector.dnit[CompositeKey](?tt.comps);
+    vector.dnit[ShapeKey](?tt.shapes);
+}
+
+# record the member types of a composite so an access chain can walk it
+# ---
+# tt:      the table
+# id:      the composite type id
+# members: the member type ids (one entry for an array's element)
+# count:   number of members, or 0 for an array
+fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32) {
+    var n: u32 = count;
+    if (n == 0) { n = 1; }
+    val r: R.Result[*u32, str] = A.allocate[u32](tt.b.alloc, n::usize);
+    if (R.is_err[*u32, str](r)) { tt.b.err = true; ret; }
+    val copy: *u32 = R.unwrap_ok[*u32, str](r);
+    var i: u32 = 0;
+    for (i < n) { copy[i] = members[i]; i = i + 1; }
+    var k: ShapeKey;
+    k.id = id; k.members = copy; k.count = count;
+    vector.push[ShapeKey](?tt.shapes, k);
+}
+
+# the type reached by indexing a composite at `index`
+#
+# A struct yields its `index`-th member and an array yields its element whatever the
+# index is, which is exactly what an `OpAccessChain` step produces. A vector is
+# answered from the scalar cache instead, since its shape lives there.
+# ---
+# tt:    the table
+# id:    the composite type id
+# index: the index taken at this level
+# ret:   the member type id, or 0 when `id` is not a composite this table minted
+#        or `index` is past a struct's members
+pub fun composite_member(tt: *TypeTable, id: u32, index: u32) u32 {
+    var lanes: u32 = 0;
+    val lane_ty: u32 = vector_shape(tt, id, ?lanes);
+    if (lane_ty != 0) {
+        if (index >= lanes) { ret 0; }
+        ret lane_ty;
+    }
+    var i: usize = 0;
+    for (i < tt.shapes.len) {
+        val k: *ShapeKey = ?tt.shapes.data[i];
+        if (k.id == id) {
+            if (k.count == 0) { ret k.members[0]; }
+            if (index >= k.count) { ret 0; }
+            ret k.members[index];
+        }
+        i = i + 1;
+    }
+    ret 0;
 }
 
 # find a cached scalar / pointer id by shape, or 0 when absent
@@ -346,6 +428,9 @@ pub fun type_array(tt: *TypeTable, elem: u32, count: u32, explicit_layout: bool)
     ops[0] = id; ops[1] = elem; ops[2] = len_id;
     spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_ARRAY, ?ops[0], 3);
     if (!explicit_layout) { scalar_put(tt, TAG_ARRAY, elem, count, id); }
+    var el: [1]u32;
+    el[0] = elem;
+    shape_put(tt, id, ?el[0], 0);
     ret id;
 }
 
@@ -369,6 +454,7 @@ pub fun type_struct(tt: *TypeTable, members: *u32, n: u32) u32 {
     var i: u32 = 0;
     for (i < n) { ops[1 + i] = members[i]; i = i + 1; }
     spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_STRUCT, ?ops[0], n + 1);
+    shape_put(tt, id, members, n);
     ret id;
 }
 


### PR DESCRIPTION
`Refs #2668`, `#2571`, `#2658` — **not** `Closes` on any of them; what each still needs is at the bottom.

A shader can now **read and write the members of a uniform block and a storage buffer**. Every descriptor on this target has been declared, laid out and bound but unreadable; this is the half that was missing.

```
%24 = OpAccessChain %_ptr_StorageBuffer_v4float %7 %uint_0
%25 = OpLoad %v4float %24
%27 = OpAccessChain %_ptr_StorageBuffer__arr_v4float_uint_4 %13 %uint_0
%28 = OpAccessChain %_ptr_StorageBuffer_v4float %27 %uint_0
```

#2649 gave the ordinals and #2673 gave the type a slot was allocated at. This consumes both.

## Two details that would have been wrong quietly

**The leading index is dropped.** A getelementptr's first index strides over the source pointee type *without descending into it* — `gep %p, 0, 1` is "the 0th object, then member 1" — while an `OpAccessChain`'s base already names the object. A **nonzero** leading index is pointer arithmetic across whole objects, which the logical model cannot express, so it is refused rather than dropped. Dropping it would read a different object and validate fine.

**Chains compose, and a flat test would not have caught it.** `m.mvp[2]` lowers to **two** GEPs, the second based on the first's result. An `OpAccessChain`'s base may be any pointer, so a vreg holding a chain is a legal base and carries its pointee type *and storage class* forward. My first version only accepted the variable as a base: `buf.member` passed, `buf.rows[2]` produced a wrong-typed `OpLoad`. Both int cases now index an array member for that reason.

## Why the type table needed a new query

`composite_member` — the composite analogue of `vector_shape`. Required rather than convenient: an explicitly-laid-out array or struct is deliberately **not interned**, because its `ArrayStride` / `Offset` decorations are part of its identity. So a member type cannot be recovered by asking for the same shape again, only by recording what was minted. Asking again would mint a *second* array type and the access chain's result pointer would reference the wrong one.

## Refusals: corrected, not deleted

Per the caution about deleting live guards alongside dead ones, I enumerated every shape each refusal covers and re-probed after the change:

| shape | before | after |
|---|---|---|
| uniform member read | refused | **works** |
| storage member read / write | refused | **works** |
| aggregate interface index | refused | **works** |
| nested `blk.arr[i]` | refused | **works** |
| compute reads + writes buffers | refused | **works** |
| whole-aggregate copy (`y = x`) | refused | still refused, **new message** |
| plain global, no interface role | refused | still refused, unchanged |
| local allocation / vector literal | refused | still refused, unchanged |

The uniform-member arm is **gone** — its shape works. The aggregate arm is **rewritten**: it said the ordinals were present and the emitter had yet to consume them, which was true and now is not. Left alone it would have reported a whole-block copy as an indexing failure — the same cross-wiring, one layer along. It now names what is actually left: an aggregate assignment lowers to a byte copy rather than a value load or store.

## Still open, deliberately

- **#2668** — this is its substance, but I have not re-read its acceptance closely enough to close it. Your call.
- **#2571** — its remaining half was the uniform member read, which now works.
- **#2658** — a compute stage now reads and writes storage buffers, which is acceptance item 1. The `uvec3` half stays as it was.
- **#2640** — untouched. Vector literals and zero-init are local allocations, not access chains, and are the next piece.

## Checks

- `mach test .` — 1245 passed, 0 failed
- `int/run.sh --target linux` — full suite green; `spirv-storage` gains a compute stage that actually moves data, `spirv-interface` gains `transform.model[2]`
- self-host fixpoint: `b == c`, byte-identical