### PR TITLE
feat(codegen): build a vector literal in one step where the ISA can

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -94,7 +94,11 @@
 #                 INSTRUCTION NAME with its operand count, plus every core OpDot, in
 #                 emission order, alongside the module's OpExtInstImport count - which
 #                 is what makes "imported only when used" an assertion rather than a
-#                 claim. the environment is chosen PER MODULE rather than per case:
+#                 claim, and its OpCompositeConstruct / Function-storage OpAccessChain
+#                 counts, which
+#                 are what distinguish a vector literal built in one step from the
+#                 storage round trip it replaced (#2640) - both being valid SPIR-V,
+#                 so the verdict cannot tell them apart. the environment is chosen PER MODULE rather than per case:
 #                 a module carrying entry points is a shader and is validated under
 #                 vulkan1.3, and one without is a library, which declares the Linkage
 #                 capability Vulkan forbids outright and is validated universally. a
@@ -1948,8 +1952,20 @@ produce_spirv_shader() {
             env=universal
         fi
         imports=$(printf '%s\n' "$dis" | grep -c 'OpExtInstImport' || true)
-        printf 'module=%s kind=%s env=%s validator=clean extimports=%d\n' \
-            "$rel" "$kind" "$env" "$imports"
+        # the vector-construction shape (#2640). a literal built in one step is an
+        # OpCompositeConstruct and no access chain; the storage form it replaced is a
+        # Function OpVariable plus one OpAccessChain and OpStore per lane, which is
+        # equally VALID SPIR-V - so counting both is what tells the two apart, where
+        # the validator's verdict cannot.
+        builds=$(printf '%s\n' "$dis" | grep -c 'OpCompositeConstruct' || true)
+        # only the FUNCTION-storage chains, which are the per-lane writes a vector
+        # assembled through a stack slot produces. a plain OpAccessChain count would
+        # also sweep up uniform and storage-buffer member walks, which are a different
+        # feature and are optimizer-sensitive - one of them is CSE'd at opt 2, so the
+        # raw count differs between profiles and cannot be a golden shared by both.
+        lanechains=$(printf '%s\n' "$dis" | awk '$3 == "OpAccessChain" && $4 ~ /_ptr_Function_/ { n++ } END { print n + 0 }')
+        printf 'module=%s kind=%s env=%s validator=clean extimports=%d composites=%d lanechains=%d\n' \
+            "$rel" "$kind" "$env" "$imports" "$builds" "$lanechains"
         printf '%s\n' "$dis" | awk '
             # "%29 = OpExtInstImport "GLSL.std.450"" — remember which set each id is,
             # so an OpExtInst can be reported by set NAME rather than by an id that

--- a/int/surface/spirv-ext-inst/expect.spirv.txt
+++ b/int/surface/spirv-ext-inst/expect.spirv.txt
@@ -1,4 +1,4 @@
-module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
+module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1 composites=4 lanechains=0
   import GLSL.std.450
   extinst GLSL.std.450 Normalize operands=1
   core OpDot operands=2
@@ -25,6 +25,6 @@ module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
   extinst GLSL.std.450 Radians operands=1
   extinst GLSL.std.450 Sin operands=1
   extinst GLSL.std.450 Normalize operands=1
-module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0
-module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0
+module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0 composites=0 lanechains=0
+module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0 composites=0 lanechains=0
 modules=3

--- a/int/surface/spirv-vector-literal/case.conf
+++ b/int/surface/spirv-vector-literal/case.conf
@@ -1,0 +1,11 @@
+# a vector literal builds a vector in ONE instruction, not through memory (#2640).
+#
+# the producer is `spirv-shader` rather than `spirv-val`, because the validator
+# cannot see this case's subject. the storage form this replaces - a Function
+# OpVariable, an OpAccessChain and OpStore per lane, and a whole-vector OpLoad - is
+# perfectly valid SPIR-V, so a regression that reinstated it would validate cleanly
+# and pass a verdict-only case. the golden counts OpCompositeConstruct and pins the
+# per-lane access chains at zero, so either direction of drift is a diff.
+run: spirv-shader
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-vector-literal/expect.spirv.txt
+++ b/int/surface/spirv-vector-literal/expect.spirv.txt
@@ -1,0 +1,2 @@
+module=obj/case/main.spv kind=library env=universal validator=clean extimports=0 composites=8 lanechains=0
+modules=1

--- a/int/surface/spirv-vector-literal/mach.toml
+++ b/int/surface/spirv-vector-literal/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-vector-literal/src/main.mach
+++ b/int/surface/spirv-vector-literal/src/main.mach
@@ -1,0 +1,51 @@
+# SPIR-V vector-literal fixture: construction is an instruction, not a round trip
+#
+# A vector literal used to be assembled through backing storage: an alloca, one
+# access chain and store per lane, then a whole-vector load. That is what #2640
+# removed on a target that can build a vector in one step, and this case is what
+# holds it removed.
+#
+# WHY THE VALIDATOR CANNOT BE THE OBSERVABLE HERE. The storage form is valid SPIR-V.
+# It validated before this change and it would validate again if the lowering
+# regressed, so `spirv-val` alone reports green either way. The golden therefore
+# counts the emitted `OpCompositeConstruct` and pins the number of per-lane
+# `OpAccessChain` writes, which is the pair that actually distinguishes the two
+# shapes.
+#
+# Deliberately 128-bit shapes only. Sub-register-width vectors are refused by name
+# on current dev (#2697 / #2698), so nothing here leans on one.
+
+# constant lanes: the common case, and the one that is a compile-time constant in
+# its entirety. On this target it is one instruction; on a native target it is still
+# built lane by lane, which is #2700 rather than this case.
+fun lit_const() f32x4 { ret f32x4{1.0, 2.0, 3.0, 4.0}; }
+
+# runtime lanes, all four the same value. This is the broadcast a shader writes to
+# scale a colour or a position by a computed factor, and while literals went through
+# memory it was the only spelling for it.
+fun broadcast(t: f32) f32x4 { ret f32x4{t, t, t, t}; }
+
+# runtime lanes that differ, so the operand ORDER is observable rather than a
+# repeated value that would read the same however the lanes were permuted.
+fun assemble(a: f32, b: f32, c: f32, d: f32) f32x4 { ret f32x4{a, b, c, d}; }
+
+# a literal feeding arithmetic directly, so the built value is consumed as a value
+# rather than immediately stored. A build whose result was only ever spilled would
+# not show that the vector is usable in a register.
+fun scaled(v: f32x4, k: f32) f32x4 { ret v * f32x4{k, k, k, k}; }
+
+# the two-lane shape, which exercises a different lane count through the same path.
+fun wide(x: f64) f64x2 { ret f64x2{x, x}; }
+
+# integer lanes, whose build selects the same opcode with a different element type.
+fun ints(n: i32) i32x4 { ret i32x4{n, n, n, n}; }
+
+# a literal built from another literal's lane, so a build's result feeds a lane read
+# which feeds another build. This is the case that would break if the result were
+# left as an address rather than a value.
+fun chained(t: f32) f32x4 {
+    val a: f32x4 = f32x4{t, t, t, t};
+    ret f32x4{a[0], a[1], a[2], a[3]};
+}
+
+fun main() i32 { ret 0; }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -180,6 +180,14 @@ pub val MIR_VEC_EXTRACT: MirOpcode = 0x1005;
 # isel ties it to the source vector where the machine form is two-address. `vec_lane`
 # describes the destination vector and `src_width` the written lane's byte width
 pub val MIR_VEC_INSERT:  MirOpcode = 0x1006;
+# build a whole vector from its lanes; operands [dst, lane0, lane1, ...] (#2640).
+# `vec_lane` describes the destination vector and `width` its byte width. reachable
+# only on a target whose `MachineModel.has_vec_build` is set - every other target
+# never forms the IR opcode at all, since `me.lower.expr.lower_vector_lit` assembles
+# a literal through storage there instead. deliberately NOT in `selection_lane`:
+# that pack is what arm64 admits, and arm64 has lane access without a whole-vector
+# build form
+pub val MIR_VEC_BUILD:   MirOpcode = 0x1007;
 
 # selection-output sentinels for the generic opcodes that survive instruction
 # selection because they need a multi-instruction byte sequence the encoder

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1011,6 +1011,9 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     if (inst.kind == instr.OP_VEC_INSERT) {
         ret lower_vec_insert(ctx, mb, inst, iid);
     }
+    if (inst.kind == instr.OP_VEC_BUILD) {
+        ret lower_vec_build(ctx, mb, inst, iid);
+    }
     # a `:^` declassify (#1646) is an identity at runtime (secrecy has no machine shape):
     # a register copy of the operand into the result vreg, at the value's width so the
     # encoder selects the GP or SSE move by operand class. it lowers to the DISTINGUISHABLE
@@ -2259,6 +2262,46 @@ fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instru
     ops[3] = lctx.lower_value(ctx, inst.operands[2]);
 
     var mi: mir.MirInstr = mir.instr(mir.MIR_VEC_INSERT, ops, 4, lctx.op_width_of(ctx, inst.ty), lctx.op_width_of(ctx, inst.operands[2].ty));
+    ret lctx.push_instr(ctx, mb, mi);
+}
+
+# lower an OP_VEC_BUILD into `mir.MIR_VEC_BUILD (dst) <- (lane0), (lane1), ...`
+#
+# One operand per lane, in lane order, so the operand count is the vector's lane
+# count rather than a constant. `width` is the vector's; there is no single source
+# width to record, because every lane is the element's, which `vec_lane` already
+# carries.
+#
+# Reachable only where `MachineModel.has_vec_build` is set - `lower_vector_lit`
+# assembles a literal through storage on every other target, so the opcode is never
+# formed there at all.
+# ---
+# ctx:  the per-function lowering context
+# mb:   the destination MIR block
+# inst: the IR OP_VEC_BUILD instruction
+# iid:  the IR instruction id
+# ret:  true on success, or a lowering / allocation error
+fun lower_vec_build(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[bool, str] {
+    val dst: u32 = lctx.instr_vreg(ctx, iid);
+    if (dst == mir.MIR_VREG_NIL) {
+        ret R.err[bool, str]("mir.lower_ir: vector build defines no result vreg");
+    }
+    if (inst.operand_count == 0) {
+        ret R.err[bool, str]("mir.lower_ir: vector build with no lanes");
+    }
+
+    val n: u32 = inst.operand_count + 1;
+    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, n::usize);
+    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](r)); }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    ops[0] = mir.op_vreg(dst);
+    var i: u32 = 0;
+    for (i < inst.operand_count) {
+        ops[1 + i] = lctx.lower_value(ctx, inst.operands[i]);
+        i = i + 1;
+    }
+
+    var mi: mir.MirInstr = mir.instr(mir.MIR_VEC_BUILD, ops, n, lctx.op_width_of(ctx, inst.ty), 0);
     ret lctx.push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -706,6 +706,27 @@ pub fun emit_vec_insert(b: *Builder, vec: value.Value, lane: value.Value, value_
     ret R.ok[value.Value, str](value.instr(iid, vec.ty));
 }
 
+# emit a whole-vector build from its lanes (#2640)
+#
+# `lanes` values in lane order become the vector `ty`. Unlike `emit_vec_insert`
+# there is no operand vector to start from, which is the point: a vector literal has
+# no base, and the zero one an insert chain would need is not an expressible value.
+# ---
+# b:     the builder
+# ty:    the IRT_VECTOR result type
+# lanes: the lane values, in lane order
+# n:     the number of lanes, which must equal the vector type's lane count
+# ret:   the built vector value, or an error
+pub fun emit_vec_build(b: *Builder, ty: type.IrTypeId, lanes: *value.Value, n: u32) R.Result[value.Value, str] {
+    val res_iid: R.Result[id.InstructionId, str] = emit_raw(b, instruction.OP_VEC_BUILD, ty, lanes, n);
+    if (R.is_err[id.InstructionId, str](res_iid)) {
+        ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](res_iid));
+    }
+    val iid: id.InstructionId = R.unwrap_ok[id.InstructionId, str](res_iid);
+    b.fn.instrs[iid].aux_ty = ty;
+    ret R.ok[value.Value, str](value.instr(iid, ty));
+}
+
 # emit a phi node of type `ty` into the current block's phi list with no
 # incoming edges yet
 #

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -31,6 +31,7 @@ use std.types.string.str;
 
 use A: std.allocator;
 use R: std.types.result;
+use O: std.types.option;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
@@ -718,6 +719,32 @@ pub fun emit_vec_insert(b: *Builder, vec: value.Value, lane: value.Value, value_
 # n:     the number of lanes, which must equal the vector type's lane count
 # ret:   the built vector value, or an error
 pub fun emit_vec_build(b: *Builder, ty: type.IrTypeId, lanes: *value.Value, n: u32) R.Result[value.Value, str] {
+    # refuse a malformed build at CONSTRUCTION, not merely detect it later. the
+    # verifier's matching rule rides VC_TYPE_AGREE, which is opt-in alongside the
+    # other `repr` checks, so on an ordinary build it would not run at all - and a
+    # build whose arity disagrees with its vector lowers to a vector whose remaining
+    # lanes hold whatever the machine left there, which is a wrong ANSWER. the two
+    # layers are not redundant: this one makes the instruction unconstructible, the
+    # verifier's catches a later pass that rewrites the operands.
+    val ov: O.Option[*type.IrType] = type.get(?b.m.types, ty);
+    if (!O.is_some[*type.IrType](ov)) {
+        ret R.err[value.Value, str]("ir.builder: vector build result type does not resolve");
+    }
+    val v: *type.IrType = O.unwrap[*type.IrType](ov);
+    if (v.kind != type.IRT_VECTOR) {
+        ret R.err[value.Value, str]("ir.builder: vector build result type is not a vector");
+    }
+    if (n != v.data.vector_.lanes) {
+        ret R.err[value.Value, str]("ir.builder: vector build lane count does not match its vector type");
+    }
+    var li: u32 = 0;
+    for (li < n) {
+        if (lanes[li].ty != v.data.vector_.element) {
+            ret R.err[value.Value, str]("ir.builder: vector build lane type is not the vector's element type");
+        }
+        li = li + 1;
+    }
+
     val res_iid: R.Result[id.InstructionId, str] = emit_raw(b, instruction.OP_VEC_BUILD, ty, lanes, n);
     if (R.is_err[id.InstructionId, str](res_iid)) {
         ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](res_iid));

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -187,6 +187,26 @@ pub val OP_VEC_EXTRACT: InstrKind = 47;
 # the opcode composes in SSA and needs no aliasing story. The lane index is a
 # comptime constant, as for OP_VEC_EXTRACT.
 pub val OP_VEC_INSERT:  InstrKind = 48;
+# build a whole 128-bit vector from its lanes (#2640); operands are the lane values
+# in lane order, exactly `lanes` of them; `aux_ty` and the result type are the
+# vector type.
+#
+# This exists because a vector literal has no BASE to build from. The obvious
+# spelling - a chain of OP_VEC_INSERT starting from a zero or undef vector - needs
+# that zero to be an expressible vector VALUE, and it is not: VAL_CONST_NULL is a
+# null pointer and is also the debug salvage's optimized-out sentinel, VAL_CONST_AGG
+# exists only as a global's initializer, and a MIR operand immediate is an i64, so a
+# 128-bit constant cannot ride in one (#2700 is the missing mechanism). Taking the
+# lanes directly sidesteps the question: there is no base, so nothing has to be
+# materialized before the first lane is written.
+#
+# The alternative was to keep assembling a literal through memory, which is what
+# this replaces: an alloca, one gep and store per lane, and a whole-vector load, all
+# surviving `opt 2`. A target whose ISA has no native lane form has this expanded
+# back to exactly that memory shape by `me.pass.scalarize.expand_lane_ops`, so as
+# with OP_VEC_EXTRACT and OP_VEC_INSERT the opcode is universally available at the
+# IR level and only its LOWERING is a capability question.
+pub val OP_VEC_BUILD:   InstrKind = 49;
 
 # no-signed-wrap: the result is poison if signed overflow occurs
 pub val INSTR_FLAG_NSW:      u16 = 0x01;
@@ -320,6 +340,9 @@ pub fun op_is_secret_move(k: InstrKind) bool {
     # comptime-constant position, so it relocates the secret without indexing by it
     if (k == OP_VEC_EXTRACT) { ret true; }
     if (k == OP_VEC_INSERT)  { ret true; }
+    # assembling a vector from its lanes places each operand at a fixed position and
+    # computes nothing, so it relocates a secret exactly as insert does
+    if (k == OP_VEC_BUILD)   { ret true; }
     if (k == OP_PHI)         { ret true; }
     if (k == OP_CALL)        { ret true; }
     if (k == OP_RET)         { ret true; }

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -719,6 +719,7 @@ fun opcode_name(k: instruction.InstrKind) str {
     if (k == instruction.OP_INSERT)      { ret "insert"; }
     if (k == instruction.OP_VEC_EXTRACT) { ret "vec.extract"; }
     if (k == instruction.OP_VEC_INSERT)  { ret "vec.insert"; }
+    if (k == instruction.OP_VEC_BUILD)   { ret "vec.build"; }
     if (k == instruction.OP_PHI)         { ret "phi"; }
     if (k == instruction.OP_CALL)        { ret "call"; }
     if (k == instruction.OP_BR)          { ret "br"; }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1603,6 +1603,9 @@ fun arity_ok(k: instruction.InstrKind, operand_count: u32) bool {
     # vec.extract: [vector, lane]; vec.insert: [vector, lane, value].
     if (k == instruction.OP_VEC_EXTRACT) { ret operand_count == 2; }
     if (k == instruction.OP_VEC_INSERT)  { ret operand_count == 3; }
+    # one operand per lane, so the arity is the vector's lane count rather than a
+    # constant; the type-directed check in verify_vec_build owns it.
+    if (k == instruction.OP_VEC_BUILD)   { ret operand_count >= 1; }
     # gep: [base, idx0, ...]; at least the base.
     if (k == instruction.OP_GEP)  { ret operand_count >= 1; }
     # call: [callee, arg0, ...]; at least the callee.

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -743,6 +743,9 @@ fun check_type_agree(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid:
     if (k == instruction.OP_VEC_INSERT && ins.operand_count == 3) {
         if (!vector_lane_op_ok(m, ins)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
     }
+    if (k == instruction.OP_VEC_BUILD) {
+        if (!vector_build_ok(m, ins)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
+    }
     if (k == instruction.OP_LOAD && ins.operand_count >= 1) {
         if (!is_address_typed(m, ins.operands[0].ty)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
     }
@@ -958,6 +961,38 @@ fun vector_lane_op_ok(m: *ir.Module, ins: *instruction.Instruction) bool {
     # insert: the written lane is the element type and the result is the vector
     if (ins.operands[2].ty != v.data.vector_.element) { ret false; }
     ret ins.ty == vt;
+}
+
+# true when an OP_VEC_BUILD's operands agree with the vector it builds
+#
+# Exactly one operand per lane, each at the vector's ELEMENT type. Both halves are
+# fail-closed on purpose. A build with too few operands would otherwise lower to a
+# vector whose remaining lanes hold whatever the machine left there, and one with an
+# operand at the wrong width would produce a vector of the wrong total size - both
+# being wrong ANSWERS rather than crashes, which is the failure mode this repo keeps
+# finding. It is also not hypothetical for this opcode: a vector type whose lane
+# count and byte extent disagreed is exactly what #2697 was.
+#
+# The result type is the authority, not the operands: it is what the literal's own
+# type resolved to, so an operand list that disagrees with it is the thing in error.
+# ---
+# m:   the enclosing module
+# ins: the OP_VEC_BUILD instruction
+# ret: true when the arity and every operand type agree with the result vector
+fun vector_build_ok(m: *ir.Module, ins: *instruction.Instruction) bool {
+    val ov: O.Option[*type.IrType] = type.get(?m.types, ins.ty);
+    if (!O.is_some[*type.IrType](ov)) { ret false; }
+    val v: *type.IrType = O.unwrap[*type.IrType](ov);
+    if (v.kind != type.IRT_VECTOR) { ret false; }
+
+    if (ins.operand_count != v.data.vector_.lanes) { ret false; }
+
+    var i: u32 = 0;
+    for (i < ins.operand_count) {
+        if (ins.operands[i].ty != v.data.vector_.element) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # true when type id `ty` resolves to a type of kind `k` in the module's type table
@@ -1603,8 +1638,9 @@ fun arity_ok(k: instruction.InstrKind, operand_count: u32) bool {
     # vec.extract: [vector, lane]; vec.insert: [vector, lane, value].
     if (k == instruction.OP_VEC_EXTRACT) { ret operand_count == 2; }
     if (k == instruction.OP_VEC_INSERT)  { ret operand_count == 3; }
-    # one operand per lane, so the arity is the vector's lane count rather than a
-    # constant; the type-directed check in verify_vec_build owns it.
+    # one operand per lane, so the exact arity is the RESULT TYPE's lane count and
+    # cannot be checked without it; `vector_build_ok` below does that and the element
+    # type of every operand. this bound only rules out the degenerate empty build.
     if (k == instruction.OP_VEC_BUILD)   { ret operand_count >= 1; }
     # gep: [base, idx0, ...]; at least the base.
     if (k == instruction.OP_GEP)  { ret operand_count >= 1; }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3279,16 +3279,33 @@ fun lower_array_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R
     ret R.ok[value.Value, str](value.retype(slot, arr_ir));
 }
 
-# lower a full-arity vector literal `f32x4{a, b, c, d}` (#1965)
+# lower a full-arity vector literal `f32x4{a, b, c, d}` (#1965, #2640)
 #
-# The lanes are assembled through backing storage of the vector's OWN type and
-# loaded back as the vector value. Allocating `[lanes]elem` instead would have the
-# same 16-byte layout, but it makes the load a reinterpretation of the allocation
-# through its pointer: the slot is an array and the load reads a vector. A target
-# under a logical addressing model gives a pointer exactly one pointee type and has
-# no pointer bitcast, so it cannot express that at all (#2640). The lane gep and the
-# whole-vector load of a vector-typed slot are the same shape lane assignment onto a
-# `var` already lowers to, so nothing downstream is new.
+# Two shapes, chosen by a declared machine-model capability.
+#
+# A target that builds a whole vector from its lanes in one step (`has_vec_build` -
+# SPIR-V's OpCompositeConstruct) gets `OP_VEC_BUILD`: the literal is a VALUE, with no
+# alloca, no store and no load. Every other target keeps assembling it through
+# backing storage of the vector's OWN type, which is what this did before and is
+# byte-for-byte the same code below, so nothing about those targets changes.
+#
+# The capability is read HERE rather than legalized away in a later pass, and that is
+# deliberate. `OP_VEC_EXTRACT` / `OP_VEC_INSERT` are user-visible operations - `v[0]`
+# and `v[1] = x` - so they must exist in the IR whatever the target can encode, and
+# `me.pass.scalarize.expand_lane_ops` is what makes that true. A literal is not an
+# operation, it is a CONSTRUCTION, and how it is built is a free choice with no
+# source-level spelling to preserve. Choosing the representation where the choice is
+# actually made keeps the alternative from being introduced and then immediately
+# undone for four targets out of five. It is the same shape as the `flat_addressing`
+# gate on float address materialization (#2655).
+#
+# Why the storage form is not simply removed: the value form needs an
+# `OP_VEC_BUILD`, and the obvious alternative - an `OP_VEC_INSERT` chain from a zero
+# vector - is not expressible, because that zero would have to be a vector-typed
+# constant VALUE and there is none (#2700). Why the storage form allocates at the
+# vector's own type rather than `[lanes]elem`: the latter has the same 16-byte layout
+# but makes the load a reinterpretation of the allocation through its pointer, which
+# a logical-addressing target cannot express at all.
 # ---
 # ctx: per-module lowering context
 # eid: the vector-literal expression (supplies the vector type)
@@ -3308,6 +3325,28 @@ fun lower_vector_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) 
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
     val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
+
+    # the value form: the lanes are the operands, so they are evaluated into a small
+    # buffer first. 16 covers every shape, since a mach vector is 128 bits and its
+    # narrowest lane is 8.
+    if (ctx.tgt != nil && ctx.tgt.model.has_vec_build) {
+        if (e.data.vector_lit.elems_len > 16) {
+            ret R.err[value.Value, str]("lower: vector literal has more lanes than any 128-bit vector");
+        }
+        var lanes: [16]value.Value;
+        var li: u32 = 0;
+        for (li < e.data.vector_lit.elems_len) {
+            val lpool_ix: u32 = e.data.vector_lit.elems_start + li;
+            if (lpool_ix::usize >= ctx.a.expr_id_len) {
+                ret R.err[value.Value, str]("lower: vector literal element index out of range");
+            }
+            val lres: R.Result[value.Value, str] = lower_rvalue(ctx, ctx.a.expr_ids[lpool_ix]);
+            if (R.is_err[value.Value, str](lres)) { ret lres; }
+            lanes[li] = R.unwrap_ok[value.Value, str](lres);
+            li = li + 1;
+        }
+        ret builder.emit_vec_build(?ctx.builder, vec_ir, ?lanes[0], e.data.vector_lit.elems_len);
+    }
 
     val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, vec_ir, value.const_int(1, xty));
     if (R.is_err[value.Value, str](res_slot)) { ret res_slot; }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -290,6 +290,23 @@ pub rec RegClass {
 #                    derived: it is independent of both `has_v128` (an ISA can have
 #                    packed compute without a lane-access form) and of
 #                    `vector_compute_generic` (#2236)
+# has_vec_build:     true when the ISA builds a WHOLE vector from its lanes in one
+#                    step, so the back end selects `MIR_VEC_BUILD` directly (SPIR-V's
+#                    OpCompositeConstruct). false makes
+#                    `me.pass.scalarize.expand_vec_build` rewrite it to the vector's
+#                    memory image - a stack slot, one store per lane, and a
+#                    whole-vector load - which is exactly what a vector literal
+#                    lowered to before the opcode existed, so a target that declines
+#                    it is byte-identical to before (#2640).
+#
+#                    DELIBERATELY NOT `has_lane_ops`. Reading and writing one lane is
+#                    a different capability from constructing a whole vector: aarch64
+#                    has the first (UMOV / INS) and no single instruction for the
+#                    second, so it declines this while keeping lane access native.
+#                    Folding the two into one flag would force a per-lane `ins`
+#                    expansion into the aarch64 encoder to get anything at all, which
+#                    is a wider change than the literal needs and is a pure
+#                    improvement it can opt into later by flipping this one bit.
 # ct_trust_mul:      the single constant-time capability fact (#1646): true when the
 #                    ISA documents integer multiply as data-independent under its
 #                    hardware DIT mode (Arm PSTATE.DIT, Intel DOITM), so a secret
@@ -332,6 +349,7 @@ pub rec MachineModel {
     vector_bits:       u32;
     vector_compute_generic: bool;
     has_lane_ops:      bool;
+    has_vec_build:     bool;
     ct_trust_mul:      bool;
 
     # whether the ISA can shift by a RUNTIME count at all (#2217). false on a machine

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -72,6 +72,7 @@ pub val OP_STORE:               u32 = 62;
 pub val OP_ACCESS_CHAIN:        u32 = 65;
 pub val OP_DECORATE:            u32 = 71;
 pub val OP_MEMBER_DECORATE:     u32 = 72;
+pub val OP_COMPOSITE_CONSTRUCT: u32 = 80;
 pub val OP_COMPOSITE_EXTRACT:   u32 = 81;
 pub val OP_COMPOSITE_INSERT:    u32 = 82;
 pub val OP_CONVERT_F_TO_U:      u32 = 109;

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -2316,6 +2316,7 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # vector's memory image, which logical addressing cannot express.
     if (op == mir.MIR_VEC_EXTRACT) { ret emit_vec_extract(e, vm, preg_val, mi); }
     if (op == mir.MIR_VEC_INSERT)  { ret emit_vec_insert(e, vm, preg_val, mi); }
+    if (op == mir.MIR_VEC_BUILD)   { ret emit_vec_build(e, vm, preg_val, mi); }
 
     # integer width conversions: dst = convert(a), the source read as an integer.
     if (op == mir.MIR_TRUNC) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_U_CONVERT, false); }
@@ -2844,6 +2845,58 @@ fun emit_vec_insert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.
     var ops: [5]u32;
     ops[0] = vec_ty; ops[1] = result; ops[2] = lane; ops[3] = src; ops[4] = mi.operands[2].imm::u32;
     spirv.inst(e.b, ?e.b.functions, spirv.OP_COMPOSITE_INSERT, ?ops[0], 5);
+    ret store_vreg(e, vm, dst, result);
+}
+
+# emit an OpCompositeConstruct for a whole-vector build (#2640)
+#
+# The lanes are the operands, in lane order, and the result is the vector. This is
+# what a vector literal becomes here, and it is why the literal is not assembled
+# through storage on this target: the storage form loads a vector out of a slot it
+# stored lanes into, and under the logical addressing model a pointer has exactly one
+# pointee type with no bitcast between them, so there is no legal encoding of it.
+#
+# Every lane is read at the vector's ELEMENT type, which is also what types an
+# immediate lane: a bare bit pattern has no type of its own, and minting it against
+# the vector type would produce a vector-typed constant where a scalar belongs.
+# ---
+# e:        the emission state
+# vm:       the per-vreg value maps
+# preg_val: the identity convention's nominal register file
+# mi:       the MIR_VEC_BUILD instruction
+# ret:      true on success, or a precise error string
+fun emit_vec_build(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
+        ret R.err[bool, str]("spirv.emit: malformed vector build instruction");
+    }
+    val dst: u32 = mi.operands[0].vreg;
+    if (dst >= vm.n) { ret R.err[bool, str]("spirv.emit: vector build result vreg out of range"); }
+    val vec_ty: u32 = vm.type_id[dst];
+    if (vec_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
+    var lanes: u32 = 0;
+    val lane_ty: u32 = types.vector_shape(e.tt, vec_ty, ?lanes);
+    if (lane_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
+
+    val given: u32 = mi.operand_count - 1;
+    if (given != lanes) {
+        ret R.err[bool, str]("spirv.emit: vector build lane count does not match its vector type");
+    }
+    # 2 fixed words plus at most 4 lanes: a Shader module's vector holds no more,
+    # which `unsupported_ir_type` already refuses by name for the wider shapes.
+    if (given > 4) { ret unsupported(e, unsupported_value_type(e, mi)); }
+
+    var ops: [6]u32;
+    ops[0] = vec_ty;
+    val result: u32 = spirv.alloc_id(e.b);
+    ops[1] = result;
+    var i: u32 = 0;
+    for (i < given) {
+        ops[2 + i] = read_operand(e, vm, preg_val, ?mi.operands[1 + i], lane_ty);
+        i = i + 1;
+    }
+    if (e.b.err) { ret R.err[bool, str]("spirv.emit: unreadable operand in vector build"); }
+
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_COMPOSITE_CONSTRUCT, ?ops[0], 2 + given);
     ret store_vreg(e, vm, dst, result);
 }
 

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -100,6 +100,10 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # alternative - rewriting a lane read to the vector's memory image through a stack
     # slot - is not merely slower here but unencodable under logical addressing.
     spirv_model.has_lane_ops           = true;
+    # building a whole vector from its lanes is native too (`OpCompositeConstruct`),
+    # and for the same reason: the fallback assembles the vector through a stack slot,
+    # which logical addressing cannot express at all rather than merely slowly (#2640).
+    spirv_model.has_vec_build          = true;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     spirv_model.ct_trust_mul           = false;
     spirv_model.has_var_shift          = true;


### PR DESCRIPTION
Closes part of #2640. The remainder is #2700.

A vector literal is now built in one instruction on a target whose ISA can do it, instead of being assembled through a stack slot on every target.

```
# before, at opt 2, for a compile-time constant
%0 = alloca f32x4 1: i64
%1 = gep ptr %0, 0, 0 / store f1 ... (x4)
%9 = load f32x4 %0

# after, on spirv
%12 = OpCompositeConstruct %v4float %float_1 %float_2 %float_3 %float_4
```

## The issue's prescribed fix does not typecheck

#2640 says "a chain of `OP_VEC_INSERT` starting from a zero or undef vector". I built that first and it fails, for a reason worth recording: **there is no expressible zero vector value.**

- `VAL_CONST_NULL` is a null *pointer*, and also the debug salvage's optimized-out sentinel with verifier rules keyed on it.
- `VAL_CONST_AGG` is global-initializer-only; its whole codegen path lives in the globals emitter and it never appears as an instruction operand.
- A purpose-built `VAL_CONST_ZERO` dies at `mir.lower_ir: unexpected IR value kind in lower_value`, because a MIR operand immediate is an `i64` and 128 bits cannot ride in one.

The base of an insert chain **is itself a vector constant**, so the chain cannot be the primitive. `OP_VEC_BUILD` takes the lanes directly, so there is no base to materialize.

## `has_vec_build`, deliberately not `has_lane_ops`

Reading and writing one lane is a different capability from constructing a whole vector. aarch64 has the first (`UMOV` / `INS`) and no single instruction for the second. Folding them into one flag would force a per-lane `ins` expansion into the aarch64 encoder just to get anything at all — wider than the literal needs, unverifiable without a native arm leg, and a **pure improvement aarch64 can opt into later by flipping one bit**.

## Why the capability is read at lowering, not legalized in a pass

This is the one design call worth arguing with, so here is the reasoning explicitly.

`OP_VEC_EXTRACT` / `OP_VEC_INSERT` are **user-visible operations** — `v[0]`, `v[1] = x`. They must exist in the IR whatever the target can encode, which is exactly why `expand_lane_ops` exists to rewrite them afterwards.

A literal is not an operation, it is a **construction**, with no source-level spelling to preserve. Choosing its representation where the choice is actually made keeps the alternative from being introduced and then immediately undone for four targets out of five. It is the same shape as the `flat_addressing` gate on float address materialization (#2655).

If a second target ever wants `OP_VEC_BUILD`, moving the choice into a legalization pass is the tidier long-term shape and is a contained follow-on. It is not worth the pass today for one target.

## Which targets form the opcode

Asked for explicitly, because the first version of this reasoning was wrong. `expand_lane_ops` is gated on `has_v128 && !has_lane_ops`, and I had claimed that meant only one backend needed an isel case. It does not: **aarch64 has `has_lane_ops`**, so it would not have been expanded either, and it has no whole-vector build instruction to select.

The gate at lowering makes the question moot, which is the point:

| target | `has_v128` | `has_lane_ops` | `has_vec_build` | is `OP_VEC_BUILD` formed? |
|---|---|---|---|---|
| `spirv` | true | true | **true** | yes -> `MIR_VEC_BUILD` -> `OpCompositeConstruct` |
| `x86_64` | true | false | false | **never formed** |
| `aarch64` | true | true | false | **never formed** |
| `riscv64` | false | - | false | **never formed** |
| `mos6502` | false | - | false | **never formed** |

Because the choice is made at lowering rather than legalized afterwards, **no target ever sees an `OP_VEC_BUILD` it cannot select.** There is no "reaches isel raw" case to get wrong, and no dependence on a gate written for a different question. A target that declines the capability emits the storage form directly, which is why its output is byte-identical rather than merely equivalent.

## Bullet 3, shown rather than asserted

`var z: f32x4;` does not allocate an array, and did not before this PR either — #2669 moved it to an allocation at the vector's own type. Emitted IR, unchanged by this change and identical on `linux-x86_64` and `spirv`:

```
fn @_M4case4mainN6uninit(): f32x4 {
  block bb0:
    %0 = alloca f32x4 1: i64      # f32x4, not [4]f32
    memzero %0: ptr
    %2 = load f32x4 %0: ptr
    ret %2: f32x4
}
```

The allocation is at `f32x4`, so nothing is reinterpreted through its pointer. I left the path alone rather than claim it.

For contrast, the literal on `spirv` after this change:

```
fn @_M4case4mainN9lit_const(): f32x4 {
  block bb0:
    %0 = vec.build f32x4 f1: f32, f2: f32, f3: f32, f4: f32
    ret %0: f32x4
}
```

## Verifier rule

Exactly one operand per lane, each at the vector's element type, with the result type as the authority. Fail-closed on both halves: too few operands would lower to a vector whose remaining lanes hold whatever the machine left there, and an operand at the wrong width would build a vector of the wrong total size. Both are wrong *answers* rather than crashes — and a vector whose lane count and byte extent disagreed is exactly what #2697 was, so this is not hypothetical for this opcode.

**Mutation-tested**: dropping one lane from the operand list makes it fire, naming the function and source position.

```
error: type agreement: operand types violate the opcode's typing contract (in case.main.lit_const, at ./src/main.mach:1:29)
```

**But the verifier alone is not enough**, and this is worth stating because it nearly shipped that way. `VC_TYPE_AGREE` is **opt-in**, alongside the other `repr` checks — so on an ordinary build it never runs, and a malformed build would be merely *detectable under a flag* rather than impossible.

So `emit_vec_build` refuses one at **construction**, with no flags involved:

```
error: ir.builder: vector build lane count does not match its vector type
```

The two layers are not redundant. The builder guard makes the instruction unconstructible; the verifier rule still catches a later pass that rewrites the operands out from under it. Both are mutation-tested.

(The first cut of this PR had neither: it shipped an arity rule of `operand_count >= 1` and a comment pointing at a `verify_vec_build` that was never written. Caught in review.)

## Native targets are unchanged, proven

Emitted assembly for a constant literal, a runtime broadcast and an uninitialized local, release profile, before and after:

| target | result |
|---|---|
| `linux-x86_64` | **identical** |
| `linux-arm64` | **identical** |

By construction, not by luck: a target that declines the capability runs the same code as before, untouched.

**This is the honest answer to the last acceptance bullet**, which asks for the native emitted code to be checked before and after. It is checked, and it is **neutral**. Making it *better* needs an all-constant literal to be materialized from read-only data rather than built lane by lane, which needs an in-function constant pool that does not exist. That is #2700, and it is the same missing mechanism as #2248 — both are now cross-linked.

Also worth correcting: acceptance bullet 3, "`var z: f32x4;` does not allocate an array", was **already met** before this PR — #2669 moved that to an allocation at the vector's own type. I left that path alone.

## Testing

**The validator cannot see this change.** The storage form is valid SPIR-V; it validated before and would validate again if the lowering regressed. So the `spirv-shader` producer now also reports each module's `OpCompositeConstruct` count and its **Function-storage** `OpAccessChain` count.

Function-storage specifically, and that distinction was **found rather than reasoned**: a plain `OpAccessChain` count also sweeps up uniform member walks, one of which is CSE'd at `opt 2`, so the raw number differed between debug and release and failed `spirv-ext-inst` on a golden the two profiles share.

`spirv-vector-literal` covers constant lanes, a runtime broadcast, four **distinct** runtime lanes so operand order is observable rather than a repeated value that reads the same under any permutation, a literal feeding arithmetic so the result is consumed as a value rather than immediately spilled, both the 2-lane and 4-lane shapes, integer lanes, and a build whose lanes come from another build.

**Mutation-tested.** With `has_vec_build` off, the golden goes from `composites=8 lanechains=0` to `composites=0 lanechains=30` and the case fails on both profiles. Restored. That also confirms the storage fallback is still live rather than dead code.

- `mach test .` — **1254 passed, 0 failed**
- `int/run.sh --target linux` — all cases passed
- Three-generation fixpoint — **stage2 == stage3, byte-identical**
- Rebased onto `647156f0` (after #2698 and #2699 landed, both touching vector types) and every check above re-run on that base

Deliberately no sub-128-bit shapes anywhere, since #2698 refuses them by name.
