### PR TITLE
feat(spirv): local allocations, and the vector literals that need them

### DIFF
--- a/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
+++ b/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
@@ -1,1 +1,1 @@
-error: a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)
+error: a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`) (MIR_LOAD in bump, at ./src/main.mach:24:15)

--- a/int/surface/spirv-unsupported-names-opcode/src/main.mach
+++ b/int/surface/spirv-unsupported-names-opcode/src/main.mach
@@ -1,23 +1,33 @@
-# A local array indexed by a RUNTIME value forces the front end to materialize
-# storage that no optimization can promote away, which reaches the SPIR-V backend
-# as MIR_ALLOCA. The logical addressing model has no way to express it, so the
-# backend refuses - correctly. What this case pins is the SHAPE of that refusal,
-# not the refusal itself.
+# A plain module-scope variable reaches the SPIR-V backend as a load against a
+# symbol with no storage class it could live in: a shader has no general global
+# storage, and a `val` / `var` reaches a stage only by carrying an interface role.
+# The backend refuses - correctly. What this case pins is the SHAPE of that
+# refusal, not the refusal itself.
 #
-# The runtime index is load-bearing: with a constant one the release pipeline
-# promotes the array into registers and the refusal never fires, so the case would
-# assert the message in `debug` and assert nothing at all in `release`.
+# THIS FIXTURE WAS A LOCAL ARRAY INDEXED BY A RUNTIME VALUE, and it stopped
+# refusing. A local allocation is now a Function-storage `OpVariable` and a runtime
+# index is an `OpAccessChain` with a dynamic index, so the shape compiles. The case
+# was repointed rather than deleted, because what it guards - that a refusal names
+# its opcode, its function and its position - is unchanged and still worth pinning.
 #
-# `sum_pair` is deliberately not the entry: the message has to name the function
-# the instruction is in, and a single-function fixture could satisfy that by
-# naming any function at all.
-fun sum_pair(a: i32, b: i32) i32 {
-    var buf: [2]i32;
-    buf[0] = a;
-    buf[1] = b;
-    ret buf[a % 2] + buf[b % 2];
+# The shape chosen instead is a durable one. A shader having no general global
+# storage is a property of the execution model rather than a gap in this backend,
+# so unlike the previous fixture it will not compile out from under the case.
+#
+# `bump` is deliberately not the entry: the message has to name the function the
+# instruction is in, and a single-function fixture could satisfy that by naming any
+# function at all. The global is read AND written so the refusal does not depend on
+# which of the two the backend happens to reach first.
+var counter: i32;
+
+fun bump(a: i32) i32 {
+    counter = counter + a;
+    ret counter;
 }
 
+#[stage("vertex")]
+fun vs() { }
+
 fun main() i32 {
-    ret sum_pair(1, 2);
+    ret bump(1);
 }

--- a/int/surface/spirv-vector/src/main.mach
+++ b/int/surface/spirv-vector/src/main.mach
@@ -6,15 +6,20 @@
 # Khronos validator is the observable, as in the sibling spirv-module and
 # spirv-float cases.
 #
-# WHAT IS NOT HERE, and why: a vector LITERAL (`f32x4{1.0, 2.0, 3.0, 4.0}`) and an
-# uninitialized vector local. Both lower to an `alloca [4]f32` written lane by lane
-# and then read back with a whole-vector `load f32x4` - reinterpreting an array
-# allocation as a vector through its pointer. SPIR-V's logical addressing model
-# cannot express that at all: a pointer there has exactly one pointee type and
-# there is no pointer bitcast. That is a lowering to fix ahead of the back end, not
-# an emitter gap, so the backend refuses it by name and this case builds its
-# vectors from parameters instead. When the lowering stops going through memory,
-# the literal cases belong here.
+# VECTOR LITERALS AND UNINITIALIZED LOCALS ARE HERE. They were absent while a
+# literal round-tripped through an array allocation reinterpreted as a vector,
+# which logical addressing cannot express. Three upstream changes removed that:
+# the allocation is now made at the vector's own type (#2640), a slot records the
+# type it was allocated at (#2673), and `memzero` survives as a whole-object
+# operation instead of a run of byte stores (#2669). A local allocation is now a
+# Function-storage `OpVariable`, a zero-init is one `OpStore` of `OpConstantNull`,
+# and a literal's per-lane writes are `OpAccessChain` from the ordinals MIR keeps.
+#
+# The broadcast case below is the one to keep. `f32x4{t, t, t, t}` is the only way
+# to scale a vector by a computed scalar, because the language has no implicit
+# scalar-to-vector conversion and no vector-by-scalar operator - so while literals
+# were refused there was NO way to express the most common shader operation after
+# add and multiply. A constant-lane literal alone would not have covered it.
 #
 # Also absent by construction: `i8x16` / `u8x16` and `i16x8` / `u16x8`. Every mach
 # vector is 128 bits, so those need 16 and 8 components, and a Shader module's
@@ -126,4 +131,49 @@ fun composed(a: f32x4, b: f32x4) f32x4 {
 
 fun main() i32 {
     ret 0;
+}
+
+# a vector literal with constant lanes: the classic case, and the one whose
+# allocation used to be reinterpreted.
+fun literal_const() f32x4 {
+    ret f32x4{1.0, 2.0, 3.0, 4.0};
+}
+
+# an uninitialized vector local, which is a whole-object zero rather than a
+# lane-by-lane one: `OpStore` of `OpConstantNull`, no stores per lane at all.
+fun zeroed() f32x4 {
+    var z: f32x4;
+    ret z;
+}
+
+# a literal whose lanes are RUNTIME values - the broadcast that had no other
+# spelling. Each lane is an access chain write into the local, so this exercises
+# the ordinals rather than a constant fold.
+fun broadcast(t: f32) f32x4 {
+    ret f32x4{t, t, t, t};
+}
+
+# broadcast feeding real arithmetic, which is what a shader actually writes when it
+# scales a colour or a position by a computed factor.
+fun scaled(v: f32x4, k: f32) f32x4 {
+    ret v * f32x4{k, k, k, k};
+}
+
+# a local array of vectors, indexed: a local allocation reached by an access chain
+# rather than read whole.
+fun from_array(v: f32x4) f32x4 {
+    var rows: [4]f32x4;
+    rows[0] = v;
+    rows[2] = v * v;
+    ret rows[0] + rows[2];
+}
+
+# a local record, whose plain undecorated struct type must be INTERNED - two locals
+# of one `rec` sharing one type - unlike a descriptor block, whose decorations make
+# it distinct.
+rec Pair { a: f32x4; b: f32x4; }
+fun from_record(v: f32x4) f32x4 {
+    var p: Pair;
+    p.a = v;
+    ret p.a + p.b;
 }

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -59,6 +59,7 @@ pub val OP_CONSTANT_TRUE:       u32 = 41;
 pub val OP_CONSTANT_FALSE:      u32 = 42;
 pub val OP_CONSTANT:            u32 = 43;
 pub val OP_CONSTANT_COMPOSITE:  u32 = 44;
+pub val OP_CONSTANT_NULL:       u32 = 46;
 pub val OP_FUNCTION:            u32 = 54;
 pub val OP_FUNCTION_PARAMETER:  u32 = 55;
 pub val OP_FUNCTION_END:        u32 = 56;

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -475,7 +475,7 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[
         members[i] = R.unwrap_ok[u32, str](mr);
         i = i + 1;
     }
-    val struct_id: u32 = types.type_struct(e.tt, ?members[0], n);
+    val struct_id: u32 = types.type_struct(e.tt, ?members[0], n, true);
     if (struct_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block type"); }
 
     i = 0;
@@ -834,13 +834,6 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
     }
     or (!e.has_entry) { emit_linkage_export(e, fn_id, fn_name); }
 
-    # a vector materialized through memory is refused up front, under its own name.
-    # Reaching it instruction by instruction would report the `alloca` that opens the
-    # sequence, which is the least informative part of it.
-    if (builds_vector_through_memory(e, mf)) {
-        ret unsupported(e, "constructing a vector from a literal or an uninitialized local is not yet supported by the SPIR-V target: the value is built in an ADDRESSABLE LOCAL and read back out, and this milestone emits no local allocations at all. a literal additionally writes its lanes through per-lane indices, which MIR folds into byte displacements the lane ordinal cannot be recovered from. derive the vector from an existing vector value instead - lane assignment onto a parameter, or arithmetic");
-    }
-
     # the structured shape of the body, or a refusal naming the construct.
     val cr: R.Result[cfg.Structure, str] = cfg.analyze(mf, e.alloc);
     if (R.is_err[cfg.Structure, str](cr)) { ret R.err[bool, str](R.unwrap_err[cfg.Structure, str](cr)); }
@@ -999,45 +992,6 @@ fun defining_instr(mf: *mir.MirFunction, vreg: u32) *mir.MirInstr {
 fun address_operand_index(mi: *mir.MirInstr) u32 {
     if (mi.opcode == mir.MIR_LOAD) { ret 1; }
     ret 0;
-}
-
-# whether a function materializes a vector by reading one out of a local allocation
-#
-# The signature of the vector-literal / zero-init lowering: an `alloca f32x4`
-# written lane by lane or zeroed, then a whole-vector `load f32x4` off the same
-# pointer. The ALLOCA origin is the identifying part. A vector arriving from or
-# leaving through an interface variable reads the same way at the instruction level
-# but originates in a global, and reporting it as a literal sent readers to the
-# wrong problem.
-#
-# The allocation used to be an `[4]f32` reinterpreted as a vector through its
-# pointer, which no SPIR-V back end could have accepted. That is fixed upstream: it
-# is now allocated at the vector's own type, so what remains is only that this
-# milestone emits no local allocations.
-# ---
-# e:   the emission state
-# mf:  the MIR function
-# ret: true when a vector-typed load or store reads a local allocation
-fun builds_vector_through_memory(e: *Emit, mf: *mir.MirFunction) bool {
-    var bi: u32 = 0;
-    for (bi < mf.block_count) {
-        val blk: *mir.MirBlock = ?mf.blocks[bi];
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if ((mi.opcode == mir.MIR_LOAD || mi.opcode == mir.MIR_STORE)
-                && mir.vec_lane_is_vector(mi.vec_lane)
-                && mi.operand_count == 2) {
-                var gix: u32 = 0;
-                if (address_origin(e, mf, ?mi.operands[address_operand_index(mi)], ?gix) == ADDR_ALLOCA) {
-                    ret true;
-                }
-            }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-    ret false;
 }
 
 # the diagnostic for a CFG the reconstruction cannot express, naming the function
@@ -1479,6 +1433,15 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     val r2: R.Result[bool, str] = type_computed_defs(e, mf, out, false);
     if (R.is_err[bool, str](r2)) { ret r2; }
 
+    # a local allocation becomes a Function-storage OpVariable, declared HERE rather
+    # than where the MIR_ALLOCA sits: SPIR-V requires every Function variable to be
+    # in the function's first block, ahead of any other instruction. The allocation's
+    # result vreg is an address, so it is recorded as an access chain base - the same
+    # shape an interface variable's id has - and every load, store and member walk
+    # off it then goes through machinery that already exists.
+    val ar: R.Result[bool, str] = declare_allocas(e, mf, out);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+
     # emit one OpVariable(Function) per defined vreg, at the entry, and record its id.
     i = 0;
     for (i < n) {
@@ -1493,6 +1456,73 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# declare one Function-storage OpVariable per local allocation, at the entry
+#
+# The allocated TYPE comes from the frame slot rather than from the instruction:
+# `MIR_ALLOCA` carries a slot reference, and the slot records the IR type it was
+# allocated at. Without that this could not be done at all - a size and an alignment
+# do not determine a type, and a Function variable needs one.
+# ---
+# e:   the emission state
+# mf:  the MIR function
+# out: the maps being filled
+# ret: true on success, or a precise error string
+fun declare_allocas(e: *Emit, mf: *mir.MirFunction, out: *VMaps) R.Result[bool, str] {
+    var bi: u32 = 0;
+    for (bi < mf.block_count) {
+        val blk: *mir.MirBlock = ?mf.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode != mir.MIR_ALLOCA || mi.operand_count < 2
+                || mi.operands[0].kind != mir.MIR_OP_VREG) { ii = ii + 1; cnt; }
+            val dst: u32 = mi.operands[0].vreg;
+            if (dst >= out.n) { ii = ii + 1; cnt; }
+
+            val slot: *mir.MirSlot = find_slot(mf, mi.operands[1].vreg);
+            if (slot == nil || slot.ty == mir.SLOT_TY_NIL) {
+                ret unsupported(e, "a local allocation whose type was not recorded is not supported by the SPIR-V target: a shader variable needs a type, and a size and alignment do not determine one");
+            }
+            val ty: u32 = ir_value_spv_type(e, slot.ty);
+            if (ty == 0) {
+                ret unsupported(e, unsupported_ir_type(e, slot.ty,
+                    "unsupported local allocation type in the SPIR-V target"));
+            }
+            # a slot wider than its own type is an array of them, which is pointer
+            # arithmetic across whole objects rather than one variable.
+            if (slot.size != type.byte_size(?e.ir.types, slot.ty, e.tgt)) {
+                ret unsupported(e, "a multi-element local allocation is not supported by the SPIR-V target: it is an array of whole objects reached by pointer arithmetic, which the logical addressing model has no form for");
+            }
+
+            val ptr_ty: u32 = types.type_ptr(e.tt, spirv.STORAGE_FUNCTION, ty);
+            val var_id: u32 = spirv.alloc_id(e.b);
+            var vop: [3]u32;
+            vop[0] = ptr_ty; vop[1] = var_id; vop[2] = spirv.STORAGE_FUNCTION;
+            spirv.inst(e.b, ?e.b.functions, spirv.OP_VARIABLE, ?vop[0], 3);
+            out.chain_id[dst] = var_id;
+            out.chain_ty[dst] = ty;
+            out.chain_sc[dst] = spirv.STORAGE_FUNCTION;
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the frame slot a slot-key names, or nil when none does
+# ---
+# mf:  the MIR function
+# key: the slot-key vreg
+# ret: the slot, or nil
+fun find_slot(mf: *mir.MirFunction, key: u32) *mir.MirSlot {
+    var i: u32 = 0;
+    for (i < mf.frame.slot_count) {
+        if (mf.frame.slots[i].value == key) { ret ?mf.frame.slots[i]; }
+        i = i + 1;
+    }
+    ret nil;
 }
 
 # type every vreg a computing instruction defines, from its result width and class
@@ -1518,7 +1548,7 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
             # a structural GEP defines an ADDRESS. It gets no element type and no
             # backing variable: the access chain it becomes is consumed directly by
             # the load or store that follows, never loaded as a value.
-            if (mi.opcode == mir.MIR_GEP) { ii = ii + 1; cnt; }
+            if (mi.opcode == mir.MIR_GEP || mi.opcode == mir.MIR_ALLOCA) { ii = ii + 1; cnt; }
             if (mir.instr_defines_shape(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
                 val v: u32 = mi.operands[0].vreg;
                 if (v < out.n && out.type_id[v] == 0 && !(skip_copies && is_reg_copy(mi))) {
@@ -1703,6 +1733,19 @@ fun ir_value_spv_type(e: *Emit, id: type.IrTypeId) u32 {
         val elem: u32 = ir_value_spv_type(e, t.data.array_.element);
         if (elem == 0) { ret 0; }
         ret types.type_array(e.tt, elem, t.data.array_.count, false);
+    }
+    if (t.kind == type.IRT_STRUCT) {
+        val n: u32 = t.data.struct_.field_count;
+        if (n == 0 || n > types.MAX_STRUCT_MEMBERS) { ret 0; }
+        var members: [16]u32;
+        var i: u32 = 0;
+        for (i < n) {
+            val mt: u32 = ir_value_spv_type(e, t.data.struct_.fields[i]);
+            if (mt == 0) { ret 0; }
+            members[i] = mt;
+            i = i + 1;
+        }
+        ret types.type_struct(e.tt, ?members[0], n, false);
     }
     ret 0;
 }
@@ -2101,6 +2144,35 @@ fun chain_storage(vm: *VMaps, op: *mir.MirOperand) u32 {
     ret vm.chain_sc[v];
 }
 
+# emit the zeroing of a whole object as a single store of its null value
+#
+# `MIR_MEMZERO` survives to this target as a whole-object operation (#2669) rather
+# than being expanded into a run of sized byte stores, which is what makes this one
+# instruction. `OpConstantNull` spells the zero of any type, so an aggregate needs
+# no member-by-member construction.
+# ---
+# e:   the emission state
+# mf:  the MIR function
+# vm:  the per-vreg value maps
+# mi:  the MIR_MEMZERO instruction ([dst_mem, size])
+# ret: true on success, or a precise error string
+fun emit_memzero(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 1) { ret R.err[bool, str]("spirv.emit: memzero with no destination"); }
+    var target_ty: u32 = 0;
+    var target: u32 = chain_target(vm, ?mi.operands[0], ?target_ty);
+    if (target == 0) {
+        target = interface_target(e, ?mi.operands[0]);
+        target_ty = interface_value_type(e, ?mi.operands[0]);
+    }
+    if (target == 0 || target_ty == 0) {
+        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0]));
+    }
+    var ops: [2]u32;
+    ops[0] = target; ops[1] = types.const_null(e.tt, target_ty);
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_STORE, ?ops[0], 2);
+    ret R.ok[bool, str](true);
+}
+
 # select the integer or float form of a class-polymorphic opcode
 # ---
 # lane_float: whether the operation's lanes are float
@@ -2256,9 +2328,9 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # a GEP that survives to here computed an address, which the milestone carries
     # in no form; the refusal names what the address originates in.
     if (op == mir.MIR_GEP) { ret emit_access_chain(e, mf, vm, preg_val, mi); }
-    if (op == mir.MIR_ALLOCA || op == mir.MIR_GEP) {
-        ret unsupported(e, "a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live");
-    }
+    # the allocation's variable was declared at the entry, where SPIR-V requires it.
+    if (op == mir.MIR_ALLOCA) { ret R.ok[bool, str](true); }
+    if (op == mir.MIR_MEMZERO) { ret emit_memzero(e, mf, vm, mi); }
 
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");
 }

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -87,6 +87,7 @@ val TAG_VOID:  u8 = 3;  # OpTypeVoid
 val TAG_PTR:   u8 = 4;  # OpTypePointer, `a` = storage class, `b` = pointee id
 val TAG_VEC:   u8 = 5;  # OpTypeVector, `a` = component type id, `b` = component count
 val TAG_ARRAY: u8 = 6;  # OpTypeArray (no explicit layout), `a` = element type id, `b` = length
+val TAG_NULL:  u8 = 7;  # OpConstantNull, `a` = the type the null belongs to
 
 # the largest component count a Shader module may give an OpTypeVector
 #
@@ -128,10 +129,13 @@ rec CompositeKey {
 # id:      the composite type id
 # members: owned copy of the member type ids; for an array, one entry, the element
 # count:   number of members, or 0 for an array (whose index is unbounded)
+# laid_out: whether the type carries explicit-layout decorations, which are part of
+#          its identity and so bar it from being shared with an undecorated twin
 rec ShapeKey {
     id:      u32;
     members: *u32;
     count:   u32;
+    laid_out: bool;
 }
 
 # the per-module type / constant memoization table
@@ -213,7 +217,7 @@ pub fun types_dnit(tt: *TypeTable) {
 # id:      the composite type id
 # members: the member type ids (one entry for an array's element)
 # count:   number of members, or 0 for an array
-fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32) {
+fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32, laid_out: bool) {
     var n: u32 = count;
     if (n == 0) { n = 1; }
     val r: R.Result[*u32, str] = A.allocate[u32](tt.b.alloc, n::usize);
@@ -222,7 +226,7 @@ fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32) {
     var i: u32 = 0;
     for (i < n) { copy[i] = members[i]; i = i + 1; }
     var k: ShapeKey;
-    k.id = id; k.members = copy; k.count = count;
+    k.id = id; k.members = copy; k.count = count; k.laid_out = laid_out;
     vector.push[ShapeKey](?tt.shapes, k);
 }
 
@@ -430,31 +434,43 @@ pub fun type_array(tt: *TypeTable, elem: u32, count: u32, explicit_layout: bool)
     if (!explicit_layout) { scalar_put(tt, TAG_ARRAY, elem, count, id); }
     var el: [1]u32;
     el[0] = elem;
-    shape_put(tt, id, ?el[0], 0);
+    shape_put(tt, id, ?el[0], 0, explicit_layout);
     ret id;
 }
 
 # the id of the struct type over `members`, emitting it on first use
 #
-# Not memoized. A struct type here is a uniform BLOCK, and a block carries
-# decorations - Block on the type, an Offset on every member - so two blocks with
-# the same member types are still distinct types whenever their layouts differ.
-# Interning on the member list alone would silently merge them and attach one
-# block's offsets to the other.
+# `explicit_layout` decides whether the result is interned, exactly as it does for
+# an array. A descriptor BLOCK carries decorations - Block on the type, an Offset on
+# every member - which are part of its identity, so two blocks with the same member
+# types are still distinct whenever their layouts differ, and interning on the
+# member list alone would attach one block's offsets to the other. A plain struct
+# carries no decorations, so two with the same members ARE the same type and must
+# share one id: otherwise assigning between two locals of one `rec` would be a type
+# mismatch against itself.
 # ---
 # tt:      the table
 # members: the member type ids
 # n:       number of members
+# explicit_layout: whether the result will carry Block / Offset decorations
 # ret:     the OpTypeStruct id, or 0 when the member count is out of range
-pub fun type_struct(tt: *TypeTable, members: *u32, n: u32) u32 {
+pub fun type_struct(tt: *TypeTable, members: *u32, n: u32, explicit_layout: bool) u32 {
     if (n == 0 || n > MAX_STRUCT_MEMBERS) { ret 0; }
+    if (!explicit_layout) {
+        var si: usize = 0;
+        for (si < tt.shapes.len) {
+            val k: *ShapeKey = ?tt.shapes.data[si];
+            if (!k.laid_out && k.count == n && params_equal(k.members, members, n)) { ret k.id; }
+            si = si + 1;
+        }
+    }
     val id: u32 = spirv.alloc_id(tt.b);
     var ops: [17]u32;
     ops[0] = id;
     var i: u32 = 0;
     for (i < n) { ops[1 + i] = members[i]; i = i + 1; }
     spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_STRUCT, ?ops[0], n + 1);
-    shape_put(tt, id, members, n);
+    shape_put(tt, id, members, n, explicit_layout);
     ret id;
 }
 
@@ -702,6 +718,29 @@ pub fun const_bool(tt: *TypeTable, value: bool) u32 {
     var k: ConstKey;
     k.type_id = type_id; k.lo = lo; k.hi = 0; k.id = id;
     vector.push[ConstKey](?tt.consts, k);
+    ret id;
+}
+
+# the id of the zero value of `type_id`, emitting it on first use
+#
+# `OpConstantNull` is the one form that spells a zero of ANY type - a scalar, a
+# vector, an array, a record - which is what an aggregate needs, since a composite
+# constant would otherwise have to be built lane by lane and member by member. It
+# is cached in the scalar table under its own tag, because a null and an ordinary
+# zero constant of the same type are different instructions even where they mean
+# the same value.
+# ---
+# tt:      the table
+# type_id: the type the zero belongs to
+# ret:     the OpConstantNull id
+pub fun const_null(tt: *TypeTable, type_id: u32) u32 {
+    val hit: u32 = scalar_find(tt, TAG_NULL, type_id, 0);
+    if (hit != 0) { ret hit; }
+    val id: u32 = spirv.alloc_id(tt.b);
+    var ops: [2]u32;
+    ops[0] = type_id; ops[1] = id;
+    spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_CONSTANT_NULL, ?ops[0], 2);
+    scalar_put(tt, TAG_NULL, type_id, 0, id);
     ret id;
 }
 


### PR DESCRIPTION
`Refs #2640` — **not** `Closes`. Its native half is a different target's concern; see the bottom.

Vector literals, uninitialized vectors, local arrays and local records all compile now. Each was a local allocation, and this milestone emitted none.

## The mechanism is small, because #2684 already landed

A local allocation becomes a Function-storage `OpVariable`, and its result vreg is recorded **as an access chain base** — the same shape an interface variable's id already had. So every load, store and member walk off it goes through machinery that exists. Indexing a local array needed no new code at all.

```
%11 = OpVariable %_ptr_Function_v4float Function
      OpStore %11 %13          ;; %13 = OpConstantNull
```

A zero-init is **one** store of `OpConstantNull`. That form spells the zero of any type, so an aggregate needs no member-by-member construction — and it is better output than the two stores a machine target emits for the same source.

Variables are declared at the function entry rather than where the allocation sits, because SPIR-V requires every Function variable to be in the first block.

## All three upstream changes are load-bearing

| change | without it |
|---|---|
| #2640 stage 1 — allocate at the value's own type | the allocation is an array reinterpreted through its pointer, which logical addressing cannot express at all |
| #2673 — the slot records its IR type | a size and an alignment do not determine a type, and a variable needs one |
| #2669 — `memzero` survives whole | a run of byte stores spanning object boundaries, which no access chain expresses |

## One type-table correction

`type_struct` gains the explicit-layout split `type_array` already had. A descriptor block's `Block` / `Offset` decorations are part of its identity so it must be minted fresh — but a **plain** struct carries none, and two locals of one `rec` must share a type or assigning between them is a mismatch against itself.

## The broadcast is the case that matters

`f32x4{t, t, t, t}` is the **only** way to scale a vector by a computed scalar: the language has no implicit scalar-to-vector conversion and no vector-by-scalar operator. So while literals were refused, the most common shader operation after add and multiply had no spelling at all. A constant-lane literal alone would not have covered it, so `spirv-vector` tests the runtime-lane form and the arithmetic that uses it.

## Refusals: enumerated first, then deleted

Per the standing discipline, I enumerated what each remaining refusal guards **before** touching any:

| shape | before | after |
|---|---|---|
| vector zero-init | refused | **works** |
| vector literal, constant lanes | refused | **works** |
| vector literal, runtime lanes | refused | **works** |
| local array, constant and runtime index | refused | **works** |
| local record | refused | **works** |
| whole-aggregate copy | refused | still refused, unchanged |
| plain module-scope global | refused | still refused, unchanged |

The whole-function pre-scan is **deleted** rather than narrowed, because every shape it guarded now compiles — checked one at a time rather than inferred.

## A case my change invalidated, repointed rather than deleted

`spirv-unsupported-names-opcode` **started building**. Its fixture was a local array indexed by a runtime value, chosen precisely because it could not be optimized away — and that shape now compiles, dynamic index included.

What the case guards is unchanged and still worth pinning: that a refusal names its **opcode, function and position** (#2656). So it is repointed at a plain module-scope variable, and the new golden keeps the full shape:

```
error: a plain module-scope variable is not reachable from the SPIR-V target: ...
       (MIR_LOAD in bump, at ./src/main.mach:24:15)
```

That fixture is durable in a way the old one was not: a shader having no general global storage is a property of the execution model, not a gap in this backend, so it will not compile out from under the case the way a local allocation just did.

## Why `Refs` and not `Closes`

#2640 also asks that the **native** round trip be removed and a native target's emitted code be checked before and after. That is x86-64's concern and, per #2661's analysis, wants the constant pool that #2248 was closed over. Not mine to close.

## Checks

- `mach test .` — 1245 passed, 0 failed
- `int/run.sh --target linux` — full suite green
- self-host fixpoint: `b == c`, byte-identical