### PR TITLE
comptime: accept a field descriptor's type as a generic argument, so a reflection walk can recurse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### A reflection walk can re-enter itself at a field's type (#2691)
+
+`$fields(f.type)` (#2454) let a walk descend into a record-typed field, but only **one syntactic level per `$each` someone wrote**. Closing the loop needs the walk to re-enter itself at the field's type, and the only spelling for that is a generic call — which did not parse, because a generic argument list reads with the type grammar where `f.type` is indistinguishable from a qualified `module.Type`:
+
+```mach
+fun eq[T](a: *T, b: *T) bool {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
+        }
+        $or { if (a.[f] != b.[f]) { ret false; } }
+    }
+    ret true;
+}
+```
+
+Neither of the two alternatives worked either: there is no inference from the argument, so `eq(?a.[f], ?b.[f])` resolves against the template rather than instantiating, and `$type_of` is not a type operand. All three doors were locked, which is why `std.derive` shipped a hand-unrolled ladder with a documented depth cap.
+
+#2454's one-token lookahead now extends to the generic argument list. `f.type` there is a `TYPE_KIND_FIELD_TYPE` node carrying the loop variable's name rather than a resolved type, because which field it names is decided per iteration by the unroll.
+
+**Termination is structural**, so there is no depth limit and none is needed: each descent instantiates at a field's own type, a record's fields are finite, and a record cannot contain itself by value — the compiler already refuses that as a recursive type of infinite size, verified for the direct, mutual, and generic-growing forms. A self-reference must go through a pointer, which is a different type and which `$is_record` does not select.
+
+Two implementation notes worth carrying:
+
+- **A `f.type` node is never memoized.** `resolve_type_ref` caches a syntactic node's resolved type, which is sound only because every other spelling's meaning is fixed by its source text. This one is not: a single node serves every iteration, so caching the first answer gives the second field the first field's type. Pinned by a case with two record fields of different arity, which is a wrong count rather than a silent pass.
+- **Both phases resolve it through one helper.** Sema resolves it during its own `$each` unroll; lowering resolves it during the unroll it runs for a walk whose `$fields` operand was an unbound generic parameter at template sema — which is the shape a generic derive actually has. `comptime.field_type_of_binding` is the single implementation, going through the same installed field resolver as the `f.type` value projection, so a descriptor read as a value and the same descriptor read as a type cannot land on different fields.
+
+The lookahead does not absorb real mistakes: a genuinely wrong operand in the same position (`g[nosuchmod.T]`) still reports against the type grammar, a name that is not a `$each` loop variable is reported where it is written, and `type` stays contextual so an ordinary record field called `type` is untouched.
+
+
+
 ### Changed
 
 #### `^` is stripped only where the question is about storage (#2692)

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -160,10 +160,37 @@ $each f in $fields(T) {
 }
 ```
 
-That form is what makes recursive reflection expressible: inside the loop a field's
-type has no spelling, only the descriptor. A path that is genuinely a qualified type
-name (`mod.Type`) still reads as one, and a wrong one still reports against the type
-grammar.
+The same form is valid in a **generic argument list**, which is what makes a walk
+recursive rather than merely descending (#2691):
+
+```mach
+fun eq[T](a: *T, b: *T) bool {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }   # re-enter at the field's type
+        }
+        $or { if (a.[f] != b.[f]) { ret false; } }
+    }
+    ret true;
+}
+```
+
+Without it, `$fields(f.type)` gives one level of descent per `$each` someone wrote,
+so a walk reaches only as deep as its author hand-unrolled. With it the walk is
+written once and reaches any depth.
+
+**Termination is structural and needs no depth limit.** Each descent instantiates at
+a field's own type, a record's fields are finite, and a record cannot contain itself
+by value — a self-reference must go through a pointer, which is a different type and
+which `$is_record` does not select. Note that a walk which followed references would
+not have this property: `rec Grow[T] { p: *Grow[*T]; }` is legal and has unboundedly
+many distinct instances reachable through its pointer.
+
+Inside the loop a field's type has no spelling, only the descriptor. A path that is
+genuinely a qualified type name (`mod.Type`) still reads as one, and a wrong one
+still reports against the type grammar — in the generic argument list exactly as in
+an intrinsic operand. A name that is not a `$each` loop variable is reported where
+it is written.
 
 ## Type intrinsic
 

--- a/int/regression/2691-reflection-recursion/expect.txt
+++ b/int/regression/2691-reflection-recursion/expect.txt
@@ -1,0 +1,12 @@
+equal: 1
+deepest leaf differs: 0
+depth 5 differs: 0
+depth 3 differs: 0
+depth 1 differs: 0
+sum: 28
+diamond sum: 6
+generic instance sum: 11
+two kinds sum: 116
+two kinds equal: 1
+two kinds second differs: 0
+non-deferred field count: 4

--- a/int/regression/2691-reflection-recursion/mach.toml
+++ b/int/regression/2691-reflection-recursion/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2691-reflection-recursion/src/main.mach
+++ b/int/regression/2691-reflection-recursion/src/main.mach
@@ -1,0 +1,136 @@
+# regression pin for #2691: a reflection walk re-enters itself at a field's type
+#
+# `$fields(f.type)` descends one syntactic level per written `$each`, so before
+# this a walk could only reach as deep as its author hand-unrolled. `eq[f.type]`
+# did not parse -- a generic argument list reads with the type grammar, where
+# `f.type` is indistinguishable from a qualified `module.Type` -- and there is no
+# inference from the argument, so the call resolved against the template instead.
+#
+# the walk below is written ONCE and reaches six levels. every case here differs
+# in exactly one leaf at one depth, so a walk that stops short reports two
+# different values equal and fails the pin rather than passing quietly.
+
+use std.runtime;
+use p: std.print;
+
+rec L4 { a: i64; b: i64; }
+rec L3 { d: L4; q: i64; }
+rec L2 { d: L3; q: i64; }
+rec L1 { d: L2; q: i64; }
+rec L0 { d: L1; q: i64; }
+rec L00 { d: L0; q: i64; }
+
+rec V { x: i64; }
+rec Diamond { a: V; b: V; n: i64; }
+
+rec Box[T] { v: T; }
+rec Holder { b: Box[i64]; n: i64; }
+
+# TWO record fields of DIFFERENT types at the same level. one syntactic `f.type`
+# node serves both iterations, so a walk that memoizes the node's resolved type
+# gives the second field the first field's type. these differ in arity and in
+# field name, so that mistake is a wrong answer here rather than a silent pass.
+rec Wide { w: i64; }
+rec Narrow { n1: i64; n2: i64; n3: i64; }
+rec TwoKinds { first: Wide; second: Narrow; tail: i64; }
+
+# the self-recursive walk: the descent arm instantiates this same generic at the
+# field's own type, which is the whole point of #2691.
+fun eqr[T](a: *T, b: *T) i64 {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (eqr[f.type](?a.[f], ?b.[f]) == 0) { ret 0; }
+        }
+        $or {
+            if (a.[f] != b.[f]) { ret 0; }
+        }
+    }
+    ret 1;
+}
+
+fun sumr[T](v: *T) i64 {
+    var t: i64 = 0;
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) { t = t + sumr[f.type](?v.[f]); }
+        $or                      { t = t + v.[f]; }
+    }
+    ret t;
+}
+
+# counts a record's fields, so an instantiation at the WRONG type is a wrong
+# number rather than a silent pass
+fun count[T](v: *T) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) { n = n + 1; }
+    ret n;
+}
+
+fun fill(v: *L00) {
+    v.d.d.d.d.d.a = 1; v.d.d.d.d.d.b = 2;
+    v.d.d.d.d.q = 3; v.d.d.d.q = 4; v.d.d.q = 5; v.d.q = 6; v.q = 7;
+}
+
+#[symbol("main")]
+pub fun main(argc: i64, argv: **u8) i64 {
+    var a: L00; fill(?a);
+    var b: L00; fill(?b);
+    p.printf("equal: {}\n", eqr[L00](?a, ?b));
+
+    # the deepest leaf, six levels down, is the case a walk that stops short gets
+    # wrong -- it reports these equal.
+    b.d.d.d.d.d.a = 99;
+    p.printf("deepest leaf differs: {}\n", eqr[L00](?a, ?b));
+    fill(?b);
+
+    b.d.d.d.d.q = 33;
+    p.printf("depth 5 differs: {}\n", eqr[L00](?a, ?b));
+    fill(?b);
+
+    b.d.d.q = 55;
+    p.printf("depth 3 differs: {}\n", eqr[L00](?a, ?b));
+    fill(?b);
+
+    b.q = 77;
+    p.printf("depth 1 differs: {}\n", eqr[L00](?a, ?b));
+
+    p.printf("sum: {}\n", sumr[L00](?a));
+
+    # the same type reached twice down two branches
+    var d: Diamond; d.a.x = 1; d.b.x = 2; d.n = 3;
+    p.printf("diamond sum: {}\n", sumr[Diamond](?d));
+
+    # a generic INSTANCE field descends as the record it instantiates
+    var h: Holder; h.b.v = 5; h.n = 6;
+    p.printf("generic instance sum: {}\n", sumr[Holder](?h));
+
+    # the memoization case: two differently-shaped record fields, one node
+    var tk: TwoKinds;
+    tk.first.w = 10;
+    tk.second.n1 = 1; tk.second.n2 = 2; tk.second.n3 = 3;
+    tk.tail = 100;
+    p.printf("two kinds sum: {}\n", sumr[TwoKinds](?tk));
+
+    var tk2: TwoKinds;
+    tk2.first.w = 10;
+    tk2.second.n1 = 1; tk2.second.n2 = 2; tk2.second.n3 = 3;
+    tk2.tail = 100;
+    p.printf("two kinds equal: {}\n", eqr[TwoKinds](?tk, ?tk2));
+    # differ only in the SECOND record field's last leaf
+    tk2.second.n3 = 99;
+    p.printf("two kinds second differs: {}\n", eqr[TwoKinds](?tk, ?tk2));
+
+    # THE NON-DEFERRED PATH. every walk above is generic, so its `$each` unroll is
+    # deferred to monomorphization and its type arguments resolve there. this one
+    # walks a concrete record, so the unroll and the type-arg resolution both happen
+    # at sema -- a different code path, and the one where a `f.type` node must not be
+    # memoized: one syntactic node serves both iterations, and caching the first
+    # answer gives the second field the first field's type. Wide has one field and
+    # Narrow has three, so that mistake is 2 here instead of 4.
+    var acc: i64 = 0;
+    $each f in $fields(TwoKinds) {
+        $if ($is_record(f.type)) { acc = acc + count[f.type](?tk.[f]); }
+        $or { }
+    }
+    p.printf("non-deferred field count: {}\n", acc);
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2128,6 +2128,47 @@ test "mach.lang.driver:comptime_reflection_descent" {
     ret bad;
 }
 
+# a reflection walk re-enters itself at a field's type: `eq[f.type](...)` (#2691)
+#
+# `$fields(f.type)` descends one syntactic level per written `$each`, so before this
+# a walk reached only as deep as its author hand-unrolled. the generic argument list
+# reads with the type grammar, where `f.type` is indistinguishable from a qualified
+# `module.Type`, so the spelling that closes the loop did not parse at all.
+#
+# runtime behaviour is pinned by int/regression/2691-reflection-recursion, which
+# walks six levels and perturbs one leaf at a time. these are the front-end facts.
+test "mach.lang.driver:comptime_reflection_recursion" {
+    var bad: i32 = 0;
+
+    # the self-recursive walk itself, over a nest deeper than any hand-unrolled
+    # ladder would reach
+    if (ut_layout_ok("rec I { x: u64; }\nrec M { i: I; n: u64; }\nrec O { m: M; n: u64; }\nfun w[T](v: *T) i32 { $each f in $fields(T) { $if ($is_record(f.type)) { w[f.type](?v.[f]); } $or { } } ret 0; }\nfun main() i32 { var o: O; ret w[O](?o); }\n") != 0) { bad = 1; }
+
+    # the descent really is per field: the arm reached through `f.type` sees the
+    # INNER record's fields, not the outer's
+    if (ut_arm("rec I { x: u64; }\nrec O { i: I; }\nfun w[T]() i32 { $each f in $fields(T) { $if (f.name == \"x\") { $error(\"INNER\"); } $or ($is_record(f.type)) { w[f.type](); } $or { } } ret 0; }\nfun main() i32 { ret w[O](); }\n", "INNER", "OUTER") != 0) { bad = 1; }
+
+    # a descriptor argument alongside an ordinary one, in either position
+    if (ut_layout_ok("rec I { x: u64; }\nrec O { i: I; }\nfun two[A, B](a: *A, b: *B) i32 { ret 0; }\nfun w[T](v: *T) i32 { var n: i32 = 0; $each f in $fields(T) { $if ($is_record(f.type)) { n = two[f.type, i32](?v.[f], ?n); } $or { } } ret n; }\nfun main() i32 { var o: O; ret w[O](?o); }\n") != 0) { bad = 1; }
+
+    # THE LOOKAHEAD MUST NOT ABSORB A REAL MISTAKE. a genuinely wrong operand in the
+    # same position still reports against the type grammar, which is the trade #2454
+    # made at the intrinsic position and this one has to make identically.
+    if (ut_vec_diag("fun g[T](a: *T) i32 { ret 0; }\nfun main() i32 { var x: u64; ret g[nosuchmod.T](?x); }\n",
+                    "unresolved type name") != 0) { bad = 1; }
+
+    # a name that is not a `$each` loop variable is refused where it is written,
+    # rather than resolving to a silent TYPE_ERROR later
+    if (ut_vec_diag("fun g[T](a: *T) i32 { ret 0; }\nfun main() i32 { var f: u64; var x: u64; ret g[f.type](?x); }\n",
+                    "names a `$each` field-descriptor loop variable") != 0) { bad = 1; }
+
+    # `type` stays contextual: a real record field called `type` is untouched, which
+    # is the same trade the value-side recognition already makes
+    if (ut_layout_ok("rec S { type: u64; }\nfun main() i32 { var s: S; s.type = 5; ret 0; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # an IMPORTED nominal measures in both folding positions (#2442)
 #
 # The premise the same-module-only forcing rests on: dependencies are type-checked

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -26,6 +26,11 @@ pub val TYPE_KIND_PACK:  TypeKind = 6;
 # data for the constant-time guarantee. flow-typing semantics land in #1645; the
 # parser only records the qualifier
 pub val TYPE_KIND_SECRET: TypeKind = 7;
+# a field descriptor's own type, `f.type`, written where a type is expected
+# (#2691). the only type spelling whose meaning is not fixed by the source text:
+# it names whatever field the enclosing `$each f in $fields(T)` is on, so one node
+# resolves to a different type per iteration and is never memoized
+pub val TYPE_KIND_FIELD_TYPE: TypeKind = 8;
 pub val TYPE_KIND_ERROR: TypeKind = 255;
 
 # a named type reference, optionally with generic arguments
@@ -95,6 +100,18 @@ pub rec TypeUni {
     fields_len:   u32;
 }
 
+# a field descriptor's type `f.type` used as a type spelling (#2691)
+#
+# `var_name` is the loop variable's span, not a resolved binding: the descriptor
+# it names exists only inside the enclosing `$each` body, and which field it is on
+# is decided per iteration by the unroll. resolve checks the name really is a
+# `$each` loop variable, so an ordinary record field called `type` is untouched.
+# ---
+# var_name: span of the loop variable as written (`f` in `f.type`)
+pub rec TypeFieldType {
+    var_name: token.Span;
+}
+
 # a syntactic type reference as it appears in source
 # ---
 # span: byte range of the type expression
@@ -111,5 +128,6 @@ pub rec Type {
         fun_:   TypeFun;
         rec_:   TypeRec;
         uni_:   TypeUni;
+        field_type: TypeFieldType;
     };
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -599,6 +599,44 @@ pub fun lookup(c: *ComptimeCtx, name: intern.StrId) O.Option[*NamedConst] {
     ret O.none[*NamedConst]();
 }
 
+# resolve a `f.type` TYPE SPELLING to the field's own type, given the loop
+# variable's interned name (#2691)
+#
+# The type-position counterpart of the `f.type` value projection above, and it
+# goes through the same installed field resolver, so a descriptor read as a value
+# and the same descriptor read as a type cannot disagree about which field they
+# are on.
+#
+# ONE implementation for both phases. Sema resolves this during its `$each`
+# unroll; lowering resolves it during the unroll it runs for a walk whose `$fields`
+# operand was an unbound generic parameter at template sema. Both bind the loop
+# variable the same way and both install a field resolver, so neither needs a rule
+# of its own.
+#
+# None when `name` is not bound to a field descriptor, which is the caller's cue
+# to report against the spelling rather than to guess a type.
+# ---
+# c:    the comptime context, its frame holding the active loop binding
+# name: interned name of the `$each` loop variable
+# ret:  some(sema TypeId) for the field's type, none when unbound or unavailable
+pub fun field_type_of_binding(c: *ComptimeCtx, name: intern.StrId) O.Option[u32] {
+    val bound: O.Option[*NamedConst] = lookup(c, name);
+    if (O.is_none[*NamedConst](bound)) { ret O.none[u32](); }
+    val nc: *NamedConst = O.unwrap[*NamedConst](bound);
+    if (nc.value.kind != CT_KIND_FIELD) { ret O.none[u32](); }
+
+    if (c.field_fn == nil) { ret O.none[u32](); }
+    val fn: FieldMemberFn = c.field_fn::FieldMemberFn;
+    val r: R.Result[O.Option[CTValue], str] =
+        fn(c.field_data, nc.value.data.fld.owner, nc.value.data.fld.index, FIELD_SEL_TYPE);
+    if (R.is_err[O.Option[CTValue], str](r)) { ret O.none[u32](); }
+    val o: O.Option[CTValue] = R.unwrap_ok[O.Option[CTValue], str](r);
+    if (O.is_none[CTValue](o)) { ret O.none[u32](); }
+    val v: CTValue = O.unwrap[CTValue](o);
+    if (v.kind != CT_KIND_TYPE) { ret O.none[u32](); }
+    ret O.some[u32](v.data.t);
+}
+
 # register a manifest comptime define (#1191) under `name`, readable
 # only through the `$mach.build.<name>` path. defines live in their own table,
 # isolated from the scoped `entries` environment, so a define neither shadows nor

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -305,10 +305,10 @@ fun probe_type_payload(p: *state.Parser) bool {
     var ok: bool = false;
     if (!state.at(p, token.KIND_RBRACKET)) {
         val before: usize = p.pos;
-        parse_type(p);
+        parse_type_arg(p);
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RBRACKET)) { brk; }
-            parse_type(p);
+            parse_type_arg(p);
         }
         ok = p.pos > before && !p.fatal && state.at(p, token.KIND_RBRACKET);
     }
@@ -328,15 +328,29 @@ fun probe_type_payload(p: *state.Parser) bool {
 # p:       parser state, cursor on the '['
 # out_len: receives the number of type arguments flushed
 # ret:     start index of the flushed type-argument slice
+# reads one generic argument: a field descriptor's type where the lookahead
+# matches, else an ordinary type spelling (#2691)
+#
+# Used by the committing parse and by the speculative type probe alike, so the
+# probe's verdict and the parse it commits to cannot disagree about whether an
+# argument is spellable.
+# ---
+# p:   parser state, cursor on the argument
+# ret: TypeId of the argument
+fun parse_type_arg(p: *state.Parser) id.TypeId {
+    if (at_field_type_arg(p)) { ret parse_field_type_arg(p); }
+    ret parse_type(p);
+}
+
 fun parse_type_args(p: *state.Parser, out_len: *u32) u32 {
     state.advance(p);                        # consume '['
 
     var buf: state.ListBuf[id.TypeId] = state.list_buf_init[id.TypeId]();
     if (!state.at(p, token.KIND_RBRACKET)) {
-        state.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
+        state.list_buf_push[id.TypeId](p, ?buf, parse_type_arg(p));
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RBRACKET)) { brk; }
-            state.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
+            state.list_buf_push[id.TypeId](p, ?buf, parse_type_arg(p));
         }
     }
     state.expect(p, token.KIND_RBRACKET, "expected ']' to close generic arguments");
@@ -638,6 +652,59 @@ fun at_field_type_operand(p: *state.Parser) bool {
     # two-segment form is diverted.
     val after: token.Kind = state.peek(p, 3::usize).kind;
     ret after == token.KIND_RPAREN || after == token.KIND_COMMA;
+}
+
+# whether the cursor sits on a field descriptor's `.type` in a GENERIC ARGUMENT
+# list - `eq[f.type](...)`, the spelling that lets a reflection walk re-enter
+# itself at a field's type (#2691)
+#
+# The same `IDENT . type` shape and the same one-token lookahead as
+# `at_field_type_operand`, differing only in the terminator: a generic argument
+# list closes with `]` rather than `)`. Kept as its own predicate rather than
+# widening that one's terminator set, because accepting `]` where an intrinsic
+# argument is expected would divert a genuine mis-spelling away from the type
+# grammar that should report it.
+# ---
+# p:   parser state, cursor on the argument
+# ret: true when the argument is a field descriptor's type
+fun at_field_type_arg(p: *state.Parser) bool {
+    if (!state.at(p, token.KIND_IDENT)) { ret false; }
+    if (state.peek(p, 1::usize).kind != token.KIND_DOT) { ret false; }
+
+    val member: token.Token = state.peek(p, 2::usize);
+    if (member.kind != token.KIND_IDENT) { ret false; }
+    if (!str_region_equals(p.tokens.source, member.span.offset, member.span.len, "type")) { ret false; }
+
+    val after: token.Kind = state.peek(p, 3::usize).kind;
+    ret after == token.KIND_RBRACKET || after == token.KIND_COMMA;
+}
+
+# builds the TYPE_KIND_FIELD_TYPE node for an `f.type` generic argument (#2691)
+#
+# Consumes the three tokens the lookahead matched and records the loop variable's
+# span. Which field it names is not knowable here - it is decided per iteration by
+# the `$each` unroll - so nothing is resolved at parse time.
+# ---
+# p:   parser state, cursor on the loop variable
+# ret: TypeId of the resulting node
+fun parse_field_type_arg(p: *state.Parser) id.TypeId {
+    val var_tok: token.Token = state.current(p);
+    state.advance(p);                        # the loop variable
+    state.advance(p);                        # '.'
+    val member: token.Token = state.current(p);
+    state.advance(p);                        # 'type'
+
+    var payload: type.TypeFieldType;
+    payload.var_name = var_tok.span;
+
+    var span: token.Span = var_tok.span;
+    span.len = (member.span.offset + member.span.len) - var_tok.span.offset;
+
+    var node: type.Type;
+    node.span            = span;
+    node.kind            = type.TYPE_KIND_FIELD_TYPE;
+    node.data.field_type = payload;
+    ret state.push_type(p, node);
 }
 
 # parses a type-taking intrinsic's first argument with the TYPE grammar, wrapped

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -3143,6 +3143,27 @@ fun bind_type(rc: *ResolveContext, tid: id.TypeId) R.Result[bool, str] {
     if (t.kind == atype.TYPE_KIND_SECRET) {
         ret bind_type(rc, t.data.secret.inner);
     }
+    # `f.type` in a type position (#2691) names a `$each` loop variable, not a
+    # module symbol, and which field it is on is decided per iteration. there is
+    # nothing to bind here; the name is checked against the scope below so a
+    # spelling that names no loop variable is reported now rather than resolving to
+    # a silent TYPE_ERROR in sema.
+    if (t.kind == atype.TYPE_KIND_FIELD_TYPE) {
+        val fr: R.Result[intern.StrId, str] =
+            intern.intern_span(?rc.s.interner, rc.source, t.data.field_type.var_name);
+        if (R.is_err[intern.StrId, str](fr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](fr)); }
+        val fsid: SymbolId = scope_lookup_chain(rc, rc.current_scope, R.unwrap_ok[intern.StrId, str](fr));
+        if (fsid == SYMBOL_NIL) {
+            ret diagnostic.error(?rc.s.diags, rc.a.file_id, t.data.field_type.var_name,
+                "`f.type` as a type argument names a `$each` field-descriptor loop variable; this name is not one in scope");
+        }
+        val fsym: *Symbol = ?rc.symbols[fsid];
+        if (fsym.kind != SYM_VAL || (fsym.flags & SYM_FLAG_COMPTIME) == 0) {
+            ret diagnostic.error(?rc.s.diags, rc.a.file_id, t.data.field_type.var_name,
+                "`f.type` as a type argument names a `$each` field-descriptor loop variable; this name is an ordinary binding");
+        }
+        ret R.ok[bool, str](true);
+    }
     if (t.kind == atype.TYPE_KIND_ARRAY) {
         # `[_]T` carries no length expression to bind; sema supplies the count.
         if (t.data.array.length != id.EXPR_NIL) {

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -2848,6 +2848,12 @@ fun infer_struct_lit(sc: *context.SemaContext, sl: *expr.ExprStructLit, span: to
 # tid: syntactic AstType id to resolve
 # ret: the interned semantic TypeId (TYPE_ERROR on failure)
 pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
+    # `f.type` (#2691) is answered from the LIVE `$each` binding, so one syntactic
+    # node has a different answer per iteration and neither reads nor writes the
+    # memo. every other kind's answer is fixed by its source text, which is what
+    # makes memoizing them sound.
+    if (is_field_type_node(sc, tid)) { ret resolve_type_ref_raw(sc, tid); }
+
     # a node already resolved by this pass yields the answer it yielded then, without
     # re-running the resolution or re-emitting its diagnostics (#2334). The memo exists
     # only on the main pass, whose substitution is nil throughout, so an instance
@@ -2864,6 +2870,17 @@ pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     val resolved: type.TypeId = resolve_type_ref_raw(sc, tid);
     memo_record(sc, tid, resolved, context.reported_since(sc, mark));
     ret resolved;
+}
+
+# whether `tid` is a `f.type` spelling, whose answer is per-iteration (#2691)
+# ---
+# sc:  the context
+# tid: the syntactic type node
+# ret: true when the node is TYPE_KIND_FIELD_TYPE
+fun is_field_type_node(sc: *context.SemaContext, tid: id.TypeId) bool {
+    val t_opt: O.Option[*atype.Type] = ast.get_type(sc.a, tid);
+    if (O.is_none[*atype.Type](t_opt)) { ret false; }
+    ret O.unwrap[*atype.Type](t_opt).kind == atype.TYPE_KIND_FIELD_TYPE;
 }
 
 # `tid`'s memo state for this pass (#2334)
@@ -2931,6 +2948,7 @@ fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     if (t.kind == atype.TYPE_KIND_NAMED)  { ret resolve_type_named(sc, tid, ?t.data.named, t.span); }
     if (t.kind == atype.TYPE_KIND_PTR)    { ret resolve_type_ptr(sc, ?t.data.ptr); }
     if (t.kind == atype.TYPE_KIND_SECRET) { ret resolve_type_secret(sc, ?t.data.secret); }
+    if (t.kind == atype.TYPE_KIND_FIELD_TYPE) { ret resolve_type_field_type(sc, ?t.data.field_type, t.span); }
     if (t.kind == atype.TYPE_KIND_ARRAY)  { ret resolve_type_array(sc, tid, ?t.data.array, t.span); }
     if (t.kind == atype.TYPE_KIND_FUN)   { ret resolve_type_fun(sc, ?t.data.fun_); }
     if (t.kind == atype.TYPE_KIND_REC)   { ret resolve_type_anon(sc, tid, t.data.rec_.fields_start, t.data.rec_.fields_len, type.TYPE_REC); }
@@ -2942,6 +2960,31 @@ fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
         ret R.unwrap_ok[type.TypeId, str](r);
     }
     ret type.TYPE_ERROR;
+}
+
+# FIELD_TYPE: the type of the field the enclosing `$each` is currently on (#2691)
+#
+# This is the only type spelling whose meaning is not fixed by its source text, so
+# it is the one that must never be memoized: `resolve_type_ref` caches a syntactic
+# node's answer, and caching the first iteration's field type here would give every
+# later iteration the wrong type. `resolve_type_ref_raw` is therefore the only
+# entry point, and the memo is skipped for this kind by its caller.
+#
+# Unbound means the spelling names no live descriptor - a `$each` that deferred its
+# unroll, or a name resolve let through. TYPE_ERROR without a diagnostic, matching
+# how an unbound NAMED node behaves: resolve already reports a name that is not a
+# loop variable, and the deferred case is answered per instance rather than here.
+# ---
+# sc:   the context
+# ft:   the syntactic node's payload
+# span: the spelling's span, for diagnostics
+# ret:  the field's type, or TYPE_ERROR when no descriptor is bound
+fun resolve_type_field_type(sc: *context.SemaContext, ft: *atype.TypeFieldType, span: token.Span) type.TypeId {
+    val r: R.Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, ft.var_name);
+    if (R.is_err[intern.StrId, str](r)) { ret type.TYPE_ERROR; }
+    val got: O.Option[u32] = comptime.field_type_of_binding(sc.ctx, R.unwrap_ok[intern.StrId, str](r));
+    if (O.is_none[u32](got)) { ret type.TYPE_ERROR; }
+    ret O.unwrap[u32](got)::type.TypeId;
 }
 
 # NAMED: resolve the symbol the name refers to and map it to the type it names

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2142,6 +2142,31 @@ fun report_expr(ctx: *context.LowerContext, eid: id.ExprId, message: str) R.Resu
 # e:    the resolved call node
 # argc: number of call-site type arguments
 # ret:  the owned type-argument sequence (nil when argc is 0), or an error
+# the field type a `f.type` generic argument names, read from the active `$each`
+# binding (#2691)
+#
+# None for every other type spelling, which keeps the caller on its stamped-type
+# path unchanged. The lookup itself is `comptime.field_type_of_binding`, the same
+# one sema uses, so a descriptor resolved at sema and the same descriptor resolved
+# here cannot land on different fields.
+# ---
+# ctx: per-module lowering context
+# tid: the syntactic type node of one generic argument
+# ret: some(field type) for a `f.type` spelling, none otherwise
+fun field_type_arg_of(ctx: *context.LowerContext, tid: id.TypeId) O.Option[type.TypeId] {
+    val t_opt: O.Option[*atype.Type] = ast.get_type(ctx.a, tid);
+    if (O.is_none[*atype.Type](t_opt)) { ret O.none[type.TypeId](); }
+    val t: *atype.Type = O.unwrap[*atype.Type](t_opt);
+    if (t.kind != atype.TYPE_KIND_FIELD_TYPE) { ret O.none[type.TypeId](); }
+
+    val r: R.Result[intern.StrId, str] =
+        intern.intern_span(?ctx.s.interner, context.module_source(ctx), t.data.field_type.var_name);
+    if (R.is_err[intern.StrId, str](r)) { ret O.none[type.TypeId](); }
+    val got: O.Option[u32] = comptime.field_type_of_binding(ctx.ctx, R.unwrap_ok[intern.StrId, str](r));
+    if (O.is_none[u32](got)) { ret O.none[type.TypeId](); }
+    ret O.some[type.TypeId](O.unwrap[u32](got)::type.TypeId);
+}
+
 fun collect_call_type_args(ctx: *context.LowerContext, e: *expr.Expr, argc: u32) R.Result[*type.TypeId, str] {
     if (argc == 0) { ret R.ok[*type.TypeId, str](nil); }
 
@@ -2156,7 +2181,18 @@ fun collect_call_type_args(ctx: *context.LowerContext, e: *expr.Expr, argc: u32)
             A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
             ret R.err[*type.TypeId, str]("lower: call type-argument index out of range");
         }
-        var at: type.TypeId = context.type_resolved_of(ctx, ctx.a.type_ids[pool_ix]);
+        # `f.type` (#2691) has no single stamped answer: it names whichever field the
+        # enclosing `$each` is on, so it is read from the live binding here the same
+        # way it is at sema. this path is what a walk over `$fields(T)` for a generic
+        # `T` needs, since that unroll is deferred to monomorphization and runs here.
+        var at: type.TypeId = type.TYPE_ERROR;
+        val ft: O.Option[type.TypeId] = field_type_arg_of(ctx, ctx.a.type_ids[pool_ix]);
+        if (O.is_some[type.TypeId](ft)) {
+            at = O.unwrap[type.TypeId](ft);
+        }
+        or {
+            at = context.type_resolved_of(ctx, ctx.a.type_ids[pool_ix]);
+        }
         if (ctx.subst != nil && ctx.subst_len > 0) {
             at = generics.substitute(ctx.s, at, ctx.subst, ctx.subst_len);
         }


### PR DESCRIPTION
Closes #2691.

## What was locked

`$fields(f.type)` (#2454) descends into a record-typed field, but only **one syntactic level per `$each` someone wrote**. Closing the loop needs the walk to re-enter itself at the field's type, and all three spellings for that were refused:

| spelling | diagnostic |
|---|---|
| `eq[f.type](?a.[f], ?b.[f])` | `expected a module alias before '.'` — the generic argument list reads with the type grammar, where `f.type` is indistinguishable from a qualified `module.Type` |
| `eq(?a.[f], ?b.[f])` | `type mismatch: expected *T, found *Inner` — no inference from the argument, so the call resolves against the template rather than instantiating |
| `eq[$type_of(a.[f])](...)` | `$type_of yields a comptime type, not a value` |

That is why `std.derive` shipped a hand-unrolled ladder with a documented depth cap: not a design choice, an inability to spell the recursive form.

## The change

#2454's one-token lookahead now extends to the generic argument list. `f.type` there becomes a `TYPE_KIND_FIELD_TYPE` node carrying the **loop variable's name**, not a resolved type, because which field it names is decided per iteration by the unroll.

A walk is now written once and reaches any depth:

```mach
fun eq[T](a: *T, b: *T) bool {
    $each f in $fields(T) {
        $if ($is_record(f.type)) {
            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
        }
        $or { if (a.[f] != b.[f]) { ret false; } }
    }
    ret true;
}
```

## Termination, verified against the compiler rather than argued

There is no depth limit and none is needed. Each descent instantiates at a field's own type, a record's fields are finite, and a record cannot contain itself by value. I probed that last claim rather than trusting the language argument:

| shape | compiler |
|---|---|
| `rec A { b: B; } rec B { a: A; }` | refused, "recursive type has infinite size" |
| `rec A { a: A; }` | refused |
| `rec Grow[T] { inner: Grow[*T]; }` (growing, by value) | refused |
| `rec Grow[T] { p: *Grow[*T]; }` (growing, through a pointer) | **accepted** |

A self-reference must go through a pointer, which is a different type and which `$is_record` does not select, so the by-value walk never follows one. The fourth row is pinned as a walked case in the int suite and terminates immediately.

**Worth carrying to #2693.** That fourth row has unboundedly many distinct instances reachable *through* its pointer. It is unreachable today because `$pointee_of` does not exist, but the moment reference-following lands, termination stops being structural. Noted in the docs and I will state it on #2693.

And if the structural argument were ever wrong, the failure is a diagnostic rather than a hang: the existing generic-instantiation guard (`MAX_CT_INSTANCE_DEPTH = 32`, `MAX_CT_INSTANCES = 8192`) reports "a generic instantiates itself at a growing type argument" with the derivation chain.

## Two implementation facts worth review

**A `f.type` node is never memoized.** `resolve_type_ref` caches a syntactic node's resolved type, which is sound only because every other spelling's meaning is fixed by its source text. This one is not — a single node serves every iteration, so caching the first answer gives the second field the first field's type.

I mutation-tested this rather than asserting it. Removing the memo skip and re-running the int case fails with `type mismatch: expected *<error>, found *Wide`. The pin is a record with **two record fields of different arity** (`Wide` has one field, `Narrow` has three), so the mistake is a wrong count, not a silent pass. My first version of the pin did *not* catch it — everything in it was generic, so every walk took the lowering path and never touched the sema memo. The non-deferred case had to be added specifically.

**Sema and lowering resolve it through one helper**, `comptime.field_type_of_binding`, going through the same installed field resolver as the `f.type` value projection — so a descriptor read as a value and the same descriptor read as a type cannot land on different fields. Lowering needs its own path because a walk whose `$fields` operand was an unbound generic parameter at template sema has its unroll **deferred to monomorphization**, which is the shape a generic derive actually has.

## The lookahead does not absorb real mistakes

Same trade #2454 made, pinned identically:

- `g[nosuchmod.T]` still reports `unresolved type name`, against the type grammar
- a name that is not a `$each` loop variable is reported where it is written, with a message saying what the spelling means
- `type` stays contextual, so an ordinary record field called `type` is untouched

## Files

Sema and front end: `fe/ast/type.mach`, `fe/parser/expr.mach`, `fe/comptime.mach`, `fe/resolve.mach`, `fe/sema/infer.mach`.

**One hunk in `me/lower/expr.mach`**, which is fenced for #2640. It is `collect_call_type_args` (~line 2145) plus one helper above it. glsl's live PR #2705 touches that file only at `lower_array_lit` / `lower_vector_lit` (~3279, ~3326) — different functions, over a thousand lines apart, no textual overlap. I checked rather than assuming, and flagged it before building. The hunk is additive and reviewable on its own.

No contact with `isa/asm.mach`, `x64/encode.mach`, or any spirv file.

## Tests

- `mach test .` — **1255 passed, 0 failed** (1254 before, +1 test)
- `int/regression/2691-reflection-recursion` — a six-level walk written once, perturbing **one leaf at a time at each depth**, so a walk that stops short reports two different values equal and fails rather than passing quietly. Also covers the diamond (same type down two branches), a generic-instance field, the two-different-arities memo case, and the non-deferred sema path
- **Full int suite: 217 cases, all pass on linux**
- **Self-host fixpoint**: stage2 vs stage3 byte-identical at 8327168 bytes
- mach-std at `dev`: **784 passed, 0 failed** with this compiler, no regression

The one mach-std harness case that fails is `^ secret record field`, which is #2692's consequence and is already tracked as briar-systems/mach-std#448. It fails identically on `dev` without this change.

## Downstream

This is what deletes `std.derive`'s depth cap. Each of its five ladders collapses to its own outermost level with the descent arm calling itself, and the cap disappears — a deletion rather than a rewrite, which is how the ladder was shaped for exactly this. Filed as briar-systems/mach-std#449, blocked on the release carrying this.
