### PR TITLE
feat(spirv): GLSL.std.450 and core OpDot through a #[spirv_op] decorator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,10 @@ jobs:
       # (int/surface/debuginfo) verifies the emitted DWARF with llvm-dwarfdump and
       # reads PT_LOAD extents with readelf (#2039); spirv-module
       # (int/surface/spirv-module) validates the delivered `.spv` with the Khronos
-      # spirv-val (#2245). both run on the Linux legs.
+      # spirv-val (#2245), and spirv-ext-inst additionally DISASSEMBLES it with
+      # spirv-dis to assert the instructions the emitter produced, which the
+      # validator's verdict cannot show (#2688) - both binaries ship in the same
+      # spirv-tools package. all run on the Linux legs.
       - name: install artifact validators
         if: runner.os == 'Linux'
         run: |

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -45,6 +45,7 @@ A decorator is written as an attribute:
 #[builtin("name")]   # pipeline built-in variable (global only)
 #[uniform(set, bnd)] # descriptor-bound uniform block, read-only (global only)
 #[storage(set, bnd)] # descriptor-bound storage buffer, read-write (global only)
+#[spirv_op(set,name)] # the SPIR-V instruction this function is (fun only)
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -482,6 +483,59 @@ target that forms pipeline stages. On `spirv` each becomes an `OpVariable` in th
 matching storage class, carrying the matching decoration, and the Input and Output
 variables are named in every entry point's interface list.
 
+### `spirv_op(set, name)` — a function that *is* a SPIR-V instruction
+
+A shader needs `sqrt`, `normalize`, `dot` and `mix`. None of them is an operator,
+and none of them is a call SPIR-V can make: each is one instruction. This directive
+says which one a function is, so that on a `spirv` target a call to it becomes that
+instruction, inline, rather than a call.
+
+```mach
+#[spirv_op("GLSL.std.450", "Sqrt")]
+pub fun sqrt(x: f32) f32;
+
+#[spirv_op("GLSL.std.450", "Normalize")]
+pub fun normalize(v: f32x4) f32x4;
+
+#[spirv_op("core", "OpDot")]
+pub fun dot(a: f32x4, b: f32x4) f32;
+```
+
+The first argument names the instruction set and the second the instruction within
+it. Both value sets are closed and checked at compile time, on **every** target —
+the directive is legal everywhere, so a typo caught only where it is acted on would
+go unreported on a CPU build.
+
+| Set              | Meaning                                                     |
+|------------------|-------------------------------------------------------------|
+| `"core"`         | the core opcode space; needs no import                       |
+| `"GLSL.std.450"` | the standard extended set; imported once per module, on use  |
+
+The substitution is uniform: the emitted instruction's **result type is the
+function's declared return type** and its **operands are the function's parameters
+in declaration order**. That is what lets `dot` and `length` return a scalar from
+vectors, and `refract` mix a scalar operand with vector ones, without any of them
+being a special case.
+
+`OpExtInstImport "GLSL.std.450"` is emitted **once per module and only when that
+module uses the set**. A module that calls none of these carries no import.
+
+Note that `dot` is **core `OpDot`**, not a GLSL.std.450 instruction, even though
+GLSL spells it beside `normalize` and `length`. Check each function against the
+specification rather than against GLSL's surface.
+
+On every target other than `spirv` the directive is inert, and a decorated function
+is an ordinary function. A **bodiless** one — which is what the shader-side maths
+library uses — is then an undefined symbol, so a CPU build that calls it fails at
+link time naming the symbol. That is a deliberate design choice on the library's
+part, not a property of the directive: a decorated function may have a body, and if
+it does, that body is what every non-`spirv` target runs while `spirv` substitutes
+the instruction. A `spirv` build never emits the body at all.
+
+The set of accepted instruction names is a table in `mach.lang.spirvop`, which also
+records why each omission from GLSL.std.450 is one. Adding an instruction is a row
+in it.
+
 ## Applicability
 
 | Directive   | `fun` | `ext fun` | `val` / `var` | `rec` / `uni` |
@@ -503,6 +557,7 @@ variables are named in every entry point's interface list.
 | `builtin`   |  no   |    no     |      yes      |      no       |
 | `uniform`   |  no   |    no     |      yes      |      no       |
 | `storage`   |  no   |    no     |      yes      |      no       |
+| `spirv_op`  |  yes  |    no     |      no       |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).
@@ -518,5 +573,5 @@ The set is closed. New directives require a compiler change.
 - [asm.md](asm.md) — inline `asm`, the only body a `naked` function may have
 - [val-var.md](val-var.md) — `val` / `var` bindings, and the `embed` exemption to `val`'s initializer requirement
 - [grammar.md](grammar.md#types) — the `[_]` inferred array length `embed` introduces
-- [types.md](types.md) — the SIMD vector types a shader stage computes over
+- [types.md](types.md) — the SIMD vector types a shader stage computes over and `spirv_op` operates on
 - [../manifest.md](../manifest.md) — the `vectorize` profile key `scalar` opts out of, and content-fingerprinted build inputs (`embed`, `[step]` `in`)

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -85,6 +85,22 @@
 #                 nothing, so there is no binary to run and the module tree is the
 #                 artifact; the external validator is what makes this a validity
 #                 check rather than a round-trip through mach's own reader.
+#   spirv-shader— validate the module tree AND report the instructions the emitter
+#                 actually produced for it (#2688). "the validator was happy" is not
+#                 evidence that a `sqrt` became a `Sqrt`: an emitter that stopped
+#                 substituting and left an ordinary call, or one that substituted the
+#                 wrong instruction number, produces a module spirv-val accepts. so
+#                 this disassembles each module and prints every OpExtInst by SET and
+#                 INSTRUCTION NAME with its operand count, plus every core OpDot, in
+#                 emission order, alongside the module's OpExtInstImport count - which
+#                 is what makes "imported only when used" an assertion rather than a
+#                 claim. the environment is chosen PER MODULE rather than per case:
+#                 a module carrying entry points is a shader and is validated under
+#                 vulkan1.3, and one without is a library, which declares the Linkage
+#                 capability Vulkan forbids outright and is validated universally. a
+#                 case that consumes a library dependency delivers both at once, so
+#                 one environment for the whole tree cannot be right. needs spirv-val
+#                 and spirv-dis.
 #   vector-emit — disassemble the case's own objects and report, per function,
 #                 whether the compiler EMITTED packed SIMD (#2207). the observable
 #                 execution cannot produce: a vectorizer that silently stops firing
@@ -1803,6 +1819,81 @@ spirv_val_env() {
     printf 'modules=%d validator=clean\n' "$n"
 }
 
+# produce_spirv_shader <runmode> <target> <binary>
+# validate the delivered module tree and report the instructions the emitter put in
+# it.
+#
+# spirv-val alone cannot see this case's subject. A `sh.sqrt(x)` that stopped being
+# substituted and came out as an ordinary OpFunctionCall validates. One substituted
+# with the wrong instruction number validates too, as whichever instruction that
+# number names. So the observable is the disassembly, normalized: per module, the
+# number of extended sets imported, then one line per OpExtInst naming the SET it
+# indexes and the INSTRUCTION within it, and one per core OpDot, in emission order.
+# Result ids are dropped (they renumber whenever anything else in the module
+# changes); operand COUNTS are kept, because an instruction given the wrong arity is
+# the other way to be wrong here.
+#
+# The environment is per module. A module with entry points is a shader and gets the
+# strict vulkan1.3 rules; a module without them is a library, whose Linkage
+# capability Vulkan rejects outright. A case that depends on a library delivers one
+# of each, so no single environment covers the tree.
+produce_spirv_shader() {
+    out_dir=$(dirname "$3")
+    if ! command -v spirv-val >/dev/null 2>&1; then
+        echo "int: spirv-shader: the validator is not installed (spirv-tools)" >&2
+        return 2
+    fi
+    if ! command -v spirv-dis >/dev/null 2>&1; then
+        echo "int: spirv-shader: the disassembler is not installed (spirv-tools)" >&2
+        return 2
+    fi
+    n=0
+    for m in $(find "$out_dir" -name '*.spv' | sort); do
+        dis=$(spirv-dis --no-header "$m") || return 1
+        # the module's own name, relative to the output root, so the observable does
+        # not carry the mktemp path the case was built under.
+        rel=${m#"$out_dir"/}
+        if printf '%s\n' "$dis" | grep -q '^ *OpEntryPoint '; then
+            kind=shader
+            spirv-val --target-env vulkan1.3 "$m" || return 1
+            env=vulkan1.3
+        else
+            kind=library
+            spirv-val "$m" || return 1
+            env=universal
+        fi
+        imports=$(printf '%s\n' "$dis" | grep -c 'OpExtInstImport' || true)
+        printf 'module=%s kind=%s env=%s validator=clean extimports=%d\n' \
+            "$rel" "$kind" "$env" "$imports"
+        printf '%s\n' "$dis" | awk '
+            # "%29 = OpExtInstImport "GLSL.std.450"" — remember which set each id is,
+            # so an OpExtInst can be reported by set NAME rather than by an id that
+            # renumbers on every unrelated change.
+            $3 == "OpExtInstImport" {
+                name = $4; gsub(/"/, "", name)
+                setname[$1] = name
+                printf "  import %s\n", name
+                next
+            }
+            # "%28 = OpExtInst %v4float %29 Normalize %27" — result type, set id and
+            # instruction name, then the operands.
+            $3 == "OpExtInst" {
+                s = setname[$5]; if (s == "") { s = "<unimported>" }
+                printf "  extinst %s %s operands=%d\n", s, $6, NF - 6
+                next
+            }
+            # "%33 = OpDot %float %31 %32" — core, no set involved.
+            $3 == "OpDot" { printf "  core OpDot operands=%d\n", NF - 4; next }
+        '
+        n=$((n + 1))
+    done
+    if [ "$n" -eq 0 ]; then
+        echo "int: spirv-shader: the build delivered no .spv module" >&2
+        return 2
+    fi
+    printf 'modules=%d\n' "$n"
+}
+
 # resolve_dwarfdump — print an llvm-dwarfdump on PATH, preferring the unversioned
 # name and falling back to the highest-versioned one (ubuntu ships llvm-dwarfdump-NN).
 # empty output (return 1) when none is installed.
@@ -2305,6 +2396,7 @@ produce() {
         debuginfo)   produce_debuginfo "$@" ;;
         spirv-val)   produce_spirv_val "$@" ;;
         spirv-val-vulkan) produce_spirv_val_vulkan "$@" ;;
+        spirv-shader) produce_spirv_shader "$@" ;;
         vector-emit) produce_vector_emit "$@" ;;
         vector-lanes) produce_vector_lanes "$@" ;;
         frame-elision) produce_frame_elision "$@" ;;

--- a/int/surface/spirv-ext-inst/case.conf
+++ b/int/surface/spirv-ext-inst/case.conf
@@ -1,0 +1,14 @@
+# GLSL.std.450 and core OpDot through the spirv back half (#2688), validated AND
+# disassembled host-side. the producer is `spirv-shader` rather than
+# `spirv-val-vulkan` because the validator cannot see this case's subject: a `sqrt`
+# left as a call, or substituted with the wrong instruction number, produces a
+# module spirv-val accepts. the golden names the set, the instruction and the
+# operand count of every emitted OpExtInst and OpDot.
+#
+# the producer also picks the environment PER MODULE, which this case needs and no
+# earlier spirv case did: it consumes a library dependency, so the tree holds a
+# shader module (vulkan1.3) beside `shader.math`'s own library module, whose
+# Linkage capability vulkan1.3 rejects outright.
+run: spirv-shader
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-ext-inst/expect.spirv.txt
+++ b/int/surface/spirv-ext-inst/expect.spirv.txt
@@ -1,0 +1,30 @@
+module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
+  import GLSL.std.450
+  extinst GLSL.std.450 Normalize operands=1
+  core OpDot operands=2
+  extinst GLSL.std.450 FMax operands=2
+  extinst GLSL.std.450 Sqrt operands=1
+  extinst GLSL.std.450 FMix operands=3
+  extinst GLSL.std.450 Normalize operands=1
+  extinst GLSL.std.450 Reflect operands=2
+  core OpDot operands=2
+  extinst GLSL.std.450 FClamp operands=3
+  extinst GLSL.std.450 FMax operands=2
+  extinst GLSL.std.450 Pow operands=2
+  extinst GLSL.std.450 FMix operands=3
+  extinst GLSL.std.450 FAbs operands=1
+  extinst GLSL.std.450 FMax operands=2
+  extinst GLSL.std.450 Sqrt operands=1
+  extinst GLSL.std.450 Fract operands=1
+  extinst GLSL.std.450 Floor operands=1
+  extinst GLSL.std.450 FClamp operands=3
+  extinst GLSL.std.450 Length operands=1
+  extinst GLSL.std.450 Distance operands=2
+  extinst GLSL.std.450 SmoothStep operands=3
+  extinst GLSL.std.450 Fma operands=3
+  extinst GLSL.std.450 Radians operands=1
+  extinst GLSL.std.450 Sin operands=1
+  extinst GLSL.std.450 Normalize operands=1
+module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0
+module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0
+modules=3

--- a/int/surface/spirv-ext-inst/mach.toml
+++ b/int/surface/spirv-ext-inst/mach.toml
@@ -1,0 +1,43 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+# the shader-side maths library, whose every function is one SPIR-V instruction.
+# a git dep rather than a path one on purpose: the wiring this case exists to
+# check is a call ACROSS A MODULE BOUNDARY into a real published library, which is
+# where the substitution has to happen, since a SPIR-V module is compiled per mach
+# module and a shader module may declare no linkage to call out through.
+[dep.mach-shader]
+git = "https://github.com/briar-systems/mach-shader"
+ref = "branch/main"

--- a/int/surface/spirv-ext-inst/src/main.mach
+++ b/int/surface/spirv-ext-inst/src/main.mach
@@ -1,0 +1,127 @@
+# SPIR-V extended-instruction fixture: a shader that does arithmetic a shader does
+#
+# The spirv-vector and spirv-interface cases cover the operators - add, multiply,
+# compare, lane access - and a stage's interface variables. Neither reaches past
+# `+` and `*`, which is exactly as far as a shader gets before it needs `sqrt`,
+# `normalize`, `dot` and `mix`. None of those four is an operator, and none is a
+# call SPIR-V can make: each is one instruction, drawn from the GLSL.std.450
+# extended set or, for `dot`, from the core opcode space (#2688).
+#
+# So the subject here is the substitution. `sh.normalize(n)` is written as a call
+# to a function in ANOTHER MODULE, and it must not come out as a call at all -
+# `shader.math` is compiled to its own `.spv`, a SPIR-V module is compiled per mach
+# module, and a shader module may declare no Linkage capability, so there is no
+# import for anything to bind. The call site is the only place the instruction can
+# appear, and this file is what proves it does.
+#
+# THE OBSERVABLE IS THE DISASSEMBLY, not the validator's verdict. That distinction
+# is the whole reason the case has its own producer. Every wrong outcome available
+# here passes spirv-val: a `sh.sqrt` left as an OpFunctionCall to an unresolved
+# function, an OpExtInst carrying 32 instead of 31 (that is InverseSqrt, and it
+# validates), a `dot` emitted as an OpExtInst into GLSL.std.450 rather than as core
+# OpDot (450 has no entry 148, but a plausible wrong number does exist for it), an
+# instruction given two operands where it takes three. The golden names the set,
+# the instruction and the operand count of every one, so each of those is a diff.
+#
+# `shader.math` is a GIT dependency, not a copy in this directory. The thing under
+# test is a cross-module reference resolving through a signature-only declaration
+# and picking the decorator up off the ORIGIN module's AST, which a same-module
+# copy would not exercise at all.
+
+use sh: shader.math;
+# a second module of this project that touches none of it. Its `.spv` is what makes
+# "the extended set is imported only when used" an assertion: it is a real shader
+# stage doing real arithmetic, and its row in the golden reads `extimports=0`. A
+# module with nothing in it would prove nothing, since an empty module imports
+# nothing whatever the rule is.
+use case.plain;
+
+#[input(0)] var in_normal:   f32x4;
+#[input(1)] var in_light:    f32x4;
+#[input(2)] var in_view:     f32x4;
+#[input(3)] var in_rough:    f32;
+
+#[output(0)] var out_colour: f32x4;
+
+#[builtin("position")] var position: f32x4;
+
+rec Material {
+    albedo:  f32x4;
+    ambient: f32x4;
+}
+#[uniform(0, 0)] var material: Material;
+
+# the fragment stage from the issue, written out. It reaches four different shapes
+# of extended instruction in one expression chain and is the case's centre:
+#
+#   Normalize   one vector operand,  vector result
+#   OpDot       two vector operands, SCALAR result - and CORE, not extended
+#   FMax        two scalar operands, scalar result
+#   FMix        three vector operands
+#
+# The scalar-from-vector shapes matter more than they look. A call's result vreg is
+# typed from the callee's declared return type, and the callee here is a
+# declaration in another module; typing it from the move instead gave `dot` a
+# vector-typed backing variable and `sqrt` a 64-bit one, from identical IR, and the
+# module then failed at the store rather than at the call.
+#[stage("fragment")]
+fun frag_main() {
+    val n: f32x4 = sh.normalize(in_normal);
+    val d: f32   = sh.max(sh.dot(n, in_light), 0.0);
+    val s: f32   = sh.sqrt(d);
+    out_colour   = sh.mix4(material.ambient, material.albedo, f32x4{s, s, s, s});
+}
+
+# a specular term, which is where the exponential family earns its place. `pow` and
+# `clamp` are the three-operand and two-operand scalar forms, and `reflect` is a
+# two-vector geometric one whose result feeds another instruction rather than a
+# store - the emitter has to hand an OpExtInst's result id straight on as another
+# instruction's operand, not only into a variable.
+#[stage("fragment")]
+fun spec_main() {
+    val n: f32x4 = sh.normalize(in_normal);
+    val r: f32x4 = sh.reflect(in_view, n);
+    val c: f32   = sh.clamp(sh.dot(r, in_light), 0.0, 1.0);
+    val e: f32   = sh.pow(c, sh.max(in_rough, 0.001));
+    out_colour   = sh.mix4(material.ambient, material.albedo, f32x4{e, e, e, e});
+}
+
+# the per-lane forms, which are a distinct emitter path from the scalar ones only
+# in the types they carry - and that is the point of exercising both. `abs4`,
+# `sqrt4` and `floor4` are the SAME GLSL.std.450 instructions as `abs`, `sqrt` and
+# `floor`; a result type taken from the operands rather than from the declared
+# return would still validate here and be wrong in the scalar functions above.
+#[stage("fragment")]
+fun lane_main() {
+    val a: f32x4 = sh.abs4(in_normal);
+    val b: f32x4 = sh.sqrt4(sh.max4(a, material.ambient));
+    val c: f32x4 = sh.floor4(sh.fract4(b));
+    out_colour   = sh.clamp4(c, material.ambient, material.albedo);
+}
+
+# the length / distance pair: vector in, scalar out, like `dot`, but extended
+# rather than core. Having both a core and an extended instruction with that shape
+# in the same module is what would catch the two being swapped.
+#[stage("fragment")]
+fun dist_main() {
+    val l: f32 = sh.length(in_normal);
+    val d: f32 = sh.distance(in_view, in_light);
+    val t: f32 = sh.smooth_step(0.0, l, d);
+    out_colour = f32x4{t, t, t, t};
+}
+
+# a vertex stage, so the module is not fragment-only and the substitution is shown
+# to be independent of the execution model. `fma` is the three-operand scalar form
+# and `radians` a one-operand one that is nearly free to get wrong: it takes and
+# returns a scalar, so an emitter that dropped the operand entirely would produce
+# an instruction of the right arity for something else.
+#[stage("vertex")]
+fun vertex_main() {
+    val k: f32 = sh.fma(in_rough, 2.0, 1.0);
+    val a: f32 = sh.sin(sh.radians(k));
+    position   = sh.normalize(f32x4{a, k, in_rough, 1.0});
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/int/surface/spirv-ext-inst/src/plain.mach
+++ b/int/surface/spirv-ext-inst/src/plain.mach
@@ -1,0 +1,20 @@
+# the on-demand half of the case: a shader that uses none of `shader.math`
+#
+# `OpExtInstImport "GLSL.std.450"` is required to be emitted only when the module
+# actually uses the set (#2688), and the only way to assert a negative is to have a
+# module that would show the import if the rule were dropped. So this is a real
+# stage doing real arithmetic - not an empty module, which would read
+# `extimports=0` however the emitter behaved - and its row in the golden is the
+# assertion.
+#
+# It is a separate mach module rather than another function in main.mach on
+# purpose: the import is a per-MODULE fact, and main.mach's own module does use the
+# set, so a function inside it could never show the absence.
+
+#[input(4)]  var plain_in:  f32x4;
+#[output(4)] var plain_out: f32x4;
+
+#[stage("fragment")]
+fun plain_main() {
+    plain_out = (plain_in + plain_in) * plain_in;
+}

--- a/int/surface/spirv-op-refused/case.conf
+++ b/int/surface/spirv-op-refused/case.conf
@@ -1,0 +1,14 @@
+# `#[spirv_op(set, name)]` names a closed value set, and this is the case that
+# holds it closed (#2688). A misspelt instruction is the failure with no other
+# symptom: the decorator would carry no opcode, the call would stay an ordinary
+# call, and on a shader target that call resolves to nothing at all - so the
+# report would arrive as a driver rejecting the module, not as an error on the
+# line that caused it.
+#
+# The build target is linux ON PURPOSE. The check belongs on EVERY target, not
+# only the one that acts on the decorator: which target a module is built for is
+# not a property of its source, and a library carrying this typo would otherwise
+# compile clean on every CPU build and fail only for whoever built it for a GPU.
+# Running the case where the decorator is inert is what asserts that.
+run: build-fails
+targets: linux

--- a/int/surface/spirv-op-refused/expect.linux.txt
+++ b/int/surface/spirv-op-refused/expect.linux.txt
@@ -1,0 +1,4 @@
+error: unknown SPIR-V instruction set; `spirv_op` accepts "core" or "GLSL.std.450"
+error: that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one
+error: that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one
+error: that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one

--- a/int/surface/spirv-op-refused/mach.toml
+++ b/int/surface/spirv-op-refused/mach.toml
@@ -1,0 +1,30 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/int"
+
+# a CPU target, deliberately. `#[spirv_op]` is inert here - nothing on this target
+# reads it - and the point of the case is that its value sets are still closed.
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-op-refused/src/main.mach
+++ b/int/surface/spirv-op-refused/src/main.mach
@@ -1,0 +1,33 @@
+# `#[spirv_op]` value sets are closed, on every target
+#
+# Both halves are checked and both are reported, because they are different
+# mistakes: an instruction set that does not exist, and an instruction that set
+# does not define. Reporting only a combined refusal would leave "GLSL.std.450
+# defines no Sqrtf" unsaid, which is the more useful of the two.
+#
+# The whole point of this file is that it is built for a CPU target, where the
+# decorator does nothing whatever. It still must not compile.
+
+# a set nobody registers. it must NOT fall back to the extended set, which is what
+# would make the typo invisible.
+#[spirv_op("GLSL.std.451", "Sqrt")]
+pub fun bad_set(x: f32) f32;
+
+# a plausible misspelling of a real instruction. `Sqrtf` is what a C programmer
+# reaches for, and GLSL.std.450 has no such entry.
+#[spirv_op("GLSL.std.450", "Sqrtf")]
+pub fun bad_name(x: f32) f32;
+
+# a real GLSL.std.450 instruction looked up in the CORE set, which is the mistake
+# the `dot` split invites in the other direction: the sets answer only for their
+# own instructions, and neither borrows from the other.
+#[spirv_op("core", "Normalize")]
+pub fun wrong_set(v: f32x4) f32x4;
+
+# core `OpDot` asked for from the extended set, the same mistake mirrored. This is
+# the one a reader is most likely to make, since GLSL spells `dot` beside
+# `normalize` and `length`.
+#[spirv_op("GLSL.std.450", "OpDot")]
+pub fun dot_is_core(a: f32x4, b: f32x4) f32;
+
+fun main() i32 { ret 0; }

--- a/int/surface/spirv-shader-only/case.conf
+++ b/int/surface/spirv-shader-only/case.conf
@@ -1,0 +1,16 @@
+# `shader.math` is a shader-only module and this is the case that keeps it one
+# (#2688).
+#
+# The library's functions have no bodies. On a SPIR-V target that is invisible,
+# because no call to one is ever emitted as a call - the call site becomes the
+# instruction. On any other target a program that calls one must FAIL TO LINK,
+# naming the symbol, and that is the observable here.
+#
+# The alternative the project rejected was native bodies, so the same source also
+# runs on a CPU. The only sensible implementation of each would have been to call
+# `std.math`, which would make `sh.sqrt` and `math.sqrt_f32` the same function on a
+# CPU and different functions on a GPU - the one outcome of the three that never
+# errors and is always slightly wrong. A decision documented in a README is a
+# decision until someone gives the library a body; this case is what makes it hold.
+run: build-fails
+targets: linux

--- a/int/surface/spirv-shader-only/expect.linux.txt
+++ b/int/surface/spirv-shader-only/expect.linux.txt
@@ -1,0 +1,1 @@
+error: undefined symbol: _M6shader4mathN4sqrt

--- a/int/surface/spirv-shader-only/mach.toml
+++ b/int/surface/spirv-shader-only/mach.toml
@@ -1,0 +1,33 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/int"
+
+# a CPU target, deliberately: the whole case is what `shader.math` does on one.
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-shader]
+git = "https://github.com/briar-systems/mach-shader"
+ref = "branch/main"

--- a/int/surface/spirv-shader-only/src/main.mach
+++ b/int/surface/spirv-shader-only/src/main.mach
@@ -1,0 +1,16 @@
+# `shader.math` on a CPU target: a link error, loudly, at build time
+#
+# This is the documented failure mode of a shader-only module, asserted rather than
+# described. The observable is the linker naming the undefined symbol, so a change
+# that gave these functions bodies - or that made the reference resolve to
+# something, anything, silently - fails here.
+#
+# The mangled name is part of the observable on purpose. "undefined symbol" alone
+# would still pass if the wrong symbol went missing.
+
+use sh: shader.math;
+
+fun main() i32 {
+    if (sh.sqrt(4.0) > 1.0) { ret 0; }
+    ret 1;
+}

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -50,6 +50,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.spirvop;
 use mach.lang.type;
 
 # re-export sema's shared state and accessor API (which lives in the context
@@ -1488,6 +1489,48 @@ fun validate_stage_value(sc: *context.SemaContext, dec: *decl.Decorator) {
     context.report(sc, arg.span, "unknown pipeline stage; `stage` accepts \"vertex\", \"fragment\", or \"compute\"");
 }
 
+# report unless a `#[spirv_op(set, name)]` names an instruction the compiler can
+# actually emit
+#
+# The pair is looked up in `spirvop`, the same table lowering resolves the opcode
+# from, so an accepted spelling here and an emitted opcode there cannot drift. Both
+# halves are reported separately: an unknown set and an unknown name in a known set
+# are different mistakes, and "GLSL.std.450 defines no Sqrtf" is a more useful
+# diagnostic than a single combined refusal.
+# ---
+# sc:  the context
+# d:   the decorated decl
+# dec: the `spirv_op` decorator
+fun validate_spirv_op(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    if (d.kind != decl.DECL_KIND_FUN) {
+        context.report(sc, dec.name, "`spirv_op` decorator applies only to functions");
+        ret;
+    }
+    if (dec.args_len != 2) {
+        context.report(sc, dec.name, "`spirv_op` decorator takes two string arguments: the instruction set and the instruction name");
+        ret;
+    }
+    val opt_set: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
+    val opt_nam: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + 1]);
+    if (O.is_none[*expr.Expr](opt_set) || O.is_none[*expr.Expr](opt_nam)) { ret; }
+    val set_e: *expr.Expr = O.unwrap[*expr.Expr](opt_set);
+    val nam_e: *expr.Expr = O.unwrap[*expr.Expr](opt_nam);
+    if (set_e.kind != expr.EXPR_KIND_LIT_STR || nam_e.kind != expr.EXPR_KIND_LIT_STR) {
+        context.report(sc, dec.name, "`spirv_op` decorator arguments must be string literals");
+        ret;
+    }
+    if (set_e.span.len < 2::usize || nam_e.span.len < 2::usize) { ret; }
+
+    val set_v: u8 = spirvop.set_of(sc.source, set_e.span.offset + 1::usize, set_e.span.len - 2::usize);
+    if (set_v == spirvop.SPV_SET_NONE) {
+        context.report(sc, set_e.span, "unknown SPIR-V instruction set; `spirv_op` accepts \"core\" or \"GLSL.std.450\"");
+        ret;
+    }
+    if (spirvop.opcode_of(set_v, sc.source, nam_e.span.offset + 1::usize, nam_e.span.len - 2::usize) == spirvop.SPV_OP_NONE) {
+        context.report(sc, nam_e.span, "that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one");
+    }
+}
+
 # whether `kind` is a valid `align` target: a global binding or a rec/uni nominal
 #
 # A `def` alias is excluded - it is transparent (no layout of its own, emits no
@@ -1724,7 +1767,17 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
     # agreement - is checked by the pre-type-resolution pass that has to read the
     # file anyway (#2507). Re-checking any of it here would report it twice.
     if (decorator_named(sc, dec, "embed")) { ret; }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage");
+    # `#[spirv_op(set, name)]` says a function IS one SPIR-V instruction, so a call
+    # to it on a SPIR-V target becomes that instruction instead of a call. Both
+    # names are closed here rather than in the back end: the decorator is legal on
+    # every target (which target a module is built for is not a property of the
+    # source), so a typo checked only where it is acted on would go unreported on
+    # every CPU build of the same library.
+    if (decorator_named(sc, dec, "spirv_op")) {
+        validate_spirv_op(sc, d, dec);
+        ret;
+    }
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage, spirv_op");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -31,6 +31,7 @@ use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
+use mach.lang.spirvop;
 
 use semtype: mach.lang.type;
 
@@ -310,6 +311,16 @@ pub rec Block {
 #              its siblings is the single-invocation workgroup
 # wg_y:        workgroup y dimension; 1 when the decorator is absent
 # wg_z:        workgroup z dimension; 1 when the decorator is absent
+# spv_set:     the SPIR-V instruction set a `#[spirv_op(set, name)]` decorator names
+#              (one of spirvop.SPV_SET_*), or SPV_SET_NONE for an ordinary function.
+#              carried on the DEFINITION and stamped onto the signature-only extern
+#              declaration a caller in another module creates, because a SPIR-V
+#              module is compiled per mach module: the call site is the only place
+#              the instruction can be substituted, and by then all the caller holds
+#              of the callee is that declaration
+# spv_op:      the opcode within `spv_set`, resolved by `spirvop.opcode_of`; a core
+#              opcode for SPV_SET_CORE, an extended instruction number otherwise.
+#              meaningless when `spv_set` is SPV_SET_NONE
 # disp:        bare source name of the function. inert debug metadata like `loc`
 #              (#1689): the machine-code path never reads it; only the `-g` DWARF
 #              producer does, for a readable DW_AT_name instead of the mangled linkage
@@ -356,6 +367,8 @@ pub rec Function {
     wg_x:        u32;
     wg_y:        u32;
     wg_z:        u32;
+    spv_set:     u8;
+    spv_op:      u32;
     disp:        intern.StrId;
     ret_sem:     semtype.TypeId;
 
@@ -762,6 +775,8 @@ pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId
     f.wg_x        = 1;
     f.wg_y        = 1;
     f.wg_z        = 1;
+    f.spv_set     = spirvop.SPV_SET_NONE;
+    f.spv_op      = spirvop.SPV_OP_NONE;
     f.disp        = intern.STR_NIL;
     f.ret_sem     = semtype.TYPE_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](alloc, map.hash_u32, map.eq_u32);

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -14,6 +14,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -21,6 +22,7 @@ use R: std.types.result;
 
 use mach.lang.fe.ast;
 use adecl: mach.lang.fe.ast.decl;
+use aexpr: mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
@@ -36,6 +38,7 @@ use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.spirvop;
 use target:  mach.lang.target.resolved;
 use mach.lang.type;
 
@@ -1745,9 +1748,62 @@ pub fun expr_symbol_of(lc: *LowerContext, eid: id.ExprId) resolve.SymbolId {
 # lc:  the context
 # ret: the module's source text, or the empty string
 pub fun module_source(lc: *LowerContext) str {
-    val sf: O.Option[*source.SourceFile] = source.get(?lc.s.sources, lc.a.file_id);
+    ret ast_source(lc, lc.a);
+}
+
+# return the source text an arbitrary module's AST was parsed from
+#
+# `module_source` answers for the module being lowered; a cross-module reference
+# needs the same answer for the module the referent was DECLARED in, whose
+# decorator spans index that text and not this one.
+# ---
+# lc:  the context
+# a:   the AST whose source text is wanted
+# ret: the source text, or the empty string for an unregistered file id
+pub fun ast_source(lc: *LowerContext, a: *ast.Ast) str {
+    if (a == nil) { ret ""; }
+    val sf: O.Option[*source.SourceFile] = source.get(?lc.s.sources, a.file_id);
     if (O.is_none[*source.SourceFile](sf)) { ret ""; }
     ret O.unwrap[*source.SourceFile](sf).text;
+}
+
+# read a function decl's `#[spirv_op(set, name)]` into a resolved set tag and opcode
+#
+# Both arguments are string literals sema has already closed against the same
+# `spirvop` table, so an unrecognized spelling cannot reach here; SPV_SET_NONE
+# covers the decorator being absent, which is every ordinary function.
+#
+# The decl and its source text are passed rather than taken from the context
+# because this is read on BOTH sides of a module boundary: on the definition, where
+# they are the module being lowered, and at a call site in another module, where
+# they belong to the callee's origin module.
+# ---
+# a:      the AST the decl belongs to
+# src:    that AST's source text
+# d:      the function's decl
+# out_op: receives the opcode within the set, untouched when there is no decorator
+# ret:    one of spirvop.SPV_SET_*
+pub fun decl_spirv_op(a: *ast.Ast, src: str, d: *adecl.Decl, out_op: *u32) u8 {
+    if (a == nil || d == nil) { ret spirvop.SPV_SET_NONE; }
+    var i: u32 = 0;
+    for (i < d.decorators_len) {
+        val dec: *adecl.Decorator = ?a.decorators[d.decorators_start + i];
+        if (!str_region_equals(src, dec.name.offset, dec.name.len, "spirv_op")) { i = i + 1; cnt; }
+        if (dec.args_len != 2) { ret spirvop.SPV_SET_NONE; }
+        val opt_set: O.Option[*aexpr.Expr] = ast.get_expr(a, a.expr_ids[dec.args_start]);
+        val opt_nam: O.Option[*aexpr.Expr] = ast.get_expr(a, a.expr_ids[dec.args_start + 1]);
+        if (O.is_none[*aexpr.Expr](opt_set) || O.is_none[*aexpr.Expr](opt_nam)) { ret spirvop.SPV_SET_NONE; }
+        val set_e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_set);
+        val nam_e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_nam);
+        if (set_e.span.len < 2::usize || nam_e.span.len < 2::usize) { ret spirvop.SPV_SET_NONE; }
+        val set_v: u8 = spirvop.set_of(src, set_e.span.offset + 1::usize, set_e.span.len - 2::usize);
+        if (set_v == spirvop.SPV_SET_NONE) { ret spirvop.SPV_SET_NONE; }
+        val op: u32 = spirvop.opcode_of(set_v, src, nam_e.span.offset + 1::usize, nam_e.span.len - 2::usize);
+        if (op == spirvop.SPV_OP_NONE) { ret spirvop.SPV_SET_NONE; }
+        @out_op = op;
+        ret set_v;
+    }
+    ret spirvop.SPV_SET_NONE;
 }
 
 # emit an OP_DBG_VALUE binding the source variable named by `name_span` (type

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -155,6 +155,13 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
     ctx.m.functions[fn_index].wg_x  = decl_workgroup_dim(ctx, d, 0);
     ctx.m.functions[fn_index].wg_y  = decl_workgroup_dim(ctx, d, 1);
     ctx.m.functions[fn_index].wg_z  = decl_workgroup_dim(ctx, d, 2);
+    # the SPIR-V instruction a `#[spirv_op(set, name)]` says this function IS. Read
+    # onto the definition as well as onto the extern declaration a caller in another
+    # module creates, so a module that defines one and calls it locally substitutes
+    # the instruction too, and so the SPIR-V emitter can skip emitting a body that
+    # would never be called on that target.
+    ctx.m.functions[fn_index].spv_set =
+        context.decl_spirv_op(ctx.a, context.module_source(ctx), d, ?ctx.m.functions[fn_index].spv_op);
 
     # a declared `ext fun` is a genuine foreign C import (a strict subset of the
     # FN_FLAG_EXTERN this function also carries): its calls marshal their arguments to

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -46,6 +46,7 @@ use mach.lang.me.lower.context;
 use mach.lang.me.lower.mangle;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.spirvop;
 use mach.lang.type;
 
 # lower an expression to its rvalue: the loaded value it denotes
@@ -708,7 +709,10 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     # reference; it falls through to the global-load path below, so a call
     # through it loads the stored pointer and dispatches indirectly.
     if (names_function(ctx, sym)) {
-        ret fn_reference(ctx, link, vty, references_import_function(ctx, sym));
+        val res_fn: R.Result[value.Value, str] = fn_reference(ctx, link, vty, references_import_function(ctx, sym));
+        if (R.is_err[value.Value, str](res_fn)) { ret res_fn; }
+        stamp_spirv_op(ctx, sym, R.unwrap_ok[value.Value, str](res_fn));
+        ret res_fn;
     }
 
     # a module-level `val` whose initializer folded is a constant at every use, in
@@ -854,6 +858,35 @@ fun references_import_data(ctx: *context.LowerContext, sym: *resolve.Symbol) boo
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
     ret (d.flags & decl.DECL_FLAG_EXT) != 0;
+}
+
+# carry a cross-module callee's `#[spirv_op(set, name)]` onto the extern declaration
+# this module created for it
+#
+# A SPIR-V module is compiled per mach module and a SPIR-V shader module cannot call
+# out of itself at all: Vulkan forbids the Linkage capability, so there is no import
+# for the linker to bind. The substitution therefore has to happen at the call site,
+# and by the time the back end sees it, all this module holds of `sh.normalize` is
+# the signature-only declaration `ensure_extern_function` synthesized from a name and
+# a type. Reading the decorator off the ORIGIN module's decl - the same way
+# `references_import_function` reads `ext` - is what puts the instruction back on it.
+#
+# A no-op for an ordinary function, and for every non-SPIR-V target, which never
+# looks at the field.
+# ---
+# ctx: per-module lowering context
+# sym: the symbol naming the callee
+# v:   the VAL_FN reference just formed for it
+fun stamp_spirv_op(ctx: *context.LowerContext, sym: *resolve.Symbol, v: value.Value) {
+    if (v.kind != value.VAL_FN || v.data.fn_ix >= ctx.m.function_len) { ret; }
+    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    if (origin_ast == nil) { ret; }
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    if (O.is_none[*decl.Decl](opt_d)) { ret; }
+    val fi: u32 = v.data.fn_ix;
+    val set_v: u8 = context.decl_spirv_op(origin_ast, context.ast_source(ctx, origin_ast),
+                                          O.unwrap[*decl.Decl](opt_d), ?ctx.m.functions[fi].spv_op);
+    if (set_v != spirvop.SPV_SET_NONE) { ctx.m.functions[fi].spv_set = set_v; }
 }
 
 # whether a symbol names a genuine foreign C function import (a declared `ext fun`)

--- a/src/lang/spirvop.mach
+++ b/src/lang/spirvop.mach
@@ -1,0 +1,194 @@
+# SPIR-V instruction table for the `#[spirv_op(set, name)]` decorator
+#
+# A shader needs `sqrt`, `normalize` and `mix`, and none of them is an operator or
+# a call SPIR-V can express: each is one SPIR-V instruction, drawn either from the
+# core opcode space or from an extended instruction set the module imports. The
+# decorator is how a mach function says which instruction it IS on a SPIR-V target,
+# so the mapping lives on the declaration rather than in a `$`-name the language
+# would have to grow one of per function.
+#
+# This module is the single place a `(set, name)` pair becomes a number. Sema calls
+# it to close the value set - a typo is a compile error on the decorator, not a
+# module that quietly calls nothing - and lowering calls it to resolve the number
+# onto the IR function. One table, two readers, so the accepted spellings and the
+# emitted opcodes cannot drift apart.
+#
+# It is a leaf: it holds only spec numbers and string comparisons, imports no
+# compiler module, and is named by `fe.sema`, `me.lower.decl`, `me.lower.expr` and
+# `target.isa.spirv.emit` alike. The SPIR-V back end owns the emission mechanics
+# (which section the import lands in, when it is emitted); the numbers are here so
+# the front end can check them without depending on a back end.
+#
+# THE GROWTH AXIS IS A ROW. Adding a GLSL.std.450 instruction is one line in
+# `opcode_of`; adding a whole new extended set is a `SPV_SET_*` tag, a row in
+# `set_of`, its import string in `set_import_name`, and its instructions' rows. The
+# set is carried explicitly rather than inferred from the instruction name so a
+# second set whose names collide with GLSL.std.450's stays unambiguous.
+#
+# WHAT IS DELIBERATELY ABSENT from the GLSL.std.450 rows below, and why, since the
+# spec's set is far larger than this:
+#
+#   - `Modf` and `Frexp` take a pointer operand to write their second result
+#     through. SPIR-V here is LOGICAL addressing: a pointer has exactly one pointee
+#     type and no pointer may be cast, and mach has no way to hand the back end a
+#     Function-storage out-pointer at a call site. The `*Struct` forms avoid the
+#     pointer but return a two-member struct mach cannot spell as a return type.
+#   - `Cross` is defined only for 3-component float vectors. mach has no `f32x3`
+#     (briar-systems/mach#2687), so there is no type to declare it at. It becomes a
+#     row the day that lands.
+#   - `Determinant` and `MatrixInverse` need a matrix type, which mach does not
+#     have by design - doc/types.md puts matrices in a library over vectors.
+#   - the `Pack*` / `Unpack*` family reinterprets one width's bits as another's,
+#     which is exactly what logical addressing forbids.
+#   - `InterpolateAt*` require the InterpolationFunction capability, which the
+#     module does not declare.
+#   - the integer `UMin` / `SMin` / `UMax` / `SMax` / `UClamp` / `SClamp` and the
+#     `Find*Msb` bit-scan family are ordinary integer arithmetic that a CPU target
+#     computes identically. They are not the shader gap, and routing them through a
+#     shader-only module would make code less portable, not more.
+#   - `NMin` / `NMax` / `NClamp` differ from the `F` forms only in NaN handling.
+#     Both spellings existing with no visible difference is a trap; the `F` forms
+#     are what GLSL's own `min` / `max` / `clamp` compile to.
+
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_region_equals;
+
+# the instruction set an operation is drawn from. NONE is the absence of the
+# decorator, which is every ordinary function
+pub val SPV_SET_NONE:    u8 = 0;
+pub val SPV_SET_CORE:    u8 = 1;
+pub val SPV_SET_GLSL450: u8 = 2;
+
+# no instruction of that name exists in that set. distinct from opcode 0, which is
+# the core `OpNop`
+pub val SPV_OP_NONE: u32 = 0xFFFFFFFF;
+
+# the instruction set a `#[spirv_op(set, ...)]` first argument names
+#
+# "core" is the core opcode space, whose instructions need no import; every other
+# accepted spelling is an extended set's literal name, which is also the string the
+# module's OpExtInstImport carries.
+# ---
+# src: the source text holding the argument
+# off: byte offset of the argument's content (quotes already stripped)
+# len: byte length of the content
+# ret: one of SPV_SET_*, or SPV_SET_NONE when the name is not an accepted set
+pub fun set_of(src: str, off: usize, len: usize) u8 {
+    if (str_region_equals(src, off, len, "core"))          { ret SPV_SET_CORE; }
+    if (str_region_equals(src, off, len, "GLSL.std.450"))  { ret SPV_SET_GLSL450; }
+    ret SPV_SET_NONE;
+}
+
+# the literal name an extended set is imported under, or the empty string for the
+# core set, which is never imported
+# ---
+# set: one of SPV_SET_*
+# ret: the OpExtInstImport operand string
+pub fun set_import_name(set: u8) str {
+    if (set == SPV_SET_GLSL450) { ret "GLSL.std.450"; }
+    ret "";
+}
+
+# the opcode a `#[spirv_op(set, name)]` second argument names within `set`
+#
+# For SPV_SET_CORE this is the core opcode itself; for an extended set it is the
+# instruction number the OpExtInst carries after the set's id. Returns SPV_OP_NONE
+# for a name the set does not define, which is what closes the decorator's value
+# set in sema.
+# ---
+# set: the set the name is looked up in, one of SPV_SET_*
+# src: the source text holding the argument
+# off: byte offset of the argument's content (quotes already stripped)
+# len: byte length of the content
+# ret: the opcode, or SPV_OP_NONE
+pub fun opcode_of(set: u8, src: str, off: usize, len: usize) u32 {
+    if (set == SPV_SET_CORE) {
+        # the dot product is NOT a GLSL.std.450 instruction, which is the single
+        # easiest thing to get wrong here: GLSL spells `dot` alongside `normalize`
+        # and `length`, so it reads like one of the set, and an OpExtInst carrying
+        # some invented number for it would assemble and validate as whatever
+        # instruction that number happens to be. It is core OpDot.
+        if (str_region_equals(src, off, len, "OpDot")) { ret 148; }
+        ret SPV_OP_NONE;
+    }
+    if (set != SPV_SET_GLSL450) { ret SPV_OP_NONE; }
+
+    # common-value maths
+    if (str_region_equals(src, off, len, "FAbs"))        { ret 4; }
+    if (str_region_equals(src, off, len, "FSign"))       { ret 6; }
+    if (str_region_equals(src, off, len, "Floor"))       { ret 8; }
+    if (str_region_equals(src, off, len, "Ceil"))        { ret 9; }
+    if (str_region_equals(src, off, len, "Fract"))       { ret 10; }
+
+    # trigonometry, including the angle conversions GLSL exposes beside it
+    if (str_region_equals(src, off, len, "Radians"))     { ret 11; }
+    if (str_region_equals(src, off, len, "Degrees"))     { ret 12; }
+    if (str_region_equals(src, off, len, "Sin"))         { ret 13; }
+    if (str_region_equals(src, off, len, "Cos"))         { ret 14; }
+    if (str_region_equals(src, off, len, "Tan"))         { ret 15; }
+    if (str_region_equals(src, off, len, "Asin"))        { ret 16; }
+    if (str_region_equals(src, off, len, "Acos"))        { ret 17; }
+    if (str_region_equals(src, off, len, "Atan"))        { ret 18; }
+    if (str_region_equals(src, off, len, "Atan2"))       { ret 25; }
+
+    # exponentials
+    if (str_region_equals(src, off, len, "Pow"))         { ret 26; }
+    if (str_region_equals(src, off, len, "Exp"))         { ret 27; }
+    if (str_region_equals(src, off, len, "Log"))         { ret 28; }
+    if (str_region_equals(src, off, len, "Exp2"))        { ret 29; }
+    if (str_region_equals(src, off, len, "Log2"))        { ret 30; }
+    if (str_region_equals(src, off, len, "Sqrt"))        { ret 31; }
+    if (str_region_equals(src, off, len, "InverseSqrt")) { ret 32; }
+
+    # range and interpolation
+    if (str_region_equals(src, off, len, "FMin"))        { ret 37; }
+    if (str_region_equals(src, off, len, "FMax"))        { ret 40; }
+    if (str_region_equals(src, off, len, "FClamp"))      { ret 43; }
+    if (str_region_equals(src, off, len, "FMix"))        { ret 46; }
+    if (str_region_equals(src, off, len, "Step"))        { ret 48; }
+    if (str_region_equals(src, off, len, "SmoothStep"))  { ret 49; }
+    if (str_region_equals(src, off, len, "Fma"))         { ret 50; }
+
+    # geometry. every one of these takes and returns whole vectors, which is why
+    # they belong to the set rather than to a scalar library
+    if (str_region_equals(src, off, len, "Length"))      { ret 66; }
+    if (str_region_equals(src, off, len, "Distance"))    { ret 67; }
+    if (str_region_equals(src, off, len, "Normalize"))   { ret 69; }
+    if (str_region_equals(src, off, len, "FaceForward")) { ret 70; }
+    if (str_region_equals(src, off, len, "Reflect"))     { ret 71; }
+    if (str_region_equals(src, off, len, "Refract"))     { ret 72; }
+
+    ret SPV_OP_NONE;
+}
+
+test "mach.lang.spirvop.opcode_of:sets_are_separate" {
+    # `dot` is core, not extended, and the extended set must not answer for it.
+    if (opcode_of(SPV_SET_CORE, "OpDot", 0::usize, 5::usize) != 148) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "OpDot", 0::usize, 5::usize) != SPV_OP_NONE) { ret 1; }
+    # and the extended names must not answer from the core set.
+    if (opcode_of(SPV_SET_GLSL450, "Sqrt", 0::usize, 4::usize) != 31) { ret 1; }
+    if (opcode_of(SPV_SET_CORE, "Sqrt", 0::usize, 4::usize) != SPV_OP_NONE) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.spirvop.opcode_of:prefix_is_not_a_match" {
+    # a region compare, not a prefix compare: "Exp" and "Exp2" are different
+    # instructions and "Log" is not the head of "Log2".
+    if (opcode_of(SPV_SET_GLSL450, "Exp2", 0::usize, 4::usize) != 29) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "Exp2", 0::usize, 3::usize) != 27) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "Atan2", 0::usize, 5::usize) != 25) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "Atan2", 0::usize, 4::usize) != 18) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.spirvop.set_of:closed" {
+    if (set_of("core", 0::usize, 4::usize) != SPV_SET_CORE) { ret 1; }
+    if (set_of("GLSL.std.450", 0::usize, 12::usize) != SPV_SET_GLSL450) { ret 1; }
+    # an unknown set is refused rather than defaulted to the extended one, which is
+    # what keeps a typo from silently importing GLSL.std.450.
+    if (set_of("GLSL.std.451", 0::usize, 12::usize) != SPV_SET_NONE) { ret 1; }
+    if (!str_equals(set_import_name(SPV_SET_GLSL450), "GLSL.std.450")) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -42,6 +42,8 @@ pub val SPV_GENERATOR: u32 = 0;
 # instruction's first word; the high 16 bits carry the instruction's total word
 # count (`inst_word`)
 pub val OP_NAME:                u32 = 5;
+pub val OP_EXT_INST_IMPORT:     u32 = 11;
+pub val OP_EXT_INST:            u32 = 12;
 pub val OP_MEMORY_MODEL:        u32 = 14;
 pub val OP_ENTRY_POINT:         u32 = 15;
 pub val OP_EXECUTION_MODE:      u32 = 16;
@@ -94,6 +96,11 @@ pub val OP_F_DIV:               u32 = 136;
 pub val OP_U_MOD:               u32 = 137;
 pub val OP_S_REM:               u32 = 138;
 pub val OP_F_REM:               u32 = 140;
+# the dot product is CORE, not GLSL.std.450. GLSL spells `dot` beside `normalize`
+# and `length`, so it reads like a member of the extended set, and an OpExtInst
+# carrying an invented number for it would still assemble and validate - as
+# whichever instruction that number happens to name
+pub val OP_DOT:                 u32 = 148;
 pub val OP_SELECT:              u32 = 169;
 pub val OP_I_EQUAL:             u32 = 170;
 pub val OP_I_NOT_EQUAL:         u32 = 171;
@@ -242,6 +249,11 @@ pub val SELECTION_CONTROL_NONE: u32 = 0;
 # alloc:        allocator backing every section vector and the serialized image
 # next_id:      the next id to hand out; equals the id bound at serialize time
 # caps:         OpCapability instructions
+# ext_imports:  OpExtInstImport instructions, one per extended instruction set the
+#               module actually uses. its own section because SPIR-V fixes its
+#               position - after every capability, before the memory model - while
+#               the emitter discovers the need mid-body, at the first call that
+#               lowers to an OpExtInst
 # memory_model: the single OpMemoryModel instruction
 # entry_points: OpEntryPoint instructions
 # exec_modes:   OpExecutionMode instructions
@@ -254,6 +266,7 @@ pub rec Builder {
     alloc:        *A.Allocator;
     next_id:      u32;
     caps:         Vec;
+    ext_imports:  Vec;
     memory_model: Vec;
     entry_points: Vec;
     exec_modes:   Vec;
@@ -342,6 +355,7 @@ pub fun builder_init(alloc: *A.Allocator) Builder {
     b.alloc        = alloc;
     b.next_id      = 1;
     b.caps         = vec_init();
+    b.ext_imports  = vec_init();
     b.memory_model = vec_init();
     b.entry_points = vec_init();
     b.exec_modes   = vec_init();
@@ -358,6 +372,7 @@ pub fun builder_init(alloc: *A.Allocator) Builder {
 # b: the builder to tear down
 pub fun builder_dnit(b: *Builder) {
     vec_dnit(b, ?b.caps);
+    vec_dnit(b, ?b.ext_imports);
     vec_dnit(b, ?b.memory_model);
     vec_dnit(b, ?b.entry_points);
     vec_dnit(b, ?b.exec_modes);
@@ -404,6 +419,29 @@ pub fun inst(b: *Builder, v: *Vec, opcode: u32, ops: *u32, n: u32) {
     }
 }
 
+# import an extended instruction set, returning the id an OpExtInst names it by
+#
+# One import per set per module, which the caller enforces by caching the returned
+# id: importing the same set twice is invalid, not merely wasteful. Lands in its own
+# section, so it serializes after every capability and before the memory model
+# wherever in the emission the need was discovered.
+# ---
+# b:   the builder
+# set: the set's literal name, e.g. "GLSL.std.450"
+# ret: the set's result id
+pub fun ext_inst_import(b: *Builder, set: str) u32 {
+    val id: u32 = alloc_id(b);
+    var ops: [17]u32;
+    ops[0] = id;
+    val n: u32 = string_words(set);
+    # 16 words is 63 characters of set name, past every set the specification
+    # registers; a longer one would silently truncate, so it is refused outright.
+    if (n > 16) { b.err = true; ret id; }
+    pack_string(set, ?ops[1]);
+    inst(b, ?b.ext_imports, OP_EXT_INST_IMPORT, ?ops[0], 1 + n);
+    ret id;
+}
+
 # the number of words a SPIR-V literal string occupies: its bytes plus a NUL
 # terminator, rounded up to a whole word
 # ---
@@ -443,9 +481,9 @@ pub fun pack_string(s: str, out: *u32) u32 {
 # frame the header and concatenate the sections into the final module byte image
 #
 # The word bound is the current `next_id` (one past the highest id handed out).
-# Sections are emitted in SPIR-V's required order: capabilities, memory model,
-# entry points, execution modes, decorations, types / constants, then function
-# bodies. Every word is serialized
+# Sections are emitted in SPIR-V's required order: capabilities, extended
+# instruction set imports, memory model, entry points, execution modes,
+# decorations, types / constants, then function bodies. Every word is serialized
 # little-endian. The returned buffer is allocated from the builder's allocator and
 # owned by the caller.
 # ---
@@ -455,7 +493,7 @@ pub fun pack_string(s: str, out: *u32) u32 {
 pub fun serialize(b: *Builder, out_len: *u32) R.Result[*u8, str] {
     if (b.err) { ret R.err[*u8, str]("spirv: module builder hit an allocation error"); }
 
-    val total_words: u32 = 5 + b.caps.len + b.memory_model.len + b.entry_points.len
+    val total_words: u32 = 5 + b.caps.len + b.ext_imports.len + b.memory_model.len + b.entry_points.len
                          + b.exec_modes.len + b.decorations.len
                          + b.types_consts.len + b.functions.len;
     val total_bytes: u32 = total_words * 4;
@@ -472,6 +510,7 @@ pub fun serialize(b: *Builder, out_len: *u32) R.Result[*u8, str] {
     pos = put_word(buf, pos, 0);  # schema, reserved 0
 
     pos = put_section(buf, pos, ?b.caps);
+    pos = put_section(buf, pos, ?b.ext_imports);
     pos = put_section(buf, pos, ?b.memory_model);
     pos = put_section(buf, pos, ?b.entry_points);
     pos = put_section(buf, pos, ?b.exec_modes);

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -56,6 +56,7 @@ use R: std.types.result;
 
 use mach.lang.intern;
 use mach.lang.source;
+use mach.lang.spirvop;
 use mach.lang.target.resolved;
 use mach.lang.me.ir;
 use mach.lang.me.ir.type;
@@ -113,6 +114,13 @@ rec Emit {
     iface_len: u32;
     gslot:     *u32;
     iface_use: *u8;
+
+    # the id each extended instruction set was imported under, indexed by
+    # spirvop.SPV_SET_*; 0 means "not imported yet". indexed rather than one field
+    # per set so a second set is a row in `spirvop`, not a change here. the import
+    # is minted at the FIRST call that needs it, which is what makes it on demand:
+    # a module using none of them carries no OpExtInstImport at all
+    ext_ids:   [8]u32;
 
     # the refusal context: which function is being emitted and which instruction
     # is being translated, so a refusal can say so without every site threading
@@ -195,6 +203,8 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
     e.gvar_ids = nil; e.gtype_ids = nil; e.gstorage = nil; e.iface_ids = nil; e.iface_len = 0;
     e.gslot = nil; e.iface_use = nil;
+    var xi: u32 = 0;
+    for (xi < 8) { e.ext_ids[xi] = 0; xi = xi + 1; }
     e.srcmap = mirmod.srcmap; e.cur_fn = nil; e.cur_instr = nil;
 
     # a module is a shader module or a library module, never both, and which one is
@@ -253,6 +263,15 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
         # a body-less MIR function (an extern declaration) lowers to an empty shell;
         # it contributes no OpFunction (SPIR-V imports are a later phase).
         if (mf.block_count == 0) { fi = fi + 1; cnt; }
+        # a function that IS a SPIR-V instruction contributes no OpFunction either.
+        # It has a mach body - that is what makes `shader.math` a real library on a
+        # CPU target rather than a set of declarations - but on this target every
+        # call to it becomes the instruction, so the body is unreachable. Emitting it
+        # anyway would be worse than dead weight: the native body is written in terms
+        # of the bit manipulation a CPU needs, which is exactly what logical
+        # addressing refuses, so the module would fail to build over code nothing
+        # calls.
+        if (instruction_mapped(e.ir, mf.name)) { fi = fi + 1; cnt; }
         val fr: R.Result[bool, str] = emit_function(?e, mf);
         if (R.is_err[bool, str](fr)) {
             emit_dnit(?e, irmod.function_len);
@@ -1403,10 +1422,19 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
                 val v: u32 = mi.operands[0].vreg;
                 var t: u32 = 0;
                 if (callee != intern.STR_NIL) {
-                    val cix: u32 = ir_function_index(e.ir, callee);
-                    if (cix != IR_FN_NONE) {
+                    # by RECORD, not by `ir_function_index`, which skips a
+                    # declaration because its answer also selects a pre-allocated
+                    # SPIR-V id. What is wanted here is the callee's declared RETURN
+                    # TYPE, which a signature-only declaration has just as much as a
+                    # definition does. Looking it up the other way left every
+                    # cross-module call's result typed by the move's machine width
+                    # instead: an `f32` came back 64 bits wide and a scalar returned
+                    # from vector arguments came back a vector, and the module failed
+                    # validation at the store rather than at the call.
+                    val cfn: *ir.Function = ir_function_record(e.ir, callee);
+                    if (cfn != nil) {
                         var cvoid: bool = false;
-                        t = ir_return_spv_type(e, ?e.ir.functions[cix], ?cvoid);
+                        t = ir_return_spv_type(e, cfn, ?cvoid);
                         if (cvoid) { t = 0; }
                     }
                     callee = intern.STR_NIL;
@@ -2353,6 +2381,18 @@ fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] 
     if (callee.kind != mir.MIR_OP_SYM) {
         ret unsupported(e, "a call through a function pointer is not yet supported by the SPIR-V target");
     }
+
+    # a callee carrying `#[spirv_op(set, name)]` is not called at all: it IS one
+    # instruction, and this call site becomes that instruction. Checked before the
+    # in-module lookup below, because the whole point is that the callee is usually
+    # NOT in this module - a SPIR-V module is compiled per mach module and a shader
+    # module may declare no linkage, so `shader.math` could not be called even if
+    # its body were emitted.
+    val xfn: *ir.Function = ir_function_record(e.ir, callee.sym);
+    if (xfn != nil && xfn.spv_set != spirvop.SPV_SET_NONE) {
+        ret emit_spirv_op(e, preg_val, xfn);
+    }
+
     val fix: u32 = ir_function_index(e.ir, callee.sym);
     if (fix == IR_FN_NONE || e.fn_ids == nil || e.fn_ids[fix] == 0) {
         ret unsupported(e, "a call to a function defined outside the module is not yet supported by the SPIR-V target");
@@ -2386,6 +2426,137 @@ fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] 
         preg_val.is_imm[0] = false;
     }
     ret R.ok[bool, str](true);
+}
+
+# emit the single SPIR-V instruction a `#[spirv_op(set, name)]` callee stands for
+#
+# The contract is uniform across every instruction in the table and is what makes
+# adding one a row rather than a case: the result type is the mach function's
+# declared return type, and the operands are its parameters in declaration order,
+# read out of the identity convention's register file exactly as a real call's
+# arguments would be. That covers the awkward members without special-casing them -
+# `Length` and `OpDot` return a scalar from vectors, `Refract` mixes a scalar
+# operand with vector ones, `FClamp` and `SmoothStep` take three.
+#
+# The signature is read from the IR function's type rather than from `params`,
+# because for a cross-module callee the declaration is signature-only: it was
+# synthesized from a name and a type and has no parameter list of its own.
+#
+# A core-set instruction is emitted directly; an extended one is an OpExtInst
+# naming the imported set's id and the instruction number within it, with the set
+# imported here on first use.
+# ---
+# e:        the emission state
+# preg_val: the identity convention's nominal register file
+# fn:       the callee's IR function record, carrying spv_set / spv_op
+# ret:      true on success, or a precise error string
+fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[bool, str] {
+    val sig_opt: O.Option[*type.IrType] = type.get(?e.ir.types, fn.sig);
+    if (O.is_none[*type.IrType](sig_opt)) {
+        ret R.err[bool, str]("spirv.emit: a `spirv_op` callee has no signature type");
+    }
+    val sig: *type.IrType = O.unwrap[*type.IrType](sig_opt);
+    if (sig.kind != type.IRT_FN) {
+        ret R.err[bool, str]("spirv.emit: a `spirv_op` callee's signature is not a function type");
+    }
+    val argc: u32 = sig.data.fn.param_count;
+    # 12 operands is past every instruction in the table (the widest is three) and
+    # leaves the fixed operand array a comfortable size.
+    if (argc > 12) {
+        ret unsupported(e, "a `spirv_op` function takes at most 12 parameters on the SPIR-V target");
+    }
+
+    var returns_void: bool = false;
+    val ret_ty: u32 = ir_return_spv_type(e, fn, ?returns_void);
+    if (ret_ty == 0) { ret unsupported(e, "unsupported return type in the SPIR-V target"); }
+    # every instruction in the table produces a value. a void one would leave the
+    # result register holding whatever the previous call left there, which is the
+    # silent-wrong-value failure this decorator exists to avoid.
+    if (returns_void) {
+        ret unsupported(e, "a `spirv_op` function must return a value; a SPIR-V instruction has a result id");
+    }
+
+    var ops: [16]u32;
+    var base: u32 = 2;
+    ops[0] = ret_ty;
+    val result: u32 = spirv.alloc_id(e.b);
+    ops[1] = result;
+    if (fn.spv_set != spirvop.SPV_SET_CORE) {
+        val set_id: u32 = ext_set_id(e, fn.spv_set);
+        if (set_id == 0) {
+            ret R.err[bool, str]("spirv.emit: a `spirv_op` names an instruction set with no import name");
+        }
+        ops[2] = set_id;
+        ops[3] = fn.spv_op;
+        base = 4;
+    }
+
+    var i: u32 = 0;
+    for (i < argc) {
+        val aid: u32 = reg_value(e, preg_val, i, ir_value_spv_type(e, sig.data.fn.params[i]));
+        if (aid == 0) { ret R.err[bool, str]("spirv.emit: `spirv_op` argument with no pre-colored value"); }
+        ops[base + i] = aid;
+        i = i + 1;
+    }
+
+    var opcode: u32 = spirv.OP_EXT_INST;
+    if (fn.spv_set == spirvop.SPV_SET_CORE) { opcode = fn.spv_op; }
+    spirv.inst(e.b, ?e.b.functions, opcode, ?ops[0], base + argc);
+
+    # the return register, which the result move reads next - the same handoff a
+    # real OpFunctionCall makes.
+    preg_val.val_id[0] = result;
+    preg_val.is_imm[0] = false;
+    ret R.ok[bool, str](true);
+}
+
+# the id an extended instruction set is imported under, importing it on first use
+#
+# One OpExtInstImport per set per module: a second import of the same set is
+# invalid, so the id is cached rather than re-minted. Returns 0 when the set has no
+# import name, which is the core set and never reaches here.
+# ---
+# e:   the emission state
+# set: one of spirvop.SPV_SET_*
+# ret: the set's id, or 0
+fun ext_set_id(e: *Emit, set: u8) u32 {
+    if (set::u32 >= 8) { ret 0; }
+    if (e.ext_ids[set::u32] != 0) { ret e.ext_ids[set::u32]; }
+    val name: str = spirvop.set_import_name(set);
+    if (str_len(name) == 0::usize) { ret 0; }
+    val id: u32 = spirv.ext_inst_import(e.b, name);
+    e.ext_ids[set::u32] = id;
+    ret id;
+}
+
+# the IR function record of the given interned name, defined or merely declared
+#
+# `ir_function_index` deliberately skips FN_FLAG_EXTERN entries, since its answer
+# selects a pre-allocated SPIR-V id and a declaration has none. A `spirv_op` callee
+# is normally exactly such a declaration - the definition is in another mach module
+# - so its record is looked up separately.
+# ---
+# irmod: the IR module
+# name:  the interned function name
+# ret:   the function record, or nil
+fun ir_function_record(irmod: *ir.Module, name: intern.StrId) *ir.Function {
+    var i: u32 = 0;
+    for (i < irmod.function_len) {
+        if (irmod.functions[i].name == name) { ret ?irmod.functions[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# whether the named function is one a `#[spirv_op(...)]` maps to an instruction
+# ---
+# irmod: the IR module
+# name:  the interned function name
+# ret:   true when the function carries a SPIR-V instruction mapping
+fun instruction_mapped(irmod: *ir.Module, name: intern.StrId) bool {
+    val fn: *ir.Function = ir_function_record(irmod, name);
+    if (fn == nil) { ret false; }
+    ret fn.spv_set != spirvop.SPV_SET_NONE;
 }
 
 # produce an SSA value id for an operand, materializing a load / constant as needed


### PR DESCRIPTION
Closes #2688.

A shader can now write `sqrt`, `normalize`, `dot`, `mix`, `max`, `min`, `clamp`,
`pow` and about thirty more. `OpExtInstImport "GLSL.std.450"` is emitted once per
module and only when that module uses the set, and each call site becomes the
instruction itself.

## The shape

Three pieces, split along the line the issue drew.

**`#[spirv_op(set, name)]`** — a decorator saying which SPIR-V instruction a
function *is*. Not a `$`-name: a `$normalize` would be new language surface per
function, meaningful on exactly one backend, which is the wart the decorator
channel exists to avoid.

**`mach.lang.spirvop`** — the single place a `(set, name)` pair becomes a number.
Sema reads it to close the value set; lowering reads it to resolve the opcode. One
table, two readers, so the accepted spellings and the emitted opcodes cannot drift.

**`briar-systems/mach-shader`** — the library, published and wired up. `shader.math`
is ~50 declarations over `f32` and `f32x4`.

The split is where it is because the compiler must not know about a particular
library's namespace. Nothing in this repo names `shader.math`; the compiler knows
only how to read a decorator and how to emit an instruction. Anyone can declare
their own.

## Carrying the mapping across a module boundary

This is the load-bearing part and it is not obvious from the issue.

**A SPIR-V module is compiled per mach module.** `use sh: shader.math` produces a
second `.spv`, and a shader module may declare no Linkage capability — Vulkan
forbids it outright — so there is no import for anything to bind. `sh.normalize`
could never be *called*, even if its body were emitted. The call site is the only
place the substitution can happen.

By the time the back end sees that call, all the caller holds of the callee is the
signature-only declaration `ensure_extern_function` synthesized from a name and a
type. So the decorator is read off the **origin module's** decl — the same way
`references_import_function` reads `ext` — and stamped onto that declaration. That
is `stamp_spirv_op` in `me/lower/expr.mach`.

## Which went where, and why

| Function | Where it lands | Why |
|---|---|---|
| `dot` | **core `OpDot`** (148) | Not a GLSL.std.450 instruction at all, despite GLSL spelling it beside `normalize` and `length`. The set has no entry 148. |
| `normalize`, `length`, `distance`, `reflect`, `refract`, `face_forward` | GLSL.std.450 66–72 | genuinely extended |
| `sqrt`, `inverse_sqrt`, `pow`, `exp`, `log`, `exp2`, `log2` | GLSL.std.450 26–32 | |
| `min`, `max`, `clamp`, `mix`, `step`, `smooth_step`, `fma` | GLSL.std.450 37–50 | the `F` forms, not `N` and not the integer ones — see below |
| `abs`, `sign`, `floor`, `ceil`, `fract`, `radians`, `degrees` | GLSL.std.450 4–12 | |
| `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2` | GLSL.std.450 13–25 | |

Each number was checked against `SPIRV-Headers`' `GLSL.std.450.h`, not against
memory. The `dot` split is the one a reader is most likely to get wrong, and an
`OpExtInst` carrying an invented number for it would still assemble and validate —
as whichever instruction that number happens to name. It has a comment at both the
opcode constant and the table row saying so, and the `spirv-op-refused` fixture
asserts that neither set answers for the other's instructions.

## The cut line

Everything selected is a pure value-to-value instruction, needs only the `Shader`
capability, and is defined for the float and float-vector types mach can spell.
What is out, and why each is reasoned rather than pending:

- **`Modf`, `Frexp`** take a pointer to write their second result through. SPIR-V
  here is **logical addressing**: a pointer has exactly one pointee type, none may
  be cast, and mach has no way to hand the back end a Function-storage out-pointer
  at a call site. The `*Struct` forms avoid the pointer but return a two-member
  struct that is not a spellable mach return type. Dropped rather than bent.
- **`Cross`** is defined only for 3-component vectors. `f32x3` is #2687. It is a
  row the day that lands.
- **`Determinant`, `MatrixInverse`** need a matrix type mach does not have by
  design — `doc/types.md` puts matrices in a library over vectors.
- **`Pack*` / `Unpack*`** reinterpret one width's bits as another's, which logical
  addressing forbids.
- **`InterpolateAt*`** need the `InterpolationFunction` capability the module does
  not declare.
- **integer `UMin` / `SMin` / `UMax` / `SMax` / `UClamp` / `SClamp`, `Find*Msb`** are
  ordinary integer arithmetic a CPU computes identically. They are not the shader
  gap, and routing them through a shader-only module would make code *less*
  portable.
- **`NMin`, `NMax`, `NClamp`** differ from the `F` forms only in NaN handling. Both
  spellings existing with no visible difference is a trap; the `F` forms are what
  GLSL's own `min` / `max` / `clamp` compile to.

Adding any of these later is a row in `spirvop.opcode_of` plus a declaration in
`mach-shader`. The lowering contract does not change: the result type is the mach
function's declared return type and the operands are its parameters in declaration
order, which already covers the hardest members here — `Length` and `OpDot` return
a scalar from vectors, `Refract` mixes a scalar operand with vector ones, `FClamp`
and `SmoothStep` take three.

## The native-fallback decision

**`shader.math` is a shader-only module, deliberately.** Nothing in it has a body.
On a SPIR-V target that is invisible. On any other target, a program that calls one
fails to link, naming the symbol:

```
error: undefined symbol: _M6shader4mathN4sqrt
```

The alternative — native bodies, so the same source runs on a CPU — would mean
writing a second float-maths library beside the one `mach-std` already owns, and
the only sensible implementation of each would be to call `std.math`. That is
exactly the substitution the issue rejects: it would make `sh.sqrt` and
`math.sqrt_f32` the same function on a CPU and different functions on a GPU, which
is the worst of the three options because it is the one that never errors. A link
failure at build time is loud, early, and impossible to ship past.

The decorator itself does not require this. A decorated function **may** have a
body, and if it does, that body is what every non-`spirv` target runs while `spirv`
substitutes the instruction. The choice is the library's, and
`int/surface/spirv-shader-only` is what keeps it made: a documented decision is a
decision until someone quietly gives the library a body.

The precision contract is documented in `mach-shader`'s README and module header:
nothing there is IEEE-exact and nothing is portable between drivers.

## Testing

The observable is **the disassembly**, not the validator's verdict. Every wrong
outcome available here passes `spirv-val`:

- a `sh.sqrt` left as an `OpFunctionCall` to an unresolved function
- an `OpExtInst` carrying 32 instead of 31 — that is `InverseSqrt`, and it validates
- `dot` sent into GLSL.std.450 rather than core `OpDot`
- an instruction given two operands where it takes three

So the new `spirv-shader` producer disassembles each module and prints every
`OpExtInst` by **set and instruction name with its operand count**, plus every core
`OpDot`, in emission order. The golden:

```
module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
  import GLSL.std.450
  extinst GLSL.std.450 Normalize operands=1
  core OpDot operands=2
  extinst GLSL.std.450 FMax operands=2
  extinst GLSL.std.450 Sqrt operands=1
  extinst GLSL.std.450 FMix operands=3
  ...
module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0
module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0
modules=3
```

`plain.spv` is a **real shader stage doing real arithmetic** that touches none of
`shader.math`. Its `extimports=0` is what makes "imported only when used" an
assertion; an empty module would read the same however the emitter behaved.

The producer also picks the environment **per module**, which this case needs and
no earlier spirv case did: it consumes a library dependency, so the tree holds a
shader module (`vulkan1.3`) beside `shader.math`'s own library module, whose
Linkage capability `vulkan1.3` rejects outright. One environment for the whole tree
cannot be right once a case has a dependency.

Three cases in all: `spirv-ext-inst` (the above, against the published
`mach-shader` as a **git** dependency, since the subject is a cross-module
reference), `spirv-op-refused` (the value sets are closed — built for a **CPU**
target, because that is where a library carrying the typo would otherwise compile
clean), `spirv-shader-only` (the link failure, naming the symbol).

- `mach test .` — 1248 passed, 0 failed, including 3 new `mach.lang.spirvop` tests
- `int/run.sh --target linux` — 207 cases, all passed
- `int/lib/check-target-matrix.sh` — 353 case x leg pairs OK

## Drive-by fix

A call's result vreg was typed from the **move** rather than from the callee's
declaration. `ir_function_index` skips a declaration deliberately — its answer also
selects a pre-allocated SPIR-V id — but what the type map wants is the declared
return type, which a declaration has just as much as a definition does. Looked up
the other way, an `f32` result came back 64 bits wide and a scalar returned from
vector arguments came back a vector, from identical IR, and the module failed
validation at the store rather than at the call. Latent before this PR, since
cross-module calls were refused outright.

## Companion

`briar-systems/mach-shader` is published with `shader.math`, a README covering the
precision contract, the shader-only decision and the omission list, and an MIT
licence.
