### PR TITLE
release: 4.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,10 @@ jobs:
       # (int/surface/debuginfo) verifies the emitted DWARF with llvm-dwarfdump and
       # reads PT_LOAD extents with readelf (#2039); spirv-module
       # (int/surface/spirv-module) validates the delivered `.spv` with the Khronos
-      # spirv-val (#2245). both run on the Linux legs.
+      # spirv-val (#2245), and spirv-ext-inst additionally DISASSEMBLES it with
+      # spirv-dis to assert the instructions the emitter produced, which the
+      # validator's verdict cannot show (#2688) - both binaries ship in the same
+      # spirv-tools package. all run on the Linux legs.
       - name: install artifact validators
         if: runner.os == 'Linux'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.13.0] - 2026-08-07
+
+**Two source-compatibility changes.** A type may no longer be declared with a vector form's name, and the comptime shape predicates no longer see through `^`.
 
 ### Changed
 
@@ -36,6 +38,44 @@ Reasoning by analogy to #2297 (field resolution) and #2373 (cast width) is what 
 A walk still has to classify **positively** for this to refuse rather than skip: gate on the shapes you handle and refuse the fallthrough, which is what `std.derive` does and what the docs now prescribe. Because all three predicates answer false for `^T`, "nothing classifies it" is a usable secrecy signal on its own.
 
 Blast radius: no user-level consumer in this repo. In mach-std every consumer is `std.derive`, where a `^`-wrapped record field now fails with derive's own written message instead of the raw intrinsic error.
+
+#### A type may not be declared with a vector form's name (#2687)
+`rec u8x16 { a: i64; }` used to compile clean and be silently unreachable: the builtin won every use, and the only symptom was a later error pointing at the wrong thing. `uni` and `def` behaved the same. It is now refused as a name collision.
+
+The guard keys on the spelling rather than on the target's vector width, so `f32x3` and `f32x7` are reserved everywhere. Otherwise a name would be claimable on a 128-bit target and collide on a wider one from identical source.
+
+**Values are unaffected.** A vector spelling is read in type position only, so `val f32x4` remains legal and is not shadowed by anything.
+
+### Added
+
+#### GLSL.std.450 extended instructions for shader stages (#2688)
+A `#[spirv_op(set, name)]` decorator declares which SPIR-V instruction a function *is*, over two sets: `"core"` and `"GLSL.std.450"`. 33 extended instructions plus core `OpDot`, covering the common-value, trigonometric, exponential, range/interpolation and geometry families. The extended set is imported only when used.
+
+The compiler names no library: it knows how to read the decorator and emit the instruction, nothing more. `briar-systems/mach-shader` provides `shader.math` over these, and anyone may declare their own.
+
+Deliberately shader-only. A decorated function may carry a body, and that body runs on every non-spirv target; a bodiless one called from a CPU build fails at link naming the symbol. A native fallback would make `sh.sqrt` and `math.sqrt_f32` the same function on a CPU and a different one on a GPU, which is the only outcome that never errors.
+
+#### A vector is read as the form `TxN`, bounded by the target's vector width (#2687, partial)
+Vector types were a table of ten hard-coded spellings. They are now read as `<element>x<lanes>` and bounded by a new `MachineModel.vector_bits`, which is 128 on every current target.
+
+The bound is a width rather than the `has_v128` capability: rv64gc and mos6502 declare no vector unit and still admit every 128-bit spelling today through scalarization, so gating on the capability would refuse names that compile correctly, and a boolean cannot express a wider future target at all.
+
+A vector's extent is now lane-derived rather than a flat 16 bytes. Size is `lane_size * lanes`. Alignment is the full size when the vector fills the vector register and one lane otherwise -- a vector that fills the register aligns to its whole size because the machine's vector load requires it, and a narrower one is a packed aggregate. All ten former spellings are exactly 128 bits and are unchanged in both size and alignment.
+
+**`vec3` is not delivered yet.** A vector narrower than the vector register is refused by name, because codegen cannot carry one: `op_width_of` answers a single number for both a value's register width and its memory footprint, which is invisible while every vector is 16 bytes and truncating once they are not (#2697). The form, the bound, the layout rule and the documentation are in, and lifting the restriction is deleting one check.
+
+### Fixed
+
+#### A darwin link failed when load commands exceeded one page (#2690)
+The Mach-O header reservation was hardcoded at one page, so an image whose load commands exceeded 4096 bytes was refused outright with `macho: dyn-exec header exceeds the one-page reservation`. Nothing in the format caps them there -- `sizeofcmds` is a `uint32`.
+
+The reservation is now computed from the actual load commands and rounded to the target's page size. It grows **inside** `__TEXT`, so `__TEXT` still maps at the image base and `__PAGEZERO` is unchanged; widening the gap below the first segment instead would have slid both down, which is #2599.
+
+Reachable by any objective-c consumer rather than only unusually large images: #2606 stopped coalescing input sections, and every surviving section costs an 80-byte `section_64`. Sixty `#[section]` globals cross the cap on section count alone.
+
+#### SPIR-V access chains, local allocations, and a dead shuffle constant (#2649)
+A GEP's index list now survives to a logical-addressing target as member ordinals rather than being folded into a byte displacement, so a struct member read lowers to `OpAccessChain` instead of being unrepresentable. Local allocations and a dead shuffle constant were fixed alongside it.
+
 
 ## [4.12.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### `^` is stripped only where the question is about storage (#2692)
+
+**This is a contract change, and the contract it changes was unsound.**
+
+`comptime-intrinsics.md` documented `^` as stripped before a shape predicate answers, so `^Pair` was a record. `$fields(^Pair)` refuses, and the doc's own descent idiom pairs the two:
+
+```mach
+$if ($is_record(f.type)) {
+    $each g in $fields(f.type) { ... }   # descend
+} $or { ... }
+```
+
+The rule and its counterexample were nine lines apart in the same section. For a `^`-wrapped record field the gate answered yes and the intrinsic it gates then refused the same operand, so a walk written exactly as prescribed failed with `$fields requires a record type` — a message asserting the operand is not a record, immediately after a predicate said it was. No gate could prevent it, because no predicate distinguished `^Inner` from `Inner`.
+
+`$is_record` / `$is_union` / `$is_pointer` now answer about the **outermost** constructor, and `^` is a constructor. All three answer false for `^T`, so a reflection walk refuses a secret rather than descending into secret storage. `$type_name` stops stripping too and spells `^Pair` — its stated purpose is to be the spelling diagnostics print, and a diagnostic prints `^Pair`, so stripping was a drift on the one qualifier where drift matters most.
+
+That leaves one rule for the whole surface: **`^` is stripped only where the question is about storage.** `$size_of` / `$align_of` / `$offset_of` strip, because storage is exactly what they ask. Nothing else does.
+
+Outermost means outermost, which is `type.is_secret` and not `type.carries_secret`: `^*u8` is a secret pointer and answers false, while `*^u8` is a public pointer to secret storage and is still a pointer. `Box[^u64]` is a record, because the instance is not itself secret — its field is, and the field is where a walk meets the question.
+
+**Why this direction rather than making `$fields` accept `^Rec`.** Under that alternative a walk descends into a secret record and each leaf action meets the secrecy gates on its own: formatting is refused at the variadic boundary, comparison is refused as a branch on a secret, hashing is refused as a cast that drops `^`. All true — and a memberwise **copy** is accepted, correctly, since secret to secret is what the lattice permits. Safety would then be a property of which leaf actions happen to exist rather than of the contract, and the next walk whose leaf touches no gate descends into a secret with nothing to stop it. Refusing at the gate puts the guarantee in the contract.
+
+Reasoning by analogy to #2297 (field resolution) and #2373 (cast width) is what produced the old rule. Those are storage questions — a secret occupies its base type's storage and has its base type's fields — and stripping is right for both. A predicate that gates a walk is not a storage question, and carrying the analogy across is the defect.
+
+A walk still has to classify **positively** for this to refuse rather than skip: gate on the shapes you handle and refuse the fallthrough, which is what `std.derive` does and what the docs now prescribe. Because all three predicates answer false for `^T`, "nothing classifies it" is a usable secrecy signal on its own.
+
+Blast radius: no user-level consumer in this repo. In mach-std every consumer is `std.derive`, where a `^`-wrapped record field now fails with derive's own written message instead of the raw intrinsic error.
+
 ## [4.12.0] - 2026-08-07
 
 **Contains a critical correctness fix. Anyone on 4.11.0 or earlier should upgrade.**

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -93,10 +93,22 @@ $is_pointer(T)          # T is a reference: the raw `ptr` or a typed `*U`
 They are **comptime-only** — a gate condition selects an arm, and there is no
 runtime boolean for one to become, so using a predicate as a value is an error.
 
-A `^` secret wrapper is stripped before the question is answered: `^Pair` is a
-record, because `^T` is a wrapper over `T`'s storage. A generic instance answers as
-the declaration it instantiates, so `Box[i64]` is a record — which is the type a
-reflection loop actually meets.
+**`^` is a constructor, and a predicate answers about the outermost one.** `^Pair`
+is a secret, not a record, so all three answer false and a reflection walk refuses
+it instead of descending into secret storage. That is what keeps a predicate and
+`$fields` in agreement: `$fields(^Pair)` refuses, so a gate that called `^Pair` a
+record would send a walk into an operand the intrinsic then rejects.
+
+Outermost means outermost. `^*u8` is a secret pointer and answers false; `*^u8` is
+a **public** pointer to secret storage and is still a pointer, since the address is
+public. A generic instance answers as the declaration it instantiates, so `Box[i64]`
+is a record — which is the type a reflection loop actually meets — and `Box[^u64]`
+is a record too, because the instance is not itself secret; its field is, and the
+field is where a walk meets the question.
+
+Because all three answer false for `^T`, "nothing classifies it" is itself a usable
+signal: a walk that gates on the three predicates and refuses the fallthrough
+refuses secrets without needing to ask about secrecy directly.
 
 ```mach
 rec Inner { x: u64; y: u64; }
@@ -118,7 +130,22 @@ $type_name(T)           # the type's spelling, as a NUL-terminated string
 Unlike the predicates this **is** a value (`*u8`), usable anywhere one is. The
 spelling is the same one diagnostics print, so a name a program reads and a name an
 error reports cannot drift. Composites spell compositely (`$type_name(*Pair)` is
-`"*Pair"`), and a `^` wrapper is stripped as it is for the predicates.
+`"*Pair"`), and `^` spells too: `$type_name(^Pair)` is `"^Pair"`. Stripping it would
+be a drift on the one qualifier where a drift matters most, since a diagnostic about
+that type prints `^Pair`.
+
+## Where `^` is stripped
+
+One rule covers the whole surface: **`^` is stripped only where the question is
+about storage.**
+
+| asks about | strips `^` |
+|---|---|
+| `$size_of` / `$align_of` / `$offset_of` | yes — a secret occupies its base type's storage |
+| `$is_record` / `$is_union` / `$is_pointer` | no — `^T` is a secret, not a `T` |
+| `$type_name` | no — the spelling is `^T` |
+| `$fields` | no — a secret record is refused, not walked |
+| type comparison (`f.type == u64`) | no — `^u64` is not `u64` |
 
 ## The type operand
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -45,6 +45,7 @@ A decorator is written as an attribute:
 #[builtin("name")]   # pipeline built-in variable (global only)
 #[uniform(set, bnd)] # descriptor-bound uniform block, read-only (global only)
 #[storage(set, bnd)] # descriptor-bound storage buffer, read-write (global only)
+#[spirv_op(set,name)] # the SPIR-V instruction this function is (fun only)
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -482,6 +483,59 @@ target that forms pipeline stages. On `spirv` each becomes an `OpVariable` in th
 matching storage class, carrying the matching decoration, and the Input and Output
 variables are named in every entry point's interface list.
 
+### `spirv_op(set, name)` — a function that *is* a SPIR-V instruction
+
+A shader needs `sqrt`, `normalize`, `dot` and `mix`. None of them is an operator,
+and none of them is a call SPIR-V can make: each is one instruction. This directive
+says which one a function is, so that on a `spirv` target a call to it becomes that
+instruction, inline, rather than a call.
+
+```mach
+#[spirv_op("GLSL.std.450", "Sqrt")]
+pub fun sqrt(x: f32) f32;
+
+#[spirv_op("GLSL.std.450", "Normalize")]
+pub fun normalize(v: f32x4) f32x4;
+
+#[spirv_op("core", "OpDot")]
+pub fun dot(a: f32x4, b: f32x4) f32;
+```
+
+The first argument names the instruction set and the second the instruction within
+it. Both value sets are closed and checked at compile time, on **every** target —
+the directive is legal everywhere, so a typo caught only where it is acted on would
+go unreported on a CPU build.
+
+| Set              | Meaning                                                     |
+|------------------|-------------------------------------------------------------|
+| `"core"`         | the core opcode space; needs no import                       |
+| `"GLSL.std.450"` | the standard extended set; imported once per module, on use  |
+
+The substitution is uniform: the emitted instruction's **result type is the
+function's declared return type** and its **operands are the function's parameters
+in declaration order**. That is what lets `dot` and `length` return a scalar from
+vectors, and `refract` mix a scalar operand with vector ones, without any of them
+being a special case.
+
+`OpExtInstImport "GLSL.std.450"` is emitted **once per module and only when that
+module uses the set**. A module that calls none of these carries no import.
+
+Note that `dot` is **core `OpDot`**, not a GLSL.std.450 instruction, even though
+GLSL spells it beside `normalize` and `length`. Check each function against the
+specification rather than against GLSL's surface.
+
+On every target other than `spirv` the directive is inert, and a decorated function
+is an ordinary function. A **bodiless** one — which is what the shader-side maths
+library uses — is then an undefined symbol, so a CPU build that calls it fails at
+link time naming the symbol. That is a deliberate design choice on the library's
+part, not a property of the directive: a decorated function may have a body, and if
+it does, that body is what every non-`spirv` target runs while `spirv` substitutes
+the instruction. A `spirv` build never emits the body at all.
+
+The set of accepted instruction names is a table in `mach.lang.spirvop`, which also
+records why each omission from GLSL.std.450 is one. Adding an instruction is a row
+in it.
+
 ## Applicability
 
 | Directive   | `fun` | `ext fun` | `val` / `var` | `rec` / `uni` |
@@ -503,6 +557,7 @@ variables are named in every entry point's interface list.
 | `builtin`   |  no   |    no     |      yes      |      no       |
 | `uniform`   |  no   |    no     |      yes      |      no       |
 | `storage`   |  no   |    no     |      yes      |      no       |
+| `spirv_op`  |  yes  |    no     |      no       |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).
@@ -518,5 +573,5 @@ The set is closed. New directives require a compiler change.
 - [asm.md](asm.md) — inline `asm`, the only body a `naked` function may have
 - [val-var.md](val-var.md) — `val` / `var` bindings, and the `embed` exemption to `val`'s initializer requirement
 - [grammar.md](grammar.md#types) — the `[_]` inferred array length `embed` introduces
-- [types.md](types.md) — the SIMD vector types a shader stage computes over
+- [types.md](types.md) — the SIMD vector types a shader stage computes over and `spirv_op` operates on
 - [../manifest.md](../manifest.md) — the `vectorize` profile key `scalar` opts out of, and content-fingerprinted build inputs (`embed`, `[step]` `in`)

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -21,25 +21,52 @@ There is no compiler `bool`. `bool` is a stdlib `def bool: u8;` with `true` /
 
 ## SIMD vectors
 
-Ten 128-bit vector types are compiler-seeded, each a fixed number of lanes of a
-primitive numeric element:
+A vector type is a **form**, not a fixed list: any primitive numeric element
+followed by `x` and a lane count.
 
 ```mach
-f32x4  f64x2                    # float lanes
+f32x4  f32x3  f32x2  f64x2      # float lanes
 i8x16  i16x8  i32x4  i64x2      # signed integer lanes
 u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 ```
 
-These ten are the complete set. The spelling is `<u|i|f><width>x<count>` with a
-**single** `x` — there are no other vector types and no multi-`x` shapes. A name
-like `f32x4x4` is not a vector type (it resolves as an ordinary identifier); a
-matrix is an algorithm over vectors and belongs in a library over vector
-elements, not the language. A vector spelling is recognized only in type
-position, so a value may still be named `f32x4` without colliding with the type.
+The spelling is `<u|i|f><width>x<count>` with a **single** `x`. A name like
+`f32x4x4` is not a vector type (it resolves as an ordinary identifier); a matrix
+is an algorithm over vectors and belongs in a library over vector elements, not
+the language. A vector spelling is recognized only in type position, so a value
+may still be named `f32x4` without colliding with the type.
 
-Every seeded vector is exactly 128 bits: `$size_of` and `$align_of` are both
-`16`. Arrays of vectors (`[4]f32x4`) and pointers to vectors (`*f32x4`) are
-ordinary composite types over a vector element.
+Two rules bound the form:
+
+- **At least 2 lanes.** `f32x1` is refused; a one-lane vector is just its scalar.
+- **No wider than the target's vector register.** Every current target is 128
+  bits, so `f32x7` (224 bits) is refused by name. The error names the width you
+  asked for and the width the target has, rather than reporting an unknown type.
+
+`ptr` is not a lane element: its width is target-defined rather than a scalar bit
+count, so `ptrx2` is not a vector spelling.
+
+### Size and alignment
+
+`$size_of` is **lane-derived**: `lanes × element size`, packed, with no padding
+up to the register width.
+
+| type | `$size_of` | `$align_of` |
+|---|---|---|
+| `f32x4` | 16 | 16 |
+| `f32x3` | 12 | 4 |
+| `f32x2` | 8 | 4 |
+| `i16x4` | 8 | 2 |
+
+`$align_of` is deliberately **discontinuous at the register width**. A vector
+that *fills* the vector register aligns to its whole size, because the machine's
+vector load requires it. A narrower one is a packed aggregate that scalarizes or
+loads piecewise, so it aligns to a single lane. This is what makes `[N]f32x3` a
+usable packed vertex buffer: padding `f32x3` to 16 bytes would make it
+indistinguishable from `f32x4` in memory.
+
+Arrays of vectors (`[4]f32x4`) and pointers to vectors (`*f32x4`) are ordinary
+composite types over a vector element.
 
 **Literals** are full-arity — one initializer per lane, mirroring array literals.
 The lane count must match exactly; too few or too many lanes is a compile error.

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -35,8 +35,26 @@ u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 The spelling is `<u|i|f><width>x<count>` with a **single** `x`. A name like
 `f32x4x4` is not a vector type (it resolves as an ordinary identifier); a matrix
 is an algorithm over vectors and belongs in a library over vector elements, not
-the language. A vector spelling is recognized only in type position, so a value
-may still be named `f32x4` without colliding with the type.
+the language.
+
+A vector spelling is recognized only in **type position**, so a *value* may still
+be named `f32x4` without colliding with the type:
+
+```mach
+val f32x4: i64 = 7;             # fine: values are a different position
+```
+
+A **type** may not. `rec`, `uni`, and `def` reject a name spelled as a vector
+form, because a type declared with a vector's name would be silently unreachable
+— every use in type position resolves to the vector instead:
+
+```mach
+rec f32x3 { x: f32; }           # error: `f32x3` is spelled as a vector type
+```
+
+This holds for any well-formed spelling, including ones this target does not
+currently admit (`f32x3`, `f32x7`), so the name cannot be claimed and then
+collide when the bound moves.
 
 Three rules bound the form:
 

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -24,8 +24,10 @@ There is no compiler `bool`. `bool` is a stdlib `def bool: u8;` with `true` /
 A vector type is a **form**, not a fixed list: any primitive numeric element
 followed by `x` and a lane count.
 
+On a 128-bit target the spellings this currently accepts are:
+
 ```mach
-f32x4  f32x3  f32x2  f64x2      # float lanes
+f32x4  f64x2                    # float lanes
 i8x16  i16x8  i32x4  i64x2      # signed integer lanes
 u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 ```
@@ -36,12 +38,17 @@ is an algorithm over vectors and belongs in a library over vector elements, not
 the language. A vector spelling is recognized only in type position, so a value
 may still be named `f32x4` without colliding with the type.
 
-Two rules bound the form:
+Three rules bound the form:
 
 - **At least 2 lanes.** `f32x1` is refused; a one-lane vector is just its scalar.
 - **No wider than the target's vector register.** Every current target is 128
   bits, so `f32x7` (224 bits) is refused by name. The error names the width you
   asked for and the width the target has, rather than reporting an unknown type.
+- **Currently, exactly as wide as the register.** A vector *narrower* than the
+  vector register (`f32x3`, `f32x2`) is read and laid out correctly but refused
+  by name for now, because codegen cannot yet carry a value whose register width
+  and memory footprint differ. This restriction is temporary and is the only
+  thing between the form and `vec3`.
 
 `ptr` is not a lane element: its width is target-defined rather than a scalar bit
 count, so `ptrx2` is not a vector spelling.
@@ -49,7 +56,8 @@ count, so `ptrx2` is not a vector spelling.
 ### Size and alignment
 
 `$size_of` is **lane-derived**: `lanes × element size`, packed, with no padding
-up to the register width.
+up to the register width. (The sub-register rows below are the rule the layout
+already implements; those spellings are not yet accepted — see above.)
 
 | type | `$size_of` | `$align_of` |
 |---|---|---|

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -85,6 +85,22 @@
 #                 nothing, so there is no binary to run and the module tree is the
 #                 artifact; the external validator is what makes this a validity
 #                 check rather than a round-trip through mach's own reader.
+#   spirv-shader— validate the module tree AND report the instructions the emitter
+#                 actually produced for it (#2688). "the validator was happy" is not
+#                 evidence that a `sqrt` became a `Sqrt`: an emitter that stopped
+#                 substituting and left an ordinary call, or one that substituted the
+#                 wrong instruction number, produces a module spirv-val accepts. so
+#                 this disassembles each module and prints every OpExtInst by SET and
+#                 INSTRUCTION NAME with its operand count, plus every core OpDot, in
+#                 emission order, alongside the module's OpExtInstImport count - which
+#                 is what makes "imported only when used" an assertion rather than a
+#                 claim. the environment is chosen PER MODULE rather than per case:
+#                 a module carrying entry points is a shader and is validated under
+#                 vulkan1.3, and one without is a library, which declares the Linkage
+#                 capability Vulkan forbids outright and is validated universally. a
+#                 case that consumes a library dependency delivers both at once, so
+#                 one environment for the whole tree cannot be right. needs spirv-val
+#                 and spirv-dis.
 #   vector-emit — disassemble the case's own objects and report, per function,
 #                 whether the compiler EMITTED packed SIMD (#2207). the observable
 #                 execution cannot produce: a vectorizer that silently stops firing
@@ -1803,6 +1819,81 @@ spirv_val_env() {
     printf 'modules=%d validator=clean\n' "$n"
 }
 
+# produce_spirv_shader <runmode> <target> <binary>
+# validate the delivered module tree and report the instructions the emitter put in
+# it.
+#
+# spirv-val alone cannot see this case's subject. A `sh.sqrt(x)` that stopped being
+# substituted and came out as an ordinary OpFunctionCall validates. One substituted
+# with the wrong instruction number validates too, as whichever instruction that
+# number names. So the observable is the disassembly, normalized: per module, the
+# number of extended sets imported, then one line per OpExtInst naming the SET it
+# indexes and the INSTRUCTION within it, and one per core OpDot, in emission order.
+# Result ids are dropped (they renumber whenever anything else in the module
+# changes); operand COUNTS are kept, because an instruction given the wrong arity is
+# the other way to be wrong here.
+#
+# The environment is per module. A module with entry points is a shader and gets the
+# strict vulkan1.3 rules; a module without them is a library, whose Linkage
+# capability Vulkan rejects outright. A case that depends on a library delivers one
+# of each, so no single environment covers the tree.
+produce_spirv_shader() {
+    out_dir=$(dirname "$3")
+    if ! command -v spirv-val >/dev/null 2>&1; then
+        echo "int: spirv-shader: the validator is not installed (spirv-tools)" >&2
+        return 2
+    fi
+    if ! command -v spirv-dis >/dev/null 2>&1; then
+        echo "int: spirv-shader: the disassembler is not installed (spirv-tools)" >&2
+        return 2
+    fi
+    n=0
+    for m in $(find "$out_dir" -name '*.spv' | sort); do
+        dis=$(spirv-dis --no-header "$m") || return 1
+        # the module's own name, relative to the output root, so the observable does
+        # not carry the mktemp path the case was built under.
+        rel=${m#"$out_dir"/}
+        if printf '%s\n' "$dis" | grep -q '^ *OpEntryPoint '; then
+            kind=shader
+            spirv-val --target-env vulkan1.3 "$m" || return 1
+            env=vulkan1.3
+        else
+            kind=library
+            spirv-val "$m" || return 1
+            env=universal
+        fi
+        imports=$(printf '%s\n' "$dis" | grep -c 'OpExtInstImport' || true)
+        printf 'module=%s kind=%s env=%s validator=clean extimports=%d\n' \
+            "$rel" "$kind" "$env" "$imports"
+        printf '%s\n' "$dis" | awk '
+            # "%29 = OpExtInstImport "GLSL.std.450"" — remember which set each id is,
+            # so an OpExtInst can be reported by set NAME rather than by an id that
+            # renumbers on every unrelated change.
+            $3 == "OpExtInstImport" {
+                name = $4; gsub(/"/, "", name)
+                setname[$1] = name
+                printf "  import %s\n", name
+                next
+            }
+            # "%28 = OpExtInst %v4float %29 Normalize %27" — result type, set id and
+            # instruction name, then the operands.
+            $3 == "OpExtInst" {
+                s = setname[$5]; if (s == "") { s = "<unimported>" }
+                printf "  extinst %s %s operands=%d\n", s, $6, NF - 6
+                next
+            }
+            # "%33 = OpDot %float %31 %32" — core, no set involved.
+            $3 == "OpDot" { printf "  core OpDot operands=%d\n", NF - 4; next }
+        '
+        n=$((n + 1))
+    done
+    if [ "$n" -eq 0 ]; then
+        echo "int: spirv-shader: the build delivered no .spv module" >&2
+        return 2
+    fi
+    printf 'modules=%d\n' "$n"
+}
+
 # resolve_dwarfdump — print an llvm-dwarfdump on PATH, preferring the unversioned
 # name and falling back to the highest-versioned one (ubuntu ships llvm-dwarfdump-NN).
 # empty output (return 1) when none is installed.
@@ -2305,6 +2396,7 @@ produce() {
         debuginfo)   produce_debuginfo "$@" ;;
         spirv-val)   produce_spirv_val "$@" ;;
         spirv-val-vulkan) produce_spirv_val_vulkan "$@" ;;
+        spirv-shader) produce_spirv_shader "$@" ;;
         vector-emit) produce_vector_emit "$@" ;;
         vector-lanes) produce_vector_lanes "$@" ;;
         frame-elision) produce_frame_elision "$@" ;;

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -614,6 +614,91 @@ produce_macho_mod_init() {
     echo "mod_init_func=type9-rebased"
 }
 
+# produce_macho_header_span <runmode> <target> <binary>
+# Assert that a darwin image whose load commands exceed one page linked, and that
+# its header agrees with the span the linker reserved below the first segment.
+#
+# The Mach-O header carries an 80-byte section_64 per named section and an
+# LC_LOAD_DYLIB per dependency, so it grows with the image; `sizeofcmds` is a
+# uint32 and the format caps it nowhere near a page. A fixed one-page reservation
+# refused the link outright (#2690).
+#
+# Size alone would be a weak observable. The reservation is what places __TEXT:
+# the header occupies the gap between the image base and the first segment, so a
+# writer that widened the gap on its own would slide __TEXT, and __PAGEZERO with
+# it, below the base - the defect of #2599, which every size check would still
+# pass. The framing is therefore asserted alongside: __PAGEZERO spans the whole low
+# region, __TEXT is based exactly where __PAGEZERO ends, and the header sits at
+# file offset 0 inside it.
+#
+# The page size is read from the image's own cputype rather than passed in, since
+# the leg here is linux and darwin maps 16 KiB pages on arm64 and 4 KiB on x86_64.
+produce_macho_header_span() {
+    bin=$3
+    magic=$(read_le_uint "$bin" 0 4)
+    [ "$magic" = "4277009103" ] || { echo "int: macho-header-span: not a 64-bit mach-o (magic $magic)" >&2; return 2; }
+
+    cputype=$(read_le_uint "$bin" 4 4)
+    case "$cputype" in
+        16777223) page=4096  ;;   # CPU_TYPE_X86_64
+        16777228) page=16384 ;;   # CPU_TYPE_ARM64
+        *) echo "int: macho-header-span: unexpected cputype $cputype" >&2; return 2 ;;
+    esac
+
+    ncmds=$(read_le_uint "$bin" 16 4)
+    sizeofcmds=$(read_le_uint "$bin" 20 4)
+
+    pagezero_size=
+    text_vmaddr=
+    text_fileoff=
+    sect_addr=
+    sect_fileoff=
+    dylibs=0
+    off=32
+    i=0
+    while [ "$i" -lt "$ncmds" ]; do
+        cmd=$(read_le_uint "$bin" "$off" 4)
+        cmdsize=$(read_le_uint "$bin" $((off + 4)) 4)
+        case "$cmd" in
+            25)   # LC_SEGMENT_64
+                name=$(dd if="$bin" bs=1 skip=$((off + 8)) count=16 2>/dev/null | tr '\0' '\n' | head -n 1)
+                if [ "$name" = "__PAGEZERO" ]; then
+                    pagezero_size=$(read_le_uint "$bin" $((off + 32)) 8)
+                fi
+                if [ "$name" = "__TEXT" ]; then
+                    text_vmaddr=$(read_le_uint "$bin" $((off + 24)) 8)
+                    text_fileoff=$(read_le_uint "$bin" $((off + 40)) 8)
+                    nsects=$(read_le_uint "$bin" $((off + 64)) 4)
+                    [ "$nsects" -gt 0 ] || { echo "int: macho-header-span: __TEXT carries no section" >&2; return 2; }
+                    sect_addr=$(read_le_uint "$bin" $((off + 72 + 32)) 8)
+                    sect_fileoff=$(read_le_uint "$bin" $((off + 72 + 48)) 4)
+                fi
+                ;;
+            12) dylibs=$((dylibs + 1)) ;;   # LC_LOAD_DYLIB
+        esac
+        [ "$cmdsize" -ge 8 ] || { echo "int: macho-header-span: zero-size load command" >&2; return 2; }
+        off=$((off + cmdsize))
+        i=$((i + 1))
+    done
+
+    [ -n "$pagezero_size" ] || { echo "int: macho-header-span: no __PAGEZERO" >&2; return 2; }
+    [ -n "$text_vmaddr" ]   || { echo "int: macho-header-span: no __TEXT" >&2; return 2; }
+
+    # the reservation is the gap the header fills: from __TEXT's start to its first
+    # section's content.
+    reservation=$((sect_addr - text_vmaddr))
+
+    printf 'sizeofcmds_over_one_page=%s\n' "$(( sizeofcmds > page ))"
+    printf 'multiple_dylib_loads=%s\n' "$(( dylibs > 1 ))"
+    printf 'reservation_whole_pages=%s\n' "$(( reservation > 0 && reservation % page == 0 ))"
+    printf 'header_fits_reservation=%s\n' "$(( 32 + sizeofcmds <= reservation ))"
+    printf 'first_section_fileoff_is_reservation=%s\n' "$(( sect_fileoff == reservation ))"
+    printf 'pagezero_vmsize=0x%x\n' "$pagezero_size"
+    printf 'text_vmaddr=0x%x\n' "$text_vmaddr"
+    printf 'text_fileoff=%s\n' "$text_fileoff"
+    printf 'pagezero_abuts_text=%s\n' "$(( pagezero_size == text_vmaddr ))"
+}
+
 # produce_macho_sections <runmode> <target> <binary>
 # Assert that a linked darwin image kept the (segment, section) identity of its
 # inputs, which is what a name-based runtime scan needs: libobjc walks
@@ -2381,6 +2466,7 @@ produce() {
         embed-dedup) produce_embed_dedup "$@" ;;
         macho-framing) produce_macho_framing "$@" ;;
         macho-sections) produce_macho_sections "$@" ;;
+        macho-header-span) produce_macho_header_span "$@" ;;
         macho-imports) produce_macho_imports "$@" ;;
         macho-mod-init) produce_macho_mod_init "$@" ;;
         macho-abs-bind) produce_macho_abs_bind "$@" ;;

--- a/int/surface/macho-header-span-aarch64/case.conf
+++ b/int/surface/macho-header-span-aarch64/case.conf
@@ -1,0 +1,14 @@
+# the arm64 half of macho-header-span-x86_64: the same fixture, the same header
+# reservation contract, and a 16 KiB darwin page instead of 4 KiB (#2690).
+#
+# Both legs are needed because the two targets share the Mach-O writer but not the
+# page size, so a reservation sized from a hardcoded 4096 would pass on x86_64 and
+# still refuse this link. On Apple Silicon the kernel additionally admits a signed
+# image only when the header lies inside the signed, mapped __TEXT, so the golden
+# pins the header at file offset 0 inside a __TEXT based exactly on the image base.
+#
+# Read host-side on the cheap linux leg; the image is never run.
+run: macho-header-span
+targets: linux
+build-target: darwin-aarch64
+build-flags: --pie

--- a/int/surface/macho-header-span-aarch64/expect.darwin-aarch64.txt
+++ b/int/surface/macho-header-span-aarch64/expect.darwin-aarch64.txt
@@ -1,0 +1,9 @@
+sizeofcmds_over_one_page=1
+multiple_dylib_loads=1
+reservation_whole_pages=1
+header_fits_reservation=1
+first_section_fileoff_is_reservation=1
+pagezero_vmsize=0x100000000
+text_vmaddr=0x100000000
+text_fileoff=0
+pagezero_abuts_text=1

--- a/int/surface/macho-header-span-aarch64/mach.toml
+++ b/int/surface/macho-header-span-aarch64/mach.toml
@@ -1,0 +1,108 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["System", "objc", "cxx", "iconv", "z", "xml2", "bz2", "curses"]
+need = []
+
+[link.System]
+source = "system"
+name = "/usr/lib/libSystem.B.dylib"
+library = "System"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.objc]
+source = "system"
+name = "/usr/lib/libobjc.A.dylib"
+library = "objc"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.cxx]
+source = "system"
+name = "/usr/lib/libc++.1.dylib"
+library = "cxx"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.iconv]
+source = "system"
+name = "/usr/lib/libiconv.2.dylib"
+library = "iconv"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.z]
+source = "system"
+name = "/usr/lib/libz.1.dylib"
+library = "z"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.xml2]
+source = "system"
+name = "/usr/lib/libxml2.2.dylib"
+library = "xml2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.bz2]
+source = "system"
+name = "/usr/lib/libbz2.1.0.dylib"
+library = "bz2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.curses]
+source = "system"
+name = "/usr/lib/libcurses.dylib"
+library = "curses"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/macho-header-span-aarch64/src/main.mach
+++ b/int/surface/macho-header-span-aarch64/src/main.mach
@@ -1,0 +1,928 @@
+# a Mach-O header outgrows its one-page reservation as soon as an image carries
+# enough named sections: since #2606 the linker preserves input section identity,
+# and every surviving section is another 80-byte section_64 in the header. A
+# vendored objective-c archive carries dozens (__objc_classlist, __objc_const,
+# __objc_data, __cstring, __gcc_except_tab, ...) alongside its system-library
+# dependencies, which is how briar-systems/mach-glfw#32 reached 4 KiB of load
+# commands and was refused (#2690).
+#
+# The 224 `#[section]` globals below stand in for that section table without
+# needing the macOS SDK to build one: they cross the reservation on both darwin
+# page sizes (4 KiB x86_64, 16 KiB arm64). The system-library dependencies in
+# mach.toml are the second contributor, an LC_LOAD_DYLIB each, and they make the
+# image the shape the reported consumer has rather than a section table alone.
+#
+# The program is never RUN - the observable is the emitted header, read host-side
+# on the linux leg - so the imports need only be referenced, not called correctly.
+#[library("System")]
+ext fun Sleep(ms: u32);
+
+#[library("objc")]
+ext fun objc_msgSend(recv: u64, sel: u64);
+
+#[library("z")]
+ext fun compressBound(n: u64) u64;
+
+#[section(".mach_sec000")] #[symbol("g_000")]
+pub var g_000: u64 = 1;
+
+#[section(".mach_sec001")] #[symbol("g_001")]
+pub var g_001: u64 = 2;
+
+#[section(".mach_sec002")] #[symbol("g_002")]
+pub var g_002: u64 = 3;
+
+#[section(".mach_sec003")] #[symbol("g_003")]
+pub var g_003: u64 = 4;
+
+#[section(".mach_sec004")] #[symbol("g_004")]
+pub var g_004: u64 = 5;
+
+#[section(".mach_sec005")] #[symbol("g_005")]
+pub var g_005: u64 = 6;
+
+#[section(".mach_sec006")] #[symbol("g_006")]
+pub var g_006: u64 = 7;
+
+#[section(".mach_sec007")] #[symbol("g_007")]
+pub var g_007: u64 = 8;
+
+#[section(".mach_sec008")] #[symbol("g_008")]
+pub var g_008: u64 = 9;
+
+#[section(".mach_sec009")] #[symbol("g_009")]
+pub var g_009: u64 = 10;
+
+#[section(".mach_sec010")] #[symbol("g_010")]
+pub var g_010: u64 = 11;
+
+#[section(".mach_sec011")] #[symbol("g_011")]
+pub var g_011: u64 = 12;
+
+#[section(".mach_sec012")] #[symbol("g_012")]
+pub var g_012: u64 = 13;
+
+#[section(".mach_sec013")] #[symbol("g_013")]
+pub var g_013: u64 = 14;
+
+#[section(".mach_sec014")] #[symbol("g_014")]
+pub var g_014: u64 = 15;
+
+#[section(".mach_sec015")] #[symbol("g_015")]
+pub var g_015: u64 = 16;
+
+#[section(".mach_sec016")] #[symbol("g_016")]
+pub var g_016: u64 = 17;
+
+#[section(".mach_sec017")] #[symbol("g_017")]
+pub var g_017: u64 = 18;
+
+#[section(".mach_sec018")] #[symbol("g_018")]
+pub var g_018: u64 = 19;
+
+#[section(".mach_sec019")] #[symbol("g_019")]
+pub var g_019: u64 = 20;
+
+#[section(".mach_sec020")] #[symbol("g_020")]
+pub var g_020: u64 = 21;
+
+#[section(".mach_sec021")] #[symbol("g_021")]
+pub var g_021: u64 = 22;
+
+#[section(".mach_sec022")] #[symbol("g_022")]
+pub var g_022: u64 = 23;
+
+#[section(".mach_sec023")] #[symbol("g_023")]
+pub var g_023: u64 = 24;
+
+#[section(".mach_sec024")] #[symbol("g_024")]
+pub var g_024: u64 = 25;
+
+#[section(".mach_sec025")] #[symbol("g_025")]
+pub var g_025: u64 = 26;
+
+#[section(".mach_sec026")] #[symbol("g_026")]
+pub var g_026: u64 = 27;
+
+#[section(".mach_sec027")] #[symbol("g_027")]
+pub var g_027: u64 = 28;
+
+#[section(".mach_sec028")] #[symbol("g_028")]
+pub var g_028: u64 = 29;
+
+#[section(".mach_sec029")] #[symbol("g_029")]
+pub var g_029: u64 = 30;
+
+#[section(".mach_sec030")] #[symbol("g_030")]
+pub var g_030: u64 = 31;
+
+#[section(".mach_sec031")] #[symbol("g_031")]
+pub var g_031: u64 = 32;
+
+#[section(".mach_sec032")] #[symbol("g_032")]
+pub var g_032: u64 = 33;
+
+#[section(".mach_sec033")] #[symbol("g_033")]
+pub var g_033: u64 = 34;
+
+#[section(".mach_sec034")] #[symbol("g_034")]
+pub var g_034: u64 = 35;
+
+#[section(".mach_sec035")] #[symbol("g_035")]
+pub var g_035: u64 = 36;
+
+#[section(".mach_sec036")] #[symbol("g_036")]
+pub var g_036: u64 = 37;
+
+#[section(".mach_sec037")] #[symbol("g_037")]
+pub var g_037: u64 = 38;
+
+#[section(".mach_sec038")] #[symbol("g_038")]
+pub var g_038: u64 = 39;
+
+#[section(".mach_sec039")] #[symbol("g_039")]
+pub var g_039: u64 = 40;
+
+#[section(".mach_sec040")] #[symbol("g_040")]
+pub var g_040: u64 = 41;
+
+#[section(".mach_sec041")] #[symbol("g_041")]
+pub var g_041: u64 = 42;
+
+#[section(".mach_sec042")] #[symbol("g_042")]
+pub var g_042: u64 = 43;
+
+#[section(".mach_sec043")] #[symbol("g_043")]
+pub var g_043: u64 = 44;
+
+#[section(".mach_sec044")] #[symbol("g_044")]
+pub var g_044: u64 = 45;
+
+#[section(".mach_sec045")] #[symbol("g_045")]
+pub var g_045: u64 = 46;
+
+#[section(".mach_sec046")] #[symbol("g_046")]
+pub var g_046: u64 = 47;
+
+#[section(".mach_sec047")] #[symbol("g_047")]
+pub var g_047: u64 = 48;
+
+#[section(".mach_sec048")] #[symbol("g_048")]
+pub var g_048: u64 = 49;
+
+#[section(".mach_sec049")] #[symbol("g_049")]
+pub var g_049: u64 = 50;
+
+#[section(".mach_sec050")] #[symbol("g_050")]
+pub var g_050: u64 = 51;
+
+#[section(".mach_sec051")] #[symbol("g_051")]
+pub var g_051: u64 = 52;
+
+#[section(".mach_sec052")] #[symbol("g_052")]
+pub var g_052: u64 = 53;
+
+#[section(".mach_sec053")] #[symbol("g_053")]
+pub var g_053: u64 = 54;
+
+#[section(".mach_sec054")] #[symbol("g_054")]
+pub var g_054: u64 = 55;
+
+#[section(".mach_sec055")] #[symbol("g_055")]
+pub var g_055: u64 = 56;
+
+#[section(".mach_sec056")] #[symbol("g_056")]
+pub var g_056: u64 = 57;
+
+#[section(".mach_sec057")] #[symbol("g_057")]
+pub var g_057: u64 = 58;
+
+#[section(".mach_sec058")] #[symbol("g_058")]
+pub var g_058: u64 = 59;
+
+#[section(".mach_sec059")] #[symbol("g_059")]
+pub var g_059: u64 = 60;
+
+#[section(".mach_sec060")] #[symbol("g_060")]
+pub var g_060: u64 = 61;
+
+#[section(".mach_sec061")] #[symbol("g_061")]
+pub var g_061: u64 = 62;
+
+#[section(".mach_sec062")] #[symbol("g_062")]
+pub var g_062: u64 = 63;
+
+#[section(".mach_sec063")] #[symbol("g_063")]
+pub var g_063: u64 = 64;
+
+#[section(".mach_sec064")] #[symbol("g_064")]
+pub var g_064: u64 = 65;
+
+#[section(".mach_sec065")] #[symbol("g_065")]
+pub var g_065: u64 = 66;
+
+#[section(".mach_sec066")] #[symbol("g_066")]
+pub var g_066: u64 = 67;
+
+#[section(".mach_sec067")] #[symbol("g_067")]
+pub var g_067: u64 = 68;
+
+#[section(".mach_sec068")] #[symbol("g_068")]
+pub var g_068: u64 = 69;
+
+#[section(".mach_sec069")] #[symbol("g_069")]
+pub var g_069: u64 = 70;
+
+#[section(".mach_sec070")] #[symbol("g_070")]
+pub var g_070: u64 = 71;
+
+#[section(".mach_sec071")] #[symbol("g_071")]
+pub var g_071: u64 = 72;
+
+#[section(".mach_sec072")] #[symbol("g_072")]
+pub var g_072: u64 = 73;
+
+#[section(".mach_sec073")] #[symbol("g_073")]
+pub var g_073: u64 = 74;
+
+#[section(".mach_sec074")] #[symbol("g_074")]
+pub var g_074: u64 = 75;
+
+#[section(".mach_sec075")] #[symbol("g_075")]
+pub var g_075: u64 = 76;
+
+#[section(".mach_sec076")] #[symbol("g_076")]
+pub var g_076: u64 = 77;
+
+#[section(".mach_sec077")] #[symbol("g_077")]
+pub var g_077: u64 = 78;
+
+#[section(".mach_sec078")] #[symbol("g_078")]
+pub var g_078: u64 = 79;
+
+#[section(".mach_sec079")] #[symbol("g_079")]
+pub var g_079: u64 = 80;
+
+#[section(".mach_sec080")] #[symbol("g_080")]
+pub var g_080: u64 = 81;
+
+#[section(".mach_sec081")] #[symbol("g_081")]
+pub var g_081: u64 = 82;
+
+#[section(".mach_sec082")] #[symbol("g_082")]
+pub var g_082: u64 = 83;
+
+#[section(".mach_sec083")] #[symbol("g_083")]
+pub var g_083: u64 = 84;
+
+#[section(".mach_sec084")] #[symbol("g_084")]
+pub var g_084: u64 = 85;
+
+#[section(".mach_sec085")] #[symbol("g_085")]
+pub var g_085: u64 = 86;
+
+#[section(".mach_sec086")] #[symbol("g_086")]
+pub var g_086: u64 = 87;
+
+#[section(".mach_sec087")] #[symbol("g_087")]
+pub var g_087: u64 = 88;
+
+#[section(".mach_sec088")] #[symbol("g_088")]
+pub var g_088: u64 = 89;
+
+#[section(".mach_sec089")] #[symbol("g_089")]
+pub var g_089: u64 = 90;
+
+#[section(".mach_sec090")] #[symbol("g_090")]
+pub var g_090: u64 = 91;
+
+#[section(".mach_sec091")] #[symbol("g_091")]
+pub var g_091: u64 = 92;
+
+#[section(".mach_sec092")] #[symbol("g_092")]
+pub var g_092: u64 = 93;
+
+#[section(".mach_sec093")] #[symbol("g_093")]
+pub var g_093: u64 = 94;
+
+#[section(".mach_sec094")] #[symbol("g_094")]
+pub var g_094: u64 = 95;
+
+#[section(".mach_sec095")] #[symbol("g_095")]
+pub var g_095: u64 = 96;
+
+#[section(".mach_sec096")] #[symbol("g_096")]
+pub var g_096: u64 = 97;
+
+#[section(".mach_sec097")] #[symbol("g_097")]
+pub var g_097: u64 = 98;
+
+#[section(".mach_sec098")] #[symbol("g_098")]
+pub var g_098: u64 = 99;
+
+#[section(".mach_sec099")] #[symbol("g_099")]
+pub var g_099: u64 = 100;
+
+#[section(".mach_sec100")] #[symbol("g_100")]
+pub var g_100: u64 = 101;
+
+#[section(".mach_sec101")] #[symbol("g_101")]
+pub var g_101: u64 = 102;
+
+#[section(".mach_sec102")] #[symbol("g_102")]
+pub var g_102: u64 = 103;
+
+#[section(".mach_sec103")] #[symbol("g_103")]
+pub var g_103: u64 = 104;
+
+#[section(".mach_sec104")] #[symbol("g_104")]
+pub var g_104: u64 = 105;
+
+#[section(".mach_sec105")] #[symbol("g_105")]
+pub var g_105: u64 = 106;
+
+#[section(".mach_sec106")] #[symbol("g_106")]
+pub var g_106: u64 = 107;
+
+#[section(".mach_sec107")] #[symbol("g_107")]
+pub var g_107: u64 = 108;
+
+#[section(".mach_sec108")] #[symbol("g_108")]
+pub var g_108: u64 = 109;
+
+#[section(".mach_sec109")] #[symbol("g_109")]
+pub var g_109: u64 = 110;
+
+#[section(".mach_sec110")] #[symbol("g_110")]
+pub var g_110: u64 = 111;
+
+#[section(".mach_sec111")] #[symbol("g_111")]
+pub var g_111: u64 = 112;
+
+#[section(".mach_sec112")] #[symbol("g_112")]
+pub var g_112: u64 = 113;
+
+#[section(".mach_sec113")] #[symbol("g_113")]
+pub var g_113: u64 = 114;
+
+#[section(".mach_sec114")] #[symbol("g_114")]
+pub var g_114: u64 = 115;
+
+#[section(".mach_sec115")] #[symbol("g_115")]
+pub var g_115: u64 = 116;
+
+#[section(".mach_sec116")] #[symbol("g_116")]
+pub var g_116: u64 = 117;
+
+#[section(".mach_sec117")] #[symbol("g_117")]
+pub var g_117: u64 = 118;
+
+#[section(".mach_sec118")] #[symbol("g_118")]
+pub var g_118: u64 = 119;
+
+#[section(".mach_sec119")] #[symbol("g_119")]
+pub var g_119: u64 = 120;
+
+#[section(".mach_sec120")] #[symbol("g_120")]
+pub var g_120: u64 = 121;
+
+#[section(".mach_sec121")] #[symbol("g_121")]
+pub var g_121: u64 = 122;
+
+#[section(".mach_sec122")] #[symbol("g_122")]
+pub var g_122: u64 = 123;
+
+#[section(".mach_sec123")] #[symbol("g_123")]
+pub var g_123: u64 = 124;
+
+#[section(".mach_sec124")] #[symbol("g_124")]
+pub var g_124: u64 = 125;
+
+#[section(".mach_sec125")] #[symbol("g_125")]
+pub var g_125: u64 = 126;
+
+#[section(".mach_sec126")] #[symbol("g_126")]
+pub var g_126: u64 = 127;
+
+#[section(".mach_sec127")] #[symbol("g_127")]
+pub var g_127: u64 = 128;
+
+#[section(".mach_sec128")] #[symbol("g_128")]
+pub var g_128: u64 = 129;
+
+#[section(".mach_sec129")] #[symbol("g_129")]
+pub var g_129: u64 = 130;
+
+#[section(".mach_sec130")] #[symbol("g_130")]
+pub var g_130: u64 = 131;
+
+#[section(".mach_sec131")] #[symbol("g_131")]
+pub var g_131: u64 = 132;
+
+#[section(".mach_sec132")] #[symbol("g_132")]
+pub var g_132: u64 = 133;
+
+#[section(".mach_sec133")] #[symbol("g_133")]
+pub var g_133: u64 = 134;
+
+#[section(".mach_sec134")] #[symbol("g_134")]
+pub var g_134: u64 = 135;
+
+#[section(".mach_sec135")] #[symbol("g_135")]
+pub var g_135: u64 = 136;
+
+#[section(".mach_sec136")] #[symbol("g_136")]
+pub var g_136: u64 = 137;
+
+#[section(".mach_sec137")] #[symbol("g_137")]
+pub var g_137: u64 = 138;
+
+#[section(".mach_sec138")] #[symbol("g_138")]
+pub var g_138: u64 = 139;
+
+#[section(".mach_sec139")] #[symbol("g_139")]
+pub var g_139: u64 = 140;
+
+#[section(".mach_sec140")] #[symbol("g_140")]
+pub var g_140: u64 = 141;
+
+#[section(".mach_sec141")] #[symbol("g_141")]
+pub var g_141: u64 = 142;
+
+#[section(".mach_sec142")] #[symbol("g_142")]
+pub var g_142: u64 = 143;
+
+#[section(".mach_sec143")] #[symbol("g_143")]
+pub var g_143: u64 = 144;
+
+#[section(".mach_sec144")] #[symbol("g_144")]
+pub var g_144: u64 = 145;
+
+#[section(".mach_sec145")] #[symbol("g_145")]
+pub var g_145: u64 = 146;
+
+#[section(".mach_sec146")] #[symbol("g_146")]
+pub var g_146: u64 = 147;
+
+#[section(".mach_sec147")] #[symbol("g_147")]
+pub var g_147: u64 = 148;
+
+#[section(".mach_sec148")] #[symbol("g_148")]
+pub var g_148: u64 = 149;
+
+#[section(".mach_sec149")] #[symbol("g_149")]
+pub var g_149: u64 = 150;
+
+#[section(".mach_sec150")] #[symbol("g_150")]
+pub var g_150: u64 = 151;
+
+#[section(".mach_sec151")] #[symbol("g_151")]
+pub var g_151: u64 = 152;
+
+#[section(".mach_sec152")] #[symbol("g_152")]
+pub var g_152: u64 = 153;
+
+#[section(".mach_sec153")] #[symbol("g_153")]
+pub var g_153: u64 = 154;
+
+#[section(".mach_sec154")] #[symbol("g_154")]
+pub var g_154: u64 = 155;
+
+#[section(".mach_sec155")] #[symbol("g_155")]
+pub var g_155: u64 = 156;
+
+#[section(".mach_sec156")] #[symbol("g_156")]
+pub var g_156: u64 = 157;
+
+#[section(".mach_sec157")] #[symbol("g_157")]
+pub var g_157: u64 = 158;
+
+#[section(".mach_sec158")] #[symbol("g_158")]
+pub var g_158: u64 = 159;
+
+#[section(".mach_sec159")] #[symbol("g_159")]
+pub var g_159: u64 = 160;
+
+#[section(".mach_sec160")] #[symbol("g_160")]
+pub var g_160: u64 = 161;
+
+#[section(".mach_sec161")] #[symbol("g_161")]
+pub var g_161: u64 = 162;
+
+#[section(".mach_sec162")] #[symbol("g_162")]
+pub var g_162: u64 = 163;
+
+#[section(".mach_sec163")] #[symbol("g_163")]
+pub var g_163: u64 = 164;
+
+#[section(".mach_sec164")] #[symbol("g_164")]
+pub var g_164: u64 = 165;
+
+#[section(".mach_sec165")] #[symbol("g_165")]
+pub var g_165: u64 = 166;
+
+#[section(".mach_sec166")] #[symbol("g_166")]
+pub var g_166: u64 = 167;
+
+#[section(".mach_sec167")] #[symbol("g_167")]
+pub var g_167: u64 = 168;
+
+#[section(".mach_sec168")] #[symbol("g_168")]
+pub var g_168: u64 = 169;
+
+#[section(".mach_sec169")] #[symbol("g_169")]
+pub var g_169: u64 = 170;
+
+#[section(".mach_sec170")] #[symbol("g_170")]
+pub var g_170: u64 = 171;
+
+#[section(".mach_sec171")] #[symbol("g_171")]
+pub var g_171: u64 = 172;
+
+#[section(".mach_sec172")] #[symbol("g_172")]
+pub var g_172: u64 = 173;
+
+#[section(".mach_sec173")] #[symbol("g_173")]
+pub var g_173: u64 = 174;
+
+#[section(".mach_sec174")] #[symbol("g_174")]
+pub var g_174: u64 = 175;
+
+#[section(".mach_sec175")] #[symbol("g_175")]
+pub var g_175: u64 = 176;
+
+#[section(".mach_sec176")] #[symbol("g_176")]
+pub var g_176: u64 = 177;
+
+#[section(".mach_sec177")] #[symbol("g_177")]
+pub var g_177: u64 = 178;
+
+#[section(".mach_sec178")] #[symbol("g_178")]
+pub var g_178: u64 = 179;
+
+#[section(".mach_sec179")] #[symbol("g_179")]
+pub var g_179: u64 = 180;
+
+#[section(".mach_sec180")] #[symbol("g_180")]
+pub var g_180: u64 = 181;
+
+#[section(".mach_sec181")] #[symbol("g_181")]
+pub var g_181: u64 = 182;
+
+#[section(".mach_sec182")] #[symbol("g_182")]
+pub var g_182: u64 = 183;
+
+#[section(".mach_sec183")] #[symbol("g_183")]
+pub var g_183: u64 = 184;
+
+#[section(".mach_sec184")] #[symbol("g_184")]
+pub var g_184: u64 = 185;
+
+#[section(".mach_sec185")] #[symbol("g_185")]
+pub var g_185: u64 = 186;
+
+#[section(".mach_sec186")] #[symbol("g_186")]
+pub var g_186: u64 = 187;
+
+#[section(".mach_sec187")] #[symbol("g_187")]
+pub var g_187: u64 = 188;
+
+#[section(".mach_sec188")] #[symbol("g_188")]
+pub var g_188: u64 = 189;
+
+#[section(".mach_sec189")] #[symbol("g_189")]
+pub var g_189: u64 = 190;
+
+#[section(".mach_sec190")] #[symbol("g_190")]
+pub var g_190: u64 = 191;
+
+#[section(".mach_sec191")] #[symbol("g_191")]
+pub var g_191: u64 = 192;
+
+#[section(".mach_sec192")] #[symbol("g_192")]
+pub var g_192: u64 = 193;
+
+#[section(".mach_sec193")] #[symbol("g_193")]
+pub var g_193: u64 = 194;
+
+#[section(".mach_sec194")] #[symbol("g_194")]
+pub var g_194: u64 = 195;
+
+#[section(".mach_sec195")] #[symbol("g_195")]
+pub var g_195: u64 = 196;
+
+#[section(".mach_sec196")] #[symbol("g_196")]
+pub var g_196: u64 = 197;
+
+#[section(".mach_sec197")] #[symbol("g_197")]
+pub var g_197: u64 = 198;
+
+#[section(".mach_sec198")] #[symbol("g_198")]
+pub var g_198: u64 = 199;
+
+#[section(".mach_sec199")] #[symbol("g_199")]
+pub var g_199: u64 = 200;
+
+#[section(".mach_sec200")] #[symbol("g_200")]
+pub var g_200: u64 = 201;
+
+#[section(".mach_sec201")] #[symbol("g_201")]
+pub var g_201: u64 = 202;
+
+#[section(".mach_sec202")] #[symbol("g_202")]
+pub var g_202: u64 = 203;
+
+#[section(".mach_sec203")] #[symbol("g_203")]
+pub var g_203: u64 = 204;
+
+#[section(".mach_sec204")] #[symbol("g_204")]
+pub var g_204: u64 = 205;
+
+#[section(".mach_sec205")] #[symbol("g_205")]
+pub var g_205: u64 = 206;
+
+#[section(".mach_sec206")] #[symbol("g_206")]
+pub var g_206: u64 = 207;
+
+#[section(".mach_sec207")] #[symbol("g_207")]
+pub var g_207: u64 = 208;
+
+#[section(".mach_sec208")] #[symbol("g_208")]
+pub var g_208: u64 = 209;
+
+#[section(".mach_sec209")] #[symbol("g_209")]
+pub var g_209: u64 = 210;
+
+#[section(".mach_sec210")] #[symbol("g_210")]
+pub var g_210: u64 = 211;
+
+#[section(".mach_sec211")] #[symbol("g_211")]
+pub var g_211: u64 = 212;
+
+#[section(".mach_sec212")] #[symbol("g_212")]
+pub var g_212: u64 = 213;
+
+#[section(".mach_sec213")] #[symbol("g_213")]
+pub var g_213: u64 = 214;
+
+#[section(".mach_sec214")] #[symbol("g_214")]
+pub var g_214: u64 = 215;
+
+#[section(".mach_sec215")] #[symbol("g_215")]
+pub var g_215: u64 = 216;
+
+#[section(".mach_sec216")] #[symbol("g_216")]
+pub var g_216: u64 = 217;
+
+#[section(".mach_sec217")] #[symbol("g_217")]
+pub var g_217: u64 = 218;
+
+#[section(".mach_sec218")] #[symbol("g_218")]
+pub var g_218: u64 = 219;
+
+#[section(".mach_sec219")] #[symbol("g_219")]
+pub var g_219: u64 = 220;
+
+#[section(".mach_sec220")] #[symbol("g_220")]
+pub var g_220: u64 = 221;
+
+#[section(".mach_sec221")] #[symbol("g_221")]
+pub var g_221: u64 = 222;
+
+#[section(".mach_sec222")] #[symbol("g_222")]
+pub var g_222: u64 = 223;
+
+#[section(".mach_sec223")] #[symbol("g_223")]
+pub var g_223: u64 = 224;
+
+#[symbol("start")]
+pub fun _start() {
+    var total: u64 = 0;
+    total = total + g_000;
+    total = total + g_001;
+    total = total + g_002;
+    total = total + g_003;
+    total = total + g_004;
+    total = total + g_005;
+    total = total + g_006;
+    total = total + g_007;
+    total = total + g_008;
+    total = total + g_009;
+    total = total + g_010;
+    total = total + g_011;
+    total = total + g_012;
+    total = total + g_013;
+    total = total + g_014;
+    total = total + g_015;
+    total = total + g_016;
+    total = total + g_017;
+    total = total + g_018;
+    total = total + g_019;
+    total = total + g_020;
+    total = total + g_021;
+    total = total + g_022;
+    total = total + g_023;
+    total = total + g_024;
+    total = total + g_025;
+    total = total + g_026;
+    total = total + g_027;
+    total = total + g_028;
+    total = total + g_029;
+    total = total + g_030;
+    total = total + g_031;
+    total = total + g_032;
+    total = total + g_033;
+    total = total + g_034;
+    total = total + g_035;
+    total = total + g_036;
+    total = total + g_037;
+    total = total + g_038;
+    total = total + g_039;
+    total = total + g_040;
+    total = total + g_041;
+    total = total + g_042;
+    total = total + g_043;
+    total = total + g_044;
+    total = total + g_045;
+    total = total + g_046;
+    total = total + g_047;
+    total = total + g_048;
+    total = total + g_049;
+    total = total + g_050;
+    total = total + g_051;
+    total = total + g_052;
+    total = total + g_053;
+    total = total + g_054;
+    total = total + g_055;
+    total = total + g_056;
+    total = total + g_057;
+    total = total + g_058;
+    total = total + g_059;
+    total = total + g_060;
+    total = total + g_061;
+    total = total + g_062;
+    total = total + g_063;
+    total = total + g_064;
+    total = total + g_065;
+    total = total + g_066;
+    total = total + g_067;
+    total = total + g_068;
+    total = total + g_069;
+    total = total + g_070;
+    total = total + g_071;
+    total = total + g_072;
+    total = total + g_073;
+    total = total + g_074;
+    total = total + g_075;
+    total = total + g_076;
+    total = total + g_077;
+    total = total + g_078;
+    total = total + g_079;
+    total = total + g_080;
+    total = total + g_081;
+    total = total + g_082;
+    total = total + g_083;
+    total = total + g_084;
+    total = total + g_085;
+    total = total + g_086;
+    total = total + g_087;
+    total = total + g_088;
+    total = total + g_089;
+    total = total + g_090;
+    total = total + g_091;
+    total = total + g_092;
+    total = total + g_093;
+    total = total + g_094;
+    total = total + g_095;
+    total = total + g_096;
+    total = total + g_097;
+    total = total + g_098;
+    total = total + g_099;
+    total = total + g_100;
+    total = total + g_101;
+    total = total + g_102;
+    total = total + g_103;
+    total = total + g_104;
+    total = total + g_105;
+    total = total + g_106;
+    total = total + g_107;
+    total = total + g_108;
+    total = total + g_109;
+    total = total + g_110;
+    total = total + g_111;
+    total = total + g_112;
+    total = total + g_113;
+    total = total + g_114;
+    total = total + g_115;
+    total = total + g_116;
+    total = total + g_117;
+    total = total + g_118;
+    total = total + g_119;
+    total = total + g_120;
+    total = total + g_121;
+    total = total + g_122;
+    total = total + g_123;
+    total = total + g_124;
+    total = total + g_125;
+    total = total + g_126;
+    total = total + g_127;
+    total = total + g_128;
+    total = total + g_129;
+    total = total + g_130;
+    total = total + g_131;
+    total = total + g_132;
+    total = total + g_133;
+    total = total + g_134;
+    total = total + g_135;
+    total = total + g_136;
+    total = total + g_137;
+    total = total + g_138;
+    total = total + g_139;
+    total = total + g_140;
+    total = total + g_141;
+    total = total + g_142;
+    total = total + g_143;
+    total = total + g_144;
+    total = total + g_145;
+    total = total + g_146;
+    total = total + g_147;
+    total = total + g_148;
+    total = total + g_149;
+    total = total + g_150;
+    total = total + g_151;
+    total = total + g_152;
+    total = total + g_153;
+    total = total + g_154;
+    total = total + g_155;
+    total = total + g_156;
+    total = total + g_157;
+    total = total + g_158;
+    total = total + g_159;
+    total = total + g_160;
+    total = total + g_161;
+    total = total + g_162;
+    total = total + g_163;
+    total = total + g_164;
+    total = total + g_165;
+    total = total + g_166;
+    total = total + g_167;
+    total = total + g_168;
+    total = total + g_169;
+    total = total + g_170;
+    total = total + g_171;
+    total = total + g_172;
+    total = total + g_173;
+    total = total + g_174;
+    total = total + g_175;
+    total = total + g_176;
+    total = total + g_177;
+    total = total + g_178;
+    total = total + g_179;
+    total = total + g_180;
+    total = total + g_181;
+    total = total + g_182;
+    total = total + g_183;
+    total = total + g_184;
+    total = total + g_185;
+    total = total + g_186;
+    total = total + g_187;
+    total = total + g_188;
+    total = total + g_189;
+    total = total + g_190;
+    total = total + g_191;
+    total = total + g_192;
+    total = total + g_193;
+    total = total + g_194;
+    total = total + g_195;
+    total = total + g_196;
+    total = total + g_197;
+    total = total + g_198;
+    total = total + g_199;
+    total = total + g_200;
+    total = total + g_201;
+    total = total + g_202;
+    total = total + g_203;
+    total = total + g_204;
+    total = total + g_205;
+    total = total + g_206;
+    total = total + g_207;
+    total = total + g_208;
+    total = total + g_209;
+    total = total + g_210;
+    total = total + g_211;
+    total = total + g_212;
+    total = total + g_213;
+    total = total + g_214;
+    total = total + g_215;
+    total = total + g_216;
+    total = total + g_217;
+    total = total + g_218;
+    total = total + g_219;
+    total = total + g_220;
+    total = total + g_221;
+    total = total + g_222;
+    total = total + g_223;
+    Sleep(total::u32);
+    objc_msgSend(total, 0);
+    total = compressBound(total);
+}

--- a/int/surface/macho-header-span-x86_64/case.conf
+++ b/int/surface/macho-header-span-x86_64/case.conf
@@ -1,0 +1,19 @@
+# a darwin image whose load commands exceed the one-page header reservation links,
+# and its header lands inside the span the linker reserved (#2690).
+#
+# The reservation is the linker's, decided when it assigns virtual addresses, not
+# the writer's: __TEXT is based exactly on the image base and the header fills the
+# gap below the first segment. So growing the header has to grow that gap, or
+# __TEXT - and __PAGEZERO under it - slides below the base, which is #2599. The
+# golden therefore pins the framing alongside the size, since a fix that only
+# widened the span in the writer would pass a size-only check while reintroducing
+# the older defect.
+#
+# Read host-side on the cheap linux leg; the image is never run. The aarch64 twin
+# is a separate case because the two share the writer but not the page size (4 KiB
+# here, 16 KiB there), so only running both proves the reservation is sized from
+# the target's page rather than a constant.
+run: macho-header-span
+targets: linux
+build-target: darwin-x86_64
+build-flags: --pie

--- a/int/surface/macho-header-span-x86_64/expect.darwin-x86_64.txt
+++ b/int/surface/macho-header-span-x86_64/expect.darwin-x86_64.txt
@@ -1,0 +1,9 @@
+sizeofcmds_over_one_page=1
+multiple_dylib_loads=1
+reservation_whole_pages=1
+header_fits_reservation=1
+first_section_fileoff_is_reservation=1
+pagezero_vmsize=0x100000000
+text_vmaddr=0x100000000
+text_fileoff=0
+pagezero_abuts_text=1

--- a/int/surface/macho-header-span-x86_64/mach.toml
+++ b/int/surface/macho-header-span-x86_64/mach.toml
@@ -1,0 +1,108 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["System", "objc", "cxx", "iconv", "z", "xml2", "bz2", "curses"]
+need = []
+
+[link.System]
+source = "system"
+name = "/usr/lib/libSystem.B.dylib"
+library = "System"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.objc]
+source = "system"
+name = "/usr/lib/libobjc.A.dylib"
+library = "objc"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.cxx]
+source = "system"
+name = "/usr/lib/libc++.1.dylib"
+library = "cxx"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.iconv]
+source = "system"
+name = "/usr/lib/libiconv.2.dylib"
+library = "iconv"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.z]
+source = "system"
+name = "/usr/lib/libz.1.dylib"
+library = "z"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.xml2]
+source = "system"
+name = "/usr/lib/libxml2.2.dylib"
+library = "xml2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.bz2]
+source = "system"
+name = "/usr/lib/libbz2.1.0.dylib"
+library = "bz2"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[link.curses]
+source = "system"
+name = "/usr/lib/libcurses.dylib"
+library = "curses"
+symbols = []
+os = ["darwin"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/int/surface/macho-header-span-x86_64/src/main.mach
+++ b/int/surface/macho-header-span-x86_64/src/main.mach
@@ -1,0 +1,928 @@
+# a Mach-O header outgrows its one-page reservation as soon as an image carries
+# enough named sections: since #2606 the linker preserves input section identity,
+# and every surviving section is another 80-byte section_64 in the header. A
+# vendored objective-c archive carries dozens (__objc_classlist, __objc_const,
+# __objc_data, __cstring, __gcc_except_tab, ...) alongside its system-library
+# dependencies, which is how briar-systems/mach-glfw#32 reached 4 KiB of load
+# commands and was refused (#2690).
+#
+# The 224 `#[section]` globals below stand in for that section table without
+# needing the macOS SDK to build one: they cross the reservation on both darwin
+# page sizes (4 KiB x86_64, 16 KiB arm64). The system-library dependencies in
+# mach.toml are the second contributor, an LC_LOAD_DYLIB each, and they make the
+# image the shape the reported consumer has rather than a section table alone.
+#
+# The program is never RUN - the observable is the emitted header, read host-side
+# on the linux leg - so the imports need only be referenced, not called correctly.
+#[library("System")]
+ext fun Sleep(ms: u32);
+
+#[library("objc")]
+ext fun objc_msgSend(recv: u64, sel: u64);
+
+#[library("z")]
+ext fun compressBound(n: u64) u64;
+
+#[section(".mach_sec000")] #[symbol("g_000")]
+pub var g_000: u64 = 1;
+
+#[section(".mach_sec001")] #[symbol("g_001")]
+pub var g_001: u64 = 2;
+
+#[section(".mach_sec002")] #[symbol("g_002")]
+pub var g_002: u64 = 3;
+
+#[section(".mach_sec003")] #[symbol("g_003")]
+pub var g_003: u64 = 4;
+
+#[section(".mach_sec004")] #[symbol("g_004")]
+pub var g_004: u64 = 5;
+
+#[section(".mach_sec005")] #[symbol("g_005")]
+pub var g_005: u64 = 6;
+
+#[section(".mach_sec006")] #[symbol("g_006")]
+pub var g_006: u64 = 7;
+
+#[section(".mach_sec007")] #[symbol("g_007")]
+pub var g_007: u64 = 8;
+
+#[section(".mach_sec008")] #[symbol("g_008")]
+pub var g_008: u64 = 9;
+
+#[section(".mach_sec009")] #[symbol("g_009")]
+pub var g_009: u64 = 10;
+
+#[section(".mach_sec010")] #[symbol("g_010")]
+pub var g_010: u64 = 11;
+
+#[section(".mach_sec011")] #[symbol("g_011")]
+pub var g_011: u64 = 12;
+
+#[section(".mach_sec012")] #[symbol("g_012")]
+pub var g_012: u64 = 13;
+
+#[section(".mach_sec013")] #[symbol("g_013")]
+pub var g_013: u64 = 14;
+
+#[section(".mach_sec014")] #[symbol("g_014")]
+pub var g_014: u64 = 15;
+
+#[section(".mach_sec015")] #[symbol("g_015")]
+pub var g_015: u64 = 16;
+
+#[section(".mach_sec016")] #[symbol("g_016")]
+pub var g_016: u64 = 17;
+
+#[section(".mach_sec017")] #[symbol("g_017")]
+pub var g_017: u64 = 18;
+
+#[section(".mach_sec018")] #[symbol("g_018")]
+pub var g_018: u64 = 19;
+
+#[section(".mach_sec019")] #[symbol("g_019")]
+pub var g_019: u64 = 20;
+
+#[section(".mach_sec020")] #[symbol("g_020")]
+pub var g_020: u64 = 21;
+
+#[section(".mach_sec021")] #[symbol("g_021")]
+pub var g_021: u64 = 22;
+
+#[section(".mach_sec022")] #[symbol("g_022")]
+pub var g_022: u64 = 23;
+
+#[section(".mach_sec023")] #[symbol("g_023")]
+pub var g_023: u64 = 24;
+
+#[section(".mach_sec024")] #[symbol("g_024")]
+pub var g_024: u64 = 25;
+
+#[section(".mach_sec025")] #[symbol("g_025")]
+pub var g_025: u64 = 26;
+
+#[section(".mach_sec026")] #[symbol("g_026")]
+pub var g_026: u64 = 27;
+
+#[section(".mach_sec027")] #[symbol("g_027")]
+pub var g_027: u64 = 28;
+
+#[section(".mach_sec028")] #[symbol("g_028")]
+pub var g_028: u64 = 29;
+
+#[section(".mach_sec029")] #[symbol("g_029")]
+pub var g_029: u64 = 30;
+
+#[section(".mach_sec030")] #[symbol("g_030")]
+pub var g_030: u64 = 31;
+
+#[section(".mach_sec031")] #[symbol("g_031")]
+pub var g_031: u64 = 32;
+
+#[section(".mach_sec032")] #[symbol("g_032")]
+pub var g_032: u64 = 33;
+
+#[section(".mach_sec033")] #[symbol("g_033")]
+pub var g_033: u64 = 34;
+
+#[section(".mach_sec034")] #[symbol("g_034")]
+pub var g_034: u64 = 35;
+
+#[section(".mach_sec035")] #[symbol("g_035")]
+pub var g_035: u64 = 36;
+
+#[section(".mach_sec036")] #[symbol("g_036")]
+pub var g_036: u64 = 37;
+
+#[section(".mach_sec037")] #[symbol("g_037")]
+pub var g_037: u64 = 38;
+
+#[section(".mach_sec038")] #[symbol("g_038")]
+pub var g_038: u64 = 39;
+
+#[section(".mach_sec039")] #[symbol("g_039")]
+pub var g_039: u64 = 40;
+
+#[section(".mach_sec040")] #[symbol("g_040")]
+pub var g_040: u64 = 41;
+
+#[section(".mach_sec041")] #[symbol("g_041")]
+pub var g_041: u64 = 42;
+
+#[section(".mach_sec042")] #[symbol("g_042")]
+pub var g_042: u64 = 43;
+
+#[section(".mach_sec043")] #[symbol("g_043")]
+pub var g_043: u64 = 44;
+
+#[section(".mach_sec044")] #[symbol("g_044")]
+pub var g_044: u64 = 45;
+
+#[section(".mach_sec045")] #[symbol("g_045")]
+pub var g_045: u64 = 46;
+
+#[section(".mach_sec046")] #[symbol("g_046")]
+pub var g_046: u64 = 47;
+
+#[section(".mach_sec047")] #[symbol("g_047")]
+pub var g_047: u64 = 48;
+
+#[section(".mach_sec048")] #[symbol("g_048")]
+pub var g_048: u64 = 49;
+
+#[section(".mach_sec049")] #[symbol("g_049")]
+pub var g_049: u64 = 50;
+
+#[section(".mach_sec050")] #[symbol("g_050")]
+pub var g_050: u64 = 51;
+
+#[section(".mach_sec051")] #[symbol("g_051")]
+pub var g_051: u64 = 52;
+
+#[section(".mach_sec052")] #[symbol("g_052")]
+pub var g_052: u64 = 53;
+
+#[section(".mach_sec053")] #[symbol("g_053")]
+pub var g_053: u64 = 54;
+
+#[section(".mach_sec054")] #[symbol("g_054")]
+pub var g_054: u64 = 55;
+
+#[section(".mach_sec055")] #[symbol("g_055")]
+pub var g_055: u64 = 56;
+
+#[section(".mach_sec056")] #[symbol("g_056")]
+pub var g_056: u64 = 57;
+
+#[section(".mach_sec057")] #[symbol("g_057")]
+pub var g_057: u64 = 58;
+
+#[section(".mach_sec058")] #[symbol("g_058")]
+pub var g_058: u64 = 59;
+
+#[section(".mach_sec059")] #[symbol("g_059")]
+pub var g_059: u64 = 60;
+
+#[section(".mach_sec060")] #[symbol("g_060")]
+pub var g_060: u64 = 61;
+
+#[section(".mach_sec061")] #[symbol("g_061")]
+pub var g_061: u64 = 62;
+
+#[section(".mach_sec062")] #[symbol("g_062")]
+pub var g_062: u64 = 63;
+
+#[section(".mach_sec063")] #[symbol("g_063")]
+pub var g_063: u64 = 64;
+
+#[section(".mach_sec064")] #[symbol("g_064")]
+pub var g_064: u64 = 65;
+
+#[section(".mach_sec065")] #[symbol("g_065")]
+pub var g_065: u64 = 66;
+
+#[section(".mach_sec066")] #[symbol("g_066")]
+pub var g_066: u64 = 67;
+
+#[section(".mach_sec067")] #[symbol("g_067")]
+pub var g_067: u64 = 68;
+
+#[section(".mach_sec068")] #[symbol("g_068")]
+pub var g_068: u64 = 69;
+
+#[section(".mach_sec069")] #[symbol("g_069")]
+pub var g_069: u64 = 70;
+
+#[section(".mach_sec070")] #[symbol("g_070")]
+pub var g_070: u64 = 71;
+
+#[section(".mach_sec071")] #[symbol("g_071")]
+pub var g_071: u64 = 72;
+
+#[section(".mach_sec072")] #[symbol("g_072")]
+pub var g_072: u64 = 73;
+
+#[section(".mach_sec073")] #[symbol("g_073")]
+pub var g_073: u64 = 74;
+
+#[section(".mach_sec074")] #[symbol("g_074")]
+pub var g_074: u64 = 75;
+
+#[section(".mach_sec075")] #[symbol("g_075")]
+pub var g_075: u64 = 76;
+
+#[section(".mach_sec076")] #[symbol("g_076")]
+pub var g_076: u64 = 77;
+
+#[section(".mach_sec077")] #[symbol("g_077")]
+pub var g_077: u64 = 78;
+
+#[section(".mach_sec078")] #[symbol("g_078")]
+pub var g_078: u64 = 79;
+
+#[section(".mach_sec079")] #[symbol("g_079")]
+pub var g_079: u64 = 80;
+
+#[section(".mach_sec080")] #[symbol("g_080")]
+pub var g_080: u64 = 81;
+
+#[section(".mach_sec081")] #[symbol("g_081")]
+pub var g_081: u64 = 82;
+
+#[section(".mach_sec082")] #[symbol("g_082")]
+pub var g_082: u64 = 83;
+
+#[section(".mach_sec083")] #[symbol("g_083")]
+pub var g_083: u64 = 84;
+
+#[section(".mach_sec084")] #[symbol("g_084")]
+pub var g_084: u64 = 85;
+
+#[section(".mach_sec085")] #[symbol("g_085")]
+pub var g_085: u64 = 86;
+
+#[section(".mach_sec086")] #[symbol("g_086")]
+pub var g_086: u64 = 87;
+
+#[section(".mach_sec087")] #[symbol("g_087")]
+pub var g_087: u64 = 88;
+
+#[section(".mach_sec088")] #[symbol("g_088")]
+pub var g_088: u64 = 89;
+
+#[section(".mach_sec089")] #[symbol("g_089")]
+pub var g_089: u64 = 90;
+
+#[section(".mach_sec090")] #[symbol("g_090")]
+pub var g_090: u64 = 91;
+
+#[section(".mach_sec091")] #[symbol("g_091")]
+pub var g_091: u64 = 92;
+
+#[section(".mach_sec092")] #[symbol("g_092")]
+pub var g_092: u64 = 93;
+
+#[section(".mach_sec093")] #[symbol("g_093")]
+pub var g_093: u64 = 94;
+
+#[section(".mach_sec094")] #[symbol("g_094")]
+pub var g_094: u64 = 95;
+
+#[section(".mach_sec095")] #[symbol("g_095")]
+pub var g_095: u64 = 96;
+
+#[section(".mach_sec096")] #[symbol("g_096")]
+pub var g_096: u64 = 97;
+
+#[section(".mach_sec097")] #[symbol("g_097")]
+pub var g_097: u64 = 98;
+
+#[section(".mach_sec098")] #[symbol("g_098")]
+pub var g_098: u64 = 99;
+
+#[section(".mach_sec099")] #[symbol("g_099")]
+pub var g_099: u64 = 100;
+
+#[section(".mach_sec100")] #[symbol("g_100")]
+pub var g_100: u64 = 101;
+
+#[section(".mach_sec101")] #[symbol("g_101")]
+pub var g_101: u64 = 102;
+
+#[section(".mach_sec102")] #[symbol("g_102")]
+pub var g_102: u64 = 103;
+
+#[section(".mach_sec103")] #[symbol("g_103")]
+pub var g_103: u64 = 104;
+
+#[section(".mach_sec104")] #[symbol("g_104")]
+pub var g_104: u64 = 105;
+
+#[section(".mach_sec105")] #[symbol("g_105")]
+pub var g_105: u64 = 106;
+
+#[section(".mach_sec106")] #[symbol("g_106")]
+pub var g_106: u64 = 107;
+
+#[section(".mach_sec107")] #[symbol("g_107")]
+pub var g_107: u64 = 108;
+
+#[section(".mach_sec108")] #[symbol("g_108")]
+pub var g_108: u64 = 109;
+
+#[section(".mach_sec109")] #[symbol("g_109")]
+pub var g_109: u64 = 110;
+
+#[section(".mach_sec110")] #[symbol("g_110")]
+pub var g_110: u64 = 111;
+
+#[section(".mach_sec111")] #[symbol("g_111")]
+pub var g_111: u64 = 112;
+
+#[section(".mach_sec112")] #[symbol("g_112")]
+pub var g_112: u64 = 113;
+
+#[section(".mach_sec113")] #[symbol("g_113")]
+pub var g_113: u64 = 114;
+
+#[section(".mach_sec114")] #[symbol("g_114")]
+pub var g_114: u64 = 115;
+
+#[section(".mach_sec115")] #[symbol("g_115")]
+pub var g_115: u64 = 116;
+
+#[section(".mach_sec116")] #[symbol("g_116")]
+pub var g_116: u64 = 117;
+
+#[section(".mach_sec117")] #[symbol("g_117")]
+pub var g_117: u64 = 118;
+
+#[section(".mach_sec118")] #[symbol("g_118")]
+pub var g_118: u64 = 119;
+
+#[section(".mach_sec119")] #[symbol("g_119")]
+pub var g_119: u64 = 120;
+
+#[section(".mach_sec120")] #[symbol("g_120")]
+pub var g_120: u64 = 121;
+
+#[section(".mach_sec121")] #[symbol("g_121")]
+pub var g_121: u64 = 122;
+
+#[section(".mach_sec122")] #[symbol("g_122")]
+pub var g_122: u64 = 123;
+
+#[section(".mach_sec123")] #[symbol("g_123")]
+pub var g_123: u64 = 124;
+
+#[section(".mach_sec124")] #[symbol("g_124")]
+pub var g_124: u64 = 125;
+
+#[section(".mach_sec125")] #[symbol("g_125")]
+pub var g_125: u64 = 126;
+
+#[section(".mach_sec126")] #[symbol("g_126")]
+pub var g_126: u64 = 127;
+
+#[section(".mach_sec127")] #[symbol("g_127")]
+pub var g_127: u64 = 128;
+
+#[section(".mach_sec128")] #[symbol("g_128")]
+pub var g_128: u64 = 129;
+
+#[section(".mach_sec129")] #[symbol("g_129")]
+pub var g_129: u64 = 130;
+
+#[section(".mach_sec130")] #[symbol("g_130")]
+pub var g_130: u64 = 131;
+
+#[section(".mach_sec131")] #[symbol("g_131")]
+pub var g_131: u64 = 132;
+
+#[section(".mach_sec132")] #[symbol("g_132")]
+pub var g_132: u64 = 133;
+
+#[section(".mach_sec133")] #[symbol("g_133")]
+pub var g_133: u64 = 134;
+
+#[section(".mach_sec134")] #[symbol("g_134")]
+pub var g_134: u64 = 135;
+
+#[section(".mach_sec135")] #[symbol("g_135")]
+pub var g_135: u64 = 136;
+
+#[section(".mach_sec136")] #[symbol("g_136")]
+pub var g_136: u64 = 137;
+
+#[section(".mach_sec137")] #[symbol("g_137")]
+pub var g_137: u64 = 138;
+
+#[section(".mach_sec138")] #[symbol("g_138")]
+pub var g_138: u64 = 139;
+
+#[section(".mach_sec139")] #[symbol("g_139")]
+pub var g_139: u64 = 140;
+
+#[section(".mach_sec140")] #[symbol("g_140")]
+pub var g_140: u64 = 141;
+
+#[section(".mach_sec141")] #[symbol("g_141")]
+pub var g_141: u64 = 142;
+
+#[section(".mach_sec142")] #[symbol("g_142")]
+pub var g_142: u64 = 143;
+
+#[section(".mach_sec143")] #[symbol("g_143")]
+pub var g_143: u64 = 144;
+
+#[section(".mach_sec144")] #[symbol("g_144")]
+pub var g_144: u64 = 145;
+
+#[section(".mach_sec145")] #[symbol("g_145")]
+pub var g_145: u64 = 146;
+
+#[section(".mach_sec146")] #[symbol("g_146")]
+pub var g_146: u64 = 147;
+
+#[section(".mach_sec147")] #[symbol("g_147")]
+pub var g_147: u64 = 148;
+
+#[section(".mach_sec148")] #[symbol("g_148")]
+pub var g_148: u64 = 149;
+
+#[section(".mach_sec149")] #[symbol("g_149")]
+pub var g_149: u64 = 150;
+
+#[section(".mach_sec150")] #[symbol("g_150")]
+pub var g_150: u64 = 151;
+
+#[section(".mach_sec151")] #[symbol("g_151")]
+pub var g_151: u64 = 152;
+
+#[section(".mach_sec152")] #[symbol("g_152")]
+pub var g_152: u64 = 153;
+
+#[section(".mach_sec153")] #[symbol("g_153")]
+pub var g_153: u64 = 154;
+
+#[section(".mach_sec154")] #[symbol("g_154")]
+pub var g_154: u64 = 155;
+
+#[section(".mach_sec155")] #[symbol("g_155")]
+pub var g_155: u64 = 156;
+
+#[section(".mach_sec156")] #[symbol("g_156")]
+pub var g_156: u64 = 157;
+
+#[section(".mach_sec157")] #[symbol("g_157")]
+pub var g_157: u64 = 158;
+
+#[section(".mach_sec158")] #[symbol("g_158")]
+pub var g_158: u64 = 159;
+
+#[section(".mach_sec159")] #[symbol("g_159")]
+pub var g_159: u64 = 160;
+
+#[section(".mach_sec160")] #[symbol("g_160")]
+pub var g_160: u64 = 161;
+
+#[section(".mach_sec161")] #[symbol("g_161")]
+pub var g_161: u64 = 162;
+
+#[section(".mach_sec162")] #[symbol("g_162")]
+pub var g_162: u64 = 163;
+
+#[section(".mach_sec163")] #[symbol("g_163")]
+pub var g_163: u64 = 164;
+
+#[section(".mach_sec164")] #[symbol("g_164")]
+pub var g_164: u64 = 165;
+
+#[section(".mach_sec165")] #[symbol("g_165")]
+pub var g_165: u64 = 166;
+
+#[section(".mach_sec166")] #[symbol("g_166")]
+pub var g_166: u64 = 167;
+
+#[section(".mach_sec167")] #[symbol("g_167")]
+pub var g_167: u64 = 168;
+
+#[section(".mach_sec168")] #[symbol("g_168")]
+pub var g_168: u64 = 169;
+
+#[section(".mach_sec169")] #[symbol("g_169")]
+pub var g_169: u64 = 170;
+
+#[section(".mach_sec170")] #[symbol("g_170")]
+pub var g_170: u64 = 171;
+
+#[section(".mach_sec171")] #[symbol("g_171")]
+pub var g_171: u64 = 172;
+
+#[section(".mach_sec172")] #[symbol("g_172")]
+pub var g_172: u64 = 173;
+
+#[section(".mach_sec173")] #[symbol("g_173")]
+pub var g_173: u64 = 174;
+
+#[section(".mach_sec174")] #[symbol("g_174")]
+pub var g_174: u64 = 175;
+
+#[section(".mach_sec175")] #[symbol("g_175")]
+pub var g_175: u64 = 176;
+
+#[section(".mach_sec176")] #[symbol("g_176")]
+pub var g_176: u64 = 177;
+
+#[section(".mach_sec177")] #[symbol("g_177")]
+pub var g_177: u64 = 178;
+
+#[section(".mach_sec178")] #[symbol("g_178")]
+pub var g_178: u64 = 179;
+
+#[section(".mach_sec179")] #[symbol("g_179")]
+pub var g_179: u64 = 180;
+
+#[section(".mach_sec180")] #[symbol("g_180")]
+pub var g_180: u64 = 181;
+
+#[section(".mach_sec181")] #[symbol("g_181")]
+pub var g_181: u64 = 182;
+
+#[section(".mach_sec182")] #[symbol("g_182")]
+pub var g_182: u64 = 183;
+
+#[section(".mach_sec183")] #[symbol("g_183")]
+pub var g_183: u64 = 184;
+
+#[section(".mach_sec184")] #[symbol("g_184")]
+pub var g_184: u64 = 185;
+
+#[section(".mach_sec185")] #[symbol("g_185")]
+pub var g_185: u64 = 186;
+
+#[section(".mach_sec186")] #[symbol("g_186")]
+pub var g_186: u64 = 187;
+
+#[section(".mach_sec187")] #[symbol("g_187")]
+pub var g_187: u64 = 188;
+
+#[section(".mach_sec188")] #[symbol("g_188")]
+pub var g_188: u64 = 189;
+
+#[section(".mach_sec189")] #[symbol("g_189")]
+pub var g_189: u64 = 190;
+
+#[section(".mach_sec190")] #[symbol("g_190")]
+pub var g_190: u64 = 191;
+
+#[section(".mach_sec191")] #[symbol("g_191")]
+pub var g_191: u64 = 192;
+
+#[section(".mach_sec192")] #[symbol("g_192")]
+pub var g_192: u64 = 193;
+
+#[section(".mach_sec193")] #[symbol("g_193")]
+pub var g_193: u64 = 194;
+
+#[section(".mach_sec194")] #[symbol("g_194")]
+pub var g_194: u64 = 195;
+
+#[section(".mach_sec195")] #[symbol("g_195")]
+pub var g_195: u64 = 196;
+
+#[section(".mach_sec196")] #[symbol("g_196")]
+pub var g_196: u64 = 197;
+
+#[section(".mach_sec197")] #[symbol("g_197")]
+pub var g_197: u64 = 198;
+
+#[section(".mach_sec198")] #[symbol("g_198")]
+pub var g_198: u64 = 199;
+
+#[section(".mach_sec199")] #[symbol("g_199")]
+pub var g_199: u64 = 200;
+
+#[section(".mach_sec200")] #[symbol("g_200")]
+pub var g_200: u64 = 201;
+
+#[section(".mach_sec201")] #[symbol("g_201")]
+pub var g_201: u64 = 202;
+
+#[section(".mach_sec202")] #[symbol("g_202")]
+pub var g_202: u64 = 203;
+
+#[section(".mach_sec203")] #[symbol("g_203")]
+pub var g_203: u64 = 204;
+
+#[section(".mach_sec204")] #[symbol("g_204")]
+pub var g_204: u64 = 205;
+
+#[section(".mach_sec205")] #[symbol("g_205")]
+pub var g_205: u64 = 206;
+
+#[section(".mach_sec206")] #[symbol("g_206")]
+pub var g_206: u64 = 207;
+
+#[section(".mach_sec207")] #[symbol("g_207")]
+pub var g_207: u64 = 208;
+
+#[section(".mach_sec208")] #[symbol("g_208")]
+pub var g_208: u64 = 209;
+
+#[section(".mach_sec209")] #[symbol("g_209")]
+pub var g_209: u64 = 210;
+
+#[section(".mach_sec210")] #[symbol("g_210")]
+pub var g_210: u64 = 211;
+
+#[section(".mach_sec211")] #[symbol("g_211")]
+pub var g_211: u64 = 212;
+
+#[section(".mach_sec212")] #[symbol("g_212")]
+pub var g_212: u64 = 213;
+
+#[section(".mach_sec213")] #[symbol("g_213")]
+pub var g_213: u64 = 214;
+
+#[section(".mach_sec214")] #[symbol("g_214")]
+pub var g_214: u64 = 215;
+
+#[section(".mach_sec215")] #[symbol("g_215")]
+pub var g_215: u64 = 216;
+
+#[section(".mach_sec216")] #[symbol("g_216")]
+pub var g_216: u64 = 217;
+
+#[section(".mach_sec217")] #[symbol("g_217")]
+pub var g_217: u64 = 218;
+
+#[section(".mach_sec218")] #[symbol("g_218")]
+pub var g_218: u64 = 219;
+
+#[section(".mach_sec219")] #[symbol("g_219")]
+pub var g_219: u64 = 220;
+
+#[section(".mach_sec220")] #[symbol("g_220")]
+pub var g_220: u64 = 221;
+
+#[section(".mach_sec221")] #[symbol("g_221")]
+pub var g_221: u64 = 222;
+
+#[section(".mach_sec222")] #[symbol("g_222")]
+pub var g_222: u64 = 223;
+
+#[section(".mach_sec223")] #[symbol("g_223")]
+pub var g_223: u64 = 224;
+
+#[symbol("start")]
+pub fun _start() {
+    var total: u64 = 0;
+    total = total + g_000;
+    total = total + g_001;
+    total = total + g_002;
+    total = total + g_003;
+    total = total + g_004;
+    total = total + g_005;
+    total = total + g_006;
+    total = total + g_007;
+    total = total + g_008;
+    total = total + g_009;
+    total = total + g_010;
+    total = total + g_011;
+    total = total + g_012;
+    total = total + g_013;
+    total = total + g_014;
+    total = total + g_015;
+    total = total + g_016;
+    total = total + g_017;
+    total = total + g_018;
+    total = total + g_019;
+    total = total + g_020;
+    total = total + g_021;
+    total = total + g_022;
+    total = total + g_023;
+    total = total + g_024;
+    total = total + g_025;
+    total = total + g_026;
+    total = total + g_027;
+    total = total + g_028;
+    total = total + g_029;
+    total = total + g_030;
+    total = total + g_031;
+    total = total + g_032;
+    total = total + g_033;
+    total = total + g_034;
+    total = total + g_035;
+    total = total + g_036;
+    total = total + g_037;
+    total = total + g_038;
+    total = total + g_039;
+    total = total + g_040;
+    total = total + g_041;
+    total = total + g_042;
+    total = total + g_043;
+    total = total + g_044;
+    total = total + g_045;
+    total = total + g_046;
+    total = total + g_047;
+    total = total + g_048;
+    total = total + g_049;
+    total = total + g_050;
+    total = total + g_051;
+    total = total + g_052;
+    total = total + g_053;
+    total = total + g_054;
+    total = total + g_055;
+    total = total + g_056;
+    total = total + g_057;
+    total = total + g_058;
+    total = total + g_059;
+    total = total + g_060;
+    total = total + g_061;
+    total = total + g_062;
+    total = total + g_063;
+    total = total + g_064;
+    total = total + g_065;
+    total = total + g_066;
+    total = total + g_067;
+    total = total + g_068;
+    total = total + g_069;
+    total = total + g_070;
+    total = total + g_071;
+    total = total + g_072;
+    total = total + g_073;
+    total = total + g_074;
+    total = total + g_075;
+    total = total + g_076;
+    total = total + g_077;
+    total = total + g_078;
+    total = total + g_079;
+    total = total + g_080;
+    total = total + g_081;
+    total = total + g_082;
+    total = total + g_083;
+    total = total + g_084;
+    total = total + g_085;
+    total = total + g_086;
+    total = total + g_087;
+    total = total + g_088;
+    total = total + g_089;
+    total = total + g_090;
+    total = total + g_091;
+    total = total + g_092;
+    total = total + g_093;
+    total = total + g_094;
+    total = total + g_095;
+    total = total + g_096;
+    total = total + g_097;
+    total = total + g_098;
+    total = total + g_099;
+    total = total + g_100;
+    total = total + g_101;
+    total = total + g_102;
+    total = total + g_103;
+    total = total + g_104;
+    total = total + g_105;
+    total = total + g_106;
+    total = total + g_107;
+    total = total + g_108;
+    total = total + g_109;
+    total = total + g_110;
+    total = total + g_111;
+    total = total + g_112;
+    total = total + g_113;
+    total = total + g_114;
+    total = total + g_115;
+    total = total + g_116;
+    total = total + g_117;
+    total = total + g_118;
+    total = total + g_119;
+    total = total + g_120;
+    total = total + g_121;
+    total = total + g_122;
+    total = total + g_123;
+    total = total + g_124;
+    total = total + g_125;
+    total = total + g_126;
+    total = total + g_127;
+    total = total + g_128;
+    total = total + g_129;
+    total = total + g_130;
+    total = total + g_131;
+    total = total + g_132;
+    total = total + g_133;
+    total = total + g_134;
+    total = total + g_135;
+    total = total + g_136;
+    total = total + g_137;
+    total = total + g_138;
+    total = total + g_139;
+    total = total + g_140;
+    total = total + g_141;
+    total = total + g_142;
+    total = total + g_143;
+    total = total + g_144;
+    total = total + g_145;
+    total = total + g_146;
+    total = total + g_147;
+    total = total + g_148;
+    total = total + g_149;
+    total = total + g_150;
+    total = total + g_151;
+    total = total + g_152;
+    total = total + g_153;
+    total = total + g_154;
+    total = total + g_155;
+    total = total + g_156;
+    total = total + g_157;
+    total = total + g_158;
+    total = total + g_159;
+    total = total + g_160;
+    total = total + g_161;
+    total = total + g_162;
+    total = total + g_163;
+    total = total + g_164;
+    total = total + g_165;
+    total = total + g_166;
+    total = total + g_167;
+    total = total + g_168;
+    total = total + g_169;
+    total = total + g_170;
+    total = total + g_171;
+    total = total + g_172;
+    total = total + g_173;
+    total = total + g_174;
+    total = total + g_175;
+    total = total + g_176;
+    total = total + g_177;
+    total = total + g_178;
+    total = total + g_179;
+    total = total + g_180;
+    total = total + g_181;
+    total = total + g_182;
+    total = total + g_183;
+    total = total + g_184;
+    total = total + g_185;
+    total = total + g_186;
+    total = total + g_187;
+    total = total + g_188;
+    total = total + g_189;
+    total = total + g_190;
+    total = total + g_191;
+    total = total + g_192;
+    total = total + g_193;
+    total = total + g_194;
+    total = total + g_195;
+    total = total + g_196;
+    total = total + g_197;
+    total = total + g_198;
+    total = total + g_199;
+    total = total + g_200;
+    total = total + g_201;
+    total = total + g_202;
+    total = total + g_203;
+    total = total + g_204;
+    total = total + g_205;
+    total = total + g_206;
+    total = total + g_207;
+    total = total + g_208;
+    total = total + g_209;
+    total = total + g_210;
+    total = total + g_211;
+    total = total + g_212;
+    total = total + g_213;
+    total = total + g_214;
+    total = total + g_215;
+    total = total + g_216;
+    total = total + g_217;
+    total = total + g_218;
+    total = total + g_219;
+    total = total + g_220;
+    total = total + g_221;
+    total = total + g_222;
+    total = total + g_223;
+    Sleep(total::u32);
+    objc_msgSend(total, 0);
+    total = compressBound(total);
+}

--- a/int/surface/spirv-ext-inst/case.conf
+++ b/int/surface/spirv-ext-inst/case.conf
@@ -1,0 +1,14 @@
+# GLSL.std.450 and core OpDot through the spirv back half (#2688), validated AND
+# disassembled host-side. the producer is `spirv-shader` rather than
+# `spirv-val-vulkan` because the validator cannot see this case's subject: a `sqrt`
+# left as a call, or substituted with the wrong instruction number, produces a
+# module spirv-val accepts. the golden names the set, the instruction and the
+# operand count of every emitted OpExtInst and OpDot.
+#
+# the producer also picks the environment PER MODULE, which this case needs and no
+# earlier spirv case did: it consumes a library dependency, so the tree holds a
+# shader module (vulkan1.3) beside `shader.math`'s own library module, whose
+# Linkage capability vulkan1.3 rejects outright.
+run: spirv-shader
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-ext-inst/expect.spirv.txt
+++ b/int/surface/spirv-ext-inst/expect.spirv.txt
@@ -1,0 +1,30 @@
+module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
+  import GLSL.std.450
+  extinst GLSL.std.450 Normalize operands=1
+  core OpDot operands=2
+  extinst GLSL.std.450 FMax operands=2
+  extinst GLSL.std.450 Sqrt operands=1
+  extinst GLSL.std.450 FMix operands=3
+  extinst GLSL.std.450 Normalize operands=1
+  extinst GLSL.std.450 Reflect operands=2
+  core OpDot operands=2
+  extinst GLSL.std.450 FClamp operands=3
+  extinst GLSL.std.450 FMax operands=2
+  extinst GLSL.std.450 Pow operands=2
+  extinst GLSL.std.450 FMix operands=3
+  extinst GLSL.std.450 FAbs operands=1
+  extinst GLSL.std.450 FMax operands=2
+  extinst GLSL.std.450 Sqrt operands=1
+  extinst GLSL.std.450 Fract operands=1
+  extinst GLSL.std.450 Floor operands=1
+  extinst GLSL.std.450 FClamp operands=3
+  extinst GLSL.std.450 Length operands=1
+  extinst GLSL.std.450 Distance operands=2
+  extinst GLSL.std.450 SmoothStep operands=3
+  extinst GLSL.std.450 Fma operands=3
+  extinst GLSL.std.450 Radians operands=1
+  extinst GLSL.std.450 Sin operands=1
+  extinst GLSL.std.450 Normalize operands=1
+module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0
+module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0
+modules=3

--- a/int/surface/spirv-ext-inst/mach.toml
+++ b/int/surface/spirv-ext-inst/mach.toml
@@ -1,0 +1,43 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+# the shader-side maths library, whose every function is one SPIR-V instruction.
+# a git dep rather than a path one on purpose: the wiring this case exists to
+# check is a call ACROSS A MODULE BOUNDARY into a real published library, which is
+# where the substitution has to happen, since a SPIR-V module is compiled per mach
+# module and a shader module may declare no linkage to call out through.
+[dep.mach-shader]
+git = "https://github.com/briar-systems/mach-shader"
+ref = "branch/main"

--- a/int/surface/spirv-ext-inst/src/main.mach
+++ b/int/surface/spirv-ext-inst/src/main.mach
@@ -1,0 +1,127 @@
+# SPIR-V extended-instruction fixture: a shader that does arithmetic a shader does
+#
+# The spirv-vector and spirv-interface cases cover the operators - add, multiply,
+# compare, lane access - and a stage's interface variables. Neither reaches past
+# `+` and `*`, which is exactly as far as a shader gets before it needs `sqrt`,
+# `normalize`, `dot` and `mix`. None of those four is an operator, and none is a
+# call SPIR-V can make: each is one instruction, drawn from the GLSL.std.450
+# extended set or, for `dot`, from the core opcode space (#2688).
+#
+# So the subject here is the substitution. `sh.normalize(n)` is written as a call
+# to a function in ANOTHER MODULE, and it must not come out as a call at all -
+# `shader.math` is compiled to its own `.spv`, a SPIR-V module is compiled per mach
+# module, and a shader module may declare no Linkage capability, so there is no
+# import for anything to bind. The call site is the only place the instruction can
+# appear, and this file is what proves it does.
+#
+# THE OBSERVABLE IS THE DISASSEMBLY, not the validator's verdict. That distinction
+# is the whole reason the case has its own producer. Every wrong outcome available
+# here passes spirv-val: a `sh.sqrt` left as an OpFunctionCall to an unresolved
+# function, an OpExtInst carrying 32 instead of 31 (that is InverseSqrt, and it
+# validates), a `dot` emitted as an OpExtInst into GLSL.std.450 rather than as core
+# OpDot (450 has no entry 148, but a plausible wrong number does exist for it), an
+# instruction given two operands where it takes three. The golden names the set,
+# the instruction and the operand count of every one, so each of those is a diff.
+#
+# `shader.math` is a GIT dependency, not a copy in this directory. The thing under
+# test is a cross-module reference resolving through a signature-only declaration
+# and picking the decorator up off the ORIGIN module's AST, which a same-module
+# copy would not exercise at all.
+
+use sh: shader.math;
+# a second module of this project that touches none of it. Its `.spv` is what makes
+# "the extended set is imported only when used" an assertion: it is a real shader
+# stage doing real arithmetic, and its row in the golden reads `extimports=0`. A
+# module with nothing in it would prove nothing, since an empty module imports
+# nothing whatever the rule is.
+use case.plain;
+
+#[input(0)] var in_normal:   f32x4;
+#[input(1)] var in_light:    f32x4;
+#[input(2)] var in_view:     f32x4;
+#[input(3)] var in_rough:    f32;
+
+#[output(0)] var out_colour: f32x4;
+
+#[builtin("position")] var position: f32x4;
+
+rec Material {
+    albedo:  f32x4;
+    ambient: f32x4;
+}
+#[uniform(0, 0)] var material: Material;
+
+# the fragment stage from the issue, written out. It reaches four different shapes
+# of extended instruction in one expression chain and is the case's centre:
+#
+#   Normalize   one vector operand,  vector result
+#   OpDot       two vector operands, SCALAR result - and CORE, not extended
+#   FMax        two scalar operands, scalar result
+#   FMix        three vector operands
+#
+# The scalar-from-vector shapes matter more than they look. A call's result vreg is
+# typed from the callee's declared return type, and the callee here is a
+# declaration in another module; typing it from the move instead gave `dot` a
+# vector-typed backing variable and `sqrt` a 64-bit one, from identical IR, and the
+# module then failed at the store rather than at the call.
+#[stage("fragment")]
+fun frag_main() {
+    val n: f32x4 = sh.normalize(in_normal);
+    val d: f32   = sh.max(sh.dot(n, in_light), 0.0);
+    val s: f32   = sh.sqrt(d);
+    out_colour   = sh.mix4(material.ambient, material.albedo, f32x4{s, s, s, s});
+}
+
+# a specular term, which is where the exponential family earns its place. `pow` and
+# `clamp` are the three-operand and two-operand scalar forms, and `reflect` is a
+# two-vector geometric one whose result feeds another instruction rather than a
+# store - the emitter has to hand an OpExtInst's result id straight on as another
+# instruction's operand, not only into a variable.
+#[stage("fragment")]
+fun spec_main() {
+    val n: f32x4 = sh.normalize(in_normal);
+    val r: f32x4 = sh.reflect(in_view, n);
+    val c: f32   = sh.clamp(sh.dot(r, in_light), 0.0, 1.0);
+    val e: f32   = sh.pow(c, sh.max(in_rough, 0.001));
+    out_colour   = sh.mix4(material.ambient, material.albedo, f32x4{e, e, e, e});
+}
+
+# the per-lane forms, which are a distinct emitter path from the scalar ones only
+# in the types they carry - and that is the point of exercising both. `abs4`,
+# `sqrt4` and `floor4` are the SAME GLSL.std.450 instructions as `abs`, `sqrt` and
+# `floor`; a result type taken from the operands rather than from the declared
+# return would still validate here and be wrong in the scalar functions above.
+#[stage("fragment")]
+fun lane_main() {
+    val a: f32x4 = sh.abs4(in_normal);
+    val b: f32x4 = sh.sqrt4(sh.max4(a, material.ambient));
+    val c: f32x4 = sh.floor4(sh.fract4(b));
+    out_colour   = sh.clamp4(c, material.ambient, material.albedo);
+}
+
+# the length / distance pair: vector in, scalar out, like `dot`, but extended
+# rather than core. Having both a core and an extended instruction with that shape
+# in the same module is what would catch the two being swapped.
+#[stage("fragment")]
+fun dist_main() {
+    val l: f32 = sh.length(in_normal);
+    val d: f32 = sh.distance(in_view, in_light);
+    val t: f32 = sh.smooth_step(0.0, l, d);
+    out_colour = f32x4{t, t, t, t};
+}
+
+# a vertex stage, so the module is not fragment-only and the substitution is shown
+# to be independent of the execution model. `fma` is the three-operand scalar form
+# and `radians` a one-operand one that is nearly free to get wrong: it takes and
+# returns a scalar, so an emitter that dropped the operand entirely would produce
+# an instruction of the right arity for something else.
+#[stage("vertex")]
+fun vertex_main() {
+    val k: f32 = sh.fma(in_rough, 2.0, 1.0);
+    val a: f32 = sh.sin(sh.radians(k));
+    position   = sh.normalize(f32x4{a, k, in_rough, 1.0});
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/int/surface/spirv-ext-inst/src/plain.mach
+++ b/int/surface/spirv-ext-inst/src/plain.mach
@@ -1,0 +1,20 @@
+# the on-demand half of the case: a shader that uses none of `shader.math`
+#
+# `OpExtInstImport "GLSL.std.450"` is required to be emitted only when the module
+# actually uses the set (#2688), and the only way to assert a negative is to have a
+# module that would show the import if the rule were dropped. So this is a real
+# stage doing real arithmetic - not an empty module, which would read
+# `extimports=0` however the emitter behaved - and its row in the golden is the
+# assertion.
+#
+# It is a separate mach module rather than another function in main.mach on
+# purpose: the import is a per-MODULE fact, and main.mach's own module does use the
+# set, so a function inside it could never show the absence.
+
+#[input(4)]  var plain_in:  f32x4;
+#[output(4)] var plain_out: f32x4;
+
+#[stage("fragment")]
+fun plain_main() {
+    plain_out = (plain_in + plain_in) * plain_in;
+}

--- a/int/surface/spirv-interface/src/main.mach
+++ b/int/surface/spirv-interface/src/main.mach
@@ -8,9 +8,11 @@
 # Block-decorated struct with explicit member offsets, and an entry point must name
 # its Input and Output variables.
 #
-# NOT here: reading a MEMBER of the uniform block (`camera.view`). It is refused by
-# name, because SPIR-V reaches a member through an `OpAccessChain` naming its
-# ordinal and MIR has already folded that walk into a byte displacement (#2649).
+# Reading a MEMBER of the uniform block IS here now (#2649): MIR keeps the GEP's
+# index list on a logical-addressing target, so the walk reaches the back end as
+# ordinals and becomes an `OpAccessChain`. `transform.model[2]` is the nested case -
+# a struct member that is an array, indexed - which lowers to two chained GEPs and
+# is what a flat `camera.view` would not exercise.
 #
 # A scalar `f32` interface variable IS here, in both directions, and it is the
 # #2655 pin. It used to be refused alongside the member walk: MIR materialized a
@@ -93,7 +95,7 @@ rec Scene {
 fun vertex_main() {
     position    = in_position;
     point_size  = 1.0;
-    vary_colour = in_colour;
+    vary_colour = in_colour + camera.tint + transform.model[2];
 }
 
 # a second vertex stage doing arithmetic between the interface reads and writes, so

--- a/int/surface/spirv-op-refused/case.conf
+++ b/int/surface/spirv-op-refused/case.conf
@@ -1,0 +1,14 @@
+# `#[spirv_op(set, name)]` names a closed value set, and this is the case that
+# holds it closed (#2688). A misspelt instruction is the failure with no other
+# symptom: the decorator would carry no opcode, the call would stay an ordinary
+# call, and on a shader target that call resolves to nothing at all - so the
+# report would arrive as a driver rejecting the module, not as an error on the
+# line that caused it.
+#
+# The build target is linux ON PURPOSE. The check belongs on EVERY target, not
+# only the one that acts on the decorator: which target a module is built for is
+# not a property of its source, and a library carrying this typo would otherwise
+# compile clean on every CPU build and fail only for whoever built it for a GPU.
+# Running the case where the decorator is inert is what asserts that.
+run: build-fails
+targets: linux

--- a/int/surface/spirv-op-refused/expect.linux.txt
+++ b/int/surface/spirv-op-refused/expect.linux.txt
@@ -1,0 +1,4 @@
+error: unknown SPIR-V instruction set; `spirv_op` accepts "core" or "GLSL.std.450"
+error: that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one
+error: that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one
+error: that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one

--- a/int/surface/spirv-op-refused/mach.toml
+++ b/int/surface/spirv-op-refused/mach.toml
@@ -1,0 +1,30 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/int"
+
+# a CPU target, deliberately. `#[spirv_op]` is inert here - nothing on this target
+# reads it - and the point of the case is that its value sets are still closed.
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-op-refused/src/main.mach
+++ b/int/surface/spirv-op-refused/src/main.mach
@@ -1,0 +1,33 @@
+# `#[spirv_op]` value sets are closed, on every target
+#
+# Both halves are checked and both are reported, because they are different
+# mistakes: an instruction set that does not exist, and an instruction that set
+# does not define. Reporting only a combined refusal would leave "GLSL.std.450
+# defines no Sqrtf" unsaid, which is the more useful of the two.
+#
+# The whole point of this file is that it is built for a CPU target, where the
+# decorator does nothing whatever. It still must not compile.
+
+# a set nobody registers. it must NOT fall back to the extended set, which is what
+# would make the typo invisible.
+#[spirv_op("GLSL.std.451", "Sqrt")]
+pub fun bad_set(x: f32) f32;
+
+# a plausible misspelling of a real instruction. `Sqrtf` is what a C programmer
+# reaches for, and GLSL.std.450 has no such entry.
+#[spirv_op("GLSL.std.450", "Sqrtf")]
+pub fun bad_name(x: f32) f32;
+
+# a real GLSL.std.450 instruction looked up in the CORE set, which is the mistake
+# the `dot` split invites in the other direction: the sets answer only for their
+# own instructions, and neither borrows from the other.
+#[spirv_op("core", "Normalize")]
+pub fun wrong_set(v: f32x4) f32x4;
+
+# core `OpDot` asked for from the extended set, the same mistake mirrored. This is
+# the one a reader is most likely to make, since GLSL spells `dot` beside
+# `normalize` and `length`.
+#[spirv_op("GLSL.std.450", "OpDot")]
+pub fun dot_is_core(a: f32x4, b: f32x4) f32;
+
+fun main() i32 { ret 0; }

--- a/int/surface/spirv-shader-only/case.conf
+++ b/int/surface/spirv-shader-only/case.conf
@@ -1,0 +1,16 @@
+# `shader.math` is a shader-only module and this is the case that keeps it one
+# (#2688).
+#
+# The library's functions have no bodies. On a SPIR-V target that is invisible,
+# because no call to one is ever emitted as a call - the call site becomes the
+# instruction. On any other target a program that calls one must FAIL TO LINK,
+# naming the symbol, and that is the observable here.
+#
+# The alternative the project rejected was native bodies, so the same source also
+# runs on a CPU. The only sensible implementation of each would have been to call
+# `std.math`, which would make `sh.sqrt` and `math.sqrt_f32` the same function on a
+# CPU and different functions on a GPU - the one outcome of the three that never
+# errors and is always slightly wrong. A decision documented in a README is a
+# decision until someone gives the library a body; this case is what makes it hold.
+run: build-fails
+targets: linux

--- a/int/surface/spirv-shader-only/expect.linux.txt
+++ b/int/surface/spirv-shader-only/expect.linux.txt
@@ -1,0 +1,1 @@
+error: undefined symbol: _M6shader4mathN4sqrt

--- a/int/surface/spirv-shader-only/mach.toml
+++ b/int/surface/spirv-shader-only/mach.toml
@@ -1,0 +1,33 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/int"
+
+# a CPU target, deliberately: the whole case is what `shader.math` does on one.
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-shader]
+git = "https://github.com/briar-systems/mach-shader"
+ref = "branch/main"

--- a/int/surface/spirv-shader-only/src/main.mach
+++ b/int/surface/spirv-shader-only/src/main.mach
@@ -1,0 +1,16 @@
+# `shader.math` on a CPU target: a link error, loudly, at build time
+#
+# This is the documented failure mode of a shader-only module, asserted rather than
+# described. The observable is the linker naming the undefined symbol, so a change
+# that gave these functions bodies - or that made the reference resolve to
+# something, anything, silently - fails here.
+#
+# The mangled name is part of the observable on purpose. "undefined symbol" alone
+# would still pass if the wrong symbol went missing.
+
+use sh: shader.math;
+
+fun main() i32 {
+    if (sh.sqrt(4.0) > 1.0) { ret 0; }
+    ret 1;
+}

--- a/int/surface/spirv-storage/src/main.mach
+++ b/int/surface/spirv-storage/src/main.mach
@@ -19,11 +19,16 @@
 # here. Both halves of that are checked: this case declares the shapes a uniform
 # block cannot carry, and the spirv-interface case keeps the uniform-side refusal.
 #
-# NOT here: reading or writing any of these buffers. A block member is reached
-# through an `OpAccessChain` naming its ordinal, and MIR folds the member walk into
-# a byte displacement before the back end sees it, so the member access is refused
-# by name. The buffers are declared, laid out and bound correctly - which the
-# validator confirms - and become readable when the ordinal survives lowering.
+# Reading and writing these buffers IS here now. MIR keeps a GEP's index list on a
+# logical-addressing target (#2649), so a member walk reaches the back end as
+# ordinals and becomes an `OpAccessChain`. A compute stage can therefore read its
+# input buffer and write its output one, which is what #2658 said no compute shader
+# could do.
+#
+# The nested cases matter more than the flat ones: `out.rows[i]` lowers to TWO
+# chained GEPs, the second based on the first's result, so the emitter has to accept
+# a pointer as an access chain's base rather than only the variable. A flat
+# `buf.member` would pass without exercising that at all.
 #
 # Also not here: the three compute built-ins. `global_invocation`,
 # `local_invocation` and `workgroup_id` are three-component unsigned vectors by the
@@ -67,8 +72,25 @@ rec Config {
 }
 #[uniform(2, 0)] var config: Config;
 
+# a read-write buffer the compute stage moves data through. `rows` is an array
+# member, so writing `rows[i]` exercises the CHAINED access-chain path - two GEPs,
+# the second based on the first's result - rather than a single flat member walk,
+# which is the case a flat `buf.member` would leave untested.
+rec Scratch {
+    acc:  f32x4;
+    rows: [4]f32x4;
+}
+#[storage(3, 0)] var scratch: Scratch;
+
+# a compute stage that actually moves data: reads one storage buffer, writes
+# another, and indexes an array member on the way. This is the shape #2658 named as
+# impossible - a stage that can be dispatched and can read or write nothing.
 #[stage("compute")] #[workgroup(64, 1, 1)]
-fun simulate() { }
+fun simulate() {
+    scratch.acc = particles.velocity[0] + particles.velocity[1];
+    scratch.rows[0] = particles.position[0];
+    scratch.rows[3] = scratch.acc * scratch.acc;
+}
 
 #[stage("compute")] #[workgroup(8, 8, 1)]
 fun reduce() { }

--- a/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
+++ b/int/surface/spirv-unsupported-names-opcode/expect.spirv.txt
@@ -1,1 +1,1 @@
-error: a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live (MIR_ALLOCA in sum_pair, at ./src/main.mach:15:5)
+error: a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`) (MIR_LOAD in bump, at ./src/main.mach:24:15)

--- a/int/surface/spirv-unsupported-names-opcode/src/main.mach
+++ b/int/surface/spirv-unsupported-names-opcode/src/main.mach
@@ -1,23 +1,33 @@
-# A local array indexed by a RUNTIME value forces the front end to materialize
-# storage that no optimization can promote away, which reaches the SPIR-V backend
-# as MIR_ALLOCA. The logical addressing model has no way to express it, so the
-# backend refuses - correctly. What this case pins is the SHAPE of that refusal,
-# not the refusal itself.
+# A plain module-scope variable reaches the SPIR-V backend as a load against a
+# symbol with no storage class it could live in: a shader has no general global
+# storage, and a `val` / `var` reaches a stage only by carrying an interface role.
+# The backend refuses - correctly. What this case pins is the SHAPE of that
+# refusal, not the refusal itself.
 #
-# The runtime index is load-bearing: with a constant one the release pipeline
-# promotes the array into registers and the refusal never fires, so the case would
-# assert the message in `debug` and assert nothing at all in `release`.
+# THIS FIXTURE WAS A LOCAL ARRAY INDEXED BY A RUNTIME VALUE, and it stopped
+# refusing. A local allocation is now a Function-storage `OpVariable` and a runtime
+# index is an `OpAccessChain` with a dynamic index, so the shape compiles. The case
+# was repointed rather than deleted, because what it guards - that a refusal names
+# its opcode, its function and its position - is unchanged and still worth pinning.
 #
-# `sum_pair` is deliberately not the entry: the message has to name the function
-# the instruction is in, and a single-function fixture could satisfy that by
-# naming any function at all.
-fun sum_pair(a: i32, b: i32) i32 {
-    var buf: [2]i32;
-    buf[0] = a;
-    buf[1] = b;
-    ret buf[a % 2] + buf[b % 2];
+# The shape chosen instead is a durable one. A shader having no general global
+# storage is a property of the execution model rather than a gap in this backend,
+# so unlike the previous fixture it will not compile out from under the case.
+#
+# `bump` is deliberately not the entry: the message has to name the function the
+# instruction is in, and a single-function fixture could satisfy that by naming any
+# function at all. The global is read AND written so the refusal does not depend on
+# which of the two the backend happens to reach first.
+var counter: i32;
+
+fun bump(a: i32) i32 {
+    counter = counter + a;
+    ret counter;
 }
 
+#[stage("vertex")]
+fun vs() { }
+
 fun main() i32 {
-    ret sum_pair(1, 2);
+    ret bump(1);
 }

--- a/int/surface/spirv-vector/src/main.mach
+++ b/int/surface/spirv-vector/src/main.mach
@@ -6,15 +6,20 @@
 # Khronos validator is the observable, as in the sibling spirv-module and
 # spirv-float cases.
 #
-# WHAT IS NOT HERE, and why: a vector LITERAL (`f32x4{1.0, 2.0, 3.0, 4.0}`) and an
-# uninitialized vector local. Both lower to an `alloca [4]f32` written lane by lane
-# and then read back with a whole-vector `load f32x4` - reinterpreting an array
-# allocation as a vector through its pointer. SPIR-V's logical addressing model
-# cannot express that at all: a pointer there has exactly one pointee type and
-# there is no pointer bitcast. That is a lowering to fix ahead of the back end, not
-# an emitter gap, so the backend refuses it by name and this case builds its
-# vectors from parameters instead. When the lowering stops going through memory,
-# the literal cases belong here.
+# VECTOR LITERALS AND UNINITIALIZED LOCALS ARE HERE. They were absent while a
+# literal round-tripped through an array allocation reinterpreted as a vector,
+# which logical addressing cannot express. Three upstream changes removed that:
+# the allocation is now made at the vector's own type (#2640), a slot records the
+# type it was allocated at (#2673), and `memzero` survives as a whole-object
+# operation instead of a run of byte stores (#2669). A local allocation is now a
+# Function-storage `OpVariable`, a zero-init is one `OpStore` of `OpConstantNull`,
+# and a literal's per-lane writes are `OpAccessChain` from the ordinals MIR keeps.
+#
+# The broadcast case below is the one to keep. `f32x4{t, t, t, t}` is the only way
+# to scale a vector by a computed scalar, because the language has no implicit
+# scalar-to-vector conversion and no vector-by-scalar operator - so while literals
+# were refused there was NO way to express the most common shader operation after
+# add and multiply. A constant-lane literal alone would not have covered it.
 #
 # Also absent by construction: `i8x16` / `u8x16` and `i16x8` / `u16x8`. Every mach
 # vector is 128 bits, so those need 16 and 8 components, and a Shader module's
@@ -126,4 +131,49 @@ fun composed(a: f32x4, b: f32x4) f32x4 {
 
 fun main() i32 {
     ret 0;
+}
+
+# a vector literal with constant lanes: the classic case, and the one whose
+# allocation used to be reinterpreted.
+fun literal_const() f32x4 {
+    ret f32x4{1.0, 2.0, 3.0, 4.0};
+}
+
+# an uninitialized vector local, which is a whole-object zero rather than a
+# lane-by-lane one: `OpStore` of `OpConstantNull`, no stores per lane at all.
+fun zeroed() f32x4 {
+    var z: f32x4;
+    ret z;
+}
+
+# a literal whose lanes are RUNTIME values - the broadcast that had no other
+# spelling. Each lane is an access chain write into the local, so this exercises
+# the ordinals rather than a constant fold.
+fun broadcast(t: f32) f32x4 {
+    ret f32x4{t, t, t, t};
+}
+
+# broadcast feeding real arithmetic, which is what a shader actually writes when it
+# scales a colour or a position by a computed factor.
+fun scaled(v: f32x4, k: f32) f32x4 {
+    ret v * f32x4{k, k, k, k};
+}
+
+# a local array of vectors, indexed: a local allocation reached by an access chain
+# rather than read whole.
+fun from_array(v: f32x4) f32x4 {
+    var rows: [4]f32x4;
+    rows[0] = v;
+    rows[2] = v * v;
+    ret rows[0] + rows[2];
+}
+
+# a local record, whose plain undecorated struct type must be INTERNED - two locals
+# of one `rec` sharing one type - unlike a descriptor block, whose decorations make
+# it distinct.
+rec Pair { a: f32x4; b: f32x4; }
+fun from_record(v: f32x4) f32x4 {
+    var p: Pair;
+    p.a = v;
+    ret p.a + p.b;
 }

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.12.0"
+version = "4.13.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -795,10 +795,15 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     # assign each merged section a virtual address (an executable or a shared
     # object; a relocatable library carries none). sections are placed in canonical
     # order from the OS base, each kind page-aligned; a position-independent image
-    # (PIE or shared) is based a page above.
+    # (PIE or shared) is based a page above. the header reservation above the base is
+    # provisional until the dynamic plan is built and the image shape can be measured
+    # (see `measure_header_shape` below); a format whose header outgrows it reassigns
+    # from the measured shape then.
     val assign_vaddrs: bool = (mode == LINK_EXE) || shared;
+    var header_reserve: u64 = 0;
     if (assign_vaddrs) {
-        assign_section_vaddrs(tgt, merged, position_independent);
+        header_reserve = header_reserve_bytes(tgt, position_independent, nil::*of.HeaderShape);
+        assign_section_vaddrs(tgt, merged, header_reserve);
         finalize_placement_vaddrs(merged, placements, sec_total);
     }
 
@@ -832,7 +837,7 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
             ret R.err[bool, str](R.unwrap_err[bool, str](gp_r));
         }
         if (local_got.count > 0) {
-            assign_section_vaddrs(tgt, merged, position_independent);
+            assign_section_vaddrs(tgt, merged, header_reserve);
             finalize_placement_vaddrs(merged, placements, sec_total);
             finalize_local_got_vaddrs(merged, ?local_got);
 
@@ -920,6 +925,37 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
                 free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
+            }
+        }
+
+        # the image shape is settled now, so the header reservation can be sized for
+        # real. a format whose header outgrew the provisional page gets a wider span,
+        # which moves every load segment up: virtual addresses are reassigned and the
+        # symbol table recollected before any relocation reads an address. the header
+        # size does not depend on those addresses, so this converges in one step.
+        if (assign_vaddrs) {
+            var shape: of.HeaderShape;
+            measure_header_shape(s, ?out_img, merged, ?groups, ?dyn, position_independent, ?shape);
+            val want: u64 = header_reserve_bytes(tgt, position_independent, ?shape);
+            if (want > header_reserve) {
+                header_reserve = want;
+                assign_section_vaddrs(tgt, merged, header_reserve);
+                finalize_placement_vaddrs(merged, placements, sec_total);
+                if (local_got.count > 0) { finalize_local_got_vaddrs(merged, ?local_got); }
+
+                map.dnit[intern.StrId, SymbolLoc](?sym_locs);
+                sym_locs = map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
+                val recollect: R.Result[bool, str] = collect_symbols(
+                    s, modules, module_count, placements, sec_base, ?sym_locs,
+                    assign_vaddrs, ?atoms);
+                if (R.is_err[bool, str](recollect)) {
+                    free_dynstate(alloc, ?dyn);
+                    obj.dnit(?out_img);
+                    free_local_got_plan(alloc, ?local_got);
+                    map.dnit[intern.StrId, SymbolLoc](?sym_locs);
+                    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
+                    ret R.err[bool, str](R.unwrap_err[bool, str](recollect));
+                }
             }
         }
 
@@ -3707,16 +3743,11 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
 # give each used merged section a base virtual address,
 # starting from the OS base and page-aligning each kind's start
 #
-# An image whose header maps inside its first load segment reserves the first page
+# An image whose header maps inside its first load segment reserves `reserve` bytes
 # above the base for it, so that segment (which maps the header at its start)
 # begins exactly at the base - for Mach-O, __TEXT on the base with __PAGEZERO
-# spanning [0, base). The writer asserts the header fits the one-page reservation.
-#
-# Two independent things ask for the reservation and it is one page either way: a
-# position-independent image (PIE or shared) always reserves it, and so does any
-# format that maps its header inside the first segment (`of.header_in_first_segment`,
-# true for Mach-O), whose non-PIE layout would otherwise be framed a page below the
-# base (#2599).
+# spanning [0, base). `header_reserve_bytes` sizes the reservation; the writer lays
+# the header into exactly it and fails if the header outgrew it.
 #
 # Each kind's start is aligned up to at least the OS page, so every merged segment
 # begins on a fresh page and thus owns its trailing (partial) page - no two segments
@@ -3724,15 +3755,15 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
 # the `.data.rel.ro` RELRO region up to a page boundary cannot reach into the following
 # segment's pages.
 # ---
-# tgt:    active target - supplies the OS base address and page size
-# merged: the per-kind accumulators, whose vaddrs are assigned in place
-# pie:    true when the image is position-independent (PIE or shared)
-fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection, pie: bool) {
+# tgt:     active target - supplies the OS base address and page size
+# merged:  the per-kind accumulators, whose vaddrs are assigned in place
+# reserve: bytes left above the base for the image header, from
+#          `header_reserve_bytes`; 0 for a format that maps its header elsewhere
+fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection, reserve: u64) {
     val base: u64 = os_base_addr(tgt);
     val page: u64 = os_page_size(tgt);
 
-    var va: u64 = base;
-    if (pie || header_reserve_page(tgt)) { va = base + page; }
+    var va: u64 = base + reserve;
     var i: u32 = 0;
     for (i < MERGED_KIND_COUNT) {
         if (merged[i].used && is_loadable_kind(merged[i].kind)) {
@@ -6389,18 +6420,98 @@ fun image_name(modules: *of.ObjectImage, module_count: u32) intern.StrId {
 }
 
 # whether the target's object format maps the image header inside the first load
-# segment, so the linker must leave a page above the base for it
+# segment, so the linker must leave room above the base for it
 #
-# The reservation belongs to the format, not to position independence: Mach-O
-# frames __TEXT one header span below its first content byte in both the
-# LC_MAIN and LC_UNIXTHREAD layouts, so without the gap a non-PIE image is based
-# a page low and its __PAGEZERO is short by the same page (#2599)
+# Whether to reserve, not how much - `header_reserve_bytes` sizes it. The
+# reservation belongs to the format, not to position independence: Mach-O frames
+# __TEXT one header span below its first content byte in both the LC_MAIN and
+# LC_UNIXTHREAD layouts, so without the gap a non-PIE image is based a page low and
+# its __PAGEZERO is short by the same page (#2599)
 # ---
 # tgt: active target - supplies the object-format vtable
-# ret: true when a header page must be reserved above the image base
+# ret: true when a header span must be reserved above the image base
 fun header_reserve_page(tgt: *target.Target) bool {
     if (tgt.of == nil) { ret false; }
     ret tgt.of.header_in_first_segment;
+}
+
+# how many bytes to leave above the image base for the header, before the first
+# load segment
+#
+# Two independent things ask for a reservation: a position-independent image (PIE
+# or shared) always wants one, and so does any format that maps its header inside
+# the first segment (`of.header_in_first_segment`, true for Mach-O), whose non-PIE
+# layout would otherwise be framed a page below the base (#2599). One page covers
+# both, except for a format whose header grows with the image: Mach-O carries a
+# command per segment, section and dependency and outgrows a page on a large link
+# (#2690), so it sizes the span itself through `of.header_span`.
+#
+# `shape` is nil on the provisional first assignment, before the dynamic plan
+# exists. That reserves a page, which is what every image got before; the caller
+# measures the real shape once the plan is built and reassigns if it wants more.
+# ---
+# tgt:   active target - supplies the page size and the object-format vtable
+# pie:   true when the image is position-independent (PIE or shared)
+# shape: the measured image shape, or nil before it is known
+# ret:   bytes to reserve above the base, a multiple of the page size
+fun header_reserve_bytes(tgt: *target.Target, pie: bool, shape: *of.HeaderShape) u64 {
+    if (!pie && !header_reserve_page(tgt)) { ret 0; }
+    val page: u64 = os_page_size(tgt);
+    if (tgt.of == nil || tgt.of.header_span == nil || shape == nil) { ret page; }
+    val want: u64 = tgt.of.header_span(shape, page);
+    if (want <= page) { ret page; }
+    ret bin.align_up_u64(want, page);
+}
+
+# measure the image shape the header reservation is sized from
+#
+# Every field is settled by the time the dynamic plan is built, and none of them
+# depends on a virtual address, so measuring here and reassigning virtual addresses
+# from the answer converges in one step rather than iterating.
+# ---
+# s:       shared session, for the interner the format resolves names through
+# out_img: the merged image, for its non-allocated debug sections
+# merged:  the per-kind accumulators
+# groups:  the planned named-section groups
+# dyn:     the dynamic-link state (its plan may name no dependency)
+# pie:     true when the image is position-independent
+# shape:   out - the measured shape
+fun measure_header_shape(s: *session.Session, out_img: *of.ObjectImage, merged: *MergedSection,
+                         groups: *SectionGroups, dyn: *DynState, pie: bool,
+                         shape: *of.HeaderShape) {
+    shape.itn       = ?s.interner;
+    shape.libs      = dyn.info.libs;
+    shape.lib_count = dyn.info.lib_count;
+    shape.pie       = pie;
+    shape.imports   = dyn.info.import_count > 0;
+
+    # the segments and sections `build_load_segments` will produce, counted the same
+    # way it counts them.
+    var segs:  u32 = 0;
+    var sects: u32 = 0;
+    var k:     u32 = 0;
+    for (k < MERGED_KIND_COUNT) {
+        if (is_loadable_kind(merged[k].kind) && merged[k].used && merged[k].len > 0) {
+            segs = segs + 1;
+            var i: u32 = 0;
+            for (i < groups.count) {
+                if (groups.items[i].slot == k && groups.items[i].len > 0) { sects = sects + 1; }
+                i = i + 1;
+            }
+        }
+        k = k + 1;
+    }
+
+    var dbg: u32 = 0;
+    var d:   u32 = 0;
+    for (d < out_img.section_count) {
+        if (out_img.sections[d].kind == of.SK_DEBUG) { dbg = dbg + 1; }
+        d = d + 1;
+    }
+
+    shape.seg_count   = segs;
+    shape.sect_count  = sects;
+    shape.debug_count = dbg;
 }
 
 # the base virtual address for the active target's executables. a per-target

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -376,7 +376,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     if (request.release(ctx.req)) { build_mode_id = comptime.MODE_RELEASE; }
     var build_pie: u32 = 0;
     if (ctx.req.pie) { build_pie = 1; }
-    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.compiler_name, p.compiler_ver);
+    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.target.model.vector_bits, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$bin.*` roots (the selected target's
     # declared tuple lives under `$project.target.*`); the target tuple comes from
     # the selected entry (set before any module loads).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2012,19 +2012,40 @@ test "mach.lang.driver:comptime_type_predicates" {
     # an INSTANCE of a record answers as the record: post-#2168 that is the type a
     # reflection loop actually meets for `Box[i64]`
     if (ut_arm("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
-    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $is_union, mirrored
     if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_union(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
     if (ut_arm("uni Box[T] { v: T; w: u32; }\nfun main() i32 { $if ($is_union(Box[i64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
-    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # $is_pointer covers BOTH spellings of a reference
     if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     if (ut_arm("fun main() i32 { $if ($is_pointer(ptr)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
-    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # `^` IS A CONSTRUCTOR AND A PREDICATE ANSWERS ABOUT THE OUTERMOST ONE (#2692).
+    # every predicate answers false for a `^`-qualified type, so a reflection walk
+    # refuses it rather than descending into secret storage. this reverses the
+    # earlier rule, under which `$is_record(^P)` was true while `$fields(^P)` refused
+    # the same operand - the gate and the intrinsic it gates disagreed, so a walk
+    # written exactly as the docs prescribe descended into a type `$fields` refused.
+    # pinned per predicate: a fix that made one of the three consistent and left the
+    # other two stripping would just move the hole.
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_union(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^*P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_record(^u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    # a `^` record is not a union or a pointer either: all three answer false, which
+    # is what makes "nothing classifies it" a usable signal on its own.
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_union(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_pointer(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    # OUTERMOST ONLY, which is the difference between `type.is_secret` and
+    # `type.carries_secret`. a PUBLIC pointer to secret storage is still a pointer:
+    # the address is public and detect-but-do-not-follow is the right treatment.
+    if (ut_arm("fun main() i32 { $if ($is_pointer(*^u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # a generic INSTANCE at a secret argument is not itself secret: `Box[^u64]` is a
+    # record whose field is secret, and the field is where the refusal belongs.
+    if (ut_arm("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_record(Box[^u64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # a predicate is comptime-only: there is no runtime boolean for one to become
     if (ut_vec_diag("rec P { a: u64; }\nfun main() i32 { val b: u8 = $is_record(P); ret 0; }\n",
@@ -2044,8 +2065,11 @@ test "mach.lang.driver:comptime_type_name" {
     if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # a composite spells compositely rather than degrading to the nominal
     if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(*Pair) == \"*Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
-    # the secret wrapper is stripped here too, so `^Pair` names `Pair`
-    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # `^` IS NOT stripped here (#2692). this name is meant to be the spelling sema
+    # prints in a diagnostic, and a diagnostic prints `^Pair` - yielding "Pair" would
+    # be a drift on the one qualifier where a drift matters most.
+    if (ut_arm("rec Pair { a: u64; }\nfun main() i32 { $if ($type_name(^Pair) == \"^Pair\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($type_name(*^u8) == \"*^u8\") { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
     # unlike the predicates it IS a value, usable outside a gate
     if (ut_layout_ok("rec Pair { a: u64; }\nfun main() i32 { val n: *u8 = $type_name(Pair); ret 0; }\n") != 0) { bad = 1; }
 
@@ -2067,11 +2091,34 @@ test "mach.lang.driver:comptime_reflection_descent" {
     # the spelling is pinned where a derive-style formatter would actually read it
     if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
-    # a SECRET-typed field met through the loop: the #2297 / #2373 shape arriving via
-    # the descriptor rather than as a literal `^T` spelling, which is how a real walk
-    # would meet it. an unstripped query answers "not a record" and the derive walk
-    # silently skips the field.
-    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # a SECRET-typed field met through the loop, which is how a real walk meets one
+    # rather than as a literal `^T` spelling. it answers NOT a record (#2692), so the
+    # walk refuses it instead of descending into secret storage.
+    #
+    # this reverses the earlier expectation, which was reasoned by analogy to
+    # #2297 (field resolution) and #2373 (cast width). those two are STORAGE
+    # questions - a secret occupies its base type's storage and has its base type's
+    # fields - and stripping is right for both. a predicate that gates a walk is not
+    # a storage question, and carrying the analogy across is what produced a gate
+    # that disagreed with the `$fields` it gates.
+    #
+    # the analogy's stated worry was that an unstripped query makes a walk silently
+    # SKIP the field. that is a property of how the walk writes its fallthrough, not
+    # of the predicate: a walk that classifies positively (record, or one of an
+    # explicit set of leaf types) and refuses everything else refuses the secret,
+    # which is the idiom the docs now prescribe and the one std.derive uses. and the
+    # old answer never bought a descent anyway - `$fields(^Inner)` refuses, so the
+    # walk failed there instead, with a message naming the wrong thing.
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+
+    # the positive-classification idiom itself: a `^` field reaches neither the
+    # descent arm nor the scalar arm, so a walk whose fallthrough is an $error
+    # refuses it by construction.
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($is_record(f.type)) { $error(\"REC\"); } $or (f.type == u64) { $error(\"SCALAR\"); } $or { $error(\"REFUSED\"); } } ret 0; }\n", "REFUSED", "REC") != 0) { bad = 1; }
+
+    # `$type_name` through the descriptor spells the `^`, so a refusal message can
+    # name what it refused
+    if (ut_arm("rec Inner { x: u64; }\nrec Outer { i: ^Inner; }\nfun main() i32 { $each f in $fields(Outer) { $if ($type_name(f.type) == \"^Inner\") { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
 
     # and the whole shape together: gate, then descend, over a MIXED record - which
     # is the case that could not be written at all before, since the inner $fields

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6309,6 +6309,11 @@ test "mach.lang.driver:vector_form_bounds_reported_as_themselves" {
         "narrower than this target's 128-bit vector register")) { bad = 1; }
     if (!ut_sema_rejects_with("fun main() i64 { var v: f32x2; ret 0; }\n",
         "narrower than this target's 128-bit vector register")) { bad = 1; }
+    # ...and it names the issue that lifts it, so the reader has a thread to pull
+    # rather than a dead end. asserted separately: the needle above still matches if
+    # the reference is dropped, so it would not have caught that on its own.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x3; ret 0; }\n",
+        "(#2697)")) { bad = 1; }
 
     # DEGENERATE LANE COUNT: its own sentence, not a width failure.
     if (!ut_sema_rejects_with("fun main() i64 { var v: f32x1; ret 0; }\n",

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6256,6 +6256,43 @@ test "mach.lang.driver:secret_gates_rejected" {
 # vector width (#2687), so the three refusals must each be reported as themselves rather
 # than collapsing into "unresolved type name", which is what a table lookup would say
 # about every one of them
+# a `rec` / `uni` / `def` whose name is spelled as a vector form is refused, because a
+# type spelling is read in type position ahead of scope and the declaration would be
+# silently unreachable (#2687). the hazard predates the form for the ten seeded names -
+# `rec u8x16` compiled clean and `$size_of(u8x16)` answered 16 from the builtin - so the
+# rule covers the ten too rather than being two rules wearing one name
+test "mach.lang.driver:vector_named_type_declaration_rejected" {
+    var bad: i32 = 0;
+    val need: str = "cannot also name a type";
+
+    # the ten that were already hazardous before the form existed
+    if (!ut_sema_rejects_with("rec u8x16 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+    if (!ut_sema_rejects_with("uni i32x4 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+    if (!ut_sema_rejects_with("def f32x4: i64;\nfun main() i64 { ret 0; }\n", need))        { bad = 1; }
+
+    # a shape the target does not currently admit is reserved just the same: `f32x3` and
+    # `f32x7` are still vector SPELLINGS, and letting a type take the name would plant a
+    # collision for whenever the bound moves.
+    if (!ut_sema_rejects_with("rec f32x3 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+    if (!ut_sema_rejects_with("rec f32x7 { a: i64; }\nfun main() i64 { ret 0; }\n", need))  { bad = 1; }
+
+    # NOT A VECTOR SPELLING: ordinary type names are untouched, which is the arm that
+    # must not be lost - the guard keys on the grammar, not on containing an `x`.
+    if (!ut_sema_clean("rec matrix4 { a: i64; }\nfun main() i64 { ret 0; }\n"))             { bad = 1; }
+    if (!ut_sema_clean("rec Vertex { pos: i64; }\nfun main() i64 { ret 0; }\n"))            { bad = 1; }
+    if (!ut_sema_clean("rec f32x04 { a: i64; }\nfun main() i64 { ret 0; }\n"))              { bad = 1; }
+    if (!ut_sema_clean("def ptrx2: i64;\nfun main() i64 { ret 0; }\n"))                     { bad = 1; }
+
+    # VALUES ARE UNAFFECTED. a value named for a vector is not shadowed by anything,
+    # since the form is read in type position only, and mach's own sources name locals
+    # after the shapes they carry. refusing these would be a break for no hazard.
+    if (!ut_sema_clean("fun main() i64 { val f32x4: i64 = 7; ret f32x4; }\n"))               { bad = 1; }
+    if (!ut_sema_clean("fun i32x4() i64 { ret 3; }\nfun main() i64 { ret i32x4(); }\n"))    { bad = 1; }
+    if (!ut_sema_clean("var u8x16: i64;\nfun main() i64 { ret u8x16; }\n"))                 { bad = 1; }
+
+    ret bad;
+}
+
 test "mach.lang.driver:vector_form_bounds_reported_as_themselves" {
     var bad: i32 = 0;
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6252,6 +6252,55 @@ test "mach.lang.driver:secret_gates_rejected" {
 # The predicate keys on the DECLARATION, not the type: a bare generic name types as
 # `fun(T) T`, but so does a local of that type, and the address of that VARIABLE is a
 # legitimate `*fun(T) T` which must keep working.
+# a vector spelling is READ as the form `<element>x<lanes>` and bounded by the target's
+# vector width (#2687), so the three refusals must each be reported as themselves rather
+# than collapsing into "unresolved type name", which is what a table lookup would say
+# about every one of them
+test "mach.lang.driver:vector_form_bounds_reported_as_themselves" {
+    var bad: i32 = 0;
+
+    # TOO WIDE: names the width asked for and the width the target has.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x7; ret 0; }\n",
+        "is 224 bits wide, more than this target's 128-bit vector width")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f64x3; ret 0; }\n",
+        "is 192 bits wide, more than this target's 128-bit vector width")) { bad = 1; }
+
+    # SUB-WIDTH: refused because codegen cannot carry a vector narrower than the
+    # register yet, and the message says so rather than blaming the spelling. this is
+    # the arm that must change to a clean compile when that restriction lifts.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x3; ret 0; }\n",
+        "narrower than this target's 128-bit vector register")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x2; ret 0; }\n",
+        "narrower than this target's 128-bit vector register")) { bad = 1; }
+
+    # DEGENERATE LANE COUNT: its own sentence, not a width failure.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x1; ret 0; }\n",
+        "needs at least 2 lanes")) { bad = 1; }
+
+    # NOT A VECTOR AT ALL: still an ordinary unresolved name, so the form reader has
+    # not swallowed identifiers that merely contain an `x`.
+    if (!ut_sema_rejects_with("fun main() i64 { var v: matrix4; ret 0; }\n",
+        "unresolved type name")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: f32x04; ret 0; }\n",
+        "unresolved type name")) { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i64 { var v: ptrx2; ret 0; }\n",
+        "unresolved type name")) { bad = 1; }
+
+    # THE REGRESSION BAR - every one of the ten shapes that resolved before #2687 still
+    # resolves, now through the form rather than a seeded name. this is the arm that
+    # must not be lost.
+    if (!ut_sema_clean("fun main() i64 { var a: f32x4; var b: f64x2; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: i8x16; var b: i16x8; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: i32x4; var b: i64x2; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: u8x16; var b: u16x8; ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("fun main() i64 { var a: u32x4; var b: u64x2; ret 0; }\n"))  { bad = 1; }
+    # a value may still be named for a vector spelling: the form is read in type
+    # position only, so this must not start colliding.
+    if (!ut_sema_clean("fun main() i64 { val f32x4: i64 = 3; ret f32x4; }\n"))      { bad = 1; }
+
+    ret bad;
+}
+
 test "mach.lang.driver:addr_of_uninstantiated_generic_rejected" {
     var bad: i32 = 0;
     val need: str = "cannot take the address of an uninstantiated generic function";

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6131,7 +6131,7 @@ fun ut_sema_extent_is(text: str, name: str, size: u32, align: u32) i32 {
         val tid: O.Option[type.TypeId] = ut_nominal_typeid(?s, name);
         if (O.is_some[type.TypeId](tid)) {
             # the corpus is built for the host x86_64 target, so pointer width is 8
-            val e: layout.Extent = generics.type_extent(?s, 8, O.unwrap[type.TypeId](tid));
+            val e: layout.Extent = generics.type_extent(?s, layout.machine(8, 128), O.unwrap[type.TypeId](tid));
             if (e.ok && e.size == size && e.align == align) { bad = 0; }
         }
     }

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -710,6 +710,10 @@ fun ast_alloc(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
 # The os, arch, abi, and pointer width this compiler binary was built for. The
 # editor resolves a buffer with no project-selected target, so `$if` predicates
 # evaluate against the running compiler rather than an unknown placeholder.
+#
+# The vector width is the named 128 rather than a registry read: the buffer's
+# context is seeded before the isa registry is brought up, and every target
+# declares the same width, so there is nothing a lookup would learn.
 # ---
 # es:  the editor session
 # ret: a host-seeded ComptimeCtx
@@ -722,6 +726,7 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         comptime.MODE_DEBUG,
         0,
         target.host_pointer_width(),
+        isa.VECTOR_BITS_128,
         intern.STR_NIL,
         intern.STR_NIL
     );

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -280,6 +280,10 @@ pub def FrameMark: u32;
 # build_pie:      1 when the build is position-independent (`--pie`), 0 otherwise;
 #                 read by `$mach.build.pie` so the runtime gates its self-relocation
 # pointer_width:  target pointer width in bytes
+# vector_bits:    the widest vector the target admits by name, in bits, which
+#                 bounds the `TxN` vector form the resolver reads (#2687). carried
+#                 here for the same reason `pointer_width` is: it is a target
+#                 machine fact the frontend needs, and the frontend has no target
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
 # entries:        scoped array of NamedConst bindings; lookup scans it in reverse
@@ -321,6 +325,7 @@ pub rec ComptimeCtx {
     build_mode_id:  u32;
     build_pie:      u32;
     pointer_width:  u32;
+    vector_bits:    u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
     entries:        *NamedConst;
@@ -370,6 +375,7 @@ fun is_i64_min(a: i64) bool {
 # build_mode_id:  active optimization mode id (MODE_DEBUG / MODE_RELEASE)
 # build_pie:      1 for a position-independent (`--pie`) build, 0 otherwise
 # pointer_width:  pointer width in bytes for the target
+# vector_bits:    widest vector the target admits by name, in bits
 # compiler_name:  interned compiler name
 # compiler_ver:   interned compiler version
 # ret:            a fresh ComptimeCtx
@@ -381,6 +387,7 @@ pub fun init(
     build_mode_id:  u32,
     build_pie:      u32,
     pointer_width:  u32,
+    vector_bits:    u32,
     compiler_name:  intern.StrId,
     compiler_ver:   intern.StrId
 ) ComptimeCtx {
@@ -392,6 +399,7 @@ pub fun init(
     c.build_mode_id  = build_mode_id;
     c.build_pie      = build_pie;
     c.pointer_width  = pointer_width;
+    c.vector_bits    = vector_bits;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
     c.entries        = nil;
@@ -3216,7 +3224,7 @@ test "mach.lang.fe.comptime.eval_lit_int:prefixes_and_separators" {
 test "mach.lang.fe.comptime.bind:frame_scoping" {
     var alloc: A.Allocator;
     page.make(?alloc);
-    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+    var c: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 0, 8, 128, intern.STR_NIL, intern.STR_NIL);
 
     val name1: intern.StrId = 1::intern.StrId;
     val name2: intern.StrId = 2::intern.StrId;

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -955,6 +955,14 @@ fun report_vector_refused(rc: *ResolveContext, span: token.Span, name: intern.St
             spelling, form.lanes::u64 * type.prim_desc(form.element).bits::u64,
             rc.ctx.vector_bits);
     }
+    # a sub-width vector is well formed and correctly laid out, and refused only
+    # because codegen cannot carry one yet. the message says that rather than
+    # blaming the spelling.
+    if (form.status == type.VEC_FORM_SUB_WIDTH) {
+        rm = format.sprint(rc.s.alloc,
+            "vector `{}` is {} bits wide, narrower than this target's {}-bit vector register; vectors narrower than the register are not supported yet",
+            spelling, form.bits, rc.ctx.vector_bits);
+    }
     if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
     val msg: str = R.unwrap_ok[str, str](rm);
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -960,7 +960,7 @@ fun report_vector_refused(rc: *ResolveContext, span: token.Span, name: intern.St
     # blaming the spelling.
     if (form.status == type.VEC_FORM_SUB_WIDTH) {
         rm = format.sprint(rc.s.alloc,
-            "vector `{}` is {} bits wide, narrower than this target's {}-bit vector register; vectors narrower than the register are not supported yet",
+            "vector `{}` is {} bits wide, narrower than this target's {}-bit vector register; codegen cannot carry a vector narrower than the register yet (#2697)",
             spelling, form.bits, rc.ctx.vector_bits);
     }
     if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
@@ -1061,11 +1061,62 @@ fun collect_one_decl(rc: *ResolveContext, decl_id: id.DeclId, scope: ScopeId, at
 # scope:     scope to bind into
 # ret:       ok(true), or an allocation error
 fun declare_decl(rc: *ResolveContext, kind: SymKind, flags: u8, name_span: token.Span, decl_id: id.DeclId, scope: ScopeId) R.Result[bool, str] {
+    val rn: R.Result[bool, str] = reject_vector_named_type(rc, kind, name_span);
+    if (R.is_err[bool, str](rn)) { ret rn; }
+
     val r: R.Result[SymbolId, str] = declare(rc, kind, flags, name_span, decl_id, 0, rc.own_module, scope);
     if (R.is_err[SymbolId, str](r)) { ret R.err[bool, str](R.unwrap_err[SymbolId, str](r)); }
     if (rc.decl_symbol != nil) {
         rc.decl_symbol[decl_id] = R.unwrap_ok[SymbolId, str](r);
     }
+    ret R.ok[bool, str](true);
+}
+
+# refuse a `rec` / `uni` / `def` whose name is spelled as a vector form
+#
+# A TYPE spelling is read in type position ahead of scope, so a type declared with a
+# vector's name is silently unreachable: `rec u8x16 { a: i64; }` compiles clean today,
+# `$size_of(u8x16)` answers 16 from the builtin, and the only symptom is a baffling
+# "no such field `a` on type u8x16" at the use site. That hazard predates #2687 for the
+# ten seeded spellings; reading the form as a grammar widens it from ten names to a
+# whole family, which is what makes reporting it worth the source break.
+#
+# ONE RULE, and it deliberately covers the ten as well. A builtin set that silently
+# shadows while a parsed set errors would be two rules wearing one name, and the ten
+# are not special any more.
+#
+# VALUES ARE UNAFFECTED, and that is not an oversight. A `val` / `var` / `fun` named
+# `f32x4` is not shadowed by anything: the form is consulted in type position only, so
+# the binding stays reachable and usable. Refusing those would break mach's own sources,
+# which name several locals after the shapes they carry (`type.mach`'s `val f32x4`,
+# `layout.mach`'s `val i16x4`), for no hazard at all.
+# ---
+# rc:        resolver state for the module being resolved
+# kind:      the symbol kind being declared
+# name_span: span of the decl's name
+# ret:       ok(true), or a reported collision
+fun reject_vector_named_type(rc: *ResolveContext, kind: SymKind, name_span: token.Span) R.Result[bool, str] {
+    if (kind != SYM_REC && kind != SYM_UNI && kind != SYM_DEF) { ret R.ok[bool, str](true); }
+    if (name_span.len == 0) { ret R.ok[bool, str](true); }
+
+    val r_id: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, name_span);
+    if (R.is_err[intern.StrId, str](r_id)) { ret R.ok[bool, str](true); }
+    val name_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_id);
+
+    val no: O.Option[str] = intern.lookup(?rc.s.interner, name_id);
+    if (O.is_none[str](no)) { ret R.ok[bool, str](true); }
+    val spelling: str = O.unwrap[str](no);
+    if (!type.is_vector_spelling(spelling)) { ret R.ok[bool, str](true); }
+
+    val rm: R.Result[str, str] = format.sprint(rc.s.alloc,
+        "`{}` is spelled as a vector type `<element>x<lanes>`, so it cannot also name a type; the declaration would be unreachable",
+        spelling);
+    if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
+    val msg: str = R.unwrap_ok[str, str](rm);
+
+    val emit: R.Result[bool, str] = diagnostic.error(?rc.s.diags, rc.a.file_id, name_span, msg);
+    A.deallocate[char](rc.s.alloc, msg::*char, str_len(msg) + 1);
+    if (R.is_err[bool, str](emit)) { ret emit; }
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -19,6 +19,7 @@
 # absorbs further operations.
 
 use std.collections.map;
+use std.format;
 use std.memory;
 use std.text.string.str_free;
 use std.types.bool.bool;
@@ -213,12 +214,15 @@ rec ResolveContext {
     prim_names: [11]intern.StrId;
     prim_syms:  [11]SymbolId;
 
-    # vector type registry: the SYM_VECTOR symbols for the ten seeded 128-bit
-    # shapes, keyed by interned spelling. recognised in type position only,
-    # exactly like the primitive registry, so a value named `f32x4` never
-    # collides with the vector type spelling.
-    vec_names: [10]intern.StrId;
-    vec_syms:  [10]SymbolId;
+    # vector type cache: spelling -> the SYM_VECTOR symbol for it. a vector is
+    # recognised by READING the form `<element>x<lanes>` rather than by matching a
+    # seeded name (#2687), so there is no fixed registry to scan and the symbol for
+    # a shape is created the first time the module names it. recognised in type
+    # position only, exactly like the primitive registry, so a value named `f32x4`
+    # never collides with the vector type spelling. the cache exists so repeated
+    # use-sites of one spelling share a single Symbol rather than inflating the
+    # symbol table per reference.
+    vec_cache: map.Map[intern.StrId, SymbolId];
 
     # caches (origin << 32 | decl) -> SymbolId for already-created
     # SYM_IMPORTED entries, so repeated `print.println` use-sites share one
@@ -405,12 +409,6 @@ pub fun resolve(
         ret R.err[ResolveResult, str](R.unwrap_err[bool, str](sp_r));
     }
 
-    val sv_r: R.Result[bool, str] = seed_vectors(?rc);
-    if (R.is_err[bool, str](sv_r)) {
-        dnit_context(?rc);
-        ret R.err[ResolveResult, str](R.unwrap_err[bool, str](sv_r));
-    }
-
     val m_opt: O.Option[*module.Module] = ast.get_module(a, a.root_module);
     if (O.is_none[*module.Module](m_opt)) {
         dnit_context(?rc);
@@ -484,6 +482,7 @@ fun init_context(
     }
 
     rc.imported_cache = map.init[u64, SymbolId](s.alloc, map.hash_u64, map.eq_u64);
+    rc.vec_cache      = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
     rc.module_index   = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
 
     # every allocation past this point is owned by the context; on a failure
@@ -556,6 +555,7 @@ fun dnit_context(rc: *ResolveContext) {
         A.deallocate[SymbolId](rc.s.alloc, rc.decl_symbol, rc.a.decl_len);
     }
     map.dnit[u64, SymbolId](?rc.imported_cache);
+    map.dnit[intern.StrId, SymbolId](?rc.vec_cache);
     map.dnit[intern.StrId, SymbolId](?rc.module_index);
 }
 
@@ -796,24 +796,21 @@ fun prior_name_span(rc: *ResolveContext, decl_id: id.DeclId) token.Span {
 # seeds the primitive type names (u8..f64, ptr) into the resolver's primitive
 # registry as SYM_PRIM symbols whose `slot` carries the primitive TypeKind
 # ordinal. primitives are recognised in type position only (see
-# `prim_symbol_for`), never bound into a value scope, so a declaration may
+# `type_spelling`), never bound into a value scope, so a declaration may
 # reuse a primitive spelling (e.g. `fun u64()`) without colliding. mirrors
 # cmach's string-based primitive resolution in sema_resolve_type
 # ---
 # rc:  resolver state for the module being resolved
 # ret: ok(true), or an allocation error
 fun seed_primitives(rc: *ResolveContext) R.Result[bool, str] {
-    val r0:  R.Result[bool, str] = seed_one_primitive(rc, 0,  "u8",  type.TYPE_U8::u32);  if (R.is_err[bool, str](r0))  { ret r0; }
-    val r1:  R.Result[bool, str] = seed_one_primitive(rc, 1,  "u16", type.TYPE_U16::u32); if (R.is_err[bool, str](r1))  { ret r1; }
-    val r2:  R.Result[bool, str] = seed_one_primitive(rc, 2,  "u32", type.TYPE_U32::u32); if (R.is_err[bool, str](r2))  { ret r2; }
-    val r3:  R.Result[bool, str] = seed_one_primitive(rc, 3,  "u64", type.TYPE_U64::u32); if (R.is_err[bool, str](r3))  { ret r3; }
-    val r4:  R.Result[bool, str] = seed_one_primitive(rc, 4,  "i8",  type.TYPE_I8::u32);  if (R.is_err[bool, str](r4))  { ret r4; }
-    val r5:  R.Result[bool, str] = seed_one_primitive(rc, 5,  "i16", type.TYPE_I16::u32); if (R.is_err[bool, str](r5))  { ret r5; }
-    val r6:  R.Result[bool, str] = seed_one_primitive(rc, 6,  "i32", type.TYPE_I32::u32); if (R.is_err[bool, str](r6))  { ret r6; }
-    val r7:  R.Result[bool, str] = seed_one_primitive(rc, 7,  "i64", type.TYPE_I64::u32); if (R.is_err[bool, str](r7))  { ret r7; }
-    val r8:  R.Result[bool, str] = seed_one_primitive(rc, 8,  "f32", type.TYPE_F32::u32); if (R.is_err[bool, str](r8))  { ret r8; }
-    val r9:  R.Result[bool, str] = seed_one_primitive(rc, 9,  "f64", type.TYPE_F64::u32); if (R.is_err[bool, str](r9))  { ret r9; }
-    val r10: R.Result[bool, str] = seed_one_primitive(rc, 10, "ptr", type.TYPE_PTR::u32); if (R.is_err[bool, str](r10)) { ret r10; }
+    # the registry index IS the TypeKind ordinal, so the spellings come straight
+    # from `type.prim_name` rather than being restated here.
+    var k: u32 = 0;
+    for (k < PRIM_COUNT) {
+        val r: R.Result[bool, str] = seed_one_primitive(rc, k, type.prim_name(k::u8), k);
+        if (R.is_err[bool, str](r)) { ret r; }
+        k = k + 1;
+    }
     ret R.ok[bool, str](true);
 }
 
@@ -839,73 +836,133 @@ fun seed_one_primitive(rc: *ResolveContext, index: u32, name: str, kind_ordinal:
     ret R.ok[bool, str](true);
 }
 
-# seeds the ten 128-bit vector type spellings (f32x4 .. u64x2) into the
-# resolver's vector registry as SYM_VECTOR symbols whose `slot` carries the
-# pre-interned semantic vector TypeId. recognised in type position only, exactly
-# like the primitive registry, so a value may reuse a vector spelling without
-# colliding. the type universe seeds the shapes at session init, so `type.vec`
-# hands back a stable id here
-# ---
-# rc:  resolver state for the module being resolved
-# ret: ok(true), or an allocation error
-fun seed_vectors(rc: *ResolveContext) R.Result[bool, str] {
-    var i: u32 = 0;
-    for (i < type.VEC_COUNT) {
-        val sh:  type.VecShape      = type.vec_shape(i);
-        val opt: O.Option[type.TypeId] = type.vec(?rc.s.types, i);
-        if (O.is_none[type.TypeId](opt)) { ret R.err[bool, str]("vector shape not seeded in the type universe"); }
-        val vtid: type.TypeId = O.unwrap[type.TypeId](opt);
+# the outcome of testing a spelling in type position
+#
+# Three cases rather than the old two, because a vector is now READ as the form
+# `<element>x<lanes>` rather than matched against a seeded name (#2687). A
+# spelling that is not a type at all must fall through to ordinary scope lookup,
+# but a well formed vector the target will not admit must NOT: reporting
+# `f32x7` as an unresolved name would describe a width problem as a typo.
+pub def TypeSpellStatus: u8;
 
-        val r: R.Result[bool, str] = seed_one_vector(rc, i, sh.name, vtid::u32);
-        if (R.is_err[bool, str](r)) { ret r; }
-        i = i + 1;
-    }
-    ret R.ok[bool, str](true);
+# not a primitive and not a vector form; the caller resolves it by other means
+pub val TYPE_SPELL_NONE:        TypeSpellStatus = 0;
+# a primitive or an admitted vector; `sym` is its symbol
+pub val TYPE_SPELL_FOUND:       TypeSpellStatus = 1;
+# a well formed vector form the target's vector width does not admit
+pub val TYPE_SPELL_VEC_REFUSED: TypeSpellStatus = 2;
+
+# what a spelling turned out to be in type position
+# ---
+# status: which of the three cases the spelling fell into
+# sym:    the symbol, when status is TYPE_SPELL_FOUND; SYMBOL_NIL otherwise
+# form:   the shape read, when the spelling was a vector form; only meaningful
+#         when status is TYPE_SPELL_VEC_REFUSED
+rec TypeSpelling {
+    status: TypeSpellStatus;
+    sym:    SymbolId;
+    form:   type.VecForm;
 }
 
-# interns one vector spelling and records it in the registry at `index` as a
-# SYM_VECTOR symbol carrying the pre-interned vector TypeId in `slot`
-# ---
-# rc:      resolver state for the module being resolved
-# index:   registry slot to fill
-# name:    the vector spelling
-# type_id: the pre-interned semantic vector TypeId
-# ret:     ok(true), or an allocation error
-fun seed_one_vector(rc: *ResolveContext, index: u32, name: str, type_id: u32) R.Result[bool, str] {
-    val r_id: R.Result[intern.StrId, str] = intern.intern(?rc.s.interner, name);
-    if (R.is_err[intern.StrId, str](r_id)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r_id)); }
-    val name_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_id);
-
-    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, SYM_VECTOR, 0, name_id, id.DECL_NIL, type_id, rc.own_module);
-    if (R.is_err[SymbolId, str](r_sym)) { ret R.err[bool, str](R.unwrap_err[SymbolId, str](r_sym)); }
-    val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
-
-    rc.vec_names[index] = name_id;
-    rc.vec_syms[index]  = sid;
-    ret R.ok[bool, str](true);
-}
-
-# returns the SYM_PRIM or SYM_VECTOR symbol for a type spelling, or SYMBOL_NIL
-# when `name` is neither a primitive nor a vector. consulted in type position,
-# taking priority over scope so a same-named value declaration never shadows the
-# type
+# the SYM_PRIM or SYM_VECTOR symbol for a type spelling
+#
+# Consulted in type position, taking priority over scope so a same-named value
+# declaration never shadows the type. Primitives come from the fixed registry;
+# a vector is read as the form `<element>x<lanes>` and bounded by the target's
+# vector width, so the ten formerly seeded spellings resolve exactly as before
+# without being enumerated anywhere (#2687).
+#
+# A vector's symbol is created on first mention and cached by spelling, so
+# repeated use-sites share one Symbol. The lane shape is interned into the type
+# universe here, which is what makes a shape the universe did not pre-seed
+# (`f32x3`) resolve at all.
 # ---
 # rc:   resolver state for the module being resolved
 # name: interned spelling to test
-# ret:  the SYM_PRIM / SYM_VECTOR symbol, or SYMBOL_NIL when `name` is neither
-fun prim_symbol_for(rc: *ResolveContext, name: intern.StrId) SymbolId {
+# ret:  what the spelling is, or an allocation error
+fun type_spelling(rc: *ResolveContext, name: intern.StrId) R.Result[TypeSpelling, str] {
+    var out: TypeSpelling;
+    out.status = TYPE_SPELL_NONE;
+    out.sym    = SYMBOL_NIL;
+
     var i: u32 = 0;
     for (i < PRIM_COUNT) {
-        if (rc.prim_names[i] == name) { ret rc.prim_syms[i]; }
+        if (rc.prim_names[i] == name) {
+            out.status = TYPE_SPELL_FOUND;
+            out.sym    = rc.prim_syms[i];
+            ret R.ok[TypeSpelling, str](out);
+        }
         i = i + 1;
     }
-    var v: u32 = 0;
-    for (v < type.VEC_COUNT) {
-        if (rc.vec_names[v] == name) { ret rc.vec_syms[v]; }
-        v = v + 1;
+
+    # a spelling already resolved to a vector symbol in this module.
+    val cached: R.Result[*SymbolId, str] = map.get[intern.StrId, SymbolId](?rc.vec_cache, ?name);
+    if (R.is_ok[*SymbolId, str](cached)) {
+        out.status = TYPE_SPELL_FOUND;
+        out.sym    = @R.unwrap_ok[*SymbolId, str](cached);
+        ret R.ok[TypeSpelling, str](out);
     }
-    ret SYMBOL_NIL;
+
+    val no: O.Option[str] = intern.lookup(?rc.s.interner, name);
+    if (O.is_none[str](no)) { ret R.ok[TypeSpelling, str](out); }
+
+    val form: type.VecForm = type.vector_form(O.unwrap[str](no), rc.ctx.vector_bits);
+    out.form = form;
+    if (form.status == type.VEC_FORM_NONE) { ret R.ok[TypeSpelling, str](out); }
+    if (form.status != type.VEC_FORM_OK) {
+        out.status = TYPE_SPELL_VEC_REFUSED;
+        ret R.ok[TypeSpelling, str](out);
+    }
+
+    val r_tid: R.Result[type.TypeId, str] = type.intern_vector(?rc.s.types, form.element, form.lanes);
+    if (R.is_err[type.TypeId, str](r_tid)) { ret R.err[TypeSpelling, str](R.unwrap_err[type.TypeId, str](r_tid)); }
+    val vtid: type.TypeId = R.unwrap_ok[type.TypeId, str](r_tid);
+
+    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, SYM_VECTOR, 0, name, id.DECL_NIL, vtid::u32, rc.own_module);
+    if (R.is_err[SymbolId, str](r_sym)) { ret R.err[TypeSpelling, str](R.unwrap_err[SymbolId, str](r_sym)); }
+    val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
+
+    val ins: R.Result[bool, str] = map.insert[intern.StrId, SymbolId](?rc.vec_cache, name, sid);
+    if (R.is_err[bool, str](ins)) { ret R.err[TypeSpelling, str](R.unwrap_err[bool, str](ins)); }
+
+    out.status = TYPE_SPELL_FOUND;
+    out.sym    = sid;
+    ret R.ok[TypeSpelling, str](out);
 }
+
+# report a well formed vector spelling the target will not admit
+#
+# Names the width that was asked for and the width the target has, so the
+# message is about the vector rather than about an unknown identifier. A
+# degenerate lane count is a different sentence: no target width would admit it.
+# ---
+# rc:   resolver state for the module being resolved
+# span: the spelling's source span
+# name: the interned spelling
+# form: the shape read from it
+# ret:  ok(true), or an allocation error
+fun report_vector_refused(rc: *ResolveContext, span: token.Span, name: intern.StrId,
+                          form: type.VecForm) R.Result[bool, str] {
+    val no: O.Option[str] = intern.lookup(?rc.s.interner, name);
+    if (O.is_none[str](no)) { ret R.ok[bool, str](true); }
+    val spelling: str = O.unwrap[str](no);
+
+    var rm: R.Result[str, str] = format.sprint(rc.s.alloc,
+        "vector `{}` needs at least 2 lanes", spelling);
+    if (form.status == type.VEC_FORM_TOO_WIDE) {
+        rm = format.sprint(rc.s.alloc,
+            "vector `{}` is {} bits wide, more than this target's {}-bit vector width",
+            spelling, form.lanes::u64 * type.prim_desc(form.element).bits::u64,
+            rc.ctx.vector_bits);
+    }
+    if (R.is_err[str, str](rm)) { ret R.err[bool, str](R.unwrap_err[str, str](rm)); }
+    val msg: str = R.unwrap_ok[str, str](rm);
+
+    val emit: R.Result[bool, str] = diagnostic.error(?rc.s.diags, rc.a.file_id, span, msg);
+    A.deallocate[char](rc.s.alloc, msg::*char, str_len(msg) + 1);
+    ret emit;
+}
+
 
 # collect every decl in `[start, start + len)` of the decl-id pool
 # ---
@@ -2833,7 +2890,17 @@ fun bind_type_name_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str]
         if (R.is_err[intern.StrId, str](r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r)); }
         val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
 
-        var sid: SymbolId = prim_symbol_for(rc, name);
+        val rs: R.Result[TypeSpelling, str] = type_spelling(rc, name);
+        if (R.is_err[TypeSpelling, str](rs)) { ret R.err[bool, str](R.unwrap_err[TypeSpelling, str](rs)); }
+        val sp: TypeSpelling = R.unwrap_ok[TypeSpelling, str](rs);
+
+        # a well formed vector the target will not admit is a width error, not an
+        # unknown name, so it never falls through to scope lookup.
+        if (sp.status == TYPE_SPELL_VEC_REFUSED) {
+            ret report_vector_refused(rc, e.span, name, sp.form);
+        }
+
+        var sid: SymbolId = sp.sym;
         if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
         if (sid == SYMBOL_NIL) {
             val re: R.Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
@@ -3096,7 +3163,18 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
             # the primitive, taking priority over any value-scope symbol of the
             # same name (mirrors cmach's string-based primitive resolution).
             val is_single: bool = seg_end >= end;
-            if (is_single) { current_sym = prim_symbol_for(rc, seg_name); }
+            if (is_single) {
+                val rs: R.Result[TypeSpelling, str] = type_spelling(rc, seg_name);
+                if (R.is_err[TypeSpelling, str](rs)) { ret SYMBOL_NIL; }
+                val sp: TypeSpelling = R.unwrap_ok[TypeSpelling, str](rs);
+                # a width refusal is reported as itself and stops here, rather than
+                # falling through to scope lookup and an unresolved-name message.
+                if (sp.status == TYPE_SPELL_VEC_REFUSED) {
+                    report_vector_refused(rc, full, seg_name, sp.form);
+                    ret SYMBOL_NIL;
+                }
+                current_sym = sp.sym;
+            }
             if (current_sym == SYMBOL_NIL) {
                 current_sym = scope_lookup_chain(rc, rc.current_scope, seg_name);
             }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -50,6 +50,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.spirvop;
 use mach.lang.type;
 
 # re-export sema's shared state and accessor API (which lives in the context
@@ -1488,6 +1489,48 @@ fun validate_stage_value(sc: *context.SemaContext, dec: *decl.Decorator) {
     context.report(sc, arg.span, "unknown pipeline stage; `stage` accepts \"vertex\", \"fragment\", or \"compute\"");
 }
 
+# report unless a `#[spirv_op(set, name)]` names an instruction the compiler can
+# actually emit
+#
+# The pair is looked up in `spirvop`, the same table lowering resolves the opcode
+# from, so an accepted spelling here and an emitted opcode there cannot drift. Both
+# halves are reported separately: an unknown set and an unknown name in a known set
+# are different mistakes, and "GLSL.std.450 defines no Sqrtf" is a more useful
+# diagnostic than a single combined refusal.
+# ---
+# sc:  the context
+# d:   the decorated decl
+# dec: the `spirv_op` decorator
+fun validate_spirv_op(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    if (d.kind != decl.DECL_KIND_FUN) {
+        context.report(sc, dec.name, "`spirv_op` decorator applies only to functions");
+        ret;
+    }
+    if (dec.args_len != 2) {
+        context.report(sc, dec.name, "`spirv_op` decorator takes two string arguments: the instruction set and the instruction name");
+        ret;
+    }
+    val opt_set: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
+    val opt_nam: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + 1]);
+    if (O.is_none[*expr.Expr](opt_set) || O.is_none[*expr.Expr](opt_nam)) { ret; }
+    val set_e: *expr.Expr = O.unwrap[*expr.Expr](opt_set);
+    val nam_e: *expr.Expr = O.unwrap[*expr.Expr](opt_nam);
+    if (set_e.kind != expr.EXPR_KIND_LIT_STR || nam_e.kind != expr.EXPR_KIND_LIT_STR) {
+        context.report(sc, dec.name, "`spirv_op` decorator arguments must be string literals");
+        ret;
+    }
+    if (set_e.span.len < 2::usize || nam_e.span.len < 2::usize) { ret; }
+
+    val set_v: u8 = spirvop.set_of(sc.source, set_e.span.offset + 1::usize, set_e.span.len - 2::usize);
+    if (set_v == spirvop.SPV_SET_NONE) {
+        context.report(sc, set_e.span, "unknown SPIR-V instruction set; `spirv_op` accepts \"core\" or \"GLSL.std.450\"");
+        ret;
+    }
+    if (spirvop.opcode_of(set_v, sc.source, nam_e.span.offset + 1::usize, nam_e.span.len - 2::usize) == spirvop.SPV_OP_NONE) {
+        context.report(sc, nam_e.span, "that instruction set defines no instruction of this name, or the SPIR-V target does not carry it; see `mach.lang.spirvop` for the accepted names and why each omission is one");
+    }
+}
+
 # whether `kind` is a valid `align` target: a global binding or a rec/uni nominal
 #
 # A `def` alias is excluded - it is transparent (no layout of its own, emits no
@@ -1724,7 +1767,17 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
     # agreement - is checked by the pre-type-resolution pass that has to read the
     # file anyway (#2507). Re-checking any of it here would report it twice.
     if (decorator_named(sc, dec, "embed")) { ret; }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage");
+    # `#[spirv_op(set, name)]` says a function IS one SPIR-V instruction, so a call
+    # to it on a SPIR-V target becomes that instruction instead of a call. Both
+    # names are closed here rather than in the back end: the decorator is legal on
+    # every target (which target a module is built for is not a property of the
+    # source), so a typo checked only where it is acted on would go unreported on
+    # every CPU build of the same library.
+    if (decorator_named(sc, dec, "spirv_op")) {
+        validate_spirv_op(sc, d, dec);
+        ret;
+    }
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage, spirv_op");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -582,7 +582,7 @@ fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.Typ
     # DEEP (#2165): the reinterpret's `^` placement must match through the field graph, not
     # just the pointer / array spine - else `*P :~ *Q` (P has a `^` field, Q public)
     # reinterprets the secret pointee as public and reads it out.
-    if (!generics.secrecy_structure_equal_deep(sc.s, ptr_width(sc), from, to)) {
+    if (!generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), from, to)) {
         report_note(sc, span, "cast: `::` and `:~` cannot add or drop the secret qualifier `^`",
             "a public value coerces up to secret with no syntax; `:^` is the only downgrade");
         ret false;
@@ -738,8 +738,12 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     val k:  type.TypeKind = tp.kind;
     val d:  type.PrimDesc = type.prim_desc(k);
     if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) { ret d.bits / 8; }
-    # all ten vector shapes are 128-bit (#1965).
-    if (k == type.TYPE_VECTOR) { ret 16; }
+    # a vector is `lanes` lanes of its element, packed: `f32x4` is 16 and `f32x3` is
+    # 12 (#2687). measured here rather than deferred to `type_extent`, which handles
+    # only the nominal aggregates.
+    if (k == type.TYPE_VECTOR) {
+        ret (type.prim_desc(tp.data.vector.element).bits / 8) * tp.data.vector.lanes;
+    }
     # a raw `ptr`, a typed `*T`, and a function value (a code address) are all
     # pointer-sized, read from the target's pointer width.
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ptr_width(sc); }
@@ -754,7 +758,7 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     # not assumed unknown. `type_extent` reports `ok = false` rather than a wrong
     # number when it cannot decide, which sizes as 0 and fails the cast closed.
     if (k == type.TYPE_REC || k == type.TYPE_UNI || k == type.TYPE_INSTANCE) {
-        val ext: layout.Extent = generics.type_extent(sc.s, ptr_width(sc), type.strip_secret(?sc.s.types, t));
+        val ext: layout.Extent = generics.type_extent(sc.s, context.machine_of(sc), type.strip_secret(?sc.s.types, t));
         if (!ext.ok) { ret 0; }
         ret ext.size;
     }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -28,6 +28,7 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.token;
 use mach.lang.intern;
+use mach.lang.layout;
 use mach.lang.session;
 use mach.lang.type;
 
@@ -961,6 +962,17 @@ pub fun symbol_by_id(sc: *SemaContext, sid: resolve.SymbolId) O.Option[*resolve.
 # ret: the active target's pointer width in bytes
 pub fun ptr_width_of(sc: *SemaContext) u32 {
     ret sc.ctx.pointer_width;
+}
+
+# the target facts the layout fold reads, from the active comptime context
+#
+# The frontend has no target; `ComptimeCtx` carries the per-build target facts it
+# needs, so both the pointer width and the vector width come from there (#2687).
+# ---
+# sc:  the active sema context
+# ret: the Machine the layout policy folds against
+pub fun machine_of(sc: *SemaContext) layout.Machine {
+    ret layout.machine(sc.ctx.pointer_width, sc.ctx.vector_bits);
 }
 
 # emit a SEVERITY_ERROR diagnostic at `span`

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -433,8 +433,13 @@ fun describe_type(ctx: ptr, id: u32) layout.Node {
     if (d.class == type.PRIM_CLASS_PTR || t.kind == type.TYPE_POINTER || t.kind == type.TYPE_FUN) {
         ret layout.node(layout.NODE_POINTER);
     }
-    # all ten vector shapes are 128-bit (#1965).
-    if (t.kind == type.TYPE_VECTOR) { ret layout.node(layout.NODE_VECTOR); }
+    # a vector's extent is lane-derived, so the node carries its lane shape (#2687).
+    if (t.kind == type.TYPE_VECTOR) {
+        var n: layout.Node = layout.node(layout.NODE_VECTOR);
+        n.bytes = type.prim_desc(t.data.vector.element).bits / 8;
+        n.count = t.data.vector.lanes;
+        ret n;
+    }
 
     if (t.kind == type.TYPE_ARRAY) {
         var n: layout.Node = layout.node(layout.NODE_ARRAY);
@@ -503,11 +508,11 @@ val SEMA_LAYOUT_MAX_DEPTH: u32 = 64;
 # layout with, so the two cannot disagree (#2289).
 # ---
 # s:         the session (type universe, lazy instance fields, align overrides)
-# ptr_width: the target's pointer width in bytes
+# m:         the target facts the layout fold reads
 # tid:       the type to measure
 # ret:       the determined Extent, or `ok = false` when it cannot be computed
-pub fun type_extent(s: *session.Session, ptr_width: u32, tid: type.TypeId) layout.Extent {
-    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, ptr_width,
+pub fun type_extent(s: *session.Session, m: layout.Machine, tid: type.TypeId) layout.Extent {
+    ret layout.extent_of(s::ptr, describe_type, describe_type_field, tid::u32, m,
                          SEMA_LAYOUT_MAX_DEPTH);
 }
 
@@ -565,15 +570,15 @@ rec SecrecyPairScan {
 # a:   the first type
 # b:   the second type
 # ret: true when `a` and `b` carry `^` at identical positions
-pub fun secrecy_structure_equal_deep(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.TypeId) bool {
+pub fun secrecy_structure_equal_deep(s: *session.Session, m: layout.Machine, a: type.TypeId, b: type.TypeId) bool {
     if (!contains_secret_deep(s, a) && !contains_secret_deep(s, b)) { ret true; }
     var scan: SecrecyPairScan;
     scan.len = 0;
-    ret sse_deep_walk(s, ptr_width, a, b, ?scan);
+    ret sse_deep_walk(s, m, a, b, ?scan);
 }
 
 # the recursive lockstep worker for `secrecy_structure_equal_deep`
-fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.TypeId, scan: *SecrecyPairScan) bool {
+fun sse_deep_walk(s: *session.Session, m: layout.Machine, a: type.TypeId, b: type.TypeId, scan: *SecrecyPairScan) bool {
     if (type.is_secret(?s.types, a) != type.is_secret(?s.types, b)) { ret false; }
 
     val sa: type.TypeId = type.strip_secret(?s.types, a);
@@ -585,11 +590,11 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
     val tb: *type.Type = O.unwrap[*type.Type](ob);
 
     if (ta.kind == type.TYPE_POINTER && tb.kind == type.TYPE_POINTER) {
-        ret sse_deep_walk(s, ptr_width, ta.data.pointer.base, tb.data.pointer.base, scan);
+        ret sse_deep_walk(s, m, ta.data.pointer.base, tb.data.pointer.base, scan);
     }
     if (ta.kind == type.TYPE_ARRAY && tb.kind == type.TYPE_ARRAY) {
         # every element shares the base's secrecy, so the count is irrelevant to placement.
-        ret sse_deep_walk(s, ptr_width, ta.data.array.base, tb.data.array.base, scan);
+        ret sse_deep_walk(s, m, ta.data.array.base, tb.data.array.base, scan);
     }
     if (ta.kind == type.TYPE_FUN && tb.kind == type.TYPE_FUN) {
         # two function types place `^` identically iff same arity, the return pair matches,
@@ -598,13 +603,13 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
         # would call `id` treating a secret arg as public - rejected here). Differing arity
         # cannot be aligned, so it fails closed.
         if (ta.data.fn.params_len != tb.data.fn.params_len) { ret false; }
-        if (!sse_deep_walk(s, ptr_width, ta.data.fn.ret_type, tb.data.fn.ret_type, scan)) { ret false; }
+        if (!sse_deep_walk(s, m, ta.data.fn.ret_type, tb.data.fn.ret_type, scan)) { ret false; }
         var pi: u32 = 0;
         for (pi < ta.data.fn.params_len) {
             val pa: O.Option[type.TypeId] = type.get_param(?s.types, ta.data.fn.params_start + pi);
             val pb: O.Option[type.TypeId] = type.get_param(?s.types, tb.data.fn.params_start + pi);
             if (O.is_none[type.TypeId](pa) || O.is_none[type.TypeId](pb)) { ret false; }
-            if (!sse_deep_walk(s, ptr_width, O.unwrap[type.TypeId](pa), O.unwrap[type.TypeId](pb), scan)) { ret false; }
+            if (!sse_deep_walk(s, m, O.unwrap[type.TypeId](pa), O.unwrap[type.TypeId](pb), scan)) { ret false; }
             pi = pi + 1;
         }
         ret true;
@@ -660,10 +665,10 @@ fun sse_deep_walk(s: *session.Session, ptr_width: u32, a: type.TypeId, b: type.T
             if (O.is_none[*type.FieldEntry](fa) || O.is_none[*type.FieldEntry](fb)) { ret false; }
             val ty_a: type.TypeId = O.unwrap[*type.FieldEntry](fa).ty;
             val ty_b: type.TypeId = O.unwrap[*type.FieldEntry](fb).ty;
-            if (!sse_deep_walk(s, ptr_width, ty_a, ty_b, scan)) { ret false; }
+            if (!sse_deep_walk(s, m, ty_a, ty_b, scan)) { ret false; }
 
-            val ea: layout.Extent = type_extent(s, ptr_width, ty_a);
-            val eb: layout.Extent = type_extent(s, ptr_width, ty_b);
+            val ea: layout.Extent = type_extent(s, m, ty_a);
+            val eb: layout.Extent = type_extent(s, m, ty_b);
             if (!ea.ok || !eb.ok)                           { ret false; }
             if (ea.size != eb.size || ea.align != eb.align) { ret false; }
             f = f + 1;
@@ -1216,7 +1221,7 @@ fun check_uni_variants(sc: *sema.SemaContext, nom: type.TypeId, args: *type.Type
         val raw: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
         val ty:  type.TypeId = subst_or_self(s, raw, args, arg_len);
         if (type_mentions_gparam(s, ty)) { ret; }
-        if (!secrecy_structure_equal_deep(s, sema.ptr_width_of(sc), first, ty)) {
+        if (!secrecy_structure_equal_deep(s, sema.machine_of(sc), first, ty)) {
             if (sema.uni_report_mark(sc.uni_reports, key)) {
                 sema.report(sc, span, "union variants must agree on secrecy: this instantiation makes overlapping fields part secret `^` and part public, which would alias the same storage at two classifications");
             }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -435,7 +435,7 @@ fun fold_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, span: token.
         ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
     }
 
-    val ext: layout.Extent = generics.type_extent(sc.s, context.ptr_width_of(sc), tid);
+    val ext: layout.Extent = generics.type_extent(sc.s, context.machine_of(sc), tid);
     if (!ext.ok) {
         context.report(sc, span, "the layout of the type named by this intrinsic could not be determined");
         ret O.some[O.Option[comptime.CTValue]](O.none[comptime.CTValue]());
@@ -614,7 +614,7 @@ fun check_uni_secrecy(sc: *context.SemaContext, nom: type.TypeId, fields_start: 
         # aliases the secret bytes under the public `Q` overlay and reads them out. A
         # shallow `is_secret` per variant treats `P` as public and misses it.
         if (!cyclic) {
-            if (!generics.secrecy_structure_equal_deep(sc.s, context.ptr_width_of(sc), first_ty, ty)) {
+            if (!generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), first_ty, ty)) {
                 context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
             }
         }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -339,7 +339,8 @@ fun ensure_layout_fields(sc: *context.SemaContext, ty: type.TypeId, depth: u32) 
 #
 # The shape rule itself is `type.shape_kind` - shared with the lowering-side twin so
 # a gate folded at sema and the same gate deferred to monomorphization cannot
-# disagree. Here it only maps that kind onto the asked question.
+# disagree. Here it only maps that kind onto the asked question, after the `^` rule
+# below.
 # ---
 # data:  the *SemaContext, erased to a ptr by the installer
 # tid:   the already-resolved TypeId to ask about
@@ -359,6 +360,25 @@ pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.O
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
 
+    # `^` IS A CONSTRUCTOR, AND A PREDICATE ANSWERS ABOUT THE OUTERMOST ONE (#2692).
+    # `^Rec` is a secret, not a record, so every predicate answers false and a
+    # reflection walk refuses it rather than descending into secret storage. this is
+    # what makes the answers agree with `$fields`, which refuses `^Rec`: the gate and
+    # the intrinsic it gates used to disagree, so a walk written exactly as the docs
+    # prescribe descended into a type `$fields` then refused.
+    #
+    # `type.is_secret` and not `type.carries_secret`: the question is the outermost
+    # constructor only. `^*u8` is a secret pointer and answers false, while `*^u8` is
+    # a PUBLIC pointer to secret storage and stays a pointer - `carries_secret` walks
+    # the spine and would refuse that second shape, which is genuinely fine.
+    #
+    # this sits ahead of the generic-parameter deferral on purpose: `^T` is a secret
+    # whatever `T` turns out to be, so the answer exists at the template and there is
+    # nothing to defer.
+    if (type.is_secret(?s.types, t) && which != comptime.TYPE_QUERY_NAME) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_bool(false)));
+    }
+
     # AN UNBOUND GENERIC PARAMETER IS UNANSWERABLE HERE, not false (#2465). The
     # template sees a placeholder, which is not a record, a union or a pointer - so
     # answering would prune one arm for every instantiation alike. None defers the
@@ -370,8 +390,10 @@ pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.O
 
     if (which == comptime.TYPE_QUERY_NAME) {
         # `typename.type_to_str` is the spelling sema already uses in diagnostics, so
-        # the name a program reads and the name an error prints cannot drift.
-        val r: R.Result[str, str] = typename.type_to_str(s, type.strip_secret(?s.types, t));
+        # the name a program reads and the name an error prints cannot drift - which
+        # is why `^` is NOT stripped here (#2692). a diagnostic prints `^Pair`, so
+        # yielding "Pair" would be a drift on the one qualifier where it matters most.
+        val r: R.Result[str, str] = typename.type_to_str(s, t);
         if (R.is_err[str, str](r)) { ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[str, str](r)); }
         val text: str = R.unwrap_ok[str, str](r);
         val ir_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, text);

--- a/src/lang/layout.mach
+++ b/src/lang/layout.mach
@@ -60,7 +60,7 @@ pub val NODE_UNKNOWN:   NodeKind = 0;
 pub val NODE_SCALAR:    NodeKind = 1;
 # a pointer or function value: the target's pointer width, aligned to it
 pub val NODE_POINTER:   NodeKind = 2;
-# a 128-bit vector: 16 bytes, 16-byte aligned
+# a vector of `count` lanes each `bytes` wide; its extent is lane-derived (#2687)
 pub val NODE_VECTOR:    NodeKind = 3;
 # `count` elements of node `child`
 pub val NODE_ARRAY:     NodeKind = 4;
@@ -70,6 +70,33 @@ pub val NODE_AGGREGATE: NodeKind = 5;
 # following field nor lowers an enclosing aggregate's alignment
 pub val NODE_ZERO:      NodeKind = 6;
 
+# the target facts the fold reads
+#
+# Bundled rather than passed as loose parameters because the fold's dependence on the
+# target is an axis that grows: `ptr_width` was the only such fact until a vector's
+# alignment came to turn on the register width. A new fact is a field here rather than
+# another positional argument threaded through three call sites.
+# ---
+# ptr_width:   the target's pointer width in bytes
+# vector_bits: the widest vector the target admits, in bits, which is the width at
+#              which a vector is register-resident rather than a packed aggregate
+pub rec Machine {
+    ptr_width:   u32;
+    vector_bits: u32;
+}
+
+# a Machine from its two facts
+# ---
+# ptr_width:   the target's pointer width in bytes
+# vector_bits: the target's vector register width in bits
+# ret:         the assembled Machine
+pub fun machine(ptr_width: u32, vector_bits: u32) Machine {
+    var m: Machine;
+    m.ptr_width   = ptr_width;
+    m.vector_bits = vector_bits;
+    ret m;
+}
+
 # one type node, described by the caller in terms this policy folds
 #
 # Only the fields its `kind` selects are read, so a describer fills the rest with
@@ -78,7 +105,9 @@ pub val NODE_ZERO:      NodeKind = 6;
 # ---
 # kind:        which storage shape this node has
 # bytes:       NODE_SCALAR: the scalar's width in bytes
+#              NODE_VECTOR: one lane's width in bytes
 # count:       NODE_ARRAY: the element count
+#              NODE_VECTOR: the lane count
 # child:       NODE_ARRAY: the element's node id
 # field_count: NODE_AGGREGATE: the number of fields
 # decl_align:  NODE_AGGREGATE: an `#[align(...)]` override, 0 for none
@@ -210,12 +239,12 @@ pub fun round_up(value: u32, align: u32) u32 {
 # describe:  names a node's storage shape
 # field:     names an aggregate's field node ids
 # id:        the node to measure
-# ptr_width: the target's pointer width in bytes
+# m:         the target facts the fold reads
 # max_depth: the depth past which the walk declines; DEPTH_UNBOUNDED for an acyclic graph
 # ret:       the determined Extent, or `ok = false` with a cause when it cannot be computed
-pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32,
+pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, m: Machine,
                   max_depth: u32) Extent {
-    ret walk(ctx, describe, field, id, ptr_width, 0, max_depth);
+    ret walk(ctx, describe, field, id, m, 0, max_depth);
 }
 
 # the byte offset of field `field_ix` within aggregate node `id`
@@ -228,11 +257,11 @@ pub fun extent_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width
 # field:     names an aggregate's field node ids
 # id:        the aggregate node
 # field_ix:  the zero-based field index
-# ptr_width: the target's pointer width in bytes
+# m:         the target facts the fold reads
 # max_depth: the depth past which the walk declines; DEPTH_UNBOUNDED for an acyclic graph
 # ret:       an Extent whose `size` is the offset, or `ok = false` with a cause
 pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, field_ix: u32,
-                        ptr_width: u32, max_depth: u32) Extent {
+                        m: Machine, max_depth: u32) Extent {
     val n: Node = describe(ctx, id);
     if (n.kind != NODE_AGGREGATE)  { ret unknown_extent(EXTENT_NOT_AGGREGATE); }
     if (field_ix >= n.field_count) { ret unknown_extent(EXTENT_FIELD_RANGE); }
@@ -241,7 +270,7 @@ pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, fie
     var offset: u32 = 0;
     var i:      u32 = 0;
     for (i < n.field_count) {
-        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, 1, max_depth);
+        val fe: Extent = walk(ctx, describe, field, field(ctx, id, i), m, 1, max_depth);
         if (!fe.ok) { ret unknown_extent(fe.cause); }
         offset = round_up(offset, fe.align);
         if (i == field_ix) { ret extent(offset, fe.align); }
@@ -258,7 +287,7 @@ pub fun field_offset_of(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, fie
 # `max_depth` of DEPTH_UNBOUNDED disables the depth test entirely, so an acyclic caller
 # pays nothing and no legal graph is refused. A failing child's cause propagates
 # unchanged, so a depth failure eight levels down still reports as a depth failure.
-fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, depth: u32,
+fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, m: Machine, depth: u32,
          max_depth: u32) Extent {
     if (max_depth != DEPTH_UNBOUNDED && depth > max_depth) { ret unknown_extent(EXTENT_DEPTH); }
 
@@ -266,11 +295,27 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
 
     if (n.kind == NODE_ZERO)    { ret extent(0, 1); }
     if (n.kind == NODE_SCALAR)  { ret extent(n.bytes, n.bytes); }
-    if (n.kind == NODE_POINTER) { ret extent(ptr_width, ptr_width); }
-    if (n.kind == NODE_VECTOR)  { ret extent(16, 16); }
+    if (n.kind == NODE_POINTER) { ret extent(m.ptr_width, m.ptr_width); }
+
+    # a vector's extent is lane-derived: `lanes` lanes of `bytes` each, packed, with
+    # NO padding to the vector register (#2687). a packed `f32x3` is 12 bytes, which is
+    # what makes `[N]f32x3` a usable vertex buffer - padding it to 16 would make it
+    # indistinguishable from `f32x4` in memory and withhold the reason for having it.
+    #
+    # THE ALIGNMENT IS DISCONTINUOUS AT THE REGISTER WIDTH, DELIBERATELY. A vector that
+    # FILLS the vector register aligns to its whole size, because the machine's vector
+    # load requires it. A narrower one is a packed aggregate that scalarizes or loads
+    # piecewise, so it aligns only to one lane. This reads as an inconsistency on first
+    # meeting and is not one: do not "fix" it into uniformity, which would either
+    # over-align every vertex attribute or under-align every register-resident vector.
+    if (n.kind == NODE_VECTOR) {
+        val size: u32 = n.bytes * n.count;
+        if (size * 8 >= m.vector_bits) { ret extent(size, size); }
+        ret extent(size, n.bytes);
+    }
 
     if (n.kind == NODE_ARRAY) {
-        val e: Extent = walk(ctx, describe, field, n.child, ptr_width, depth + 1, max_depth);
+        val e: Extent = walk(ctx, describe, field, n.child, m, depth + 1, max_depth);
         if (!e.ok) { ret unknown_extent(e.cause); }
         # widen the product: a total past a u32 would wrap and report a wrong extent.
         val total: u64 = e.size::u64 * n.count::u64;
@@ -284,7 +329,7 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, ptr_width: u32, de
         var widest: u32 = 0;
         var i:      u32 = 0;
         for (i < n.field_count) {
-            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), ptr_width, depth + 1, max_depth);
+            val e: Extent = walk(ctx, describe, field, field(ctx, id, i), m, depth + 1, max_depth);
             if (!e.ok) { ret unknown_extent(e.cause); }
             if (e.align > align) { align = e.align; }
             if (n.overlays) {
@@ -365,10 +410,70 @@ fun tg_chain(n: u32) {
 # when the graph was merely deeper than the bound. Each cause must now be nameable, and
 # a cause raised deep in a walk must reach the top UNCHANGED rather than being flattened
 # into "a field failed", or the message is still wrong just less obviously.
+# a vector's extent is lane-derived, and the alignment is DISCONTINUOUS at the vector
+# register width by design: a vector that fills the register aligns to its whole size,
+# a narrower one aligns to a single lane. the regression bar is that every one of the
+# ten shapes the compiler shipped before #2687 is exactly 128 bits and so still
+# measures (16, 16) - lane-derived layout is a pure extension here, not an ABI change
+test "mach.lang.layout.extent:vector_is_lane_derived" {
+    # a helper shape: `lanes` lanes of `bytes` each.
+    tg_nodes[0]       = node(NODE_VECTOR);
+
+    # THE REGRESSION BAR: all ten pre-#2687 shapes are 128-bit and measure (16, 16).
+    # (element bytes, lanes) for f32x4 f64x2 i8x16 i16x8 i32x4 i64x2 u8x16 u16x8 u32x4 u64x2
+    var eb: [10]u32;
+    var ln: [10]u32;
+    eb[0] = 4; ln[0] = 4;   eb[1] = 8; ln[1] = 2;
+    eb[2] = 1; ln[2] = 16;  eb[3] = 2; ln[3] = 8;
+    eb[4] = 4; ln[4] = 4;   eb[5] = 8; ln[5] = 2;
+    eb[6] = 1; ln[6] = 16;  eb[7] = 2; ln[7] = 8;
+    eb[8] = 4; ln[8] = 4;   eb[9] = 8; ln[9] = 2;
+
+    var i: u32 = 0;
+    for (i < 10) {
+        tg_nodes[0].bytes = eb[i];
+        tg_nodes[0].count = ln[i];
+        val e: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+        if (!e.ok)        { ret 1; }
+        if (e.size != 16) { ret 1; }
+        if (e.align != 16) { ret 1; }
+        i = i + 1;
+    }
+
+    # SUB-WIDTH: packed, and aligned to ONE LANE rather than to the register. f32x3 is
+    # 12 bytes so that `[N]f32x3` is a usable packed vertex buffer.
+    tg_nodes[0].bytes = 4; tg_nodes[0].count = 3;
+    val v3: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (v3.size != 12) { ret 1; }
+    if (v3.align != 4) { ret 1; }
+
+    tg_nodes[0].bytes = 4; tg_nodes[0].count = 2;
+    val v2: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (v2.size != 8) { ret 1; }
+    if (v2.align != 4) { ret 1; }
+
+    tg_nodes[0].bytes = 2; tg_nodes[0].count = 4;
+    val i16x4: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (i16x4.size != 8) { ret 1; }
+    if (i16x4.align != 2) { ret 1; }
+
+    # THE DISCONTINUITY, stated as a test so it cannot be "fixed" into uniformity
+    # without failing here: the same f32x4 shape is register-aligned on a 128-bit
+    # target and lane-aligned on a wider one, where it no longer fills the register.
+    tg_nodes[0].bytes = 4; tg_nodes[0].count = 4;
+    val at128: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
+    if (at128.align != 16) { ret 1; }
+    val at256: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 256), DEPTH_UNBOUNDED);
+    if (at256.size != 16) { ret 1; }
+    if (at256.align != 4) { ret 1; }
+
+    ret 0;
+}
+
 test "mach.lang.layout.extent:causes_are_distinguishable" {
     # a node the describer cannot classify
     tg_nodes[0] = node(NODE_UNKNOWN);
-    val unk: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val unk: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (unk.ok)                            { ret 1; }
     if (unk.cause != EXTENT_UNKNOWN_NODE)  { ret 1; }
 
@@ -377,7 +482,7 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_nodes[0].field_count = 1;
     tg_fields[0]            = 1;
     tg_nodes[1]             = node(NODE_UNKNOWN);
-    val prop: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val prop: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (prop.ok)                           { ret 1; }
     if (prop.cause != EXTENT_UNKNOWN_NODE) { ret 1; }
 
@@ -394,18 +499,18 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_nodes[1].count       = 4294967295;
     tg_nodes[2]             = node(NODE_SCALAR);
     tg_nodes[2].bytes       = 4;
-    val prop2: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val prop2: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (prop2.ok)                             { ret 1; }
     if (prop2.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
 
     # the same, through field_offset_of's own propagation path
-    val prop3: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, 8, DEPTH_UNBOUNDED);
+    val prop3: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (prop3.ok)                             { ret 1; }
     if (prop3.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
 
     # a depth failure raised below an aggregate must arrive as a DEPTH failure too
     tg_chain(8);
-    val prop4: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 3);
+    val prop4: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 3);
     if (prop4.ok)                    { ret 1; }
     if (prop4.cause != EXTENT_DEPTH) { ret 1; }
 
@@ -415,20 +520,20 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_nodes[0].count = 4294967295;
     tg_nodes[1]       = node(NODE_SCALAR);
     tg_nodes[1].bytes = 4;
-    val ovf: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val ovf: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (ovf.ok)                             { ret 1; }
     if (ovf.cause != EXTENT_ARRAY_OVERFLOW) { ret 1; }
 
     # deeper than the caller's bound
     tg_chain(8);
-    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 3);
+    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 3);
     if (deep.ok)                   { ret 1; }
     if (deep.cause != EXTENT_DEPTH) { ret 1; }
 
     # a field offset asked of something that is not an aggregate
     tg_nodes[0]       = node(NODE_SCALAR);
     tg_nodes[0].bytes = 4;
-    val nag: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, 8, DEPTH_UNBOUNDED);
+    val nag: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (nag.ok)                            { ret 1; }
     if (nag.cause != EXTENT_NOT_AGGREGATE) { ret 1; }
 
@@ -438,13 +543,13 @@ test "mach.lang.layout.extent:causes_are_distinguishable" {
     tg_fields[0]            = 1;
     tg_nodes[1]             = node(NODE_SCALAR);
     tg_nodes[1].bytes       = 4;
-    val rng: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 3, 8, DEPTH_UNBOUNDED);
+    val rng: Extent = field_offset_of(nil, tg_describe, tg_field, 0, 3, machine(8, 128), DEPTH_UNBOUNDED);
     if (rng.ok)                          { ret 1; }
     if (rng.cause != EXTENT_FIELD_RANGE) { ret 1; }
 
     # and a determined extent carries EXTENT_OK, so `cause` is never stale from a
     # previous failure
-    val good: Extent = extent_of(nil, tg_describe, tg_field, 1, 8, DEPTH_UNBOUNDED);
+    val good: Extent = extent_of(nil, tg_describe, tg_field, 1, machine(8, 128), DEPTH_UNBOUNDED);
     if (!good.ok)                 { ret 1; }
     if (good.cause != EXTENT_OK)  { ret 1; }
     ret 0;
@@ -458,18 +563,18 @@ test "mach.lang.layout.extent:unbounded_walks_past_any_constant" {
     # 70 levels: past the 64 that used to be hardcoded, and past any bound a caller
     # would plausibly pick
     tg_chain(70);
-    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, DEPTH_UNBOUNDED);
+    val deep: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), DEPTH_UNBOUNDED);
     if (!deep.ok)          { ret 1; }
     if (deep.size  != 1)   { ret 1; }
     if (deep.align != 1)   { ret 1; }
 
     # the same graph declines under a bound below its depth, and says why
-    val bounded: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 64);
+    val bounded: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 64);
     if (bounded.ok)                    { ret 1; }
     if (bounded.cause != EXTENT_DEPTH) { ret 1; }
 
     # a bound at or above the depth admits it
-    val fits: Extent = extent_of(nil, tg_describe, tg_field, 0, 8, 69);
+    val fits: Extent = extent_of(nil, tg_describe, tg_field, 0, machine(8, 128), 69);
     if (!fits.ok)        { ret 1; }
     if (fits.size != 1)  { ret 1; }
     ret 0;

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -31,6 +31,7 @@ use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
+use mach.lang.spirvop;
 
 use semtype: mach.lang.type;
 
@@ -310,6 +311,16 @@ pub rec Block {
 #              its siblings is the single-invocation workgroup
 # wg_y:        workgroup y dimension; 1 when the decorator is absent
 # wg_z:        workgroup z dimension; 1 when the decorator is absent
+# spv_set:     the SPIR-V instruction set a `#[spirv_op(set, name)]` decorator names
+#              (one of spirvop.SPV_SET_*), or SPV_SET_NONE for an ordinary function.
+#              carried on the DEFINITION and stamped onto the signature-only extern
+#              declaration a caller in another module creates, because a SPIR-V
+#              module is compiled per mach module: the call site is the only place
+#              the instruction can be substituted, and by then all the caller holds
+#              of the callee is that declaration
+# spv_op:      the opcode within `spv_set`, resolved by `spirvop.opcode_of`; a core
+#              opcode for SPV_SET_CORE, an extended instruction number otherwise.
+#              meaningless when `spv_set` is SPV_SET_NONE
 # disp:        bare source name of the function. inert debug metadata like `loc`
 #              (#1689): the machine-code path never reads it; only the `-g` DWARF
 #              producer does, for a readable DW_AT_name instead of the mangled linkage
@@ -356,6 +367,8 @@ pub rec Function {
     wg_x:        u32;
     wg_y:        u32;
     wg_z:        u32;
+    spv_set:     u8;
+    spv_op:      u32;
     disp:        intern.StrId;
     ret_sem:     semtype.TypeId;
 
@@ -762,6 +775,8 @@ pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId
     f.wg_x        = 1;
     f.wg_y        = 1;
     f.wg_z        = 1;
+    f.spv_set     = spirvop.SPV_SET_NONE;
+    f.spv_op      = spirvop.SPV_OP_NONE;
     f.disp        = intern.STR_NIL;
     f.ret_sem     = semtype.TYPE_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](alloc, map.hash_u32, map.eq_u32);

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -69,8 +69,10 @@ pub val IRT_FN:     IrTypeKind = 6;
 # a union: its members overlap at offset 0; size is the max member size and
 # align the max member align. shares the struct payload (the member type list)
 pub val IRT_UNION:  IrTypeKind = 7;
-# a 128-bit SIMD vector of `lanes` elements of `element` (#1965). register-class,
-# not aggregate: it flows in one vector register, 16-byte size and alignment
+# a SIMD vector of `lanes` elements of `element` (#1965). register-class, not
+# aggregate. its extent is lane-derived (#2687): size is `lanes * element size`, and
+# alignment is the whole size for a vector that fills the target's vector register,
+# one lane for a narrower one
 pub val IRT_VECTOR: IrTypeKind = 8;
 
 # array payload: an element type and a fixed element count, stored inline so an
@@ -267,7 +269,7 @@ pub fun is_float_scalar(t: *IrTypeTable, id: IrTypeId) bool {
     ret O.unwrap[*IrType](opt_get).kind == IRT_FLOAT;
 }
 
-# whether a type is a 128-bit vector (#1965)
+# whether a type is a vector (#1965)
 #
 # The single classifier the backend consults to route a vector value to the
 # vector register bank and to guard against it reaching unimplemented selection.
@@ -367,7 +369,7 @@ pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) R.Result[Ir
     ret intern_inline(t, ir);
 }
 
-# intern a 128-bit vector type (#1965)
+# intern a vector type (#1965)
 # ---
 # t:       the table
 # element: scalar element IrTypeId (an IRT_INT or IRT_FLOAT)
@@ -462,8 +464,16 @@ fun describe_node(ctx: ptr, id: u32) layout.Node {
     }
     # a first-class `fun(...)` value is a function pointer, so it lays out as one.
     if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret layout.node(layout.NODE_POINTER); }
-    # all ten vector shapes are 128-bit (#1965).
-    if (ir.kind == IRT_VECTOR) { ret layout.node(layout.NODE_VECTOR); }
+    # a vector's extent is lane-derived, so the node carries its lane shape (#2687).
+    # the lane width comes from the element type, which is always a scalar.
+    if (ir.kind == IRT_VECTOR) {
+        val opt_el: O.Option[*IrType] = get(t, ir.data.vector_.element);
+        if (O.is_none[*IrType](opt_el)) { ret layout.node(layout.NODE_UNKNOWN); }
+        var n: layout.Node = layout.node(layout.NODE_VECTOR);
+        n.bytes = bits_to_bytes(O.unwrap[*IrType](opt_el).data.bits);
+        n.count = ir.data.vector_.lanes;
+        ret n;
+    }
     if (ir.kind == IRT_ARRAY) {
         var n: layout.Node = layout.node(layout.NODE_ARRAY);
         n.child = ir.data.array_.element;
@@ -505,7 +515,7 @@ fun describe_field(ctx: ptr, id: u32, index: u32) u32 {
 # that construction already rules out.
 fun ir_extent(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target, what: str) layout.Extent {
     val e: layout.Extent = layout.extent_of(t::ptr, describe_node, describe_field, id,
-                                            ptr_width_of(tgt), layout.DEPTH_UNBOUNDED);
+                                            machine_of(tgt), layout.DEPTH_UNBOUNDED);
     if (!e.ok) { panic_cause(what, e.cause); }
     ret e;
 }
@@ -543,17 +553,17 @@ fun append_str(buf: *u8, n: usize, cap: usize, s: str) usize {
     ret o;
 }
 
-# the target's pointer width, which every layout query needs
+# the target facts every layout query needs
 #
-# A Target with no ISA is not a resolved target and cannot answer this. The layout
-# reads the width up front rather than only on reaching a pointer, so an unresolved
-# target is reported here instead of surfacing as a fault deep in a walk - or, worse,
-# going unnoticed on the types that happen not to contain a pointer.
-fun ptr_width_of(tgt: *target.Target) u32 {
+# A Target with no ISA is not a resolved target and cannot answer these. The layout
+# reads them up front rather than only on reaching a pointer or a vector, so an
+# unresolved target is reported here instead of surfacing as a fault deep in a walk -
+# or, worse, going unnoticed on the types that happen to contain neither.
+fun machine_of(tgt: *target.Target) layout.Machine {
     if (tgt == nil || tgt.isa == nil) {
         panic("ir.type: layout query needs a resolved target with an instruction set\n");
     }
-    ret tgt.isa.pointer_width;
+    ret layout.machine(tgt.isa.pointer_width, tgt.model.vector_bits);
 }
 
 # the size in bytes of an IR type for the given target
@@ -601,7 +611,7 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 # ret:      byte offset of the field
 pub fun byte_offset(t: *IrTypeTable, id: IrTypeId, field_ix: u32, tgt: *target.Target) u32 {
     val e: layout.Extent = layout.field_offset_of(t::ptr, describe_node, describe_field, id,
-                                                  field_ix, ptr_width_of(tgt), layout.DEPTH_UNBOUNDED);
+                                                  field_ix, machine_of(tgt), layout.DEPTH_UNBOUNDED);
     if (!e.ok) { panic_cause("ir.type.byte_offset: ", e.cause); }
     ret e.size;
 }
@@ -900,8 +910,9 @@ test "mach.lang.me.ir.type.intern_struct:align_override" {
     ret 0;
 }
 
-# IRT_VECTOR interns and dedups by (element, lanes), sizes and aligns to 16, and
-# is register-class (not aggregate) (#1965)
+# IRT_VECTOR interns and dedups by (element, lanes), is register-class (not
+# aggregate) (#1965), and lays out lane-derived: a vector filling the target's vector
+# register aligns to its whole size, a narrower one to a single lane (#2687)
 test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -930,11 +941,30 @@ test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     var arch: isa.IsaVTable = isa.machine_isa(isa.ARCH_UNKNOWN, "test", 0, 8, nil, nil, nil);
     var tgt: target.Target;
     tgt.isa = ?arch;
+    # the layout turns on the vector register width, so the test target must declare
+    # one. left at 0 this proves nothing: every vector would compare as register-filling.
+    tgt.model.vector_bits = 128;
 
+    # f32x4 fills the 128-bit register, so it is register-aligned.
     if (byte_size(?types, vecty, ?tgt)  != 16) { dnit(?types); ret 1; }
     if (byte_align(?types, vecty, ?tgt) != 16) { dnit(?types); ret 1; }
     # register-class, not aggregate.
     if (is_aggregate(?types, vecty))           { dnit(?types); ret 1; }
+
+    # f32x3 is narrower than the register: packed to 12 bytes and aligned to one lane,
+    # which is what makes an array of them a usable packed vertex buffer.
+    val r4: R.Result[IrTypeId, str] = intern_vector(?types, f32ty, 3);
+    if (R.is_err[IrTypeId, str](r4)) { dnit(?types); ret 1; }
+    val v3: IrTypeId = R.unwrap_ok[IrTypeId, str](r4);
+    if (byte_size(?types, v3, ?tgt)  != 12) { dnit(?types); ret 1; }
+    if (byte_align(?types, v3, ?tgt) != 4)  { dnit(?types); ret 1; }
+    if (is_aggregate(?types, v3))           { dnit(?types); ret 1; }
+
+    # the same f32x4 on a 256-bit target no longer fills the register, so it drops to
+    # lane alignment while keeping its size. this is the discontinuity, not a bug.
+    tgt.model.vector_bits = 256;
+    if (byte_size(?types, vecty, ?tgt)  != 16) { dnit(?types); ret 1; }
+    if (byte_align(?types, vecty, ?tgt) != 4)  { dnit(?types); ret 1; }
 
     dnit(?types);
     ret 0;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -14,6 +14,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_region_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -21,6 +22,7 @@ use R: std.types.result;
 
 use mach.lang.fe.ast;
 use adecl: mach.lang.fe.ast.decl;
+use aexpr: mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
@@ -36,6 +38,7 @@ use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.spirvop;
 use target:  mach.lang.target.resolved;
 use mach.lang.type;
 
@@ -1745,9 +1748,62 @@ pub fun expr_symbol_of(lc: *LowerContext, eid: id.ExprId) resolve.SymbolId {
 # lc:  the context
 # ret: the module's source text, or the empty string
 pub fun module_source(lc: *LowerContext) str {
-    val sf: O.Option[*source.SourceFile] = source.get(?lc.s.sources, lc.a.file_id);
+    ret ast_source(lc, lc.a);
+}
+
+# return the source text an arbitrary module's AST was parsed from
+#
+# `module_source` answers for the module being lowered; a cross-module reference
+# needs the same answer for the module the referent was DECLARED in, whose
+# decorator spans index that text and not this one.
+# ---
+# lc:  the context
+# a:   the AST whose source text is wanted
+# ret: the source text, or the empty string for an unregistered file id
+pub fun ast_source(lc: *LowerContext, a: *ast.Ast) str {
+    if (a == nil) { ret ""; }
+    val sf: O.Option[*source.SourceFile] = source.get(?lc.s.sources, a.file_id);
     if (O.is_none[*source.SourceFile](sf)) { ret ""; }
     ret O.unwrap[*source.SourceFile](sf).text;
+}
+
+# read a function decl's `#[spirv_op(set, name)]` into a resolved set tag and opcode
+#
+# Both arguments are string literals sema has already closed against the same
+# `spirvop` table, so an unrecognized spelling cannot reach here; SPV_SET_NONE
+# covers the decorator being absent, which is every ordinary function.
+#
+# The decl and its source text are passed rather than taken from the context
+# because this is read on BOTH sides of a module boundary: on the definition, where
+# they are the module being lowered, and at a call site in another module, where
+# they belong to the callee's origin module.
+# ---
+# a:      the AST the decl belongs to
+# src:    that AST's source text
+# d:      the function's decl
+# out_op: receives the opcode within the set, untouched when there is no decorator
+# ret:    one of spirvop.SPV_SET_*
+pub fun decl_spirv_op(a: *ast.Ast, src: str, d: *adecl.Decl, out_op: *u32) u8 {
+    if (a == nil || d == nil) { ret spirvop.SPV_SET_NONE; }
+    var i: u32 = 0;
+    for (i < d.decorators_len) {
+        val dec: *adecl.Decorator = ?a.decorators[d.decorators_start + i];
+        if (!str_region_equals(src, dec.name.offset, dec.name.len, "spirv_op")) { i = i + 1; cnt; }
+        if (dec.args_len != 2) { ret spirvop.SPV_SET_NONE; }
+        val opt_set: O.Option[*aexpr.Expr] = ast.get_expr(a, a.expr_ids[dec.args_start]);
+        val opt_nam: O.Option[*aexpr.Expr] = ast.get_expr(a, a.expr_ids[dec.args_start + 1]);
+        if (O.is_none[*aexpr.Expr](opt_set) || O.is_none[*aexpr.Expr](opt_nam)) { ret spirvop.SPV_SET_NONE; }
+        val set_e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_set);
+        val nam_e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_nam);
+        if (set_e.span.len < 2::usize || nam_e.span.len < 2::usize) { ret spirvop.SPV_SET_NONE; }
+        val set_v: u8 = spirvop.set_of(src, set_e.span.offset + 1::usize, set_e.span.len - 2::usize);
+        if (set_v == spirvop.SPV_SET_NONE) { ret spirvop.SPV_SET_NONE; }
+        val op: u32 = spirvop.opcode_of(set_v, src, nam_e.span.offset + 1::usize, nam_e.span.len - 2::usize);
+        if (op == spirvop.SPV_OP_NONE) { ret spirvop.SPV_SET_NONE; }
+        @out_op = op;
+        ret set_v;
+    }
+    ret spirvop.SPV_SET_NONE;
 }
 
 # emit an OP_DBG_VALUE binding the source variable named by `name_span` (type

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -155,6 +155,13 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
     ctx.m.functions[fn_index].wg_x  = decl_workgroup_dim(ctx, d, 0);
     ctx.m.functions[fn_index].wg_y  = decl_workgroup_dim(ctx, d, 1);
     ctx.m.functions[fn_index].wg_z  = decl_workgroup_dim(ctx, d, 2);
+    # the SPIR-V instruction a `#[spirv_op(set, name)]` says this function IS. Read
+    # onto the definition as well as onto the extern declaration a caller in another
+    # module creates, so a module that defines one and calls it locally substitutes
+    # the instruction too, and so the SPIR-V emitter can skip emitting a body that
+    # would never be called on that target.
+    ctx.m.functions[fn_index].spv_set =
+        context.decl_spirv_op(ctx.a, context.module_source(ctx), d, ?ctx.m.functions[fn_index].spv_op);
 
     # a declared `ext fun` is a genuine foreign C import (a strict subset of the
     # FN_FLAG_EXTERN this function also carries): its calls marshal their arguments to

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -46,6 +46,7 @@ use mach.lang.me.lower.context;
 use mach.lang.me.lower.mangle;
 use mach.lang.session;
 use mach.lang.source;
+use mach.lang.spirvop;
 use mach.lang.type;
 
 # lower an expression to its rvalue: the loaded value it denotes
@@ -708,7 +709,10 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     # reference; it falls through to the global-load path below, so a call
     # through it loads the stored pointer and dispatches indirectly.
     if (names_function(ctx, sym)) {
-        ret fn_reference(ctx, link, vty, references_import_function(ctx, sym));
+        val res_fn: R.Result[value.Value, str] = fn_reference(ctx, link, vty, references_import_function(ctx, sym));
+        if (R.is_err[value.Value, str](res_fn)) { ret res_fn; }
+        stamp_spirv_op(ctx, sym, R.unwrap_ok[value.Value, str](res_fn));
+        ret res_fn;
     }
 
     # a module-level `val` whose initializer folded is a constant at every use, in
@@ -854,6 +858,35 @@ fun references_import_data(ctx: *context.LowerContext, sym: *resolve.Symbol) boo
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
     ret (d.flags & decl.DECL_FLAG_EXT) != 0;
+}
+
+# carry a cross-module callee's `#[spirv_op(set, name)]` onto the extern declaration
+# this module created for it
+#
+# A SPIR-V module is compiled per mach module and a SPIR-V shader module cannot call
+# out of itself at all: Vulkan forbids the Linkage capability, so there is no import
+# for the linker to bind. The substitution therefore has to happen at the call site,
+# and by the time the back end sees it, all this module holds of `sh.normalize` is
+# the signature-only declaration `ensure_extern_function` synthesized from a name and
+# a type. Reading the decorator off the ORIGIN module's decl - the same way
+# `references_import_function` reads `ext` - is what puts the instruction back on it.
+#
+# A no-op for an ordinary function, and for every non-SPIR-V target, which never
+# looks at the field.
+# ---
+# ctx: per-module lowering context
+# sym: the symbol naming the callee
+# v:   the VAL_FN reference just formed for it
+fun stamp_spirv_op(ctx: *context.LowerContext, sym: *resolve.Symbol, v: value.Value) {
+    if (v.kind != value.VAL_FN || v.data.fn_ix >= ctx.m.function_len) { ret; }
+    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    if (origin_ast == nil) { ret; }
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    if (O.is_none[*decl.Decl](opt_d)) { ret; }
+    val fi: u32 = v.data.fn_ix;
+    val set_v: u8 = context.decl_spirv_op(origin_ast, context.ast_source(ctx, origin_ast),
+                                          O.unwrap[*decl.Decl](opt_d), ?ctx.m.functions[fi].spv_op);
+    if (set_v != spirvop.SPV_SET_NONE) { ctx.m.functions[fi].spv_set = set_v; }
 }
 
 # whether a symbol names a genuine foreign C function import (a declared `ext fun`)

--- a/src/lang/spirvop.mach
+++ b/src/lang/spirvop.mach
@@ -1,0 +1,194 @@
+# SPIR-V instruction table for the `#[spirv_op(set, name)]` decorator
+#
+# A shader needs `sqrt`, `normalize` and `mix`, and none of them is an operator or
+# a call SPIR-V can express: each is one SPIR-V instruction, drawn either from the
+# core opcode space or from an extended instruction set the module imports. The
+# decorator is how a mach function says which instruction it IS on a SPIR-V target,
+# so the mapping lives on the declaration rather than in a `$`-name the language
+# would have to grow one of per function.
+#
+# This module is the single place a `(set, name)` pair becomes a number. Sema calls
+# it to close the value set - a typo is a compile error on the decorator, not a
+# module that quietly calls nothing - and lowering calls it to resolve the number
+# onto the IR function. One table, two readers, so the accepted spellings and the
+# emitted opcodes cannot drift apart.
+#
+# It is a leaf: it holds only spec numbers and string comparisons, imports no
+# compiler module, and is named by `fe.sema`, `me.lower.decl`, `me.lower.expr` and
+# `target.isa.spirv.emit` alike. The SPIR-V back end owns the emission mechanics
+# (which section the import lands in, when it is emitted); the numbers are here so
+# the front end can check them without depending on a back end.
+#
+# THE GROWTH AXIS IS A ROW. Adding a GLSL.std.450 instruction is one line in
+# `opcode_of`; adding a whole new extended set is a `SPV_SET_*` tag, a row in
+# `set_of`, its import string in `set_import_name`, and its instructions' rows. The
+# set is carried explicitly rather than inferred from the instruction name so a
+# second set whose names collide with GLSL.std.450's stays unambiguous.
+#
+# WHAT IS DELIBERATELY ABSENT from the GLSL.std.450 rows below, and why, since the
+# spec's set is far larger than this:
+#
+#   - `Modf` and `Frexp` take a pointer operand to write their second result
+#     through. SPIR-V here is LOGICAL addressing: a pointer has exactly one pointee
+#     type and no pointer may be cast, and mach has no way to hand the back end a
+#     Function-storage out-pointer at a call site. The `*Struct` forms avoid the
+#     pointer but return a two-member struct mach cannot spell as a return type.
+#   - `Cross` is defined only for 3-component float vectors. mach has no `f32x3`
+#     (briar-systems/mach#2687), so there is no type to declare it at. It becomes a
+#     row the day that lands.
+#   - `Determinant` and `MatrixInverse` need a matrix type, which mach does not
+#     have by design - doc/types.md puts matrices in a library over vectors.
+#   - the `Pack*` / `Unpack*` family reinterprets one width's bits as another's,
+#     which is exactly what logical addressing forbids.
+#   - `InterpolateAt*` require the InterpolationFunction capability, which the
+#     module does not declare.
+#   - the integer `UMin` / `SMin` / `UMax` / `SMax` / `UClamp` / `SClamp` and the
+#     `Find*Msb` bit-scan family are ordinary integer arithmetic that a CPU target
+#     computes identically. They are not the shader gap, and routing them through a
+#     shader-only module would make code less portable, not more.
+#   - `NMin` / `NMax` / `NClamp` differ from the `F` forms only in NaN handling.
+#     Both spellings existing with no visible difference is a trap; the `F` forms
+#     are what GLSL's own `min` / `max` / `clamp` compile to.
+
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_region_equals;
+
+# the instruction set an operation is drawn from. NONE is the absence of the
+# decorator, which is every ordinary function
+pub val SPV_SET_NONE:    u8 = 0;
+pub val SPV_SET_CORE:    u8 = 1;
+pub val SPV_SET_GLSL450: u8 = 2;
+
+# no instruction of that name exists in that set. distinct from opcode 0, which is
+# the core `OpNop`
+pub val SPV_OP_NONE: u32 = 0xFFFFFFFF;
+
+# the instruction set a `#[spirv_op(set, ...)]` first argument names
+#
+# "core" is the core opcode space, whose instructions need no import; every other
+# accepted spelling is an extended set's literal name, which is also the string the
+# module's OpExtInstImport carries.
+# ---
+# src: the source text holding the argument
+# off: byte offset of the argument's content (quotes already stripped)
+# len: byte length of the content
+# ret: one of SPV_SET_*, or SPV_SET_NONE when the name is not an accepted set
+pub fun set_of(src: str, off: usize, len: usize) u8 {
+    if (str_region_equals(src, off, len, "core"))          { ret SPV_SET_CORE; }
+    if (str_region_equals(src, off, len, "GLSL.std.450"))  { ret SPV_SET_GLSL450; }
+    ret SPV_SET_NONE;
+}
+
+# the literal name an extended set is imported under, or the empty string for the
+# core set, which is never imported
+# ---
+# set: one of SPV_SET_*
+# ret: the OpExtInstImport operand string
+pub fun set_import_name(set: u8) str {
+    if (set == SPV_SET_GLSL450) { ret "GLSL.std.450"; }
+    ret "";
+}
+
+# the opcode a `#[spirv_op(set, name)]` second argument names within `set`
+#
+# For SPV_SET_CORE this is the core opcode itself; for an extended set it is the
+# instruction number the OpExtInst carries after the set's id. Returns SPV_OP_NONE
+# for a name the set does not define, which is what closes the decorator's value
+# set in sema.
+# ---
+# set: the set the name is looked up in, one of SPV_SET_*
+# src: the source text holding the argument
+# off: byte offset of the argument's content (quotes already stripped)
+# len: byte length of the content
+# ret: the opcode, or SPV_OP_NONE
+pub fun opcode_of(set: u8, src: str, off: usize, len: usize) u32 {
+    if (set == SPV_SET_CORE) {
+        # the dot product is NOT a GLSL.std.450 instruction, which is the single
+        # easiest thing to get wrong here: GLSL spells `dot` alongside `normalize`
+        # and `length`, so it reads like one of the set, and an OpExtInst carrying
+        # some invented number for it would assemble and validate as whatever
+        # instruction that number happens to be. It is core OpDot.
+        if (str_region_equals(src, off, len, "OpDot")) { ret 148; }
+        ret SPV_OP_NONE;
+    }
+    if (set != SPV_SET_GLSL450) { ret SPV_OP_NONE; }
+
+    # common-value maths
+    if (str_region_equals(src, off, len, "FAbs"))        { ret 4; }
+    if (str_region_equals(src, off, len, "FSign"))       { ret 6; }
+    if (str_region_equals(src, off, len, "Floor"))       { ret 8; }
+    if (str_region_equals(src, off, len, "Ceil"))        { ret 9; }
+    if (str_region_equals(src, off, len, "Fract"))       { ret 10; }
+
+    # trigonometry, including the angle conversions GLSL exposes beside it
+    if (str_region_equals(src, off, len, "Radians"))     { ret 11; }
+    if (str_region_equals(src, off, len, "Degrees"))     { ret 12; }
+    if (str_region_equals(src, off, len, "Sin"))         { ret 13; }
+    if (str_region_equals(src, off, len, "Cos"))         { ret 14; }
+    if (str_region_equals(src, off, len, "Tan"))         { ret 15; }
+    if (str_region_equals(src, off, len, "Asin"))        { ret 16; }
+    if (str_region_equals(src, off, len, "Acos"))        { ret 17; }
+    if (str_region_equals(src, off, len, "Atan"))        { ret 18; }
+    if (str_region_equals(src, off, len, "Atan2"))       { ret 25; }
+
+    # exponentials
+    if (str_region_equals(src, off, len, "Pow"))         { ret 26; }
+    if (str_region_equals(src, off, len, "Exp"))         { ret 27; }
+    if (str_region_equals(src, off, len, "Log"))         { ret 28; }
+    if (str_region_equals(src, off, len, "Exp2"))        { ret 29; }
+    if (str_region_equals(src, off, len, "Log2"))        { ret 30; }
+    if (str_region_equals(src, off, len, "Sqrt"))        { ret 31; }
+    if (str_region_equals(src, off, len, "InverseSqrt")) { ret 32; }
+
+    # range and interpolation
+    if (str_region_equals(src, off, len, "FMin"))        { ret 37; }
+    if (str_region_equals(src, off, len, "FMax"))        { ret 40; }
+    if (str_region_equals(src, off, len, "FClamp"))      { ret 43; }
+    if (str_region_equals(src, off, len, "FMix"))        { ret 46; }
+    if (str_region_equals(src, off, len, "Step"))        { ret 48; }
+    if (str_region_equals(src, off, len, "SmoothStep"))  { ret 49; }
+    if (str_region_equals(src, off, len, "Fma"))         { ret 50; }
+
+    # geometry. every one of these takes and returns whole vectors, which is why
+    # they belong to the set rather than to a scalar library
+    if (str_region_equals(src, off, len, "Length"))      { ret 66; }
+    if (str_region_equals(src, off, len, "Distance"))    { ret 67; }
+    if (str_region_equals(src, off, len, "Normalize"))   { ret 69; }
+    if (str_region_equals(src, off, len, "FaceForward")) { ret 70; }
+    if (str_region_equals(src, off, len, "Reflect"))     { ret 71; }
+    if (str_region_equals(src, off, len, "Refract"))     { ret 72; }
+
+    ret SPV_OP_NONE;
+}
+
+test "mach.lang.spirvop.opcode_of:sets_are_separate" {
+    # `dot` is core, not extended, and the extended set must not answer for it.
+    if (opcode_of(SPV_SET_CORE, "OpDot", 0::usize, 5::usize) != 148) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "OpDot", 0::usize, 5::usize) != SPV_OP_NONE) { ret 1; }
+    # and the extended names must not answer from the core set.
+    if (opcode_of(SPV_SET_GLSL450, "Sqrt", 0::usize, 4::usize) != 31) { ret 1; }
+    if (opcode_of(SPV_SET_CORE, "Sqrt", 0::usize, 4::usize) != SPV_OP_NONE) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.spirvop.opcode_of:prefix_is_not_a_match" {
+    # a region compare, not a prefix compare: "Exp" and "Exp2" are different
+    # instructions and "Log" is not the head of "Log2".
+    if (opcode_of(SPV_SET_GLSL450, "Exp2", 0::usize, 4::usize) != 29) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "Exp2", 0::usize, 3::usize) != 27) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "Atan2", 0::usize, 5::usize) != 25) { ret 1; }
+    if (opcode_of(SPV_SET_GLSL450, "Atan2", 0::usize, 4::usize) != 18) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.spirvop.set_of:closed" {
+    if (set_of("core", 0::usize, 4::usize) != SPV_SET_CORE) { ret 1; }
+    if (set_of("GLSL.std.450", 0::usize, 12::usize) != SPV_SET_GLSL450) { ret 1; }
+    # an unknown set is refused rather than defaulted to the extended one, which is
+    # what keeps a typo from silently importing GLSL.std.450.
+    if (set_of("GLSL.std.451", 0::usize, 12::usize) != SPV_SET_NONE) { ret 1; }
+    if (!str_equals(set_import_name(SPV_SET_GLSL450), "GLSL.std.450")) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -1192,6 +1192,33 @@ test "mach.lang.target.select:has_v128_capability" {
     ret 0;
 }
 
+# vector_bits is the width bound the `TxN` form resolves against, declared by
+# every target including the two with no vector unit at all. a target that
+# scalarizes still has a vector width, so this is independent of has_v128 and
+# must never be derived from it (#2687)
+test "mach.lang.target.select:vector_bits_bound" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    val tx: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "linux", "sysv64", "");
+    if (R.is_err[resolved.Target, str](tx)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tx).model.vector_bits != 128) { ret 1; }
+
+    val ta: R.Result[resolved.Target, str] = select_of(?reg, "aarch64", "linux", "aapcs64", "");
+    if (R.is_err[resolved.Target, str](ta)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](ta).model.vector_bits != 128) { ret 1; }
+
+    # the two targets with has_v128 false still declare the width: they admit
+    # every 128-bit spelling and scalarize it, so a 0 here would refuse names
+    # that compile correctly today.
+    val tr: R.Result[resolved.Target, str] = select_of(?reg, "riscv64", "linux", "lp64", "");
+    if (R.is_err[resolved.Target, str](tr)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tr).model.has_v128)            { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tr).model.vector_bits != 128)  { ret 1; }
+
+    ret 0;
+}
+
 # a 128-bit vector classifies as one SSE-class value under SysV (#2014): a single XMM
 # argument register (not the two-eightbyte split an all-float aggregate takes) and XMM0
 # for the return, both at the full 16-byte width

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -253,6 +253,25 @@ pub rec RegClass {
 #                    derived from the float bank width (#1965). the shared MIR
 #                    lowerer gates its vector path on this: a vector op on a target
 #                    without it is a defined per-target compile error, not an ICE
+# vector_bits:       the widest vector the target admits BY NAME, in bits, which
+#                    bounds the `TxN` vector form the frontend resolves (#2687).
+#                    128 on every target today.
+#
+#                    DISTINCT FROM `has_v128`, and the two must never be
+#                    conflated: this is how wide a vector may be SPELLED, that one
+#                    is whether a SIMD unit exists to run it. They are independent
+#                    in the direction that matters: rv64gc and mos6502 both set
+#                    `has_v128` false and still admit every 128-bit shape, which
+#                    `me.pass.scalarize` turns into per-lane scalar code. So a
+#                    target without a vector unit still has a vector width, and
+#                    gating the spelling on `has_v128` would refuse names that
+#                    compile correctly today.
+#
+#                    This is the axis the super-128 shapes grow along: a target
+#                    that gains ymm / zmm / SVE register classes raises this and
+#                    the frontend admits the wider spellings with no change. A
+#                    boolean cannot express that, which is why the bound is a
+#                    width rather than a second capability flag.
 # vector_compute_generic: true when the backend selects 128-bit vector compute
 #                    (lane-wise arithmetic / bitwise / shift / compare) from the
 #                    generic MIR opcodes carrying `vec_lane`, so the shared lowerer
@@ -302,6 +321,7 @@ pub rec MachineModel {
     red_zone:          u32;
     shadow_space:      u32;
     has_v128:          bool;
+    vector_bits:       u32;
     vector_compute_generic: bool;
     has_lane_ops:      bool;
     ct_trust_mul:      bool;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -299,6 +299,14 @@ pub rec RegClass {
 #                    this flag - it governs integer multiply alone. conservative
 #                    default false on every target until the DIT/DOITM enablement
 #                    (stdlib ct.begin/ct.end) lands to prove the mode is set
+# the width of a 128-bit SIMD vector unit, in bits
+#
+# The `vector_bits` every current target declares, and the width the editor's
+# neutral host context reads when no target has been selected. Named rather than
+# written as a bare 128 in six places, so raising a target past it is a visible
+# edit at that target rather than a changed literal.
+pub val VECTOR_BITS_128: u32 = 128;
+
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -239,7 +239,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
     # NEON 128-bit vector unit is baseline on aarch64 (#1965).
     arm64_model.has_v128        = true;
-    arm64_model.vector_bits     = 128;
+    arm64_model.vector_bits     = isa.VECTOR_BITS_128;
     # NEON selects vector ops from the scalar-shaped shared handlers in the aarch64
     # isel, not the generic MIR path, so vector compute is not pre-routed.
     arm64_model.vector_compute_generic = false;

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -239,6 +239,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
     # NEON 128-bit vector unit is baseline on aarch64 (#1965).
     arm64_model.has_v128        = true;
+    arm64_model.vector_bits     = 128;
     # NEON selects vector ops from the scalar-shaped shared handlers in the aarch64
     # isel, not the generic MIR path, so vector compute is not pre-routed.
     arm64_model.vector_compute_generic = false;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -118,7 +118,7 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the machine word IS one byte, so every move is full-width and extends nothing.
     mos6502_model.endianness      = isa.ENDIAN_LITTLE;
     mos6502_model.has_v128        = false;
-    mos6502_model.vector_bits     = 128;
+    mos6502_model.vector_bits     = isa.VECTOR_BITS_128;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -118,6 +118,7 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the machine word IS one byte, so every move is full-width and extends nothing.
     mos6502_model.endianness      = isa.ENDIAN_LITTLE;
     mos6502_model.has_v128        = false;
+    mos6502_model.vector_bits     = 128;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -287,7 +287,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
     # vector ops scalarize before MIR lowering and none reaches the vector path.
     riscv64_model.has_v128        = false;
-    riscv64_model.vector_bits     = 128;
+    riscv64_model.vector_bits     = isa.VECTOR_BITS_128;
     riscv64_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -287,6 +287,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
     # vector ops scalarize before MIR lowering and none reaches the vector path.
     riscv64_model.has_v128        = false;
+    riscv64_model.vector_bits     = 128;
     riscv64_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -42,6 +42,8 @@ pub val SPV_GENERATOR: u32 = 0;
 # instruction's first word; the high 16 bits carry the instruction's total word
 # count (`inst_word`)
 pub val OP_NAME:                u32 = 5;
+pub val OP_EXT_INST_IMPORT:     u32 = 11;
+pub val OP_EXT_INST:            u32 = 12;
 pub val OP_MEMORY_MODEL:        u32 = 14;
 pub val OP_ENTRY_POINT:         u32 = 15;
 pub val OP_EXECUTION_MODE:      u32 = 16;
@@ -94,6 +96,11 @@ pub val OP_F_DIV:               u32 = 136;
 pub val OP_U_MOD:               u32 = 137;
 pub val OP_S_REM:               u32 = 138;
 pub val OP_F_REM:               u32 = 140;
+# the dot product is CORE, not GLSL.std.450. GLSL spells `dot` beside `normalize`
+# and `length`, so it reads like a member of the extended set, and an OpExtInst
+# carrying an invented number for it would still assemble and validate - as
+# whichever instruction that number happens to name
+pub val OP_DOT:                 u32 = 148;
 pub val OP_SELECT:              u32 = 169;
 pub val OP_I_EQUAL:             u32 = 170;
 pub val OP_I_NOT_EQUAL:         u32 = 171;
@@ -242,6 +249,11 @@ pub val SELECTION_CONTROL_NONE: u32 = 0;
 # alloc:        allocator backing every section vector and the serialized image
 # next_id:      the next id to hand out; equals the id bound at serialize time
 # caps:         OpCapability instructions
+# ext_imports:  OpExtInstImport instructions, one per extended instruction set the
+#               module actually uses. its own section because SPIR-V fixes its
+#               position - after every capability, before the memory model - while
+#               the emitter discovers the need mid-body, at the first call that
+#               lowers to an OpExtInst
 # memory_model: the single OpMemoryModel instruction
 # entry_points: OpEntryPoint instructions
 # exec_modes:   OpExecutionMode instructions
@@ -254,6 +266,7 @@ pub rec Builder {
     alloc:        *A.Allocator;
     next_id:      u32;
     caps:         Vec;
+    ext_imports:  Vec;
     memory_model: Vec;
     entry_points: Vec;
     exec_modes:   Vec;
@@ -342,6 +355,7 @@ pub fun builder_init(alloc: *A.Allocator) Builder {
     b.alloc        = alloc;
     b.next_id      = 1;
     b.caps         = vec_init();
+    b.ext_imports  = vec_init();
     b.memory_model = vec_init();
     b.entry_points = vec_init();
     b.exec_modes   = vec_init();
@@ -358,6 +372,7 @@ pub fun builder_init(alloc: *A.Allocator) Builder {
 # b: the builder to tear down
 pub fun builder_dnit(b: *Builder) {
     vec_dnit(b, ?b.caps);
+    vec_dnit(b, ?b.ext_imports);
     vec_dnit(b, ?b.memory_model);
     vec_dnit(b, ?b.entry_points);
     vec_dnit(b, ?b.exec_modes);
@@ -404,6 +419,29 @@ pub fun inst(b: *Builder, v: *Vec, opcode: u32, ops: *u32, n: u32) {
     }
 }
 
+# import an extended instruction set, returning the id an OpExtInst names it by
+#
+# One import per set per module, which the caller enforces by caching the returned
+# id: importing the same set twice is invalid, not merely wasteful. Lands in its own
+# section, so it serializes after every capability and before the memory model
+# wherever in the emission the need was discovered.
+# ---
+# b:   the builder
+# set: the set's literal name, e.g. "GLSL.std.450"
+# ret: the set's result id
+pub fun ext_inst_import(b: *Builder, set: str) u32 {
+    val id: u32 = alloc_id(b);
+    var ops: [17]u32;
+    ops[0] = id;
+    val n: u32 = string_words(set);
+    # 16 words is 63 characters of set name, past every set the specification
+    # registers; a longer one would silently truncate, so it is refused outright.
+    if (n > 16) { b.err = true; ret id; }
+    pack_string(set, ?ops[1]);
+    inst(b, ?b.ext_imports, OP_EXT_INST_IMPORT, ?ops[0], 1 + n);
+    ret id;
+}
+
 # the number of words a SPIR-V literal string occupies: its bytes plus a NUL
 # terminator, rounded up to a whole word
 # ---
@@ -443,9 +481,9 @@ pub fun pack_string(s: str, out: *u32) u32 {
 # frame the header and concatenate the sections into the final module byte image
 #
 # The word bound is the current `next_id` (one past the highest id handed out).
-# Sections are emitted in SPIR-V's required order: capabilities, memory model,
-# entry points, execution modes, decorations, types / constants, then function
-# bodies. Every word is serialized
+# Sections are emitted in SPIR-V's required order: capabilities, extended
+# instruction set imports, memory model, entry points, execution modes,
+# decorations, types / constants, then function bodies. Every word is serialized
 # little-endian. The returned buffer is allocated from the builder's allocator and
 # owned by the caller.
 # ---
@@ -455,7 +493,7 @@ pub fun pack_string(s: str, out: *u32) u32 {
 pub fun serialize(b: *Builder, out_len: *u32) R.Result[*u8, str] {
     if (b.err) { ret R.err[*u8, str]("spirv: module builder hit an allocation error"); }
 
-    val total_words: u32 = 5 + b.caps.len + b.memory_model.len + b.entry_points.len
+    val total_words: u32 = 5 + b.caps.len + b.ext_imports.len + b.memory_model.len + b.entry_points.len
                          + b.exec_modes.len + b.decorations.len
                          + b.types_consts.len + b.functions.len;
     val total_bytes: u32 = total_words * 4;
@@ -472,6 +510,7 @@ pub fun serialize(b: *Builder, out_len: *u32) R.Result[*u8, str] {
     pos = put_word(buf, pos, 0);  # schema, reserved 0
 
     pos = put_section(buf, pos, ?b.caps);
+    pos = put_section(buf, pos, ?b.ext_imports);
     pos = put_section(buf, pos, ?b.memory_model);
     pos = put_section(buf, pos, ?b.entry_points);
     pos = put_section(buf, pos, ?b.exec_modes);

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -70,7 +70,6 @@ pub val OP_STORE:               u32 = 62;
 pub val OP_ACCESS_CHAIN:        u32 = 65;
 pub val OP_DECORATE:            u32 = 71;
 pub val OP_MEMBER_DECORATE:     u32 = 72;
-pub val OP_VECTOR_SHUFFLE:      u32 = 79;
 pub val OP_COMPOSITE_EXTRACT:   u32 = 81;
 pub val OP_COMPOSITE_INSERT:    u32 = 82;
 pub val OP_CONVERT_F_TO_U:      u32 = 109;

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -59,6 +59,7 @@ pub val OP_CONSTANT_TRUE:       u32 = 41;
 pub val OP_CONSTANT_FALSE:      u32 = 42;
 pub val OP_CONSTANT:            u32 = 43;
 pub val OP_CONSTANT_COMPOSITE:  u32 = 44;
+pub val OP_CONSTANT_NULL:       u32 = 46;
 pub val OP_FUNCTION:            u32 = 54;
 pub val OP_FUNCTION_PARAMETER:  u32 = 55;
 pub val OP_FUNCTION_END:        u32 = 56;

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -82,6 +82,10 @@ use mach.lang.target.isa.spirv.types;
 # has_entry: whether any function in the module declares a pipeline stage, which
 #           decides whether this is a shader module (entry points, no Linkage) or a
 #           library module (Linkage exports, no entry point)
+# gtype_ids: the SPIR-V VALUE type each interface variable was declared with, and
+#           gstorage its storage class. An access chain's result is a pointer to a
+#           member of that exact type, and a laid-out block's array members are not
+#           interned, so the declared id has to be remembered rather than rebuilt.
 # gvar_ids: SPIR-V OpVariable id per IR global index, allocated before any body is
 #           emitted so a load or store can name a variable declared later (0 for a
 #           global carrying no interface role)
@@ -103,6 +107,8 @@ rec Emit {
     fn_ids:    *u32;
     has_entry: bool;
     gvar_ids:  *u32;
+    gtype_ids: *u32;
+    gstorage:  *u32;
     iface_ids: *u32;
     iface_len: u32;
     gslot:     *u32;
@@ -125,11 +131,18 @@ rec Emit {
 # type_id: SPIR-V element type id per vreg (0 when the vreg has no determined type)
 # var_id:  SPIR-V OpVariable id per vreg (0 when the vreg needs no variable)
 # is_bool: whether the vreg holds a boolean (defined by a comparison)
+# chain_id: for a vreg defined by an access chain, the resulting POINTER id, and
+#          chain_ty the type it points at. Such a vreg holds an address rather than
+#          a value, so it gets no backing variable and is never loaded as one; the
+#          load or store that consumes it addresses through the chain instead
 # n:       number of vregs
 rec VMaps {
     type_id: *u32;
     var_id:  *u32;
     is_bool: *bool;
+    chain_id: *u32;
+    chain_ty: *u32;
+    chain_sc: *u32;
     n:       u32;
 }
 
@@ -180,7 +193,7 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     var e: Emit;
     e.alloc = mirmod.alloc; e.interner = mirmod.interner;
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
-    e.gvar_ids = nil; e.iface_ids = nil; e.iface_len = 0;
+    e.gvar_ids = nil; e.gtype_ids = nil; e.gstorage = nil; e.iface_ids = nil; e.iface_len = 0;
     e.gslot = nil; e.iface_use = nil;
     e.srcmap = mirmod.srcmap; e.cur_fn = nil; e.cur_instr = nil;
 
@@ -284,6 +297,14 @@ fun emit_dnit(e: *Emit, n: u32) {
         A.deallocate[u32](e.alloc, e.gslot, e.ir.global_len::usize);
     }
     e.gslot = nil;
+    if (e.gtype_ids != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.gtype_ids, e.ir.global_len::usize);
+    }
+    e.gtype_ids = nil;
+    if (e.gstorage != nil && e.ir.global_len > 0) {
+        A.deallocate[u32](e.alloc, e.gstorage, e.ir.global_len::usize);
+    }
+    e.gstorage = nil;
     if (e.iface_use != nil && n > 0 && e.iface_len > 0) {
         A.deallocate[u8](e.alloc, e.iface_use, (n * e.iface_len)::usize);
     }
@@ -319,9 +340,15 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
     val rs: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
     if (R.is_err[*u32, str](rs)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rs)); }
     e.gslot = R.unwrap_ok[*u32, str](rs);
+    val rt: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rt)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rt)); }
+    e.gtype_ids = R.unwrap_ok[*u32, str](rt);
+    val rc: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rc)); }
+    e.gstorage = R.unwrap_ok[*u32, str](rc);
 
     var i: u32 = 0;
-    for (i < n) { e.gvar_ids[i] = 0; e.iface_ids[i] = 0; e.gslot[i] = 0; i = i + 1; }
+    for (i < n) { e.gvar_ids[i] = 0; e.iface_ids[i] = 0; e.gslot[i] = 0; e.gtype_ids[i] = 0; e.gstorage[i] = 0; i = i + 1; }
 
     i = 0;
     for (i < n) {
@@ -362,7 +389,9 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
         var vop: [3]u32;
         vop[0] = ptr_ty; vop[1] = var_id; vop[2] = storage;
         spirv.inst(e.b, ?e.b.types_consts, spirv.OP_VARIABLE, ?vop[0], 3);
-        e.gvar_ids[i] = var_id;
+        e.gvar_ids[i]  = var_id;
+        e.gtype_ids[i] = value_ty;
+        e.gstorage[i]  = storage;
 
         if (g.iface == ir.IFACE_INPUT || g.iface == ir.IFACE_OUTPUT) {
             decorate(e, var_id, spirv.DECOR_LOCATION, g.iface_a);
@@ -1371,6 +1400,9 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     out.type_id = nil;
     out.var_id  = nil;
     out.is_bool = nil;
+    out.chain_id = nil;
+    out.chain_ty = nil;
+    out.chain_sc = nil;
     if (n == 0) { ret R.ok[bool, str](true); }
 
     val rt: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
@@ -1382,9 +1414,18 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     val rb: R.Result[*bool, str] = A.allocate[bool](e.alloc, n::usize);
     if (R.is_err[*bool, str](rb)) { ret R.err[bool, str](R.unwrap_err[*bool, str](rb)); }
     out.is_bool = R.unwrap_ok[*bool, str](rb);
+    val rch: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rch)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rch)); }
+    out.chain_id = R.unwrap_ok[*u32, str](rch);
+    val rct: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rct)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rct)); }
+    out.chain_ty = R.unwrap_ok[*u32, str](rct);
+    val rcs: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+    if (R.is_err[*u32, str](rcs)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rcs)); }
+    out.chain_sc = R.unwrap_ok[*u32, str](rcs);
 
     var i: u32 = 0;
-    for (i < n) { out.type_id[i] = 0; out.var_id[i] = 0; out.is_bool[i] = false; i = i + 1; }
+    for (i < n) { out.type_id[i] = 0; out.var_id[i] = 0; out.is_bool[i] = false; out.chain_id[i] = 0; out.chain_ty[i] = 0; out.chain_sc[i] = 0; i = i + 1; }
 
     # a vreg fed from a nominal register is typed by the DECLARATION behind that
     # register, never by the move: the ABI pre-coloring is emitted at the machine
@@ -1474,6 +1515,10 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
+            # a structural GEP defines an ADDRESS. It gets no element type and no
+            # backing variable: the access chain it becomes is consumed directly by
+            # the load or store that follows, never loaded as a value.
+            if (mi.opcode == mir.MIR_GEP) { ii = ii + 1; cnt; }
             if (mir.instr_defines_shape(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
                 val v: u32 = mi.operands[0].vreg;
                 if (v < out.n && out.type_id[v] == 0 && !(skip_copies && is_reg_copy(mi))) {
@@ -1555,7 +1600,11 @@ fun vmaps_dnit(e: *Emit, vm: *VMaps) {
     if (vm.type_id != nil) { A.deallocate[u32](e.alloc, vm.type_id, vm.n::usize); }
     if (vm.var_id != nil)  { A.deallocate[u32](e.alloc, vm.var_id, vm.n::usize); }
     if (vm.is_bool != nil) { A.deallocate[bool](e.alloc, vm.is_bool, vm.n::usize); }
-    vm.type_id = nil; vm.var_id = nil; vm.is_bool = nil; vm.n = 0;
+    if (vm.chain_id != nil) { A.deallocate[u32](e.alloc, vm.chain_id, vm.n::usize); }
+    if (vm.chain_ty != nil) { A.deallocate[u32](e.alloc, vm.chain_ty, vm.n::usize); }
+    if (vm.chain_sc != nil) { A.deallocate[u32](e.alloc, vm.chain_sc, vm.n::usize); }
+    vm.type_id = nil; vm.var_id = nil; vm.is_bool = nil;
+    vm.chain_id = nil; vm.chain_ty = nil; vm.chain_sc = nil; vm.n = 0;
 }
 
 # the SPIR-V scalar type of one lane of a lane descriptor, or 0 when unmappable
@@ -1792,12 +1841,15 @@ fun interface_target(e: *Emit, op: *mir.MirOperand) u32 {
 # the diagnostic for an addressed access the milestone cannot carry, named by what
 # the address actually originates in
 #
-# Several lowerings land here and each is fixed somewhere different, so each says
-# so. A member walk into a uniform block, and an index into any other aggregate,
-# need this emitter to build an access chain from the ordinals MIR now keeps;
-# anything else is ordinary addressed memory this milestone does not have.
-# Reporting any of them under another's name sends a reader to the wrong problem,
-# which is exactly what the first version of this did.
+# Each lowering that lands here is fixed somewhere different, so each says so, and
+# reporting one under another's name sends a reader to the wrong problem - which is
+# what the first version of this did, twice.
+#
+# A member walk no longer arrives at all: MIR keeps the GEP's index list on this
+# target (#2649) and the emitter builds an `OpAccessChain` from it, so reading and
+# writing a block member is supported. What is left here is a whole-AGGREGATE copy,
+# which lowers to a byte copy rather than a value load or store, and addressed
+# memory with no interface variable behind it.
 #
 # A scalar `f32` / `f64` interface variable used to have an arm here, because the
 # float address materialization was applied on every target and destroyed the
@@ -1817,11 +1869,8 @@ fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand
     if (g.iface == ir.IFACE_NONE) {
         ret "a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`)";
     }
-    if (g.iface == ir.IFACE_UNIFORM) {
-        ret "reading a member of a `#[uniform(...)]` block is not yet supported by the SPIR-V target: SPIR-V reaches one through an OpAccessChain naming the member's ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the block itself is declared correctly, with its Block decoration and member offsets";
-    }
     if (is_aggregate_type(e, g.ty)) {
-        ret "indexing into an aggregate shader interface variable is not yet supported by the SPIR-V target: SPIR-V reaches an element through an OpAccessChain naming its ORDINAL. MIR now KEEPS the walk on a logical-addressing target rather than folding it to a byte displacement (#2649), so the ordinals are present on the `MIR_GEP` as operands 2 onward; what is missing is this emitter building the access chain from them. the variable itself is declared correctly; read or write it whole";
+        ret "copying a whole record or array to or from a shader interface variable is not supported by the SPIR-V target: an aggregate assignment lowers to a byte copy, which addresses the object rather than loading or storing a value of it. reading and writing its MEMBERS individually is supported, and is what a shader wants anyway - a whole-block copy would move the descriptor's contents rather than the values in it";
     }
     ret "this shader interface variable is reachable only as a whole-variable read or write in the SPIR-V target";
 }
@@ -1849,7 +1898,9 @@ fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0]));
     }
-    val var_id: u32 = interface_target(e, ?mi.operands[1]);
+    var chain_ty: u32 = 0;
+    var var_id: u32 = chain_target(vm, ?mi.operands[1], ?chain_ty);
+    if (var_id == 0) { var_id = interface_target(e, ?mi.operands[1]); }
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1])); }
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n || vm.type_id[dst] == 0) {
@@ -1875,9 +1926,14 @@ fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs
 # ret:      true on success, or a precise error string
 fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count != 2) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
-    val var_id: u32 = interface_target(e, ?mi.operands[0]);
+    var chain_ty: u32 = 0;
+    var var_id: u32 = chain_target(vm, ?mi.operands[0], ?chain_ty);
+    var value_ty: u32 = chain_ty;
+    if (var_id == 0) {
+        var_id = interface_target(e, ?mi.operands[0]);
+        value_ty = interface_value_type(e, ?mi.operands[0]);
+    }
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
-    val value_ty: u32 = interface_value_type(e, ?mi.operands[0]);
     val value: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], value_ty);
     if (e.b.err || value == 0) { ret R.err[bool, str]("spirv.emit: unreadable value in an interface store"); }
     var ops: [2]u32;
@@ -1902,6 +1958,147 @@ fun interface_value_type(e: *Emit, op: *mir.MirOperand) u32 {
         i = i + 1;
     }
     ret 0;
+}
+
+# emit an OpAccessChain for a structural GEP into a shader interface variable
+#
+# MIR now keeps a GEP's index list on this target rather than folding it to a byte
+# displacement, which is what makes this expressible at all: SPIR-V reaches a member
+# by its ORDINAL and an offset does not determine one.
+#
+# THE LEADING INDEX IS DROPPED, and that is not a detail. A getelementptr's first
+# index strides over the source pointee type without descending into it - `gep %p, 0,
+# 1` is "the 0th object, then member 1" - while an OpAccessChain's base pointer
+# already names the object, so it takes only the descending indices. A NONZERO
+# leading index is pointer arithmetic across whole objects, which the logical model
+# has no form for; it is refused rather than dropped, because dropping it would
+# silently read the wrong object.
+#
+# The result is a pointer, recorded on the destination vreg rather than stored into
+# a backing variable, and the load or store that consumes it addresses through it.
+# ---
+# e:        the emission state
+# mf:       the MIR function
+# vm:       the per-vreg value maps
+# preg_val: the identity convention's nominal register file
+# mi:       the MIR_GEP instruction ([dst, base, idx...])
+# ret:      true on success, or a precise error string
+fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs,
+                      mi: *mir.MirInstr) R.Result[bool, str] {
+    # a two-operand GEP is the FLAT form, an address materialization with no index
+    # list; nothing on this target should produce one.
+    if (mi.operand_count < 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
+        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
+    }
+    # the base is either the interface variable itself or a chain already built off
+    # it: `m.mvp[2]` lowers to two GEPs, the second based on the first's result, and
+    # an OpAccessChain's base may be any pointer.
+    var base_id: u32 = 0;
+    var base_ty: u32 = 0;
+    var base_sc: u32 = 0;
+    var prior_ty: u32 = 0;
+    val prior: u32 = chain_target(vm, ?mi.operands[1], ?prior_ty);
+    if (prior != 0) {
+        base_id = prior;
+        base_ty = prior_ty;
+        base_sc = chain_storage(vm, ?mi.operands[1]);
+    }
+    or {
+        var gix: u32 = 0;
+        if (address_origin(e, mf, ?mi.operands[1], ?gix) != ADDR_GLOBAL) {
+            ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
+        }
+        val g: *ir.Global = ?e.ir.globals[gix];
+        if (g.iface == ir.IFACE_NONE || e.gvar_ids[gix] == 0) {
+            ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
+        }
+        base_id = e.gvar_ids[gix];
+        base_ty = e.gtype_ids[gix];
+        base_sc = e.gstorage[gix];
+    }
+
+    # index 0 strides over whole objects; only 0 names this one.
+    if (mi.operands[2].kind != mir.MIR_OP_IMM || mi.operands[2].imm != 0) {
+        ret unsupported(e, "pointer arithmetic across whole objects is not supported by the SPIR-V target: a logical pointer names one object, so a getelementptr's leading index may only be 0");
+    }
+
+    val dst: u32 = mi.operands[0].vreg;
+    if (dst >= vm.n) { ret R.err[bool, str]("spirv.emit: access chain result vreg out of range"); }
+
+    val count: u32 = mi.operand_count - 3;
+    if (count == 0 || count > 8) {
+        ret unsupported(e, "an access chain of more than 8 levels is not supported by the SPIR-V target");
+    }
+
+    var idx: [8]u32;
+    var cur: u32 = base_ty;
+    var k: u32 = 0;
+    for (k < count) {
+        val opnd: *mir.MirOperand = ?mi.operands[3 + k];
+        if (opnd.kind == mir.MIR_OP_IMM) {
+            if (opnd.imm < 0) { ret unsupported(e, "a negative index is not supported by the SPIR-V target"); }
+            cur = types.composite_member(e.tt, cur, opnd.imm::u32);
+            idx[k] = types.const_int(e.tt, 32, opnd.imm);
+        }
+        or {
+            # a runtime index is legal into an array, whose element type does not
+            # depend on it, and never into a struct, whose member type does.
+            val elem: u32 = types.composite_member(e.tt, cur, 0);
+            var lanes: u32 = 0;
+            if (elem == 0 || types.vector_shape(e.tt, cur, ?lanes) != 0) {
+                ret unsupported(e, "a runtime index into a record or vector is not supported by the SPIR-V target: SPIR-V takes a struct member and a vector lane by a constant ordinal, since the type reached depends on which one it is");
+            }
+            idx[k] = read_operand(e, vm, preg_val, opnd, types.type_int(e.tt, 32));
+            cur = elem;
+        }
+        if (cur == 0 || idx[k] == 0) {
+            ret unsupported(e, "an index reaches past the end of its aggregate in the SPIR-V target");
+        }
+        k = k + 1;
+    }
+    if (e.b.err) { ret R.err[bool, str]("spirv.emit: unreadable index in an access chain"); }
+
+    val ptr_ty: u32 = types.type_ptr(e.tt, base_sc, cur);
+    val result: u32 = spirv.alloc_id(e.b);
+    var ops: [11]u32;
+    ops[0] = ptr_ty; ops[1] = result; ops[2] = base_id;
+    k = 0;
+    for (k < count) { ops[3 + k] = idx[k]; k = k + 1; }
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_ACCESS_CHAIN, ?ops[0], count + 3);
+
+    vm.chain_id[dst] = result;
+    vm.chain_ty[dst] = cur;
+    vm.chain_sc[dst] = base_sc;
+    ret R.ok[bool, str](true);
+}
+
+# the access chain an address operand resolves to, or 0 when it is not one
+# ---
+# vm:      the per-vreg value maps
+# op:      the address operand
+# out_ty:  receives the type the chain points at
+# ret:     the pointer id, or 0
+fun chain_target(vm: *VMaps, op: *mir.MirOperand, out_ty: *u32) u32 {
+    @out_ty = 0;
+    var v: u32 = mir.MIR_VREG_NIL;
+    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg; }
+    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg; }
+    if (v == mir.MIR_VREG_NIL || v >= vm.n) { ret 0; }
+    @out_ty = vm.chain_ty[v];
+    ret vm.chain_id[v];
+}
+
+# the storage class of the access chain an address operand resolves to
+# ---
+# vm: the per-vreg value maps
+# op: the address operand
+# ret: the storage class, or 0
+fun chain_storage(vm: *VMaps, op: *mir.MirOperand) u32 {
+    var v: u32 = mir.MIR_VREG_NIL;
+    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg; }
+    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg; }
+    if (v == mir.MIR_VREG_NIL || v >= vm.n) { ret 0; }
+    ret vm.chain_sc[v];
 }
 
 # select the integer or float form of a class-polymorphic opcode
@@ -2058,9 +2255,7 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     if (op == mir.MIR_STORE) { ret emit_global_store(e, mf, vm, preg_val, mi); }
     # a GEP that survives to here computed an address, which the milestone carries
     # in no form; the refusal names what the address originates in.
-    if (op == mir.MIR_GEP && mi.operand_count >= 2) {
-        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
-    }
+    if (op == mir.MIR_GEP) { ret emit_access_chain(e, mf, vm, preg_val, mi); }
     if (op == mir.MIR_ALLOCA || op == mir.MIR_GEP) {
         ret unsupported(e, "a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live");
     }

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -56,6 +56,7 @@ use R: std.types.result;
 
 use mach.lang.intern;
 use mach.lang.source;
+use mach.lang.spirvop;
 use mach.lang.target.resolved;
 use mach.lang.me.ir;
 use mach.lang.me.ir.type;
@@ -113,6 +114,13 @@ rec Emit {
     iface_len: u32;
     gslot:     *u32;
     iface_use: *u8;
+
+    # the id each extended instruction set was imported under, indexed by
+    # spirvop.SPV_SET_*; 0 means "not imported yet". indexed rather than one field
+    # per set so a second set is a row in `spirvop`, not a change here. the import
+    # is minted at the FIRST call that needs it, which is what makes it on demand:
+    # a module using none of them carries no OpExtInstImport at all
+    ext_ids:   [8]u32;
 
     # the refusal context: which function is being emitted and which instruction
     # is being translated, so a refusal can say so without every site threading
@@ -195,6 +203,8 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
     e.tgt = tgt; e.ir = irmod; e.b = ?b; e.tt = ?tt; e.fn_ids = nil;
     e.gvar_ids = nil; e.gtype_ids = nil; e.gstorage = nil; e.iface_ids = nil; e.iface_len = 0;
     e.gslot = nil; e.iface_use = nil;
+    var xi: u32 = 0;
+    for (xi < 8) { e.ext_ids[xi] = 0; xi = xi + 1; }
     e.srcmap = mirmod.srcmap; e.cur_fn = nil; e.cur_instr = nil;
 
     # a module is a shader module or a library module, never both, and which one is
@@ -253,6 +263,15 @@ pub fun emit_module(tgt: *resolved.Target, irmod: *ir.Module,
         # a body-less MIR function (an extern declaration) lowers to an empty shell;
         # it contributes no OpFunction (SPIR-V imports are a later phase).
         if (mf.block_count == 0) { fi = fi + 1; cnt; }
+        # a function that IS a SPIR-V instruction contributes no OpFunction either.
+        # It has a mach body - that is what makes `shader.math` a real library on a
+        # CPU target rather than a set of declarations - but on this target every
+        # call to it becomes the instruction, so the body is unreachable. Emitting it
+        # anyway would be worse than dead weight: the native body is written in terms
+        # of the bit manipulation a CPU needs, which is exactly what logical
+        # addressing refuses, so the module would fail to build over code nothing
+        # calls.
+        if (instruction_mapped(e.ir, mf.name)) { fi = fi + 1; cnt; }
         val fr: R.Result[bool, str] = emit_function(?e, mf);
         if (R.is_err[bool, str](fr)) {
             emit_dnit(?e, irmod.function_len);
@@ -1403,10 +1422,19 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
                 val v: u32 = mi.operands[0].vreg;
                 var t: u32 = 0;
                 if (callee != intern.STR_NIL) {
-                    val cix: u32 = ir_function_index(e.ir, callee);
-                    if (cix != IR_FN_NONE) {
+                    # by RECORD, not by `ir_function_index`, which skips a
+                    # declaration because its answer also selects a pre-allocated
+                    # SPIR-V id. What is wanted here is the callee's declared RETURN
+                    # TYPE, which a signature-only declaration has just as much as a
+                    # definition does. Looking it up the other way left every
+                    # cross-module call's result typed by the move's machine width
+                    # instead: an `f32` came back 64 bits wide and a scalar returned
+                    # from vector arguments came back a vector, and the module failed
+                    # validation at the store rather than at the call.
+                    val cfn: *ir.Function = ir_function_record(e.ir, callee);
+                    if (cfn != nil) {
                         var cvoid: bool = false;
-                        t = ir_return_spv_type(e, ?e.ir.functions[cix], ?cvoid);
+                        t = ir_return_spv_type(e, cfn, ?cvoid);
                         if (cvoid) { t = 0; }
                     }
                     callee = intern.STR_NIL;
@@ -2353,6 +2381,18 @@ fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] 
     if (callee.kind != mir.MIR_OP_SYM) {
         ret unsupported(e, "a call through a function pointer is not yet supported by the SPIR-V target");
     }
+
+    # a callee carrying `#[spirv_op(set, name)]` is not called at all: it IS one
+    # instruction, and this call site becomes that instruction. Checked before the
+    # in-module lookup below, because the whole point is that the callee is usually
+    # NOT in this module - a SPIR-V module is compiled per mach module and a shader
+    # module may declare no linkage, so `shader.math` could not be called even if
+    # its body were emitted.
+    val xfn: *ir.Function = ir_function_record(e.ir, callee.sym);
+    if (xfn != nil && xfn.spv_set != spirvop.SPV_SET_NONE) {
+        ret emit_spirv_op(e, preg_val, xfn);
+    }
+
     val fix: u32 = ir_function_index(e.ir, callee.sym);
     if (fix == IR_FN_NONE || e.fn_ids == nil || e.fn_ids[fix] == 0) {
         ret unsupported(e, "a call to a function defined outside the module is not yet supported by the SPIR-V target");
@@ -2386,6 +2426,137 @@ fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] 
         preg_val.is_imm[0] = false;
     }
     ret R.ok[bool, str](true);
+}
+
+# emit the single SPIR-V instruction a `#[spirv_op(set, name)]` callee stands for
+#
+# The contract is uniform across every instruction in the table and is what makes
+# adding one a row rather than a case: the result type is the mach function's
+# declared return type, and the operands are its parameters in declaration order,
+# read out of the identity convention's register file exactly as a real call's
+# arguments would be. That covers the awkward members without special-casing them -
+# `Length` and `OpDot` return a scalar from vectors, `Refract` mixes a scalar
+# operand with vector ones, `FClamp` and `SmoothStep` take three.
+#
+# The signature is read from the IR function's type rather than from `params`,
+# because for a cross-module callee the declaration is signature-only: it was
+# synthesized from a name and a type and has no parameter list of its own.
+#
+# A core-set instruction is emitted directly; an extended one is an OpExtInst
+# naming the imported set's id and the instruction number within it, with the set
+# imported here on first use.
+# ---
+# e:        the emission state
+# preg_val: the identity convention's nominal register file
+# fn:       the callee's IR function record, carrying spv_set / spv_op
+# ret:      true on success, or a precise error string
+fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[bool, str] {
+    val sig_opt: O.Option[*type.IrType] = type.get(?e.ir.types, fn.sig);
+    if (O.is_none[*type.IrType](sig_opt)) {
+        ret R.err[bool, str]("spirv.emit: a `spirv_op` callee has no signature type");
+    }
+    val sig: *type.IrType = O.unwrap[*type.IrType](sig_opt);
+    if (sig.kind != type.IRT_FN) {
+        ret R.err[bool, str]("spirv.emit: a `spirv_op` callee's signature is not a function type");
+    }
+    val argc: u32 = sig.data.fn.param_count;
+    # 12 operands is past every instruction in the table (the widest is three) and
+    # leaves the fixed operand array a comfortable size.
+    if (argc > 12) {
+        ret unsupported(e, "a `spirv_op` function takes at most 12 parameters on the SPIR-V target");
+    }
+
+    var returns_void: bool = false;
+    val ret_ty: u32 = ir_return_spv_type(e, fn, ?returns_void);
+    if (ret_ty == 0) { ret unsupported(e, "unsupported return type in the SPIR-V target"); }
+    # every instruction in the table produces a value. a void one would leave the
+    # result register holding whatever the previous call left there, which is the
+    # silent-wrong-value failure this decorator exists to avoid.
+    if (returns_void) {
+        ret unsupported(e, "a `spirv_op` function must return a value; a SPIR-V instruction has a result id");
+    }
+
+    var ops: [16]u32;
+    var base: u32 = 2;
+    ops[0] = ret_ty;
+    val result: u32 = spirv.alloc_id(e.b);
+    ops[1] = result;
+    if (fn.spv_set != spirvop.SPV_SET_CORE) {
+        val set_id: u32 = ext_set_id(e, fn.spv_set);
+        if (set_id == 0) {
+            ret R.err[bool, str]("spirv.emit: a `spirv_op` names an instruction set with no import name");
+        }
+        ops[2] = set_id;
+        ops[3] = fn.spv_op;
+        base = 4;
+    }
+
+    var i: u32 = 0;
+    for (i < argc) {
+        val aid: u32 = reg_value(e, preg_val, i, ir_value_spv_type(e, sig.data.fn.params[i]));
+        if (aid == 0) { ret R.err[bool, str]("spirv.emit: `spirv_op` argument with no pre-colored value"); }
+        ops[base + i] = aid;
+        i = i + 1;
+    }
+
+    var opcode: u32 = spirv.OP_EXT_INST;
+    if (fn.spv_set == spirvop.SPV_SET_CORE) { opcode = fn.spv_op; }
+    spirv.inst(e.b, ?e.b.functions, opcode, ?ops[0], base + argc);
+
+    # the return register, which the result move reads next - the same handoff a
+    # real OpFunctionCall makes.
+    preg_val.val_id[0] = result;
+    preg_val.is_imm[0] = false;
+    ret R.ok[bool, str](true);
+}
+
+# the id an extended instruction set is imported under, importing it on first use
+#
+# One OpExtInstImport per set per module: a second import of the same set is
+# invalid, so the id is cached rather than re-minted. Returns 0 when the set has no
+# import name, which is the core set and never reaches here.
+# ---
+# e:   the emission state
+# set: one of spirvop.SPV_SET_*
+# ret: the set's id, or 0
+fun ext_set_id(e: *Emit, set: u8) u32 {
+    if (set::u32 >= 8) { ret 0; }
+    if (e.ext_ids[set::u32] != 0) { ret e.ext_ids[set::u32]; }
+    val name: str = spirvop.set_import_name(set);
+    if (str_len(name) == 0::usize) { ret 0; }
+    val id: u32 = spirv.ext_inst_import(e.b, name);
+    e.ext_ids[set::u32] = id;
+    ret id;
+}
+
+# the IR function record of the given interned name, defined or merely declared
+#
+# `ir_function_index` deliberately skips FN_FLAG_EXTERN entries, since its answer
+# selects a pre-allocated SPIR-V id and a declaration has none. A `spirv_op` callee
+# is normally exactly such a declaration - the definition is in another mach module
+# - so its record is looked up separately.
+# ---
+# irmod: the IR module
+# name:  the interned function name
+# ret:   the function record, or nil
+fun ir_function_record(irmod: *ir.Module, name: intern.StrId) *ir.Function {
+    var i: u32 = 0;
+    for (i < irmod.function_len) {
+        if (irmod.functions[i].name == name) { ret ?irmod.functions[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# whether the named function is one a `#[spirv_op(...)]` maps to an instruction
+# ---
+# irmod: the IR module
+# name:  the interned function name
+# ret:   true when the function carries a SPIR-V instruction mapping
+fun instruction_mapped(irmod: *ir.Module, name: intern.StrId) bool {
+    val fn: *ir.Function = ir_function_record(irmod, name);
+    if (fn == nil) { ret false; }
+    ret fn.spv_set != spirvop.SPV_SET_NONE;
 }
 
 # produce an SSA value id for an operand, materializing a load / constant as needed

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -475,7 +475,7 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[
         members[i] = R.unwrap_ok[u32, str](mr);
         i = i + 1;
     }
-    val struct_id: u32 = types.type_struct(e.tt, ?members[0], n);
+    val struct_id: u32 = types.type_struct(e.tt, ?members[0], n, true);
     if (struct_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block type"); }
 
     i = 0;
@@ -834,13 +834,6 @@ fun emit_function(e: *Emit, mf: *mir.MirFunction) R.Result[bool, str] {
     }
     or (!e.has_entry) { emit_linkage_export(e, fn_id, fn_name); }
 
-    # a vector materialized through memory is refused up front, under its own name.
-    # Reaching it instruction by instruction would report the `alloca` that opens the
-    # sequence, which is the least informative part of it.
-    if (builds_vector_through_memory(e, mf)) {
-        ret unsupported(e, "constructing a vector from a literal or an uninitialized local is not yet supported by the SPIR-V target: the value is built in an ADDRESSABLE LOCAL and read back out, and this milestone emits no local allocations at all. a literal additionally writes its lanes through per-lane indices, which MIR folds into byte displacements the lane ordinal cannot be recovered from. derive the vector from an existing vector value instead - lane assignment onto a parameter, or arithmetic");
-    }
-
     # the structured shape of the body, or a refusal naming the construct.
     val cr: R.Result[cfg.Structure, str] = cfg.analyze(mf, e.alloc);
     if (R.is_err[cfg.Structure, str](cr)) { ret R.err[bool, str](R.unwrap_err[cfg.Structure, str](cr)); }
@@ -999,45 +992,6 @@ fun defining_instr(mf: *mir.MirFunction, vreg: u32) *mir.MirInstr {
 fun address_operand_index(mi: *mir.MirInstr) u32 {
     if (mi.opcode == mir.MIR_LOAD) { ret 1; }
     ret 0;
-}
-
-# whether a function materializes a vector by reading one out of a local allocation
-#
-# The signature of the vector-literal / zero-init lowering: an `alloca f32x4`
-# written lane by lane or zeroed, then a whole-vector `load f32x4` off the same
-# pointer. The ALLOCA origin is the identifying part. A vector arriving from or
-# leaving through an interface variable reads the same way at the instruction level
-# but originates in a global, and reporting it as a literal sent readers to the
-# wrong problem.
-#
-# The allocation used to be an `[4]f32` reinterpreted as a vector through its
-# pointer, which no SPIR-V back end could have accepted. That is fixed upstream: it
-# is now allocated at the vector's own type, so what remains is only that this
-# milestone emits no local allocations.
-# ---
-# e:   the emission state
-# mf:  the MIR function
-# ret: true when a vector-typed load or store reads a local allocation
-fun builds_vector_through_memory(e: *Emit, mf: *mir.MirFunction) bool {
-    var bi: u32 = 0;
-    for (bi < mf.block_count) {
-        val blk: *mir.MirBlock = ?mf.blocks[bi];
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if ((mi.opcode == mir.MIR_LOAD || mi.opcode == mir.MIR_STORE)
-                && mir.vec_lane_is_vector(mi.vec_lane)
-                && mi.operand_count == 2) {
-                var gix: u32 = 0;
-                if (address_origin(e, mf, ?mi.operands[address_operand_index(mi)], ?gix) == ADDR_ALLOCA) {
-                    ret true;
-                }
-            }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-    ret false;
 }
 
 # the diagnostic for a CFG the reconstruction cannot express, naming the function
@@ -1479,6 +1433,15 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     val r2: R.Result[bool, str] = type_computed_defs(e, mf, out, false);
     if (R.is_err[bool, str](r2)) { ret r2; }
 
+    # a local allocation becomes a Function-storage OpVariable, declared HERE rather
+    # than where the MIR_ALLOCA sits: SPIR-V requires every Function variable to be
+    # in the function's first block, ahead of any other instruction. The allocation's
+    # result vreg is an address, so it is recorded as an access chain base - the same
+    # shape an interface variable's id has - and every load, store and member walk
+    # off it then goes through machinery that already exists.
+    val ar: R.Result[bool, str] = declare_allocas(e, mf, out);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+
     # emit one OpVariable(Function) per defined vreg, at the entry, and record its id.
     i = 0;
     for (i < n) {
@@ -1493,6 +1456,73 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# declare one Function-storage OpVariable per local allocation, at the entry
+#
+# The allocated TYPE comes from the frame slot rather than from the instruction:
+# `MIR_ALLOCA` carries a slot reference, and the slot records the IR type it was
+# allocated at. Without that this could not be done at all - a size and an alignment
+# do not determine a type, and a Function variable needs one.
+# ---
+# e:   the emission state
+# mf:  the MIR function
+# out: the maps being filled
+# ret: true on success, or a precise error string
+fun declare_allocas(e: *Emit, mf: *mir.MirFunction, out: *VMaps) R.Result[bool, str] {
+    var bi: u32 = 0;
+    for (bi < mf.block_count) {
+        val blk: *mir.MirBlock = ?mf.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode != mir.MIR_ALLOCA || mi.operand_count < 2
+                || mi.operands[0].kind != mir.MIR_OP_VREG) { ii = ii + 1; cnt; }
+            val dst: u32 = mi.operands[0].vreg;
+            if (dst >= out.n) { ii = ii + 1; cnt; }
+
+            val slot: *mir.MirSlot = find_slot(mf, mi.operands[1].vreg);
+            if (slot == nil || slot.ty == mir.SLOT_TY_NIL) {
+                ret unsupported(e, "a local allocation whose type was not recorded is not supported by the SPIR-V target: a shader variable needs a type, and a size and alignment do not determine one");
+            }
+            val ty: u32 = ir_value_spv_type(e, slot.ty);
+            if (ty == 0) {
+                ret unsupported(e, unsupported_ir_type(e, slot.ty,
+                    "unsupported local allocation type in the SPIR-V target"));
+            }
+            # a slot wider than its own type is an array of them, which is pointer
+            # arithmetic across whole objects rather than one variable.
+            if (slot.size != type.byte_size(?e.ir.types, slot.ty, e.tgt)) {
+                ret unsupported(e, "a multi-element local allocation is not supported by the SPIR-V target: it is an array of whole objects reached by pointer arithmetic, which the logical addressing model has no form for");
+            }
+
+            val ptr_ty: u32 = types.type_ptr(e.tt, spirv.STORAGE_FUNCTION, ty);
+            val var_id: u32 = spirv.alloc_id(e.b);
+            var vop: [3]u32;
+            vop[0] = ptr_ty; vop[1] = var_id; vop[2] = spirv.STORAGE_FUNCTION;
+            spirv.inst(e.b, ?e.b.functions, spirv.OP_VARIABLE, ?vop[0], 3);
+            out.chain_id[dst] = var_id;
+            out.chain_ty[dst] = ty;
+            out.chain_sc[dst] = spirv.STORAGE_FUNCTION;
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the frame slot a slot-key names, or nil when none does
+# ---
+# mf:  the MIR function
+# key: the slot-key vreg
+# ret: the slot, or nil
+fun find_slot(mf: *mir.MirFunction, key: u32) *mir.MirSlot {
+    var i: u32 = 0;
+    for (i < mf.frame.slot_count) {
+        if (mf.frame.slots[i].value == key) { ret ?mf.frame.slots[i]; }
+        i = i + 1;
+    }
+    ret nil;
 }
 
 # type every vreg a computing instruction defines, from its result width and class
@@ -1518,7 +1548,7 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
             # a structural GEP defines an ADDRESS. It gets no element type and no
             # backing variable: the access chain it becomes is consumed directly by
             # the load or store that follows, never loaded as a value.
-            if (mi.opcode == mir.MIR_GEP) { ii = ii + 1; cnt; }
+            if (mi.opcode == mir.MIR_GEP || mi.opcode == mir.MIR_ALLOCA) { ii = ii + 1; cnt; }
             if (mir.instr_defines_shape(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
                 val v: u32 = mi.operands[0].vreg;
                 if (v < out.n && out.type_id[v] == 0 && !(skip_copies && is_reg_copy(mi))) {
@@ -1703,6 +1733,19 @@ fun ir_value_spv_type(e: *Emit, id: type.IrTypeId) u32 {
         val elem: u32 = ir_value_spv_type(e, t.data.array_.element);
         if (elem == 0) { ret 0; }
         ret types.type_array(e.tt, elem, t.data.array_.count, false);
+    }
+    if (t.kind == type.IRT_STRUCT) {
+        val n: u32 = t.data.struct_.field_count;
+        if (n == 0 || n > types.MAX_STRUCT_MEMBERS) { ret 0; }
+        var members: [16]u32;
+        var i: u32 = 0;
+        for (i < n) {
+            val mt: u32 = ir_value_spv_type(e, t.data.struct_.fields[i]);
+            if (mt == 0) { ret 0; }
+            members[i] = mt;
+            i = i + 1;
+        }
+        ret types.type_struct(e.tt, ?members[0], n, false);
     }
     ret 0;
 }
@@ -2101,6 +2144,35 @@ fun chain_storage(vm: *VMaps, op: *mir.MirOperand) u32 {
     ret vm.chain_sc[v];
 }
 
+# emit the zeroing of a whole object as a single store of its null value
+#
+# `MIR_MEMZERO` survives to this target as a whole-object operation (#2669) rather
+# than being expanded into a run of sized byte stores, which is what makes this one
+# instruction. `OpConstantNull` spells the zero of any type, so an aggregate needs
+# no member-by-member construction.
+# ---
+# e:   the emission state
+# mf:  the MIR function
+# vm:  the per-vreg value maps
+# mi:  the MIR_MEMZERO instruction ([dst_mem, size])
+# ret: true on success, or a precise error string
+fun emit_memzero(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 1) { ret R.err[bool, str]("spirv.emit: memzero with no destination"); }
+    var target_ty: u32 = 0;
+    var target: u32 = chain_target(vm, ?mi.operands[0], ?target_ty);
+    if (target == 0) {
+        target = interface_target(e, ?mi.operands[0]);
+        target_ty = interface_value_type(e, ?mi.operands[0]);
+    }
+    if (target == 0 || target_ty == 0) {
+        ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0]));
+    }
+    var ops: [2]u32;
+    ops[0] = target; ops[1] = types.const_null(e.tt, target_ty);
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_STORE, ?ops[0], 2);
+    ret R.ok[bool, str](true);
+}
+
 # select the integer or float form of a class-polymorphic opcode
 # ---
 # lane_float: whether the operation's lanes are float
@@ -2256,9 +2328,9 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # a GEP that survives to here computed an address, which the milestone carries
     # in no form; the refusal names what the address originates in.
     if (op == mir.MIR_GEP) { ret emit_access_chain(e, mf, vm, preg_val, mi); }
-    if (op == mir.MIR_ALLOCA || op == mir.MIR_GEP) {
-        ret unsupported(e, "a local allocation is not supported by the SPIR-V target: a shader has no stack, so a value needing addressable storage has nowhere to live");
-    }
+    # the allocation's variable was declared at the entry, where SPIR-V requires it.
+    if (op == mir.MIR_ALLOCA) { ret R.ok[bool, str](true); }
+    if (op == mir.MIR_MEMZERO) { ret emit_memzero(e, mf, vm, mi); }
 
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");
 }

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -87,6 +87,7 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # emitter intact rather than being scalarized to per-lane work over stack slots -
     # which a logically-addressed module could not express anyway, having no stack.
     spirv_model.has_v128               = true;
+    spirv_model.vector_bits            = 128;
     # vector compute is selected from the generic MIR opcodes carrying `vec_lane`.
     # a vector is IRT_VECTOR, not IRT_FLOAT, so the scalar float dispatch never fires
     # for one whatever this says: a vector float add reaches MIR as the

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -87,7 +87,7 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # emitter intact rather than being scalarized to per-lane work over stack slots -
     # which a logically-addressed module could not express anyway, having no stack.
     spirv_model.has_v128               = true;
-    spirv_model.vector_bits            = 128;
+    spirv_model.vector_bits            = isa.VECTOR_BITS_128;
     # vector compute is selected from the generic MIR opcodes carrying `vec_lane`.
     # a vector is IRT_VECTOR, not IRT_FLOAT, so the scalar float dispatch never fires
     # for one whatever this says: a vector float add reaches MIR as the

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -116,6 +116,24 @@ rec CompositeKey {
     id:         u32;
 }
 
+# the member types of one composite (struct or array) this table minted
+#
+# A composite's own instruction names its members, but nothing reads instructions
+# back, and an `OpAccessChain` result type is the member type at an index - so the
+# shape has to be recoverable from the id. This is the composite analogue of
+# `vector_shape`. It matters most for an explicitly-laid-out array or struct, which
+# is deliberately NOT interned (its decorations are part of its identity), so it
+# cannot be rebuilt by asking for the same shape again.
+# ---
+# id:      the composite type id
+# members: owned copy of the member type ids; for an array, one entry, the element
+# count:   number of members, or 0 for an array (whose index is unbounded)
+rec ShapeKey {
+    id:      u32;
+    members: *u32;
+    count:   u32;
+}
+
 # the per-module type / constant memoization table
 #
 # Threads the builder so a cache miss can allocate an id and emit the defining
@@ -127,12 +145,14 @@ rec CompositeKey {
 # consts:  memoized scalar constants
 # fns:     memoized function types
 # comps:   memoized composite (vector) constants
+# shapes:  member types of every struct / array minted, for walking an access chain
 pub rec TypeTable {
     b:       *spirv.Builder;
     scalars: Vector[ScalarKey];
     consts:  Vector[ConstKey];
     fns:     Vector[FnKey];
     comps:   Vector[CompositeKey];
+    shapes:  Vector[ShapeKey];
 }
 
 # construct an empty type table over a builder
@@ -146,6 +166,7 @@ pub fun types_init(b: *spirv.Builder) TypeTable {
     tt.consts  = vector.init[ConstKey](b.alloc);
     tt.fns     = vector.init[FnKey](b.alloc);
     tt.comps   = vector.init[CompositeKey](b.alloc);
+    tt.shapes  = vector.init[ShapeKey](b.alloc);
     ret tt;
 }
 
@@ -172,7 +193,68 @@ pub fun types_dnit(tt: *TypeTable) {
     vector.dnit[ScalarKey](?tt.scalars);
     vector.dnit[ConstKey](?tt.consts);
     vector.dnit[FnKey](?tt.fns);
+    var si: usize = 0;
+    for (si < tt.shapes.len) {
+        val sk: *ShapeKey = ?tt.shapes.data[si];
+        if (sk.members != nil) {
+            var n: u32 = sk.count;
+            if (n == 0) { n = 1; }
+            A.deallocate[u32](tt.b.alloc, sk.members, n::usize);
+        }
+        si = si + 1;
+    }
     vector.dnit[CompositeKey](?tt.comps);
+    vector.dnit[ShapeKey](?tt.shapes);
+}
+
+# record the member types of a composite so an access chain can walk it
+# ---
+# tt:      the table
+# id:      the composite type id
+# members: the member type ids (one entry for an array's element)
+# count:   number of members, or 0 for an array
+fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32) {
+    var n: u32 = count;
+    if (n == 0) { n = 1; }
+    val r: R.Result[*u32, str] = A.allocate[u32](tt.b.alloc, n::usize);
+    if (R.is_err[*u32, str](r)) { tt.b.err = true; ret; }
+    val copy: *u32 = R.unwrap_ok[*u32, str](r);
+    var i: u32 = 0;
+    for (i < n) { copy[i] = members[i]; i = i + 1; }
+    var k: ShapeKey;
+    k.id = id; k.members = copy; k.count = count;
+    vector.push[ShapeKey](?tt.shapes, k);
+}
+
+# the type reached by indexing a composite at `index`
+#
+# A struct yields its `index`-th member and an array yields its element whatever the
+# index is, which is exactly what an `OpAccessChain` step produces. A vector is
+# answered from the scalar cache instead, since its shape lives there.
+# ---
+# tt:    the table
+# id:    the composite type id
+# index: the index taken at this level
+# ret:   the member type id, or 0 when `id` is not a composite this table minted
+#        or `index` is past a struct's members
+pub fun composite_member(tt: *TypeTable, id: u32, index: u32) u32 {
+    var lanes: u32 = 0;
+    val lane_ty: u32 = vector_shape(tt, id, ?lanes);
+    if (lane_ty != 0) {
+        if (index >= lanes) { ret 0; }
+        ret lane_ty;
+    }
+    var i: usize = 0;
+    for (i < tt.shapes.len) {
+        val k: *ShapeKey = ?tt.shapes.data[i];
+        if (k.id == id) {
+            if (k.count == 0) { ret k.members[0]; }
+            if (index >= k.count) { ret 0; }
+            ret k.members[index];
+        }
+        i = i + 1;
+    }
+    ret 0;
 }
 
 # find a cached scalar / pointer id by shape, or 0 when absent
@@ -346,6 +428,9 @@ pub fun type_array(tt: *TypeTable, elem: u32, count: u32, explicit_layout: bool)
     ops[0] = id; ops[1] = elem; ops[2] = len_id;
     spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_ARRAY, ?ops[0], 3);
     if (!explicit_layout) { scalar_put(tt, TAG_ARRAY, elem, count, id); }
+    var el: [1]u32;
+    el[0] = elem;
+    shape_put(tt, id, ?el[0], 0);
     ret id;
 }
 
@@ -369,6 +454,7 @@ pub fun type_struct(tt: *TypeTable, members: *u32, n: u32) u32 {
     var i: u32 = 0;
     for (i < n) { ops[1 + i] = members[i]; i = i + 1; }
     spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_STRUCT, ?ops[0], n + 1);
+    shape_put(tt, id, members, n);
     ret id;
 }
 

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -87,6 +87,7 @@ val TAG_VOID:  u8 = 3;  # OpTypeVoid
 val TAG_PTR:   u8 = 4;  # OpTypePointer, `a` = storage class, `b` = pointee id
 val TAG_VEC:   u8 = 5;  # OpTypeVector, `a` = component type id, `b` = component count
 val TAG_ARRAY: u8 = 6;  # OpTypeArray (no explicit layout), `a` = element type id, `b` = length
+val TAG_NULL:  u8 = 7;  # OpConstantNull, `a` = the type the null belongs to
 
 # the largest component count a Shader module may give an OpTypeVector
 #
@@ -128,10 +129,13 @@ rec CompositeKey {
 # id:      the composite type id
 # members: owned copy of the member type ids; for an array, one entry, the element
 # count:   number of members, or 0 for an array (whose index is unbounded)
+# laid_out: whether the type carries explicit-layout decorations, which are part of
+#          its identity and so bar it from being shared with an undecorated twin
 rec ShapeKey {
     id:      u32;
     members: *u32;
     count:   u32;
+    laid_out: bool;
 }
 
 # the per-module type / constant memoization table
@@ -213,7 +217,7 @@ pub fun types_dnit(tt: *TypeTable) {
 # id:      the composite type id
 # members: the member type ids (one entry for an array's element)
 # count:   number of members, or 0 for an array
-fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32) {
+fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32, laid_out: bool) {
     var n: u32 = count;
     if (n == 0) { n = 1; }
     val r: R.Result[*u32, str] = A.allocate[u32](tt.b.alloc, n::usize);
@@ -222,7 +226,7 @@ fun shape_put(tt: *TypeTable, id: u32, members: *u32, count: u32) {
     var i: u32 = 0;
     for (i < n) { copy[i] = members[i]; i = i + 1; }
     var k: ShapeKey;
-    k.id = id; k.members = copy; k.count = count;
+    k.id = id; k.members = copy; k.count = count; k.laid_out = laid_out;
     vector.push[ShapeKey](?tt.shapes, k);
 }
 
@@ -430,31 +434,43 @@ pub fun type_array(tt: *TypeTable, elem: u32, count: u32, explicit_layout: bool)
     if (!explicit_layout) { scalar_put(tt, TAG_ARRAY, elem, count, id); }
     var el: [1]u32;
     el[0] = elem;
-    shape_put(tt, id, ?el[0], 0);
+    shape_put(tt, id, ?el[0], 0, explicit_layout);
     ret id;
 }
 
 # the id of the struct type over `members`, emitting it on first use
 #
-# Not memoized. A struct type here is a uniform BLOCK, and a block carries
-# decorations - Block on the type, an Offset on every member - so two blocks with
-# the same member types are still distinct types whenever their layouts differ.
-# Interning on the member list alone would silently merge them and attach one
-# block's offsets to the other.
+# `explicit_layout` decides whether the result is interned, exactly as it does for
+# an array. A descriptor BLOCK carries decorations - Block on the type, an Offset on
+# every member - which are part of its identity, so two blocks with the same member
+# types are still distinct whenever their layouts differ, and interning on the
+# member list alone would attach one block's offsets to the other. A plain struct
+# carries no decorations, so two with the same members ARE the same type and must
+# share one id: otherwise assigning between two locals of one `rec` would be a type
+# mismatch against itself.
 # ---
 # tt:      the table
 # members: the member type ids
 # n:       number of members
+# explicit_layout: whether the result will carry Block / Offset decorations
 # ret:     the OpTypeStruct id, or 0 when the member count is out of range
-pub fun type_struct(tt: *TypeTable, members: *u32, n: u32) u32 {
+pub fun type_struct(tt: *TypeTable, members: *u32, n: u32, explicit_layout: bool) u32 {
     if (n == 0 || n > MAX_STRUCT_MEMBERS) { ret 0; }
+    if (!explicit_layout) {
+        var si: usize = 0;
+        for (si < tt.shapes.len) {
+            val k: *ShapeKey = ?tt.shapes.data[si];
+            if (!k.laid_out && k.count == n && params_equal(k.members, members, n)) { ret k.id; }
+            si = si + 1;
+        }
+    }
     val id: u32 = spirv.alloc_id(tt.b);
     var ops: [17]u32;
     ops[0] = id;
     var i: u32 = 0;
     for (i < n) { ops[1 + i] = members[i]; i = i + 1; }
     spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_TYPE_STRUCT, ?ops[0], n + 1);
-    shape_put(tt, id, members, n);
+    shape_put(tt, id, members, n, explicit_layout);
     ret id;
 }
 
@@ -702,6 +718,29 @@ pub fun const_bool(tt: *TypeTable, value: bool) u32 {
     var k: ConstKey;
     k.type_id = type_id; k.lo = lo; k.hi = 0; k.id = id;
     vector.push[ConstKey](?tt.consts, k);
+    ret id;
+}
+
+# the id of the zero value of `type_id`, emitting it on first use
+#
+# `OpConstantNull` is the one form that spells a zero of ANY type - a scalar, a
+# vector, an array, a record - which is what an aggregate needs, since a composite
+# constant would otherwise have to be built lane by lane and member by member. It
+# is cached in the scalar table under its own tag, because a null and an ordinary
+# zero constant of the same type are different instructions even where they mean
+# the same value.
+# ---
+# tt:      the table
+# type_id: the type the zero belongs to
+# ret:     the OpConstantNull id
+pub fun const_null(tt: *TypeTable, type_id: u32) u32 {
+    val hit: u32 = scalar_find(tt, TAG_NULL, type_id, 0);
+    if (hit != 0) { ret hit; }
+    val id: u32 = spirv.alloc_id(tt.b);
+    var ops: [2]u32;
+    ops[0] = type_id; ops[1] = id;
+    spirv.inst(tt.b, ?tt.b.types_consts, spirv.OP_CONSTANT_NULL, ?ops[0], 2);
+    scalar_put(tt, TAG_NULL, type_id, 0, id);
     ret id;
 }
 

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -287,7 +287,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.endianness      = isa.ENDIAN_LITTLE;
     # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
     x64_model.has_v128        = true;
-    x64_model.vector_bits     = 128;
+    x64_model.vector_bits     = isa.VECTOR_BITS_128;
     # SSE2 packed compute selects from the generic MIR opcodes carrying vec_lane,
     # so the shared lowerer routes vector compute through the generic path (#2014).
     x64_model.vector_compute_generic = true;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -287,6 +287,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.endianness      = isa.ENDIAN_LITTLE;
     # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
     x64_model.has_v128        = true;
+    x64_model.vector_bits     = 128;
     # SSE2 packed compute selects from the generic MIR opcodes carrying vec_lane,
     # so the shared lowerer routes vector compute through the generic path (#2014).
     x64_model.vector_compute_generic = true;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -855,6 +855,48 @@ pub rec ExecutableSectionLocation {
 # ret:    enclosing executable-section start and one-based section number
 pub def ExecutableSectionLocationFn: fun(u64, u64, u32) ExecutableSectionLocation;
 
+# everything an image header's size scales with, for a format that maps its header
+# inside the first load segment and so needs the span reserved before the linker
+# assigns virtual addresses
+#
+# The header cannot be written until the segments are laid out, and the segments
+# cannot be laid out until the span below them is known, so the linker measures the
+# shape first and asks the format how many bytes it wants. Every field here is
+# settled once the dynamic plan is built and none of them depends on a virtual
+# address, so the measurement is exact one pass before the writer runs.
+# ---
+# itn:         interner resolving the dependency name ids
+# libs:        loader dependencies the image will name, or nil when there are none
+# lib_count:   number of loader dependencies
+# seg_count:   loadable load segments the image will carry
+# sect_count:  named sections across all those segments
+# debug_count: non-allocated debug sections the writer frames separately
+# pie:         true when the image is position-independent
+# imports:     true when the image binds dynamic imports, which may add
+#              format-synthesized stub/pointer segments of its own
+pub rec HeaderShape {
+    itn:         *intern.Interner;
+    libs:        *DynLib;
+    lib_count:   u32;
+    seg_count:   u32;
+    sect_count:  u32;
+    debug_count: u32;
+    pie:         bool;
+    imports:     bool;
+}
+
+# how many bytes a format reserves below the first load segment for its header
+#
+# The result is an upper bound rounded up to a whole number of pages, never an
+# estimate to be corrected later: the writer lays the header into exactly this span
+# and pads the remainder, so reserving more than the header needs costs padding
+# while reserving less fails the link.
+# ---
+# arg 0: the measured image shape
+# arg 1: the target's page size
+# ret:   reserved bytes, a multiple of the page size
+pub def HeaderSpanFn: fun(*HeaderShape, u64) u64;
+
 # maximum number of instruction sets an OfVTable's ISA-coverage list holds
 val OF_ISA_MAX: u32 = 8;
 
@@ -955,6 +997,12 @@ val OF_ISA_MAX: u32 = 8;
 #                 __PAGEZERO - lands a page below the base (#2599). false for a
 #                 format that maps its header outside any segment, or that
 #                 reserves the span itself inside the first section (PE)
+# header_span:    optional sizing for that reservation: given the measured image
+#                 shape, the bytes the format wants below the first load segment.
+#                 nil reserves a single page, which is all a format whose header
+#                 does not grow with the image needs. a format whose header carries
+#                 one command per segment, section and dependency outgrows a page
+#                 (#2690) and must supply this
 # executable_section_location: optional format-owned mapping from a linker load
 #                 segment to its enclosing final executable section. section-relative
 #                 relocations consult it before executable emission; nil means the
@@ -979,6 +1027,7 @@ pub rec OfVTable {
     shared_input_ext:    str;
     import_address_prefix: str;
     header_in_first_segment: bool;
+    header_span:         HeaderSpanFn;
     executable_section_location: ExecutableSectionLocationFn;
 }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1543,6 +1543,7 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # Mach-O image, position-independent or not, so __TEXT lands on the base and
     # __PAGEZERO spans the whole low region below it (#2599).
     macho_vtable.header_in_first_segment = true;
+    macho_vtable.header_span = header_span;
     macho_vtable.executable_section_location = nil;
 
     # Mach-O relocates and writes for the two Apple-silicon-era isas.
@@ -1849,6 +1850,89 @@ fun macho_dwarf_free(alloc: *A.Allocator, d: *MachoDwarf, debug_count: u32) {
     d.sec_offs = nil;
 }
 
+# the bytes reserved below the first load segment for the mach header + load
+# commands, installed as the of.HeaderSpanFn
+#
+# A Mach-O header carries one command per segment, one section_64 per named section
+# and one per dependency, so it grows with the image and a fixed one-page
+# reservation caps a link that the format itself does not cap - `sizeofcmds` is a
+# uint32 (#2690). An objective-c input reaches that cap easily: since #2606 the
+# linker preserves input section identity, so every __objc_* section a vendored
+# archive carries is another 80 bytes here.
+#
+# The result is an upper bound, not the exact size. The writer lays the header into
+# this span and pads the rest of it, so over-reserving costs padding inside __TEXT's
+# leading pages while under-reserving fails the link - every term below therefore
+# takes the larger reading where the arch or the layout is not yet fixed: both
+# platform commands are counted, the entry command is the larger of LC_UNIXTHREAD's
+# thread state and LC_MAIN, and each load segment is charged a command of its own
+# even though adjacent same-protection segments collapse into one.
+# ---
+# shape: the measured image shape
+# page:  the target's page size
+# ret:   reserved bytes, rounded up to a whole number of pages
+fun header_span(shape: *of.HeaderShape, page: u64) u64 {
+    if (shape == nil) { ret page; }
+
+    # __PAGEZERO and __LINKEDIT frame the load segments, and an image that binds
+    # imports also carries the synthesized __STUBS and __GOT.
+    var seg_cmds:   u32 = shape.seg_count + 2;
+    var sect_total: u32 = shape.sect_count;
+    if (shape.imports) {
+        seg_cmds   = seg_cmds + 2;
+        sect_total = sect_total + 2;
+    }
+
+    var entry_cmd: usize = 16 + ARM_THREAD_STATE64_COUNT::usize * 4;
+    if (16 + X86_THREAD_STATE64_COUNT::usize * 4 > entry_cmd) {
+        entry_cmd = 16 + X86_THREAD_STATE64_COUNT::usize * 4;
+    }
+    if (ENTRY_POINT_CMD_SIZE > entry_cmd) { entry_cmd = ENTRY_POINT_CMD_SIZE; }
+
+    var size: usize = MACH_HEADER_64_SIZE
+                    + seg_cmds::usize * SEGMENT_CMD_64_SIZE
+                    + sect_total::usize * SECTION_64_SIZE
+                    + DYLD_INFO_CMD_SIZE + SYMTAB_CMD_SIZE + DYSYMTAB_CMD_SIZE
+                    + dylinker_cmd_size() + entry_cmd + LINKEDIT_DATA_CMD_SIZE
+                    + BUILD_VERSION_CMD_SIZE + UUID_CMD_SIZE
+                    + macho_dwarf_cmd_bytes(shape.debug_count);
+
+    var i: u32 = 0;
+    for (i < shape.lib_count) {
+        size = size + dylib_cmd_size(bin.resolve_name(shape.itn, shape.libs[i].soname));
+        if (shape.libs[i].rpath != intern.STR_NIL
+            && !rpath_seen_before(shape.libs, i, shape.libs[i].rpath)) {
+            size = size + rpath_cmd_size(bin.resolve_name(shape.itn, shape.libs[i].rpath));
+        }
+        i = i + 1;
+    }
+
+    ret bin.align_up_u64(size::u64, page);
+}
+
+# the header span the linker reserved for this image: the gap it left between the
+# image base and the first load segment's virtual address
+#
+# The writer does not choose this. The reservation is fixed during vaddr assignment
+# (`of.HeaderSpanFn`), and __TEXT is based exactly on `image_base` because the
+# header occupies that gap - widening the span here instead would slide __TEXT, and
+# __PAGEZERO under it, below the base (#2599).
+# ---
+# segs:       the linker's load segments
+# seg_count:  number of load segments
+# image_base: the linker's image base
+# ret:        ok(the reserved bytes), or an error when no header fits below the base
+fun reserved_header_span(segs: *of.LoadSegment, seg_count: u32,
+                         image_base: u64) R.Result[usize, str] {
+    if (seg_count == 0 || segs == nil) {
+        ret R.err[usize, str]("macho: image has no load segments to map the header into");
+    }
+    if (segs[0].vaddr <= image_base) {
+        ret R.err[usize, str]("macho: base address too low to map the header");
+    }
+    ret R.ok[usize, str]((segs[0].vaddr - image_base)::usize);
+}
+
 # write a static MH_EXECUTE Mach-O, installed as the of.ExecFn
 #
 # Frames the linker's laid-out load segments with a leading __PAGEZERO (the
@@ -1872,7 +1956,8 @@ fun macho_dwarf_free(alloc: *A.Allocator, d: *MachoDwarf, debug_count: u32) {
 # seg_count:  number of segments
 # page_size:  segment-alignment page (unused; Mach-O maps its own fixed per-arch vm
 #             page via `macho_page_size` - 16 KiB arm64, 4 KiB x86_64)
-# image_base: linker image base (unused; Mach-O derives framing from segment vaddrs)
+# image_base: linker image base; __TEXT is based exactly here and the header fills
+#             the span the linker reserved between it and the first segment
 # entry:      program entry-point virtual address
 # funcs:      per-function metadata (unused)
 # func_count: number of entries in funcs (unused)
@@ -1901,10 +1986,11 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # (#1698); the structure round-trips in the of.macho parser unit test.
     val have_dwarf: bool = debug_count > 0;
 
-    # __PAGEZERO spans the low region below __TEXT; it is present whenever the image
-    # base is non-zero (darwin executables always carry one). its exact span depends
-    # on hdr_span, computed once the load-command size is known below.
-    var has_pagezero: bool = seg_count > 0 && segs[0].vaddr > 0;
+    # __PAGEZERO spans [0, base), so it is present exactly when the image base is
+    # non-zero (darwin executables always carry one). __TEXT is based on the base, so
+    # the span is the base itself - reading it off the first segment instead would
+    # make it depend on the header span, which is not yet known here.
+    val has_pagezero: bool = image_base > 0;
     # a static image has no loader-applied rebases, so no segment is dyld's
     # rebased-then-read-only __DATA_CONST and the load segments collapse purely by
     # protection: the linker's rodata and rel.ro segments are one read-only Mach-O
@@ -1927,30 +2013,22 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
 
     # the mach header + load commands map into __TEXT's first hdr_span bytes: the
     # Apple Silicon kernel admits a signed image only when the header lies inside the
-    # signed, mapped __TEXT. the first linker segment must therefore sit strictly
-    # above hdr_span, leaving room for the header below it and a non-empty
-    # __PAGEZERO under that - the linker reserves exactly this page for every Mach-O
-    # image (`of.header_in_first_segment`), position-independent or not.
-    if (header_end > exec_page::usize) {
-        ret R.err[bool, str]("macho: exec header exceeds the one-page reservation");
+    # signed, mapped __TEXT. the first linker segment therefore sits hdr_span above
+    # the base, leaving room for the header below it and a non-empty __PAGEZERO under
+    # that - the linker reserved exactly that span (`of.header_in_first_segment`,
+    # sized through `header_span`), position-independent or not.
+    val hs: R.Result[usize, str] = reserved_header_span(segs, seg_count, image_base);
+    if (R.is_err[usize, str](hs)) { ret R.err[bool, str](R.unwrap_err[usize, str](hs)); }
+    val hdr_span: usize = R.unwrap_ok[usize, str](hs);
+    if (header_end > hdr_span) {
+        ret R.err[bool, str]("macho: exec header exceeds the linker's reservation");
     }
-    val hdr_span: usize = exec_page::usize;
-    if (seg_count > 0 && segs[0].vaddr <= hdr_span::u64) {
-        ret R.err[bool, str]("macho: exec base address too low to map the header");
-    }
-    var text_va:       u64 = 0;
-    var pagezero_size: u64 = 0;
-    if (seg_count > 0) {
-        text_va       = segs[0].vaddr - hdr_span::u64;
-        pagezero_size = text_va;
-    }
+    val text_va:       u64 = segs[0].vaddr - hdr_span::u64;
+    val pagezero_size: u64 = text_va;
 
-    var seg_offsets: *usize = nil;
-    if (seg_count > 0) {
-        val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
-        if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("macho: exec offset table alloc failed"); }
-        seg_offsets = R.unwrap_ok[*usize, str](ro);
-    }
+    val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
+    if (R.is_err[*usize, str](ro)) { ret R.err[bool, str]("macho: exec offset table alloc failed"); }
+    val seg_offsets: *usize = R.unwrap_ok[*usize, str](ro);
 
     # the first linker segment's bytes follow the header at hdr_span; the rest are
     # page-aligned in turn. __TEXT (the first segment) therefore shares its file
@@ -1979,7 +2057,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     val dwp: R.Result[MachoDwarf, str] =
         macho_dwarf_plan(alloc, debug, debug_count, total_size, macho_page_size(arch_id)::usize);
     if (R.is_err[MachoDwarf, str](dwp)) {
-        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
         ret R.err[bool, str](R.unwrap_err[MachoDwarf, str](dwp));
     }
     dw = R.unwrap_ok[MachoDwarf, str](dwp);
@@ -1988,9 +2066,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # __TEXT - the first segment, now carrying the header - is the executable segment
     # the code signature authorizes: it starts at file offset 0 and spans the header
     # plus the linker's text bytes.
-    var exec_base:  u64 = 0;
-    var exec_limit: u64 = 0;
-    if (seg_count > 0) { exec_limit = hdr_span::u64 + segs[0].filesz::u64; }
+    val exec_base:  u64 = 0;
+    val exec_limit: u64 = hdr_span::u64 + segs[0].filesz::u64;
 
     # the ad-hoc code signature lives in a trailing __LINKEDIT segment and covers
     # every byte before it (including the __DWARF bytes), so it is laid out last and
@@ -2007,7 +2084,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
         macho_dwarf_free(alloc, ?dw, debug_count);
-        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
         ret R.err[bool, str]("macho: exec buffer alloc failed");
     }
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
@@ -2053,7 +2130,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     write_code_signature(buf, code_limit, name, code_limit, exec_base, exec_limit);
 
     macho_dwarf_free(alloc, ?dw, debug_count);
-    if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+    A.deallocate[usize](alloc, seg_offsets, seg_count::usize);
 
     val wr: R.Result[bool, str] = bin.write_atomic(itn, alloc, path, buf, total_size, 0o755,
         "macho: exec", "macho: could not create output file",
@@ -3373,7 +3450,8 @@ fun macho_got_ordinal(dyn: *of.DynamicInfo, import_index: u32) u32 {
 # seg_count:   number of segments
 # page_size:   segment-alignment page (unused; Mach-O maps its own fixed per-arch vm
 #              page via `macho_page_size`)
-# image_base:  linker image base (unused; Mach-O derives framing from segment vaddrs)
+# image_base:  linker image base; __TEXT is based exactly here and the header fills
+#              the span the linker reserved between it and the first segment
 # entry:       program entry-point virtual address
 # funcs:       per-function metadata (unused)
 # func_count:  number of entries in funcs (unused)
@@ -3448,7 +3526,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # the linker's load segments collapse into + (stubs, got when there are function
     # imports) + __LINKEDIT.
     val grp_count: u32 = seg_group_count(dyn, segs, seg_count);
-    var seg_cmds: u32 = frame_cmd_count(dyn, segs, seg_count, segs[0].vaddr > 0) + 1;  # + __LINKEDIT
+    var seg_cmds: u32 = frame_cmd_count(dyn, segs, seg_count, image_base > 0) + 1;  # + __LINKEDIT
     if (nstub > 0) { seg_cmds = seg_cmds + 1; }   # __STUBS
     if (ngot > 0)  { seg_cmds = seg_cmds + 1; }   # __GOT
 
@@ -3500,18 +3578,16 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     }
 
     var lay: MachoDynLayout;
-    # a PIE image reserves exactly one page for the header so __TEXT maps at the OS
-    # base (the linker reserved that page above the base when assigning vaddrs); a
-    # non-PIE image maps the header below the linker's first segment, sized to fit.
-    # the linker reserved exactly one page above the image base for the header, so
-    # the header span is that page for both layouts: growing it instead would push
-    # __TEXT (and __PAGEZERO with it) below the base (#2599).
-    if (MACH_HEADER_64_SIZE + sizeofcmds > page) {
-        ret R.err[bool, str]("macho: dyn-exec header exceeds the one-page reservation");
-    }
-    lay.hdr_span = page;
-    if (segs[0].vaddr <= lay.hdr_span::u64) {
-        ret R.err[bool, str]("macho: dyn-exec base address too low to map the header");
+    # the header maps into __TEXT's first hdr_span bytes in both layouts, so __TEXT
+    # is based exactly on the image base and __PAGEZERO spans the whole low region
+    # under it. the span is the one the linker reserved when it assigned vaddrs
+    # (`of.HeaderSpanFn`); growing it here instead would push __TEXT, and __PAGEZERO
+    # with it, below the base (#2599).
+    val hs: R.Result[usize, str] = reserved_header_span(segs, seg_count, image_base);
+    if (R.is_err[usize, str](hs)) { ret R.err[bool, str](R.unwrap_err[usize, str](hs)); }
+    lay.hdr_span = R.unwrap_ok[usize, str](hs);
+    if (MACH_HEADER_64_SIZE + sizeofcmds > lay.hdr_span) {
+        ret R.err[bool, str]("macho: dyn-exec header exceeds the linker's reservation");
     }
     lay.text_va       = segs[0].vaddr - lay.hdr_span::u64;
     lay.pagezero_size = lay.text_va;
@@ -5340,11 +5416,13 @@ fun ts_exec_x64() u8 {
     var code: [8]u8;
     var k: usize = 0;
     for (k < 8) { code[k] = 0x90; k = k + 1; }
+    # the linker leaves the header span above the base, so its first segment starts
+    # there and __TEXT is based exactly on the base.
     val base:  u64 = 0x100000000;
-    val entry: u64 = base + 0;
+    val entry: u64 = base + 4096;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].vaddr = base + 4096; segs[0].filesz = 8; segs[0].memsz = 8;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_exe");
@@ -5423,11 +5501,13 @@ fun ts_exec_arm64() u8 {
     var code: [8]u8;
     bin.write_u32_le(?code[0], 0, 0xD503201F);  # nop
     bin.write_u32_le(?code[0], 4, 0xD65F03C0);  # ret
+    # arm64 darwin maps 16 KiB pages, so the header span the linker leaves above the
+    # base is that much.
     val base:  u64 = 0x100000000;
-    val entry: u64 = base + 0;
+    val entry: u64 = base + 16384;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].vaddr = base + 16384; segs[0].filesz = 8; segs[0].memsz = 8;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_a64exe");
@@ -5530,11 +5610,14 @@ fun ts_dyn_exec(arch_id: u32) u8 {
         # a second instruction loads an imported data address through GOT_LOAD.
         code[7] = 0x48; code[8] = 0x8B; code[9] = 0x05;
     }
-    val base:  u64 = 0x100000000;
-    val entry: u64 = base;
+    val base:   u64 = 0x100000000;
+    # the linker leaves the arch page above the base for the header, so its first
+    # segment starts there.
+    val seg_va: u64 = base + macho_page_size(arch_id);
+    val entry:  u64 = seg_va;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = seg_va; segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     var libs: [1]of.DynLib;
@@ -5558,12 +5641,12 @@ fun ts_dyn_exec(arch_id: u32) u8 {
 
     var fx: [1]of.PltFixup;
     fx[0].seg_index = 0; fx[0].seg_offset = fixup_off; fx[0].import_index = 1;
-    fx[0].patch_vaddr = base + fixup_off::u64; fx[0].addend = fixup_add;
+    fx[0].patch_vaddr = seg_va + fixup_off::u64; fx[0].addend = fixup_add;
 
     var gx: [1]of.ImportAddrFixup;
     if (arch_id == isa.ARCH_X86_64) {
         gx[0].seg_index = 0; gx[0].seg_offset = 10; gx[0].import_index = 0;
-        gx[0].patch_vaddr = base + 10; gx[0].kind = of.RK_GOTPCREL; gx[0].addend = -4;
+        gx[0].patch_vaddr = seg_va + 10; gx[0].kind = of.RK_GOTPCREL; gx[0].addend = -4;
         dyn.import_addr_fixups = ?gx[0];
         dyn.import_addr_fixup_count = 1;
     }
@@ -5814,6 +5897,7 @@ fun t_rebase_vaddr(buf: *u8, nth: u32) u64 {
 # seg_count: number of load segments
 # dyn:       the dynamic-link plan
 # entry:     the entry virtual address
+# base:      the image base the linker reserved the header span above
 # ret:       the emitted image bytes, or an error string
 # give each hand-built load segment the one named section a link of mach's own
 # objects would produce for it, since those objects carry one section name per kind
@@ -5848,13 +5932,13 @@ fun t_name_segs(alloc: *A.Allocator, itn: *intern.Interner, segs: *of.LoadSegmen
 
 fun t_emit_dyn(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
                segs: *of.LoadSegment, seg_count: u32, dyn: *of.DynamicInfo,
-               entry: u64) R.Result[Vector[u8], str] {
+               entry: u64, base: u64) R.Result[Vector[u8], str] {
     if (t_name_segs(alloc, itn, segs, seg_count) != 0) { ret R.err[Vector[u8], str]("names"); }
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_seg");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[Vector[u8], str]("temp"); }
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val em: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count,
-                                                0x4000, segs[0].vaddr, entry,
+                                                0x4000, base, entry,
                                                 nil::*of.ExecFunction, 0, dyn, nil::*of.PltFixup, 0,
                                                 nil::*of.Section, 0, nil::*of.Section, 0,
                                                 fs.temp_path(?tf)::*u8, "machoseg"::*u8, of.image_options_default(of.SUBSYSTEM_CONSOLE));
@@ -5998,7 +6082,7 @@ fun ts_exec_frames_like_dyn() u8 {
     var dyn: of.DynamicInfo;
     dyn.interp = intern.STR_NIL;
     dyn.pie = true;
-    val dr: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 3, ?dyn, first);
+    val dr: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 3, ?dyn, first, base);
     if (R.is_err[Vector[u8], str](dr)) { ret 1; }
     val dynb: Vector[u8] = R.unwrap_ok[Vector[u8], str](dr);
 
@@ -6046,6 +6130,193 @@ fun ts_exec_frames_like_dyn() u8 {
     ret 0;
 }
 
+# write `segs` through both executable writers and hand each image back, so a fact
+# that must hold of the Mach-O framing can be asserted on the layouts together
+# ---
+# alloc:     allocator for the temp files and the returned bytes
+# itn:       interner the writers resolve names through
+# isa_vt:    the instruction-set vtable
+# segs:      the load segments to frame
+# seg_count: number of load segments
+# base:      the image base the header span was reserved above
+# stat:      out - the static (LC_UNIXTHREAD) image bytes
+# dynb:      out - the dyld-loaded (LC_MAIN) image bytes
+# ret:       0 when both writers succeeded, 1 otherwise
+fun t_emit_both(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
+                segs: *of.LoadSegment, seg_count: u32, base: u64,
+                stat: *Vector[u8], dynb: *Vector[u8]) u8 {
+    val opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    val entry: u64 = segs[0].vaddr;
+
+    val sf: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_both_s");
+    if (R.is_err[fs.TempFile, str](sf)) { ret 1; }
+    var stf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](sf);
+    val se: R.Result[bool, str] = emit_exec(alloc, itn, isa_vt, segs, seg_count,
+                                            macho_page_size(isa_vt.id), base, entry,
+                                            nil::*of.ExecFunction, 0, nil::*of.Section, 0,
+                                            nil::*of.Section, 0,
+                                            fs.temp_path(?stf)::*u8, "machoboth"::*u8, opts);
+    if (R.is_err[bool, str](se)) { fs.temp_close_and_remove(?stf); ret 1; }
+    val sb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?stf));
+    fs.temp_close_and_remove(?stf);
+    if (R.is_err[Vector[u8], str](sb)) { ret 1; }
+
+    var dyn: of.DynamicInfo;
+    dyn.interp = intern.STR_NIL;
+    dyn.pie = true;
+    val df: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_both_d");
+    if (R.is_err[fs.TempFile, str](df)) { ret 1; }
+    var dtf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](df);
+    val de: R.Result[bool, str] = emit_dyn_exec(alloc, itn, isa_vt, segs, seg_count,
+                                                macho_page_size(isa_vt.id), base, entry,
+                                                nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                nil::*of.Section, 0, nil::*of.Section, 0,
+                                                fs.temp_path(?dtf)::*u8, "machoboth"::*u8, opts);
+    if (R.is_err[bool, str](de)) { fs.temp_close_and_remove(?dtf); ret 1; }
+    val db: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?dtf));
+    fs.temp_close_and_remove(?dtf);
+    if (R.is_err[Vector[u8], str](db)) { ret 1; }
+
+    @stat = R.unwrap_ok[Vector[u8], str](sb);
+    @dynb = R.unwrap_ok[Vector[u8], str](db);
+    ret 0;
+}
+
+# an image whose load commands outgrow one page still links, and its header lands
+# inside the span the linker reserved rather than pushing __TEXT off the base
+#
+# A Mach-O header carries an 80-byte section_64 per named section, and since #2606
+# the linker preserves input section identity instead of coalescing, so an
+# objective-c input contributes one per __objc_* section and the header clears a
+# page long before the address space runs out. `sizeofcmds` is a uint32, so the
+# format caps nothing here - a one-page cap was the linker's, and refusing the link
+# was #2690.
+#
+# Both halves matter. The wide reservation must produce the same framing the narrow
+# one did (__PAGEZERO spanning the whole low region, __TEXT based exactly on the
+# base, the header at file offset 0 inside it), or widening it would have
+# reintroduced the image-slid-a-page-low defect of #2599. And the same fixture
+# offered only the old one-page span must be REFUSED by both writers: without that,
+# a writer that quietly truncated its own load commands would pass everything above
+fun ts_header_span_multi_page(arch_id: u32) u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(arch_id);
+
+    val pg:    u64 = macho_page_size(arch_id);
+    val nsect: u32 = 256;
+
+    var bytes: [2048]u8;
+    var k: usize = 0;
+    for (k < 2048) { bytes[k] = 0; k = k + 1; }
+
+    val sr: R.Result[*of.LoadSection, str] = A.zallocate[of.LoadSection](?alloc, nsect::usize);
+    if (R.is_err[*of.LoadSection, str](sr)) { ret 1; }
+    val secs: *of.LoadSection = R.unwrap_ok[*of.LoadSection, str](sr);
+
+    # "__sNNN" - distinct names, since a section table with a repeated name would
+    # rebind every by-name lookup and is not what a real link produces.
+    var nm: [8]u8;
+    nm[0] = 0x5F; nm[1] = 0x5F; nm[2] = 0x73; nm[6] = 0; nm[7] = 0;
+    var i: u32 = 0;
+    for (i < nsect) {
+        nm[3] = (48 + (i / 100) % 10)::u8;
+        nm[4] = (48 + (i / 10) % 10)::u8;
+        nm[5] = (48 + i % 10)::u8;
+        secs[i].name   = t_intern(?itn, ?nm[0]);
+        if (secs[i].name == intern.STR_NIL) { ret 1; }
+        secs[i].kind   = of.SK_TEXT;
+        secs[i].offset = i * 8;
+        secs[i].len    = 8;
+        secs[i].align  = 8;
+        i = i + 1;
+    }
+
+    var segs: [1]of.LoadSegment;
+    segs[0].filesz = 2048; segs[0].memsz = 2048;
+    segs[0].flags  = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE;
+    segs[0].bytes  = ?bytes[0];
+    segs[0].sections      = secs;
+    segs[0].section_count = nsect;
+
+    # the span the linker would reserve for this shape, through the same vtable hook
+    # it calls during vaddr assignment.
+    var shape: of.HeaderShape;
+    shape.itn         = ?itn;
+    shape.libs        = nil::*of.DynLib;
+    shape.lib_count   = 0;
+    shape.seg_count   = 1;
+    shape.sect_count  = nsect;
+    shape.debug_count = 0;
+    shape.pie         = true;
+    shape.imports     = false;
+    val span: u64 = header_span(?shape, pg);
+    if (span <= pg)          { ret 1; }   # the fixture must outgrow one page
+    if ((span % pg) != 0)    { ret 1; }   # ... in whole pages
+
+    val base: u64 = 0x100000000;
+    segs[0].vaddr = base + span;
+
+    var stat: Vector[u8];
+    var dynb: Vector[u8];
+    if (t_emit_both(?alloc, ?itn, ?isa_vt, ?segs[0], 1, base, ?stat, ?dynb) != 0) { ret 1; }
+
+    var w: u32 = 0;
+    for (w < 2) {
+        var buf: *u8 = stat.data;
+        if (w == 1) { buf = dynb.data; }
+
+        # the header really is over a page, and it fits the reservation.
+        val sizeofcmds: usize = bin.read_u32_le(buf, 20)::usize;
+        if (sizeofcmds::u64 <= pg)                              { ret 1; }
+        if (MACH_HEADER_64_SIZE + sizeofcmds > span::usize)     { ret 1; }
+
+        # __PAGEZERO spans the whole low region and __TEXT is based exactly on the
+        # base, with the header at file offset 0 inside it (#2599).
+        val pz: usize = t_find_seg(buf, "__PAGEZERO");
+        val tx: usize = t_find_seg(buf, "__TEXT");
+        if (pz == 0 || tx == 0)                                 { ret 1; }
+        if (bin.read_u64_le(buf, pz + 24) != 0)                 { ret 1; }
+        if (bin.read_u64_le(buf, pz + 32) != base)              { ret 1; }
+        if (bin.read_u64_le(buf, tx + 24) != base)              { ret 1; }
+        if (bin.read_u64_le(buf, tx + 40) != 0)                 { ret 1; }
+        if (bin.read_u32_le(buf, tx + 64) != nsect)             { ret 1; }
+
+        # the first section starts where the reservation ends, in both address and
+        # file offset, so the header and the content agree on where the header stops.
+        val s0: usize = tx + SEGMENT_CMD_64_SIZE;
+        if (bin.read_u64_le(buf, s0 + 32) != base + span)       { ret 1; }
+        if (bin.read_u32_le(buf, s0 + 48)::u64 != span)         { ret 1; }
+        w = w + 1;
+    }
+
+    # offered only the page the linker used to reserve unconditionally, both writers
+    # refuse rather than emit a header that overruns its span.
+    segs[0].vaddr = base + pg;
+    val opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_span_bad");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val bad_s: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1,
+                                               pg, base, base + pg,
+                                               nil::*of.ExecFunction, 0, nil::*of.Section, 0,
+                                               nil::*of.Section, 0,
+                                               fs.temp_path(?tf)::*u8, "machospanbad"::*u8, opts);
+    var dyn: of.DynamicInfo;
+    dyn.interp = intern.STR_NIL;
+    dyn.pie = true;
+    val bad_d: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1,
+                                                   pg, base, base + pg,
+                                                   nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                   nil::*of.Section, 0, nil::*of.Section, 0,
+                                                   fs.temp_path(?tf)::*u8, "machospanbad"::*u8, opts);
+    fs.temp_close_and_remove(?tf);
+    if (!R.is_err[bool, str](bad_s)) { ret 1; }
+    if (!R.is_err[bool, str](bad_d)) { ret 1; }
+    ret 0;
+}
+
 # the Mach-O segment table a PIE link with distinct rodata and rel.ro segments must
 # produce: exactly one segment is SG_READ_ONLY - the one the rebase stream writes
 # into, which is also the only one that may be named __DATA_CONST - while un-rebased
@@ -6070,19 +6341,21 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     for (k < 80) { bytes[k] = 0; k = k + 1; }
 
     # text, data, rodata, rel.ro, bss - each on its own 16 KiB page, in the linker's
-    # per-kind segment order.
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
+    # per-kind segment order, starting one page above the base where the linker
+    # reserved the header span.
+    val base:  u64 = 0x100000000;
+    val pg:    u64 = 0x4000;
+    val first: u64 = base + pg;
     var segs: [5]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE;  segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
     segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
     segs[2].flags = of.SEG_FLAG_READ;                        segs[2].bytes = ?bytes[32];
-    segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
+    segs[3].vaddr = first + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
     segs[3].flags = of.SEG_FLAG_READ;                        segs[3].bytes = ?bytes[48];
-    segs[4].vaddr = base + pg * 4; segs[4].filesz = 0;  segs[4].memsz = 16;
+    segs[4].vaddr = first + pg * 4; segs[4].filesz = 0;  segs[4].memsz = 16;
     segs[4].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;    segs[4].bytes = nil;
 
     # pointers to slide in rel.ro and in data: a writable segment is already writable
@@ -6098,7 +6371,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     dyn.base_reloc_count = 2;
     dyn.pie = true;
 
-    val r1: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, base);
+    val r1: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, first, base);
     if (R.is_err[Vector[u8], str](r1)) { ret 1; }
     val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](r1);
 
@@ -6108,7 +6381,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     if (t_count_segs_named(buf.data, "__DATA_CONST") != 1)                   { ret 1; }
     val dc: usize = t_find_seg(buf.data, "__DATA_CONST");
     if (dc == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, dc + 24) != base + pg * 3)                 { ret 1; }
+    if (bin.read_u64_le(buf.data, dc + 24) != first + pg * 3)                 { ret 1; }
     if ((bin.read_u32_le(buf.data, dc + 68) & SG_READ_ONLY) == 0)            { ret 1; }
     if (bin.read_u32_le(buf.data, dc + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
     if (bin.read_u32_le(buf.data, dc + 64) != 1)                             { ret 1; }
@@ -6118,7 +6391,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     if (t_count_segs_named(buf.data, "__RODATA") != 1)                       { ret 1; }
     val rd: usize = t_find_seg(buf.data, "__RODATA");
     if (rd == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg * 2)                 { ret 1; }
+    if (bin.read_u64_le(buf.data, rd + 24) != first + pg * 2)                 { ret 1; }
     if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)                  { ret 1; }
     if (bin.read_u32_le(buf.data, rd + 56) != VM_PROT_READ)                  { ret 1; }
     if ((bin.read_u32_le(buf.data, rd + 68) & SG_READ_ONLY) != 0)            { ret 1; }
@@ -6128,7 +6401,7 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     # after fixups, faulting the program's first store to a pointer-valued global.
     val dt: usize = t_find_seg(buf.data, "__DATA");
     if (dt == 0)                                                             { ret 1; }
-    if (bin.read_u64_le(buf.data, dt + 24) != base + pg)                     { ret 1; }
+    if (bin.read_u64_le(buf.data, dt + 24) != first + pg)                     { ret 1; }
     if (bin.read_u32_le(buf.data, dt + 60) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
     if (bin.read_u32_le(buf.data, dt + 56) != (VM_PROT_READ | VM_PROT_WRITE)) { ret 1; }
     if ((bin.read_u32_le(buf.data, dt + 68) & SG_READ_ONLY) != 0)            { ret 1; }
@@ -6136,31 +6409,31 @@ fun ts_dyn_exec_relro_segments(arch_id: u32) u8 {
     # every section names the segment it lives in, and each rebase resolves through
     # its selected segment back to the address the linker recorded.
     if (!t_sections_match_segname(buf.data))                                 { ret 1; }
-    if (t_rebase_vaddr(buf.data, 0) != base + pg)                            { ret 1; }
-    if (t_rebase_vaddr(buf.data, 1) != base + pg * 3)                        { ret 1; }
+    if (t_rebase_vaddr(buf.data, 0) != first + pg)                            { ret 1; }
+    if (t_rebase_vaddr(buf.data, 1) != first + pg * 3)                        { ret 1; }
     if (t_rebase_vaddr(buf.data, 2) != 0)                                    { ret 1; }
 
     # rodata rebased as well: both read-only segments now need dyld's fixup pass, and
     # Mach-O maps one such segment - they share it, carrying a section each, so the
     # image keeps exactly one SG_READ_ONLY instead of being refused.
     dyn.base_reloc_count = 3;
-    val r2: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, base);
+    val r2: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 5, ?dyn, first, base);
     if (R.is_err[Vector[u8], str](r2)) { ret 1; }
     val buf2: Vector[u8] = R.unwrap_ok[Vector[u8], str](r2);
     if (t_count_sg_read_only(buf2.data) != 1)                                { ret 1; }
     if (t_count_segs_named(buf2.data, "__DATA_CONST") != 1)                  { ret 1; }
     if (t_count_segs_named(buf2.data, "__RODATA") != 0)                      { ret 1; }
     val dc2: usize = t_find_seg(buf2.data, "__DATA_CONST");
-    if (bin.read_u64_le(buf2.data, dc2 + 24) != base + pg * 2)               { ret 1; }
+    if (bin.read_u64_le(buf2.data, dc2 + 24) != first + pg * 2)               { ret 1; }
     if (bin.read_u32_le(buf2.data, dc2 + 64) != 2)                           { ret 1; }
     if (bin.read_u64_le(buf2.data, dc2 + 32)
         != bin.align_up_u64(pg + 16, macho_page_size(arch_id)))              { ret 1; }
     if (!t_sections_match_segname(buf2.data))                                { ret 1; }
     # the merged members share one command index, and their offsets are measured from
     # that command's address, not from the member's own.
-    if (t_rebase_vaddr(buf2.data, 0) != base + pg)                           { ret 1; }
-    if (t_rebase_vaddr(buf2.data, 1) != base + pg * 2)                       { ret 1; }
-    if (t_rebase_vaddr(buf2.data, 2) != base + pg * 3)                       { ret 1; }
+    if (t_rebase_vaddr(buf2.data, 0) != first + pg)                           { ret 1; }
+    if (t_rebase_vaddr(buf2.data, 1) != first + pg * 2)                       { ret 1; }
+    if (t_rebase_vaddr(buf2.data, 2) != first + pg * 3)                       { ret 1; }
     ret 0;
 }
 
@@ -6179,16 +6452,17 @@ fun ts_dyn_exec_split_data_const() u8 {
     var k: usize = 0;
     for (k < 64) { bytes[k] = 0; k = k + 1; }
 
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
+    val base:  u64 = 0x100000000;
+    val pg:    u64 = 0x4000;
+    val first: u64 = base + pg;
     var segs: [4]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
     segs[1].flags = of.SEG_FLAG_READ;                       segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
     segs[2].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE;   segs[2].bytes = ?bytes[32];
-    segs[3].vaddr = base + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
+    segs[3].vaddr = first + pg * 3; segs[3].filesz = 16; segs[3].memsz = 16;
     segs[3].flags = of.SEG_FLAG_READ;                       segs[3].bytes = ?bytes[48];
 
     var brs: [2]of.BaseReloc;
@@ -6201,7 +6475,7 @@ fun ts_dyn_exec_split_data_const() u8 {
     dyn.base_reloc_count = 2;
     dyn.pie = true;
 
-    val r: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 4, ?dyn, base);
+    val r: R.Result[Vector[u8], str] = t_emit_dyn(?alloc, ?itn, ?isa_vt, ?segs[0], 4, ?dyn, first, base);
     if (!R.is_err[Vector[u8], str](r))                                       { ret 1; }
     val msg: str = R.unwrap_err[Vector[u8], str](r);
     # the diagnostic names both offending segments and a relocation inside the second.
@@ -6225,14 +6499,15 @@ fun ts_exec_merges_read_only() u8 {
     var k: usize = 0;
     for (k < 48) { bytes[k] = 0; k = k + 1; }
 
-    val base: u64 = 0x100000000;
-    val pg:   u64 = 0x4000;
+    val base:  u64 = 0x100000000;
+    val pg:    u64 = 0x4000;
+    val first: u64 = base + pg;
     var segs: [3]of.LoadSegment;
-    segs[0].vaddr = base;          segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].vaddr = first;          segs[0].filesz = 16; segs[0].memsz = 16;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?bytes[0];
-    segs[1].vaddr = base + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].vaddr = first + pg;     segs[1].filesz = 16; segs[1].memsz = 16;
     segs[1].flags = of.SEG_FLAG_READ;                       segs[1].bytes = ?bytes[16];
-    segs[2].vaddr = base + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].vaddr = first + pg * 2; segs[2].filesz = 16; segs[2].memsz = 16;
     segs[2].flags = of.SEG_FLAG_READ;                       segs[2].bytes = ?bytes[32];
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "macho_exec_ro");
@@ -6240,7 +6515,7 @@ fun ts_exec_merges_read_only() u8 {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     if (t_name_segs(?alloc, ?itn, ?segs[0], 3) != 0) { ret 1; }
     val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 3,
-                                            pg, base, base,
+                                            pg, base, first,
                                             nil::*of.ExecFunction, 0, nil::*of.Section, 0,
                                             nil::*of.Section, 0,
                                             fs.temp_path(?tf)::*u8, "machoexecro"::*u8, of.image_options_default(of.SUBSYSTEM_CONSOLE));
@@ -6255,7 +6530,7 @@ fun ts_exec_merges_read_only() u8 {
     if (rd == 0)                                                             { ret 1; }
     # one command spanning both read-only segments, from the first's address to the
     # second's end.
-    if (bin.read_u64_le(buf.data, rd + 24) != base + pg)                     { ret 1; }
+    if (bin.read_u64_le(buf.data, rd + 24) != first + pg)                     { ret 1; }
     if (bin.read_u64_le(buf.data, rd + 32)
         != bin.align_up_u64(pg + 16, EXEC_PAGE_SIZE))                        { ret 1; }
     if (bin.read_u32_le(buf.data, rd + 60) != VM_PROT_READ)                  { ret 1; }
@@ -6487,6 +6762,8 @@ test "mach.lang.target.of.macho:dyn_exec" {
     if (ts_dyn_exec_split_data_const() != 0)               { ret 1; }
     if (ts_exec_merges_read_only() != 0)                   { ret 1; }
     if (ts_exec_frames_like_dyn() != 0)                    { ret 1; }
+    if (ts_header_span_multi_page(isa.ARCH_X86_64) != 0)   { ret 1; }
+    if (ts_header_span_multi_page(isa.ARCH_AARCH64) != 0)  { ret 1; }
     if (ts_import_address_fixup_validation() != 0)         { ret 1; }
     ret 0;
 }
@@ -6509,10 +6786,10 @@ fun ts_exec_debug_roundtrip() u8 {
     var k: usize = 0;
     for (k < 8) { code[k] = 0x90; k = k + 1; }
     val base:  u64 = 0x100000000;
-    val entry: u64 = base;
+    val entry: u64 = base + 4096;
 
     var segs: [1]of.LoadSegment;
-    segs[0].vaddr = base; segs[0].filesz = 8; segs[0].memsz = 8;
+    segs[0].vaddr = base + 4096; segs[0].filesz = 8; segs[0].memsz = 8;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?code[0];
 
     var info_bytes: [4]u8;

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -292,6 +292,21 @@ pub rec VecForm {
     bits:    u32;
 }
 
+# whether `name` is spelled as a vector form at all, regardless of any target bound
+#
+# The declaration guard reads this rather than `vector_form`'s status, because whether
+# a spelling COLLIDES with the vector grammar must not depend on the target's width.
+# `rec f32x8` is a landmine on a 128-bit target too: the very same source is a real
+# vector type on a 256-bit one, so the name is reserved on both or the rule is not one
+# rule. The bound passed here is therefore irrelevant and only OK / TOO_WIDE /
+# SUB_WIDTH can differ by it, never NONE.
+# ---
+# name: the spelling to test
+# ret:  true when `name` parses as `<element>x<lanes>`
+pub fun is_vector_spelling(name: str) bool {
+    ret vector_form(name, 0).status != VEC_FORM_NONE;
+}
+
 # read `name` as the vector form `<element>x<lanes>`, bounded by `vector_bits`
 #
 # THE FORM, NOT A TABLE (#2687). A vector type is any primitive scalar element

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -264,6 +264,20 @@ pub val VEC_FORM_OK:        VecFormStatus = 1;
 pub val VEC_FORM_TOO_WIDE:  VecFormStatus = 2;
 # a well formed element with a degenerate lane count (0 or 1)
 pub val VEC_FORM_BAD_LANES: VecFormStatus = 3;
+# a well formed shape within the width bound but NARROWER than the vector register
+#
+# Temporary, and the only thing standing between this form and `vec3` (#2687). The
+# frontend and the layout policy both carry a sub-width vector correctly; the backend
+# does not, because a sub-width vector is the first value whose REGISTER width (a whole
+# vector register) and MEMORY footprint (its packed lane bytes) differ, and
+# `be.codegen.mir.context.op_width_of` answers one number for both. Carrying a move at
+# the memory width truncates the top lane, and carrying a store at the register width
+# clobbers the next field. Splitting the two is a backend project.
+#
+# Refused BY NAME here rather than accepted and miscompiled: a shape that resolves and
+# then silently drops a lane is far worse than one that does not resolve. Lifting this
+# is deleting the status and its one check, not a rewrite.
+pub val VEC_FORM_SUB_WIDTH:  VecFormStatus = 4;
 
 # the shape a `TxN` spelling denotes, and whether the target admits it
 # ---
@@ -352,7 +366,11 @@ pub fun vector_form(name: str, vector_bits: u32) VecForm {
     val width: u64 = prim_desc(element).bits::u64 * lanes;
     if (width > vector_bits::u64) { f.status = VEC_FORM_TOO_WIDE; ret f; }
 
-    f.bits   = width::u32;
+    f.bits = width::u32;
+    # a vector that does not FILL the register is well formed and correctly laid out,
+    # but the backend cannot carry one yet (see VEC_FORM_SUB_WIDTH).
+    if (width < vector_bits::u64) { f.status = VEC_FORM_SUB_WIDTH; ret f; }
+
     f.status = VEC_FORM_OK;
     ret f;
 }
@@ -1975,23 +1993,29 @@ test "mach.lang.type.vector_form:reads_the_form_and_the_bound" {
         vi = vi + 1;
     }
 
-    # the sub-128 forms the issue exists for, with their element and lane count
-    # checked rather than only their acceptance.
+    # the sub-128 forms the issue exists for. READ correctly - element, lane count and
+    # width are all recovered - but refused as SUB_WIDTH rather than accepted, because
+    # the backend cannot carry a vector narrower than the register yet. this is the one
+    # status that is expected to become VEC_FORM_OK later.
     val v3: VecForm = vector_form("f32x3", 128);
-    if (v3.status != VEC_FORM_OK) { ret 1; }
-    if (v3.element != TYPE_F32)   { ret 1; }
-    if (v3.lanes != 3)            { ret 1; }
-    if (v3.bits != 96)            { ret 1; }
+    if (v3.status != VEC_FORM_SUB_WIDTH) { ret 1; }
+    if (v3.element != TYPE_F32)          { ret 1; }
+    if (v3.lanes != 3)                   { ret 1; }
+    if (v3.bits != 96)                   { ret 1; }
 
     val u3: VecForm = vector_form("u32x3", 128);
-    if (u3.status != VEC_FORM_OK) { ret 1; }
-    if (u3.element != TYPE_U32)   { ret 1; }
-    if (u3.lanes != 3)            { ret 1; }
+    if (u3.status != VEC_FORM_SUB_WIDTH) { ret 1; }
+    if (u3.element != TYPE_U32)          { ret 1; }
+    if (u3.lanes != 3)                   { ret 1; }
 
     val v2: VecForm = vector_form("f32x2", 128);
-    if (v2.status != VEC_FORM_OK) { ret 1; }
-    if (v2.lanes != 2)            { ret 1; }
-    if (v2.bits != 64)            { ret 1; }
+    if (v2.status != VEC_FORM_SUB_WIDTH) { ret 1; }
+    if (v2.lanes != 2)                   { ret 1; }
+    if (v2.bits != 64)                   { ret 1; }
+
+    # the sub-width refusal is about the REGISTER, not the spelling: the very same
+    # f32x4 that fills a 128-bit register is sub-width on a 256-bit one.
+    if (vector_form("f32x4", 256).status != VEC_FORM_SUB_WIDTH) { ret 1; }
 
     # REFUSED: wider than the bound. f32x7 is 224 bits, so a 128-bit target must
     # report it as too wide rather than as an unknown name.
@@ -2012,11 +2036,11 @@ test "mach.lang.type.vector_form:reads_the_form_and_the_bound" {
     # REFUSED: a degenerate lane count is its own outcome, not a width failure.
     if (vector_form("f32x1", 128).status != VEC_FORM_BAD_LANES) { ret 1; }
 
-    # the bound is the target's, not a constant: a 64-bit vector unit admits
-    # f32x2 and refuses the f32x4 a 128-bit one takes.
+    # the bound is the target's, not a constant: a 64-bit vector unit fills on f32x2
+    # and refuses the f32x4 a 128-bit one takes.
     if (vector_form("f32x2", 64).status != VEC_FORM_OK)        { ret 1; }
     if (vector_form("f32x4", 64).status != VEC_FORM_TOO_WIDE)  { ret 1; }
-    # and a wider unit admits what 128 bits refuses, so the form does not itself
+    # and a wider unit fills on what 128 bits refuses, so the form does not itself
     # cap at 128 (the super-128 register classes are a separate problem).
     if (vector_form("f32x8", 256).status != VEC_FORM_OK) { ret 1; }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -20,6 +20,9 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_len;
+use std.types.string.str_region_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -209,6 +212,143 @@ pub fun vec_shape(index: u32) VecShape {
     or (index == 9) { s.name = "u64x2"; s.element = TYPE_U64; s.lanes = 2;  }
 
     ret s;
+}
+
+# the source spelling of a primitive TypeKind, the inverse of the ordinal
+#
+# The one place a primitive's spelling is written down. The resolver's primitive
+# registry and the `TxN` vector form both read it, so a spelling can never drift
+# between the name a program writes and the element a vector form accepts.
+# ---
+# kind: the primitive TypeKind to spell
+# ret:  the spelling, or nil for a non-primitive kind
+pub fun prim_name(kind: TypeKind) str {
+    if      (kind == TYPE_U8)  { ret "u8";  }
+    or (kind == TYPE_U16) { ret "u16"; }
+    or (kind == TYPE_U32) { ret "u32"; }
+    or (kind == TYPE_U64) { ret "u64"; }
+    or (kind == TYPE_I8)  { ret "i8";  }
+    or (kind == TYPE_I16) { ret "i16"; }
+    or (kind == TYPE_I32) { ret "i32"; }
+    or (kind == TYPE_I64) { ret "i64"; }
+    or (kind == TYPE_F32) { ret "f32"; }
+    or (kind == TYPE_F64) { ret "f64"; }
+    or (kind == TYPE_PTR) { ret "ptr"; }
+    ret nil;
+}
+
+# how reading a spelling as the vector form `<element>x<lanes>` came out
+#
+# Three outcomes rather than two, because "this is not a vector spelling" and
+# "this is a vector the target will not admit" need different diagnostics: the
+# first falls through to ordinary name resolution, the second must name the
+# vector and the bound it exceeded (#2687).
+pub def VecFormStatus: u8;
+
+# the largest lane count the form reader carries as a number. a count past this
+# is clamped to `MAX_VEC_LANES + 1`, so it still reports as too wide without the
+# digit loop carrying an unbounded value
+pub val MAX_VEC_LANES: u32 = 65535;
+
+# not a vector spelling at all; the caller resolves the name by other means
+pub val VEC_FORM_NONE:      VecFormStatus = 0;
+# a well formed shape within the target's bound
+pub val VEC_FORM_OK:        VecFormStatus = 1;
+# a well formed shape wider than the target's vector width admits
+pub val VEC_FORM_TOO_WIDE:  VecFormStatus = 2;
+# a well formed element with a degenerate lane count (0 or 1)
+pub val VEC_FORM_BAD_LANES: VecFormStatus = 3;
+
+# the shape a `TxN` spelling denotes, and whether the target admits it
+# ---
+# status:  which of the four outcomes reading the spelling produced
+# element: lane scalar TypeKind; only meaningful when status is not VEC_FORM_NONE
+# lanes:   lane count; only meaningful when status is not VEC_FORM_NONE
+# bits:    element bits times lanes, the width the bound is tested against
+pub rec VecForm {
+    status:  VecFormStatus;
+    element: TypeKind;
+    lanes:   u32;
+    bits:    u32;
+}
+
+# read `name` as the vector form `<element>x<lanes>`, bounded by `vector_bits`
+#
+# THE FORM, NOT A TABLE (#2687). A vector type is any primitive scalar element
+# followed by `x` and a lane count, admitted when the total width fits the
+# target's vector register width. The ten formerly seeded spellings are exactly
+# the forms whose width is 128, so they keep resolving unchanged and are no
+# longer special.
+#
+# `ptr` is not a lane element: its width is target-defined rather than a scalar
+# bit count, so no lane count gives it a well defined vector width. A lane count
+# below 2 is refused rather than admitted as a degenerate one-lane vector, which
+# has no register representation and which SPIR-V's OpTypeVector forbids
+# outright.
+#
+# The width product is computed in u64 so an absurd lane count reports as too
+# wide rather than wrapping u32 into a shape that appears to fit.
+# ---
+# name:        the spelling to read
+# vector_bits: the widest vector the target admits, in bits
+# ret:         the shape and whether the target admits it
+pub fun vector_form(name: str, vector_bits: u32) VecForm {
+    var f: VecForm;
+    f.status  = VEC_FORM_NONE;
+    f.element = TYPE_U8;
+    f.lanes   = 0;
+    f.bits    = 0;
+
+    if (name == nil) { ret f; }
+    val n: usize = str_len(name);
+    # the shortest well formed spelling is `u8x2`, so anything shorter cannot be
+    # one. tested before the split so the `n - 1` below never underflows.
+    if (n < 4) { ret f; }
+
+    # no primitive spelling contains an `x`, so the first one splits the form.
+    var split: usize = 0;
+    for (split < n && name[split] != 'x') { split = split + 1; }
+    if (split == 0) { ret f; }
+    if (split >= n - 1) { ret f; }
+
+    var element: TypeKind = TYPE_U8;
+    var found:   bool     = false;
+    var k:       u32      = 0;
+    for (k < PRIM_COUNT) {
+        val kind: TypeKind = k::u8;
+        if (kind != TYPE_PTR && str_region_equals(name, 0, split, prim_name(kind))) {
+            element = kind;
+            found   = true;
+        }
+        k = k + 1;
+    }
+    if (!found) { ret f; }
+
+    # a strict decimal lane count: digits only, and no leading zero, so a
+    # near-miss identifier stays an ordinary unresolved name.
+    if (name[split + 1] == '0') { ret f; }
+    var lanes: u64   = 0;
+    var i:     usize = split + 1;
+    for (i < n) {
+        val c: u8 = name[i];
+        if (c < '0' || c > '9') { ret f; }
+        lanes = lanes * 10 + (c - '0')::u64;
+        if (lanes > MAX_VEC_LANES::u64) { lanes = MAX_VEC_LANES::u64 + 1; }
+        i = i + 1;
+    }
+
+    f.element = element;
+    f.lanes   = lanes::u32;
+    if (lanes > MAX_VEC_LANES::u64) { f.lanes = MAX_VEC_LANES + 1; }
+
+    if (lanes < 2) { f.status = VEC_FORM_BAD_LANES; ret f; }
+
+    val width: u64 = prim_desc(element).bits::u64 * lanes;
+    if (width > vector_bits::u64) { f.status = VEC_FORM_TOO_WIDE; ret f; }
+
+    f.bits   = width::u32;
+    f.status = VEC_FORM_OK;
+    ret f;
 }
 
 # fixed-size array type payload
@@ -1809,6 +1949,111 @@ test "mach.lang.type.is_union:instance_follows_its_nominal" {
     if (is_record(?ti, u32_id))  { dnit(?ti); ret 1; }
 
     dnit(?ti);
+    ret 0;
+}
+
+# `vector_form` reads `<element>x<lanes>` and separates the three outcomes: a
+# shape the target admits, a shape too wide for it, and a spelling that is not a
+# vector at all. the ten formerly seeded spellings are exactly the 128-bit forms
+test "mach.lang.type.vector_form:reads_the_form_and_the_bound" {
+    # every one of the ten shapes the compiler used to seed by name reads back as
+    # itself under a 128-bit bound. this is the regression bar (#2687).
+    var vi: u32 = 0;
+    for (vi < VEC_COUNT) {
+        val sh: VecShape = vec_shape(vi);
+        val f:  VecForm  = vector_form(sh.name, 128);
+        if (f.status  != VEC_FORM_OK) { ret 1; }
+        if (f.element != sh.element)  { ret 1; }
+        if (f.lanes   != sh.lanes)    { ret 1; }
+        if (f.bits    != 128)         { ret 1; }
+        vi = vi + 1;
+    }
+
+    # the sub-128 forms the issue exists for, with their element and lane count
+    # checked rather than only their acceptance.
+    val v3: VecForm = vector_form("f32x3", 128);
+    if (v3.status != VEC_FORM_OK) { ret 1; }
+    if (v3.element != TYPE_F32)   { ret 1; }
+    if (v3.lanes != 3)            { ret 1; }
+    if (v3.bits != 96)            { ret 1; }
+
+    val u3: VecForm = vector_form("u32x3", 128);
+    if (u3.status != VEC_FORM_OK) { ret 1; }
+    if (u3.element != TYPE_U32)   { ret 1; }
+    if (u3.lanes != 3)            { ret 1; }
+
+    val v2: VecForm = vector_form("f32x2", 128);
+    if (v2.status != VEC_FORM_OK) { ret 1; }
+    if (v2.lanes != 2)            { ret 1; }
+    if (v2.bits != 64)            { ret 1; }
+
+    # REFUSED: wider than the bound. f32x7 is 224 bits, so a 128-bit target must
+    # report it as too wide rather than as an unknown name.
+    val w7: VecForm = vector_form("f32x7", 128);
+    if (w7.status != VEC_FORM_TOO_WIDE) { ret 1; }
+    if (w7.element != TYPE_F32)         { ret 1; }
+    if (w7.lanes != 7)                  { ret 1; }
+
+    # REFUSED: exactly one lane past the bound, the boundary case.
+    if (vector_form("f32x5", 128).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+    if (vector_form("i8x17", 128).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+    if (vector_form("f64x3", 128).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+
+    # REFUSED: a lane count so large the width product would wrap a u32 still
+    # reports too wide, never a shape that appears to fit.
+    if (vector_form("u64x4294967295", 128).status != VEC_FORM_TOO_WIDE) { ret 1; }
+
+    # REFUSED: a degenerate lane count is its own outcome, not a width failure.
+    if (vector_form("f32x1", 128).status != VEC_FORM_BAD_LANES) { ret 1; }
+
+    # the bound is the target's, not a constant: a 64-bit vector unit admits
+    # f32x2 and refuses the f32x4 a 128-bit one takes.
+    if (vector_form("f32x2", 64).status != VEC_FORM_OK)        { ret 1; }
+    if (vector_form("f32x4", 64).status != VEC_FORM_TOO_WIDE)  { ret 1; }
+    # and a wider unit admits what 128 bits refuses, so the form does not itself
+    # cap at 128 (the super-128 register classes are a separate problem).
+    if (vector_form("f32x8", 256).status != VEC_FORM_OK) { ret 1; }
+
+    # NOT A VECTOR: these fall through to ordinary name resolution rather than
+    # producing a vector diagnostic.
+    if (vector_form(nil, 128).status     != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("", 128).status      != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f32", 128).status   != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f32x", 128).status  != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("x4", 128).status    != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f33x4", 128).status != VEC_FORM_NONE) { ret 1; }
+    if (vector_form("f32x4y", 128).status != VEC_FORM_NONE) { ret 1; }
+    # a leading zero is not a lane count, so `f32x04` stays an ordinary name.
+    if (vector_form("f32x04", 128).status != VEC_FORM_NONE) { ret 1; }
+    # `ptr` has no scalar bit width, so no lane count makes a vector of it.
+    if (vector_form("ptrx2", 128).status  != VEC_FORM_NONE) { ret 1; }
+    # a user identifier that merely contains an x is untouched.
+    if (vector_form("matrix4", 128).status != VEC_FORM_NONE) { ret 1; }
+
+    ret 0;
+}
+
+# `prim_name` round-trips every primitive ordinal to its spelling, so the
+# resolver's registry and the vector form read one table
+test "mach.lang.type.prim_name:spells_every_primitive" {
+    if (!str_equals(prim_name(TYPE_U8),  "u8"))  { ret 1; }
+    if (!str_equals(prim_name(TYPE_U16), "u16")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_U32), "u32")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_U64), "u64")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_I8),  "i8"))  { ret 1; }
+    if (!str_equals(prim_name(TYPE_I16), "i16")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_I32), "i32")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_I64), "i64")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_F32), "f32")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_F64), "f64")) { ret 1; }
+    if (!str_equals(prim_name(TYPE_PTR), "ptr")) { ret 1; }
+    # every ordinal below PRIM_COUNT has a spelling, and a non-primitive has none
+    var k: u32 = 0;
+    for (k < PRIM_COUNT) {
+        if (prim_name(k::u8) == nil) { ret 1; }
+        k = k + 1;
+    }
+    if (prim_name(TYPE_VECTOR) != nil) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -77,14 +77,17 @@ pub val TYPE_PACK: TypeKind = 18;
 # to the same machine shape as `T`; it constrains only sema's flow typing
 pub val TYPE_SECRET: TypeKind = 19;
 
-# a 128-bit SIMD vector type `<u|i|f><width>x<count>` (#1965). the portable
-# vector model: all ten seeded shapes are legal on every target, with a payload
-# carrying the lane scalar kind and lane count. lowers to a 16-byte register-class
-# value; whether a lane-wise op is one instruction or a scalar expansion is a
-# backend concern
+# a SIMD vector type spelled `<element>x<lanes>` (#1965, generalized in #2687). the
+# portable vector model: any primitive scalar element and any lane count whose total
+# width fits the target's vector register is legal on every target, with a payload
+# carrying the lane scalar kind and lane count. its extent is lane-derived, so
+# `f32x4` is 16 bytes and `f32x3` is 12; whether a lane-wise op is one instruction or
+# a scalar expansion is a backend concern
 pub val TYPE_VECTOR: TypeKind = 20;
 
-# number of seeded vector types (the ten 128-bit shapes)
+# number of PRE-SEEDED vector types. no longer the set of legal vectors, which is the
+# `TxN` form bounded by the target's vector width (#2687): these ten 128-bit shapes
+# are merely interned at session init so they have stable TypeIds
 pub val VEC_COUNT: u32 = 10;
 
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
@@ -161,10 +164,11 @@ pub rec TypeSecret {
     base: TypeId;
 }
 
-# 128-bit SIMD vector type payload (#1965)
+# SIMD vector type payload (#1965)
 #
-# Two vectors are identical iff (element, lanes) match. `element` is one of the
-# ten scalar prim kinds; `lanes` is 2, 4, 8, or 16 so that element*lanes is 128.
+# Two vectors are identical iff (element, lanes) match. `element` is one of the ten
+# scalar prim kinds (never `ptr`, which has no scalar bit width); `lanes` is at least
+# 2, and `element bits * lanes` is bounded by the target's vector width (#2687).
 # ---
 # element: lane scalar TypeKind (u8..i64, f32, f64)
 # lanes:   lane count
@@ -175,8 +179,10 @@ pub rec TypeVector {
 
 # the spelling, lane scalar, and lane count of one seeded vector type
 #
-# The single source of truth for the ten shapes, shared by the interner's init
-# seeding and the resolver's name registry, keyed by ordinal.
+# The ten shapes the interner pre-seeds at init so they have stable TypeIds. NOT the
+# set of legal vectors: that is the `TxN` form `vector_form` reads, bounded by the
+# target's vector width (#2687). Kept as the fixture the regression tests measure the
+# pre-#2687 shapes against.
 # ---
 # name:    source spelling, e.g. "f32x4"
 # element: lane scalar TypeKind
@@ -796,7 +802,7 @@ pub fun is_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret O.unwrap[*Type](opt_type).kind == TYPE_SECRET;
 }
 
-# whether `tid` is a 128-bit vector type (#1965)
+# whether `tid` is a vector type (#1965)
 #
 # A secret `^T` is classified by its inner type, so a secret vector still reports
 # as a vector for layout and lane classification.
@@ -1045,7 +1051,7 @@ pub fun intern_array(ti: *TypeInterner, base: TypeId, count: u32) R.Result[TypeI
     ret intern_dedup(ti, t);
 }
 
-# intern a 128-bit vector type (#1965)
+# intern a vector type (#1965)
 #
 # Returns an existing TypeId when the same (element, lanes) shape has been
 # interned before.


### PR DESCRIPTION
Integration merge for 4.13.0. See the CHANGELOG entry and #2707.

Ten merges since 4.12.0. Two source-compatibility changes (`^` no longer stripped by the shape predicates, #2692; a type may not be declared with a vector form name, #2687), the GLSL.std.450 shader instruction set (#2688), the `TxN` vector form with lane-derived layout (#2687, partial), the Mach-O header reservation fix (#2690), and the SPIR-V access chain work (#2649).

`vec3` is deliberately not shipped: sub-register-width vectors are refused by name pending #2697.