### PR TITLE
fix(type): refuse a sub-register vector rather than miscompile it

### DIFF
--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -24,8 +24,10 @@ There is no compiler `bool`. `bool` is a stdlib `def bool: u8;` with `true` /
 A vector type is a **form**, not a fixed list: any primitive numeric element
 followed by `x` and a lane count.
 
+On a 128-bit target the spellings this currently accepts are:
+
 ```mach
-f32x4  f32x3  f32x2  f64x2      # float lanes
+f32x4  f64x2                    # float lanes
 i8x16  i16x8  i32x4  i64x2      # signed integer lanes
 u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 ```
@@ -36,12 +38,17 @@ is an algorithm over vectors and belongs in a library over vector elements, not
 the language. A vector spelling is recognized only in type position, so a value
 may still be named `f32x4` without colliding with the type.
 
-Two rules bound the form:
+Three rules bound the form:
 
 - **At least 2 lanes.** `f32x1` is refused; a one-lane vector is just its scalar.
 - **No wider than the target's vector register.** Every current target is 128
   bits, so `f32x7` (224 bits) is refused by name. The error names the width you
   asked for and the width the target has, rather than reporting an unknown type.
+- **Currently, exactly as wide as the register.** A vector *narrower* than the
+  vector register (`f32x3`, `f32x2`) is read and laid out correctly but refused
+  by name for now, because codegen cannot yet carry a value whose register width
+  and memory footprint differ. This restriction is temporary and is the only
+  thing between the form and `vec3`.
 
 `ptr` is not a lane element: its width is target-defined rather than a scalar bit
 count, so `ptrx2` is not a vector spelling.
@@ -49,7 +56,8 @@ count, so `ptrx2` is not a vector spelling.
 ### Size and alignment
 
 `$size_of` is **lane-derived**: `lanes × element size`, packed, with no padding
-up to the register width.
+up to the register width. (The sub-register rows below are the rule the layout
+already implements; those spellings are not yet accepted — see above.)
 
 | type | `$size_of` | `$align_of` |
 |---|---|---|

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6252,6 +6252,55 @@ test "mach.lang.driver:secret_gates_rejected" {
 # The predicate keys on the DECLARATION, not the type: a bare generic name types as
 # `fun(T) T`, but so does a local of that type, and the address of that VARIABLE is a
 # legitimate `*fun(T) T` which must keep working.
+# a vector spelling is READ as the form `<element>x<lanes>` and bounded by the target's
+# vector width (#2687), so the three refusals must each be reported as themselves rather
+# than collapsing into "unresolved type name", which is what a table lookup would say
+# about every one of them
+test "mach.lang.driver:vector_form_bounds_reported_as_themselves" {
+    var bad: i32 = 0;
+
+    # TOO WIDE: names the width asked for and the width the target has.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x7; ret 0; }\n",
+        "is 224 bits wide, more than this target's 128-bit vector width")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f64x3; ret 0; }\n",
+        "is 192 bits wide, more than this target's 128-bit vector width")) { bad = 1; }
+
+    # SUB-WIDTH: refused because codegen cannot carry a vector narrower than the
+    # register yet, and the message says so rather than blaming the spelling. this is
+    # the arm that must change to a clean compile when that restriction lifts.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x3; ret 0; }\n",
+        "narrower than this target's 128-bit vector register")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x2; ret 0; }\n",
+        "narrower than this target's 128-bit vector register")) { bad = 1; }
+
+    # DEGENERATE LANE COUNT: its own sentence, not a width failure.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x1; ret 0; }\n",
+        "needs at least 2 lanes")) { bad = 1; }
+
+    # NOT A VECTOR AT ALL: still an ordinary unresolved name, so the form reader has
+    # not swallowed identifiers that merely contain an `x`.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: matrix4; ret 0; }\n",
+        "unresolved type name")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x04; ret 0; }\n",
+        "unresolved type name")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: ptrx2; ret 0; }\n",
+        "unresolved type name")) { bad = 1; }
+
+    # THE REGRESSION BAR - every one of the ten shapes that resolved before #2687 still
+    # resolves, now through the form rather than a seeded name. this is the arm that
+    # must not be lost.
+    if (!ut_sema_clean("fun main() i64 { var a: f32x4; var b: f64x2; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: i8x16; var b: i16x8; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: i32x4; var b: i64x2; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: u8x16; var b: u16x8; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: u32x4; var b: u64x2; ret 0; }\n"))  { bad = 1; }
+    # a value may still be named for a vector spelling: the form is read in type
+    # position only, so this must not start colliding.
+    if (!ut_sema_clean("fun main() i64 { val f32x4: i64 = 3; ret f32x4; }\n"))      { bad = 1; }
+
+    ret bad;
+}
+
 test "mach.lang.driver:addr_of_uninstantiated_generic_rejected" {
     var bad: i32 = 0;
     val need: str = "cannot take the address of an uninstantiated generic function";

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -955,6 +955,14 @@ fun report_vector_refused(rc: *ResolveContext, span: token.Span, name: intern.St
             spelling, form.lanes::u64 * type.prim_desc(form.element).bits::u64,
             rc.ctx.vector_bits);
     }
+    # a sub-width vector is well formed and correctly laid out, and refused only
+    # because codegen cannot carry one yet. the message says that rather than
+    # blaming the spelling.
+    if (form.status == type.VEC_FORM_SUB_WIDTH) {
+        rm = format.sprint(rc.s.alloc,
+            "vector `{}` is {} bits wide, narrower than this target's {}-bit vector register; vectors narrower than the register are not supported yet",
+            spelling, form.bits, rc.ctx.vector_bits);
+    }
     if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
     val msg: str = R.unwrap_ok[str, str](rm);
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -264,6 +264,20 @@ pub val VEC_FORM_OK:        VecFormStatus = 1;
 pub val VEC_FORM_TOO_WIDE:  VecFormStatus = 2;
 # a well formed element with a degenerate lane count (0 or 1)
 pub val VEC_FORM_BAD_LANES: VecFormStatus = 3;
+# a well formed shape within the width bound but NARROWER than the vector register
+#
+# Temporary, and the only thing standing between this form and `vec3` (#2687). The
+# frontend and the layout policy both carry a sub-width vector correctly; the backend
+# does not, because a sub-width vector is the first value whose REGISTER width (a whole
+# vector register) and MEMORY footprint (its packed lane bytes) differ, and
+# `be.codegen.mir.context.op_width_of` answers one number for both. Carrying a move at
+# the memory width truncates the top lane, and carrying a store at the register width
+# clobbers the next field. Splitting the two is a backend project.
+#
+# Refused BY NAME here rather than accepted and miscompiled: a shape that resolves and
+# then silently drops a lane is far worse than one that does not resolve. Lifting this
+# is deleting the status and its one check, not a rewrite.
+pub val VEC_FORM_SUB_WIDTH:  VecFormStatus = 4;
 
 # the shape a `TxN` spelling denotes, and whether the target admits it
 # ---
@@ -352,7 +366,11 @@ pub fun vector_form(name: str, vector_bits: u32) VecForm {
     val width: u64 = prim_desc(element).bits::u64 * lanes;
     if (width > vector_bits::u64) { f.status = VEC_FORM_TOO_WIDE; ret f; }
 
-    f.bits   = width::u32;
+    f.bits = width::u32;
+    # a vector that does not FILL the register is well formed and correctly laid out,
+    # but the backend cannot carry one yet (see VEC_FORM_SUB_WIDTH).
+    if (width < vector_bits::u64) { f.status = VEC_FORM_SUB_WIDTH; ret f; }
+
     f.status = VEC_FORM_OK;
     ret f;
 }
@@ -1975,23 +1993,29 @@ test "mach.lang.type.vector_form:reads_the_form_and_the_bound" {
         vi = vi + 1;
     }
 
-    # the sub-128 forms the issue exists for, with their element and lane count
-    # checked rather than only their acceptance.
+    # the sub-128 forms the issue exists for. READ correctly - element, lane count and
+    # width are all recovered - but refused as SUB_WIDTH rather than accepted, because
+    # the backend cannot carry a vector narrower than the register yet. this is the one
+    # status that is expected to become VEC_FORM_OK later.
     val v3: VecForm = vector_form("f32x3", 128);
-    if (v3.status != VEC_FORM_OK) { ret 1; }
-    if (v3.element != TYPE_F32)   { ret 1; }
-    if (v3.lanes != 3)            { ret 1; }
-    if (v3.bits != 96)            { ret 1; }
+    if (v3.status != VEC_FORM_SUB_WIDTH) { ret 1; }
+    if (v3.element != TYPE_F32)          { ret 1; }
+    if (v3.lanes != 3)                   { ret 1; }
+    if (v3.bits != 96)                   { ret 1; }
 
     val u3: VecForm = vector_form("u32x3", 128);
-    if (u3.status != VEC_FORM_OK) { ret 1; }
-    if (u3.element != TYPE_U32)   { ret 1; }
-    if (u3.lanes != 3)            { ret 1; }
+    if (u3.status != VEC_FORM_SUB_WIDTH) { ret 1; }
+    if (u3.element != TYPE_U32)          { ret 1; }
+    if (u3.lanes != 3)                   { ret 1; }
 
     val v2: VecForm = vector_form("f32x2", 128);
-    if (v2.status != VEC_FORM_OK) { ret 1; }
-    if (v2.lanes != 2)            { ret 1; }
-    if (v2.bits != 64)            { ret 1; }
+    if (v2.status != VEC_FORM_SUB_WIDTH) { ret 1; }
+    if (v2.lanes != 2)                   { ret 1; }
+    if (v2.bits != 64)                   { ret 1; }
+
+    # the sub-width refusal is about the REGISTER, not the spelling: the very same
+    # f32x4 that fills a 128-bit register is sub-width on a 256-bit one.
+    if (vector_form("f32x4", 256).status != VEC_FORM_SUB_WIDTH) { ret 1; }
 
     # REFUSED: wider than the bound. f32x7 is 224 bits, so a 128-bit target must
     # report it as too wide rather than as an unknown name.
@@ -2012,11 +2036,11 @@ test "mach.lang.type.vector_form:reads_the_form_and_the_bound" {
     # REFUSED: a degenerate lane count is its own outcome, not a width failure.
     if (vector_form("f32x1", 128).status != VEC_FORM_BAD_LANES) { ret 1; }
 
-    # the bound is the target's, not a constant: a 64-bit vector unit admits
-    # f32x2 and refuses the f32x4 a 128-bit one takes.
+    # the bound is the target's, not a constant: a 64-bit vector unit fills on f32x2
+    # and refuses the f32x4 a 128-bit one takes.
     if (vector_form("f32x2", 64).status != VEC_FORM_OK)        { ret 1; }
     if (vector_form("f32x4", 64).status != VEC_FORM_TOO_WIDE)  { ret 1; }
-    # and a wider unit admits what 128 bits refuses, so the form does not itself
+    # and a wider unit fills on what 128 bits refuses, so the form does not itself
     # cap at 128 (the super-128 register classes are a separate problem).
     if (vector_form("f32x8", 256).status != VEC_FORM_OK) { ret 1; }
 


### PR DESCRIPTION
Fixed the miscompile #2695 left on `dev`.

```
i32x3{10,20,30} + i32x3{1,2,3}   ->  lanes 11, 22, 0     (lane sum 33, correct 66)
```

## Cause

`src/lang/be/codegen/mir/context.mach`, `op_width_of`, sizes a value from a ladder of `1/2/4/8/16` and otherwise falls through to `gpr_width`. Its own doc comment says it returns *"the operand width in bytes (1, 2, 4, 8, or 16 for a vector)"* — so this is **not a function behaving incorrectly, it is a caller asking a question the contract does not cover**, which is why the ladder reads as reasonable.

Invisible before lane-derived layout because every vector was exactly 16 bytes, so a vector's register width and its memory footprint were the same number. Separating them is what exposed it.

The obvious fix does not work either, and both were measured rather than reasoned about. Carrying a vector at the full register width fixes the arithmetic exactly (lane sum 66) and then overruns a 12-byte slot: `rec Packed { v: i32x3; guard: i32; }` with `guard` written first returns **0** instead of 99.

Splitting the two widths is filed as **#2697**, whose acceptance deletes this refusal as a one-line change.

## The affected set is wider than 12 bytes, and the refusal is conservative on purpose

| shape | size | result |
|---|---|---|
| `i8x3` | 3 | correct |
| `i16x3` | 6 | correct |
| `i32x2` | 8 | correct |
| `i8x9` | 9 | **last lane wrong** |
| `i16x5` | 10 | **last lane wrong** |
| `i32x3` / `f32x3` | 12 | **last lane wrong** |
| `i16x7` | 14 | **last lane wrong** |
| `i32x4` | 16 | correct |

The rule is **any size strictly between `gpr_width` and 16**: below 8 the 8-byte move over-reads but carries every byte, at 8 and 16 it hits a rung, between 9 and 15 it truncates. The hole is **target-dependent**, not a property of 12.

**This refuses every sub-register-width vector, including the 3, 6 and 8-byte shapes that currently work.** Deliberately:

1. Those shapes work **by accident** — correct because an over-wide move is harmless, not because anything carries them deliberately. Nothing exercises them and the same conflation sits underneath them.
2. The correct set is defined against `gpr_width`, so *which* sub-width vectors happen to work is per-target. One rule refusing all of them is right on every target; a rule tuned to x86-64 would admit shapes that break where the GP word is narrower.

A reader who tests `i32x2`, finds it working, and concludes the refusal is wrong should read this section.

## Diagnostics

```
error: vector `f32x3` is 96 bits wide, narrower than this target's 128-bit vector register; codegen cannot carry a vector narrower than the register yet (#2697)
error: vector `f32x7` is 224 bits wide, more than this target's 128-bit vector width
error: vector `f32x1` needs at least 2 lanes
error: unresolved type name `matrix4`
```

## Unchanged from #2695

The form, `vector_bits`, the lane-derived layout fold, `doc/language/types.md`, and the repaired `dedup_size_align` test all stay exactly as merged — ABI classification and the SPIR-V leg still need them underneath.

Correcting my own earlier wording: **`f32x2` was never one of the ten.** Those are `f32x4 f64x2 i8x16 i16x8 i32x4 i64x2 u8x16 u16x8 u32x4 u64x2`, all exactly 128 bits. `f32x2` became spellable only under the form, so neither wrong-width case is a regression of shipped behaviour — both are new surface that has never been correct.

## Tests

Pinned per boundary, so an implementation refusing everything would fail: **accepted at exactly 128** (all ten, individually), **refused below**, **refused above**, plus the degenerate lane count and the not-a-vector fall-through. Verified by mutation.

## CI cannot catch this class

**CI went fully green on the miscompiling commit** — every leg, including all three `int` matrices. The 42 `vector_runtime` cases all cover the ten 128-bit shapes; nothing exercises a sub-128 vector at runtime.

Green on this repo currently means *"128-bit vectors work"*, not *"vectors work"*. Anyone reviewing #2697 should run lane values rather than trust the matrix.

Refs #2687, #2697.

---

*Note: the vector-name reservation rule discussed during review is **not** in this PR — it landed after the merge and is now [#2699](https://github.com/briar-systems/mach/pull/2699).*
