### PR TITLE
feat(ct): model x86-64 flags taint in #[oblivious] inline asm

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -216,6 +216,30 @@ On a target whose grammar has no flag reader at all, every one of these facts is
 vacuous, and that vacuity is asserted per target rather than assumed: adding an
 aarch64 `cset` later has to state its facts deliberately.
 
+The rows whose facts could wrongly *permit* a leak are measured against the CPU
+rather than asserted from a manual — `int/surface/ct-flags-hardware` runs each
+instruction twice with the flags preset all-set and all-clear and reports what it
+actually defines, preserves, and reads. Three rows are exempt and stay a reasoned
+classification: `popfq`, `iretq` and `syscall` take their flags from the stack,
+the interrupt frame, or a masked prior RFLAGS, and no experiment of that shape can
+tell you where a value came *from*.
+
+**What the walk does not model is memory.** A secret spilled to the stack and
+reloaded comes back in a register the walk believes is public, and every check
+downstream of it is defeated:
+
+```
+mov rax, {r}
+mov [rsp], rax
+mov rbx, [rsp]
+mov rcx, [rbx]     # a secret-derived address, accepted
+```
+
+The direct form of that — `mov rax, {r}` then `mov rbx, [rax]` — *is* refused, so
+the gate works and this path specifically escapes it. Taint is a register set with
+no memory domain, on every target, and closing it is tracked as #2706. Reading the
+flags model above as evidence that laundering is closed in general would be wrong.
+
 The variable-latency check also bites unevenly: x86-64's and aarch64's asm grammars
 carry no divide, multiply or float instruction at all, so it reaches only their
 register-count shifts. riscv64's grammar admits the whole M-extension, so on that

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -184,18 +184,37 @@ declared type. What the walk cannot model, it refuses:
 | a body that does not parse | nothing to analyze |
 | a data directive (`.byte`, `.word`, `.long`, `.quad`) | its payload can encode any instruction |
 | a mnemonic the target has not classified | its timing behaviour is unknown |
-| **a flags-conditioned branch** (x86-64 `jcc`, aarch64 `b.<cond>`) | its condition rides the flags register, which the inline-asm effect model does not represent (#2460) |
+| **a flags-conditioned branch on a secret** (x86-64 `jcc`, aarch64 `b.<cond>`) | the flags it reads were filled from a secret |
 
 That last row is a per-target asymmetry worth stating precisely, because getting it
 wrong was a real hole (#2477). A branch whose condition is a **register operand** is
 visible to the walk and is checked: aarch64's `cbz`/`cbnz`, and every riscv64 branch,
 which compares two registers — RISC-V has no flags register at all. A branch whose
-condition rides the **flags register** cannot be checked, because the effect model
-carries no flags, so a `cmp` of a secret before it would be invisible: those are
-refused. x86-64's `jcc` family is flags-conditioned, and so is **aarch64's
-`b.<cond>`** — which is easy to miss, because `b.<cond>` does not appear in aarch64's
-mnemonic table at all. It is admitted by the grammar's *decode hook*, carrying the
-unconditional branch's own opcode with the condition in its flags.
+condition rides the **flags register** is checked against a separate flags-taint
+state (#2460): a `cmp` of a secret marks the flags secret-derived, and a later `jcc`
+reading them is refused, while a compare-and-branch over public data is accepted.
+x86-64's `jcc` family is flags-conditioned, and so is **aarch64's `b.<cond>`** —
+which is easy to miss, because `b.<cond>` does not appear in aarch64's mnemonic table
+at all. It is admitted by the grammar's *decode hook*, carrying the unconditional
+branch's own opcode with the condition in its flags.
+
+The flags model is deliberately more than a single "writes flags" bit, because one
+bit has no correct value for two families. `inc` and `dec` write every status flag
+**except** carry, and the shifts write nothing at all when the count is zero — so
+neither can be taken to have refreshed the flags. A secret `cmp`, a public `inc`, and
+a `jc` is therefore still refused: the carry the branch reads is the secret one. Only
+an instruction that unconditionally overwrites every flag this grammar can read
+(`add`, `sub`, `cmp`, `test`, `and`, `or`, `xor`, `neg`, `cmpxchg`, `xadd`) clears
+the taint. `popfq`, `iretq` and `syscall` load or mask flags from somewhere the model
+does not represent, so they taint unconditionally and never clear.
+
+A `setcc` **consumes** a flag into a register, so with secret-derived flags its
+destination is secret too — otherwise a secret could be laundered out of the flags
+and used as a memory index, which the address check would then miss.
+
+On a target whose grammar has no flag reader at all, every one of these facts is
+vacuous, and that vacuity is asserted per target rather than assumed: adding an
+aarch64 `cset` later has to state its facts deliberately.
 
 The variable-latency check also bites unevenly: x86-64's and aarch64's asm grammars
 carry no divide, multiply or float instruction at all, so it reaches only their

--- a/int/surface/ct-flags-hardware/case.conf
+++ b/int/surface/ct-flags-hardware/case.conf
@@ -1,0 +1,14 @@
+# the flags facts `mach.lang.ct` asserts, measured against the CPU (#2460)
+#
+# The security surface of the #[oblivious] inline-asm flags model is eighteen rows
+# whose facts, if wrong, silently PERMIT a leak. Nobody working on this has the
+# Intel SDM, so those facts were inferred - and inferred confidence is exactly what
+# is worthless as a security argument. This measures them instead, on the part the
+# emitted code actually runs on, and it re-measures on every CI run rather than
+# once in a session transcript.
+#
+# linux only, and x86_64 only: the probe is x86-64 inline asm and the facts are
+# x86-64's. The other targets' flags facts are vacuous and are pinned by unit tests
+# in their own encoders instead.
+run: exec
+targets: linux

--- a/int/surface/ct-flags-hardware/expect.txt
+++ b/int/surface/ct-flags-hardware/expect.txt
@@ -1,0 +1,26 @@
+add ZF:defined CF:defined reads:0
+sub ZF:defined CF:defined reads:0
+cmp ZF:defined CF:defined reads:0
+test ZF:defined CF:defined reads:0
+and ZF:defined CF:defined reads:0
+or ZF:defined CF:defined reads:0
+xor ZF:defined CF:defined reads:0
+neg ZF:defined CF:defined reads:0
+neg0 ZF:defined CF:defined reads:0
+xadd ZF:defined CF:defined reads:0
+inc ZF:defined CF:preserved reads:0
+dec ZF:defined CF:preserved reads:0
+shl1 ZF:defined CF:defined reads:0
+shl0 ZF:preserved CF:preserved reads:0
+shr0 ZF:preserved CF:preserved reads:0
+sar0 ZF:preserved CF:preserved reads:0
+not ZF:preserved CF:preserved reads:0
+mov ZF:preserved CF:preserved reads:0
+lea ZF:preserved CF:preserved reads:0
+xchg ZF:preserved CF:preserved reads:0
+setb ZF:preserved CF:preserved reads:1
+setae ZF:preserved CF:preserved reads:1
+jc ZF:preserved CF:preserved reads:0
+popfq NOT MEASURABLE: opaque flag source, classified by reasoning
+iretq NOT MEASURABLE: opaque flag source, classified by reasoning
+syscall NOT MEASURABLE: opaque flag source, classified by reasoning

--- a/int/surface/ct-flags-hardware/mach.toml
+++ b/int/surface/ct-flags-hardware/mach.toml
@@ -1,0 +1,46 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "cc -c -O1 probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/ct-flags-hardware/probe.c
+++ b/int/surface/ct-flags-hardware/probe.c
@@ -1,0 +1,111 @@
+/* Measures the flags facts `mach.lang.ct` asserts, against the CPU this runs on.
+ *
+ * Two probes, both from the same pair of runs: the instruction is executed twice
+ * with identical operands, once with RFLAGS preset all-set and once all-clear.
+ *
+ *   WRITER probe  - read RFLAGS back. A flag with the same result in both runs is
+ *                   DEFINED by the instruction; one that comes out equal to its
+ *                   input in both is PRESERVED. That is the `defines_flags`
+ *                   predicate, measured.
+ *   READER probe  - read the DESTINATION REGISTER back. If it differs between the
+ *                   two presets, the instruction consumed a flag. That is the
+ *                   `reads_flags` predicate, measured.
+ */
+#include <stdint.h>
+
+#define FSET   0x0CD5UL   /* every arithmetic flag set   */
+#define FCLR   0x0002UL   /* every arithmetic flag clear (bit 1 is reserved-1) */
+#define ZF     0x0040UL
+#define CF     0x0001UL
+
+/* Run INSN once with RFLAGS preset to `pre`, and report BOTH observables from that
+   single run: the flags afterwards, and the destination register afterwards. One
+   macro rather than two so the writer and reader probes cannot drift apart in the
+   operands or the preset they use. */
+#define RUN(INSN, A, B, PRE, OUTF, OUTD)                                       \
+    do { uint64_t _a = (A), _b = (B), _d = 0, _o;                              \
+         __asm__ volatile ("push %[p]\n\tpopfq\n\t" INSN                       \
+                           "\n\tpushfq\n\tpop %[o]"                            \
+             : [o]"=&r"(_o), [d]"+r"(_d), [x]"+r"(_a), [y]"+r"(_b)             \
+             : [p]"r"((uint64_t)(PRE)) : "cc", "memory");                      \
+         (OUTF) = _o; (OUTD) = _d; } while (0)
+
+static const char *verdict(uint64_t hi, uint64_t lo, uint64_t bit) {
+    int oh = (hi & bit) != 0, ol = (lo & bit) != 0;
+    if (oh == ol) return "defined";
+    if (oh == ((FSET & bit) != 0) && ol == ((FCLR & bit) != 0)) return "preserved";
+    return "varies";
+}
+
+extern int ct_probe_line(const char *name, const char *zf, const char *cf, int reads);
+extern int ct_probe_note(const char *name);
+
+#define W2(NAME, INSN, A, B)                                                   \
+    do { uint64_t _hi, _lo, _dh, _dl;                                          \
+         RUN(INSN, A, B, FSET, _hi, _dh);                                      \
+         RUN(INSN, A, B, FCLR, _lo, _dl);                                      \
+         ct_probe_line(NAME, verdict(_hi,_lo,ZF), verdict(_hi,_lo,CF), _dh != _dl); \
+    } while (0)
+
+void ct_flags_probe(void) {
+    /* the ten rows classified `defines_flags`: every one must measure defined/defined */
+    W2("add",     "add %[y], %[x]",            5, 3);
+    W2("sub",     "sub %[y], %[x]",            5, 3);
+    W2("cmp",     "cmp %[y], %[x]",            5, 3);
+    W2("test",    "test %[y], %[x]",           5, 3);
+    W2("and",     "and %[y], %[x]",            5, 3);
+    W2("or",      "or %[y], %[x]",             5, 3);
+    W2("xor",     "xor %[y], %[x]",            5, 3);
+    W2("neg",     "neg %[x]",                  5, 0);
+    W2("neg0",    "neg %[x]",                  0, 0);
+    W2("xadd",    "xadd %[y], %[x]",           5, 3);
+
+    /* the traps: partial writers that must NOT be read as defining */
+    W2("inc",     "inc %[x]",                  5, 0);
+    W2("dec",     "dec %[x]",                  5, 0);
+    W2("shl1",    "shl $1, %[x]",              5, 0);
+    W2("shl0",    "shl $0, %[x]",              5, 0);
+    W2("shr0",    "shr $0, %[x]",              5, 0);
+    W2("sar0",    "sar $0, %[x]",              5, 0);
+
+    /* rows classified as writing no observable flag */
+    W2("not",     "not %[x]",                  5, 0);
+    W2("mov",     "mov %[y], %[x]",            5, 3);
+    W2("lea",     "lea 1(%[y]), %[x]",         5, 3);
+    W2("xchg",    "xchg %[y], %[x]",           5, 3);
+
+    /* the SETcc rows: the reader probe is the point. they write no flag, and their
+       DESTINATION must differ between the two presets - that difference IS the
+       laundering path `reads_flags` exists to close. */
+    W2("setb",    "setb %b[d]",                5, 3);
+    W2("setae",   "setae %b[d]",               5, 3);
+
+    /* A BRANCH CONSUMES A FLAG AND THE READER PROBE CANNOT SEE IT.
+       `jc` reads CF, but a taken branch leaves no register difference to measure,
+       so the probe reports reads:0. That is a limit of the probe, NOT a fact about
+       `jc`, and it is the structural reason the ten `j*` rows do not need
+       `reads_flags`: they are refused outright by `cond_flags` before any fold. */
+    W2("jc",      "jc 1f\n\t1:",                5, 3);
+
+    /* THE ROWS THIS HARNESS CANNOT CLASSIFY, PRINTED SO THE GAP IS IN THE ARTIFACT
+       RATHER THAN ONLY IN A COMMENT.
+
+       `popfq` PASSES THE WRITER PROBE AS "defines BOTH". The incoming flags really
+       do not affect the result, so the probe is right on its own terms and wrong as
+       a classification: the value came from the stack, which the model does not
+       represent and an attacker may control. Classifying it `defines_flags` on this
+       evidence would let it clear a taint from an arbitrary source.
+
+       `defines_flags` asks "does this instruction overwrite the flags with a value
+       derived from its own operands?" The probe measures only the first half. For
+       these three the second half is false, and no experiment of this shape can
+       tell you that - the question is where the value came FROM, which is
+       structural.
+
+       So: do not extend this harness to classify these rows from their output. If
+       you are here because you noticed the probe handles them fine, that is the
+       trap. */
+    ct_probe_note("popfq");
+    ct_probe_note("iretq");
+    ct_probe_note("syscall");
+}

--- a/int/surface/ct-flags-hardware/src/main.mach
+++ b/int/surface/ct-flags-hardware/src/main.mach
@@ -1,0 +1,35 @@
+# Prints what the CPU says about each instruction's flags behaviour (#2460).
+#
+# The golden is the measurement. A row whose hardware behaviour stops matching the
+# classification in `x64/encode.mach` fails here, which is what converts the
+# eighteen-row security surface from inferred to checked.
+#
+# THE OUTPUT IS NOT UNIFORMLY EVIDENCE. Three rows print NOT MEASURABLE, and the
+# reason is in probe.c: `popfq` passes the writer probe cleanly and is still not a
+# definer, because the flags came from the stack. Do not read those lines as a gap
+# waiting to be filled.
+
+use std.runtime;
+use std.types.size.usize;
+use std.types.string.str;
+use p: std.print;
+
+ext fun ct_flags_probe();
+
+#[symbol("ct_probe_line")]
+pub fun probe_line(name: *u8, zf: *u8, cf: *u8, reads: i32) i32 {
+    p.printlnf("{} ZF:{} CF:{} reads:{}", name::str, zf::str, cf::str, reads);
+    ret 0;
+}
+
+#[symbol("ct_probe_note")]
+pub fun probe_note(name: *u8) i32 {
+    p.printlnf("{} NOT MEASURABLE: opaque flag source, classified by reasoning", name::str);
+    ret 0;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    ct_flags_probe();
+    ret 0;
+}

--- a/src/lang/ct.mach
+++ b/src/lang/ct.mach
@@ -157,25 +157,132 @@ test "mach.lang.ct.ct_cap:table" {
 # constant-time guarantee, so a flags-conditioned branch is REFUSED outright rather
 # than analyzed. Lifting that needs flags in the effect model, tracked as #2460.
 # ---
-# op:         the constant-time class of the operation
-# known:      false when the ISA has not classified this mnemonic (refuse on secret)
-# cond_flags: a conditional branch whose condition rides the flags register
-# cond_reg:   a conditional branch whose condition is a register operand
+# op:            the constant-time class of the operation
+# known:         false when the ISA has not classified this mnemonic (refuse on secret)
+# cond_flags:    a conditional branch whose condition rides the flags register
+# cond_reg:      a conditional branch whose condition is a register operand
+# flags_stated:  whether an ISA deliberately stated this row's flags facts (#2460)
+# writes_flags:  MAY write an observable flag, so secret operands taint FLAGS
+# defines_flags: UNCONDITIONALLY overwrites every observable flag, so public
+#                operands make FLAGS clean. implies writes_flags. ONLY THIS CLEARS
+# opaque_flags:  loads FLAGS from something the model does not represent, so it
+#                taints unconditionally, independent of operands
+# reads_flags:   consumes an observable flag into a register, so a tainted FLAGS
+#                makes this instruction's outputs secret
 pub rec AsmClass {
-    op:         CtOp;
-    known:      bool;
-    cond_flags: bool;
-    cond_reg:   bool;
+    op:            CtOp;
+    known:         bool;
+    cond_flags:    bool;
+    cond_reg:      bool;
+    flags_stated:  bool;
+    writes_flags:  bool;
+    defines_flags: bool;
+    opaque_flags:  bool;
+    reads_flags:   bool;
 }
 
 # an unclassified mnemonic: refuses the moment a secret reaches it
+#
+# THE FLAGS DEFAULTS ARE DELIBERATELY ASYMMETRIC, and the asymmetry is the whole
+# security argument (#2460). A row nobody thought about must fail SAFE:
+#
+#   writes_flags  TRUE  - it taints FLAGS when its operands are secret
+#   defines_flags FALSE - it never clears a taint
+#   opaque_flags  FALSE - it is not an unmodeled flag source (those are named)
+#   reads_flags   FALSE - see below
+#
+# So the only facts that can wrongly PERMIT are the ones an ISA sets explicitly.
+# Setting `writes_flags` false is a precision optimization, not a correctness
+# requirement: omitting it costs a spurious taint, which the next defining
+# instruction clears, and a false refusal is safe where a false accept is not.
+#
+# `reads_flags` defaults FALSE rather than true, breaking the pattern, because
+# true is not the conservative choice here - it is merely the blunt one. Every
+# instruction executed while FLAGS is dirty would taint its destination,
+# including `mov`, which refuses far more than it protects. It is set on the
+# rows that genuinely consume a flag into a register.
 pub fun asm_unknown() AsmClass {
     var a: AsmClass;
-    a.op         = CT_OP_NONE;
-    a.known      = false;
-    a.cond_flags = false;
-    a.cond_reg   = false;
+    a.op            = CT_OP_NONE;
+    a.known         = false;
+    a.cond_flags    = false;
+    a.cond_reg      = false;
+    a.flags_stated  = false;
+    a.writes_flags  = true;
+    a.defines_flags = false;
+    a.opaque_flags  = false;
+    a.reads_flags   = false;
     ret a;
+}
+
+# the row writes no flag this grammar can observe
+#
+# A precision statement, not a security one: it says a secret passing through
+# this instruction leaves FLAGS alone, so a later `jcc` is not refused for a
+# reason that does not exist. Getting it wrong costs false refusals.
+pub fun flags_untouched(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = false;
+    o.defines_flags = false;
+    ret o;
+}
+
+# the row unconditionally overwrites EVERY observable flag, so public operands
+# leave FLAGS clean
+#
+# THE ONLY FACT THAT CLEARS TAINT, and therefore the one that can turn a leak
+# into a passing build. Set it only where the instruction writes both ZF and CF
+# on every path, for every operand value. `inc` / `dec` do not (no CF), and the
+# shifts do not (nothing at count 0) - those take `flags_written` instead.
+pub fun flags_defined(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = true;
+    o.defines_flags = true;
+    ret o;
+}
+
+# the row MAY write an observable flag but does not define every one of them
+#
+# Taints on secret operands and never clears - the state `inc`, `dec` and the
+# shifts need, and the one a single boolean could not express.
+pub fun flags_written(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = true;
+    o.defines_flags = false;
+    ret o;
+}
+
+# the row loads FLAGS from somewhere the model does not represent
+#
+# Taints UNCONDITIONALLY, because the taint rule for an ordinary writer is
+# operand-conditioned and these rows have no operands to condition on: a flag
+# value arriving from memory, the interrupt frame, or a masked prior RFLAGS is
+# unmodeled whatever the register file holds.
+pub fun flags_opaque(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = true;
+    o.defines_flags = false;
+    o.opaque_flags  = true;
+    ret o;
+}
+
+# the row consumes an observable flag into a register
+#
+# A tainted FLAGS makes this instruction's outputs secret-derived, so its written
+# registers are tainted the same way an instruction reading a secret register is.
+# Without it a `setcc` launders a secret out of FLAGS into a register the model
+# then treats as public, and a later memory access indexed by it is accepted.
+pub fun flags_read(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.reads_flags   = true;
+    o.writes_flags  = false;
+    o.defines_flags = false;
+    ret o;
 }
 
 # a classified straight-line mnemonic of constant-time class `op`
@@ -189,9 +296,15 @@ pub fun asm_op(op: CtOp) AsmClass {
     ret a;
 }
 
-# a conditional branch whose condition rides the flags register: always refused
+# a conditional branch whose condition rides the flags register
+#
+# States its own flags facts: it reads a flag and writes none. The read is what
+# `ct_check_item` refuses on when FLAGS is tainted; `reads_flags` is not set,
+# because a refused branch has no outputs to taint and marking it would only
+# make the reader set ambiguous between "consumed into a register" and
+# "consumed into the program counter".
 pub fun asm_branch_flags() AsmClass {
-    var a: AsmClass = asm_op(CT_OP_NONE);
+    var a: AsmClass = flags_untouched(asm_op(CT_OP_NONE));
     a.cond_flags = true;
     ret a;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11704,6 +11704,21 @@ test "mach.lang.driver:oblivious_asm_validated_not_refused" {
     if (ut_codegen_target_ok("#[oblivious]\nfun ll(p: *i64) i64 { var v: i64 = 0; asm aarch64 { ldr x12, {p}\n ldaxr x9, [x12]\n stlxr w10, x9, [x12]\n cbnz w10, 1f\n1:\n nop } ret v; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-arm64") != 0) { bad = 1; }
     if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm riscv64 { nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-riscv64") != 0) { bad = 1; }
 
+    # THE LIFT (#2460). A compare-and-branch over PUBLIC data is now accepted on
+    # x86-64. Before the flags model this was refused outright, whether or not the
+    # block carried a secret, because the walk could not tell the two apart.
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { cmp rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+
+    # and a secret compare followed by a DEFINING public compare is accepted too:
+    # `cmp` overwrites every flag this grammar can read, so the second one leaves
+    # nothing of the first behind. This is the case that distinguishes a real model
+    # from a blanket "any secret anywhere in the block poisons it" rule.
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n cmp rbx, rcx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+
+    # a `setcc` over PUBLIC flags is not a laundering path, so its destination stays
+    # public and may index memory. The refusal twin of this is in the leaks test.
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { cmp rax, rbx\n setb bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+
     ret bad;
 }
 
@@ -11714,13 +11729,59 @@ test "mach.lang.driver:oblivious_asm_leaks_refused" {
     var bad: i32 = 0;
 
     # THE NIGHTMARE CASE. `cmp {secret}, rbx ; je` conditions the branch on FLAGS,
-    # which the inline-asm effect model does not represent - so a register-only walk
-    # would pass it as leak-free. Refused on x86-64 whether or not a secret is
-    # present, and the message says why and where the lift is tracked.
+    # which a register-only walk would pass as leak-free. Still refused, but since
+    # #2460 it is refused because the SECRET reached FLAGS rather than because the
+    # model could not see FLAGS at all: the `cmp` reads a secret binding and taints
+    # them, and the `je` consumes that taint.
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "linux", "its condition rides the flags register") != 0) { bad = 1; }
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
-        "linux", "#2460") != 0) { bad = 1; }
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # THE UNSOUND DIRECTION (#2460). `inc` writes ZF but NOT CF, so it must not be
+    # taken to have refreshed FLAGS: a `jc` after it reads a CF still derived from
+    # the secret `cmp`. This is the case a two-fact "writes flags therefore clears"
+    # model accepts, and it is the reason `defines_flags` exists as a separate fact.
+    # It fails the moment `inc` is given `defines_flags`.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n inc rax\n jc 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    # the same for a shift, which writes nothing at all at count 0
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n shl rax, 1\n jc 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # EACH PARTIAL WRITER TAINTS ON ITS OWN SECRET OPERAND. `inc` / `dec` and the
+    # three shifts may write an observable flag, so a secret passing through one
+    # makes FLAGS secret-derived even though none of them DEFINES every flag.
+    #
+    # All five are spelled out rather than one standing for the family: the mutation
+    # sweep showed that testing `inc` and `shl` alone left `dec`, `shr` and `sar`
+    # with no behavioural coverage, so their `writes_flags` could be deleted with the
+    # suite still green - a fact nothing depends on, which is indistinguishable from
+    # a fact that is wrong.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n inc rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n dec rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n shl rax, 1\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n shr rax, 1\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n sar rax, 1\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # AN UNMODELED FLAG SOURCE taints unconditionally: `popfq` loads FLAGS from the
+    # stack, which the model does not represent, so a `je` after it is refused even
+    # though nothing in the block reads a secret binding. These rows carry NO
+    # operands, so an operand-conditioned taint rule could never fire for them.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { popfq\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # A SECRET LAUNDERED OUT OF FLAGS. `setb` consumes CF into a register, so that
+    # register is secret-derived; indexing memory with it leaks through the cache.
+    # Without `reads_flags` the model knows FLAGS is tainted and still calls `bl`
+    # public, which is a silent pass of exactly the kind this issue exists to close.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n setb bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "addresses memory with a secret value") != 0) { bad = 1; }
 
     # a data directive's payload can encode ANY instruction, including a secret-
     # dependent branch. there is nothing to analyze, so it is refused on KIND -
@@ -12667,3 +12728,141 @@ test "mach.lang.driver:comptime_arm_does_not_mask_cross_module_conflict" {
     ret bad;
 }
 
+
+# A TAINT SURVIVES EVERY ROW THAT DOES NOT DEFINE EVERY OBSERVABLE FLAG
+#
+# One case per grammar row, generated from the row list rather than written for
+# the interesting few. The mutation sweep is why: testing `inc` and `shl` and
+# letting them stand for the family left `dec`, `shr` and `sar` with no
+# behavioural coverage at all, so their facts could be deleted with the suite
+# still green - and a fact nothing depends on is indistinguishable from a fact
+# that is wrong.
+#
+# Each block taints FLAGS with a secret `cmp`, executes ONE row with entirely
+# public operands, and then reads CF. The row must not have cleared the taint, so
+# the read is refused. Give any of these rows `defines_flags` and its case fails.
+test "mach.lang.driver:oblivious_asm_taint_survives_every_non_defining_row" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n mov rbx, rdx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n lea rbx, [rdx]\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n xchg rbx, rdx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n movzx rbx, dl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n movsx rbx, dl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n shl rbx, 1\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n shr rbx, 1\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n sar rbx, 1\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n not rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n inc rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n dec rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n push rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n pop rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n setb bl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n setae bl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n jmp 1f\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n call 1f\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n lidt [rbx]\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n in al, 0x60\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n out 0x60, al\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n ret\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n hlt\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cli\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n sti\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n rdtsc\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n rdmsr\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n wrmsr\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n mfence\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n pause\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n nop\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cld\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n pushfq\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n swapgs\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    ret bad;
+}
+
+# AND IT IS CLEARED BY EVERY ROW THAT DOES DEFINE THEM
+#
+# The other direction, and the reason this model is not simply "any secret in the
+# block poisons it": an instruction that unconditionally overwrites every flag
+# this grammar can read leaves nothing of the earlier secret behind, so a branch
+# after it is public and is accepted. Remove any of these rows' `defines_flags`
+# and its case fails, which is what makes the fact load-bearing rather than
+# merely asserted.
+test "mach.lang.driver:oblivious_asm_taint_cleared_by_every_defining_row" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n add rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n sub rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n and rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n or rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n xor rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cmp rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n test rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n neg rbx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cmpxchg rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n xadd rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    ret bad;
+}
+
+# AN UNMODELED FLAG SOURCE TAINTS WITH NO SECRET IN SIGHT
+#
+# `popfq` and `iretq` load FLAGS from the stack or the interrupt frame, and
+# `syscall` masks the existing RFLAGS - none of which this model represents. All
+# three carry NO operands, so the ordinary "secret operand taints" rule is
+# structurally unable to fire for them and they need their own unconditional
+# arm. Nothing in these blocks reads a secret binding at all.
+test "mach.lang.driver:oblivious_asm_unmodeled_flag_sources_taint" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { popfq\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { iretq\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { syscall\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    ret bad;
+}
+
+# BOTH SETcc SPELLINGS CARRY A SECRET OUT OF FLAGS AND INTO A REGISTER
+#
+# `setb` and `setae` are distinct grammar rows on distinct opcodes, so covering
+# one leaves the other free to launder. The destination becomes secret-derived,
+# and indexing memory with it leaks through the cache.
+test "mach.lang.driver:oblivious_asm_setcc_does_not_launder_flags" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n setb bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "addresses memory with a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n setae bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "addresses memory with a secret value") != 0) { bad = 1; }
+    ret bad;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -12866,3 +12866,37 @@ test "mach.lang.driver:oblivious_asm_setcc_does_not_launder_flags" {
         "linux", "addresses memory with a secret value") != 0) { bad = 1; }
     ret bad;
 }
+
+# EVERY DEFINING ROW ALSO TAINTS ON ITS OWN SECRET OPERAND
+#
+# `defines_flags` implies `writes_flags`, and the second half needs its own
+# coverage: a definer whose operands are secret must TAINT, not clear. The clear
+# arm requires public operands, so these two behaviours are disjoint and a test of
+# one says nothing about the other.
+#
+# One case per row rather than one for the family. The mutation sweep is why:
+# with only `cmp` covered, deleting `writes_flags` from `add`, `sub`, `and`, `or`,
+# `xor`, `test`, `neg`, `cmpxchg` or `xadd` left the suite green - nine facts that
+# nothing depended on, which reads identically to nine facts that are wrong.
+test "mach.lang.driver:oblivious_asm_defining_rows_taint_on_secret_operands" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n add rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n sub rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n and rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n or rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n xor rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n test rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n neg rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmpxchg rbx, rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n xadd rbx, rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    ret bad;
+}

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -8424,6 +8424,29 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_condi
     if (asm_ct_class(A64M_B, 0).cond_reg)  { bad = 1; }
     if (asm_ct_class(A64M_BL, 0).cond_reg) { bad = 1; }
 
+    # THE FLAGS MODEL IS VACUOUS HERE, AND THAT IS PINNED RATHER THAN ASSUMED
+    # (#2460). aarch64 has NZCV, so unlike riscv64 the absence of flag taint is a
+    # property of this GRAMMAR rather than of the architecture: no static row
+    # consumes a condition flag into a register, so no `defines_flags` fact on this
+    # target can ever clear a taint that anything observes.
+    #
+    # `b.<cond>` DOES read NZCV and arrives through the decode hook, where #2477
+    # gives it `cond_flags` - and `ct_check_item` refuses a `cond_flags` row on a
+    # tainted FLAGS, so that path stays closed. What this asserts is that nothing in
+    # the static table reads flags into a register the way x86-64's SETcc does.
+    #
+    # Adding an aarch64 `cset` / `csel` row later must therefore state `reads_flags`,
+    # and this test is what forces that to be a deliberate act rather than a silent
+    # widening on a target the x86-64 work never touched.
+    var fi: usize = 0;
+    for (fi < A64_MNEMONIC_COUNT) {
+        val fc: ct.AsmClass = asm_ct_class(A64_MNEMONICS[fi].code, A64_MNEMONICS[fi].flags);
+        if (fc.reads_flags)   { bad = 1; }
+        if (fc.defines_flags) { bad = 1; }
+        if (fc.opaque_flags)  { bad = 1; }
+        fi = fi + 1;
+    }
+
     # check (c) is near-vacuous HERE: no divide, multiply or float row exists, and the
     # register-count shifts are the only variable-latency shape.
     if (asm_ct_class(A64M_LSLV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -2159,6 +2159,10 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
     cursor_init(?c, g, body, nil, nil, nil, nil);
 
     var taint: u32 = 0;
+    # whether FLAGS currently holds a secret-derived value. a separate domain from
+    # the register bitmask because x86-64 conditions its branches on it and nothing
+    # in the register model represents it (#2460)
+    var flags_taint: bool = false;
     var item: Item;
     var done: bool = false;
     for (!done) {
@@ -2168,7 +2172,7 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
         }
         if (!R.unwrap_ok[bool, str](pr)) { done = true; }
         or {
-            val vr: R.Result[bool, str] = ct_check_item(g, body, ?item, ?taint, secret_names, n_secret, trust_mul, trust_shift);
+            val vr: R.Result[bool, str] = ct_check_item(g, body, ?item, ?taint, ?flags_taint, secret_names, n_secret, trust_mul, trust_shift);
             if (R.is_err[bool, str](vr)) { ret vr; }
         }
     }
@@ -2179,7 +2183,7 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
 #
 # Split out so the walk above reads as the loop it is. `taint` is updated in place:
 # an instruction that reads a secret taints the registers it writes.
-fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
+fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32, flags_taint: *bool,
                   secret_names: *str, n_secret: u32,
                   trust_mul: bool, trust_shift: bool) R.Result[bool, str] {
     if (item.kind == AI_LABEL) { ret R.ok[bool, str](true); }
@@ -2205,11 +2209,14 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
     val cls: ct.AsmClass = g.ct_class(item.code, item.flags);
     val reads_secret: bool = item_reads_secret(body, item, @taint, secret_names, n_secret);
 
-    # a conditional branch whose condition rides the flags register cannot be checked
-    # at all: the effect model represents no flags, so a preceding `cmp` of a secret
-    # is invisible here. refused whether or not this block carries a secret (#2460).
-    if (cls.cond_flags) {
-        ret R.err[bool, str]("contains a conditional branch inside an #[oblivious] inline-asm block; its condition rides the flags register, which this compiler's inline-asm effect model does not represent, so the branch cannot be verified constant-time (see issue #2460). use a branch-free sequence, or move the branch outside the #[oblivious] function");
+    # a conditional branch whose condition rides the flags register is refused when
+    # FLAGS holds a secret-derived value, and accepted otherwise. before #2460 the
+    # effect model represented no flags at all, so a preceding `cmp` of a secret was
+    # invisible and the whole family was refused outright; `flags_taint` is now
+    # tracked beside the register set, so a genuinely public compare-and-branch is
+    # admitted and only a secret-dependent one is refused.
+    if (cls.cond_flags && @flags_taint) {
+        ret R.err[bool, str]("branches on a secret value inside an #[oblivious] inline-asm block; its condition rides the flags register, which a preceding instruction filled from a secret, so the branch's timing reveals the secret. select branch-free over public data, or `:^`-declassify when disclosure is intended");
     }
 
     # (a) a register-conditioned branch on a secret leaks through the taken path.
@@ -2279,11 +2286,33 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
     # silently DROPPED, which is the fail-open direction. Every grammar here numbers
     # its general-purpose registers below 32, and a target that did not would need this
     # set widened before its bodies could be validated.
-    if (reads_secret) {
+    # an instruction that CONSUMES a tainted flag carries the secret out of FLAGS and
+    # into whatever it writes, so it folds exactly as one reading a secret register
+    # does. Without this a `setcc` launders a secret into a register the model then
+    # treats as public, and a later access indexed by it is accepted.
+    val secret_in: bool = reads_secret || (cls.reads_flags && @flags_taint);
+
+    if (secret_in) {
         @taint = @taint | item.implicit;
         if ((item.writes & AW_OP0) != 0 && item.nops > 0) { taint_written(?item.ops[0], taint); }
         if ((item.writes & AW_OP1) != 0 && item.nops > 1) { taint_written(?item.ops[1], taint); }
     }
+
+    # fold the FLAGS taint. the arms are ordered, and the order is the model:
+    #
+    #   opaque   - a flag value from memory, the stack, or a masked prior RFLAGS.
+    #              unconditional, because these rows carry no operands to condition
+    #              on and an operand-conditioned rule could never fire for them.
+    #   writes   - a MAY-write with a secret operand taints.
+    #   defines  - an unconditional overwrite of every observable flag, with public
+    #              operands, is the ONLY thing that clears.
+    #
+    # anything else leaves FLAGS unchanged, which is what `inc` / `dec` and the
+    # shifts need: they write some flags but not all, so they must neither clear a
+    # standing taint nor be treated as having refreshed it.
+    if (cls.opaque_flags)                        { @flags_taint = true; }
+    or (cls.writes_flags && secret_in)           { @flags_taint = true; }
+    or (cls.defines_flags && !secret_in)         { @flags_taint = false; }
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -6802,6 +6802,20 @@ test "mach.lang.target.isa.riscv64.encode.asm_ct_class:m_extension_is_variable_l
         if (asm_ct_class(RV_MNEMONICS[i].code, RV_MNEMONICS[i].flags).cond_flags) { bad = 1; }
         i = i + 1;
     }
+
+    # THE FLAGS MODEL IS VACUOUS HERE, AND THAT IS PINNED RATHER THAN ASSUMED
+    # (#2460). RISC-V has no flags register at all, so no row can read, define or
+    # opaquely load one, and every flags fact on this target is vacuously satisfied.
+    # Asserting it means a future row that somehow acquired one would fail here
+    # rather than pass by inheriting a model built for a different architecture.
+    var fi: usize = 0;
+    for (fi < RV_MNEMONIC_COUNT) {
+        val fc: ct.AsmClass = asm_ct_class(RV_MNEMONICS[fi].code, RV_MNEMONICS[fi].flags);
+        if (fc.reads_flags)   { bad = 1; }
+        if (fc.defines_flags) { bad = 1; }
+        if (fc.opaque_flags)  { bad = 1; }
+        fi = fi + 1;
+    }
     ret bad;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -7796,28 +7796,49 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     if (code == x64.MOV::u32 || code == x64.MOVZX::u32 || code == x64.MOVSX::u32 ||
         code == x64.LEA::u32 || code == x64.PUSH::u32  || code == x64.POP::u32 ||
         code == x64.XCHG::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     # integer add / sub / bitwise / compare / test / neg / not / inc / dec, and the
     # SETcc byte materializers: fixed-latency on every x86-64 part.
+    #
+    # FLAGS: this family splits three ways, and the split is the security property
+    # (#2460). `defines_flags` is the only fact that CLEARS a taint, so it is set
+    # only where every observable flag - ZF and CF, the complete set this grammar
+    # can read - is written unconditionally, for every operand value.
     if (code == x64.ADD::u32 || code == x64.SUB::u32 || code == x64.AND::u32 ||
         code == x64.OR::u32  || code == x64.XOR::u32 || code == x64.CMP::u32 ||
-        code == x64.TEST::u32 || code == x64.NEG::u32 || code == x64.NOT::u32 ||
-        code == x64.INC::u32 || code == x64.DEC::u32 ||
-        code == x64.SETB::u32 || code == x64.SETAE::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        code == x64.TEST::u32 || code == x64.NEG::u32) {
+        ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # `inc` / `dec` write every status flag EXCEPT CF, which this grammar reads
+    # through `jc` / `jnc` / `setc`. So they may taint and must never clear: a `jc`
+    # after a secret `cmp` and a public `inc` still reads a secret-derived CF.
+    if (code == x64.INC::u32 || code == x64.DEC::u32) {
+        ret ct.flags_written(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # `not` writes no flag at all, unlike every one of its bitwise siblings.
+    if (code == x64.NOT::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # the SETcc byte materializers CONSUME CF into a register. That makes the
+    # destination secret-derived whenever FLAGS is tainted, which is what stops a
+    # secret being laundered out of FLAGS and used as a memory index.
+    if (code == x64.SETB::u32 || code == x64.SETAE::u32) {
+        ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
     }
     # the shifts: variable-latency ONLY through a register (`cl`) count, which is the
     # single variable-latency form this grammar can express. the shared gate reads the
     # COUNT operand alone (`ct.ct_op_gates_count_only`), so a constant-count shift of a
     # secret value stays constant-time.
     if (code == x64.SHL::u32 || code == x64.SHR::u32 || code == x64.SAR::u32) {
-        ret ct.asm_op(ct.CT_OP_VAR_SHIFT);
+        ret ct.flags_written(ct.asm_op(ct.CT_OP_VAR_SHIFT));
     }
     # atomics and fences: see the conditional row above.
-    if (code == x64.CMPXCHG::u32 || code == x64.XADD::u32 ||
-        code == x64.MFENCE::u32  || code == x64.PAUSE::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+    if (code == x64.CMPXCHG::u32 || code == x64.XADD::u32) {
+        ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
+    }
+    if (code == x64.MFENCE::u32 || code == x64.PAUSE::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     # PORT I/O AND THE PRIVILEGED SET (#2468). None of these has an operand-dependent
     # latency, which is what `CtOp` classifies, so all are CT_OP_NONE - but two deserve
@@ -7846,20 +7867,39 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     # not through the exchange. The two system-register moves are data movement at fixed
     # latency, and WHICH register each names is part of the instruction word rather than
     # an operand, so it can never be secret.
+    #
+    # FLAGS: `cld` / `cli` / `sti` write DF and IF, which nothing in this grammar
+    # reads, so they neither taint nor clear. The rest of this group writes no flag.
     if (code == x64.IN::u32    || code == x64.OUT::u32   || code == x64.CLI::u32 ||
         code == x64.STI::u32   || code == x64.LIDT::u32  || code == x64.RDTSC::u32 ||
         code == x64.RDMSR::u32 || code == x64.WRMSR::u32 || code == x64.CLD::u32 ||
-        code == x64.PUSHFQ::u32 || code == x64.POPFQ::u32 || code == x64.IRETQ::u32 ||
         code == x64.SWAPGS::u32 || code == x64.MOV_CR::u32 || code == x64.MOV_SEG::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # UNMODELED FLAG SOURCES. `popfq` loads FLAGS from the stack and `iretq` from the
+    # interrupt frame - memory this model does not represent - and `syscall` masks
+    # the EXISTING RFLAGS through IA32_FMASK, so a standing taint survives it.
+    #
+    # These taint UNCONDITIONALLY rather than on a secret operand, because all three
+    # carry NO operands: an operand-conditioned rule is structurally unable to fire
+    # for them, so setting `writes_flags` alone would read as correct in the table
+    # and never once take effect.
+    if (code == x64.POPFQ::u32 || code == x64.IRETQ::u32 || code == x64.SYSCALL::u32) {
+        ret ct.flags_opaque(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # `pushfq` moves FLAGS the other way, into memory. The register-only taint model
+    # cannot follow it there, which is the same boundary that leaves `mov [rsp],
+    # {secret}` untracked; it is not specific to flags and #2460 does not change it.
+    # It writes no flag, so it neither taints nor clears.
+    if (code == x64.PUSHFQ::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
 
     # control transfer with no condition: the target is public by construction (a
     # symbol or a numeric local label), so it reveals nothing about a secret.
     if (code == x64.JMP::u32 || code == x64.CALL::u32 || code == x64.RET::u32 ||
-        code == x64.SYSCALL::u32 || code == x64.NOP::u32 || code == x64.HLT::u32 ||
-        code == x64.UD2::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        code == x64.NOP::u32 || code == x64.HLT::u32 || code == x64.UD2::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     # every conditional jump: refused, per the flags note above.
     if (code == x64.JE::u32  || code == x64.JNE::u32 || code == x64.JB::u32 ||
@@ -7884,6 +7924,140 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_is_classifi
         if (!cls.known) { bad = 1; }
         i = i + 1;
     }
+    ret bad;
+}
+
+# every mnemonic the x86-64 grammar admits states its flags facts
+#
+# The twin of `every_grammar_row_is_classified`, in the same shape and for the same
+# reason (#2460). The DEFAULTS already fail safe - an unstated row taints on secret
+# operands and never clears - so a forgotten row cannot leak. What it can do is
+# refuse silently and imprecisely, and a row nobody considered is indistinguishable
+# from a row someone considered and got wrong. This makes adding one a test failure.
+#
+# To see it fail, add a grammar row whose `asm_ct_class` arm omits a flags
+# constructor: `ct.asm_op(...)` alone leaves `flags_stated` false.
+test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_states_flags" {
+    var bad: i32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
+        if (!cls.flags_stated) { bad = 1; }
+        # `defines_flags` is the fact that CLEARS, so it may never stand alone: a row
+        # that clears without writing is incoherent, and the constructors cannot
+        # produce it. Pinned so a hand-built AsmClass cannot either.
+        if (cls.defines_flags && !cls.writes_flags) { bad = 1; }
+        i = i + 1;
+    }
+    ret bad;
+}
+
+# the set of rows that can read an observable flag is EXACTLY these fifteen
+#
+# `defines_flags` is decidable only because the observable flag set is ZF and CF.
+# Adding `jo` or `js` to this grammar would widen that set, and the meaning of
+# `defines_flags` would change underneath every row already classified - each of
+# which would silently become potentially wrong, with nothing failing anywhere.
+#
+# So the reader set is pinned by NAME here rather than counted. Adding a sixteenth
+# reader is then a deliberate act that breaks this test and forces the ten
+# `defines_flags` rows to be re-justified against the wider set, which is exactly
+# the review that must not be skipped.
+test "mach.lang.target.isa.x64.encode.asm_ct_class:flag_reader_set_is_exactly_fifteen" {
+    var readers: [15]str;
+    readers[0]  = "je";   readers[1]  = "jz";   readers[2]  = "jne";
+    readers[3]  = "jnz";  readers[4]  = "jc";   readers[5]  = "jb";
+    readers[6]  = "jnc";  readers[7]  = "jae";  readers[8]  = "jnb";
+    readers[9]  = "setc"; readers[10] = "setb"; readers[11] = "setnc";
+    readers[12] = "setae"; readers[13] = "setnb"; readers[14] = "pushfq";
+
+    var bad: i32 = 0;
+    var found: u32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val nm: str = X64_MNEMONICS[i].name;
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
+        val is_reader: bool = cls.cond_flags || cls.reads_flags;
+
+        var listed: bool = false;
+        var j: usize = 0;
+        for (j < 15) {
+            if (str_equals(nm, readers[j])) { listed = true; }
+            j = j + 1;
+        }
+        # `pushfq` is listed because it reads every flag, but it reads them into
+        # MEMORY, which the register-only taint model cannot follow - so it is a
+        # reader the classification cannot mark, and the asymmetry is deliberate.
+        if (str_equals(nm, "pushfq")) {
+            if (is_reader) { bad = 1; }
+            found = found + 1;
+        }
+        or {
+            if (is_reader && !listed)  { bad = 1; }
+            if (!is_reader && listed)  { bad = 1; }
+            if (listed) { found = found + 1; }
+        }
+        i = i + 1;
+    }
+    if (found != 15) { bad = 1; }
+    ret bad;
+}
+
+# the rows that can wrongly PERMIT are exactly the fifteen named here
+#
+# With the defaults inverted, an unconsidered row fails safe: it taints and never
+# clears. Only two facts can turn a leak into a passing build - `defines_flags`,
+# which clears a taint, and `opaque_flags`, whose absence lets an unmodeled flag
+# source go untracked. This pins that surface so it stays small and reviewable.
+#
+# THIS IS THE AUDIT LIST. No row's facts in this file have been verified against
+# the Intel SDM; every one is inferred. These thirteen instructions are the bounded
+# set someone with the manual has to check, and the test exists so it cannot grow
+# quietly. The two questions are: does each `defines_flags` instruction write BOTH
+# ZF and CF unconditionally, and are those three the complete set of unmodeled flag
+# sources in this grammar?
+test "mach.lang.target.isa.x64.encode.asm_ct_class:permitting_surface_is_bounded" {
+    var bad: i32 = 0;
+    var defines: u32 = 0;
+    var opaque: u32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
+        if (cls.defines_flags) { defines = defines + 1; }
+        if (cls.opaque_flags)  { opaque  = opaque + 1; }
+        i = i + 1;
+    }
+    # add sub cmp test and or xor neg cmpxchg xadd, plus the `lock cmpxchg` and
+    # `lock xadd` rows, which are prefixed spellings of two of those ten and define
+    # flags identically. So fifteen ROWS carry thirteen distinct instructions, and
+    # the audit below is over the instructions rather than the spellings.
+    if (defines != 12) { bad = 1; }
+    # popfq iretq syscall
+    if (opaque != 3) { bad = 1; }
+
+    if (!asm_ct_class(x64.ADD::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.SUB::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.CMP::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.TEST::u32, 0).defines_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.AND::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.OR::u32, 0).defines_flags)      { bad = 1; }
+    if (!asm_ct_class(x64.XOR::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.NEG::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.CMPXCHG::u32, 0).defines_flags) { bad = 1; }
+    if (!asm_ct_class(x64.XADD::u32, 0).defines_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.POPFQ::u32, 0).opaque_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.IRETQ::u32, 0).opaque_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.SYSCALL::u32, 0).opaque_flags)  { bad = 1; }
+
+    # THE TRAPS, pinned negatively. Each of these is a row a two-fact model, or a
+    # careless reading of "writes flags", would let clear a taint.
+    if (asm_ct_class(x64.INC::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.DEC::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.SHL::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.SHR::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.SAR::u32, 0).defines_flags) { bad = 1; }
+    if (!asm_ct_class(x64.INC::u32, 0).writes_flags) { bad = 1; }
+    if (!asm_ct_class(x64.SHL::u32, 0).writes_flags) { bad = 1; }
     ret bad;
 }
 

--- a/tools/ct-flags-mutate.py
+++ b/tools/ct-flags-mutate.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Mutation harness for the #[oblivious] inline-asm flags facts (#2460).
+
+For every row of the x86-64 grammar, flip one flags fact in the direction that
+would let a leak through, and assert the suite notices. A mutation the suite does
+NOT notice is a fact nothing depends on, which is indistinguishable from a fact
+that is wrong.
+
+Run from the repo root:
+
+    python3 tools/ct-flags-mutate.py
+
+It rewrites `x64/encode.mach` once per mutation by renaming the shipping
+classifier and wrapping it, then restores the file byte-for-byte. The pristine
+copy lives outside the tree so an interrupted run cannot leave a mutated
+classifier staged. Takes roughly 10 minutes: one full `mach test .` per
+applicable mutation.
+
+WHAT THIS PROVES, AND WHAT IT DOES NOT. It shows each fact is load-bearing: some
+test observes it. It does NOT show any fact is TRUE — a row that is confidently
+wrong in a self-consistent way passes every mutation here. Truth is measured
+separately, against the CPU, by `int/surface/ct-flags-hardware`.
+
+TWO MODES, AND THE DEFAULT IS THE HONEST ONE.
+
+Three unit tests in `x64/encode.mach` assert the facts DIRECTLY - they read
+`defines_flags` and friends off the classifier and check them. With those active
+almost every mutation dies, but most of those kills are the table catching a
+change to itself, which says nothing about whether the walk depends on the fact.
+
+    --behavioural   (default) stub those tests out in the pristine copy, so a
+                    mutation can only be caught by a test that observes the
+                    COMPILER'S VERDICT on a program. This is the number to report.
+    --with-asserts  leave them in. Useful only to confirm the fact-pinning tests
+                    themselves still work.
+
+On the shipping tree these differ sharply: 56 killed behaviourally versus nearly
+everything with the assertions in. If you find yourself reporting the larger
+number, you are reporting that the table agrees with itself.
+
+Read the survivor list, never just the count. A survivor is either a structural
+impossibility (fine, and the three classes are named in the PR for #2460) or a
+gap in the tests (not fine). They look identical from the outside, and the only
+way to tell is to work out why no program could observe it.
+"""
+import subprocess, shutil, sys, os
+
+W = os.environ.get("MACH_ROOT", os.getcwd())
+SRC = W + "/src/lang/target/isa/x64/encode.mach"
+# the untouched copy every mutation is built from, and what SRC is restored to.
+# written beside the run rather than in the tree, so an interrupted run cannot
+# leave a mutated classifier committed.
+PRISTINE = os.environ.get("CT_PRISTINE", "/tmp/ct-flags-pristine.mach")
+# the mutation BASE (possibly with fact-asserting tests stubbed) and the byte-exact
+# ORIGINAL are two different files. Restoring the tree from the base would delete
+# whatever the base stubbed out, which is a silent edit to the shipped source.
+ORIGINAL = PRISTINE + ".orig"
+
+DEFINES = "ADD SUB AND OR XOR CMP TEST NEG CMPXCHG XADD".split()
+WRITTEN = "INC DEC SHL SHR SAR".split()
+OPAQUE  = "POPFQ IRETQ SYSCALL".split()
+READ    = "SETB SETAE".split()
+BRANCH  = "JE JNE JB JAE".split()
+# every ROW of the shipping grammar, name -> code. rows outnumber codes: `jz` and
+# `je` are one instruction under two spellings, and both are mutated, because the
+# bar is stated per row.
+ROWS = [l.strip().split("|") for l in
+        subprocess.run(["python3","-c","""
+import re,sys
+t=open(sys.argv[1]).read()
+for m in re.finditer(r'name: *"([a-z0-9 _]+)", *code: *x64\\.([A-Z0-9_]+)', t):
+    print(m.group(1)+"|"+m.group(2))
+""", SRC], capture_output=True, text=True).stdout.splitlines() if l.strip()]
+
+def facts(code):
+    """the facts the shipping classifier sets for a code, so a mutation that cannot
+    change anything is reported as a no-op rather than counted as a survivor."""
+    if code in DEFINES: return dict(writes=1, defines=1, opaque=0, reads=0)
+    if code in WRITTEN: return dict(writes=1, defines=0, opaque=0, reads=0)
+    if code in OPAQUE:  return dict(writes=1, defines=0, opaque=1, reads=0)
+    if code in READ:    return dict(writes=0, defines=0, opaque=0, reads=1)
+    return dict(writes=0, defines=0, opaque=0, reads=0)
+
+MUT = {
+    # the row stops tainting: catches a fact that must taint
+    "no_taint":    "a.writes_flags = false; a.opaque_flags = false;",
+    # the row starts clearing: catches a fact that must NOT clear (unsound direction)
+    "force_clear": "a.writes_flags = true; a.defines_flags = true;",
+    # the row stops propagating out of FLAGS: catches the setcc laundering guard
+    "no_read":     "a.reads_flags = false;",
+    # the row stops clearing: catches a clear nothing relies on
+    "no_clear":    "a.defines_flags = false;",
+}
+
+def plan():
+    """the full 60-row x 3-fact grid the issue states as the bar.
+
+    Each row gets one mutation per falsifiable fact:
+      no_taint    - stop tainting        (writes_flags / opaque_flags -> off)
+      force_clear - start clearing       (defines_flags -> on)
+      no_read     - stop propagating     (reads_flags -> off)
+    A mutation that cannot change the class for that row is a NO-OP, reported as
+    such: counting it either way would misstate the evidence."""
+    out = []
+    for name, code in ROWS:
+        f = facts(code)
+        out.append((name, code, "no_taint",    bool(f["writes"] or f["opaque"])))
+        out.append((name, code, "force_clear", not f["defines"]))
+        out.append((name, code, "no_read",     bool(f["reads"])))
+    return out
+
+def apply(code, mut):
+    t = open(PRISTINE).read()
+    assert "pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {" in t
+    t = t.replace("pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {",
+                  "fun asm_ct_class_mutated_base(code: u32, flags: u16) ct.AsmClass {", 1)
+    wrapper = (
+        "pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {\n"
+        "    var a: ct.AsmClass = asm_ct_class_mutated_base(code, flags);\n"
+        "    if (code == x64.%s::u32) { %s }\n"
+        "    ret a;\n"
+        "}\n\n" % (code, MUT[mut])
+    )
+    t = wrapper + t if False else t.replace(
+        "fun asm_ct_class_mutated_base(code: u32, flags: u16) ct.AsmClass {",
+        wrapper + "fun asm_ct_class_mutated_base(code: u32, flags: u16) ct.AsmClass {", 1)
+    open(SRC, "w").write(t)
+
+def run():
+    r = subprocess.run(["mach", "test", "."], cwd=W, capture_output=True, text=True)
+    return r.returncode == 0   # True == suite green == mutation SURVIVED
+
+# Take the pristine copy from the tree at startup, and refuse to run if the tree is
+# already mutated - a previous run that died mid-mutation would otherwise have its
+# wrapper baked into the baseline, and every subsequent result would be measured
+# against a classifier nobody wrote.
+BEHAVIOURAL = "--with-asserts" not in sys.argv
+
+# the tests that assert the facts directly rather than observing a verdict
+FACT_TESTS = ["permitting_surface_is_bounded",
+              "flag_reader_set_is_exactly_fifteen",
+              "every_grammar_row_states_flags"]
+
+_src = open(SRC).read()
+if "asm_ct_class_mutated_base" in _src:
+    sys.exit("refusing to start: %s still carries a mutation wrapper.\n"
+             "restore it (git checkout) before running." % SRC)
+
+if BEHAVIOURAL:
+    for _n in FACT_TESTS:
+        _h = 'test "mach.lang.target.isa.x64.encode.asm_ct_class:%s" {' % _n
+        _i = _src.index(_h)
+        _j = _src.index("\n}\n", _src.index("ret ", _i)) + 3
+        _src = _src[:_i] + _h + "\n    ret 0;\n}\n" + _src[_j:]
+open(ORIGINAL, "w").write(open(SRC).read())
+open(PRISTINE, "w").write(_src)
+print("mode: %s" % ("behavioural (fact-asserting tests stubbed)" if BEHAVIOURAL
+                    else "with-asserts"), flush=True)
+
+killed, survived, noop = [], [], []
+tasks = plan()
+print("grid: %d mutations (%d rows x 3 facts)" % (len(tasks), len(ROWS)), flush=True)
+for i, (name, code, mut, applicable) in enumerate(tasks):
+    if not applicable:
+        noop.append((name, mut)); continue
+    apply(code, mut)
+    green = run()
+    (survived if green else killed).append((name, mut))
+    print("[%3d/%3d] %-14s %-12s %s" % (i+1, len(tasks), name, mut,
+          "SURVIVED" if green else "killed"), flush=True)
+shutil.copy(ORIGINAL, SRC)
+
+print("\n=== RESULT ===")
+print("grid:      %d" % len(tasks))
+print("applicable:%d" % (len(killed)+len(survived)))
+print("killed:    %d" % len(killed))
+print("survived:  %d" % len(survived))
+print("no-op:     %d  (fact not set on that row; the mutation changes nothing)" % len(noop))
+for n, m in survived:
+    print("  SURVIVOR %-14s %s" % (n, m))


### PR DESCRIPTION
Closes #2460

Implements the five-fact model: the four-fact design from the issue, plus `reads_flags` per the decision to fold it in.

## What changed

```
cmp rax, rbx ; je                       -> accepted   (public compare-and-branch, the lift)
cmp {secret} ; je                       -> refused
cmp {secret} ; inc rax ; jc             -> refused    (inc never writes CF)
cmp {secret} ; cmp rbx, rcx ; je        -> accepted   (a definer clears)
popfq ; jc                              -> refused    (flags from unmodeled memory)
cmp {secret} ; setb bl ; mov rcx, [rbx] -> refused    (laundering out of FLAGS)
```

## The facts are measured, not asserted

`int/surface/ct-flags-hardware` runs each instruction twice with RFLAGS preset all-set and all-clear. Reading RFLAGS back measures `defines_flags`; reading the **destination register** back, from the same two runs, measures `reads_flags`. The golden is the measurement, so a row whose hardware behaviour stops matching its classification fails CI.

```
add   ZF:defined   CF:defined   reads:0
inc   ZF:defined   CF:preserved reads:0     <- the unsoundness, on hardware
shl1  ZF:defined   CF:defined   reads:0
shl0  ZF:preserved CF:preserved reads:0     <- count-dependent, measured
setb  ZF:preserved CF:preserved reads:1     <- the laundering path
jc    ZF:preserved CF:preserved reads:0     <- see below
```

**What the hardware case does not do**, stated because it would be easy to over-read: it measures the CPU and diffs against a recorded golden. Nothing mechanically ties that measurement to `asm_ct_class`. So it catches the CPU disagreeing with what we recorded, and it catches a probed row's behaviour changing — but a *new* grammar row added with a wrong fact and no probe entry passes it. `every_grammar_row_states_flags` forces such a row to state a fact; neither test checks the fact is right. Closing that needs the probe list and the classifier compared mechanically, which the int-case boundary does not currently allow (the fixture is a standalone project and cannot import `mach.lang.ct`). Worth doing; not done here.

**Three rows print `NOT MEASURABLE`, and that is load-bearing.** `popfq` passes the writer probe as *defines BOTH* — the incoming flags genuinely do not affect the result, so the probe is right on its own terms and **wrong as a classification**, because the value came from the stack. `defines_flags` asks whether an instruction overwrites the flags from *its own operands*; the probe measures only the first half. Where the value came **from** is structural and no experiment of this shape answers it. The probe prints the caveat itself, so the gap is in the artifact rather than only in a comment — someone who notices the probe "handles them fine" is looking at the trap.

**`jc` reports `reads:0` and does read CF.** A branch leaves no register difference to measure. That is a limit of the probe, not a fact about `jc`, and it is the structural reason the nine `j*` rows need no `reads_flags`: `cond_flags` refuses them before any fold.

## Mutation bar: 180 grid, 56 killed, 17 structural survivors

`tools/ct-flags-mutate.py`, in the repo. 60 rows × 3 falsifiable facts. 107 are no-ops (the fact is not set on that row, so the mutation changes nothing) and are reported as such rather than counted either way. Of the 73 applicable, **56 killed, 17 survived**:

| survivors | why no program can observe it |
|---|---|
| `je` `jz` `jne` `jnz` `jc` `jb` `jnc` `jae` `jnb` | the `cond_flags` refusal returns before the fold; with clean flags, clearing is a no-op |
| `popfq` `iretq` `syscall` | the `opaque_flags` arm runs first and taints unconditionally, so the `defines_flags` arm is unreachable |
| `setc` `setb` `setnc` `setae` `setnb` | reading a tainted flag sets `secret_in`, and the clear arm requires `!secret_in` |

All 17 are `force_clear`. Each is checkable by reading the fold in `ct_check_item`.

**Read that table with suspicion, and re-derive it rather than trusting the label.** During this work `in` and `out` sat in the survivor list looking exactly like a fourth structural class. They were not: my fixture tainted `rax`, their `al` operand aliases it, and the row's own read of the taint set `secret_in`, which blocks the clear arm. A test artifact, not a property of the instruction. Changing the taint carrier to `rsi` killed both.

**"Structurally unobservable" and "my fixture happened to mask it" are indistinguishable from outside a survivor list.** The only way to tell them apart is to work out why no program could observe it, which is why each class above cites the specific arm of the fold that makes it unreachable.

**The tool defaults to stubbing the three tests that assert the facts directly**, and that default is the point. With them active almost everything dies — but most of those kills are the table catching a change to itself, which says nothing about whether the walk depends on the fact.

The sequence is more informative than the final number:

| | result | what it meant |
|---|---|---|
| first sweep, fact-asserting tests **active** | 67/70 killed | looked thorough |
| same sweep, those tests **stubbed** | **20/70** | most facts were load-bearing on nothing |
| after one behavioural case per grammar row | 61/70 | the correction |
| moved to the full 180 grid, all three fact-tests stubbed | exposed 11 more | the nine definers' `writes_flags`, uncovered because only `cmp` was tested |
| after per-definer cases | **56 killed / 17 survivors** | current |

Twice the same shape: a family tested through one representative, with the siblings' facts deletable and the suite still green.

Closing that gap is most of the test work here. Two families had one representative covered and the rest uncovered — deleting `writes_flags` from nine definers, or from `dec`/`shr`/`sar`, left the suite green. Nine and three facts nothing depended on, which reads identically to facts that are wrong. Both now have one case per row.

**What the bar does not show.** That a fact is *true*. A row confidently wrong in a self-consistent way passes every mutation. Truth is the hardware case's job, which is why both exist.

## Why this was missed

`SETB`/`SETAE` sit in `asm_ct_class` in the same `CT_OP_NONE` branch as `add`/`sub`/`cmp`, under the comment *"the SETcc byte materializers: fixed-latency on every x86-64 part."*

**That comment is correct.** `CtOp` classifies operand-dependent **latency**, and `setcc` has none. The taxonomy answered its own question accurately, and the model then treated that answer as the whole story. The leak is a **cache/address leak through dataflow**, not a timing leak, and `CtOp` was never the axis that would catch it.

Anyone adding a `cmov` row should read that twice: the CT_OP classification does not speak to flag dataflow, and a row can be correctly `CT_OP_NONE` and still need `reads_flags`.

## The security surface is 18 rows

The defaults are asymmetric and that is the argument: `writes_flags` defaults **true**, `defines_flags` and `opaque_flags` and `reads_flags` default **false**, so an unconsidered row taints and never clears. Only explicitly-set facts can wrongly permit — 10 `defines_flags` (12 rows, with the two `lock` spellings), 3 `opaque_flags`, 5 `reads_flags`. Pinned by `permitting_surface_is_bounded` so the set cannot grow quietly.

## What this does NOT close — #2706

A secret spilled to memory and reloaded still launders, on every target:

```
mov rax, {r}
mov [rsp], rax
mov rbx, [rsp]
mov rcx, [rbx]     # secret-derived address, accepted
```

The direct form (`mov rax, {r}` / `mov rbx, [rax]`) **is** refused, so the gate works and this path escapes it. Taint is a register set with no memory domain — pre-existing, equally true before and after this change, and unchanged by it. Filed as **#2706** with the reproducer and a preferred design.

This is stated at the same prominence as the rest deliberately: a reader who sees `setcc` closed will otherwise conclude laundering is closed in general.

## Also in scope

- **Fail-closed** via `flags_stated`, mirroring `AsmClass.known`. Demonstrated by dropping a row's flags constructor. It is a **test-time** completeness pin, not a runtime refusal — the inverted defaults already make an unstated row safe.
- **Reader set pinned by name to exactly fifteen**, so adding `jo` or `js` breaks a test rather than silently changing what `defines_flags` means under every classified row. `pushfq` is listed but asserted *not* to be a marked reader: it reads flags into **memory**.
- **arm64 and riscv64 vacuity pinned**, so an aarch64 `cset` added later must state its facts deliberately.
- `doc/language/secrecy.md` updated, including the memory boundary.

## Verification

- `mach test .` green (1253/1253)
- `int/run.sh --target linux` green, including the hardware case
- Self-host fixpoint holds
- The mutation tool restores the tree byte-for-byte; verified after the final run
