### PR TITLE
fix(link): size the mach-o header reservation from the image

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -614,6 +614,91 @@ produce_macho_mod_init() {
     echo "mod_init_func=type9-rebased"
 }
 
+# produce_macho_header_span <runmode> <target> <binary>
+# Assert that a darwin image whose load commands exceed one page linked, and that
+# its header agrees with the span the linker reserved below the first segment.
+#
+# The Mach-O header carries an 80-byte section_64 per named section and an
+# LC_LOAD_DYLIB per dependency, so it grows with the image; `sizeofcmds` is a
+# uint32 and the format caps it nowhere near a page. A fixed one-page reservation
+# refused the link outright (#2690).
+#
+# Size alone would be a weak observable. The reservation is what places __TEXT:
+# the header occupies the gap between the image base and the first segment, so a
+# writer that widened the gap on its own would slide __TEXT, and __PAGEZERO with
+# it, below the base - the defect of #2599, which every size check would still
+# pass. The framing is therefore asserted alongside: __PAGEZERO spans the whole low
+# region, __TEXT is based exactly where __PAGEZERO ends, and the header sits at
+# file offset 0 inside it.
+#
+# The page size is read from the image's own cputype rather than passed in, since
+# the leg here is linux and darwin maps 16 KiB pages on arm64 and 4 KiB on x86_64.
+produce_macho_header_span() {
+    bin=$3
+    magic=$(read_le_uint "$bin" 0 4)
+    [ "$magic" = "4277009103" ] || { echo "int: macho-header-span: not a 64-bit mach-o (magic $magic)" >&2; return 2; }
+
+    cputype=$(read_le_uint "$bin" 4 4)
+    case "$cputype" in
+        16777223) page=4096  ;;   # CPU_TYPE_X86_64
+        16777228) page=16384 ;;   # CPU_TYPE_ARM64
+        *) echo "int: macho-header-span: unexpected cputype $cputype" >&2; return 2 ;;
+    esac
+
+    ncmds=$(read_le_uint "$bin" 16 4)
+    sizeofcmds=$(read_le_uint "$bin" 20 4)
+
+    pagezero_size=
+    text_vmaddr=
+    text_fileoff=
+    sect_addr=
+    sect_fileoff=
+    dylibs=0
+    off=32
+    i=0
+    while [ "$i" -lt "$ncmds" ]; do
+        cmd=$(read_le_uint "$bin" "$off" 4)
+        cmdsize=$(read_le_uint "$bin" $((off + 4)) 4)
+        case "$cmd" in
+            25)   # LC_SEGMENT_64
+                name=$(dd if="$bin" bs=1 skip=$((off + 8)) count=16 2>/dev/null | tr '\0' '\n' | head -n 1)
+                if [ "$name" = "__PAGEZERO" ]; then
+                    pagezero_size=$(read_le_uint "$bin" $((off + 32)) 8)
+                fi
+                if [ "$name" = "__TEXT" ]; then
+                    text_vmaddr=$(read_le_uint "$bin" $((off + 24)) 8)
+                    text_fileoff=$(read_le_uint "$bin" $((off + 40)) 8)
+                    nsects=$(read_le_uint "$bin" $((off + 64)) 4)
+                    [ "$nsects" -gt 0 ] || { echo "int: macho-header-span: __TEXT carries no section" >&2; return 2; }
+                    sect_addr=$(read_le_uint "$bin" $((off + 72 + 32)) 8)
+                    sect_fileoff=$(read_le_uint "$bin" $((off + 72 + 48)) 4)
+                fi
+                ;;
+            12) dylibs=$((dylibs + 1)) ;;   # LC_LOAD_DYLIB
+        esac
+        [ "$cmdsize" -ge 8 ] || { echo "int: macho-header-span: zero-size load command" >&2; return 2; }
+        off=$((off + cmdsize))
+        i=$((i + 1))
+    done
+
+    [ -n "$pagezero_size" ] || { echo "int: macho-header-span: no __PAGEZERO" >&2; return 2; }
+    [ -n "$text_vmaddr" ]   || { echo "int: macho-header-span: no __TEXT" >&2; return 2; }
+
+    # the reservation is the gap the header fills: from __TEXT's start to its first
+    # section's content.
+    reservation=$((sect_addr - text_vmaddr))
+
+    printf 'sizeofcmds_over_one_page=%s\n' "$(( sizeofcmds > page ))"
+    printf 'multiple_dylib_loads=%s\n' "$(( dylibs > 1 ))"
+    printf 'reservation_whole_pages=%s\n' "$(( reservation > 0 && reservation % page == 0 ))"
+    printf 'header_fits_reservation=%s\n' "$(( 32 + sizeofcmds <= reservation ))"
+    printf 'first_section_fileoff_is_reservation=%s\n' "$(( sect_fileoff == reservation ))"
+    printf 'pagezero_vmsize=0x%x\n' "$pagezero_size"
+    printf 'text_vmaddr=0x%x\n' "$text_vmaddr"
+    printf 'text_fileoff=%s\n' "$text_fileoff"
+    printf 'pagezero_abuts_text=%s\n' "$(( pagezero_size == text_vmaddr ))"
+}
+
 # produce_macho_sections <runmode> <target> <binary>
 # Assert that a linked darwin image kept the (segment, section) identity of its
 # inputs, which is what a name-based runtime scan needs: libobjc walks
@@ -2381,6 +2466,7 @@ produce() {
         embed-dedup) produce_embed_dedup "$@" ;;
         macho-framing) produce_macho_framing "$@" ;;
         macho-sections) produce_macho_sections "$@" ;;
+        macho-header-span) produce_macho_header_span "$@" ;;
         macho-imports) produce_macho_imports "$@" ;;
         macho-mod-init) produce_macho_mod_init "$@" ;;
         macho-abs-bind) produce_macho_abs_bind "$@" ;;

--- a/int/surface/macho-header-span-aarch64/case.conf
+++ b/int/surface/macho-header-span-aarch64/case.conf
@@ -1,0 +1,14 @@
+# the arm64 half of macho-header-span-x86_64: the same fixture, the same header
+# reservation contract, and a 16 KiB darwin page instead of 4 KiB (#2690).
+#
+# Both legs are needed because the two targets share the Mach-O writer but not the
+# page size, so a reservation sized from a hardcoded 4096 would pass on x86_64 and
+# still refuse this link. On Apple Silicon the kernel additionally admits a signed
+# image only when the header lies inside the signed, mapped __TEXT, so the golden
+# pins the header at file offset 0 inside a __TEXT based exactly on the image base.
+#
+# Read host-side on the cheap linux leg; the image is never run.
+run: macho-header-span
+targets: linux
+build-target: darwin-aarch64
+build-flags: --pie

--- a/int/surface/macho-header-span-aarch64/expect.darwin-aarch64.txt
+++ b/int/surface/macho-header-span-aarch64/expect.darwin-aarch64.txt
@@ -1,0 +1,9 @@
+sizeofcmds_over_one_page=1
+multiple_dylib_loads=1
+reservation_whole_pages=1
+header_fits_reservation=1
+first_section_fileoff_is_reservation=1
+pagezero_vmsize=0x100000000
+text_vmaddr=0x100000000
+text_fileoff=0
+pagezero_abuts_text=1

--- a/int/surface/macho-header-span-aarch64/mach.toml
+++ b/int/surface/macho-header-span-aarch64/mach.toml
@@ -1,0 +1,108 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["System", "objc", "cxx", "iconv", "z", "xml2", "bz2", "curses"]
+need = []
+
+[link.System]
+source = "system"
+name = "/usr/lib/libSystem.B.dylib"
+library = "System"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.objc]
+source = "system"
+name = "/usr/lib/libobjc.A.dylib"
+library = "objc"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.cxx]
+source = "system"
+name = "/usr/lib/libc++.1.dylib"
+library = "cxx"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.iconv]
+source = "system"
+name = "/usr/lib/libiconv.2.dylib"
+library = "iconv"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.z]
+source = "system"
+name = "/usr/lib/libz.1.dylib"
+library = "z"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.xml2]
+source = "system"
+name = "/usr/lib/libxml2.2.dylib"
+library = "xml2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.bz2]
+source = "system"
+name = "/usr/lib/libbz2.1.0.dylib"
+library = "bz2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.curses]
+source = "system"
+name = "/usr/lib/libcurses.dylib"
+library = "curses"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/macho-header-span-aarch64/src/main.mach
+++ b/int/surface/macho-header-span-aarch64/src/main.mach
@@ -1,0 +1,928 @@
+# a Mach-O header outgrows its one-page reservation as soon as an image carries
+# enough named sections: since #2606 the linker preserves input section identity,
+# and every surviving section is another 80-byte section_64 in the header. A
+# vendored objective-c archive carries dozens (__objc_classlist, __objc_const,
+# __objc_data, __cstring, __gcc_except_tab, ...) alongside its system-library
+# dependencies, which is how briar-systems/mach-glfw#32 reached 4 KiB of load
+# commands and was refused (#2690).
+#
+# The 224 `#[section]` globals below stand in for that section table without
+# needing the macOS SDK to build one: they cross the reservation on both darwin
+# page sizes (4 KiB x86_64, 16 KiB arm64). The system-library dependencies in
+# mach.toml are the second contributor, an LC_LOAD_DYLIB each, and they make the
+# image the shape the reported consumer has rather than a section table alone.
+#
+# The program is never RUN - the observable is the emitted header, read host-side
+# on the linux leg - so the imports need only be referenced, not called correctly.
+#[library("System")]
+ext fun Sleep(ms: u32);
+
+#[library("objc")]
+ext fun objc_msgSend(recv: u64, sel: u64);
+
+#[library("z")]
+ext fun compressBound(n: u64) u64;
+
+#[section(".mach_sec000")] #[symbol("g_000")]
+pub var g_000: u64 = 1;
+
+#[section(".mach_sec001")] #[symbol("g_001")]
+pub var g_001: u64 = 2;
+
+#[section(".mach_sec002")] #[symbol("g_002")]
+pub var g_002: u64 = 3;
+
+#[section(".mach_sec003")] #[symbol("g_003")]
+pub var g_003: u64 = 4;
+
+#[section(".mach_sec004")] #[symbol("g_004")]
+pub var g_004: u64 = 5;
+
+#[section(".mach_sec005")] #[symbol("g_005")]
+pub var g_005: u64 = 6;
+
+#[section(".mach_sec006")] #[symbol("g_006")]
+pub var g_006: u64 = 7;
+
+#[section(".mach_sec007")] #[symbol("g_007")]
+pub var g_007: u64 = 8;
+
+#[section(".mach_sec008")] #[symbol("g_008")]
+pub var g_008: u64 = 9;
+
+#[section(".mach_sec009")] #[symbol("g_009")]
+pub var g_009: u64 = 10;
+
+#[section(".mach_sec010")] #[symbol("g_010")]
+pub var g_010: u64 = 11;
+
+#[section(".mach_sec011")] #[symbol("g_011")]
+pub var g_011: u64 = 12;
+
+#[section(".mach_sec012")] #[symbol("g_012")]
+pub var g_012: u64 = 13;
+
+#[section(".mach_sec013")] #[symbol("g_013")]
+pub var g_013: u64 = 14;
+
+#[section(".mach_sec014")] #[symbol("g_014")]
+pub var g_014: u64 = 15;
+
+#[section(".mach_sec015")] #[symbol("g_015")]
+pub var g_015: u64 = 16;
+
+#[section(".mach_sec016")] #[symbol("g_016")]
+pub var g_016: u64 = 17;
+
+#[section(".mach_sec017")] #[symbol("g_017")]
+pub var g_017: u64 = 18;
+
+#[section(".mach_sec018")] #[symbol("g_018")]
+pub var g_018: u64 = 19;
+
+#[section(".mach_sec019")] #[symbol("g_019")]
+pub var g_019: u64 = 20;
+
+#[section(".mach_sec020")] #[symbol("g_020")]
+pub var g_020: u64 = 21;
+
+#[section(".mach_sec021")] #[symbol("g_021")]
+pub var g_021: u64 = 22;
+
+#[section(".mach_sec022")] #[symbol("g_022")]
+pub var g_022: u64 = 23;
+
+#[section(".mach_sec023")] #[symbol("g_023")]
+pub var g_023: u64 = 24;
+
+#[section(".mach_sec024")] #[symbol("g_024")]
+pub var g_024: u64 = 25;
+
+#[section(".mach_sec025")] #[symbol("g_025")]
+pub var g_025: u64 = 26;
+
+#[section(".mach_sec026")] #[symbol("g_026")]
+pub var g_026: u64 = 27;
+
+#[section(".mach_sec027")] #[symbol("g_027")]
+pub var g_027: u64 = 28;
+
+#[section(".mach_sec028")] #[symbol("g_028")]
+pub var g_028: u64 = 29;
+
+#[section(".mach_sec029")] #[symbol("g_029")]
+pub var g_029: u64 = 30;
+
+#[section(".mach_sec030")] #[symbol("g_030")]
+pub var g_030: u64 = 31;
+
+#[section(".mach_sec031")] #[symbol("g_031")]
+pub var g_031: u64 = 32;
+
+#[section(".mach_sec032")] #[symbol("g_032")]
+pub var g_032: u64 = 33;
+
+#[section(".mach_sec033")] #[symbol("g_033")]
+pub var g_033: u64 = 34;
+
+#[section(".mach_sec034")] #[symbol("g_034")]
+pub var g_034: u64 = 35;
+
+#[section(".mach_sec035")] #[symbol("g_035")]
+pub var g_035: u64 = 36;
+
+#[section(".mach_sec036")] #[symbol("g_036")]
+pub var g_036: u64 = 37;
+
+#[section(".mach_sec037")] #[symbol("g_037")]
+pub var g_037: u64 = 38;
+
+#[section(".mach_sec038")] #[symbol("g_038")]
+pub var g_038: u64 = 39;
+
+#[section(".mach_sec039")] #[symbol("g_039")]
+pub var g_039: u64 = 40;
+
+#[section(".mach_sec040")] #[symbol("g_040")]
+pub var g_040: u64 = 41;
+
+#[section(".mach_sec041")] #[symbol("g_041")]
+pub var g_041: u64 = 42;
+
+#[section(".mach_sec042")] #[symbol("g_042")]
+pub var g_042: u64 = 43;
+
+#[section(".mach_sec043")] #[symbol("g_043")]
+pub var g_043: u64 = 44;
+
+#[section(".mach_sec044")] #[symbol("g_044")]
+pub var g_044: u64 = 45;
+
+#[section(".mach_sec045")] #[symbol("g_045")]
+pub var g_045: u64 = 46;
+
+#[section(".mach_sec046")] #[symbol("g_046")]
+pub var g_046: u64 = 47;
+
+#[section(".mach_sec047")] #[symbol("g_047")]
+pub var g_047: u64 = 48;
+
+#[section(".mach_sec048")] #[symbol("g_048")]
+pub var g_048: u64 = 49;
+
+#[section(".mach_sec049")] #[symbol("g_049")]
+pub var g_049: u64 = 50;
+
+#[section(".mach_sec050")] #[symbol("g_050")]
+pub var g_050: u64 = 51;
+
+#[section(".mach_sec051")] #[symbol("g_051")]
+pub var g_051: u64 = 52;
+
+#[section(".mach_sec052")] #[symbol("g_052")]
+pub var g_052: u64 = 53;
+
+#[section(".mach_sec053")] #[symbol("g_053")]
+pub var g_053: u64 = 54;
+
+#[section(".mach_sec054")] #[symbol("g_054")]
+pub var g_054: u64 = 55;
+
+#[section(".mach_sec055")] #[symbol("g_055")]
+pub var g_055: u64 = 56;
+
+#[section(".mach_sec056")] #[symbol("g_056")]
+pub var g_056: u64 = 57;
+
+#[section(".mach_sec057")] #[symbol("g_057")]
+pub var g_057: u64 = 58;
+
+#[section(".mach_sec058")] #[symbol("g_058")]
+pub var g_058: u64 = 59;
+
+#[section(".mach_sec059")] #[symbol("g_059")]
+pub var g_059: u64 = 60;
+
+#[section(".mach_sec060")] #[symbol("g_060")]
+pub var g_060: u64 = 61;
+
+#[section(".mach_sec061")] #[symbol("g_061")]
+pub var g_061: u64 = 62;
+
+#[section(".mach_sec062")] #[symbol("g_062")]
+pub var g_062: u64 = 63;
+
+#[section(".mach_sec063")] #[symbol("g_063")]
+pub var g_063: u64 = 64;
+
+#[section(".mach_sec064")] #[symbol("g_064")]
+pub var g_064: u64 = 65;
+
+#[section(".mach_sec065")] #[symbol("g_065")]
+pub var g_065: u64 = 66;
+
+#[section(".mach_sec066")] #[symbol("g_066")]
+pub var g_066: u64 = 67;
+
+#[section(".mach_sec067")] #[symbol("g_067")]
+pub var g_067: u64 = 68;
+
+#[section(".mach_sec068")] #[symbol("g_068")]
+pub var g_068: u64 = 69;
+
+#[section(".mach_sec069")] #[symbol("g_069")]
+pub var g_069: u64 = 70;
+
+#[section(".mach_sec070")] #[symbol("g_070")]
+pub var g_070: u64 = 71;
+
+#[section(".mach_sec071")] #[symbol("g_071")]
+pub var g_071: u64 = 72;
+
+#[section(".mach_sec072")] #[symbol("g_072")]
+pub var g_072: u64 = 73;
+
+#[section(".mach_sec073")] #[symbol("g_073")]
+pub var g_073: u64 = 74;
+
+#[section(".mach_sec074")] #[symbol("g_074")]
+pub var g_074: u64 = 75;
+
+#[section(".mach_sec075")] #[symbol("g_075")]
+pub var g_075: u64 = 76;
+
+#[section(".mach_sec076")] #[symbol("g_076")]
+pub var g_076: u64 = 77;
+
+#[section(".mach_sec077")] #[symbol("g_077")]
+pub var g_077: u64 = 78;
+
+#[section(".mach_sec078")] #[symbol("g_078")]
+pub var g_078: u64 = 79;
+
+#[section(".mach_sec079")] #[symbol("g_079")]
+pub var g_079: u64 = 80;
+
+#[section(".mach_sec080")] #[symbol("g_080")]
+pub var g_080: u64 = 81;
+
+#[section(".mach_sec081")] #[symbol("g_081")]
+pub var g_081: u64 = 82;
+
+#[section(".mach_sec082")] #[symbol("g_082")]
+pub var g_082: u64 = 83;
+
+#[section(".mach_sec083")] #[symbol("g_083")]
+pub var g_083: u64 = 84;
+
+#[section(".mach_sec084")] #[symbol("g_084")]
+pub var g_084: u64 = 85;
+
+#[section(".mach_sec085")] #[symbol("g_085")]
+pub var g_085: u64 = 86;
+
+#[section(".mach_sec086")] #[symbol("g_086")]
+pub var g_086: u64 = 87;
+
+#[section(".mach_sec087")] #[symbol("g_087")]
+pub var g_087: u64 = 88;
+
+#[section(".mach_sec088")] #[symbol("g_088")]
+pub var g_088: u64 = 89;
+
+#[section(".mach_sec089")] #[symbol("g_089")]
+pub var g_089: u64 = 90;
+
+#[section(".mach_sec090")] #[symbol("g_090")]
+pub var g_090: u64 = 91;
+
+#[section(".mach_sec091")] #[symbol("g_091")]
+pub var g_091: u64 = 92;
+
+#[section(".mach_sec092")] #[symbol("g_092")]
+pub var g_092: u64 = 93;
+
+#[section(".mach_sec093")] #[symbol("g_093")]
+pub var g_093: u64 = 94;
+
+#[section(".mach_sec094")] #[symbol("g_094")]
+pub var g_094: u64 = 95;
+
+#[section(".mach_sec095")] #[symbol("g_095")]
+pub var g_095: u64 = 96;
+
+#[section(".mach_sec096")] #[symbol("g_096")]
+pub var g_096: u64 = 97;
+
+#[section(".mach_sec097")] #[symbol("g_097")]
+pub var g_097: u64 = 98;
+
+#[section(".mach_sec098")] #[symbol("g_098")]
+pub var g_098: u64 = 99;
+
+#[section(".mach_sec099")] #[symbol("g_099")]
+pub var g_099: u64 = 100;
+
+#[section(".mach_sec100")] #[symbol("g_100")]
+pub var g_100: u64 = 101;
+
+#[section(".mach_sec101")] #[symbol("g_101")]
+pub var g_101: u64 = 102;
+
+#[section(".mach_sec102")] #[symbol("g_102")]
+pub var g_102: u64 = 103;
+
+#[section(".mach_sec103")] #[symbol("g_103")]
+pub var g_103: u64 = 104;
+
+#[section(".mach_sec104")] #[symbol("g_104")]
+pub var g_104: u64 = 105;
+
+#[section(".mach_sec105")] #[symbol("g_105")]
+pub var g_105: u64 = 106;
+
+#[section(".mach_sec106")] #[symbol("g_106")]
+pub var g_106: u64 = 107;
+
+#[section(".mach_sec107")] #[symbol("g_107")]
+pub var g_107: u64 = 108;
+
+#[section(".mach_sec108")] #[symbol("g_108")]
+pub var g_108: u64 = 109;
+
+#[section(".mach_sec109")] #[symbol("g_109")]
+pub var g_109: u64 = 110;
+
+#[section(".mach_sec110")] #[symbol("g_110")]
+pub var g_110: u64 = 111;
+
+#[section(".mach_sec111")] #[symbol("g_111")]
+pub var g_111: u64 = 112;
+
+#[section(".mach_sec112")] #[symbol("g_112")]
+pub var g_112: u64 = 113;
+
+#[section(".mach_sec113")] #[symbol("g_113")]
+pub var g_113: u64 = 114;
+
+#[section(".mach_sec114")] #[symbol("g_114")]
+pub var g_114: u64 = 115;
+
+#[section(".mach_sec115")] #[symbol("g_115")]
+pub var g_115: u64 = 116;
+
+#[section(".mach_sec116")] #[symbol("g_116")]
+pub var g_116: u64 = 117;
+
+#[section(".mach_sec117")] #[symbol("g_117")]
+pub var g_117: u64 = 118;
+
+#[section(".mach_sec118")] #[symbol("g_118")]
+pub var g_118: u64 = 119;
+
+#[section(".mach_sec119")] #[symbol("g_119")]
+pub var g_119: u64 = 120;
+
+#[section(".mach_sec120")] #[symbol("g_120")]
+pub var g_120: u64 = 121;
+
+#[section(".mach_sec121")] #[symbol("g_121")]
+pub var g_121: u64 = 122;
+
+#[section(".mach_sec122")] #[symbol("g_122")]
+pub var g_122: u64 = 123;
+
+#[section(".mach_sec123")] #[symbol("g_123")]
+pub var g_123: u64 = 124;
+
+#[section(".mach_sec124")] #[symbol("g_124")]
+pub var g_124: u64 = 125;
+
+#[section(".mach_sec125")] #[symbol("g_125")]
+pub var g_125: u64 = 126;
+
+#[section(".mach_sec126")] #[symbol("g_126")]
+pub var g_126: u64 = 127;
+
+#[section(".mach_sec127")] #[symbol("g_127")]
+pub var g_127: u64 = 128;
+
+#[section(".mach_sec128")] #[symbol("g_128")]
+pub var g_128: u64 = 129;
+
+#[section(".mach_sec129")] #[symbol("g_129")]
+pub var g_129: u64 = 130;
+
+#[section(".mach_sec130")] #[symbol("g_130")]
+pub var g_130: u64 = 131;
+
+#[section(".mach_sec131")] #[symbol("g_131")]
+pub var g_131: u64 = 132;
+
+#[section(".mach_sec132")] #[symbol("g_132")]
+pub var g_132: u64 = 133;
+
+#[section(".mach_sec133")] #[symbol("g_133")]
+pub var g_133: u64 = 134;
+
+#[section(".mach_sec134")] #[symbol("g_134")]
+pub var g_134: u64 = 135;
+
+#[section(".mach_sec135")] #[symbol("g_135")]
+pub var g_135: u64 = 136;
+
+#[section(".mach_sec136")] #[symbol("g_136")]
+pub var g_136: u64 = 137;
+
+#[section(".mach_sec137")] #[symbol("g_137")]
+pub var g_137: u64 = 138;
+
+#[section(".mach_sec138")] #[symbol("g_138")]
+pub var g_138: u64 = 139;
+
+#[section(".mach_sec139")] #[symbol("g_139")]
+pub var g_139: u64 = 140;
+
+#[section(".mach_sec140")] #[symbol("g_140")]
+pub var g_140: u64 = 141;
+
+#[section(".mach_sec141")] #[symbol("g_141")]
+pub var g_141: u64 = 142;
+
+#[section(".mach_sec142")] #[symbol("g_142")]
+pub var g_142: u64 = 143;
+
+#[section(".mach_sec143")] #[symbol("g_143")]
+pub var g_143: u64 = 144;
+
+#[section(".mach_sec144")] #[symbol("g_144")]
+pub var g_144: u64 = 145;
+
+#[section(".mach_sec145")] #[symbol("g_145")]
+pub var g_145: u64 = 146;
+
+#[section(".mach_sec146")] #[symbol("g_146")]
+pub var g_146: u64 = 147;
+
+#[section(".mach_sec147")] #[symbol("g_147")]
+pub var g_147: u64 = 148;
+
+#[section(".mach_sec148")] #[symbol("g_148")]
+pub var g_148: u64 = 149;
+
+#[section(".mach_sec149")] #[symbol("g_149")]
+pub var g_149: u64 = 150;
+
+#[section(".mach_sec150")] #[symbol("g_150")]
+pub var g_150: u64 = 151;
+
+#[section(".mach_sec151")] #[symbol("g_151")]
+pub var g_151: u64 = 152;
+
+#[section(".mach_sec152")] #[symbol("g_152")]
+pub var g_152: u64 = 153;
+
+#[section(".mach_sec153")] #[symbol("g_153")]
+pub var g_153: u64 = 154;
+
+#[section(".mach_sec154")] #[symbol("g_154")]
+pub var g_154: u64 = 155;
+
+#[section(".mach_sec155")] #[symbol("g_155")]
+pub var g_155: u64 = 156;
+
+#[section(".mach_sec156")] #[symbol("g_156")]
+pub var g_156: u64 = 157;
+
+#[section(".mach_sec157")] #[symbol("g_157")]
+pub var g_157: u64 = 158;
+
+#[section(".mach_sec158")] #[symbol("g_158")]
+pub var g_158: u64 = 159;
+
+#[section(".mach_sec159")] #[symbol("g_159")]
+pub var g_159: u64 = 160;
+
+#[section(".mach_sec160")] #[symbol("g_160")]
+pub var g_160: u64 = 161;
+
+#[section(".mach_sec161")] #[symbol("g_161")]
+pub var g_161: u64 = 162;
+
+#[section(".mach_sec162")] #[symbol("g_162")]
+pub var g_162: u64 = 163;
+
+#[section(".mach_sec163")] #[symbol("g_163")]
+pub var g_163: u64 = 164;
+
+#[section(".mach_sec164")] #[symbol("g_164")]
+pub var g_164: u64 = 165;
+
+#[section(".mach_sec165")] #[symbol("g_165")]
+pub var g_165: u64 = 166;
+
+#[section(".mach_sec166")] #[symbol("g_166")]
+pub var g_166: u64 = 167;
+
+#[section(".mach_sec167")] #[symbol("g_167")]
+pub var g_167: u64 = 168;
+
+#[section(".mach_sec168")] #[symbol("g_168")]
+pub var g_168: u64 = 169;
+
+#[section(".mach_sec169")] #[symbol("g_169")]
+pub var g_169: u64 = 170;
+
+#[section(".mach_sec170")] #[symbol("g_170")]
+pub var g_170: u64 = 171;
+
+#[section(".mach_sec171")] #[symbol("g_171")]
+pub var g_171: u64 = 172;
+
+#[section(".mach_sec172")] #[symbol("g_172")]
+pub var g_172: u64 = 173;
+
+#[section(".mach_sec173")] #[symbol("g_173")]
+pub var g_173: u64 = 174;
+
+#[section(".mach_sec174")] #[symbol("g_174")]
+pub var g_174: u64 = 175;
+
+#[section(".mach_sec175")] #[symbol("g_175")]
+pub var g_175: u64 = 176;
+
+#[section(".mach_sec176")] #[symbol("g_176")]
+pub var g_176: u64 = 177;
+
+#[section(".mach_sec177")] #[symbol("g_177")]
+pub var g_177: u64 = 178;
+
+#[section(".mach_sec178")] #[symbol("g_178")]
+pub var g_178: u64 = 179;
+
+#[section(".mach_sec179")] #[symbol("g_179")]
+pub var g_179: u64 = 180;
+
+#[section(".mach_sec180")] #[symbol("g_180")]
+pub var g_180: u64 = 181;
+
+#[section(".mach_sec181")] #[symbol("g_181")]
+pub var g_181: u64 = 182;
+
+#[section(".mach_sec182")] #[symbol("g_182")]
+pub var g_182: u64 = 183;
+
+#[section(".mach_sec183")] #[symbol("g_183")]
+pub var g_183: u64 = 184;
+
+#[section(".mach_sec184")] #[symbol("g_184")]
+pub var g_184: u64 = 185;
+
+#[section(".mach_sec185")] #[symbol("g_185")]
+pub var g_185: u64 = 186;
+
+#[section(".mach_sec186")] #[symbol("g_186")]
+pub var g_186: u64 = 187;
+
+#[section(".mach_sec187")] #[symbol("g_187")]
+pub var g_187: u64 = 188;
+
+#[section(".mach_sec188")] #[symbol("g_188")]
+pub var g_188: u64 = 189;
+
+#[section(".mach_sec189")] #[symbol("g_189")]
+pub var g_189: u64 = 190;
+
+#[section(".mach_sec190")] #[symbol("g_190")]
+pub var g_190: u64 = 191;
+
+#[section(".mach_sec191")] #[symbol("g_191")]
+pub var g_191: u64 = 192;
+
+#[section(".mach_sec192")] #[symbol("g_192")]
+pub var g_192: u64 = 193;
+
+#[section(".mach_sec193")] #[symbol("g_193")]
+pub var g_193: u64 = 194;
+
+#[section(".mach_sec194")] #[symbol("g_194")]
+pub var g_194: u64 = 195;
+
+#[section(".mach_sec195")] #[symbol("g_195")]
+pub var g_195: u64 = 196;
+
+#[section(".mach_sec196")] #[symbol("g_196")]
+pub var g_196: u64 = 197;
+
+#[section(".mach_sec197")] #[symbol("g_197")]
+pub var g_197: u64 = 198;
+
+#[section(".mach_sec198")] #[symbol("g_198")]
+pub var g_198: u64 = 199;
+
+#[section(".mach_sec199")] #[symbol("g_199")]
+pub var g_199: u64 = 200;
+
+#[section(".mach_sec200")] #[symbol("g_200")]
+pub var g_200: u64 = 201;
+
+#[section(".mach_sec201")] #[symbol("g_201")]
+pub var g_201: u64 = 202;
+
+#[section(".mach_sec202")] #[symbol("g_202")]
+pub var g_202: u64 = 203;
+
+#[section(".mach_sec203")] #[symbol("g_203")]
+pub var g_203: u64 = 204;
+
+#[section(".mach_sec204")] #[symbol("g_204")]
+pub var g_204: u64 = 205;
+
+#[section(".mach_sec205")] #[symbol("g_205")]
+pub var g_205: u64 = 206;
+
+#[section(".mach_sec206")] #[symbol("g_206")]
+pub var g_206: u64 = 207;
+
+#[section(".mach_sec207")] #[symbol("g_207")]
+pub var g_207: u64 = 208;
+
+#[section(".mach_sec208")] #[symbol("g_208")]
+pub var g_208: u64 = 209;
+
+#[section(".mach_sec209")] #[symbol("g_209")]
+pub var g_209: u64 = 210;
+
+#[section(".mach_sec210")] #[symbol("g_210")]
+pub var g_210: u64 = 211;
+
+#[section(".mach_sec211")] #[symbol("g_211")]
+pub var g_211: u64 = 212;
+
+#[section(".mach_sec212")] #[symbol("g_212")]
+pub var g_212: u64 = 213;
+
+#[section(".mach_sec213")] #[symbol("g_213")]
+pub var g_213: u64 = 214;
+
+#[section(".mach_sec214")] #[symbol("g_214")]
+pub var g_214: u64 = 215;
+
+#[section(".mach_sec215")] #[symbol("g_215")]
+pub var g_215: u64 = 216;
+
+#[section(".mach_sec216")] #[symbol("g_216")]
+pub var g_216: u64 = 217;
+
+#[section(".mach_sec217")] #[symbol("g_217")]
+pub var g_217: u64 = 218;
+
+#[section(".mach_sec218")] #[symbol("g_218")]
+pub var g_218: u64 = 219;
+
+#[section(".mach_sec219")] #[symbol("g_219")]
+pub var g_219: u64 = 220;
+
+#[section(".mach_sec220")] #[symbol("g_220")]
+pub var g_220: u64 = 221;
+
+#[section(".mach_sec221")] #[symbol("g_221")]
+pub var g_221: u64 = 222;
+
+#[section(".mach_sec222")] #[symbol("g_222")]
+pub var g_222: u64 = 223;
+
+#[section(".mach_sec223")] #[symbol("g_223")]
+pub var g_223: u64 = 224;
+
+#[symbol("start")]
+pub fun _start() {
+    var total: u64 = 0;
+    total = total + g_000;
+    total = total + g_001;
+    total = total + g_002;
+    total = total + g_003;
+    total = total + g_004;
+    total = total + g_005;
+    total = total + g_006;
+    total = total + g_007;
+    total = total + g_008;
+    total = total + g_009;
+    total = total + g_010;
+    total = total + g_011;
+    total = total + g_012;
+    total = total + g_013;
+    total = total + g_014;
+    total = total + g_015;
+    total = total + g_016;
+    total = total + g_017;
+    total = total + g_018;
+    total = total + g_019;
+    total = total + g_020;
+    total = total + g_021;
+    total = total + g_022;
+    total = total + g_023;
+    total = total + g_024;
+    total = total + g_025;
+    total = total + g_026;
+    total = total + g_027;
+    total = total + g_028;
+    total = total + g_029;
+    total = total + g_030;
+    total = total + g_031;
+    total = total + g_032;
+    total = total + g_033;
+    total = total + g_034;
+    total = total + g_035;
+    total = total + g_036;
+    total = total + g_037;
+    total = total + g_038;
+    total = total + g_039;
+    total = total + g_040;
+    total = total + g_041;
+    total = total + g_042;
+    total = total + g_043;
+    total = total + g_044;
+    total = total + g_045;
+    total = total + g_046;
+    total = total + g_047;
+    total = total + g_048;
+    total = total + g_049;
+    total = total + g_050;
+    total = total + g_051;
+    total = total + g_052;
+    total = total + g_053;
+    total = total + g_054;
+    total = total + g_055;
+    total = total + g_056;
+    total = total + g_057;
+    total = total + g_058;
+    total = total + g_059;
+    total = total + g_060;
+    total = total + g_061;
+    total = total + g_062;
+    total = total + g_063;
+    total = total + g_064;
+    total = total + g_065;
+    total = total + g_066;
+    total = total + g_067;
+    total = total + g_068;
+    total = total + g_069;
+    total = total + g_070;
+    total = total + g_071;
+    total = total + g_072;
+    total = total + g_073;
+    total = total + g_074;
+    total = total + g_075;
+    total = total + g_076;
+    total = total + g_077;
+    total = total + g_078;
+    total = total + g_079;
+    total = total + g_080;
+    total = total + g_081;
+    total = total + g_082;
+    total = total + g_083;
+    total = total + g_084;
+    total = total + g_085;
+    total = total + g_086;
+    total = total + g_087;
+    total = total + g_088;
+    total = total + g_089;
+    total = total + g_090;
+    total = total + g_091;
+    total = total + g_092;
+    total = total + g_093;
+    total = total + g_094;
+    total = total + g_095;
+    total = total + g_096;
+    total = total + g_097;
+    total = total + g_098;
+    total = total + g_099;
+    total = total + g_100;
+    total = total + g_101;
+    total = total + g_102;
+    total = total + g_103;
+    total = total + g_104;
+    total = total + g_105;
+    total = total + g_106;
+    total = total + g_107;
+    total = total + g_108;
+    total = total + g_109;
+    total = total + g_110;
+    total = total + g_111;
+    total = total + g_112;
+    total = total + g_113;
+    total = total + g_114;
+    total = total + g_115;
+    total = total + g_116;
+    total = total + g_117;
+    total = total + g_118;
+    total = total + g_119;
+    total = total + g_120;
+    total = total + g_121;
+    total = total + g_122;
+    total = total + g_123;
+    total = total + g_124;
+    total = total + g_125;
+    total = total + g_126;
+    total = total + g_127;
+    total = total + g_128;
+    total = total + g_129;
+    total = total + g_130;
+    total = total + g_131;
+    total = total + g_132;
+    total = total + g_133;
+    total = total + g_134;
+    total = total + g_135;
+    total = total + g_136;
+    total = total + g_137;
+    total = total + g_138;
+    total = total + g_139;
+    total = total + g_140;
+    total = total + g_141;
+    total = total + g_142;
+    total = total + g_143;
+    total = total + g_144;
+    total = total + g_145;
+    total = total + g_146;
+    total = total + g_147;
+    total = total + g_148;
+    total = total + g_149;
+    total = total + g_150;
+    total = total + g_151;
+    total = total + g_152;
+    total = total + g_153;
+    total = total + g_154;
+    total = total + g_155;
+    total = total + g_156;
+    total = total + g_157;
+    total = total + g_158;
+    total = total + g_159;
+    total = total + g_160;
+    total = total + g_161;
+    total = total + g_162;
+    total = total + g_163;
+    total = total + g_164;
+    total = total + g_165;
+    total = total + g_166;
+    total = total + g_167;
+    total = total + g_168;
+    total = total + g_169;
+    total = total + g_170;
+    total = total + g_171;
+    total = total + g_172;
+    total = total + g_173;
+    total = total + g_174;
+    total = total + g_175;
+    total = total + g_176;
+    total = total + g_177;
+    total = total + g_178;
+    total = total + g_179;
+    total = total + g_180;
+    total = total + g_181;
+    total = total + g_182;
+    total = total + g_183;
+    total = total + g_184;
+    total = total + g_185;
+    total = total + g_186;
+    total = total + g_187;
+    total = total + g_188;
+    total = total + g_189;
+    total = total + g_190;
+    total = total + g_191;
+    total = total + g_192;
+    total = total + g_193;
+    total = total + g_194;
+    total = total + g_195;
+    total = total + g_196;
+    total = total + g_197;
+    total = total + g_198;
+    total = total + g_199;
+    total = total + g_200;
+    total = total + g_201;
+    total = total + g_202;
+    total = total + g_203;
+    total = total + g_204;
+    total = total + g_205;
+    total = total + g_206;
+    total = total + g_207;
+    total = total + g_208;
+    total = total + g_209;
+    total = total + g_210;
+    total = total + g_211;
+    total = total + g_212;
+    total = total + g_213;
+    total = total + g_214;
+    total = total + g_215;
+    total = total + g_216;
+    total = total + g_217;
+    total = total + g_218;
+    total = total + g_219;
+    total = total + g_220;
+    total = total + g_221;
+    total = total + g_222;
+    total = total + g_223;
+    Sleep(total::u32);
+    objc_msgSend(total, 0);
+    total = compressBound(total);
+}

--- a/int/surface/macho-header-span-x86_64/case.conf
+++ b/int/surface/macho-header-span-x86_64/case.conf
@@ -1,0 +1,19 @@
+# a darwin image whose load commands exceed the one-page header reservation links,
+# and its header lands inside the span the linker reserved (#2690).
+#
+# The reservation is the linker's, decided when it assigns virtual addresses, not
+# the writer's: __TEXT is based exactly on the image base and the header fills the
+# gap below the first segment. So growing the header has to grow that gap, or
+# __TEXT - and __PAGEZERO under it - slides below the base, which is #2599. The
+# golden therefore pins the framing alongside the size, since a fix that only
+# widened the span in the writer would pass a size-only check while reintroducing
+# the older defect.
+#
+# Read host-side on the cheap linux leg; the image is never run. The aarch64 twin
+# is a separate case because the two share the writer but not the page size (4 KiB
+# here, 16 KiB there), so only running both proves the reservation is sized from
+# the target's page rather than a constant.
+run: macho-header-span
+targets: linux
+build-target: darwin-x86_64
+build-flags: --pie

--- a/int/surface/macho-header-span-x86_64/expect.darwin-x86_64.txt
+++ b/int/surface/macho-header-span-x86_64/expect.darwin-x86_64.txt
@@ -1,0 +1,9 @@
+sizeofcmds_over_one_page=1
+multiple_dylib_loads=1
+reservation_whole_pages=1
+header_fits_reservation=1
+first_section_fileoff_is_reservation=1
+pagezero_vmsize=0x100000000
+text_vmaddr=0x100000000
+text_fileoff=0
+pagezero_abuts_text=1

--- a/int/surface/macho-header-span-x86_64/mach.toml
+++ b/int/surface/macho-header-span-x86_64/mach.toml
@@ -1,0 +1,108 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["System", "objc", "cxx", "iconv", "z", "xml2", "bz2", "curses"]
+need = []
+
+[link.System]
+source = "system"
+name = "/usr/lib/libSystem.B.dylib"
+library = "System"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.objc]
+source = "system"
+name = "/usr/lib/libobjc.A.dylib"
+library = "objc"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.cxx]
+source = "system"
+name = "/usr/lib/libc++.1.dylib"
+library = "cxx"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.iconv]
+source = "system"
+name = "/usr/lib/libiconv.2.dylib"
+library = "iconv"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.z]
+source = "system"
+name = "/usr/lib/libz.1.dylib"
+library = "z"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.xml2]
+source = "system"
+name = "/usr/lib/libxml2.2.dylib"
+library = "xml2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.bz2]
+source = "system"
+name = "/usr/lib/libbz2.1.0.dylib"
+library = "bz2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.curses]
+source = "system"
+name = "/usr/lib/libcurses.dylib"
+library = "curses"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/macho-header-span-x86_64/src/main.mach
+++ b/int/surface/macho-header-span-x86_64/src/main.mach
@@ -1,0 +1,928 @@
+# a Mach-O header outgrows its one-page reservation as soon as an image carries
+# enough named sections: since #2606 the linker preserves input section identity,
+# and every surviving section is another 80-byte section_64 in the header. A
+# vendored objective-c archive carries dozens (__objc_classlist, __objc_const,
+# __objc_data, __cstring, __gcc_except_tab, ...) alongside its system-library
+# dependencies, which is how briar-systems/mach-glfw#32 reached 4 KiB of load
+# commands and was refused (#2690).
+#
+# The 224 `#[section]` globals below stand in for that section table without
+# needing the macOS SDK to build one: they cross the reservation on both darwin
+# page sizes (4 KiB x86_64, 16 KiB arm64). The system-library dependencies in
+# mach.toml are the second contributor, an LC_LOAD_DYLIB each, and they make the
+# image the shape the reported consumer has rather than a section table alone.
+#
+# The program is never RUN - the observable is the emitted header, read host-side
+# on the linux leg - so the imports need only be referenced, not called correctly.
+#[library("System")]
+ext fun Sleep(ms: u32);
+
+#[library("objc")]
+ext fun objc_msgSend(recv: u64, sel: u64);
+
+#[library("z")]
+ext fun compressBound(n: u64) u64;
+
+#[section(".mach_sec000")] #[symbol("g_000")]
+pub var g_000: u64 = 1;
+
+#[section(".mach_sec001")] #[symbol("g_001")]
+pub var g_001: u64 = 2;
+
+#[section(".mach_sec002")] #[symbol("g_002")]
+pub var g_002: u64 = 3;
+
+#[section(".mach_sec003")] #[symbol("g_003")]
+pub var g_003: u64 = 4;
+
+#[section(".mach_sec004")] #[symbol("g_004")]
+pub var g_004: u64 = 5;
+
+#[section(".mach_sec005")] #[symbol("g_005")]
+pub var g_005: u64 = 6;
+
+#[section(".mach_sec006")] #[symbol("g_006")]
+pub var g_006: u64 = 7;
+
+#[section(".mach_sec007")] #[symbol("g_007")]
+pub var g_007: u64 = 8;
+
+#[section(".mach_sec008")] #[symbol("g_008")]
+pub var g_008: u64 = 9;
+
+#[section(".mach_sec009")] #[symbol("g_009")]
+pub var g_009: u64 = 10;
+
+#[section(".mach_sec010")] #[symbol("g_010")]
+pub var g_010: u64 = 11;
+
+#[section(".mach_sec011")] #[symbol("g_011")]
+pub var g_011: u64 = 12;
+
+#[section(".mach_sec012")] #[symbol("g_012")]
+pub var g_012: u64 = 13;
+
+#[section(".mach_sec013")] #[symbol("g_013")]
+pub var g_013: u64 = 14;
+
+#[section(".mach_sec014")] #[symbol("g_014")]
+pub var g_014: u64 = 15;
+
+#[section(".mach_sec015")] #[symbol("g_015")]
+pub var g_015: u64 = 16;
+
+#[section(".mach_sec016")] #[symbol("g_016")]
+pub var g_016: u64 = 17;
+
+#[section(".mach_sec017")] #[symbol("g_017")]
+pub var g_017: u64 = 18;
+
+#[section(".mach_sec018")] #[symbol("g_018")]
+pub var g_018: u64 = 19;
+
+#[section(".mach_sec019")] #[symbol("g_019")]
+pub var g_019: u64 = 20;
+
+#[section(".mach_sec020")] #[symbol("g_020")]
+pub var g_020: u64 = 21;
+
+#[section(".mach_sec021")] #[symbol("g_021")]
+pub var g_021: u64 = 22;
+
+#[section(".mach_sec022")] #[symbol("g_022")]
+pub var g_022: u64 = 23;
+
+#[section(".mach_sec023")] #[symbol("g_023")]
+pub var g_023: u64 = 24;
+
+#[section(".mach_sec024")] #[symbol("g_024")]
+pub var g_024: u64 = 25;
+
+#[section(".mach_sec025")] #[symbol("g_025")]
+pub var g_025: u64 = 26;
+
+#[section(".mach_sec026")] #[symbol("g_026")]
+pub var g_026: u64 = 27;
+
+#[section(".mach_sec027")] #[symbol("g_027")]
+pub var g_027: u64 = 28;
+
+#[section(".mach_sec028")] #[symbol("g_028")]
+pub var g_028: u64 = 29;
+
+#[section(".mach_sec029")] #[symbol("g_029")]
+pub var g_029: u64 = 30;
+
+#[section(".mach_sec030")] #[symbol("g_030")]
+pub var g_030: u64 = 31;
+
+#[section(".mach_sec031")] #[symbol("g_031")]
+pub var g_031: u64 = 32;
+
+#[section(".mach_sec032")] #[symbol("g_032")]
+pub var g_032: u64 = 33;
+
+#[section(".mach_sec033")] #[symbol("g_033")]
+pub var g_033: u64 = 34;
+
+#[section(".mach_sec034")] #[symbol("g_034")]
+pub var g_034: u64 = 35;
+
+#[section(".mach_sec035")] #[symbol("g_035")]
+pub var g_035: u64 = 36;
+
+#[section(".mach_sec036")] #[symbol("g_036")]
+pub var g_036: u64 = 37;
+
+#[section(".mach_sec037")] #[symbol("g_037")]
+pub var g_037: u64 = 38;
+
+#[section(".mach_sec038")] #[symbol("g_038")]
+pub var g_038: u64 = 39;
+
+#[section(".mach_sec039")] #[symbol("g_039")]
+pub var g_039: u64 = 40;
+
+#[section(".mach_sec040")] #[symbol("g_040")]
+pub var g_040: u64 = 41;
+
+#[section(".mach_sec041")] #[symbol("g_041")]
+pub var g_041: u64 = 42;
+
+#[section(".mach_sec042")] #[symbol("g_042")]
+pub var g_042: u64 = 43;
+
+#[section(".mach_sec043")] #[symbol("g_043")]
+pub var g_043: u64 = 44;
+
+#[section(".mach_sec044")] #[symbol("g_044")]
+pub var g_044: u64 = 45;
+
+#[section(".mach_sec045")] #[symbol("g_045")]
+pub var g_045: u64 = 46;
+
+#[section(".mach_sec046")] #[symbol("g_046")]
+pub var g_046: u64 = 47;
+
+#[section(".mach_sec047")] #[symbol("g_047")]
+pub var g_047: u64 = 48;
+
+#[section(".mach_sec048")] #[symbol("g_048")]
+pub var g_048: u64 = 49;
+
+#[section(".mach_sec049")] #[symbol("g_049")]
+pub var g_049: u64 = 50;
+
+#[section(".mach_sec050")] #[symbol("g_050")]
+pub var g_050: u64 = 51;
+
+#[section(".mach_sec051")] #[symbol("g_051")]
+pub var g_051: u64 = 52;
+
+#[section(".mach_sec052")] #[symbol("g_052")]
+pub var g_052: u64 = 53;
+
+#[section(".mach_sec053")] #[symbol("g_053")]
+pub var g_053: u64 = 54;
+
+#[section(".mach_sec054")] #[symbol("g_054")]
+pub var g_054: u64 = 55;
+
+#[section(".mach_sec055")] #[symbol("g_055")]
+pub var g_055: u64 = 56;
+
+#[section(".mach_sec056")] #[symbol("g_056")]
+pub var g_056: u64 = 57;
+
+#[section(".mach_sec057")] #[symbol("g_057")]
+pub var g_057: u64 = 58;
+
+#[section(".mach_sec058")] #[symbol("g_058")]
+pub var g_058: u64 = 59;
+
+#[section(".mach_sec059")] #[symbol("g_059")]
+pub var g_059: u64 = 60;
+
+#[section(".mach_sec060")] #[symbol("g_060")]
+pub var g_060: u64 = 61;
+
+#[section(".mach_sec061")] #[symbol("g_061")]
+pub var g_061: u64 = 62;
+
+#[section(".mach_sec062")] #[symbol("g_062")]
+pub var g_062: u64 = 63;
+
+#[section(".mach_sec063")] #[symbol("g_063")]
+pub var g_063: u64 = 64;
+
+#[section(".mach_sec064")] #[symbol("g_064")]
+pub var g_064: u64 = 65;
+
+#[section(".mach_sec065")] #[symbol("g_065")]
+pub var g_065: u64 = 66;
+
+#[section(".mach_sec066")] #[symbol("g_066")]
+pub var g_066: u64 = 67;
+
+#[section(".mach_sec067")] #[symbol("g_067")]
+pub var g_067: u64 = 68;
+
+#[section(".mach_sec068")] #[symbol("g_068")]
+pub var g_068: u64 = 69;
+
+#[section(".mach_sec069")] #[symbol("g_069")]
+pub var g_069: u64 = 70;
+
+#[section(".mach_sec070")] #[symbol("g_070")]
+pub var g_070: u64 = 71;
+
+#[section(".mach_sec071")] #[symbol("g_071")]
+pub var g_071: u64 = 72;
+
+#[section(".mach_sec072")] #[symbol("g_072")]
+pub var g_072: u64 = 73;
+
+#[section(".mach_sec073")] #[symbol("g_073")]
+pub var g_073: u64 = 74;
+
+#[section(".mach_sec074")] #[symbol("g_074")]
+pub var g_074: u64 = 75;
+
+#[section(".mach_sec075")] #[symbol("g_075")]
+pub var g_075: u64 = 76;
+
+#[section(".mach_sec076")] #[symbol("g_076")]
+pub var g_076: u64 = 77;
+
+#[section(".mach_sec077")] #[symbol("g_077")]
+pub var g_077: u64 = 78;
+
+#[section(".mach_sec078")] #[symbol("g_078")]
+pub var g_078: u64 = 79;
+
+#[section(".mach_sec079")] #[symbol("g_079")]
+pub var g_079: u64 = 80;
+
+#[section(".mach_sec080")] #[symbol("g_080")]
+pub var g_080: u64 = 81;
+
+#[section(".mach_sec081")] #[symbol("g_081")]
+pub var g_081: u64 = 82;
+
+#[section(".mach_sec082")] #[symbol("g_082")]
+pub var g_082: u64 = 83;
+
+#[section(".mach_sec083")] #[symbol("g_083")]
+pub var g_083: u64 = 84;
+
+#[section(".mach_sec084")] #[symbol("g_084")]
+pub var g_084: u64 = 85;
+
+#[section(".mach_sec085")] #[symbol("g_085")]
+pub var g_085: u64 = 86;
+
+#[section(".mach_sec086")] #[symbol("g_086")]
+pub var g_086: u64 = 87;
+
+#[section(".mach_sec087")] #[symbol("g_087")]
+pub var g_087: u64 = 88;
+
+#[section(".mach_sec088")] #[symbol("g_088")]
+pub var g_088: u64 = 89;
+
+#[section(".mach_sec089")] #[symbol("g_089")]
+pub var g_089: u64 = 90;
+
+#[section(".mach_sec090")] #[symbol("g_090")]
+pub var g_090: u64 = 91;
+
+#[section(".mach_sec091")] #[symbol("g_091")]
+pub var g_091: u64 = 92;
+
+#[section(".mach_sec092")] #[symbol("g_092")]
+pub var g_092: u64 = 93;
+
+#[section(".mach_sec093")] #[symbol("g_093")]
+pub var g_093: u64 = 94;
+
+#[section(".mach_sec094")] #[symbol("g_094")]
+pub var g_094: u64 = 95;
+
+#[section(".mach_sec095")] #[symbol("g_095")]
+pub var g_095: u64 = 96;
+
+#[section(".mach_sec096")] #[symbol("g_096")]
+pub var g_096: u64 = 97;
+
+#[section(".mach_sec097")] #[symbol("g_097")]
+pub var g_097: u64 = 98;
+
+#[section(".mach_sec098")] #[symbol("g_098")]
+pub var g_098: u64 = 99;
+
+#[section(".mach_sec099")] #[symbol("g_099")]
+pub var g_099: u64 = 100;
+
+#[section(".mach_sec100")] #[symbol("g_100")]
+pub var g_100: u64 = 101;
+
+#[section(".mach_sec101")] #[symbol("g_101")]
+pub var g_101: u64 = 102;
+
+#[section(".mach_sec102")] #[symbol("g_102")]
+pub var g_102: u64 = 103;
+
+#[section(".mach_sec103")] #[symbol("g_103")]
+pub var g_103: u64 = 104;
+
+#[section(".mach_sec104")] #[symbol("g_104")]
+pub var g_104: u64 = 105;
+
+#[section(".mach_sec105")] #[symbol("g_105")]
+pub var g_105: u64 = 106;
+
+#[section(".mach_sec106")] #[symbol("g_106")]
+pub var g_106: u64 = 107;
+
+#[section(".mach_sec107")] #[symbol("g_107")]
+pub var g_107: u64 = 108;
+
+#[section(".mach_sec108")] #[symbol("g_108")]
+pub var g_108: u64 = 109;
+
+#[section(".mach_sec109")] #[symbol("g_109")]
+pub var g_109: u64 = 110;
+
+#[section(".mach_sec110")] #[symbol("g_110")]
+pub var g_110: u64 = 111;
+
+#[section(".mach_sec111")] #[symbol("g_111")]
+pub var g_111: u64 = 112;
+
+#[section(".mach_sec112")] #[symbol("g_112")]
+pub var g_112: u64 = 113;
+
+#[section(".mach_sec113")] #[symbol("g_113")]
+pub var g_113: u64 = 114;
+
+#[section(".mach_sec114")] #[symbol("g_114")]
+pub var g_114: u64 = 115;
+
+#[section(".mach_sec115")] #[symbol("g_115")]
+pub var g_115: u64 = 116;
+
+#[section(".mach_sec116")] #[symbol("g_116")]
+pub var g_116: u64 = 117;
+
+#[section(".mach_sec117")] #[symbol("g_117")]
+pub var g_117: u64 = 118;
+
+#[section(".mach_sec118")] #[symbol("g_118")]
+pub var g_118: u64 = 119;
+
+#[section(".mach_sec119")] #[symbol("g_119")]
+pub var g_119: u64 = 120;
+
+#[section(".mach_sec120")] #[symbol("g_120")]
+pub var g_120: u64 = 121;
+
+#[section(".mach_sec121")] #[symbol("g_121")]
+pub var g_121: u64 = 122;
+
+#[section(".mach_sec122")] #[symbol("g_122")]
+pub var g_122: u64 = 123;
+
+#[section(".mach_sec123")] #[symbol("g_123")]
+pub var g_123: u64 = 124;
+
+#[section(".mach_sec124")] #[symbol("g_124")]
+pub var g_124: u64 = 125;
+
+#[section(".mach_sec125")] #[symbol("g_125")]
+pub var g_125: u64 = 126;
+
+#[section(".mach_sec126")] #[symbol("g_126")]
+pub var g_126: u64 = 127;
+
+#[section(".mach_sec127")] #[symbol("g_127")]
+pub var g_127: u64 = 128;
+
+#[section(".mach_sec128")] #[symbol("g_128")]
+pub var g_128: u64 = 129;
+
+#[section(".mach_sec129")] #[symbol("g_129")]
+pub var g_129: u64 = 130;
+
+#[section(".mach_sec130")] #[symbol("g_130")]
+pub var g_130: u64 = 131;
+
+#[section(".mach_sec131")] #[symbol("g_131")]
+pub var g_131: u64 = 132;
+
+#[section(".mach_sec132")] #[symbol("g_132")]
+pub var g_132: u64 = 133;
+
+#[section(".mach_sec133")] #[symbol("g_133")]
+pub var g_133: u64 = 134;
+
+#[section(".mach_sec134")] #[symbol("g_134")]
+pub var g_134: u64 = 135;
+
+#[section(".mach_sec135")] #[symbol("g_135")]
+pub var g_135: u64 = 136;
+
+#[section(".mach_sec136")] #[symbol("g_136")]
+pub var g_136: u64 = 137;
+
+#[section(".mach_sec137")] #[symbol("g_137")]
+pub var g_137: u64 = 138;
+
+#[section(".mach_sec138")] #[symbol("g_138")]
+pub var g_138: u64 = 139;
+
+#[section(".mach_sec139")] #[symbol("g_139")]
+pub var g_139: u64 = 140;
+
+#[section(".mach_sec140")] #[symbol("g_140")]
+pub var g_140: u64 = 141;
+
+#[section(".mach_sec141")] #[symbol("g_141")]
+pub var g_141: u64 = 142;
+
+#[section(".mach_sec142")] #[symbol("g_142")]
+pub var g_142: u64 = 143;
+
+#[section(".mach_sec143")] #[symbol("g_143")]
+pub var g_143: u64 = 144;
+
+#[section(".mach_sec144")] #[symbol("g_144")]
+pub var g_144: u64 = 145;
+
+#[section(".mach_sec145")] #[symbol("g_145")]
+pub var g_145: u64 = 146;
+
+#[section(".mach_sec146")] #[symbol("g_146")]
+pub var g_146: u64 = 147;
+
+#[section(".mach_sec147")] #[symbol("g_147")]
+pub var g_147: u64 = 148;
+
+#[section(".mach_sec148")] #[symbol("g_148")]
+pub var g_148: u64 = 149;
+
+#[section(".mach_sec149")] #[symbol("g_149")]
+pub var g_149: u64 = 150;
+
+#[section(".mach_sec150")] #[symbol("g_150")]
+pub var g_150: u64 = 151;
+
+#[section(".mach_sec151")] #[symbol("g_151")]
+pub var g_151: u64 = 152;
+
+#[section(".mach_sec152")] #[symbol("g_152")]
+pub var g_152: u64 = 153;
+
+#[section(".mach_sec153")] #[symbol("g_153")]
+pub var g_153: u64 = 154;
+
+#[section(".mach_sec154")] #[symbol("g_154")]
+pub var g_154: u64 = 155;
+
+#[section(".mach_sec155")] #[symbol("g_155")]
+pub var g_155: u64 = 156;
+
+#[section(".mach_sec156")] #[symbol("g_156")]
+pub var g_156: u64 = 157;
+
+#[section(".mach_sec157")] #[symbol("g_157")]
+pub var g_157: u64 = 158;
+
+#[section(".mach_sec158")] #[symbol("g_158")]
+pub var g_158: u64 = 159;
+
+#[section(".mach_sec159")] #[symbol("g_159")]
+pub var g_159: u64 = 160;
+
+#[section(".mach_sec160")] #[symbol("g_160")]
+pub var g_160: u64 = 161;
+
+#[section(".mach_sec161")] #[symbol("g_161")]
+pub var g_161: u64 = 162;
+
+#[section(".mach_sec162")] #[symbol("g_162")]
+pub var g_162: u64 = 163;
+
+#[section(".mach_sec163")] #[symbol("g_163")]
+pub var g_163: u64 = 164;
+
+#[section(".mach_sec164")] #[symbol("g_164")]
+pub var g_164: u64 = 165;
+
+#[section(".mach_sec165")] #[symbol("g_165")]
+pub var g_165: u64 = 166;
+
+#[section(".mach_sec166")] #[symbol("g_166")]
+pub var g_166: u64 = 167;
+
+#[section(".mach_sec167")] #[symbol("g_167")]
+pub var g_167: u64 = 168;
+
+#[section(".mach_sec168")] #[symbol("g_168")]
+pub var g_168: u64 = 169;
+
+#[section(".mach_sec169")] #[symbol("g_169")]
+pub var g_169: u64 = 170;
+
+#[section(".mach_sec170")] #[symbol("g_170")]
+pub var g_170: u64 = 171;
+
+#[section(".mach_sec171")] #[symbol("g_171")]
+pub var g_171: u64 = 172;
+
+#[section(".mach_sec172")] #[symbol("g_172")]
+pub var g_172: u64 = 173;
+
+#[section(".mach_sec173")] #[symbol("g_173")]
+pub var g_173: u64 = 174;
+
+#[section(".mach_sec174")] #[symbol("g_174")]
+pub var g_174: u64 = 175;
+
+#[section(".mach_sec175")] #[symbol("g_175")]
+pub var g_175: u64 = 176;
+
+#[section(".mach_sec176")] #[symbol("g_176")]
+pub var g_176: u64 = 177;
+
+#[section(".mach_sec177")] #[symbol("g_177")]
+pub var g_177: u64 = 178;
+
+#[section(".mach_sec178")] #[symbol("g_178")]
+pub var g_178: u64 = 179;
+
+#[section(".mach_sec179")] #[symbol("g_179")]
+pub var g_179: u64 = 180;
+
+#[section(".mach_sec180")] #[symbol("g_180")]
+pub var g_180: u64 = 181;
+
+#[section(".mach_sec181")] #[symbol("g_181")]
+pub var g_181: u64 = 182;
+
+#[section(".mach_sec182")] #[symbol("g_182")]
+pub var g_182: u64 = 183;
+
+#[section(".mach_sec183")] #[symbol("g_183")]
+pub var g_183: u64 = 184;
+
+#[section(".mach_sec184")] #[symbol("g_184")]
+pub var g_184: u64 = 185;
+
+#[section(".mach_sec185")] #[symbol("g_185")]
+pub var g_185: u64 = 186;
+
+#[section(".mach_sec186")] #[symbol("g_186")]
+pub var g_186: u64 = 187;
+
+#[section(".mach_sec187")] #[symbol("g_187")]
+pub var g_187: u64 = 188;
+
+#[section(".mach_sec188")] #[symbol("g_188")]
+pub var g_188: u64 = 189;
+
+#[section(".mach_sec189")] #[symbol("g_189")]
+pub var g_189: u64 = 190;
+
+#[section(".mach_sec190")] #[symbol("g_190")]
+pub var g_190: u64 = 191;
+
+#[section(".mach_sec191")] #[symbol("g_191")]
+pub var g_191: u64 = 192;
+
+#[section(".mach_sec192")] #[symbol("g_192")]
+pub var g_192: u64 = 193;
+
+#[section(".mach_sec193")] #[symbol("g_193")]
+pub var g_193: u64 = 194;
+
+#[section(".mach_sec194")] #[symbol("g_194")]
+pub var g_194: u64 = 195;
+
+#[section(".mach_sec195")] #[symbol("g_195")]
+pub var g_195: u64 = 196;
+
+#[section(".mach_sec196")] #[symbol("g_196")]
+pub var g_196: u64 = 197;
+
+#[section(".mach_sec197")] #[symbol("g_197")]
+pub var g_197: u64 = 198;
+
+#[section(".mach_sec198")] #[symbol("g_198")]
+pub var g_198: u64 = 199;
+
+#[section(".mach_sec199")] #[symbol("g_199")]
+pub var g_199: u64 = 200;
+
+#[section(".mach_sec200")] #[symbol("g_200")]
+pub var g_200: u64 = 201;
+
+#[section(".mach_sec201")] #[symbol("g_201")]
+pub var g_201: u64 = 202;
+
+#[section(".mach_sec202")] #[symbol("g_202")]
+pub var g_202: u64 = 203;
+
+#[section(".mach_sec203")] #[symbol("g_203")]
+pub var g_203: u64 = 204;
+
+#[section(".mach_sec204")] #[symbol("g_204")]
+pub var g_204: u64 = 205;
+
+#[section(".mach_sec205")] #[symbol("g_205")]
+pub var g_205: u64 = 206;
+
+#[section(".mach_sec206")] #[symbol("g_206")]
+pub var g_206: u64 = 207;
+
+#[section(".mach_sec207")] #[symbol("g_207")]
+pub var g_207: u64 = 208;
+
+#[section(".mach_sec208")] #[symbol("g_208")]
+pub var g_208: u64 = 209;
+
+#[section(".mach_sec209")] #[symbol("g_209")]
+pub var g_209: u64 = 210;
+
+#[section(".mach_sec210")] #[symbol("g_210")]
+pub var g_210: u64 = 211;
+
+#[section(".mach_sec211")] #[symbol("g_211")]
+pub var g_211: u64 = 212;
+
+#[section(".mach_sec212")] #[symbol("g_212")]
+pub var g_212: u64 = 213;
+
+#[section(".mach_sec213")] #[symbol("g_213")]
+pub var g_213: u64 = 214;
+
+#[section(".mach_sec214")] #[symbol("g_214")]
+pub var g_214: u64 = 215;
+
+#[section(".mach_sec215")] #[symbol("g_215")]
+pub var g_215: u64 = 216;
+
+#[section(".mach_sec216")] #[symbol("g_216")]
+pub var g_216: u64 = 217;
+
+#[section(".mach_sec217")] #[symbol("g_217")]
+pub var g_217: u64 = 218;
+
+#[section(".mach_sec218")] #[symbol("g_218")]
+pub var g_218: u64 = 219;
+
+#[section(".mach_sec219")] #[symbol("g_219")]
+pub var g_219: u64 = 220;
+
+#[section(".mach_sec220")] #[symbol("g_220")]
+pub var g_220: u64 = 221;
+
+#[section(".mach_sec221")] #[symbol("g_221")]
+pub var g_221: u64 = 222;
+
+#[section(".mach_sec222")] #[symbol("g_222")]
+pub var g_222: u64 = 223;
+
+#[section(".mach_sec223")] #[symbol("g_223")]
+pub var g_223: u64 = 224;
+
+#[symbol("start")]
+pub fun _start() {
+    var total: u64 = 0;
+    total = total + g_000;
+    total = total + g_001;
+    total = total + g_002;
+    total = total + g_003;
+    total = total + g_004;
+    total = total + g_005;
+    total = total + g_006;
+    total = total + g_007;
+    total = total + g_008;
+    total = total + g_009;
+    total = total + g_010;
+    total = total + g_011;
+    total = total + g_012;
+    total = total + g_013;
+    total = total + g_014;
+    total = total + g_015;
+    total = total + g_016;
+    total = total + g_017;
+    total = total + g_018;
+    total = total + g_019;
+    total = total + g_020;
+    total = total + g_021;
+    total = total + g_022;
+    total = total + g_023;
+    total = total + g_024;
+    total = total + g_025;
+    total = total + g_026;
+    total = total + g_027;
+    total = total + g_028;
+    total = total + g_029;
+    total = total + g_030;
+    total = total + g_031;
+    total = total + g_032;
+    total = total + g_033;
+    total = total + g_034;
+    total = total + g_035;
+    total = total + g_036;
+    total = total + g_037;
+    total = total + g_038;
+    total = total + g_039;
+    total = total + g_040;
+    total = total + g_041;
+    total = total + g_042;
+    total = total + g_043;
+    total = total + g_044;
+    total = total + g_045;
+    total = total + g_046;
+    total = total + g_047;
+    total = total + g_048;
+    total = total + g_049;
+    total = total + g_050;
+    total = total + g_051;
+    total = total + g_052;
+    total = total + g_053;
+    total = total + g_054;
+    total = total + g_055;
+    total = total + g_056;
+    total = total + g_057;
+    total = total + g_058;
+    total = total + g_059;
+    total = total + g_060;
+    total = total + g_061;
+    total = total + g_062;
+    total = total + g_063;
+    total = total + g_064;
+    total = total + g_065;
+    total = total + g_066;
+    total = total + g_067;
+    total = total + g_068;
+    total = total + g_069;
+    total = total + g_070;
+    total = total + g_071;
+    total = total + g_072;
+    total = total + g_073;
+    total = total + g_074;
+    total = total + g_075;
+    total = total + g_076;
+    total = total + g_077;
+    total = total + g_078;
+    total = total + g_079;
+    total = total + g_080;
+    total = total + g_081;
+    total = total + g_082;
+    total = total + g_083;
+    total = total + g_084;
+    total = total + g_085;
+    total = total + g_086;
+    total = total + g_087;
+    total = total + g_088;
+    total = total + g_089;
+    total = total + g_090;
+    total = total + g_091;
+    total = total + g_092;
+    total = total + g_093;
+    total = total + g_094;
+    total = total + g_095;
+    total = total + g_096;
+    total = total + g_097;
+    total = total + g_098;
+    total = total + g_099;
+    total = total + g_100;
+    total = total + g_101;
+    total = total + g_102;
+    total = total + g_103;
+    total = total + g_104;
+    total = total + g_105;
+    total = total + g_106;
+    total = total + g_107;
+    total = total + g_108;
+    total = total + g_109;
+    total = total + g_110;
+    total = total + g_111;
+    total = total + g_112;
+    total = total + g_113;
+    total = total + g_114;
+    total = total + g_115;
+    total = total + g_116;
+    total = total + g_117;
+    total = total + g_118;
+    total = total + g_119;
+    total = total + g_120;
+    total = total + g_121;
+    total = total + g_122;
+    total = total + g_123;
+    total = total + g_124;
+    total = total + g_125;
+    total = total + g_126;
+    total = total + g_127;
+    total = total + g_128;
+    total = total + g_129;
+    total = total + g_130;
+    total = total + g_131;
+    total = total + g_132;
+    total = total + g_133;
+    total = total + g_134;
+    total = total + g_135;
+    total = total + g_136;
+    total = total + g_137;
+    total = total + g_138;
+    total = total + g_139;
+    total = total + g_140;
+    total = total + g_141;
+    total = total + g_142;
+    total = total + g_143;
+    total = total + g_144;
+    total = total + g_145;
+    total = total + g_146;
+    total = total + g_147;
+    total = total + g_148;
+    total = total + g_149;
+    total = total + g_150;
+    total = total + g_151;
+    total = total + g_152;
+    total = total + g_153;
+    total = total + g_154;
+    total = total + g_155;
+    total = total + g_156;
+    total = total + g_157;
+    total = total + g_158;
+    total = total + g_159;
+    total = total + g_160;
+    total = total + g_161;
+    total = total + g_162;
+    total = total + g_163;
+    total = total + g_164;
+    total = total + g_165;
+    total = total + g_166;
+    total = total + g_167;
+    total = total + g_168;
+    total = total + g_169;
+    total = total + g_170;
+    total = total + g_171;
+    total = total + g_172;
+    total = total + g_173;
+    total = total + g_174;
+    total = total + g_175;
+    total = total + g_176;
+    total = total + g_177;
+    total = total + g_178;
+    total = total + g_179;
+    total = total + g_180;
+    total = total + g_181;
+    total = total + g_182;
+    total = total + g_183;
+    total = total + g_184;
+    total = total + g_185;
+    total = total + g_186;
+    total = total + g_187;
+    total = total + g_188;
+    total = total + g_189;
+    total = total + g_190;
+    total = total + g_191;
+    total = total + g_192;
+    total = total + g_193;
+    total = total + g_194;
+    total = total + g_195;
+    total = total + g_196;
+    total = total + g_197;
+    total = total + g_198;
+    total = total + g_199;
+    total = total + g_200;
+    total = total + g_201;
+    total = total + g_202;
+    total = total + g_203;
+    total = total + g_204;
+    total = total + g_205;
+    total = total + g_206;
+    total = total + g_207;
+    total = total + g_208;
+    total = total + g_209;
+    total = total + g_210;
+    total = total + g_211;
+    total = total + g_212;
+    total = total + g_213;
+    total = total + g_214;
+    total = total + g_215;
+    total = total + g_216;
+    total = total + g_217;
+    total = total + g_218;
+    total = total + g_219;
+    total = total + g_220;
+    total = total + g_221;
+    total = total + g_222;
+    total = total + g_223;
+    Sleep(total::u32);
+    objc_msgSend(total, 0);
+    total = compressBound(total);
+}

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -795,10 +795,15 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     # assign each merged section a virtual address (an executable or a shared
     # object; a relocatable library carries none). sections are placed in canonical
     # order from the OS base, each kind page-aligned; a position-independent image
-    # (PIE or shared) is based a page above.
+    # (PIE or shared) is based a page above. the header reservation above the base is
+    # provisional until the dynamic plan is built and the image shape can be measured
+    # (see `measure_header_shape` below); a format whose header outgrows it reassigns
+    # from the measured shape then.
     val assign_vaddrs: bool = (mode == LINK_EXE) || shared;
+    var header_reserve: u64 = 0;
     if (assign_vaddrs) {
-        assign_section_vaddrs(tgt, merged, position_independent);
+        header_reserve = header_reserve_bytes(tgt, position_independent, nil::*of.HeaderShape);
+        assign_section_vaddrs(tgt, merged, header_reserve);
         finalize_placement_vaddrs(merged, placements, sec_total);
     }
 
@@ -832,7 +837,7 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
             ret R.err[bool, str](R.unwrap_err[bool, str](gp_r));
         }
         if (local_got.count > 0) {
-            assign_section_vaddrs(tgt, merged, position_independent);
+            assign_section_vaddrs(tgt, merged, header_reserve);
             finalize_placement_vaddrs(merged, placements, sec_total);
             finalize_local_got_vaddrs(merged, ?local_got);
 
@@ -920,6 +925,37 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
                 free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
+            }
+        }
+
+        # the image shape is settled now, so the header reservation can be sized for
+        # real. a format whose header outgrew the provisional page gets a wider span,
+        # which moves every load segment up: virtual addresses are reassigned and the
+        # symbol table recollected before any relocation reads an address. the header
+        # size does not depend on those addresses, so this converges in one step.
+        if (assign_vaddrs) {
+            var shape: of.HeaderShape;
+            measure_header_shape(s, ?out_img, merged, ?groups, ?dyn, position_independent, ?shape);
+            val want: u64 = header_reserve_bytes(tgt, position_independent, ?shape);
+            if (want > header_reserve) {
+                header_reserve = want;
+                assign_section_vaddrs(tgt, merged, header_reserve);
+                finalize_placement_vaddrs(merged, placements, sec_total);
+                if (local_got.count > 0) { finalize_local_got_vaddrs(merged, ?local_got); }
+
+                map.dnit[intern.StrId, SymbolLoc](?sym_locs);
+                sym_locs = map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
+                val recollect: R.Result[bool, str] = collect_symbols(
+                    s, modules, module_count, placements, sec_base, ?sym_locs,
+                    assign_vaddrs, ?atoms);
+                if (R.is_err[bool, str](recollect)) {
+                    free_dynstate(alloc, ?dyn);
+                    obj.dnit(?out_img);
+                    free_local_got_plan(alloc, ?local_got);
+                    map.dnit[intern.StrId, SymbolLoc](?sym_locs);
+                    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
+                    ret R.err[bool, str](R.unwrap_err[bool, str](recollect));
+                }
             }
         }
 
@@ -3707,16 +3743,11 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
 # give each used merged section a base virtual address,
 # starting from the OS base and page-aligning each kind's start
 #
-# An image whose header maps inside its first load segment reserves the first page
+# An image whose header maps inside its first load segment reserves `reserve` bytes
 # above the base for it, so that segment (which maps the header at its start)
 # begins exactly at the base - for Mach-O, __TEXT on the base with __PAGEZERO
-# spanning [0, base). The writer asserts the header fits the one-page reservation.
-#
-# Two independent things ask for the reservation and it is one page either way: a
-# position-independent image (PIE or shared) always reserves it, and so does any
-# format that maps its header inside the first segment (`of.header_in_first_segment`,
-# true for Mach-O), whose non-PIE layout would otherwise be framed a page below the
-# base (#2599).
+# spanning [0, base). `header_reserve_bytes` sizes the reservation; the writer lays
+# the header into exactly it and fails if the header outgrew it.
 #
 # Each kind's start is aligned up to at least the OS page, so every merged segment
 # begins on a fresh page and thus owns its trailing (partial) page - no two segments
@@ -3724,15 +3755,15 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
 # the `.data.rel.ro` RELRO region up to a page boundary cannot reach into the following
 # segment's pages.
 # ---
-# tgt:    active target - supplies the OS base address and page size
-# merged: the per-kind accumulators, whose vaddrs are assigned in place
-# pie:    true when the image is position-independent (PIE or shared)
-fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection, pie: bool) {
+# tgt:     active target - supplies the OS base address and page size
+# merged:  the per-kind accumulators, whose vaddrs are assigned in place
+# reserve: bytes left above the base for the image header, from
+#          `header_reserve_bytes`; 0 for a format that maps its header elsewhere
+fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection, reserve: u64) {
     val base: u64 = os_base_addr(tgt);
     val page: u64 = os_page_size(tgt);
 
-    var va: u64 = base;
-    if (pie || header_reserve_page(tgt)) { va = base + page; }
+    var va: u64 = base + reserve;
     var i: u32 = 0;
     for (i < MERGED_KIND_COUNT) {
         if (merged[i].used && is_loadable_kind(merged[i].kind)) {
@@ -6389,18 +6420,98 @@ fun image_name(modules: *of.ObjectImage, module_count: u32) intern.StrId {
 }
 
 # whether the target's object format maps the image header inside the first load
-# segment, so the linker must leave a page above the base for it
+# segment, so the linker must leave room above the base for it
 #
-# The reservation belongs to the format, not to position independence: Mach-O
-# frames __TEXT one header span below its first content byte in both the
-# LC_MAIN and LC_UNIXTHREAD layouts, so without the gap a non-PIE image is based
-# a page low and its __PAGEZERO is short by the same page (#2599)
+# Whether to reserve, not how much - `header_reserve_bytes` sizes it. The
+# reservation belongs to the format, not to position independence: Mach-O frames
+# __TEXT one header span below its first content byte in both the LC_MAIN and
+# LC_UNIXTHREAD layouts, so without the gap a non-PIE image is based a page low and
+# its __PAGEZERO is short by the same page (#2599)
 # ---
 # tgt: active target - supplies the object-format vtable
-# ret: true when a header page must be reserved above the image base
+# ret: true when a header span must be reserved above the image base
 fun header_reserve_page(tgt: *target.Target) bool {
     if (tgt.of == nil) { ret false; }
     ret tgt.of.header_in_first_segment;
+}
+
+# how many bytes to leave above the image base for the header, before the first
+# load segment
+#
+# Two independent things ask for a reservation: a position-independent image (PIE
+# or shared) always wants one, and so does any format that maps its header inside
+# the first segment (`of.header_in_first_segment`, true for Mach-O), whose non-PIE
+# layout would otherwise be framed a page below the base (#2599). One page covers
+# both, except for a format whose header grows with the image: Mach-O carries a
+# command per segment, section and dependency and outgrows a page on a large link
+# (#2690), so it sizes the span itself through `of.header_span`.
+#
+# `shape` is nil on the provisional first assignment, before the dynamic plan
+# exists. That reserves a page, which is what every image got before; the caller
+# measures the real shape once the plan is built and reassigns if it wants more.
+# ---
+# tgt:   active target - supplies the page size and the object-format vtable
+# pie:   true when the image is position-independent (PIE or shared)
+# shape: the measured image shape, or nil before it is known
+# ret:   bytes to reserve above the base, a multiple of the page size
+fun header_reserve_bytes(tgt: *target.Target, pie: bool, shape: *of.HeaderShape) u64 {
+    if (!pie && !header_reserve_page(tgt)) { ret 0; }
+    val page: u64 = os_page_size(tgt);
+    if (tgt.of == nil || tgt.of.header_span == nil || shape == nil) { ret page; }
+    val want: u64 = tgt.of.header_span(shape, page);
+    if (want <= page) { ret page; }
+    ret bin.align_up_u64(want, page);
+}
+
+# measure the image shape the header reservation is sized from
+#
+# Every field is settled by the time the dynamic plan is built, and none of them
+# depends on a virtual address, so measuring here and reassigning virtual addresses
+# from the answer converges in one step rather than iterating.
+# ---
+# s:       shared session, for the interner the format resolves names through
+# out_img: the merged image, for its non-allocated debug sections
+# merged:  the per-kind accumulators
+# groups:  the planned named-section groups
+# dyn:     the dynamic-link state (its plan may name no dependency)
+# pie:     true when the image is position-independent
+# shape:   out - the measured shape
+fun measure_header_shape(s: *session.Session, out_img: *of.ObjectImage, merged: *MergedSection,
+                         groups: *SectionGroups, dyn: *DynState, pie: bool,
+                         shape: *of.HeaderShape) {
+    shape.itn       = ?s.interner;
+    shape.libs      = dyn.info.libs;
+    shape.lib_count = dyn.info.lib_count;
+    shape.pie       = pie;
+    shape.imports   = dyn.info.import_count > 0;
+
+    # the segments and sections `build_load_segments` will produce, counted the same
+    # way it counts them.
+    var segs:  u32 = 0;
+    var sects: u32 = 0;
+    var k:     u32 = 0;
+    for (k < MERGED_KIND_COUNT) {
+        if (is_loadable_kind(merged[k].kind) && merged[k].used && merged[k].len > 0) {
+            segs = segs + 1;
+            var i: u32 = 0;
+            for (i < groups.count) {
+                if (groups.items[i].slot == k && groups.items[i].len > 0) { sects = sects + 1; }
+                i = i + 1;
+            }
+        }
+        k = k + 1;
+    }
+
+    var dbg: u32 = 0;
+    var d:   u32 = 0;
+    for (d < out_img.section_count) {
+        if (out_img.sections[d].kind == of.SK_DEBUG) { dbg = dbg + 1; }
+        d = d + 1;
+    }
+
+    shape.seg_count   = segs;
+    shape.sect_count  = sects;
+    shape.debug_count = dbg;
 }
 
 # the base virtual address for the active target's executables. a per-target

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -855,6 +855,48 @@ pub rec ExecutableSectionLocation {
 # ret:    enclosing executable-section start and one-based section number
 pub def ExecutableSectionLocationFn: fun(u64, u64, u32) ExecutableSectionLocation;
 
+# everything an image header's size scales with, for a format that maps its header
+# inside the first load segment and so needs the span reserved before the linker
+# assigns virtual addresses
+#
+# The header cannot be written until the segments are laid out, and the segments
+# cannot be laid out until the span below them is known, so the linker measures the
+# shape first and asks the format how many bytes it wants. Every field here is
+# settled once the dynamic plan is built and none of them depends on a virtual
+# address, so the measurement is exact one pass before the writer runs.
+# ---
+# itn:         interner resolving the dependency name ids
+# libs:        loader dependencies the image will name, or nil when there are none
+# lib_count:   number of loader dependencies
+# seg_count:   loadable load segments the image will carry
+# sect_count:  named sections across all those segments
+# debug_count: non-allocated debug sections the writer frames separately
+# pie:         true when the image is position-independent
+# imports:     true when the image binds dynamic imports, which may add
+#              format-synthesized stub/pointer segments of its own
+pub rec HeaderShape {
+    itn:         *intern.Interner;
+    libs:        *DynLib;
+    lib_count:   u32;
+    seg_count:   u32;
+    sect_count:  u32;
+    debug_count: u32;
+    pie:         bool;
+    imports:     bool;
+}
+
+# how many bytes a format reserves below the first load segment for its header
+#
+# The result is an upper bound rounded up to a whole number of pages, never an
+# estimate to be corrected later: the writer lays the header into exactly this span
+# and pads the remainder, so reserving more than the header needs costs padding
+# while reserving less fails the link.
+# ---
+# arg 0: the measured image shape
+# arg 1: the target's page size
+# ret:   reserved bytes, a multiple of the page size
+pub def HeaderSpanFn: fun(*HeaderShape, u64) u64;
+
 # maximum number of instruction sets an OfVTable's ISA-coverage list holds
 val OF_ISA_MAX: u32 = 8;
 
@@ -955,6 +997,12 @@ val OF_ISA_MAX: u32 = 8;
 #                 __PAGEZERO - lands a page below the base (#2599). false for a
 #                 format that maps its header outside any segment, or that
 #                 reserves the span itself inside the first section (PE)
+# header_span:    optional sizing for that reservation: given the measured image
+#                 shape, the bytes the format wants below the first load segment.
+#                 nil reserves a single page, which is all a format whose header
+#                 does not grow with the image needs. a format whose header carries
+#                 one command per segment, section and dependency outgrows a page
+#                 (#2690) and must supply this
 # executable_section_location: optional format-owned mapping from a linker load
 #                 segment to its enclosing final executable section. section-relative
 #                 relocations consult it before executable emission; nil means the
@@ -979,6 +1027,7 @@ pub rec OfVTable {
     shared_input_ext:    str;
     import_address_prefix: str;
     header_in_first_segment: bool;
+    header_span:         HeaderSpanFn;
     executable_section_location: ExecutableSectionLocationFn;
 }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1543,6 +1543,7 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # Mach-O image, position-independent or not, so __TEXT lands on the base and
     # __PAGEZERO spans the whole low region below it (#2599).
     macho_vtable.header_in_first_segment = true;
+    macho_vtable.header_span = header_span;
     macho_vtable.executable_section_location = nil;
 
     # Mach-O relocates and writes for the two Apple-silicon-era isas.
@@ -1849,6 +1850,89 @@ fun macho_dwarf_free(alloc: *A.Allocator, d: *MachoDwarf, debug_count: u32) {
     d.sec_offs = nil;
 }
 
+# the bytes reserved below the first load segment for the mach header + load
+# commands, installed as the of.HeaderSpanFn
+#
+# A Mach-O header carries one command per segment, one section_64 per named section
+# and one per dependency, so it grows with the image and a fixed one-page
+# reservation caps a link that the format itself does not cap - `sizeofcmds` is a
+# uint32 (#2690). An objective-c input reaches that cap easily: since #2606 the
+# linker preserves input section identity, so every __objc_* section a vendored
+# archive carries is another 80 bytes here.
+#
+# The result is an upper bound, not the exact size. The writer lays the header into
+# this span and pads the rest of it, so over-reserving costs padding inside __TEXT's
+# leading pages while under-reserving fails the link - every term below therefore
+# takes the larger reading where the arch or the layout is not yet fixed: both
+# platform commands are counted, the entry command is the larger of LC_UNIXTHREAD's
+# thread state and LC_MAIN, and each load segment is charged a command of its own
+# even though adjacent same-protection segments collapse into one.
+# ---
+# shape: the measured image shape
+# page:  the target's page size
+# ret:   reserved bytes, rounded up to a whole number of pages
+fun header_span(shape: *of.HeaderShape, page: u64) u64 {
+    if (shape == nil) { ret page; }
+
+    # __PAGEZERO and __LINKEDIT frame the load segments, and an image that binds
+    # imports also carries the synthesized __STUBS and __GOT.
+    var seg_cmds:   u32 = shape.seg_count + 2;
+    var sect_total: u32 = shape.sect_count;
+    if (shape.imports) {
+        seg_cmds   = seg_cmds + 2;
+        sect_total = sect_total + 2;
+    }
+
+    var entry_cmd: usize = 16 + ARM_THREAD_STATE64_COUNT::usize * 4;
+    if (16 + X86_THREAD_STATE64_COUNT::usize * 4 > entry_cmd) {
+        entry_cmd = 16 + X86_THREAD_STATE64_COUNT::usize * 4;
+    }
+    if (ENTRY_POINT_CMD_SIZE > entry_cmd) { entry_cmd = ENTRY_POINT_CMD_SIZE; }
+
+    var size: usize = MACH_HEADER_64_SIZE
+                    + seg_cmds::usize * SEGMENT_CMD_64_SIZE
+                    + sect_total::usize * SECTION_64_SIZE
+                    + DYLD_INFO_CMD_SIZE + SYMTAB_CMD_SIZE + DYSYMTAB_CMD_SIZE
+                    + dylinker_cmd_size() + entry_cmd + LINKEDIT_DATA_CMD_SIZE
+                    + BUILD_VERSION_CMD_SIZE + UUID_CMD_SIZE
+                    + macho_dwarf_cmd_bytes(shape.debug_count);
+
+    var i: u32 = 0;
+    for (i < shape.lib_count) {
+        size = size + dylib_cmd_size(bin.resolve_name(shape.itn, shape.libs[i].soname));
+        if (shape.libs[i].rpath != intern.STR_NIL
+            && !rpath_seen_before(shape.libs, i, shape.libs[i].rpath)) {
+            size = size + rpath_cmd_size(bin.resolve_name(shape.itn, shape.libs[i].rpath));
+        }
+        i = i + 1;
+    }
+
+    ret bin.align_up_u64(size::u64, page);
+}
+
+# the header span the linker reserved for this image: the gap it left between the
+# image base and the first load segment's virtual address
+#
+# The writer does not choose this. The reservation is fixed during vaddr assignment
+# (`of.HeaderSpanFn`), and __TEXT is based exactly on `image_base` because the
+# header occupies that gap - widening the span here instead would slide __TEXT, and
+# __PAGEZERO under it, below the base (#2599).
+# ---
+# segs:       the linker's load segments
+# seg_count:  number of load segments
+# image_base: the linker's image base
+# ret:        ok(the reserved bytes), or an error when no header fits below the base
+fun reserved_header_span(segs: *of.LoadSegment, seg_count: u32,
+                         image_base: u64) R.Result[usize, str] {
+    if (seg_count == 0 || segs == nil) {
+        ret R.err[usize, str]("macho: image has no load segments to map the header into");
+    }
+    if (segs[0].vaddr <= image_base) {
+        ret R.err[usize, str]("macho: base address too low to map the header");
+    }
+    ret R.ok[usize, str]((segs[0].vaddr - image_base)::usize);
+}
+
 # write a static MH_EXECUTE Mach-O, installed as the of.ExecFn
 #
 # Frames the linker's laid-out load segments with a leading __PAGEZERO (the
@@ -1872,7 +1956,8 @@ fun macho_dwarf_free(alloc: *A.Allocator, d: *MachoDwarf, debug_count: u32) {
 # seg_count:  number of segments
 # page_size:  segment-alignment page (unused; Mach-O maps its own fixed per-arch vm
 #             page via `macho_page_size` - 16 KiB arm64, 4 KiB x86_64)
-# image_base: linker image base (unused; Mach-O derives framing from segment vaddrs)
+# image_base: linker image base; __TEXT is based exactly here and the header fills
+#             the span the linker reserved between it and the first segment
 # entry:      program entry-point virtual address
 # funcs:      per-function metadata (unused)
 # func_count: number of entries in funcs (unused)
@@ -1901,10 +1986,11 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # (#1698); the structure round-trips in the of.macho parser unit test.
     val have_dwarf: bool = debug_count > 0;
 
-    # __PAGEZERO spans the low region below __TEXT; it is present whenever the image
-    # base is non-zero (darwin executables always carry one). its exact span depends
-    # on hdr_span, computed once the load-command size is known below.
-    var has_pagezero: bool = seg_count > 0 && segs[0].vaddr > 0;
+    # __PAGEZERO spans [0, base), so it is present exactly when the image base is
+    # non-zero (darwin executables always carry one). __TEXT is based on the base, so
+    # the span is the base itself - reading it off the first segment instead would
+    # make it depend on the header span, which is not yet known here.
+    val has_pagezero: bool = image_base > 0;
     # a static image has no loader-applied rebases, so no segment is dyld's
     # rebased-then-read-only __DATA_CONST and the load segments collapse purely by
     # protection: the linker's rodata and rel.ro segments are one read-only Mach-O
@@ -1927,30 +2013,22 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
 
     # the mach header + load commands map into __TEXT's first hdr_span bytes: the
     # Apple Silicon kernel admits a signed image only when the header lies inside the
-    # signed, mapped __TEXT. the first linker segment must therefore sit strictly
-    # above hdr_span, leaving room for the header below it and a non-empty
-    # __PAGEZERO under that - the linker reserves exactly this page for every Mach-O
-    # image (`of.header_in_first_segment`), position-independent or not.
-    if (header_end > exec_page::usize) {
-        ret R.err[bool, str]("macho: exec header exceeds the one-page reservation");
+    # signed, mapped __TEXT. the first linker segment therefore sits hdr_span above
+    # the base, leaving room for the header below it and a non-empty __PAGEZERO under
+    # that - the linker reserved exactly that span (`of.header_in_first_segment`,
+    # sized through `header_span`), position-independent or not.
+    val hs: R.Result[usize, str] = reserved_header_span(segs, seg_count, image_base);
+    if (R.is_err[usize, str](hs)) { ret R.err[bool, str](R.unwrap_err[usize, str](hs)); }
+    val hdr_span: usize = R.unwrap_ok[usize, str](hs);
+    if (header_end > hdr_span) {
+        ret R.err[bool, str]("macho: exec header exceeds the linker's reservation");
     }
-    val hdr_span: usize = exec_page::usize;
-    if (seg_count > 0 && segs[0].vaddr <= hdr_span::u64) {
-        ret R.err[bool, str]("macho: exec base address too low to map the header");
-    }
-    var text_va:       u64 = 0;
-    var pagezero_size: u64 = 0;
-    if (seg_count > 0) {
-        text_va       = segs[0].vaddr - hdr_span::u64;
-        pagezero_size = text_va;
-    }
+    val text_va:       u64 = segs[0].vaddr - hdr_span::u64;
+    val pagezero_size: u64 = text_va;
 
-    var seg_offsets: *usize = nil;
-    if (seg_count > 0) {
-        val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
-        if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("macho: exec offset table alloc failed"); }
-        seg_offsets = R.unwrap_ok[*usize, str](ro);
-    }
+    val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
+    if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("macho: exec offset table alloc failed"); }
+    val seg_offsets: *usize = R.unwrap_ok[*usize, str](ro);
 
     # the first linker segment's bytes follow the header at hdr_span; the rest are
     # page-aligned in turn. __TEXT (the first segment) therefore shares its file
@@ -1979,7 +2057,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     val dwp: R.Result[MachoDwarf, str] =
         macho_dwarf_plan(alloc, debug, debug_count, total_size, macho_page_size(arch_id)::usize);
     if (R.is_err[MachoDwarf, str](dwp)) {
-        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
         ret R.err[bool, str](R.unwrap_err[MachoDwarf, str](dwp));
     }
     dw = R.unwrap_ok[MachoDwarf, str](dwp);
@@ -1988,9 +2066,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # __TEXT - the first segment, now carrying the header - is the executable segment
     # the code signature authorizes: it starts at file offset 0 and spans the header
     # plus the linker's text bytes.
-    var exec_base:  u64 = 0;
-    var exec_limit: u64 = 0;
-    if (seg_count > 0) { exec_limit = hdr_span::u64 + segs[0].filesz::u64; }
+    val exec_base:  u64 = 0;
+    val exec_limit: u64 = hdr_span::u64 + segs[0].filesz::u64;
 
     # the ad-hoc code signature lives in a trailing __LINKEDIT segment and covers
     # every byte before it (including the __DWARF bytes), so it is laid out last and
@@ -2007,7 +2084,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
         macho_dwarf_free(alloc, ?dw, debug_count);
-        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
         ret R.err[bool, str]("macho: exec buffer alloc failed");
     }
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
@@ -2053,7 +2130,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     write_code_signature(buf, code_limit, name, code_limit, exec_base, exec_limit);
 
     macho_dwarf_free(alloc, ?dw, debug_count);
-    if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+    A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
 
     val wr: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
         "macho: exec", "macho: could not create output file",
@@ -3373,7 +3450,8 @@ fun macho_got_ordinal(dyn: *of.DynamicInfo, import_index: u32) u32 {
 # seg_count:   number of segments
 # page_size:   segment-alignment page (unused; Mach-O maps its own fixed per-arch vm
 #              page via `macho_page_size`)
-# image_base:  linker image base (unused; Mach-O derives framing from segment vaddrs)
+# image_base:  linker image base; __TEXT is based exactly here and the header fills
+#              the span the linker reserved between it and the first segment
 # entry:       program entry-point virtual address
 # funcs:       per-function metadata (unused)
 # func_count:  number of entries in funcs (unused)
@@ -3448,7 +3526,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # the linker's load segments collapse into + (stubs, got when there are function
     # imports) + __LINKEDIT.
     val grp_count: u32 = seg_group_count(dyn, segs, seg_count);
-    var seg_cmds: u32 = frame_cmd_count(dyn, segs, seg_count, segs[0].vaddr > 0) + 1;  # + __LINKEDIT
+    var seg_cmds: u32 = frame_cmd_count(dyn, segs, seg_count, image_base > 0) + 1;  # + __LINKEDIT
     if (nstub > 0) { seg_cmds = seg_cmds + 1; }   # __STUBS
     if (ngot > 0)  { seg_cmds = seg_cmds + 1; }   # __GOT
 
@@ -3500,18 +3578,16 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     }
 
     var lay: MachoDynLayout;
-    # a PIE image reserves exactly one page for the header so __TEXT maps at the OS
-    # base (the linker reserved that page above the base when assigning vaddrs); a
-    # non-PIE image maps the header below the linker's first segment, sized to fit.
-    # the linker reserved exactly one page above the image base for the header, so
-    # the header span is that page for both layouts: growing it instead would push
-    # __TEXT (and __PAGEZERO with it) below the base (#2599).
-    if (MACH_HEADER_64_SIZE + sizeofcmds > page) {
-        ret R.err[bool, str]("macho: dyn-exec header exceeds the one-page reservation");
-    }
-    lay.hdr_span = page;
-    if (segs[0].vaddr <= lay.hdr_span::u64) {
-        ret R.err[bool, str]("macho: dyn-exec base address too low to map the header");
+    # the header maps into __TEXT's first hdr_span bytes in both layouts, so __TEXT
+    # is based exactly on the image base and __PAGEZERO spans the whole low region
+    # under it. the span is the one the linker reserved when it assigned vaddrs
+    # (`of.HeaderSpanFn`); growing it here instead would push __TEXT, and __PAGEZERO
+    # with it, below the base (#2599).
+    val hs: R.Result[usize, str] = reserved_header_span(segs, seg_count, image_base);
+    if (R.is_err[usize, str](hs)) { ret R.err[bool, str](R.unwrap_err[usize, str](hs)); }
+    lay.hdr_span = R.unwrap_ok[usize, str](hs);
+    if (MACH_HEADER_64_SIZE + sizeofcmds > lay.hdr_span) {
+        ret R.err[bool, str]("macho: dyn-exec header exceeds the linker's reservation");
     }
     lay.text_va       = segs[0].vaddr - lay.hdr_span::u64;
     lay.pagezero_size = lay.text_va;
@@ -5340,11 +5416,13 @@ fun ts_exec_x64() u8 {
     var code: [8]u8;
     var k: usize = 0;
     for (k < 8) { code[k] = 0x90; k = k + 1; }
+    # the linker leaves the header span above the base, so its first segment starts
+    # there and __TEXT is based exactly on the base.
     val base:  u64 = 0x100000000;
-    val entry: u64 = base + 0;
+    val entry: u64 = base + 4096;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].vaddr = base + 4096; segs[0].filesz = 8; segs[0].memsz = 8;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_exe");
@@ -5423,11 +5501,13 @@ fun ts_exec_arm64() u8 {
     var code: [8]u8;
     bin.write_u32_le(?code[0], 0, 0xD503201F);  # nop
     bin.write_u32_le(?code[0], 4, 0xD65F03C0);  # ret
+    # arm64 darwin maps 16 KiB pages, so the header span the linker leaves above the
+    # base is that much.
     val base:  u64 = 0x100000000;
-    val entry: u64 = base + 0;
+    val entry: u64 = base + 16384;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].vaddr = base + 16384; segs[0].filesz = 8; segs[0].memsz = 8;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_a64exe");
@@ -5530,11 +5610,14 @@ fun ts_dyn_exec(arch_id: u32) u8 {
         # a second instruction loads an imported data address through GOT_LOAD.
         code[7] = 0x48; code[8] = 0x8B; code[9] = 0x05;
     }
-    val base:  u64 = 0x100000000;
-    val entry: u64 = base;
+    val base:   u64 = 0x100000000;
+    # the linker leaves the arch page above the base for the header, so its first
+    # segment starts there.
+    val seg_va: u64 = base + macho_page_size(arch_id);
+    val entry:  u64 = seg_va;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = seg_va; segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     var libs: [1]of.DynLib;
@@ -5558,12 +5641,12 @@ fun ts_dyn_exec(arch_id: u32) u8 {
 
     var fx: [1]of.PltFixup;
     fx[0].seg_index = 0; fx[0].seg_offset = fixup_off; fx[0].import_index = 1;
-    fx[0].patch_vaddr = base + fixup_off::u64; fx[0].addend = fixup_add;
+    fx[0].patch_vaddr = seg_va + fixup_off::u64; fx[0].addend = fixup_add;
 
     var gx: [1]of.ImportAddrFixup;
     if (arch_id == isa.ARCH_X86_64) {
         gx[0].seg_index = 0; gx[0].seg_offset = 10; gx[0].import_index = 0;
-        gx[0].patch_vaddr = base + 10; gx[0].kind = of.RK_GOTPCREL; gx[0].addend = -4;
+        gx[0].patch_vaddr = seg_va + 10; gx[0].kind = of.RK_GOTPCREL; gx[0].addend = -4;
         dyn.import_addr_fixups = ?gx[0];
         dyn.import_addr_fixup_count = 1;
     }
@@ -5814,6 +5897,7 @@ fun t_rebase_vaddr(buf: *u8, nth: u32) u64 {
 # seg_count: number of load segments
 # dyn:       the dynamic-link plan
 # entry:     the entry virtual address
+# base:      the image base the linker reserved the header span above
 # ret:       the emitted image bytes, or an error string
 # give each hand-built load segment the one named section a link of mach's own
 # objects would produce for it, since those objects carry one section name per kind
@@ -5848,13 +5932,13 @@ fun t_name_segs(alloc: *A.Allocator, itn: *intern.Interner, segs: *of.LoadSegmen
 
 fun t_emit_dyn(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
                segs: *of.LoadSegment, seg_count: u32, dyn: *of.DynamicInfo,
-               entry: u64) R.Result[Vector[u8], str] {
+               entry: u64, base: u64) R.Result[Vector[u8], str] {
     if (t_name_segs(alloc, itn, segs, seg_count) != 0) { ret R.err[Vector[u8], str]("names"); }
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_seg");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[Vector[u8], str]("temp"); }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val em: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count,
-                                                0x4000, segs[0].vaddr, entry,
+                                                0x4000, base, entry,
                                                 nil::*of.ExecFunction, 0, dyn, nil::*of.PltFixup, 0,
                                                 nil::*of.Section, 0, nil::*of.Section, 0,
                                                 fs.temp_path(?tf)::*u8, "machoseg"::*u8, of.image_options_default(of.SUBSYSTEM_CONSOLE));
@@ -5998,7 +6082,7 @@ fun ts_exec_frames_like_dyn() u8 {
     var dyn: of.DynamicInfo;
     dyn.interp = intern.STR_NIL;
     dyn.pie = true;
-    val dr: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 3, ?dyn, first);
+    val dr: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 3, ?dyn, first, base);
     if (R.is_err[Vector[u8], str](dr)) { ret 1; }
     val dynb: Vector[u8] = R.unwrap_ok[Vector[u8], str](dr);
 
@@ -6046,6 +6130,193 @@ fun ts_exec_frames_like_dyn() u8 {
     ret 0;
 }
 
+# write `segs` through both executable writers and hand each image back, so a fact
+# that must hold of the Mach-O framing can be asserted on the layouts together
+# ---
+# alloc:     allocator for the temp files and the returned bytes
+# itn:       interner the writers resolve names through
+# isa_vt:    the instruction-set vtable
+# segs:      the load segments to frame
+# seg_count: number of load segments
+# base:      the image base the header span was reserved above
+# stat:      out - the static (LC_UNIXTHREAD) image bytes
+# dynb:      out - the dyld-loaded (LC_MAIN) image bytes
+# ret:       0 when both writers succeeded, 1 otherwise
+fun t_emit_both(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
+                segs: *of.LoadSegment, seg_count: u32, base: u64,
+                stat: *Vector[u8], dynb: *Vector[u8]) u8 {
+    val opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    val entry: u64 = segs[0].vaddr;
+
+    val sf: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_both_s");
+    if (R.is_err[fs.TempFile, str](sf)) { ret 1; }
+    var stf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](sf);
+    val se: R.Result[bool, str] = emit_exec(alloc, itn, isa_vt, segs, seg_count,
+                                            macho_page_size(isa_vt.id), base, entry,
+                                            nil::*of.ExecFunction, 0, nil::*of.Section, 0,
+                                            nil::*of.Section, 0,
+                                            fs.temp_path(?stf)::*u8, "machoboth"::*u8, opts);
+    if (R.is_err[bool, str](se)) { fs.temp_close_and_remove(?stf); ret 1; }
+    val sb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?stf));
+    fs.temp_close_and_remove(?stf);
+    if (R.is_err[Vector[u8], str](sb)) { ret 1; }
+
+    var dyn: of.DynamicInfo;
+    dyn.interp = intern.STR_NIL;
+    dyn.pie = true;
+    val df: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_both_d");
+    if (R.is_err[fs.TempFile, str](df)) { ret 1; }
+    var dtf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](df);
+    val de: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count,
+                                                macho_page_size(isa_vt.id), base, entry,
+                                                nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                nil::*of.Section, 0, nil::*of.Section, 0,
+                                                fs.temp_path(?dtf)::*u8, "machoboth"::*u8, opts);
+    if (R.is_err[bool, str](de)) { fs.temp_close_and_remove(?dtf); ret 1; }
+    val db: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?dtf));
+    fs.temp_close_and_remove(?dtf);
+    if (R.is_err[Vector[u8], str](db)) { ret 1; }
+
+    @stat = R.unwrap_ok[Vector[u8], str](sb);
+    @dynb = R.unwrap_ok[Vector[u8], str](db);
+    ret 0;
+}
+
+# an image whose load commands outgrow one page still links, and its header lands
+# inside the span the linker reserved rather than pushing __TEXT off the base
+#
+# A Mach-O header carries an 80-byte section_64 per named section, and since #2606
+# the linker preserves input section identity instead of coalescing, so an
+# objective-c input contributes one per __objc_* section and the header clears a
+# page long before the address space runs out. `sizeofcmds` is a uint32, so the
+# format caps nothing here - a one-page cap was the linker's, and refusing the link
+# was #2690.
+#
+# Both halves matter. The wide reservation must produce the same framing the narrow
+# one did (__PAGEZERO spanning the whole low region, __TEXT based exactly on the
+# base, the header at file offset 0 inside it), or widening it would have
+# reintroduced the image-slid-a-page-low defect of #2599. And the same fixture
+# offered only the old one-page span must be REFUSED by both writers: without that,
+# a writer that quietly truncated its own load commands would pass everything above
+fun ts_header_span_multi_page(arch_id: u32) u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(arch_id);
+
+    val pg:    u64 = macho_page_size(arch_id);
+    val nsect: u32 = 256;
+
+    var bytes: [2048]u8;
+    var k: usize = 0;
+    for (k < 2048) { bytes[k] = 0; k = k + 1; }
+
+    val sr: R.Result[*of.LoadSection, str] = A.zallocate[of.LoadSection](?alloc, nsect::usize);
+    if (R.is_err[*of.LoadSection, str](sr)) { ret 1; }
+    val secs: *of.LoadSection = R.unwrap_ok[*of.LoadSection, str](sr);
+
+    # "__sNNN" - distinct names, since a section table with a repeated name would
+    # rebind every by-name lookup and is not what a real link produces.
+    var nm: [8]u8;
+    nm[0] = 0x5F; nm[1] = 0x5F; nm[2] = 0x73; nm[6] = 0; nm[7] = 0;
+    var i: u32 = 0;
+    for (i < nsect) {
+        nm[3] = (48 + (i / 100) % 10)::u8;
+        nm[4] = (48 + (i / 10) % 10)::u8;
+        nm[5] = (48 + i % 10)::u8;
+        secs[i].name   = t_intern(?itn, ?nm[0]);
+        if (secs[i].name == intern.STR_NIL) { ret 1; }
+        secs[i].kind   = of.SK_TEXT;
+        secs[i].offset = i * 8;
+        secs[i].len    = 8;
+        secs[i].align  = 8;
+        i = i + 1;
+    }
+
+    var segs: [1]of.LoadSegment;
+    segs[0].filesz = 2048; segs[0].memsz = 2048;
+    segs[0].flags  = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE;
+    segs[0].bytes  = ?bytes[0];
+    segs[0].sections      = secs;
+    segs[0].section_count = nsect;
+
+    # the span the linker would reserve for this shape, through the same vtable hook
+    # it calls during vaddr assignment.
+    var shape: of.HeaderShape;
+    shape.itn         = ?itn;
+    shape.libs        = nil::*of.DynLib;
+    shape.lib_count   = 0;
+    shape.seg_count   = 1;
+    shape.sect_count  = nsect;
+    shape.debug_count = 0;
+    shape.pie         = true;
+    shape.imports     = false;
+    val span: u64 = header_span(?shape, pg);
+    if (span <= pg)          { ret 1; }   # the fixture must outgrow one page
+    if ((span % pg) != 0)    { ret 1; }   # ... in whole pages
+
+    val base: u64 = 0x100000000;
+    segs[0].vaddr = base + span;
+
+    var stat: Vector[u8];
+    var dynb: Vector[u8];
+    if (t_emit_both(?alloc, ?itn, ?isa_vt, ?segs[0], 1, base, ?stat, ?dynb) != 0) { ret 1; }
+
+    var w: u32 = 0;
+    for (w < 2) {
+        var buf: *u8 = stat.data;
+        if (w == 1) { buf = dynb.data; }
+
+        # the header really is over a page, and it fits the reservation.
+        val sizeofcmds: usize = bin.read_u32_le(buf, 20)::usize;
+        if (sizeofcmds::u64 <= pg)                              { ret 1; }
+        if (MACH_HEADER_64_SIZE + sizeofcmds > span::usize)     { ret 1; }
+
+        # __PAGEZERO spans the whole low region and __TEXT is based exactly on the
+        # base, with the header at file offset 0 inside it (#2599).
+        val pz: usize = t_find_seg(buf, "__PAGEZERO");
+        val tx: usize = t_find_seg(buf, "__TEXT");
+        if (pz == 0 || tx == 0)                                 { ret 1; }
+        if (bin.read_u64_le(buf, pz + 24) != 0)                 { ret 1; }
+        if (bin.read_u64_le(buf, pz + 32) != base)              { ret 1; }
+        if (bin.read_u64_le(buf, tx + 24) != base)              { ret 1; }
+        if (bin.read_u64_le(buf, tx + 40) != 0)                 { ret 1; }
+        if (bin.read_u32_le(buf, tx + 64) != nsect)             { ret 1; }
+
+        # the first section starts where the reservation ends, in both address and
+        # file offset, so the header and the content agree on where the header stops.
+        val s0: usize = tx + SEGMENT_CMD_64_SIZE;
+        if (bin.read_u64_le(buf, s0 + 32) != base + span)       { ret 1; }
+        if (bin.read_u32_le(buf, s0 + 48)::u64 != span)         { ret 1; }
+        w = w + 1;
+    }
+
+    # offered only the page the linker used to reserve unconditionally, both writers
+    # refuse rather than emit a header that overruns its span.
+    segs[0].vaddr = base + pg;
+    val opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_span_bad");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val bad_s: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1,
+                                               pg, base, base + pg,
+                                               nil::*of.ExecFunction, 0, nil::*of.Section, 0,
+                                               nil::*of.Section, 0,
+                                               fs.temp_path(?tf)::*u8, "machospanbad"::*u8, opts);
+    var dyn: of.DynamicInfo;
+    dyn.interp = intern.STR_NIL;
+    dyn.pie = true;
+    val bad_d: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1,
+                                                   pg, base, base + pg,
+                                                   nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                   nil::*of.Section, 0, nil::*of.Section, 0,
+                                                   fs.temp_path(?tf)::*u8, "machospanbad"::*u8, opts);
+    fs.temp_close_and_remove(?tf);
+    if (!R.is_err[bool, str](bad_s)) { ret 1; }
+    if (!R.is_err[bool, str](bad_d)) { ret 1; }
+    ret 0;
+}
+
 # the Mach-O segment table a PIE link with distinct rodata and rel.ro segments must
 # produce: exactly one segment is SG_READ_ONLY - the one the rebase stream writes
 # into, which is also the only one that may be named __DATA_CONST - while un-rebased
@@ -6070,19 +6341,21 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     for (k < 80) { bytes[k] = 0; k = k + 1; }
 
     # text, data, rodata, rel.ro, bss - each on its own 16 KiB page, in the linker's
-    # per-kind segment order.
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
+    # per-kind segment order, starting one page above the base where the linker
+    # reserved the header span.
+    val base:  u64 = 0x100000000;
+    val pg:    u64 = 0x4000;
+    val first: u64 = base + pg;
     var segs: [5]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE;  segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
     segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
     segs[2].flags = of.SEG_FLAG_READ;                        segs[2].bytes = ?bytes[32];
-    segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
+    segs[3].vaddr = first + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
     segs[3].flags = of.SEG_FLAG_READ;                        segs[3].bytes = ?bytes[48];
-    segs[4].vaddr = base + pg * 4; segs[4].filesz = 0;  segs[4].memsz = 16;
+    segs[4].vaddr = first + pg * 4; segs[4].filesz = 0;  segs[4].memsz = 16;
     segs[4].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[4].bytes = nil;
 
     # pointers to slide in rel.ro and in data: a writable segment is already writable
@@ -6098,7 +6371,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     dyn.base_reloc_count = 2;
     dyn.pie = true;
 
-    val r1: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, base);
+    val r1: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, first, base);
     if (R.is_err[Vector[u8], str](r1)) { ret 1; }
     val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](r1);
 
@@ -6108,7 +6381,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     if (t_count_segs_named(buf.data, "__DATA_CONST") != 1)                   { ret 1; }
     val dc: usize = t_find_seg(buf.data, "__DATA_CONST");
     if (dc == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, dc + 24) != base + pg * 3)                 { ret 1; }
+    if (bin.read_u64_le(buf.data, dc + 24) != first + pg * 3)                 { ret 1; }
     if ((bin.read_u32_le(buf.data, dc + 68) & SG_READ_ONLY) == 0)            { ret 1; }
     if (bin.read_u32_le(buf.data, dc + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
     if (bin.read_u32_le(buf.data, dc + 64) != 1)                             { ret 1; }
@@ -6118,7 +6391,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     if (t_count_segs_named(buf.data, "__RODATA") != 1)                       { ret 1; }
     val rd: usize = t_find_seg(buf.data, "__RODATA");
     if (rd == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg * 2)                 { ret 1; }
+    if (bin.read_u64_le(buf.data, rd + 24) != first + pg * 2)                 { ret 1; }
     if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)                  { ret 1; }
     if (bin.read_u32_le(buf.data, rd + 56) != VM_PROT_READ)                  { ret 1; }
     if ((bin.read_u32_le(buf.data, rd + 68) & SG_READ_ONLY) != 0)            { ret 1; }
@@ -6128,7 +6401,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     # after fixups, faulting the program's first store to a pointer-valued global.
     val dt: usize = t_find_seg(buf.data, "__DATA");
     if (dt == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, dt + 24) != base + pg)                     { ret 1; }
+    if (bin.read_u64_le(buf.data, dt + 24) != first + pg)                     { ret 1; }
     if (bin.read_u32_le(buf.data, dt + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
     if (bin.read_u32_le(buf.data, dt + 56) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
     if ((bin.read_u32_le(buf.data, dt + 68) & SG_READ_ONLY) != 0)            { ret 1; }
@@ -6136,31 +6409,31 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     # every section names the segment it lives in, and each rebase resolves through
     # its selected segment back to the address the linker recorded.
     if (!t_sections_match_segname(buf.data))                                 { ret 1; }
-    if (t_rebase_vaddr(buf.data, 0) != base + pg)                            { ret 1; }
-    if (t_rebase_vaddr(buf.data, 1) != base + pg * 3)                        { ret 1; }
+    if (t_rebase_vaddr(buf.data, 0) != first + pg)                            { ret 1; }
+    if (t_rebase_vaddr(buf.data, 1) != first + pg * 3)                        { ret 1; }
     if (t_rebase_vaddr(buf.data, 2) != 0)                                    { ret 1; }
 
     # rodata rebased as well: both read-only segments now need dyld's fixup pass, and
     # Mach-O maps one such segment - they share it, carrying a section each, so the
     # image keeps exactly one SG_READ_ONLY instead of being refused.
     dyn.base_reloc_count = 3;
-    val r2: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, base);
+    val r2: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, first, base);
     if (R.is_err[Vector[u8], str](r2)) { ret 1; }
     val buf2: Vector[u8] = R.unwrap_ok[Vector[u8], str](r2);
     if (t_count_sg_read_only(buf2.data) != 1)                                { ret 1; }
     if (t_count_segs_named(buf2.data, "__DATA_CONST") != 1)                  { ret 1; }
     if (t_count_segs_named(buf2.data, "__RODATA") != 0)                      { ret 1; }
     val dc2: usize = t_find_seg(buf2.data, "__DATA_CONST");
-    if (bin.read_u64_le(buf2.data, dc2 + 24) != base + pg * 2)               { ret 1; }
+    if (bin.read_u64_le(buf2.data, dc2 + 24) != first + pg * 2)               { ret 1; }
     if (bin.read_u32_le(buf2.data, dc2 + 64) != 2)                           { ret 1; }
     if (bin.read_u64_le(buf2.data, dc2 + 32)
         != bin.align_up_u64(pg + 16, macho_page_size(arch_id)))              { ret 1; }
     if (!t_sections_match_segname(buf2.data))                                { ret 1; }
     # the merged members share one command index, and their offsets are measured from
     # that command's address, not from the member's own.
-    if (t_rebase_vaddr(buf2.data, 0) != base + pg)                           { ret 1; }
-    if (t_rebase_vaddr(buf2.data, 1) != base + pg * 2)                       { ret 1; }
-    if (t_rebase_vaddr(buf2.data, 2) != base + pg * 3)                       { ret 1; }
+    if (t_rebase_vaddr(buf2.data, 0) != first + pg)                           { ret 1; }
+    if (t_rebase_vaddr(buf2.data, 1) != first + pg * 2)                       { ret 1; }
+    if (t_rebase_vaddr(buf2.data, 2) != first + pg * 3)                       { ret 1; }
     ret 0;
 }
 
@@ -6179,16 +6452,17 @@ fun ts_dyn_exec_split_data_const() u8 {
     var k: usize = 0;
     for (k < 64) { bytes[k] = 0; k = k + 1; }
 
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
+    val base:  u64 = 0x100000000;
+    val pg:    u64 = 0x4000;
+    val first: u64 = base + pg;
     var segs: [4]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
     segs[1].flags = of.SEG_FLAG_READ;                       segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
     segs[2].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;   segs[2].bytes = ?bytes[32];
-    segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
+    segs[3].vaddr = first + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
     segs[3].flags = of.SEG_FLAG_READ;                       segs[3].bytes = ?bytes[48];
 
     var brs: [2]of.BaseReloc;
@@ -6201,7 +6475,7 @@ fun ts_dyn_exec_split_data_const() u8 {
     dyn.base_reloc_count = 2;
     dyn.pie = true;
 
-    val r: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 4, ?dyn, base);
+    val r: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 4, ?dyn, first, base);
     if (!R.is_err[Vector[u8], str](r))                                       { ret 1; }
     val msg: str = R.unwrap_err[Vector[u8], str](r);
     # the diagnostic names both offending segments and a relocation inside the second.
@@ -6225,14 +6499,15 @@ fun ts_exec_merges_read_only() u8 {
     var k: usize = 0;
     for (k < 48) { bytes[k] = 0; k = k + 1; }
 
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
+    val base:  u64 = 0x100000000;
+    val pg:    u64 = 0x4000;
+    val first: u64 = base + pg;
     var segs: [3]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
     segs[1].flags = of.SEG_FLAG_READ;                       segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
     segs[2].flags = of.SEG_FLAG_READ;                       segs[2].bytes = ?bytes[32];
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_exec_ro");
@@ -6240,7 +6515,7 @@ fun ts_exec_merges_read_only() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     if (t_name_segs(?alloc, ?itn, ?segs[0], 3) != 0) { ret 1; }
     val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 3,
-                                            pg, base, base,
+                                            pg, base, first,
                                             nil::*of.ExecFunction, 0, nil::*of.Section, 0,
                                             nil::*of.Section, 0,
                                             fs.temp_path(?tf)::*u8, "machoexecro"::*u8, of.image_options_default(of.SUBSYSTEM_CONSOLE));
@@ -6255,7 +6530,7 @@ fun ts_exec_merges_read_only() u8 {
     if (rd == 0)                                                             { ret 1; }
     # one command spanning both read-only segments, from the first's address to the
     # second's end.
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg)                     { ret 1; }
+    if (bin.read_u64_le(buf.data, rd + 24) != first + pg)                     { ret 1; }
     if (bin.read_u64_le(buf.data, rd + 32)
         != bin.align_up_u64(pg + 16, EXEC_PAGE_SIZE))                        { ret 1; }
     if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)                  { ret 1; }
@@ -6487,6 +6762,8 @@ test "mach.lang.target.of.macho:dyn_exec" {
     if (ts_dyn_exec_split_data_const() != 0)               { ret 1; }
     if (ts_exec_merges_read_only() != 0)                   { ret 1; }
     if (ts_exec_frames_like_dyn() != 0)                    { ret 1; }
+    if (ts_header_span_multi_page(isa.ARCH_X86_64) != 0)   { ret 1; }
+    if (ts_header_span_multi_page(isa.ARCH_AARCH64) != 0)  { ret 1; }
     if (ts_import_address_fixup_validation() != 0)         { ret 1; }
     ret 0;
 }
@@ -6509,10 +6786,10 @@ fun ts_exec_debug_roundtrip() u8 {
     var k: usize = 0;
     for (k < 8) { code[k] = 0x90; k = k + 1; }
     val base:  u64 = 0x100000000;
-    val entry: u64 = base;
+    val entry: u64 = base + 4096;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].vaddr = base + 4096; segs[0].filesz = 8; segs[0].memsz = 8;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     var info_bytes: [4]u8;


### PR DESCRIPTION
Closes #2690

A darwin link whose load commands exceed 4096 bytes was refused outright:

```
error: macho: dyn-exec header exceeds the one-page reservation
```

## What was wrong

The linker left exactly one page above the image base for the Mach-O header, and both executable writers hardcoded that page as the header span. Nothing in the format caps load commands there. `sizeofcmds` is a `uint32`, and the header carries one `LC_SEGMENT_64` per segment, one 80-byte `section_64` per named section and one `LC_LOAD_DYLIB` per dependency, so it grows with the image.

**The issue's #2606 hypothesis is confirmed.** `frame_sect_total` sums `segs[i].section_count`, which is exactly the input section identity #2606 stopped coalescing. The repro I built crosses the cap on section count alone: 60 `#[section]` globals produce `sizeofcmds` 5880 with 4880 of it (61 entries) coming from one segment's section table. So any objective-c consumer hits this, not only the reported one - a vendored archive's `__objc_classlist`, `__objc_const`, `__objc_data`, `__cstring`, `__gcc_except_tab` and friends each cost 80 bytes.

The cap was not the writer's to lift. The reservation is decided during vaddr assignment, and `__TEXT` is based exactly on the image base *because* the header fills the gap below the first segment. Widening the gap in the writer would have slid `__TEXT`, and `__PAGEZERO` with it, one span below the base - which is #2599.

## The ordering problem, and how it is resolved

The header size depends on the segment, section and dependency counts; the reservation has to be fixed before virtual addresses are assigned; and the dependency set is not known until symbols are resolved, which needs those addresses. That looks circular, but is not: **the header size does not depend on any address.** Counts, names and import classification are all address-independent.

So the linker measures the shape once the dynamic plan is built (`measure_header_shape`), asks the format how many bytes it wants (`of.HeaderSpanFn`), and if that exceeds the provisional page it reassigns virtual addresses, refinalizes placements and recollects symbols - all before `patch_relocations` reads a single address. One step, no iteration, no fixpoint loop.

`of.HeaderSpanFn` is the contract at the growth axis: a format states what its header costs for a measured `of.HeaderShape` and gets whatever it asks for, page-rounded. A format without the hook keeps the single page it had, so ELF, COFF, SPIR-V and raw are untouched. Mach-O's answer is a deliberate upper bound - both platform commands counted, the larger of `LC_UNIXTHREAD`'s thread state and `LC_MAIN`, a command charged per load segment even where adjacent same-protection segments collapse - because over-reserving costs padding inside `__TEXT`'s leading pages while under-reserving costs the link.

Both writers now read the span back as `segs[0].vaddr - image_base` rather than assuming a page, so `__TEXT` lands on the base by construction and `__PAGEZERO` stays non-empty beneath it on every path. **#2599 cannot regress here**: the previous derivation subtracted a constant from the segment address, which is what let the image slide; this one is anchored on the base.

## Verification

**Demonstrated failing first.** Both new `int` cases against the pre-fix compiler:

```
FAIL surface/macho-header-span-aarch64 [linux/debug] (build)
    error: macho: dyn-exec header exceeds the one-page reservation
FAIL surface/macho-header-span-x86_64 [linux/debug] (build)
    error: macho: dyn-exec header exceeds the one-page reservation
```

and passing after. The new `macho:dyn_exec` unit assertion likewise fails when `header_span` is stubbed back to one page.

Emitted images, cross-built on linux:

| | x86_64 | aarch64 |
|---|---|---|
| `sizeofcmds` | 5880 (page 4096) | 19296 (page 16384) |
| reservation | 0x2000 | 0x8000 |
| `__PAGEZERO` vmsize | 0x100000000 | 0x100000000 |
| `__TEXT` vmaddr / fileoff | 0x100000000 / 0 | 0x100000000 / 0 |
| first section fileoff | 8192 | 32768 |

- `mach test .` — 1245 passed, 0 failed
- `int/run.sh --target linux --deps pin` — all cases passed, including every existing macho structural case
- `int/lib/check-target-matrix.sh` — 352 case x leg pairs OK
- self-host fixpoint — stage3 byte-identical to stage4

Several existing macho unit fixtures placed their first load segment *at* the image base, a layout the linker has not produced since #2599 and which the writer previously papered over by subtracting a page. They now start one page above the base, matching what the linker hands the writer.

## Not verified here

`mach-glfw#32`'s darwin leg. This repo has no macOS runner, and the linking is mach's own, so the whole path is exercised cross-compiling on linux - but the end-to-end consumer needs a run in that repo against a compiler carrying this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6L67517WpZTPQDhtMsuJ2