### PR TITLE
types: resolve a vector as the form TxN bounded by the target's vector width

### DIFF
--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -21,25 +21,52 @@ There is no compiler `bool`. `bool` is a stdlib `def bool: u8;` with `true` /
 
 ## SIMD vectors
 
-Ten 128-bit vector types are compiler-seeded, each a fixed number of lanes of a
-primitive numeric element:
+A vector type is a **form**, not a fixed list: any primitive numeric element
+followed by `x` and a lane count.
 
 ```mach
-f32x4  f64x2                    # float lanes
+f32x4  f32x3  f32x2  f64x2      # float lanes
 i8x16  i16x8  i32x4  i64x2      # signed integer lanes
 u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 ```
 
-These ten are the complete set. The spelling is `<u|i|f><width>x<count>` with a
-**single** `x` — there are no other vector types and no multi-`x` shapes. A name
-like `f32x4x4` is not a vector type (it resolves as an ordinary identifier); a
-matrix is an algorithm over vectors and belongs in a library over vector
-elements, not the language. A vector spelling is recognized only in type
-position, so a value may still be named `f32x4` without colliding with the type.
+The spelling is `<u|i|f><width>x<count>` with a **single** `x`. A name like
+`f32x4x4` is not a vector type (it resolves as an ordinary identifier); a matrix
+is an algorithm over vectors and belongs in a library over vector elements, not
+the language. A vector spelling is recognized only in type position, so a value
+may still be named `f32x4` without colliding with the type.
 
-Every seeded vector is exactly 128 bits: `$size_of` and `$align_of` are both
-`16`. Arrays of vectors (`[4]f32x4`) and pointers to vectors (`*f32x4`) are
-ordinary composite types over a vector element.
+Two rules bound the form:
+
+- **At least 2 lanes.** `f32x1` is refused; a one-lane vector is just its scalar.
+- **No wider than the target's vector register.** Every current target is 128
+  bits, so `f32x7` (224 bits) is refused by name. The error names the width you
+  asked for and the width the target has, rather than reporting an unknown type.
+
+`ptr` is not a lane element: its width is target-defined rather than a scalar bit
+count, so `ptrx2` is not a vector spelling.
+
+### Size and alignment
+
+`$size_of` is **lane-derived**: `lanes × element size`, packed, with no padding
+up to the register width.
+
+| type | `$size_of` | `$align_of` |
+|---|---|---|
+| `f32x4` | 16 | 16 |
+| `f32x3` | 12 | 4 |
+| `f32x2` | 8 | 4 |
+| `i16x4` | 8 | 2 |
+
+`$align_of` is deliberately **discontinuous at the register width**. A vector
+that *fills* the vector register aligns to its whole size, because the machine's
+vector load requires it. A narrower one is a packed aggregate that scalarizes or
+loads piecewise, so it aligns to a single lane. This is what makes `[N]f32x3` a
+usable packed vertex buffer: padding `f32x3` to 16 bytes would make it
+indistinguishable from `f32x4` in memory.
+
+Arrays of vectors (`[4]f32x4`) and pointers to vectors (`*f32x4`) are ordinary
+composite types over a vector element.
 
 **Literals** are full-arity — one initializer per lane, mirroring array literals.
 The lane count must match exactly; too few or too many lanes is a compile error.

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -376,7 +376,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     if (request.release(ctx.req)) { build_mode_id = comptime.MODE_RELEASE; }
     var build_pie: u32 = 0;
     if (ctx.req.pie) { build_pie = 1; }
-    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.compiler_name, p.compiler_ver);
+    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.target.model.vector_bits, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$bin.*` roots (the selected target's
     # declared tuple lives under `$project.target.*`); the target tuple comes from
     # the selected entry (set before any module loads).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6131,7 +6131,7 @@ fun ut_sema_extent_is(text: str, name: str, size: u32, align: u32) i32 {
         val tid: O.Option[type.TypeId] = ut_nominal_typeid(?s, name);
         if (O.is_some[type.TypeId](tid)) {
             # the corpus is built for the host x86_64 target, so pointer width is 8
-            val e: layout.Extent = generics.type_extent(?s, 8, O.unwrap[type.TypeId](tid));
+            val e: layout.Extent = generics.type_extent(?s, layout.machine(8, 128), O.unwrap[type.TypeId](tid));
             if (e.ok && e.size == size && e.align == align) { bad = 0; }
         }
     }

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -710,6 +710,10 @@ fun ast_alloc(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
 # The os, arch, abi, and pointer width this compiler binary was built for. The
 # editor resolves a buffer with no project-selected target, so `$if` predicates
 # evaluate against the running compiler rather than an unknown placeholder.
+#
+# The vector width is the named 128 rather than a registry read: the buffer's
+# context is seeded before the isa registry is brought up, and every target
+# declares the same width, so there is nothing a lookup would learn.
 # ---
 # es:  the editor session
 # ret: a host-seeded ComptimeCtx
@@ -722,6 +726,7 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         comptime.MODE_DEBUG,
         0,
         target.host_pointer_width(),
+        isa.VECTOR_BITS_128,
         intern.STR_NIL,
         intern.STR_NIL
     );

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -280,6 +280,10 @@ pub def FrameMark: u32;
 # build_pie:      1 when the build is position-independent (`--pie`), 0 otherwise;
 #                 read by `$mach.build.pie` so the runtime gates its self-relocation
 # pointer_width:  target pointer width in bytes
+# vector_bits:    the widest vector the target admits by name, in bits, which
+#                 bounds the `TxN` vector form the resolver reads (#2687). carried
+#                 here for the same reason `pointer_width` is: it is a target
+#                 machine fact the frontend needs, and the frontend has no target
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
 # entries:        scoped array of NamedConst bindings; lookup scans it in reverse
@@ -321,6 +325,7 @@ pub rec ComptimeCtx {
     build_mode_id:  u32;
     build_pie:      u32;
     pointer_width:  u32;
+    vector_bits:    u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
     entries:        *NamedConst;
@@ -370,6 +375,7 @@ fun is_i64_min(a: i64) bool {
 # build_mode_id:  active optimization mode id (MODE_DEBUG / MODE_RELEASE)
 # build_pie:      1 for a position-independent (`--pie`) build, 0 otherwise
 # pointer_width:  pointer width in bytes for the target
+# vector_bits:    widest vector the target admits by name, in bits
 # compiler_name:  interned compiler name
 # compiler_ver:   interned compiler version
 # ret:            a fresh ComptimeCtx
@@ -381,6 +387,7 @@ pub fun init(
     build_mode_id:  u32,
     build_pie:      u32,
     pointer_width:  u32,
+    vector_bits:    u32,
     compiler_name:  intern.StrId,
     compiler_ver:   intern.StrId
 ) ComptimeCtx {
@@ -392,6 +399,7 @@ pub fun init(
     c.build_mode_id  = build_mode_id;
     c.build_pie      = build_pie;
     c.pointer_width  = pointer_width;
+    c.vector_bits    = vector_bits;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
     c.entries        = nil;
@@ -3216,7 +3224,7 @@ test "mach.lang.fe.comptime.eval_lit_int:prefixes_and_separators" {
 test "mach.lang.fe.comptime.bind:frame_scoping" {
     var alloc: A.Allocator;
     page.make(?alloc);
-    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 0, 8, 128, intern.STR_NIL, intern.STR_NIL);
 
     val name1: intern.StrId = 1::intern.StrId;
     val name2: intern.StrId = 2::intern.StrId;

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -19,6 +19,7 @@
 # absorbs further operations.
 
 use std.collections.map;
+use std.format;
 use std.memory;
 use std.text.string.str_free;
 use std.types.bool.bool;
@@ -213,12 +214,15 @@ rec ResolveContext {
     prim_names: [11]intern.StrId;
     prim_syms:  [11]SymbolId;
 
-    # vector type registry: the SYM_VECTOR symbols for the ten seeded 128-bit
-    # shapes, keyed by interned spelling. recognised in type position only,
-    # exactly like the primitive registry, so a value named `f32x4` never
-    # collides with the vector type spelling.
-    vec_names: [10]intern.StrId;
-    vec_syms:  [10]SymbolId;
+    # vector type cache: spelling -> the SYM_VECTOR symbol for it. a vector is
+    # recognised by READING the form `<element>x<lanes>` rather than by matching a
+    # seeded name (#2687), so there is no fixed registry to scan and the symbol for
+    # a shape is created the first time the module names it. recognised in type
+    # position only, exactly like the primitive registry, so a value named `f32x4`
+    # never collides with the vector type spelling. the cache exists so repeated
+    # use-sites of one spelling share a single Symbol rather than inflating the
+    # symbol table per reference.
+    vec_cache: map.Map[intern.StrId, SymbolId];
 
     # caches (origin << 32 | decl) -> SymbolId for already-created
     # SYM_IMPORTED entries, so repeated `print.println` use-sites share one
@@ -405,12 +409,6 @@ pub fun resolve(
         ret R.err[ResolveResult, str](R.unwrap_err[bool, str](sp_r));
     }
 
-    val sv_r: R.Result[bool, str] = seed_vectors(?rc);
-    if (R.is_err[bool, str](sv_r)) {
-        dnit_context(?rc);
-        ret R.err[ResolveResult, str](R.unwrap_err[bool, str](sv_r));
-    }
-
     val m_opt: O.Option[*module.Module] = ast.get_module(a, a.root_module);
     if (O.is_none[*module.Module](m_opt)) {
         dnit_context(?rc);
@@ -484,6 +482,7 @@ fun init_context(
     }
 
     rc.imported_cache = map.init[u64, SymbolId](s.alloc, map.hash_u64, map.eq_u64);
+    rc.vec_cache      = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
     rc.module_index   = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
 
     # every allocation past this point is owned by the context; on a failure
@@ -556,6 +555,7 @@ fun dnit_context(rc: *ResolveContext) {
         A.deallocate[SymbolId](rc.s.alloc, rc.decl_symbol, rc.a.decl_len);
     }
     map.dnit[u64, SymbolId](?rc.imported_cache);
+    map.dnit[intern.StrId, SymbolId](?rc.vec_cache);
     map.dnit[intern.StrId, SymbolId](?rc.module_index);
 }
 
@@ -796,24 +796,21 @@ fun prior_name_span(rc: *ResolveContext, decl_id: id.DeclId) token.Span {
 # seeds the primitive type names (u8..f64, ptr) into the resolver's primitive
 # registry as SYM_PRIM symbols whose `slot` carries the primitive TypeKind
 # ordinal. primitives are recognised in type position only (see
-# `prim_symbol_for`), never bound into a value scope, so a declaration may
+# `type_spelling`), never bound into a value scope, so a declaration may
 # reuse a primitive spelling (e.g. `fun u64()`) without colliding. mirrors
 # cmach's string-based primitive resolution in sema_resolve_type
 # ---
 # rc:  resolver state for the module being resolved
 # ret: ok(true), or an allocation error
 fun seed_primitives(rc: *ResolveContext) R.Result[bool, str] {
-    val r0:  R.Result[bool, str] = seed_one_primitive(rc, 0,  "u8",  type.TYPE_U8::u32);  if (R.is_err[bool, str](r0))  { ret r0; }
-    val r1:  R.Result[bool, str] = seed_one_primitive(rc, 1,  "u16", type.TYPE_U16::u32); if (R.is_err[bool, str](r1))  { ret r1; }
-    val r2:  R.Result[bool, str] = seed_one_primitive(rc, 2,  "u32", type.TYPE_U32::u32); if (R.is_err[bool, str](r2))  { ret r2; }
-    val r3:  R.Result[bool, str] = seed_one_primitive(rc, 3,  "u64", type.TYPE_U64::u32); if (R.is_err[bool, str](r3))  { ret r3; }
-    val r4:  R.Result[bool, str] = seed_one_primitive(rc, 4,  "i8",  type.TYPE_I8::u32);  if (R.is_err[bool, str](r4))  { ret r4; }
-    val r5:  R.Result[bool, str] = seed_one_primitive(rc, 5,  "i16", type.TYPE_I16::u32); if (R.is_err[bool, str](r5))  { ret r5; }
-    val r6:  R.Result[bool, str] = seed_one_primitive(rc, 6,  "i32", type.TYPE_I32::u32); if (R.is_err[bool, str](r6))  { ret r6; }
-    val r7:  R.Result[bool, str] = seed_one_primitive(rc, 7,  "i64", type.TYPE_I64::u32); if (R.is_err[bool, str](r7))  { ret r7; }
-    val r8:  R.Result[bool, str] = seed_one_primitive(rc, 8,  "f32", type.TYPE_F32::u32); if (R.is_err[bool, str](r8))  { ret r8; }
-    val r9:  R.Result[bool, str] = seed_one_primitive(rc, 9,  "f64", type.TYPE_F64::u32); if (R.is_err[bool, str](r9))  { ret r9; }
-    val r10: R.Result[bool, str] = seed_one_primitive(rc, 10, "ptr", type.TYPE_PTR::u32); if (R.is_err[bool, str](r10)) { ret r10; }
+    # the registry index IS the TypeKind ordinal, so the spellings come straight
+    # from `type.prim_name` rather than being restated here.
+    var k: u32 = 0;
+    for (k < PRIM_COUNT) {
+        val r: R.Result[bool, str] = seed_one_primitive(rc, k, type.prim_name(k::u8), k);
+        if (R.is_err[bool, str](r)) { ret r; }
+        k = k + 1;
+    }
     ret R.ok[bool, str](true);
 }
 
@@ -839,73 +836,133 @@ fun seed_one_primitive(rc: *ResolveContext, index: u32, name: str, kind_ordinal:
     ret R.ok[bool, str](true);
 }
 
-# seeds the ten 128-bit vector type spellings (f32x4 .. u64x2) into the
-# resolver's vector registry as SYM_VECTOR symbols whose `slot` carries the
-# pre-interned semantic vector TypeId. recognised in type position only, exactly
-# like the primitive registry, so a value may reuse a vector spelling without
-# colliding. the type universe seeds the shapes at session init, so `type.vec`
-# hands back a stable id here
-# ---
-# rc:  resolver state for the module being resolved
-# ret: ok(true), or an allocation error
-fun seed_vectors(rc: *ResolveContext) R.Result[bool, str] {
-    var i: u32 = 0;
-    for (i < type.VEC_COUNT) {
-        val sh:  type.VecShape      = type.vec_shape(i);
-        val opt: O.Option[type.TypeId] = type.vec(?rc.s.types, i);
-        if (O.is_none[type.TypeId](opt)) { ret R.err[bool, str]("vector shape not seeded in the type universe"); }
-        val vtid: type.TypeId = O.unwrap[type.TypeId](opt);
+# the outcome of testing a spelling in type position
+#
+# Three cases rather than the old two, because a vector is now READ as the form
+# `<element>x<lanes>` rather than matched against a seeded name (#2687). A
+# spelling that is not a type at all must fall through to ordinary scope lookup,
+# but a well formed vector the target will not admit must NOT: reporting
+# `f32x7` as an unresolved name would describe a width problem as a typo.
+pub def TypeSpellStatus: u8;
 
-        val r: R.Result[bool, str] = seed_one_vector(rc, i, sh.name, vtid::u32);
-        if (R.is_err[bool, str](r)) { ret r; }
-        i = i + 1;
-    }
-    ret R.ok[bool, str](true);
+# not a primitive and not a vector form; the caller resolves it by other means
+pub val TYPE_SPELL_NONE:        TypeSpellStatus = 0;
+# a primitive or an admitted vector; `sym` is its symbol
+pub val TYPE_SPELL_FOUND:       TypeSpellStatus = 1;
+# a well formed vector form the target's vector width does not admit
+pub val TYPE_SPELL_VEC_REFUSED: TypeSpellStatus = 2;
+
+# what a spelling turned out to be in type position
+# ---
+# status: which of the three cases the spelling fell into
+# sym:    the symbol, when status is TYPE_SPELL_FOUND; SYMBOL_NIL otherwise
+# form:   the shape read, when the spelling was a vector form; only meaningful
+#         when status is TYPE_SPELL_VEC_REFUSED
+rec TypeSpelling {
+    status: TypeSpellStatus;
+    sym:    SymbolId;
+    form:   type.VecForm;
 }
 
-# interns one vector spelling and records it in the registry at `index` as a
-# SYM_VECTOR symbol carrying the pre-interned vector TypeId in `slot`
-# ---
-# rc:      resolver state for the module being resolved
-# index:   registry slot to fill
-# name:    the vector spelling
-# type_id: the pre-interned semantic vector TypeId
-# ret:     ok(true), or an allocation error
-fun seed_one_vector(rc: *ResolveContext, index: u32, name: str, type_id: u32) R.Result[bool, str] {
-    val r_id: R.Result[intern.StrId, str] = intern.intern(?rc.s.interner, name);
-    if (R.is_err[intern.StrId, str](r_id)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r_id)); }
-    val name_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_id);
-
-    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, SYM_VECTOR, 0, name_id, id.DECL_NIL, type_id, rc.own_module);
-    if (R.is_err[SymbolId, str](r_sym)) { ret R.err[bool, str](R.unwrap_err[SymbolId, str](r_sym)); }
-    val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
-
-    rc.vec_names[index] = name_id;
-    rc.vec_syms[index]  = sid;
-    ret R.ok[bool, str](true);
-}
-
-# returns the SYM_PRIM or SYM_VECTOR symbol for a type spelling, or SYMBOL_NIL
-# when `name` is neither a primitive nor a vector. consulted in type position,
-# taking priority over scope so a same-named value declaration never shadows the
-# type
+# the SYM_PRIM or SYM_VECTOR symbol for a type spelling
+#
+# Consulted in type position, taking priority over scope so a same-named value
+# declaration never shadows the type. Primitives come from the fixed registry;
+# a vector is read as the form `<element>x<lanes>` and bounded by the target's
+# vector width, so the ten formerly seeded spellings resolve exactly as before
+# without being enumerated anywhere (#2687).
+#
+# A vector's symbol is created on first mention and cached by spelling, so
+# repeated use-sites share one Symbol. The lane shape is interned into the type
+# universe here, which is what makes a shape the universe did not pre-seed
+# (`f32x3`) resolve at all.
 # ---
 # rc:   resolver state for the module being resolved
 # name: interned spelling to test
-# ret:  the SYM_PRIM / SYM_VECTOR symbol, or SYMBOL_NIL when `name` is neither
-fun prim_symbol_for(rc: *ResolveContext, name: intern.StrId) SymbolId {
+# ret:  what the spelling is, or an allocation error
+fun type_spelling(rc: *ResolveContext, name: intern.StrId) R.Result[TypeSpelling, str] {
+    var out: TypeSpelling;
+    out.status = TYPE_SPELL_NONE;
+    out.sym    = SYMBOL_NIL;
+
     var i: u32 = 0;
     for (i < PRIM_COUNT) {
-        if (rc.prim_names[i] == name) { ret rc.prim_syms[i]; }
+        if (rc.prim_names[i] == name) {
+            out.status = TYPE_SPELL_FOUND;
+            out.sym    = rc.prim_syms[i];
+            ret R.ok[TypeSpelling, str](out);
+        }
         i = i + 1;
     }
-    var v: u32 = 0;
-    for (v < type.VEC_COUNT) {
-        if (rc.vec_names[v] == name) { ret rc.vec_syms[v]; }
-        v = v + 1;
+
+    # a spelling already resolved to a vector symbol in this module.
+    val cached: R.Result[*SymbolId, str] = map.get[intern.StrId, SymbolId](?rc.vec_cache, ?name);
+    if (R.is_ok[*SymbolId, str](cached)) {
+        out.status = TYPE_SPELL_FOUND;
+        out.sym    = @R.unwrap_ok[*SymbolId, str](cached);
+        ret R.ok[TypeSpelling, str](out);
     }
-    ret SYMBOL_NIL;
+
+    val no: O.Option[str] = intern.lookup(?rc.s.interner, name);
+    if (O.is_none[str](no)) { ret R.ok[TypeSpelling, str](out); }
+
+    val form: type.VecForm = type.vector_form(O.unwrap[str](no), rc.ctx.vector_bits);
+    out.form = form;
+    if (form.status == type.VEC_FORM_NONE) { ret R.ok[TypeSpelling, str](out); }
+    if (form.status != type.VEC_FORM_OK) {
+        out.status = TYPE_SPELL_VEC_REFUSED;
+        ret R.ok[TypeSpelling, str](out);
+    }
+
+    val r_tid: R.Result[type.TypeId, str] = type.intern_vector(?rc.s.types, form.element, form.lanes);
+    if (R.is_err[type.TypeId, str](r_tid)) { ret R.err[TypeSpelling, str](R.unwrap_err[type.TypeId, str](r_tid)); }
+    val vtid: type.TypeId = R.unwrap_ok[type.TypeId, str](r_tid);
+
+    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, SYM_VECTOR, 0, name, id.DECL_NIL, vtid::u32, rc.own_module);
+    if (R.is_err[SymbolId, str](r_sym)) { ret R.err[TypeSpelling, str](R.unwrap_err[SymbolId, str](r_sym)); }
+    val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
+
+    val ins: R.Result[bool, str] = map.insert[intern.StrId, SymbolId](?rc.vec_cache, name, sid);
+    if (R.is_err[bool, str](ins)) { ret R.err[TypeSpelling, str](R.unwrap_err[bool, str](ins)); }
+
+    out.status = TYPE_SPELL_FOUND;
+    out.sym    = sid;
+    ret R.ok[TypeSpelling, str](out);
 }
+
+# report a well formed vector spelling the target will not admit
+#
+# Names the width that was asked for and the width the target has, so the
+# message is about the vector rather than about an unknown identifier. A
+# degenerate lane count is a different sentence: no target width would admit it.
+# ---
+# rc:   resolver state for the module being resolved
+# span: the spelling's source span
+# name: the interned spelling
+# form: the shape read from it
+# ret:  ok(true), or an allocation error
+fun report_vector_refused(rc: *ResolveContext, span: token.Span, name: intern.StrId,
+                          form: type.VecForm) R.Result[bool, str] {
+    val no: O.Option[str] = intern.lookup(?rc.s.interner, name);
+    if (O.is_none[str](no)) { ret R.ok[bool, str](true); }
+    val spelling: str = O.unwrap[str](no);
+
+    var rm: R.Result[str, str] = format.sprint(rc.s.alloc,
+        "vector `{}` needs at least 2 lanes", spelling);
+    if (form.status == type.VEC_FORM_TOO_WIDE) {
+        rm = format.sprint(rc.s.alloc,
+            "vector `{}` is {} bits wide, more than this target's {}-bit vector width",
+            spelling, form.lanes::u64 * type.prim_desc(form.element).bits::u64,
+            rc.ctx.vector_bits);
+    }
+    if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
+    val msg: str = R.unwrap_ok[str, str](rm);
+
+    val emit: R.Result[bool, str] = diagnostic.error(?rc.s.diags, rc.a.file_id, span, msg);
+    A.deallocate[char](rc.s.alloc, msg::*char, str_len(msg) + 1);
+    ret emit;
+}
+
 
 # collect every decl in `[start, start + len)` of the decl-id pool
 # ---
@@ -2833,7 +2890,17 @@ fun bind_type_name_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str]
         if (R.is_err[intern.StrId, str](r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r)); }
         val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
 
-        var sid: SymbolId = prim_symbol_for(rc, name);
+        val rs: R.Result[TypeSpelling, str] = type_spelling(rc, name);
+        if (R.is_err[TypeSpelling, str](rs)) { ret R.err[bool, str](R.unwrap_err[TypeSpelling, str](rs)); }
+        val sp: TypeSpelling = R.unwrap_ok[TypeSpelling, str](rs);
+
+        # a well formed vector the target will not admit is a width error, not an
+        # unknown name, so it never falls through to scope lookup.
+        if (sp.status == TYPE_SPELL_VEC_REFUSED) {
+            ret report_vector_refused(rc, e.span, name, sp.form);
+        }
+
+        var sid: SymbolId = sp.sym;
         if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
         if (sid == SYMBOL_NIL) {
             val re: R.Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
@@ -3096,7 +3163,18 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
             # the primitive, taking priority over any value-scope symbol of the
             # same name (mirrors cmach's string-based primitive resolution).
             val is_single: bool = seg_end >= end;
-            if (is_single) { current_sym = prim_symbol_for(rc, seg_name); }
+            if (is_single) {
+                val rs: R.Result[TypeSpelling, str] = type_spelling(rc, seg_name);
+                if (R.is_err[TypeSpelling, str](rs)) { ret SYMBOL_NIL; }
+                val sp: TypeSpelling = R.unwrap_ok[TypeSpelling, str](rs);
+                # a width refusal is reported as itself and stops here, rather than
+                # falling through to scope lookup and an unresolved-name message.
+                if (sp.status == TYPE_SPELL_VEC_REFUSED) {
+                    report_vector_refused(rc, full, seg_name, sp.form);
+                    ret SYMBOL_NIL;
+                }
+                current_sym = sp.sym;
+            }
             if (current_sym == SYMBOL_NIL) {
                 current_sym = scope_lookup_chain(rc, rc.current_scope, seg_name);
             }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -582,7 +582,7 @@ fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.Typ
     # DEEP (#2165): the reinterpret's `^` placement must match through the field graph, not
     # just the pointer / array spine - else `*P :~ *Q` (P has a `^` field, Q public)
     # reinterprets the secret pointee as public and reads it out.
-    if (!generics.secrecy_structure_equal_deep(sc.s, ptr_width(sc), from, to)) {
+    if (!generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), from, to)) {
         report_note(sc, span, "cast: `::` and `:~` cannot add or drop the secret qualifier `^`",
             "a public value coerces up to secret with no syntax; `:^` is the only downgrade");
         ret false;
@@ -738,8 +738,12 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     val k:  type.TypeKind = tp.kind;
     val d:  type.PrimDesc = type.prim_desc(k);
     if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) { ret d.bits / 8; }
-    # all ten vector shapes are 128-bit (#1965).
-    if (k == type.TYPE_VECTOR) { ret 16; }
+    # a vector is `lanes` lanes of its element, packed: `f32x4` is 16 and `f32x3` is
+    # 12 (#2687). measured here rather than deferred to `type_extent`, which handles
+    # only the nominal aggregates.
+    if (k == type.TYPE_VECTOR) {
+        ret (type.prim_desc(tp.data.vector.element).bits / 8) * tp.data.vector.lanes;
+    }
     # a raw `ptr`, a typed `*T`, and a function value (a code address) are all
     # pointer-sized, read from the target's pointer width.
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ptr_width(sc); }
@@ -754,7 +758,7 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     # not assumed unknown. `type_extent` reports `ok = false` rather than a wrong
     # number when it cannot decide, which sizes as 0 and fails the cast closed.
     if (k == type.TYPE_REC || k == type.TYPE_UNI || k == type.TYPE_INSTANCE) {
-        val ext: layout.Extent = generics.type_extent(sc.s, ptr_width(sc), type.strip_secret(?sc.s.types, t));
+        val ext: layout.Extent = generics.type_extent(sc.s, context.machine_of(sc), type.strip_secret(?sc.s.types, t));
         if (!ext.ok) { ret 0; }
         ret ext.size;
     }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -28,6 +28,7 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.token;
 use mach.lang.intern;
+use mach.lang.layout;
 use mach.lang.session;
 use mach.lang.type;
 
@@ -961,6 +962,17 @@ pub fun symbol_by_id(sc: *SemaContext, sid: resolve.SymbolId) O.Option[*resolve.
 # ret: the active target's pointer width in bytes
 pub fun ptr_width_of(sc: *SemaContext) u32 {
     ret sc.ctx.pointer_width;
+}
+
+# the target facts the layout fold reads, from the active comptime context
+#
+# The frontend has no target; `ComptimeCtx` carries the per-build target facts it
+# needs, so both the pointer width and the vector width come from there (#2687).
+# ---
+# sc:  the active sema context
+# ret: the Machine the layout policy folds against
+pub fun machine_of(sc: *SemaContext) layout.Machine {
+    ret layout.machine(sc.ctx.pointer_width, sc.ctx.vector_bits);
 }
 
 # emit a SEVERITY_ERROR diagnostic at `span`

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -433,8 +433,13 @@ fun describe_type(ctx: ptr, id: u32) layout.Node {
     if (d.class == type.PRIM_CLASS_PTR || t.kind == type.TYPE_POINTER || t.kind == type.TYPE_FUN) {
         ret layout.node(layout.NODE_POINTER);
     }
-    # all ten vector shapes are 128-bit (#1965).
-    if (t.kind == type.TYPE_VECTOR) { ret layout.node(layout.NODE_VECTOR); }
+    # a vector's extent is lane-derived, so the node carries its lane shape (#2687).
+    if (t.kind == type.TYPE_VECTOR) {
+        var n: layout.Node = layout.node(layout.NODE_VECTOR);
+        n.bytes = type.prim_desc(t.data.vector.element).bits / 8;
+        n.count = t.data.vector.lanes;
+        ret n;
+    }
 
     if (t.kind == type.TYPE_ARRAY) {
         var n: layout.Node = layout.node(layout.NODE_ARRAY);
@@ -503,11 +508,11 @@ val SEMA_LAYOUT_MAX_DEPTH: u32 = 64;
 # layout with, so the two cannot disagree (#2289).
 # ---
 # s:         the session (type universe, lazy instance fields, align overrides)
-# ptr_width: the target's pointer width in bytes
+# m:         the target facts the layout fold reads
 # tid:       the type to measure
 # ret:       the determined Extent, or `ok = false` when it cannot be computed
-pub fun type_extent(s: *session.Session, ptr_width: u32, tid: type.TypeId) layout.Extent {
-    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, ptr_width,
+pub fun type_extent(s: *session.Session, m: layout.Machine, tid: type.TypeId) layout.Extent {
+    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, m,
                          SEMA_LAYOUT_MAX_DEPTH);
 }
 
@@ -565,15 +570,15 @@ rec SecrecyPairScan {
 # a:   the first type
 # b:   the second type
 # ret: true when `a` and `b` carry `^` at identical positions
-pub fun secrecy_structure_equal_deep(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.TypeId) bool {
+pub fun secrecy_structure_equal_deep(s: *session.Session, m: layout.Machine, a: type.TypeId, b: type.TypeId) bool {
     if (!contains_secret_deep(s, a) && !contains_secret_deep(s, b)) { ret true; }
     var scan: SecrecyPairScan;
     scan.len = 0;
-    ret sse_deep_walk(s, ptr_width, a, b, ?scan);
+    ret sse_deep_walk(s, m, a, b, ?scan);
 }
 
 # the recursive lockstep worker for `secrecy_structure_equal_deep`
-fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.TypeId, scan: *SecrecyPairScan) bool {
+fun sse_deep_walk(s: *session.Session, m: layout.Machine, a: type.TypeId, b: type.TypeId, scan: *SecrecyPairScan) bool {
     if (type.is_secret(?s.types, a) != type.is_secret(?s.types, b)) { ret false; }
 
     val sa: type.TypeId = type.strip_secret(?s.types, a);
@@ -585,11 +590,11 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
     val tb: *type.Type = O.unwrap[*type.Type](ob);
 
     if (ta.kind == type.TYPE_POINTER && tb.kind == type.TYPE_POINTER) {
-        ret sse_deep_walk(s, ptr_width, ta.data.pointer.base, tb.data.pointer.base, scan);
+        ret sse_deep_walk(s, m, ta.data.pointer.base, tb.data.pointer.base, scan);
     }
     if (ta.kind == type.TYPE_ARRAY && tb.kind == type.TYPE_ARRAY) {
         # every element shares the base's secrecy, so the count is irrelevant to placement.
-        ret sse_deep_walk(s, ptr_width, ta.data.array.base, tb.data.array.base, scan);
+        ret sse_deep_walk(s, m, ta.data.array.base, tb.data.array.base, scan);
     }
     if (ta.kind == type.TYPE_FUN && tb.kind == type.TYPE_FUN) {
         # two function types place `^` identically iff same arity, the return pair matches,
@@ -598,13 +603,13 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
         # would call `id` treating a secret arg as public - rejected here). Differing arity
         # cannot be aligned, so it fails closed.
         if (ta.data.fn.params_len != tb.data.fn.params_len) { ret false; }
-        if (!sse_deep_walk(s, ptr_width, ta.data.fn.ret_type, tb.data.fn.ret_type, scan)) { ret false; }
+        if (!sse_deep_walk(s, m, ta.data.fn.ret_type, tb.data.fn.ret_type, scan)) { ret false; }
         var pi: u32 = 0;
         for (pi < ta.data.fn.params_len) {
             val pa: O.Option[type.TypeId] = type.get_param(?s.types, ta.data.fn.params_start + pi);
             val pb: O.Option[type.TypeId] = type.get_param(?s.types, tb.data.fn.params_start + pi);
             if (O.is_none[type.TypeId](pa) || O.is_none[type.TypeId](pb)) { ret false; }
-            if (!sse_deep_walk(s, ptr_width, O.unwrap[type.TypeId](pa), O.unwrap[type.TypeId](pb), scan)) { ret false; }
+            if (!sse_deep_walk(s, m, O.unwrap[type.TypeId](pa), O.unwrap[type.TypeId](pb), scan)) { ret false; }
             pi = pi + 1;
         }
         ret true;
@@ -660,10 +665,10 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
             if (O.is_none[*type.FieldEntry](fa) || O.is_none[*type.FieldEntry](fb)) { ret false; }
             val ty_a: type.TypeId = O.unwrap[*type.FieldEntry](fa).ty;
             val ty_b: type.TypeId = O.unwrap[*type.FieldEntry](fb).ty;
-            if (!sse_deep_walk(s, ptr_width, ty_a, ty_b, scan)) { ret false; }
+            if (!sse_deep_walk(s, m, ty_a, ty_b, scan)) { ret false; }
 
-            val ea: layout.Extent = type_extent(s, ptr_width, ty_a);
-            val eb: layout.Extent = type_extent(s, ptr_width, ty_b);
+            val ea: layout.Extent = type_extent(s, m, ty_a);
+            val eb: layout.Extent = type_extent(s, m, ty_b);
             if (!ea.ok || !eb.ok)                           { ret false; }
             if (ea.size != eb.size || ea.align != eb.align) { ret false; }
             f = f + 1;
@@ -1216,7 +1221,7 @@ fun check_uni_variants(sc: *sema.SemaContext, nom: type.TypeId, args: *type.Type
         val raw: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
         val ty:  type.TypeId = subst_or_self(s, raw, args, arg_len);
         if (type_mentions_gparam(s, ty)) { ret; }
-        if (!secrecy_structure_equal_deep(s, sema.ptr_width_of(sc), first, ty)) {
+        if (!secrecy_structure_equal_deep(s, sema.machine_of(sc), first, ty)) {
             if (sema.uni_report_mark(sc.uni_reports, key)) {
                 sema.report(sc, span, "union variants must agree on secrecy: this instantiation makes overlapping fields part secret `^` and part public, which would alias the same storage at two classifications");
             }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -435,7 +435,7 @@ fun fold_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, span: token.
         ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
     }
 
-    val ext: layout.Extent = generics.type_extent(sc.s, context.ptr_width_of(sc), tid);
+    val ext: layout.Extent = generics.type_extent(sc.s, context.machine_of(sc), tid);
     if (!ext.ok) {
         context.report(sc, span, "the layout of the type named by this intrinsic could not be determined");
         ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
@@ -614,7 +614,7 @@ fun check_uni_secrecy(sc: *context.SemaContext, nom: type.TypeId, fields_start: 
         # aliases the secret bytes under the public `Q` overlay and reads them out. A
         # shallow `is_secret` per variant treats `P` as public and misses it.
         if (!cyclic) {
-            if (!generics.secrecy_structure_equal_deep(sc.s, context.ptr_width_of(sc), first_ty, ty)) {
+            if (!generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), first_ty, ty)) {
                 context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
             }
         }

--- a/src/lang/layout.mach
+++ b/src/lang/layout.mach
@@ -60,7 +60,7 @@ pub val NODE_UNKNOWN:   NodeKind = 0;
 pub val NODE_SCALAR:    NodeKind = 1;
 # a pointer or function value: the target's pointer width, aligned to it
 pub val NODE_POINTER:   NodeKind = 2;
-# a 128-bit vector: 16 bytes, 16-byte aligned
+# a vector of `count` lanes each `bytes` wide; its extent is lane-derived (#2687)
 pub val NODE_VECTOR:    NodeKind = 3;
 # `count` elements of node `child`
 pub val NODE_ARRAY:     NodeKind = 4;
@@ -70,6 +70,33 @@ pub val NODE_AGGREGATE: NodeKind = 5;
 # following field nor lowers an enclosing aggregate's alignment
 pub val NODE_ZERO:      NodeKind = 6;
 
+# the target facts the fold reads
+#
+# Bundled rather than passed as loose parameters because the fold's dependence on the
+# target is an axis that grows: `ptr_width` was the only such fact until a vector's
+# alignment came to turn on the register width. A new fact is a field here rather than
+# another positional argument threaded through three call sites.
+# ---
+# ptr_width:   the target's pointer width in bytes
+# vector_bits: the widest vector the target admits, in bits, which is the width at
+#              which a vector is register-resident rather than a packed aggregate
+pub rec Machine {
+    ptr_width:   u32;
+    vector_bits: u32;
+}
+
+# a Machine from its two facts
+# ---
+# ptr_width:   the target's pointer width in bytes
+# vector_bits: the target's vector register width in bits
+# ret:         the assembled Machine
+pub fun machine(ptr_width: u32, vector_bits: u32) Machine {
+    var m: Machine;
+    m.ptr_width   = ptr_width;
+    m.vector_bits = vector_bits;
+    ret m;
+}
+
 # one type node, described by the caller in terms this policy folds
 #
 # Only the fields its `kind` selects are read, so a describer fills the rest with
@@ -78,7 +105,9 @@ pub val NODE_ZERO:      NodeKind = 6;
 # ---
 # kind:        which storage shape this node has
 # bytes:       NODE_SCALAR: the scalar's width in bytes
+#              NODE_VECTOR: one lane's width in bytes
 # count:       NODE_ARRAY: the element count
+#              NODE_VECTOR: the lane count
 # child:       NODE_ARRAY: the element's node id
 # field_count: NODE_AGGREGATE: the number of fields
 # decl_align:  NODE_AGGREGATE: an `#[align(...)]` override, 0 for none
@@ -210,12 +239,12 @@ pub fun round_up(value: u32, align: u32) u32 {
 # describe:  names a node's storage shape
 # field:     names an aggregate's field node ids
 # id:        the node to measure
-# ptr_width: the target's pointer width in bytes
+# m:         the target facts the fold reads
 # max_depth: the depth past which the walk declines; DEPTH_UNBOUNDED for an acyclic graph
 # ret:       the determined Extent, or `ok = false` with a cause when it cannot be computed
-pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32,
+pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, m: Machine,
                   max_depth: u32) Extent {
-    ret walk(ctx, describe, field, id, ptr_width, 0, max_depth);
+    ret walk(ctx, describe, field, id, m, 0, max_depth);
 }
 
 # the byte offset of field `field_ix` within aggregate node `id`
@@ -228,11 +257,11 @@ pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width
 # field:     names an aggregate's field node ids
 # id:        the aggregate node
 # field_ix:  the zero-based field index
-# ptr_width: the target's pointer width in bytes
+# m:         the target facts the fold reads
 # max_depth: the depth past which the walk declines; DEPTH_UNBOUNDED for an acyclic graph
 # ret:       an Extent whose `size` is the offset, or `ok = false` with a cause
 pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, field_ix: u32,
-                        ptr_width: u32, max_depth: u32) Extent {
+                        m: Machine, max_depth: u32) Extent {
     val n: Node = describe(ctx, id);
     if (n.kind != NODE_AGGREGATE)  { ret unknown_extent(EXTENT_NOT_AGGREGATE); }
     if (field_ix >= n.field_count) { ret unknown_extent(EXTENT_FIELD_RANGE); }
@@ -241,7 +270,7 @@ pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, fie
     var offset: u32 = 0;
     var i:      u32 = 0;
     for (i < n.field_count) {
-        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, 1, max_depth);
+        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), m, 1, max_depth);
         if (!fe.ok) { ret unknown_extent(fe.cause); }
         offset = round_up(offset, fe.align);
         if (i == field_ix) { ret extent(offset, fe.align); }
@@ -258,7 +287,7 @@ pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, fie
 # `max_depth` of DEPTH_UNBOUNDED disables the depth test entirely, so an acyclic caller
 # pays nothing and no legal graph is refused. A failing child's cause propagates
 # unchanged, so a depth failure eight levels down still reports as a depth failure.
-fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, depth: u32,
+fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, m: Machine, depth: u32,
          max_depth: u32) Extent {
     if (max_depth != DEPTH_UNBOUNDED && depth > max_depth) { ret unknown_extent(EXTENT_DEPTH); }
 
@@ -266,11 +295,27 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
 
     if (n.kind == NODE_ZERO)    { ret extent(0, 1); }
     if (n.kind == NODE_SCALAR)  { ret extent(n.bytes, n.bytes); }
-    if (n.kind == NODE_POINTER) { ret extent(ptr_width, ptr_width); }
-    if (n.kind == NODE_VECTOR)  { ret extent(16, 16); }
+    if (n.kind == NODE_POINTER) { ret extent(m.ptr_width, m.ptr_width); }
+
+    # a vector's extent is lane-derived: `lanes` lanes of `bytes` each, packed, with
+    # NO padding to the vector register (#2687). a packed `f32x3` is 12 bytes, which is
+    # what makes `[N]f32x3` a usable vertex buffer - padding it to 16 would make it
+    # indistinguishable from `f32x4` in memory and withhold the reason for having it.
+    #
+    # THE ALIGNMENT IS DISCONTINUOUS AT THE REGISTER WIDTH, DELIBERATELY. A vector that
+    # FILLS the vector register aligns to its whole size, because the machine's vector
+    # load requires it. A narrower one is a packed aggregate that scalarizes or loads
+    # piecewise, so it aligns only to one lane. This reads as an inconsistency on first
+    # meeting and is not one: do not "fix" it into uniformity, which would either
+    # over-align every vertex attribute or under-align every register-resident vector.
+    if (n.kind == NODE_VECTOR) {
+        val size: u32 = n.bytes * n.count;
+        if (size * 8 >= m.vector_bits) { ret extent(size, size); }
+        ret extent(size, n.bytes);
+    }
 
     if (n.kind == NODE_ARRAY) {
-        val e: Extent = walk(ctx, describe, field, n.child, ptr_width, depth + 1, max_depth);
+        val e: Extent = walk(ctx, describe, field, n.child, m, depth + 1, max_depth);
         if (!e.ok) { ret unknown_extent(e.cause); }
         # widen the product: a total past a u32 would wrap and report a wrong extent.
         val total: u64 = e.size::u64 * n.count::u64;
@@ -284,7 +329,7 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
         var widest: u32 = 0;
         var i:      u32 = 0;
         for (i < n.field_count) {
-            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, depth + 1, max_depth);
+            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), m, depth + 1, max_depth);
             if (!e.ok) { ret unknown_extent(e.cause); }
             if (e.align > align) { align = e.align; }
             if (n.overlays) {
@@ -365,10 +410,70 @@ fun tg_chain(n: u32) {
 # when the graph was merely deeper than the bound. Each cause must now be nameable, and
 # a cause raised deep in a walk must reach the top UNCHANGED rather than being flattened
 # into "a field failed", or the message is still wrong just less obviously.
+# a vector's extent is lane-derived, and the alignment is DISCONTINUOUS at the vector
+# register width by design: a vector that fills the register aligns to its whole size,
+# a narrower one aligns to a single lane. the regression bar is that every one of the
+# ten shapes the compiler shipped before #2687 is exactly 128 bits and so still
+# measures (16, 16) - lane-derived layout is a pure extension here, not an ABI change
+test "mach.lang.layout.extent:vector_is_lane_derived" {
+    # a helper shape: `lanes` lanes of `bytes` each.
+    tg_nodes[0]       = node(NODE_VECTOR);
+
+    # THE REGRESSION BAR: all ten pre-#2687 shapes are 128-bit and measure (16, 16).
+    # (element bytes, lanes) for f32x4 f64x2 i8x16 i16x8 i32x4 i64x2 u8x16 u16x8 u32x4 u64x2
+    var eb: [10]u32;
+    var ln: [10]u32;
+    eb[0] = 4; ln[0] = 4;   eb[1] = 8; ln[1] = 2;
+    eb[2] = 1; ln[2] = 16;  eb[3] = 2; ln[3] = 8;
+    eb[4] = 4; ln[4] = 4;   eb[5] = 8; ln[5] = 2;
+    eb[6] = 1; ln[6] = 16;  eb[7] = 2; ln[7] = 8;
+    eb[8] = 4; ln[8] = 4;   eb[9] = 8; ln[9] = 2;
+
+    var i: u32 = 0;
+    for (i < 10) {
+        tg_nodes[0].bytes = eb[i];
+        tg_nodes[0].count = ln[i];
+        val e: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+        if (!e.ok)        { ret 1; }
+        if (e.size != 16) { ret 1; }
+        if (e.align != 16) { ret 1; }
+        i = i + 1;
+    }
+
+    # SUB-WIDTH: packed, and aligned to ONE LANE rather than to the register. f32x3 is
+    # 12 bytes so that `[N]f32x3` is a usable packed vertex buffer.
+    tg_nodes[0].bytes = 4; tg_nodes[0].count = 3;
+    val v3: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (v3.size != 12) { ret 1; }
+    if (v3.align != 4) { ret 1; }
+
+    tg_nodes[0].bytes = 4; tg_nodes[0].count = 2;
+    val v2: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (v2.size != 8) { ret 1; }
+    if (v2.align != 4) { ret 1; }
+
+    tg_nodes[0].bytes = 2; tg_nodes[0].count = 4;
+    val i16x4: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (i16x4.size != 8) { ret 1; }
+    if (i16x4.align != 2) { ret 1; }
+
+    # THE DISCONTINUITY, stated as a test so it cannot be "fixed" into uniformity
+    # without failing here: the same f32x4 shape is register-aligned on a 128-bit
+    # target and lane-aligned on a wider one, where it no longer fills the register.
+    tg_nodes[0].bytes = 4; tg_nodes[0].count = 4;
+    val at128: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (at128.align != 16) { ret 1; }
+    val at256: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 256), DEPTH_UNBOUNDED);
+    if (at256.size != 16) { ret 1; }
+    if (at256.align != 4) { ret 1; }
+
+    ret 0;
+}
+
 test "mach.lang.layout.extent:causes_are_distinguishable" {
     # a node the describer cannot classify
     tg_nodes[0] = node(NODE_UNKNOWN);
-    val unk: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val unk: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (unk.ok)                            { ret 1; }
     if (unk.cause != EXTENT_UNKNOWN_NODE)  { ret 1; }
 
@@ -377,7 +482,7 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_nodes[0].field_count = 1;
     tg_fields[0]            = 1;
     tg_nodes[1]             = node(NODE_UNKNOWN);
-    val prop: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val prop: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (prop.ok)                           { ret 1; }
     if (prop.cause != EXTENT_UNKNOWN_NODE) { ret 1; }
 
@@ -394,18 +499,18 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_nodes[1].count       = 4294967295;
     tg_nodes[2]             = node(NODE_SCALAR);
     tg_nodes[2].bytes       = 4;
-    val prop2: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val prop2: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (prop2.ok)                             { ret 1; }
     if (prop2.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
 
     # the same, through field_offset_of's own propagation path
-    val prop3: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, 8, DEPTH_UNBOUNDED);
+    val prop3: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (prop3.ok)                             { ret 1; }
     if (prop3.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
 
     # a depth failure raised below an aggregate must arrive as a DEPTH failure too
     tg_chain(8);
-    val prop4: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 3);
+    val prop4: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 3);
     if (prop4.ok)                    { ret 1; }
     if (prop4.cause != EXTENT_DEPTH) { ret 1; }
 
@@ -415,20 +520,20 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_nodes[0].count = 4294967295;
     tg_nodes[1]       = node(NODE_SCALAR);
     tg_nodes[1].bytes = 4;
-    val ovf: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val ovf: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (ovf.ok)                             { ret 1; }
     if (ovf.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
 
     # deeper than the caller's bound
     tg_chain(8);
-    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 3);
+    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 3);
     if (deep.ok)                   { ret 1; }
     if (deep.cause != EXTENT_DEPTH) { ret 1; }
 
     # a field offset asked of something that is not an aggregate
     tg_nodes[0]       = node(NODE_SCALAR);
     tg_nodes[0].bytes = 4;
-    val nag: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, 8, DEPTH_UNBOUNDED);
+    val nag: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (nag.ok)                            { ret 1; }
     if (nag.cause != EXTENT_NOT_AGGREGATE) { ret 1; }
 
@@ -438,13 +543,13 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_fields[0]            = 1;
     tg_nodes[1]             = node(NODE_SCALAR);
     tg_nodes[1].bytes       = 4;
-    val rng: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 3, 8, DEPTH_UNBOUNDED);
+    val rng: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 3, machine(8, 128), DEPTH_UNBOUNDED);
     if (rng.ok)                          { ret 1; }
     if (rng.cause != EXTENT_FIELD_RANGE) { ret 1; }
 
     # and a determined extent carries EXTENT_OK, so `cause` is never stale from a
     # previous failure
-    val good: Extent = extent_of(nil, tg_describe, tg_field, 1, 8, DEPTH_UNBOUNDED);
+    val good: Extent = extent_of(nil, tg_describe, tg_field, 1, machine(8, 128), DEPTH_UNBOUNDED);
     if (!good.ok)                 { ret 1; }
     if (good.cause != EXTENT_OK)  { ret 1; }
     ret 0;
@@ -458,18 +563,18 @@ test "mach.lang.layout.extent:unbounded_walks_past_any_constant" {
     # 70 levels: past the 64 that used to be hardcoded, and past any bound a caller
     # would plausibly pick
     tg_chain(70);
-    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (!deep.ok)          { ret 1; }
     if (deep.size  != 1)   { ret 1; }
     if (deep.align != 1)   { ret 1; }
 
     # the same graph declines under a bound below its depth, and says why
-    val bounded: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 64);
+    val bounded: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 64);
     if (bounded.ok)                    { ret 1; }
     if (bounded.cause != EXTENT_DEPTH) { ret 1; }
 
     # a bound at or above the depth admits it
-    val fits: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 69);
+    val fits: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 69);
     if (!fits.ok)        { ret 1; }
     if (fits.size != 1)  { ret 1; }
     ret 0;

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -69,8 +69,10 @@ pub val IRT_FN:     IrTypeKind = 6;
 # a union: its members overlap at offset 0; size is the max member size and
 # align the max member align. shares the struct payload (the member type list)
 pub val IRT_UNION:  IrTypeKind = 7;
-# a 128-bit SIMD vector of `lanes` elements of `element` (#1965). register-class,
-# not aggregate: it flows in one vector register, 16-byte size and alignment
+# a SIMD vector of `lanes` elements of `element` (#1965). register-class, not
+# aggregate. its extent is lane-derived (#2687): size is `lanes * element size`, and
+# alignment is the whole size for a vector that fills the target's vector register,
+# one lane for a narrower one
 pub val IRT_VECTOR: IrTypeKind = 8;
 
 # array payload: an element type and a fixed element count, stored inline so an
@@ -267,7 +269,7 @@ pub fun is_float_scalar(t: *IrTypeTable, id: IrTypeId) bool {
     ret O.unwrap[*IrType](opt_get).kind == IRT_FLOAT;
 }
 
-# whether a type is a 128-bit vector (#1965)
+# whether a type is a vector (#1965)
 #
 # The single classifier the backend consults to route a vector value to the
 # vector register bank and to guard against it reaching unimplemented selection.
@@ -367,7 +369,7 @@ pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) R.Result[Ir
     ret intern_inline(t, ir);
 }
 
-# intern a 128-bit vector type (#1965)
+# intern a vector type (#1965)
 # ---
 # t:       the table
 # element: scalar element IrTypeId (an IRT_INT or IRT_FLOAT)
@@ -462,8 +464,16 @@ fun describe_node(ctx: ptr, id: u32) layout.Node {
     }
     # a first-class `fun(...)` value is a function pointer, so it lays out as one.
     if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret layout.node(layout.NODE_POINTER); }
-    # all ten vector shapes are 128-bit (#1965).
-    if (ir.kind == IRT_VECTOR) { ret layout.node(layout.NODE_VECTOR); }
+    # a vector's extent is lane-derived, so the node carries its lane shape (#2687).
+    # the lane width comes from the element type, which is always a scalar.
+    if (ir.kind == IRT_VECTOR) {
+        val opt_el: O.Option[*IrType] = get(t, ir.data.vector_.element);
+        if (O.is_none[*IrType](opt_el)) { ret layout.node(layout.NODE_UNKNOWN); }
+        var n: layout.Node = layout.node(layout.NODE_VECTOR);
+        n.bytes = bits_to_bytes(O.unwrap[*IrType](opt_el).data.bits);
+        n.count = ir.data.vector_.lanes;
+        ret n;
+    }
     if (ir.kind == IRT_ARRAY) {
         var n: layout.Node = layout.node(layout.NODE_ARRAY);
         n.child = ir.data.array_.element;
@@ -505,7 +515,7 @@ fun describe_field(ctx: ptr, id: u32, index: u32) u32 {
 # that construction already rules out.
 fun ir_extent(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target, what: str) layout.Extent {
     val e: layout.Extent = layout.extent_of(t::ptr, describe_node, describe_field, id,
-                                            ptr_width_of(tgt), layout.DEPTH_UNBOUNDED);
+                                            machine_of(tgt), layout.DEPTH_UNBOUNDED);
     if (!e.ok) { panic_cause(what, e.cause); }
     ret e;
 }
@@ -543,17 +553,17 @@ fun append_str(buf: *u8, n: usize, cap: usize, s: str) usize {
     ret o;
 }
 
-# the target's pointer width, which every layout query needs
+# the target facts every layout query needs
 #
-# A Target with no ISA is not a resolved target and cannot answer this. The layout
-# reads the width up front rather than only on reaching a pointer, so an unresolved
-# target is reported here instead of surfacing as a fault deep in a walk - or, worse,
-# going unnoticed on the types that happen not to contain a pointer.
-fun ptr_width_of(tgt: *target.Target) u32 {
+# A Target with no ISA is not a resolved target and cannot answer these. The layout
+# reads them up front rather than only on reaching a pointer or a vector, so an
+# unresolved target is reported here instead of surfacing as a fault deep in a walk -
+# or, worse, going unnoticed on the types that happen to contain neither.
+fun machine_of(tgt: *target.Target) layout.Machine {
     if (tgt == nil || tgt.isa == nil) {
         panic("ir.type: layout query needs a resolved target with an instruction set\n");
     }
-    ret tgt.isa.pointer_width;
+    ret layout.machine(tgt.isa.pointer_width, tgt.model.vector_bits);
 }
 
 # the size in bytes of an IR type for the given target
@@ -601,7 +611,7 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # ret:      byte offset of the field
 pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.Target) u32 {
     val e: layout.Extent = layout.field_offset_of(t::ptr, describe_node, describe_field, id,
-                                                  field_ix, ptr_width_of(tgt), layout.DEPTH_UNBOUNDED);
+                                                  field_ix, machine_of(tgt), layout.DEPTH_UNBOUNDED);
     if (!e.ok) { panic_cause("ir.type.byte_offset: ", e.cause); }
     ret e.size;
 }
@@ -900,8 +910,9 @@ test "mach.lang.me.ir.type.intern_struct:align_override" {
     ret 0;
 }
 
-# IRT_VECTOR interns and dedups by (element, lanes), sizes and aligns to 16, and
-# is register-class (not aggregate) (#1965)
+# IRT_VECTOR interns and dedups by (element, lanes), is register-class (not
+# aggregate) (#1965), and lays out lane-derived: a vector filling the target's vector
+# register aligns to its whole size, a narrower one to a single lane (#2687)
 test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -930,11 +941,30 @@ test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
+    # the layout turns on the vector register width, so the test target must declare
+    # one. left at 0 this proves nothing: every vector would compare as register-filling.
+    tgt.model.vector_bits = 128;
 
+    # f32x4 fills the 128-bit register, so it is register-aligned.
     if (byte_size(?types, vecty, ?tgt)  != 16) { dnit(?types); ret 1; }
     if (byte_align(?types, vecty, ?tgt) != 16) { dnit(?types); ret 1; }
     # register-class, not aggregate.
     if (is_aggregate(?types, vecty))           { dnit(?types); ret 1; }
+
+    # f32x3 is narrower than the register: packed to 12 bytes and aligned to one lane,
+    # which is what makes an array of them a usable packed vertex buffer.
+    val r4: R.Result[IrTypeId, str] = intern_vector(?types, f32ty, 3);
+    if (R.is_err[IrTypeId, str](r4)) { dnit(?types); ret 1; }
+    val v3: IrTypeId = R.unwrap_ok[IrTypeId, str](r4);
+    if (byte_size(?types, v3, ?tgt)  != 12) { dnit(?types); ret 1; }
+    if (byte_align(?types, v3, ?tgt) != 4)  { dnit(?types); ret 1; }
+    if (is_aggregate(?types, v3))           { dnit(?types); ret 1; }
+
+    # the same f32x4 on a 256-bit target no longer fills the register, so it drops to
+    # lane alignment while keeping its size. this is the discontinuity, not a bug.
+    tgt.model.vector_bits = 256;
+    if (byte_size(?types, vecty, ?tgt)  != 16) { dnit(?types); ret 1; }
+    if (byte_align(?types, vecty, ?tgt) != 4)  { dnit(?types); ret 1; }
 
     dnit(?types);
     ret 0;

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -1192,6 +1192,33 @@ test "mach.lang.target.select:has_v128_capability" {
     ret 0;
 }
 
+# vector_bits is the width bound the `TxN` form resolves against, declared by
+# every target including the two with no vector unit at all. a target that
+# scalarizes still has a vector width, so this is independent of has_v128 and
+# must never be derived from it (#2687)
+test "mach.lang.target.select:vector_bits_bound" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    val tx: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "linux", "sysv64", "");
+    if (R.is_err[resolved.Target, str](tx)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tx).model.vector_bits != 128) { ret 1; }
+
+    val ta: R.Result[resolved.Target, str] = select_of(?reg, "aarch64", "linux", "aapcs64", "");
+    if (R.is_err[resolved.Target, str](ta)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](ta).model.vector_bits != 128) { ret 1; }
+
+    # the two targets with has_v128 false still declare the width: they admit
+    # every 128-bit spelling and scalarize it, so a 0 here would refuse names
+    # that compile correctly today.
+    val tr: R.Result[resolved.Target, str] = select_of(?reg, "riscv64", "linux", "lp64", "");
+    if (R.is_err[resolved.Target, str](tr)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tr).model.has_v128)            { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tr).model.vector_bits != 128)  { ret 1; }
+
+    ret 0;
+}
+
 # a 128-bit vector classifies as one SSE-class value under SysV (#2014): a single XMM
 # argument register (not the two-eightbyte split an all-float aggregate takes) and XMM0
 # for the return, both at the full 16-byte width

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -253,6 +253,25 @@ pub rec RegClass {
 #                    derived from the float bank width (#1965). the shared MIR
 #                    lowerer gates its vector path on this: a vector op on a target
 #                    without it is a defined per-target compile error, not an ICE
+# vector_bits:       the widest vector the target admits BY NAME, in bits, which
+#                    bounds the `TxN` vector form the frontend resolves (#2687).
+#                    128 on every target today.
+#
+#                    DISTINCT FROM `has_v128`, and the two must never be
+#                    conflated: this is how wide a vector may be SPELLED, that one
+#                    is whether a SIMD unit exists to run it. They are independent
+#                    in the direction that matters: rv64gc and mos6502 both set
+#                    `has_v128` false and still admit every 128-bit shape, which
+#                    `me.pass.scalarize` turns into per-lane scalar code. So a
+#                    target without a vector unit still has a vector width, and
+#                    gating the spelling on `has_v128` would refuse names that
+#                    compile correctly today.
+#
+#                    This is the axis the super-128 shapes grow along: a target
+#                    that gains ymm / zmm / SVE register classes raises this and
+#                    the frontend admits the wider spellings with no change. A
+#                    boolean cannot express that, which is why the bound is a
+#                    width rather than a second capability flag.
 # vector_compute_generic: true when the backend selects 128-bit vector compute
 #                    (lane-wise arithmetic / bitwise / shift / compare) from the
 #                    generic MIR opcodes carrying `vec_lane`, so the shared lowerer
@@ -302,6 +321,7 @@ pub rec MachineModel {
     red_zone:          u32;
     shadow_space:      u32;
     has_v128:          bool;
+    vector_bits:       u32;
     vector_compute_generic: bool;
     has_lane_ops:      bool;
     ct_trust_mul:      bool;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -299,6 +299,14 @@ pub rec RegClass {
 #                    this flag - it governs integer multiply alone. conservative
 #                    default false on every target until the DIT/DOITM enablement
 #                    (stdlib ct.begin/ct.end) lands to prove the mode is set
+# the width of a 128-bit SIMD vector unit, in bits
+#
+# The `vector_bits` every current target declares, and the width the editor's
+# neutral host context reads when no target has been selected. Named rather than
+# written as a bare 128 in six places, so raising a target past it is a visible
+# edit at that target rather than a changed literal.
+pub val VECTOR_BITS_128: u32 = 128;
+
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -239,7 +239,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
     # NEON 128-bit vector unit is baseline on aarch64 (#1965).
     arm64_model.has_v128        = true;
-    arm64_model.vector_bits     = 128;
+    arm64_model.vector_bits     = isa.VECTOR_BITS_128;
     # NEON selects vector ops from the scalar-shaped shared handlers in the aarch64
     # isel, not the generic MIR path, so vector compute is not pre-routed.
     arm64_model.vector_compute_generic = false;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -239,6 +239,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
     # NEON 128-bit vector unit is baseline on aarch64 (#1965).
     arm64_model.has_v128        = true;
+    arm64_model.vector_bits     = 128;
     # NEON selects vector ops from the scalar-shaped shared handlers in the aarch64
     # isel, not the generic MIR path, so vector compute is not pre-routed.
     arm64_model.vector_compute_generic = false;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -118,7 +118,7 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the machine word IS one byte, so every move is full-width and extends nothing.
     mos6502_model.endianness      = isa.ENDIAN_LITTLE;
     mos6502_model.has_v128        = false;
-    mos6502_model.vector_bits     = 128;
+    mos6502_model.vector_bits     = isa.VECTOR_BITS_128;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -118,6 +118,7 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the machine word IS one byte, so every move is full-width and extends nothing.
     mos6502_model.endianness      = isa.ENDIAN_LITTLE;
     mos6502_model.has_v128        = false;
+    mos6502_model.vector_bits     = 128;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -287,7 +287,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
     # vector ops scalarize before MIR lowering and none reaches the vector path.
     riscv64_model.has_v128        = false;
-    riscv64_model.vector_bits     = 128;
+    riscv64_model.vector_bits     = isa.VECTOR_BITS_128;
     riscv64_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -287,6 +287,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
     # vector ops scalarize before MIR lowering and none reaches the vector path.
     riscv64_model.has_v128        = false;
+    riscv64_model.vector_bits     = 128;
     riscv64_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -87,6 +87,7 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # emitter intact rather than being scalarized to per-lane work over stack slots -
     # which a logically-addressed module could not express anyway, having no stack.
     spirv_model.has_v128               = true;
+    spirv_model.vector_bits            = 128;
     # vector compute is selected from the generic MIR opcodes carrying `vec_lane`.
     # a vector is IRT_VECTOR, not IRT_FLOAT, so the scalar float dispatch never fires
     # for one whatever this says: a vector float add reaches MIR as the

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -87,7 +87,7 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # emitter intact rather than being scalarized to per-lane work over stack slots -
     # which a logically-addressed module could not express anyway, having no stack.
     spirv_model.has_v128               = true;
-    spirv_model.vector_bits            = 128;
+    spirv_model.vector_bits            = isa.VECTOR_BITS_128;
     # vector compute is selected from the generic MIR opcodes carrying `vec_lane`.
     # a vector is IRT_VECTOR, not IRT_FLOAT, so the scalar float dispatch never fires
     # for one whatever this says: a vector float add reaches MIR as the

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -287,7 +287,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.endianness      = isa.ENDIAN_LITTLE;
     # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
     x64_model.has_v128        = true;
-    x64_model.vector_bits     = 128;
+    x64_model.vector_bits     = isa.VECTOR_BITS_128;
     # SSE2 packed compute selects from the generic MIR opcodes carrying vec_lane,
     # so the shared lowerer routes vector compute through the generic path (#2014).
     x64_model.vector_compute_generic = true;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -287,6 +287,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.endianness      = isa.ENDIAN_LITTLE;
     # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
     x64_model.has_v128        = true;
+    x64_model.vector_bits     = 128;
     # SSE2 packed compute selects from the generic MIR opcodes carrying vec_lane,
     # so the shared lowerer routes vector compute through the generic path (#2014).
     x64_model.vector_compute_generic = true;

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -20,6 +20,9 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_len;
+use std.types.string.str_region_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -209,6 +212,143 @@ pub fun vec_shape(index: u32) VecShape {
     or (index == 9) { s.name = "u64x2"; s.element = TYPE_U64; s.lanes = 2;  }
 
     ret s;
+}
+
+# the source spelling of a primitive TypeKind, the inverse of the ordinal
+#
+# The one place a primitive's spelling is written down. The resolver's primitive
+# registry and the `TxN` vector form both read it, so a spelling can never drift
+# between the name a program writes and the element a vector form accepts.
+# ---
+# kind: the primitive TypeKind to spell
+# ret:  the spelling, or nil for a non-primitive kind
+pub fun prim_name(kind: TypeKind) str {
+    if      (kind == TYPE_U8)  { ret "u8";  }
+    or (kind == TYPE_U16) { ret "u16"; }
+    or (kind == TYPE_U32) { ret "u32"; }
+    or (kind == TYPE_U64) { ret "u64"; }
+    or (kind == TYPE_I8)  { ret "i8";  }
+    or (kind == TYPE_I16) { ret "i16"; }
+    or (kind == TYPE_I32) { ret "i32"; }
+    or (kind == TYPE_I64) { ret "i64"; }
+    or (kind == TYPE_F32) { ret "f32"; }
+    or (kind == TYPE_F64) { ret "f64"; }
+    or (kind == TYPE_PTR) { ret "ptr"; }
+    ret nil;
+}
+
+# how reading a spelling as the vector form `<element>x<lanes>` came out
+#
+# Three outcomes rather than two, because "this is not a vector spelling" and
+# "this is a vector the target will not admit" need different diagnostics: the
+# first falls through to ordinary name resolution, the second must name the
+# vector and the bound it exceeded (#2687).
+pub def VecFormStatus: u8;
+
+# the largest lane count the form reader carries as a number. a count past this
+# is clamped to `MAX_VEC_LANES + 1`, so it still reports as too wide without the
+# digit loop carrying an unbounded value
+pub val MAX_VEC_LANES: u32 = 65535;
+
+# not a vector spelling at all; the caller resolves the name by other means
+pub val VEC_FORM_NONE:      VecFormStatus = 0;
+# a well formed shape within the target's bound
+pub val VEC_FORM_OK:        VecFormStatus = 1;
+# a well formed shape wider than the target's vector width admits
+pub val VEC_FORM_TOO_WIDE:  VecFormStatus = 2;
+# a well formed element with a degenerate lane count (0 or 1)
+pub val VEC_FORM_BAD_LANES: VecFormStatus = 3;
+
+# the shape a `TxN` spelling denotes, and whether the target admits it
+# ---
+# status:  which of the four outcomes reading the spelling produced
+# element: lane scalar TypeKind; only meaningful when status is not VEC_FORM_NONE
+# lanes:   lane count; only meaningful when status is not VEC_FORM_NONE
+# bits:    element bits times lanes, the width the bound is tested against
+pub rec VecForm {
+    status:  VecFormStatus;
+    element: TypeKind;
+    lanes:   u32;
+    bits:    u32;
+}
+
+# read `name` as the vector form `<element>x<lanes>`, bounded by `vector_bits`
+#
+# THE FORM, NOT A TABLE (#2687). A vector type is any primitive scalar element
+# followed by `x` and a lane count, admitted when the total width fits the
+# target's vector register width. The ten formerly seeded spellings are exactly
+# the forms whose width is 128, so they keep resolving unchanged and are no
+# longer special.
+#
+# `ptr` is not a lane element: its width is target-defined rather than a scalar
+# bit count, so no lane count gives it a well defined vector width. A lane count
+# below 2 is refused rather than admitted as a degenerate one-lane vector, which
+# has no register representation and which SPIR-V's OpTypeVector forbids
+# outright.
+#
+# The width product is computed in u64 so an absurd lane count reports as too
+# wide rather than wrapping u32 into a shape that appears to fit.
+# ---
+# name:        the spelling to read
+# vector_bits: the widest vector the target admits, in bits
+# ret:         the shape and whether the target admits it
+pub fun vector_form(name: str, vector_bits: u32) VecForm {
+    var f: VecForm;
+    f.status  = VEC_FORM_NONE;
+    f.element = TYPE_U8;
+    f.lanes   = 0;
+    f.bits    = 0;
+
+    if (name == nil) { ret f; }
+    val n: usize = str_len(name);
+    # the shortest well formed spelling is `u8x2`, so anything shorter cannot be
+    # one. tested before the split so the `n - 1` below never underflows.
+    if (n < 4) { ret f; }
+
+    # no primitive spelling contains an `x`, so the first one splits the form.
+    var split: usize = 0;
+    for (split < n && name[split] != 'x') { split = split + 1; }
+    if (split == 0) { ret f; }
+    if (split >= n - 1) { ret f; }
+
+    var element: TypeKind = TYPE_U8;
+    var found:   bool     = false;
+    var k:       u32      = 0;
+    for (k < PRIM_COUNT) {
+        val kind: TypeKind = k::u8;
+        if (kind != TYPE_PTR && str_region_equals(name, 0, split, prim_name(kind))) {
+            element = kind;
+            found   = true;
+        }
+        k = k + 1;
+    }
+    if (!found) { ret f; }
+
+    # a strict decimal lane count: digits only, and no leading zero, so a
+    # near-miss identifier stays an ordinary unresolved name.
+    if (name[split + 1] == '0') { ret f; }
+    var lanes: u64   = 0;
+    var i:     usize = split + 1;
+    for (i < n) {
+        val c: u8 = name[i];
+        if (c < '0' || c > '9') { ret f; }
+        lanes = lanes * 10 + (c - '0')::u64;
+        if (lanes > MAX_VEC_LANES::u64) { lanes = MAX_VEC_LANES::u64 + 1; }
+        i = i + 1;
+    }
+
+    f.element = element;
+    f.lanes   = lanes::u32;
+    if (lanes > MAX_VEC_LANES::u64) { f.lanes = MAX_VEC_LANES + 1; }
+
+    if (lanes < 2) { f.status = VEC_FORM_BAD_LANES; ret f; }
+
+    val width: u64 = prim_desc(element).bits::u64 * lanes;
+    if (width > vector_bits::u64) { f.status = VEC_FORM_TOO_WIDE; ret f; }
+
+    f.bits   = width::u32;
+    f.status = VEC_FORM_OK;
+    ret f;
 }
 
 # fixed-size array type payload
@@ -1809,6 +1949,111 @@ test "mach.lang.type.is_union:instance_follows_its_nominal" {
     if (is_record(?ti, u32_id))  { dnit(?ti); ret 1; }
 
     dnit(?ti);
+    ret 0;
+}
+
+# `vector_form` reads `<element>x<lanes>` and separates the three outcomes: a
+# shape the target admits, a shape too wide for it, and a spelling that is not a
+# vector at all. the ten formerly seeded spellings are exactly the 128-bit forms
+test "mach.lang.type.vector_form:reads_the_form_and_the_bound" {
+    # every one of the ten shapes the compiler used to seed by name reads back as
+    # itself under a 128-bit bound. this is the regression bar (#2687).
+    var vi: u32 = 0;
+    for (vi < VEC_COUNT) {
+        val sh: VecShape = vec_shape(vi);
+        val f:  VecForm  = vector_form(sh.name, 128);
+        if (f.status  != VEC_FORM_OK) { ret 1; }
+        if (f.element != sh.element)  { ret 1; }
+        if (f.lanes   != sh.lanes)    { ret 1; }
+        if (f.bits    != 128)         { ret 1; }
+        vi = vi + 1;
+    }
+
+    # the sub-128 forms the issue exists for, with their element and lane count
+    # checked rather than only their acceptance.
+    val v3: VecForm = vector_form("f32x3", 128);
+    if (v3.status != VEC_FORM_OK) { ret 1; }
+    if (v3.element != TYPE_F32)   { ret 1; }
+    if (v3.lanes != 3)            { ret 1; }
+    if (v3.bits != 96)            { ret 1; }
+
+    val u3: VecForm = vector_form("u32x3", 128);
+    if (u3.status != VEC_FORM_OK) { ret 1; }
+    if (u3.element != TYPE_U32)   { ret 1; }
+    if (u3.lanes != 3)            { ret 1; }
+
+    val v2: VecForm = vector_form("f32x2", 128);
+    if (v2.status != VEC_FORM_OK) { ret 1; }
+    if (v2.lanes != 2)            { ret 1; }
+    if (v2.bits != 64)            { ret 1; }
+
+    # REFUSED: wider than the bound. f32x7 is 224 bits, so a 128-bit target must
+    # report it as too wide rather than as an unknown name.
+    val w7: VecForm = vector_form("f32x7", 128);
+    if (w7.status != VEC_FORM_TOO_WIDE) { ret 1; }
+    if (w7.element != TYPE_F32)         { ret 1; }
+    if (w7.lanes != 7)                  { ret 1; }
+
+    # REFUSED: exactly one lane past the bound, the boundary case.
+    if (vector_form("f32x5", 128).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+    if (vector_form("i8x17", 128).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+    if (vector_form("f64x3", 128).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+
+    # REFUSED: a lane count so large the width product would wrap a u32 still
+    # reports too wide, never a shape that appears to fit.
+    if (vector_form("u64x4294967295", 128).status != VEC_FORM_TOO_WIDE) { ret 1; }
+
+    # REFUSED: a degenerate lane count is its own outcome, not a width failure.
+    if (vector_form("f32x1", 128).status != VEC_FORM_BAD_LANES) { ret 1; }
+
+    # the bound is the target's, not a constant: a 64-bit vector unit admits
+    # f32x2 and refuses the f32x4 a 128-bit one takes.
+    if (vector_form("f32x2", 64).status != VEC_FORM_OK)        { ret 1; }
+    if (vector_form("f32x4", 64).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+    # and a wider unit admits what 128 bits refuses, so the form does not itself
+    # cap at 128 (the super-128 register classes are a separate problem).
+    if (vector_form("f32x8", 256).status != VEC_FORM_OK) { ret 1; }
+
+    # NOT A VECTOR: these fall through to ordinary name resolution rather than
+    # producing a vector diagnostic.
+    if (vector_form(nil, 128).status     != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("", 128).status      != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f32", 128).status   != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f32x", 128).status  != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("x4", 128).status    != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f33x4", 128).status != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f32x4y", 128).status != VEC_FORM_NONE) { ret 1; }
+    # a leading zero is not a lane count, so `f32x04` stays an ordinary name.
+    if (vector_form("f32x04", 128).status != VEC_FORM_NONE) { ret 1; }
+    # `ptr` has no scalar bit width, so no lane count makes a vector of it.
+    if (vector_form("ptrx2", 128).status  != VEC_FORM_NONE) { ret 1; }
+    # a user identifier that merely contains an x is untouched.
+    if (vector_form("matrix4", 128).status != VEC_FORM_NONE) { ret 1; }
+
+    ret 0;
+}
+
+# `prim_name` round-trips every primitive ordinal to its spelling, so the
+# resolver's registry and the vector form read one table
+test "mach.lang.type.prim_name:spells_every_primitive" {
+    if (!str_equals(prim_name(TYPE_U8),  "u8"))  { ret 1; }
+    if (!str_equals(prim_name(TYPE_U16), "u16")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_U32), "u32")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_U64), "u64")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_I8),  "i8"))  { ret 1; }
+    if (!str_equals(prim_name(TYPE_I16), "i16")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_I32), "i32")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_I64), "i64")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_F32), "f32")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_F64), "f64")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_PTR), "ptr")) { ret 1; }
+    # every ordinal below PRIM_COUNT has a spelling, and a non-primitive has none
+    var k: u32 = 0;
+    for (k < PRIM_COUNT) {
+        if (prim_name(k::u8) == nil) { ret 1; }
+        k = k + 1;
+    }
+    if (prim_name(TYPE_VECTOR) != nil) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -77,14 +77,17 @@ pub val TYPE_PACK: TypeKind = 18;
 # to the same machine shape as `T`; it constrains only sema's flow typing
 pub val TYPE_SECRET: TypeKind = 19;
 
-# a 128-bit SIMD vector type `<u|i|f><width>x<count>` (#1965). the portable
-# vector model: all ten seeded shapes are legal on every target, with a payload
-# carrying the lane scalar kind and lane count. lowers to a 16-byte register-class
-# value; whether a lane-wise op is one instruction or a scalar expansion is a
-# backend concern
+# a SIMD vector type spelled `<element>x<lanes>` (#1965, generalized in #2687). the
+# portable vector model: any primitive scalar element and any lane count whose total
+# width fits the target's vector register is legal on every target, with a payload
+# carrying the lane scalar kind and lane count. its extent is lane-derived, so
+# `f32x4` is 16 bytes and `f32x3` is 12; whether a lane-wise op is one instruction or
+# a scalar expansion is a backend concern
 pub val TYPE_VECTOR: TypeKind = 20;
 
-# number of seeded vector types (the ten 128-bit shapes)
+# number of PRE-SEEDED vector types. no longer the set of legal vectors, which is the
+# `TxN` form bounded by the target's vector width (#2687): these ten 128-bit shapes
+# are merely interned at session init so they have stable TypeIds
 pub val VEC_COUNT: u32 = 10;
 
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
@@ -161,10 +164,11 @@ pub rec TypeSecret {
     base: TypeId;
 }
 
-# 128-bit SIMD vector type payload (#1965)
+# SIMD vector type payload (#1965)
 #
-# Two vectors are identical iff (element, lanes) match. `element` is one of the
-# ten scalar prim kinds; `lanes` is 2, 4, 8, or 16 so that element*lanes is 128.
+# Two vectors are identical iff (element, lanes) match. `element` is one of the ten
+# scalar prim kinds (never `ptr`, which has no scalar bit width); `lanes` is at least
+# 2, and `element bits * lanes` is bounded by the target's vector width (#2687).
 # ---
 # element: lane scalar TypeKind (u8..i64, f32, f64)
 # lanes:   lane count
@@ -175,8 +179,10 @@ pub rec TypeVector {
 
 # the spelling, lane scalar, and lane count of one seeded vector type
 #
-# The single source of truth for the ten shapes, shared by the interner's init
-# seeding and the resolver's name registry, keyed by ordinal.
+# The ten shapes the interner pre-seeds at init so they have stable TypeIds. NOT the
+# set of legal vectors: that is the `TxN` form `vector_form` reads, bounded by the
+# target's vector width (#2687). Kept as the fixture the regression tests measure the
+# pre-#2687 shapes against.
 # ---
 # name:    source spelling, e.g. "f32x4"
 # element: lane scalar TypeKind
@@ -796,7 +802,7 @@ pub fun is_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret O.unwrap[*Type](opt_type).kind == TYPE_SECRET;
 }
 
-# whether `tid` is a 128-bit vector type (#1965)
+# whether `tid` is a vector type (#1965)
 #
 # A secret `^T` is classified by its inner type, so a secret vector still reports
 # as a vector for layout and lane classification.
@@ -1045,7 +1051,7 @@ pub fun intern_array(ti: *TypeInterner, base: TypeId, count: u32) R.Result[TypeI
     ret intern_dedup(ti, t);
 }
 
-# intern a 128-bit vector type (#1965)
+# intern a vector type (#1965)
 #
 # Returns an existing TypeId when the same (element, lanes) shape has been
 # interned before.


### PR DESCRIPTION
Refs #2687. **This is the type-and-layout half of #2687, not the whole of it.** ABI classification and the SPIR-V leg are outstanding, and `f32x3` is explicitly **not yet proven across a call boundary**. Deliberately not `Closes`.

## What this does

A vector type is now resolved by READING the form `<element>x<lanes>`, bounded by the target's vector width, and its layout is lane-derived rather than a flat 16 bytes.

The type representation never needed to change. `TYPE_VECTOR` already carried `(element, lanes)` and `typename.mach` already rendered a vector generically. Two things blocked `f32x3`:

1. `resolve.seed_vectors` put exactly ten names into a registry, so `f32x3` failed because nothing had seeded that name.
2. `layout.mach` folded a payload-free `NODE_VECTOR` as `extent(16, 16)`, so even once resolved it would have laid out as `f32x4`.

Both are gone.

## Where the bound lives, and why it is not `has_v128`

The bound is a new `MachineModel.vector_bits`, the widest vector a target admits by name. Deliberately **not** the existing `has_v128` capability:

- **They are independent in the direction that matters.** rv64gc and mos6502 both declare `has_v128` false and still admit every 128-bit shape today, which `me.pass.scalarize` turns into per-lane scalar code. A target with no vector unit still has a vector width, so gating the SPELLING on the capability would refuse names that compile correctly right now.
- **A boolean cannot express the growth axis.** A target that gains ymm / zmm / SVE raises `vector_bits` and the frontend admits the wider spellings with no change.

It reaches the frontend through `ComptimeCtx`, which already carries the per-build target facts the frontend needs, alongside `pointer_width`.

## Size and alignment

```
size  = element_size * lanes
align = size            when the vector fills the vector register
align = element_align   when it is narrower
```

| type | size | align |
|---|---|---|
| `f32x4` | 16 | 16 |
| `f32x3` | 12 | 4 |
| `f32x2` | 8 | 4 |
| `i16x4` | 8 | 2 |

Verified by compiling and running real programs, not by unit test alone. A `rec Vertex { pos: f32x3; uv: f32x2; }` measures **20 bytes**, packed, which is the motivating vertex-buffer case.

**The alignment is discontinuous at the register width, deliberately**, and the fold says so at the fold. A vector that fills the register aligns to its whole size because the machine's vector load requires it; a narrower one is a packed aggregate that scalarizes or loads piecewise. It reads as an inconsistency cold and would otherwise be "fixed" into uniformity, which would either over-align every vertex attribute or under-align every register-resident vector. Packing is the whole point: padding `f32x3` to 16 would make it indistinguishable from `f32x4` in memory and withhold the reason anyone wanted it.

`layout`'s dependence on the target is now a `layout.Machine` record rather than a loose `ptr_width`, since that dependence is an axis that grows and had just grown.

## Diagnostics

The refusal path matters as much as the accepted one, and the three outcomes stay distinct so a width problem is never described as a typo:

```
error: vector `f32x7` is 224 bits wide, more than this target's 128-bit vector width
error: vector `f64x3` is 192 bits wide, more than this target's 128-bit vector width
error: vector `f32x1` needs at least 2 lanes
error: unresolved type name `matrix4`     # not a vector form, falls through unchanged
error: unresolved type name `f32x04`      # leading zero is not a lane count
```

## The regression bar

**All ten pre-existing shapes are exactly 128 bits**, so they still measure 16 and 16 and this is a pure extension rather than an ABI change to shipped code. Pinned as a test at the fold and again at the IR layer, and asserted by walking `vec_shape` rather than by restating the spellings.

Tests assert what a form resolved TO, not merely that it resolved: element kind, lane count, and bit width. Refusals cover the exact boundary cases (`f32x5`, `i8x17`, `f64x3`), the degenerate `f32x1`, and `u64x4294967295` proving an absurd lane count reports too wide rather than wrapping u32 into a shape that appears to fit.

Every new assertion was checked by mutation rather than trusted:

- reverting the fold to `extent(16, 16)` — **fails**
- collapsing the alignment discontinuity to uniform — **fails**
- disabling the width bound with `if (false)` — **fails**

While doing that I found the existing `intern_vector:dedup_size_align` test declared **no machine model at all**, so its vector width was 0 and it could not have caught either layout mutation. Fixed, and extended with the sub-128 and 256-bit-target cases.

Full suite green (1249). Self-host fixpoint verified byte-identical (stage2 == stage3).

## What is outstanding

- **ABI classification** of a 12-byte or 8-byte vector. `f32x3` is not yet proven across a call boundary.
- **The SPIR-V leg**: `f32x3` reaching `OpTypeVector %float 3`, and the `uvec3` compute built-ins from #2658.

`doc/language/types.md` is updated: the "every vector is exactly 128 bits" guarantee is replaced by the real rule and the discontinuity is documented, rather than merely relaxed in prose.

## One behaviour change worth calling out

A vector spelling takes priority over scope in type position, which is how the ten already worked, so a user record named `u8x16` was already shadowed. Reading the form widens that set: a user type named `f32x3` is now shadowed too. Consistent with the existing rule, but it is a source-compatibility surface the issue does not mention.
