### PR TITLE
chore(spirv): drop the dead OpVectorShuffle constant

### DIFF
--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -70,7 +70,6 @@ pub val OP_STORE:               u32 = 62;
 pub val OP_ACCESS_CHAIN:        u32 = 65;
 pub val OP_DECORATE:            u32 = 71;
 pub val OP_MEMBER_DECORATE:     u32 = 72;
-pub val OP_VECTOR_SHUFFLE:      u32 = 79;
 pub val OP_COMPOSITE_EXTRACT:   u32 = 81;
 pub val OP_COMPOSITE_INSERT:    u32 = 82;
 pub val OP_CONVERT_F_TO_U:      u32 = 109;


### PR DESCRIPTION
No issue and no `Closes` — a one-line dead-constant removal, flagged while checking #2569's acceptance.

`OP_VECTOR_SHUFFLE` was declared during the vector work and never used. I added it anticipating a shuffle the IR would ask for. **It never does, and it never will:** `doc/language/policy.md` puts the long tail of SIMD ops on the library side of the compiler-vs-stdlib boundary deliberately —

> **The long tail of SIMD ops** — shuffles, reductions, gather/scatter, saturating arithmetic, specialized math. Functions over the compiler-known SIMD types.

So this is not a gap waiting to be filled. Left in place it reads as "shuffle support is planned here", which is the opposite of what the policy says — the same stale-artifact class as a comment describing a solved problem, one layer over.

Confirmed unused rather than assumed: `grep OP_VECTOR_SHUFFLE src/` returns only the declaration, and neither the IR nor MIR carries a shuffle opcode at all.

## Checks

- `mach test .` — 1245 passed, 0 failed
- `int/run.sh --target linux` — spirv cases green
- self-host fixpoint: `b == c`, byte-identical