### PR TITLE
types: reserve vector spellings, so a type named for one is reported not silently shadowed

### DIFF
--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -35,8 +35,26 @@ u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 The spelling is `<u|i|f><width>x<count>` with a **single** `x`. A name like
 `f32x4x4` is not a vector type (it resolves as an ordinary identifier); a matrix
 is an algorithm over vectors and belongs in a library over vector elements, not
-the language. A vector spelling is recognized only in type position, so a value
-may still be named `f32x4` without colliding with the type.
+the language.
+
+A vector spelling is recognized only in **type position**, so a *value* may still
+be named `f32x4` without colliding with the type:
+
+```mach
+val f32x4: i64 = 7;             # fine: values are a different position
+```
+
+A **type** may not. `rec`, `uni`, and `def` reject a name spelled as a vector
+form, because a type declared with a vector's name would be silently unreachable
+— every use in type position resolves to the vector instead:
+
+```mach
+rec f32x3 { x: f32; }           # error: `f32x3` is spelled as a vector type
+```
+
+This holds for any well-formed spelling, including ones this target does not
+currently admit (`f32x3`, `f32x7`), so the name cannot be claimed and then
+collide when the bound moves.
 
 Three rules bound the form:
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6256,6 +6256,43 @@ test "mach.lang.driver:secret_gates_rejected" {
 # vector width (#2687), so the three refusals must each be reported as themselves rather
 # than collapsing into "unresolved type name", which is what a table lookup would say
 # about every one of them
+# a `rec` / `uni` / `def` whose name is spelled as a vector form is refused, because a
+# type spelling is read in type position ahead of scope and the declaration would be
+# silently unreachable (#2687). the hazard predates the form for the ten seeded names -
+# `rec u8x16` compiled clean and `$size_of(u8x16)` answered 16 from the builtin - so the
+# rule covers the ten too rather than being two rules wearing one name
+test "mach.lang.driver:vector_named_type_declaration_rejected" {
+    var bad: i32 = 0;
+    val need: str = "cannot also name a type";
+
+    # the ten that were already hazardous before the form existed
+    if (!ut_sema_rejects_with("rec u8x16 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+    if (!ut_sema_rejects_with("uni i32x4 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+    if (!ut_sema_rejects_with("def f32x4: i64;\nfun main() i64 { ret 0; }\n", need))        { bad = 1; }
+
+    # a shape the target does not currently admit is reserved just the same: `f32x3` and
+    # `f32x7` are still vector SPELLINGS, and letting a type take the name would plant a
+    # collision for whenever the bound moves.
+    if (!ut_sema_rejects_with("rec f32x3 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+    if (!ut_sema_rejects_with("rec f32x7 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+
+    # NOT A VECTOR SPELLING: ordinary type names are untouched, which is the arm that
+    # must not be lost - the guard keys on the grammar, not on containing an `x`.
+    if (!ut_sema_clean("rec matrix4 { a: i64; }\nfun main() i64 { ret 0; }\n"))             { bad = 1; }
+    if (!ut_sema_clean("rec Vertex { pos: i64; }\nfun main() i64 { ret 0; }\n"))            { bad = 1; }
+    if (!ut_sema_clean("rec f32x04 { a: i64; }\nfun main() i64 { ret 0; }\n"))              { bad = 1; }
+    if (!ut_sema_clean("def ptrx2: i64;\nfun main() i64 { ret 0; }\n"))                     { bad = 1; }
+
+    # VALUES ARE UNAFFECTED. a value named for a vector is not shadowed by anything,
+    # since the form is read in type position only, and mach's own sources name locals
+    # after the shapes they carry. refusing these would be a break for no hazard.
+    if (!ut_sema_clean("fun main() i64 { val f32x4: i64 = 7; ret f32x4; }\n"))               { bad = 1; }
+    if (!ut_sema_clean("fun i32x4() i64 { ret 3; }\nfun main() i64 { ret i32x4(); }\n"))    { bad = 1; }
+    if (!ut_sema_clean("var u8x16: i64;\nfun main() i64 { ret u8x16; }\n"))                 { bad = 1; }
+
+    ret bad;
+}
+
 test "mach.lang.driver:vector_form_bounds_reported_as_themselves" {
     var bad: i32 = 0;
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -960,7 +960,7 @@ fun report_vector_refused(rc: *ResolveContext, span: token.Span, name: intern.St
     # blaming the spelling.
     if (form.status == type.VEC_FORM_SUB_WIDTH) {
         rm = format.sprint(rc.s.alloc,
-            "vector `{}` is {} bits wide, narrower than this target's {}-bit vector register; vectors narrower than the register are not supported yet",
+            "vector `{}` is {} bits wide, narrower than this target's {}-bit vector register; codegen cannot carry a vector narrower than the register yet (#2697)",
             spelling, form.bits, rc.ctx.vector_bits);
     }
     if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
@@ -1061,11 +1061,62 @@ fun collect_one_decl(rc: *ResolveContext, decl_id: id.DeclId, scope: ScopeId, at
 # scope:     scope to bind into
 # ret:       ok(true), or an allocation error
 fun declare_decl(rc: *ResolveContext, kind: SymKind, flags: u8, name_span: token.Span, decl_id: id.DeclId, scope: ScopeId) R.Result[bool, str] {
+    val rn: R.Result[bool, str] = reject_vector_named_type(rc, kind, name_span);
+    if (R.is_err[bool, str](rn)) { ret rn; }
+
     val r: R.Result[SymbolId, str] = declare(rc, kind, flags, name_span, decl_id, 0, rc.own_module, scope);
     if (R.is_err[SymbolId, str](r)) { ret R.err[bool, str](R.unwrap_err[SymbolId, str](r)); }
     if (rc.decl_symbol != nil) {
         rc.decl_symbol[decl_id] = R.unwrap_ok[SymbolId, str](r);
     }
+    ret R.ok[bool, str](true);
+}
+
+# refuse a `rec` / `uni` / `def` whose name is spelled as a vector form
+#
+# A TYPE spelling is read in type position ahead of scope, so a type declared with a
+# vector's name is silently unreachable: `rec u8x16 { a: i64; }` compiles clean today,
+# `$size_of(u8x16)` answers 16 from the builtin, and the only symptom is a baffling
+# "no such field `a` on type u8x16" at the use site. That hazard predates #2687 for the
+# ten seeded spellings; reading the form as a grammar widens it from ten names to a
+# whole family, which is what makes reporting it worth the source break.
+#
+# ONE RULE, and it deliberately covers the ten as well. A builtin set that silently
+# shadows while a parsed set errors would be two rules wearing one name, and the ten
+# are not special any more.
+#
+# VALUES ARE UNAFFECTED, and that is not an oversight. A `val` / `var` / `fun` named
+# `f32x4` is not shadowed by anything: the form is consulted in type position only, so
+# the binding stays reachable and usable. Refusing those would break mach's own sources,
+# which name several locals after the shapes they carry (`type.mach`'s `val f32x4`,
+# `layout.mach`'s `val i16x4`), for no hazard at all.
+# ---
+# rc:        resolver state for the module being resolved
+# kind:      the symbol kind being declared
+# name_span: span of the decl's name
+# ret:       ok(true), or a reported collision
+fun reject_vector_named_type(rc: *ResolveContext, kind: SymKind, name_span: token.Span) R.Result[bool, str] {
+    if (kind != SYM_REC && kind != SYM_UNI && kind != SYM_DEF) { ret R.ok[bool, str](true); }
+    if (name_span.len == 0) { ret R.ok[bool, str](true); }
+
+    val r_id: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, name_span);
+    if (R.is_err[intern.StrId, str](r_id)) { ret R.ok[bool, str](true); }
+    val name_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_id);
+
+    val no: O.Option[str] = intern.lookup(?rc.s.interner, name_id);
+    if (O.is_none[str](no)) { ret R.ok[bool, str](true); }
+    val spelling: str = O.unwrap[str](no);
+    if (!type.is_vector_spelling(spelling)) { ret R.ok[bool, str](true); }
+
+    val rm: R.Result[str, str] = format.sprint(rc.s.alloc,
+        "`{}` is spelled as a vector type `<element>x<lanes>`, so it cannot also name a type; the declaration would be unreachable",
+        spelling);
+    if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
+    val msg: str = R.unwrap_ok[str, str](rm);
+
+    val emit: R.Result[bool, str] = diagnostic.error(?rc.s.diags, rc.a.file_id, name_span, msg);
+    A.deallocate[char](rc.s.alloc, msg::*char, str_len(msg) + 1);
+    if (R.is_err[bool, str](emit)) { ret emit; }
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -292,6 +292,21 @@ pub rec VecForm {
     bits:    u32;
 }
 
+# whether `name` is spelled as a vector form at all, regardless of any target bound
+#
+# The declaration guard reads this rather than `vector_form`'s status, because whether
+# a spelling COLLIDES with the vector grammar must not depend on the target's width.
+# `rec f32x8` is a landmine on a 128-bit target too: the very same source is a real
+# vector type on a 256-bit one, so the name is reserved on both or the rule is not one
+# rule. The bound passed here is therefore irrelevant and only OK / TOO_WIDE /
+# SUB_WIDTH can differ by it, never NONE.
+# ---
+# name: the spelling to test
+# ret:  true when `name` parses as `<element>x<lanes>`
+pub fun is_vector_spelling(name: str) bool {
+    ret vector_form(name, 0).status != VEC_FORM_NONE;
+}
+
 # read `name` as the vector form `<element>x<lanes>`, bounded by `vector_bits`
 #
 # THE FORM, NOT A TABLE (#2687). A vector type is any primitive scalar element


### PR DESCRIPTION
Follows #2695 and #2698. This is the name-collision rule from the #2687 review; it landed just after #2698 merged, so it is its own PR.

## The hazard, checked rather than assumed

The instruction was to find out what actually happens today before writing a rule, on the theory that `seed_vectors` interning those spellings as `SYM_VECTOR` symbols might already make the declaration a redeclaration error. **It does not.** On `dev`:

```mach
rec u8x16 { a: i64; }           // compiles clean, no diagnostic at all
$size_of(u8x16)                 // 16 — the builtin wins
v.a                             // error: no such field `a` on type u8x16
```

The record is silently unreachable, and the only symptom is a baffling error at the use site that points at the wrong thing entirely. `uni` and `def` behave identically — all three were measured, not inferred.

So this is a **pre-existing silent shadow**, not something #2687 introduced. What #2687 did was widen it from ten fixed names to a whole grammar, which is what makes it worth reporting now and worth the source break.

## The rule

`rec` / `uni` / `def` whose name parses as a vector form is reported:

```
error: `u8x16` is spelled as a vector type `<element>x<lanes>`, so it cannot also name a type; the declaration would be unreachable
```

Three decisions worth stating, because each could reasonably have gone the other way:

**One rule, covering the ten as well.** Not "the builtin wins" and not "the user type wins" — the collision is reported. A builtin set that silently shadows while a parsed set errors would be two rules wearing one name, and the ten stopped being special the moment the form replaced the table.

**Keyed on the spelling, not on the target's bound.** `f32x3` and `f32x7` are reserved too, even though neither is currently an admissible type. Otherwise a name could be claimed on a 128-bit target and collide on a wider one from identical source — the reservation must not be target-dependent or it is not a reservation.

**Values are deliberately untouched.** A `val` / `var` / `fun` named `f32x4` is shadowed by nothing, because the form is read in type position only, so the binding stays reachable and usable:

```mach
val f32x4: i64 = 7;             // still fine
```

That is not an oversight or a scoping convenience. Refusing value declarations would break **mach's own sources**, which name locals after the shapes they carry — `type.mach` has `val f32x4`, `val i8x16`, `val u64x2`; `layout.mach` has `val i16x4` — for no hazard whatsoever.

## Source-compatibility impact

This is a **source break** for any program declaring a `rec` / `uni` / `def` named for a vector form. Such a program was already broken, silently — the declaration could never be referenced — so the break converts an unreachable type into a diagnostic rather than taking away working behaviour.

Refusing the ten breaks neither mach's nor mach-std's sources: full suite green, and the self-host fixpoint still byte-identical, which is itself the check that the compiler's own sources contain no such declaration.

## Tests

`mach.lang.driver:vector_named_type_declaration_rejected` covers both sides:

- refused: `rec u8x16`, `uni i32x4`, `def f32x4` (the pre-existing hazard), and `rec f32x3` / `rec f32x7` (reserved though not currently admissible)
- **accepted**: `rec matrix4`, `rec Vertex`, `rec f32x04`, `def ptrx2` — the guard keys on the grammar, not on containing an `x`
- **accepted**: `val f32x4`, `fun i32x4`, `var u8x16` — the value arm that must not be lost

Verified by mutation in both directions, since a guard like this can fail either by not firing or by firing too broadly:

- disabling the guard → the refusal arms fail
- widening it to value kinds → the value arms fail

Full suite green (1254). Self-host fixpoint byte-identical.

Refs #2687.
