### PR TITLE
test(driver): pin the #2697 reference in the sub-width refusal

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6309,6 +6309,11 @@ test "mach.lang.driver:vector_form_bounds_reported_as_themselves" {
         "narrower than this target's 128-bit vector register")) { bad = 1; }
     if (!ut_sema_rejects_with("fun main() i64 { var v: f32x2; ret 0; }\n",
         "narrower than this target's 128-bit vector register")) { bad = 1; }
+    # ...and it names the issue that lifts it, so the reader has a thread to pull
+    # rather than a dead end. asserted separately: the needle above still matches if
+    # the reference is dropped, so it would not have caught that on its own.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x3; ret 0; }\n",
+        "(#2697)")) { bad = 1; }
 
     # DEGENERATE LANE COUNT: its own sentence, not a width failure.
     if (!ut_sema_rejects_with("fun main() i64 { var v: f32x1; ret 0; }\n",


### PR DESCRIPTION
Reduced from what I first opened: **#2699 merged while this was in flight and already carried the message change**, so `dev` names #2697 in the diagnostic today. What it does not have is anything asserting that.

So this is now one test, five lines.

The existing needle for that diagnostic is `"narrower than this target's 128-bit vector register"`, which matches with or without the issue reference. Dropping the thread the reader is meant to pull would have been silent — the same "reports more than it verifies" shape that ran through this whole issue.

```mach
if (!ut_sema_rejects_with("fun main() i64 { var v: f32x3; ret 0; }\n",
    "(#2697)")) { bad = 1; }
```

Asserted separately rather than folded into the existing needle, so each checks one thing.

Verified by mutation: removing `(#2697)` from the message fails this test.

Full suite green (1254).

Refs #2687, #2697.
