### PR TITLE
chore(dep): advance mach-std to 0.25.0

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "a7457359ed8c9316f803217212b24a1a0eef994c"
+commit = "4cf942e060c91b8cb45cca270125569c1ca0e13a"


### PR DESCRIPTION
Advances the `mach-std` pin from `a7457359` (0.24.2) to `4cf942e0` (0.25.0).

The manifest already tracks `branch/main`, which is correct - stable releases only, never `dev`. The lock had simply not been advanced since mach-std's main moved.

Brings in `exec.resolve` / `exec.resolve_in` (mach-std#425), the `std.derive` recursive tier (mach-std#412, #447), riscv64 library coverage (mach-std#443), and the `^` leaf-arm fix tracking #2692 (mach-std#448).

`mach test .` 1254 passed 0 failed, and a self-build against the new dependency succeeds.

Follow-up, not in this PR: mach carries three hand-rolled PATH walks (`cli/cmd/dep.mach`, `cli/cmd/run.mach`, `cli/cmd/testing.mach`, all via `util.resolve_cmd`) which `exec.resolve` now replaces. That was the point of mach-std#425 and it is now unblocked.