### PR TITLE
comptime: answer a shape predicate about the outermost constructor, so `^` refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### `^` is stripped only where the question is about storage (#2692)
+
+**This is a contract change, and the contract it changes was unsound.**
+
+`comptime-intrinsics.md` documented `^` as stripped before a shape predicate answers, so `^Pair` was a record. `$fields(^Pair)` refuses, and the doc's own descent idiom pairs the two:
+
+```mach
+$if ($is_record(f.type)) {
+    $each g in $fields(f.type) { ... }   # descend
+} $or { ... }
+```
+
+The rule and its counterexample were nine lines apart in the same section. For a `^`-wrapped record field the gate answered yes and the intrinsic it gates then refused the same operand, so a walk written exactly as prescribed failed with `$fields requires a record type` — a message asserting the operand is not a record, immediately after a predicate said it was. No gate could prevent it, because no predicate distinguished `^Inner` from `Inner`.
+
+`$is_record` / `$is_union` / `$is_pointer` now answer about the **outermost** constructor, and `^` is a constructor. All three answer false for `^T`, so a reflection walk refuses a secret rather than descending into secret storage. `$type_name` stops stripping too and spells `^Pair` — its stated purpose is to be the spelling diagnostics print, and a diagnostic prints `^Pair`, so stripping was a drift on the one qualifier where drift matters most.
+
+That leaves one rule for the whole surface: **`^` is stripped only where the question is about storage.** `$size_of` / `$align_of` / `$offset_of` strip, because storage is exactly what they ask. Nothing else does.
+
+Outermost means outermost, which is `type.is_secret` and not `type.carries_secret`: `^*u8` is a secret pointer and answers false, while `*^u8` is a public pointer to secret storage and is still a pointer. `Box[^u64]` is a record, because the instance is not itself secret — its field is, and the field is where a walk meets the question.
+
+**Why this direction rather than making `$fields` accept `^Rec`.** Under that alternative a walk descends into a secret record and each leaf action meets the secrecy gates on its own: formatting is refused at the variadic boundary, comparison is refused as a branch on a secret, hashing is refused as a cast that drops `^`. All true — and a memberwise **copy** is accepted, correctly, since secret to secret is what the lattice permits. Safety would then be a property of which leaf actions happen to exist rather than of the contract, and the next walk whose leaf touches no gate descends into a secret with nothing to stop it. Refusing at the gate puts the guarantee in the contract.
+
+Reasoning by analogy to #2297 (field resolution) and #2373 (cast width) is what produced the old rule. Those are storage questions — a secret occupies its base type's storage and has its base type's fields — and stripping is right for both. A predicate that gates a walk is not a storage question, and carrying the analogy across is the defect.
+
+A walk still has to classify **positively** for this to refuse rather than skip: gate on the shapes you handle and refuse the fallthrough, which is what `std.derive` does and what the docs now prescribe. Because all three predicates answer false for `^T`, "nothing classifies it" is a usable secrecy signal on its own.
+
+Blast radius: no user-level consumer in this repo. In mach-std every consumer is `std.derive`, where a `^`-wrapped record field now fails with derive's own written message instead of the raw intrinsic error.
+
 ## [4.12.0] - 2026-08-07
 
 **Contains a critical correctness fix. Anyone on 4.11.0 or earlier should upgrade.**

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -93,10 +93,22 @@ $is_pointer(T)          # T is a reference: the raw `ptr` or a typed `*U`
 They are **comptime-only** — a gate condition selects an arm, and there is no
 runtime boolean for one to become, so using a predicate as a value is an error.
 
-A `^` secret wrapper is stripped before the question is answered: `^Pair` is a
-record, because `^T` is a wrapper over `T`'s storage. A generic instance answers as
-the declaration it instantiates, so `Box[i64]` is a record — which is the type a
-reflection loop actually meets.
+**`^` is a constructor, and a predicate answers about the outermost one.** `^Pair`
+is a secret, not a record, so all three answer false and a reflection walk refuses
+it instead of descending into secret storage. That is what keeps a predicate and
+`$fields` in agreement: `$fields(^Pair)` refuses, so a gate that called `^Pair` a
+record would send a walk into an operand the intrinsic then rejects.
+
+Outermost means outermost. `^*u8` is a secret pointer and answers false; `*^u8` is
+a **public** pointer to secret storage and is still a pointer, since the address is
+public. A generic instance answers as the declaration it instantiates, so `Box[i64]`
+is a record — which is the type a reflection loop actually meets — and `Box[^u64]`
+is a record too, because the instance is not itself secret; its field is, and the
+field is where a walk meets the question.
+
+Because all three answer false for `^T`, "nothing classifies it" is itself a usable
+signal: a walk that gates on the three predicates and refuses the fallthrough
+refuses secrets without needing to ask about secrecy directly.
 
 ```mach
 rec Inner { x: u64; y: u64; }
@@ -118,7 +130,22 @@ $type_name(T)           # the type's spelling, as a NUL-terminated string
 Unlike the predicates this **is** a value (`*u8`), usable anywhere one is. The
 spelling is the same one diagnostics print, so a name a program reads and a name an
 error reports cannot drift. Composites spell compositely (`$type_name(*Pair)` is
-`"*Pair"`), and a `^` wrapper is stripped as it is for the predicates.
+`"*Pair"`), and `^` spells too: `$type_name(^Pair)` is `"^Pair"`. Stripping it would
+be a drift on the one qualifier where a drift matters most, since a diagnostic about
+that type prints `^Pair`.
+
+## Where `^` is stripped
+
+One rule covers the whole surface: **`^` is stripped only where the question is
+about storage.**
+
+| asks about | strips `^` |
+|---|---|
+| `$size_of` / `$align_of` / `$offset_of` | yes — a secret occupies its base type's storage |
+| `$is_record` / `$is_union` / `$is_pointer` | no — `^T` is a secret, not a `T` |
+| `$type_name` | no — the spelling is `^T` |
+| `$fields` | no — a secret record is refused, not walked |
+| type comparison (`f.type == u64`) | no — `^u64` is not `u64` |
 
 ## The type operand
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2012,19 +2012,40 @@ test "mach.lang.driver:comptime_type_predicates" {
     # an INSTANCE of a record answers as the record: post-#2168 that is the type a
     # reflection loop actually meets for `Box[i64]`
     if (ut_arm("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
-    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $is_union, mirrored
     if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_union(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
     if (ut_arm("uni Box[T] { v: T; w: u32; }\nfun main() i32 { $if ($is_union(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
-    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $is_pointer covers BOTH spellings of a reference
     if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     if (ut_arm("fun main() i32 { $if ($is_pointer(ptr)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
-    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # `^` IS A CONSTRUCTOR AND A PREDICATE ANSWERS ABOUT THE OUTERMOST ONE (#2692).
+    # every predicate answers false for a `^`-qualified type, so a reflection walk
+    # refuses it rather than descending into secret storage. this reverses the
+    # earlier rule, under which `$is_record(^P)` was true while `$fields(^P)` refused
+    # the same operand - the gate and the intrinsic it gates disagreed, so a walk
+    # written exactly as the docs prescribe descended into a type `$fields` refused.
+    # pinned per predicate: a fix that made one of the three consistent and left the
+    # other two stripping would just move the hole.
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_record(^u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    # a `^` record is not a union or a pointer either: all three answer false, which
+    # is what makes "nothing classifies it" a usable signal on its own.
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_union(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    # OUTERMOST ONLY, which is the difference between `type.is_secret` and
+    # `type.carries_secret`. a PUBLIC pointer to secret storage is still a pointer:
+    # the address is public and detect-but-do-not-follow is the right treatment.
+    if (ut_arm("fun main() i32 { $if ($is_pointer(*^u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # a generic INSTANCE at a secret argument is not itself secret: `Box[^u64]` is a
+    # record whose field is secret, and the field is where the refusal belongs.
+    if (ut_arm("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[^u64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # a predicate is comptime-only: there is no runtime boolean for one to become
     if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { val b: u8 = $is_record(P); ret 0; }\n",
@@ -2044,8 +2065,11 @@ test "mach.lang.driver:comptime_type_name" {
     if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # a composite spells compositely rather than degrading to the nominal
     if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(*Pair) == \"*Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
-    # the secret wrapper is stripped here too, so `^Pair` names `Pair`
-    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # `^` IS NOT stripped here (#2692). this name is meant to be the spelling sema
+    # prints in a diagnostic, and a diagnostic prints `^Pair` - yielding "Pair" would
+    # be a drift on the one qualifier where a drift matters most.
+    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"^Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($type_name(*^u8) == \"*^u8\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # unlike the predicates it IS a value, usable outside a gate
     if (ut_layout_ok("rec Pair { a: u64; }\nfun main() i32 { val n: *u8 = $type_name(Pair); ret 0; }\n") != 0) { bad = 1; }
 
@@ -2067,11 +2091,34 @@ test "mach.lang.driver:comptime_reflection_descent" {
     # the spelling is pinned where a derive-style formatter would actually read it
     if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
-    # a SECRET-typed field met through the loop: the #2297 / #2373 shape arriving via
-    # the descriptor rather than as a literal `^T` spelling, which is how a real walk
-    # would meet it. an unstripped query answers "not a record" and the derive walk
-    # silently skips the field.
-    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # a SECRET-typed field met through the loop, which is how a real walk meets one
+    # rather than as a literal `^T` spelling. it answers NOT a record (#2692), so the
+    # walk refuses it instead of descending into secret storage.
+    #
+    # this reverses the earlier expectation, which was reasoned by analogy to
+    # #2297 (field resolution) and #2373 (cast width). those two are STORAGE
+    # questions - a secret occupies its base type's storage and has its base type's
+    # fields - and stripping is right for both. a predicate that gates a walk is not
+    # a storage question, and carrying the analogy across is what produced a gate
+    # that disagreed with the `$fields` it gates.
+    #
+    # the analogy's stated worry was that an unstripped query makes a walk silently
+    # SKIP the field. that is a property of how the walk writes its fallthrough, not
+    # of the predicate: a walk that classifies positively (record, or one of an
+    # explicit set of leaf types) and refuses everything else refuses the secret,
+    # which is the idiom the docs now prescribe and the one std.derive uses. and the
+    # old answer never bought a descent anyway - `$fields(^Inner)` refuses, so the
+    # walk failed there instead, with a message naming the wrong thing.
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+
+    # the positive-classification idiom itself: a `^` field reaches neither the
+    # descent arm nor the scalar arm, so a walk whose fallthrough is an $error
+    # refuses it by construction.
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"REC\"); } $or (f.type == u64) { $error(\"SCALAR\"); } $or { $error(\"REFUSED\"); } } ret 0; }\n", "REFUSED", "REC") != 0) { bad = 1; }
+
+    # `$type_name` through the descriptor spells the `^`, so a refusal message can
+    # name what it refused
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"^Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # and the whole shape together: gate, then descend, over a MIXED record - which
     # is the case that could not be written at all before, since the inner $fields

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -339,7 +339,8 @@ fun ensure_layout_fields(sc: *context.SemaContext, ty: type.TypeId, depth: u32) 
 #
 # The shape rule itself is `type.shape_kind` - shared with the lowering-side twin so
 # a gate folded at sema and the same gate deferred to monomorphization cannot
-# disagree. Here it only maps that kind onto the asked question.
+# disagree. Here it only maps that kind onto the asked question, after the `^` rule
+# below.
 # ---
 # data:  the *SemaContext, erased to a ptr by the installer
 # tid:   the already-resolved TypeId to ask about
@@ -359,6 +360,25 @@ pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.O
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
 
+    # `^` IS A CONSTRUCTOR, AND A PREDICATE ANSWERS ABOUT THE OUTERMOST ONE (#2692).
+    # `^Rec` is a secret, not a record, so every predicate answers false and a
+    # reflection walk refuses it rather than descending into secret storage. this is
+    # what makes the answers agree with `$fields`, which refuses `^Rec`: the gate and
+    # the intrinsic it gates used to disagree, so a walk written exactly as the docs
+    # prescribe descended into a type `$fields` then refused.
+    #
+    # `type.is_secret` and not `type.carries_secret`: the question is the outermost
+    # constructor only. `^*u8` is a secret pointer and answers false, while `*^u8` is
+    # a PUBLIC pointer to secret storage and stays a pointer - `carries_secret` walks
+    # the spine and would refuse that second shape, which is genuinely fine.
+    #
+    # this sits ahead of the generic-parameter deferral on purpose: `^T` is a secret
+    # whatever `T` turns out to be, so the answer exists at the template and there is
+    # nothing to defer.
+    if (type.is_secret(?s.types, t) && which != comptime.TYPE_QUERY_NAME) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_bool(false)));
+    }
+
     # AN UNBOUND GENERIC PARAMETER IS UNANSWERABLE HERE, not false (#2465). The
     # template sees a placeholder, which is not a record, a union or a pointer - so
     # answering would prune one arm for every instantiation alike. None defers the
@@ -370,8 +390,10 @@ pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.O
 
     if (which == comptime.TYPE_QUERY_NAME) {
         # `typename.type_to_str` is the spelling sema already uses in diagnostics, so
-        # the name a program reads and the name an error prints cannot drift.
-        val r: R.Result[str, str] = typename.type_to_str(s, type.strip_secret(?s.types, t));
+        # the name a program reads and the name an error prints cannot drift - which
+        # is why `^` is NOT stripped here (#2692). a diagnostic prints `^Pair`, so
+        # yielding "Pair" would be a drift on the one qualifier where it matters most.
+        val r: R.Result[str, str] = typename.type_to_str(s, t);
         if (R.is_err[str, str](r)) { ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[str, str](r)); }
         val text: str = R.unwrap_ok[str, str](r);
         val ir_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, text);


### PR DESCRIPTION
Closes #2692.

## This is a contract change, not a bug fix

Saying that plainly because the old behaviour was deliberate, and there were three independent commitments to it:

1. **`doc/language/comptime-intrinsics.md:96`** stated it as a rule *with a rationale*: "A `^` secret wrapper is stripped before the question is answered: `^Pair` is a record, because `^T` is a wrapper over `T`'s storage."
2. **Four tests pinned it**, each with a comment stating intent (`$is_record(^P)`, `$is_union(^U)`, `$is_pointer(^*P)`, `$type_name(^Pair) == "Pair"`).
3. **The implementation documented it**, routing every predicate through `type.shape_kind`, which strips.

## And the documented contract was unsound, as the doc itself shows

`$fields(^Pair)` refuses. The doc's descent idiom pairs a predicate with `$fields`:

```mach
$if ($is_record(f.type)) {
    $each g in $fields(f.type) { ... }   # descend
} $or { ... }
```

**That example sits nine lines below the stripping paragraph that breaks it.** For a `^`-wrapped record field the gate answered yes and the intrinsic it gates then refused the same operand — `$fields requires a record type`, a message asserting the operand is not a record immediately after a predicate said it was. No gate could prevent it, because no predicate distinguished `^Inner` from `Inner`, and that indistinguishability is the whole point of the stripping rule.

A rule and its counterexample have been living together in the same section. That is why this reads as a correction rather than a preference.

## The change

`^` is a constructor, and a predicate answers about the **outermost** one. All three answer false for `^T`, so a walk refuses a secret instead of descending into secret storage.

`$type_name` stops stripping too and spells `"^Pair"`. That one is not merely consistency: `$type_name`'s stated purpose is to be the spelling diagnostics print *so a program's name and an error's name cannot drift*. A diagnostic prints `^Pair`. Stripping made them drift, on the one qualifier where drift matters most.

Which leaves **one rule for the whole surface**:

> `^` is stripped only where the question is about storage.

| asks about | strips `^` |
|---|---|
| `$size_of` / `$align_of` / `$offset_of` | yes — a secret occupies its base type's storage |
| `$is_record` / `$is_union` / `$is_pointer` | no |
| `$type_name` | no |
| `$fields` | no — refused, not walked |
| type comparison (`f.type == u64`) | no |

Outermost means outermost, which is why this uses `type.is_secret` and not `type.carries_secret`: the latter walks the spine and would make `$is_pointer(*^u8)` false, refusing a shape that is genuinely fine. `^*u8` is a secret pointer and answers false; `*^u8` is a **public** pointer to secret storage and stays a pointer. `Box[^u64]` is a record, since the instance is not itself secret — its field is, and the field is where a walk meets the question.

## Why this direction, and not making `$fields` accept `^Rec`

The issue as I filed it preferred the other direction, on the argument that shape and information-flow are separate concerns and the secrecy gates would catch any leak at the leaf. **I tested that premise instead of trusting it. It is true, and it is load-bearing in the wrong place.**

| leaf | what sema says today |
|---|---|
| format | `a secret value cannot be passed to a variadic '...' argument` |
| compare | `secret value used as a branch condition` |
| hash | `cast: '::' and ':~' cannot add or drop the secret qualifier` |
| **copy** | **accepted** — correctly, since secret to secret is what the lattice permits |

That last row settles it. Under the alternative, a classifier accepts a `^Rec` field and descends, three derives happen to fail at their leaves, and **a memberwise clone silently succeeds**. Safety would be a property of which leaf actions exist today rather than of the contract, and the next walk whose leaf touches no gate descends into a secret with nothing to stop it. Refusing at the gate puts the guarantee in the contract instead.

## Where the old rule came from

The test that pinned the secret case reasoned by analogy to #2297 (field resolution) and #2373 (cast width). Both are **storage** questions — a secret occupies its base type's storage and has its base type's fields — and stripping is right for both. A predicate that gates a walk is not a storage question. Carrying the analogy across is the defect, and the one-line rule above explains #2297 and #2373 correctly while excluding the predicates.

## The skip hazard, stated rather than glossed

That test's stated worry was that an unstripped query makes a walk silently **skip** a secret field. It is a real hazard and it is now a property of how a walk writes its fallthrough, not of the predicate:

- a walk that classifies **positively** — gate on the shapes you handle, refuse the fallthrough — refuses the secret. This is what `std.derive` does and what the docs now prescribe.
- a walk whose `$or` fallthrough *acts* would skip it.

The old answer never bought a descent anyway: `$fields(^Inner)` refuses, so such a walk failed there instead, with a message naming the wrong thing. Pinned by a new test that gates record / scalar / fallthrough and asserts the secret reaches the fallthrough.

Because all three predicates now answer false for `^T`, "nothing classifies it" is a usable secrecy signal on its own, which takes some pressure off #2694.

## One site

`src/lang/fe/sema/infer.mach:answer_type_query`. Lowering's `resolve_type_query` delegates to it — "the one implementation, so a predicate folded during arm selection and the same predicate folded at monomorphization cannot answer differently" — so sema and lowering change together. No contact with `type.mach`, `layout.mach`, or `me/ir/type.mach`.

The check sits ahead of the generic-parameter deferral deliberately: `^T` is a secret whatever `T` turns out to be, so the answer exists at the template and there is nothing to defer.

## Tests

`mach test .` — **1252 passed, 0 failed** (1251 before; net +1 after inverting four pins and adding nine).

Pinned **per predicate**, so a later change to one of the three cannot silently reopen the hole: `^P` against record, union and pointer; `^u64` against record; `^*P` against pointer; and the outermost-only boundary `*^u8` still a pointer. Plus `Box[^u64]` still a record, `$type_name(^Pair) == "^Pair"`, `$type_name(*^u8) == "*^u8"`, and the descriptor path (`f.type` from a real `$each` walk) for both the predicate and the spelling.

The four inverted tests keep comments naming the new rule and why, not flipped expectations.

**Self-host fixpoint verified**: `mach build -o a`, `./a build -o b`, `./b build -o c`, `cmp b c` byte-identical at 8302592 bytes. Stage2 against stage3, not a system-built stage against itself.

## Downstream: verified, and needs sequencing

Built mach-std at `dev` (ece1fd7) with this compiler: **784 passed, 0 failed**, same 18 skipped. Plain nested records still descend, so the recursive derive tier is unaffected.

The payoff is confirmed by mach-std's own refusal harness. A `^`-wrapped record field now fails with derive's **written** message:

> `std.derive: field type is neither a scalar numeric nor a nested record ...`

instead of the raw `$fields requires a record type`. That is what #2692 was actually about.

**This requires a follow-up in mach-std, filed as briar-systems/mach-std#448.** Its harness deliberately pinned the old raw message so that exactly this change would be caught rather than slipping through, and it now fails that case — as designed. One sentence in `derive.mach`'s module doc also becomes false: it explains that a `^` field is caught because type comparison does not strip `^` "unlike the shape predicates", and after this the predicates do not strip either.

mach-std CI installs the latest mach **release**, so it stays green until this ships. The follow-up must land with or after the release carrying this change, not before.
