### PR TITLE
release: 4.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.14.0] - 2026-08-07
+
+### Added
+
+#### A field descriptor's `f.type` is accepted as a generic type argument (#2691)
+A reflection walk could descend one syntactic level per hand-written `$each`, because there was no way to re-enter a generic at a field's type. `eq[f.type](...)` was a parse error, `eq(...)` resolved against the template instead of instantiating, and `$type_of(x)` yields a comptime type rather than a value. All three doors were shut, so a recursive derive had to be a hand-unrolled ladder with a depth cap.
+
+`f.type` in a generic argument list now becomes a node carrying the **loop variable's name** rather than a resolved type, because which field it names is decided per iteration by the unroll. A walk is written once and reaches any depth:
+
+```mach
+fun eq[T](a: *T, b: *T) bool {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
+        }
+        $or { if (a.[f] != b.[f]) { ret false; } }
+    }
+    ret true;
+}
+```
+
+**Termination is structural rather than bounded by a counter**, and this was verified against the compiler rather than argued from the spec: direct, mutual, and generic-growing-by-value self-containment are all refused as "recursive type has infinite size". A self-reference must go through a pointer, and `$is_record` does not select one. Note `rec Grow[T] { p: *Grow[*T]; }` is accepted and has unboundedly many instances reachable through its pointer -- the by-value walk never follows it, but termination stops being structural the moment `$pointee_of` lands, which is recorded as a precondition on #2693.
+
+If the argument were ever wrong the failure is a diagnostic naming the derivation chain, not a hang: `MAX_CT_INSTANCE_DEPTH = 32` reports "a generic instantiates itself at a growing type argument".
+
+#### A vector literal is built in one instruction where the ISA can (#2640)
+A vector literal round-tripped through an array alloca -- four stores and a frame slot to materialize a constant -- which SPIR-V's logical addressing cannot express at all. `OP_VEC_BUILD` takes N lane values and produces the vector, lowering to `OpCompositeConstruct`.
+
+The capability is read at lowering (`has_vec_build`) rather than legalized afterwards, so **no target ever sees an `OP_VEC_BUILD` it cannot select**. Native targets keep the storage path unchanged and their emitted assembly is byte-identical. A malformed build is refused at construction with no flags required, not only by the opt-in verifier.
+
+#### Condition-flag effects are modeled in the asm effect model (#2460)
+`#[oblivious]` inline asm refused every conditional branch on x86-64, because the model had no notion of what an instruction does to FLAGS. It now carries five facts per grammar row -- `writes_flags`, `defines_flags`, `opaque_flags`, `reads_flags`, `flags_stated` -- with defaults inverted so the security-relevant surface is 18 rows rather than 60.
+
+A branch on flags derived from a secret is still refused; a branch on flags an instruction fully **defines** from public operands is not. The `defines_flags` distinction is load-bearing and subtle: `inc` and `dec` write ZF but **preserve** CF, so treating "writes flags" as "defines flags" would have accepted `cmp {secret}` / `inc` / `jc`.
+
+**The facts are measured against the CPU, not inferred.** `int/surface/ct-flags-hardware` presets RFLAGS both ways and reads back RFLAGS and the destination register, and its golden is the measurement. Three rows (`popfq`, `iretq`, `syscall`) print `NOT MEASURABLE` -- `popfq` passes the probe as "defines both", which is correct on its own terms and wrong as a classification, because the value comes from the stack.
+
+`setcc` laundering FLAGS taint into a general-purpose register is closed by `reads_flags`. General memory laundering is not, and is unchanged by this work: see #2706.
+
+### Changed
+
+#### mach-std advanced to 0.25.0 (#2710)
+Brings `exec.resolve` / `exec.resolve_in`, the `std.derive` recursive tier, and riscv64 library coverage. The manifest already tracked `branch/main`; the lock had simply not been advanced.
+
 ## [4.13.0] - 2026-08-07
 
 **Two source-compatibility changes.** A type may no longer be declared with a vector form's name, and the comptime shape predicates no longer see through `^`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### A reflection walk can re-enter itself at a field's type (#2691)
+
+`$fields(f.type)` (#2454) let a walk descend into a record-typed field, but only **one syntactic level per `$each` someone wrote**. Closing the loop needs the walk to re-enter itself at the field's type, and the only spelling for that is a generic call — which did not parse, because a generic argument list reads with the type grammar where `f.type` is indistinguishable from a qualified `module.Type`:
+
+```mach
+fun eq[T](a: *T, b: *T) bool {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
+        }
+        $or { if (a.[f] != b.[f]) { ret false; } }
+    }
+    ret true;
+}
+```
+
+Neither of the two alternatives worked either: there is no inference from the argument, so `eq(?a.[f], ?b.[f])` resolves against the template rather than instantiating, and `$type_of` is not a type operand. All three doors were locked, which is why `std.derive` shipped a hand-unrolled ladder with a documented depth cap.
+
+#2454's one-token lookahead now extends to the generic argument list. `f.type` there is a `TYPE_KIND_FIELD_TYPE` node carrying the loop variable's name rather than a resolved type, because which field it names is decided per iteration by the unroll.
+
+**Termination is structural**, so there is no depth limit and none is needed: each descent instantiates at a field's own type, a record's fields are finite, and a record cannot contain itself by value — the compiler already refuses that as a recursive type of infinite size, verified for the direct, mutual, and generic-growing forms. A self-reference must go through a pointer, which is a different type and which `$is_record` does not select.
+
+Two implementation notes worth carrying:
+
+- **A `f.type` node is never memoized.** `resolve_type_ref` caches a syntactic node's resolved type, which is sound only because every other spelling's meaning is fixed by its source text. This one is not: a single node serves every iteration, so caching the first answer gives the second field the first field's type. Pinned by a case with two record fields of different arity, which is a wrong count rather than a silent pass.
+- **Both phases resolve it through one helper.** Sema resolves it during its own `$each` unroll; lowering resolves it during the unroll it runs for a walk whose `$fields` operand was an unbound generic parameter at template sema — which is the shape a generic derive actually has. `comptime.field_type_of_binding` is the single implementation, going through the same installed field resolver as the `f.type` value projection, so a descriptor read as a value and the same descriptor read as a type cannot land on different fields.
+
+The lookahead does not absorb real mistakes: a genuinely wrong operand in the same position (`g[nosuchmod.T]`) still reports against the type grammar, a name that is not a `$each` loop variable is reported where it is written, and `type` stays contextual so an ordinary record field called `type` is untouched.
+
+
+
 ### Changed
 
 #### `^` is stripped only where the question is about storage (#2692)

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -160,10 +160,37 @@ $each f in $fields(T) {
 }
 ```
 
-That form is what makes recursive reflection expressible: inside the loop a field's
-type has no spelling, only the descriptor. A path that is genuinely a qualified type
-name (`mod.Type`) still reads as one, and a wrong one still reports against the type
-grammar.
+The same form is valid in a **generic argument list**, which is what makes a walk
+recursive rather than merely descending (#2691):
+
+```mach
+fun eq[T](a: *T, b: *T) bool {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }   # re-enter at the field's type
+        }
+        $or { if (a.[f] != b.[f]) { ret false; } }
+    }
+    ret true;
+}
+```
+
+Without it, `$fields(f.type)` gives one level of descent per `$each` someone wrote,
+so a walk reaches only as deep as its author hand-unrolled. With it the walk is
+written once and reaches any depth.
+
+**Termination is structural and needs no depth limit.** Each descent instantiates at
+a field's own type, a record's fields are finite, and a record cannot contain itself
+by value — a self-reference must go through a pointer, which is a different type and
+which `$is_record` does not select. Note that a walk which followed references would
+not have this property: `rec Grow[T] { p: *Grow[*T]; }` is legal and has unboundedly
+many distinct instances reachable through its pointer.
+
+Inside the loop a field's type has no spelling, only the descriptor. A path that is
+genuinely a qualified type name (`mod.Type`) still reads as one, and a wrong one
+still reports against the type grammar — in the generic argument list exactly as in
+an intrinsic operand. A name that is not a `$each` loop variable is reported where
+it is written.
 
 ## Type intrinsic
 

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -216,6 +216,30 @@ On a target whose grammar has no flag reader at all, every one of these facts is
 vacuous, and that vacuity is asserted per target rather than assumed: adding an
 aarch64 `cset` later has to state its facts deliberately.
 
+The rows whose facts could wrongly *permit* a leak are measured against the CPU
+rather than asserted from a manual — `int/surface/ct-flags-hardware` runs each
+instruction twice with the flags preset all-set and all-clear and reports what it
+actually defines, preserves, and reads. Three rows are exempt and stay a reasoned
+classification: `popfq`, `iretq` and `syscall` take their flags from the stack,
+the interrupt frame, or a masked prior RFLAGS, and no experiment of that shape can
+tell you where a value came *from*.
+
+**What the walk does not model is memory.** A secret spilled to the stack and
+reloaded comes back in a register the walk believes is public, and every check
+downstream of it is defeated:
+
+```
+mov rax, {r}
+mov [rsp], rax
+mov rbx, [rsp]
+mov rcx, [rbx]     # a secret-derived address, accepted
+```
+
+The direct form of that — `mov rax, {r}` then `mov rbx, [rax]` — *is* refused, so
+the gate works and this path specifically escapes it. Taint is a register set with
+no memory domain, on every target, and closing it is tracked as #2706. Reading the
+flags model above as evidence that laundering is closed in general would be wrong.
+
 The variable-latency check also bites unevenly: x86-64's and aarch64's asm grammars
 carry no divide, multiply or float instruction at all, so it reaches only their
 register-count shifts. riscv64's grammar admits the whole M-extension, so on that

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -184,18 +184,37 @@ declared type. What the walk cannot model, it refuses:
 | a body that does not parse | nothing to analyze |
 | a data directive (`.byte`, `.word`, `.long`, `.quad`) | its payload can encode any instruction |
 | a mnemonic the target has not classified | its timing behaviour is unknown |
-| **a flags-conditioned branch** (x86-64 `jcc`, aarch64 `b.<cond>`) | its condition rides the flags register, which the inline-asm effect model does not represent (#2460) |
+| **a flags-conditioned branch on a secret** (x86-64 `jcc`, aarch64 `b.<cond>`) | the flags it reads were filled from a secret |
 
 That last row is a per-target asymmetry worth stating precisely, because getting it
 wrong was a real hole (#2477). A branch whose condition is a **register operand** is
 visible to the walk and is checked: aarch64's `cbz`/`cbnz`, and every riscv64 branch,
 which compares two registers — RISC-V has no flags register at all. A branch whose
-condition rides the **flags register** cannot be checked, because the effect model
-carries no flags, so a `cmp` of a secret before it would be invisible: those are
-refused. x86-64's `jcc` family is flags-conditioned, and so is **aarch64's
-`b.<cond>`** — which is easy to miss, because `b.<cond>` does not appear in aarch64's
-mnemonic table at all. It is admitted by the grammar's *decode hook*, carrying the
-unconditional branch's own opcode with the condition in its flags.
+condition rides the **flags register** is checked against a separate flags-taint
+state (#2460): a `cmp` of a secret marks the flags secret-derived, and a later `jcc`
+reading them is refused, while a compare-and-branch over public data is accepted.
+x86-64's `jcc` family is flags-conditioned, and so is **aarch64's `b.<cond>`** —
+which is easy to miss, because `b.<cond>` does not appear in aarch64's mnemonic table
+at all. It is admitted by the grammar's *decode hook*, carrying the unconditional
+branch's own opcode with the condition in its flags.
+
+The flags model is deliberately more than a single "writes flags" bit, because one
+bit has no correct value for two families. `inc` and `dec` write every status flag
+**except** carry, and the shifts write nothing at all when the count is zero — so
+neither can be taken to have refreshed the flags. A secret `cmp`, a public `inc`, and
+a `jc` is therefore still refused: the carry the branch reads is the secret one. Only
+an instruction that unconditionally overwrites every flag this grammar can read
+(`add`, `sub`, `cmp`, `test`, `and`, `or`, `xor`, `neg`, `cmpxchg`, `xadd`) clears
+the taint. `popfq`, `iretq` and `syscall` load or mask flags from somewhere the model
+does not represent, so they taint unconditionally and never clear.
+
+A `setcc` **consumes** a flag into a register, so with secret-derived flags its
+destination is secret too — otherwise a secret could be laundered out of the flags
+and used as a memory index, which the address check would then miss.
+
+On a target whose grammar has no flag reader at all, every one of these facts is
+vacuous, and that vacuity is asserted per target rather than assumed: adding an
+aarch64 `cset` later has to state its facts deliberately.
 
 The variable-latency check also bites unevenly: x86-64's and aarch64's asm grammars
 carry no divide, multiply or float instruction at all, so it reaches only their

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -94,7 +94,11 @@
 #                 INSTRUCTION NAME with its operand count, plus every core OpDot, in
 #                 emission order, alongside the module's OpExtInstImport count - which
 #                 is what makes "imported only when used" an assertion rather than a
-#                 claim. the environment is chosen PER MODULE rather than per case:
+#                 claim, and its OpCompositeConstruct / Function-storage OpAccessChain
+#                 counts, which
+#                 are what distinguish a vector literal built in one step from the
+#                 storage round trip it replaced (#2640) - both being valid SPIR-V,
+#                 so the verdict cannot tell them apart. the environment is chosen PER MODULE rather than per case:
 #                 a module carrying entry points is a shader and is validated under
 #                 vulkan1.3, and one without is a library, which declares the Linkage
 #                 capability Vulkan forbids outright and is validated universally. a
@@ -1948,8 +1952,20 @@ produce_spirv_shader() {
             env=universal
         fi
         imports=$(printf '%s\n' "$dis" | grep -c 'OpExtInstImport' || true)
-        printf 'module=%s kind=%s env=%s validator=clean extimports=%d\n' \
-            "$rel" "$kind" "$env" "$imports"
+        # the vector-construction shape (#2640). a literal built in one step is an
+        # OpCompositeConstruct and no access chain; the storage form it replaced is a
+        # Function OpVariable plus one OpAccessChain and OpStore per lane, which is
+        # equally VALID SPIR-V - so counting both is what tells the two apart, where
+        # the validator's verdict cannot.
+        builds=$(printf '%s\n' "$dis" | grep -c 'OpCompositeConstruct' || true)
+        # only the FUNCTION-storage chains, which are the per-lane writes a vector
+        # assembled through a stack slot produces. a plain OpAccessChain count would
+        # also sweep up uniform and storage-buffer member walks, which are a different
+        # feature and are optimizer-sensitive - one of them is CSE'd at opt 2, so the
+        # raw count differs between profiles and cannot be a golden shared by both.
+        lanechains=$(printf '%s\n' "$dis" | awk '$3 == "OpAccessChain" && $4 ~ /_ptr_Function_/ { n++ } END { print n + 0 }')
+        printf 'module=%s kind=%s env=%s validator=clean extimports=%d composites=%d lanechains=%d\n' \
+            "$rel" "$kind" "$env" "$imports" "$builds" "$lanechains"
         printf '%s\n' "$dis" | awk '
             # "%29 = OpExtInstImport "GLSL.std.450"" — remember which set each id is,
             # so an OpExtInst can be reported by set NAME rather than by an id that

--- a/int/regression/2691-reflection-recursion/expect.txt
+++ b/int/regression/2691-reflection-recursion/expect.txt
@@ -1,0 +1,12 @@
+equal: 1
+deepest leaf differs: 0
+depth 5 differs: 0
+depth 3 differs: 0
+depth 1 differs: 0
+sum: 28
+diamond sum: 6
+generic instance sum: 11
+two kinds sum: 116
+two kinds equal: 1
+two kinds second differs: 0
+non-deferred field count: 4

--- a/int/regression/2691-reflection-recursion/mach.toml
+++ b/int/regression/2691-reflection-recursion/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2691-reflection-recursion/src/main.mach
+++ b/int/regression/2691-reflection-recursion/src/main.mach
@@ -1,0 +1,136 @@
+# regression pin for #2691: a reflection walk re-enters itself at a field's type
+#
+# `$fields(f.type)` descends one syntactic level per written `$each`, so before
+# this a walk could only reach as deep as its author hand-unrolled. `eq[f.type]`
+# did not parse -- a generic argument list reads with the type grammar, where
+# `f.type` is indistinguishable from a qualified `module.Type` -- and there is no
+# inference from the argument, so the call resolved against the template instead.
+#
+# the walk below is written ONCE and reaches six levels. every case here differs
+# in exactly one leaf at one depth, so a walk that stops short reports two
+# different values equal and fails the pin rather than passing quietly.
+
+use std.runtime;
+use p: std.print;
+
+rec L4 { a: i64; b: i64; }
+rec L3 { d: L4; q: i64; }
+rec L2 { d: L3; q: i64; }
+rec L1 { d: L2; q: i64; }
+rec L0 { d: L1; q: i64; }
+rec L00 { d: L0; q: i64; }
+
+rec V { x: i64; }
+rec Diamond { a: V; b: V; n: i64; }
+
+rec Box[T] { v: T; }
+rec Holder { b: Box[i64]; n: i64; }
+
+# TWO record fields of DIFFERENT types at the same level. one syntactic `f.type`
+# node serves both iterations, so a walk that memoizes the node's resolved type
+# gives the second field the first field's type. these differ in arity and in
+# field name, so that mistake is a wrong answer here rather than a silent pass.
+rec Wide { w: i64; }
+rec Narrow { n1: i64; n2: i64; n3: i64; }
+rec TwoKinds { first: Wide; second: Narrow; tail: i64; }
+
+# the self-recursive walk: the descent arm instantiates this same generic at the
+# field's own type, which is the whole point of #2691.
+fun eqr[T](a: *T, b: *T) i64 {
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (eqr[f.type](?a.[f], ?b.[f]) == 0) { ret 0; }
+        }
+        $or {
+            if (a.[f] != b.[f]) { ret 0; }
+        }
+    }
+    ret 1;
+}
+
+fun sumr[T](v: *T) i64 {
+    var t: i64 = 0;
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) { t = t + sumr[f.type](?v.[f]); }
+        $or                      { t = t + v.[f]; }
+    }
+    ret t;
+}
+
+# counts a record's fields, so an instantiation at the WRONG type is a wrong
+# number rather than a silent pass
+fun count[T](v: *T) i64 {
+    var n: i64 = 0;
+    $each f in $fields(T) { n = n + 1; }
+    ret n;
+}
+
+fun fill(v: *L00) {
+    v.d.d.d.d.d.a = 1; v.d.d.d.d.d.b = 2;
+    v.d.d.d.d.q = 3; v.d.d.d.q = 4; v.d.d.q = 5; v.d.q = 6; v.q = 7;
+}
+
+#[symbol("main")]
+pub fun main(argc: i64, argv: **u8) i64 {
+    var a: L00; fill(?a);
+    var b: L00; fill(?b);
+    p.printf("equal: {}\n", eqr[L00](?a, ?b));
+
+    # the deepest leaf, six levels down, is the case a walk that stops short gets
+    # wrong -- it reports these equal.
+    b.d.d.d.d.d.a = 99;
+    p.printf("deepest leaf differs: {}\n", eqr[L00](?a, ?b));
+    fill(?b);
+
+    b.d.d.d.d.q = 33;
+    p.printf("depth 5 differs: {}\n", eqr[L00](?a, ?b));
+    fill(?b);
+
+    b.d.d.q = 55;
+    p.printf("depth 3 differs: {}\n", eqr[L00](?a, ?b));
+    fill(?b);
+
+    b.q = 77;
+    p.printf("depth 1 differs: {}\n", eqr[L00](?a, ?b));
+
+    p.printf("sum: {}\n", sumr[L00](?a));
+
+    # the same type reached twice down two branches
+    var d: Diamond; d.a.x = 1; d.b.x = 2; d.n = 3;
+    p.printf("diamond sum: {}\n", sumr[Diamond](?d));
+
+    # a generic INSTANCE field descends as the record it instantiates
+    var h: Holder; h.b.v = 5; h.n = 6;
+    p.printf("generic instance sum: {}\n", sumr[Holder](?h));
+
+    # the memoization case: two differently-shaped record fields, one node
+    var tk: TwoKinds;
+    tk.first.w = 10;
+    tk.second.n1 = 1; tk.second.n2 = 2; tk.second.n3 = 3;
+    tk.tail = 100;
+    p.printf("two kinds sum: {}\n", sumr[TwoKinds](?tk));
+
+    var tk2: TwoKinds;
+    tk2.first.w = 10;
+    tk2.second.n1 = 1; tk2.second.n2 = 2; tk2.second.n3 = 3;
+    tk2.tail = 100;
+    p.printf("two kinds equal: {}\n", eqr[TwoKinds](?tk, ?tk2));
+    # differ only in the SECOND record field's last leaf
+    tk2.second.n3 = 99;
+    p.printf("two kinds second differs: {}\n", eqr[TwoKinds](?tk, ?tk2));
+
+    # THE NON-DEFERRED PATH. every walk above is generic, so its `$each` unroll is
+    # deferred to monomorphization and its type arguments resolve there. this one
+    # walks a concrete record, so the unroll and the type-arg resolution both happen
+    # at sema -- a different code path, and the one where a `f.type` node must not be
+    # memoized: one syntactic node serves both iterations, and caching the first
+    # answer gives the second field the first field's type. Wide has one field and
+    # Narrow has three, so that mistake is 2 here instead of 4.
+    var acc: i64 = 0;
+    $each f in $fields(TwoKinds) {
+        $if ($is_record(f.type)) { acc = acc + count[f.type](?tk.[f]); }
+        $or { }
+    }
+    p.printf("non-deferred field count: {}\n", acc);
+    ret 0;
+}

--- a/int/surface/ct-flags-hardware/case.conf
+++ b/int/surface/ct-flags-hardware/case.conf
@@ -1,0 +1,14 @@
+# the flags facts `mach.lang.ct` asserts, measured against the CPU (#2460)
+#
+# The security surface of the #[oblivious] inline-asm flags model is eighteen rows
+# whose facts, if wrong, silently PERMIT a leak. Nobody working on this has the
+# Intel SDM, so those facts were inferred - and inferred confidence is exactly what
+# is worthless as a security argument. This measures them instead, on the part the
+# emitted code actually runs on, and it re-measures on every CI run rather than
+# once in a session transcript.
+#
+# linux only, and x86_64 only: the probe is x86-64 inline asm and the facts are
+# x86-64's. The other targets' flags facts are vacuous and are pinned by unit tests
+# in their own encoders instead.
+run: exec
+targets: linux

--- a/int/surface/ct-flags-hardware/expect.txt
+++ b/int/surface/ct-flags-hardware/expect.txt
@@ -1,0 +1,26 @@
+add ZF:defined CF:defined reads:0
+sub ZF:defined CF:defined reads:0
+cmp ZF:defined CF:defined reads:0
+test ZF:defined CF:defined reads:0
+and ZF:defined CF:defined reads:0
+or ZF:defined CF:defined reads:0
+xor ZF:defined CF:defined reads:0
+neg ZF:defined CF:defined reads:0
+neg0 ZF:defined CF:defined reads:0
+xadd ZF:defined CF:defined reads:0
+inc ZF:defined CF:preserved reads:0
+dec ZF:defined CF:preserved reads:0
+shl1 ZF:defined CF:defined reads:0
+shl0 ZF:preserved CF:preserved reads:0
+shr0 ZF:preserved CF:preserved reads:0
+sar0 ZF:preserved CF:preserved reads:0
+not ZF:preserved CF:preserved reads:0
+mov ZF:preserved CF:preserved reads:0
+lea ZF:preserved CF:preserved reads:0
+xchg ZF:preserved CF:preserved reads:0
+setb ZF:preserved CF:preserved reads:1
+setae ZF:preserved CF:preserved reads:1
+jc ZF:preserved CF:preserved reads:0
+popfq NOT MEASURABLE: opaque flag source, classified by reasoning
+iretq NOT MEASURABLE: opaque flag source, classified by reasoning
+syscall NOT MEASURABLE: opaque flag source, classified by reasoning

--- a/int/surface/ct-flags-hardware/mach.toml
+++ b/int/surface/ct-flags-hardware/mach.toml
@@ -1,0 +1,46 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "cc -c -O1 probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/ct-flags-hardware/probe.c
+++ b/int/surface/ct-flags-hardware/probe.c
@@ -1,0 +1,111 @@
+/* Measures the flags facts `mach.lang.ct` asserts, against the CPU this runs on.
+ *
+ * Two probes, both from the same pair of runs: the instruction is executed twice
+ * with identical operands, once with RFLAGS preset all-set and once all-clear.
+ *
+ *   WRITER probe  - read RFLAGS back. A flag with the same result in both runs is
+ *                   DEFINED by the instruction; one that comes out equal to its
+ *                   input in both is PRESERVED. That is the `defines_flags`
+ *                   predicate, measured.
+ *   READER probe  - read the DESTINATION REGISTER back. If it differs between the
+ *                   two presets, the instruction consumed a flag. That is the
+ *                   `reads_flags` predicate, measured.
+ */
+#include <stdint.h>
+
+#define FSET   0x0CD5UL   /* every arithmetic flag set   */
+#define FCLR   0x0002UL   /* every arithmetic flag clear (bit 1 is reserved-1) */
+#define ZF     0x0040UL
+#define CF     0x0001UL
+
+/* Run INSN once with RFLAGS preset to `pre`, and report BOTH observables from that
+   single run: the flags afterwards, and the destination register afterwards. One
+   macro rather than two so the writer and reader probes cannot drift apart in the
+   operands or the preset they use. */
+#define RUN(INSN, A, B, PRE, OUTF, OUTD)                                       \
+    do { uint64_t _a = (A), _b = (B), _d = 0, _o;                              \
+         __asm__ volatile ("push %[p]\n\tpopfq\n\t" INSN                       \
+                           "\n\tpushfq\n\tpop %[o]"                            \
+             : [o]"=&r"(_o), [d]"+r"(_d), [x]"+r"(_a), [y]"+r"(_b)             \
+             : [p]"r"((uint64_t)(PRE)) : "cc", "memory");                      \
+         (OUTF) = _o; (OUTD) = _d; } while (0)
+
+static const char *verdict(uint64_t hi, uint64_t lo, uint64_t bit) {
+    int oh = (hi & bit) != 0, ol = (lo & bit) != 0;
+    if (oh == ol) return "defined";
+    if (oh == ((FSET & bit) != 0) && ol == ((FCLR & bit) != 0)) return "preserved";
+    return "varies";
+}
+
+extern int ct_probe_line(const char *name, const char *zf, const char *cf, int reads);
+extern int ct_probe_note(const char *name);
+
+#define W2(NAME, INSN, A, B)                                                   \
+    do { uint64_t _hi, _lo, _dh, _dl;                                          \
+         RUN(INSN, A, B, FSET, _hi, _dh);                                      \
+         RUN(INSN, A, B, FCLR, _lo, _dl);                                      \
+         ct_probe_line(NAME, verdict(_hi,_lo,ZF), verdict(_hi,_lo,CF), _dh != _dl); \
+    } while (0)
+
+void ct_flags_probe(void) {
+    /* the ten rows classified `defines_flags`: every one must measure defined/defined */
+    W2("add",     "add %[y], %[x]",            5, 3);
+    W2("sub",     "sub %[y], %[x]",            5, 3);
+    W2("cmp",     "cmp %[y], %[x]",            5, 3);
+    W2("test",    "test %[y], %[x]",           5, 3);
+    W2("and",     "and %[y], %[x]",            5, 3);
+    W2("or",      "or %[y], %[x]",             5, 3);
+    W2("xor",     "xor %[y], %[x]",            5, 3);
+    W2("neg",     "neg %[x]",                  5, 0);
+    W2("neg0",    "neg %[x]",                  0, 0);
+    W2("xadd",    "xadd %[y], %[x]",           5, 3);
+
+    /* the traps: partial writers that must NOT be read as defining */
+    W2("inc",     "inc %[x]",                  5, 0);
+    W2("dec",     "dec %[x]",                  5, 0);
+    W2("shl1",    "shl $1, %[x]",              5, 0);
+    W2("shl0",    "shl $0, %[x]",              5, 0);
+    W2("shr0",    "shr $0, %[x]",              5, 0);
+    W2("sar0",    "sar $0, %[x]",              5, 0);
+
+    /* rows classified as writing no observable flag */
+    W2("not",     "not %[x]",                  5, 0);
+    W2("mov",     "mov %[y], %[x]",            5, 3);
+    W2("lea",     "lea 1(%[y]), %[x]",         5, 3);
+    W2("xchg",    "xchg %[y], %[x]",           5, 3);
+
+    /* the SETcc rows: the reader probe is the point. they write no flag, and their
+       DESTINATION must differ between the two presets - that difference IS the
+       laundering path `reads_flags` exists to close. */
+    W2("setb",    "setb %b[d]",                5, 3);
+    W2("setae",   "setae %b[d]",               5, 3);
+
+    /* A BRANCH CONSUMES A FLAG AND THE READER PROBE CANNOT SEE IT.
+       `jc` reads CF, but a taken branch leaves no register difference to measure,
+       so the probe reports reads:0. That is a limit of the probe, NOT a fact about
+       `jc`, and it is the structural reason the ten `j*` rows do not need
+       `reads_flags`: they are refused outright by `cond_flags` before any fold. */
+    W2("jc",      "jc 1f\n\t1:",                5, 3);
+
+    /* THE ROWS THIS HARNESS CANNOT CLASSIFY, PRINTED SO THE GAP IS IN THE ARTIFACT
+       RATHER THAN ONLY IN A COMMENT.
+
+       `popfq` PASSES THE WRITER PROBE AS "defines BOTH". The incoming flags really
+       do not affect the result, so the probe is right on its own terms and wrong as
+       a classification: the value came from the stack, which the model does not
+       represent and an attacker may control. Classifying it `defines_flags` on this
+       evidence would let it clear a taint from an arbitrary source.
+
+       `defines_flags` asks "does this instruction overwrite the flags with a value
+       derived from its own operands?" The probe measures only the first half. For
+       these three the second half is false, and no experiment of this shape can
+       tell you that - the question is where the value came FROM, which is
+       structural.
+
+       So: do not extend this harness to classify these rows from their output. If
+       you are here because you noticed the probe handles them fine, that is the
+       trap. */
+    ct_probe_note("popfq");
+    ct_probe_note("iretq");
+    ct_probe_note("syscall");
+}

--- a/int/surface/ct-flags-hardware/src/main.mach
+++ b/int/surface/ct-flags-hardware/src/main.mach
@@ -1,0 +1,35 @@
+# Prints what the CPU says about each instruction's flags behaviour (#2460).
+#
+# The golden is the measurement. A row whose hardware behaviour stops matching the
+# classification in `x64/encode.mach` fails here, which is what converts the
+# eighteen-row security surface from inferred to checked.
+#
+# THE OUTPUT IS NOT UNIFORMLY EVIDENCE. Three rows print NOT MEASURABLE, and the
+# reason is in probe.c: `popfq` passes the writer probe cleanly and is still not a
+# definer, because the flags came from the stack. Do not read those lines as a gap
+# waiting to be filled.
+
+use std.runtime;
+use std.types.size.usize;
+use std.types.string.str;
+use p: std.print;
+
+ext fun ct_flags_probe();
+
+#[symbol("ct_probe_line")]
+pub fun probe_line(name: *u8, zf: *u8, cf: *u8, reads: i32) i32 {
+    p.printlnf("{} ZF:{} CF:{} reads:{}", name::str, zf::str, cf::str, reads);
+    ret 0;
+}
+
+#[symbol("ct_probe_note")]
+pub fun probe_note(name: *u8) i32 {
+    p.printlnf("{} NOT MEASURABLE: opaque flag source, classified by reasoning", name::str);
+    ret 0;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    ct_flags_probe();
+    ret 0;
+}

--- a/int/surface/spirv-ext-inst/expect.spirv.txt
+++ b/int/surface/spirv-ext-inst/expect.spirv.txt
@@ -1,4 +1,4 @@
-module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
+module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1 composites=4 lanechains=0
   import GLSL.std.450
   extinst GLSL.std.450 Normalize operands=1
   core OpDot operands=2
@@ -25,6 +25,6 @@ module=obj/case/main.spv kind=shader env=vulkan1.3 validator=clean extimports=1
   extinst GLSL.std.450 Radians operands=1
   extinst GLSL.std.450 Sin operands=1
   extinst GLSL.std.450 Normalize operands=1
-module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0
-module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0
+module=obj/case/plain.spv kind=shader env=vulkan1.3 validator=clean extimports=0 composites=0 lanechains=0
+module=obj/shader/math.spv kind=library env=universal validator=clean extimports=0 composites=0 lanechains=0
 modules=3

--- a/int/surface/spirv-vector-literal/case.conf
+++ b/int/surface/spirv-vector-literal/case.conf
@@ -1,0 +1,11 @@
+# a vector literal builds a vector in ONE instruction, not through memory (#2640).
+#
+# the producer is `spirv-shader` rather than `spirv-val`, because the validator
+# cannot see this case's subject. the storage form this replaces - a Function
+# OpVariable, an OpAccessChain and OpStore per lane, and a whole-vector OpLoad - is
+# perfectly valid SPIR-V, so a regression that reinstated it would validate cleanly
+# and pass a verdict-only case. the golden counts OpCompositeConstruct and pins the
+# per-lane access chains at zero, so either direction of drift is a diff.
+run: spirv-shader
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-vector-literal/expect.spirv.txt
+++ b/int/surface/spirv-vector-literal/expect.spirv.txt
@@ -1,0 +1,2 @@
+module=obj/case/main.spv kind=library env=universal validator=clean extimports=0 composites=8 lanechains=0
+modules=1

--- a/int/surface/spirv-vector-literal/mach.toml
+++ b/int/surface/spirv-vector-literal/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-vector-literal/src/main.mach
+++ b/int/surface/spirv-vector-literal/src/main.mach
@@ -1,0 +1,51 @@
+# SPIR-V vector-literal fixture: construction is an instruction, not a round trip
+#
+# A vector literal used to be assembled through backing storage: an alloca, one
+# access chain and store per lane, then a whole-vector load. That is what #2640
+# removed on a target that can build a vector in one step, and this case is what
+# holds it removed.
+#
+# WHY THE VALIDATOR CANNOT BE THE OBSERVABLE HERE. The storage form is valid SPIR-V.
+# It validated before this change and it would validate again if the lowering
+# regressed, so `spirv-val` alone reports green either way. The golden therefore
+# counts the emitted `OpCompositeConstruct` and pins the number of per-lane
+# `OpAccessChain` writes, which is the pair that actually distinguishes the two
+# shapes.
+#
+# Deliberately 128-bit shapes only. Sub-register-width vectors are refused by name
+# on current dev (#2697 / #2698), so nothing here leans on one.
+
+# constant lanes: the common case, and the one that is a compile-time constant in
+# its entirety. On this target it is one instruction; on a native target it is still
+# built lane by lane, which is #2700 rather than this case.
+fun lit_const() f32x4 { ret f32x4{1.0, 2.0, 3.0, 4.0}; }
+
+# runtime lanes, all four the same value. This is the broadcast a shader writes to
+# scale a colour or a position by a computed factor, and while literals went through
+# memory it was the only spelling for it.
+fun broadcast(t: f32) f32x4 { ret f32x4{t, t, t, t}; }
+
+# runtime lanes that differ, so the operand ORDER is observable rather than a
+# repeated value that would read the same however the lanes were permuted.
+fun assemble(a: f32, b: f32, c: f32, d: f32) f32x4 { ret f32x4{a, b, c, d}; }
+
+# a literal feeding arithmetic directly, so the built value is consumed as a value
+# rather than immediately stored. A build whose result was only ever spilled would
+# not show that the vector is usable in a register.
+fun scaled(v: f32x4, k: f32) f32x4 { ret v * f32x4{k, k, k, k}; }
+
+# the two-lane shape, which exercises a different lane count through the same path.
+fun wide(x: f64) f64x2 { ret f64x2{x, x}; }
+
+# integer lanes, whose build selects the same opcode with a different element type.
+fun ints(n: i32) i32x4 { ret i32x4{n, n, n, n}; }
+
+# a literal built from another literal's lane, so a build's result feeds a lane read
+# which feeds another build. This is the case that would break if the result were
+# left as an address rather than a value.
+fun chained(t: f32) f32x4 {
+    val a: f32x4 = f32x4{t, t, t, t};
+    ret f32x4{a[0], a[1], a[2], a[3]};
+}
+
+fun main() i32 { ret 0; }

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "a7457359ed8c9316f803217212b24a1a0eef994c"
+commit = "4cf942e060c91b8cb45cca270125569c1ca0e13a"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.13.0"
+version = "4.14.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -180,6 +180,14 @@ pub val MIR_VEC_EXTRACT: MirOpcode = 0x1005;
 # isel ties it to the source vector where the machine form is two-address. `vec_lane`
 # describes the destination vector and `src_width` the written lane's byte width
 pub val MIR_VEC_INSERT:  MirOpcode = 0x1006;
+# build a whole vector from its lanes; operands [dst, lane0, lane1, ...] (#2640).
+# `vec_lane` describes the destination vector and `width` its byte width. reachable
+# only on a target whose `MachineModel.has_vec_build` is set - every other target
+# never forms the IR opcode at all, since `me.lower.expr.lower_vector_lit` assembles
+# a literal through storage there instead. deliberately NOT in `selection_lane`:
+# that pack is what arm64 admits, and arm64 has lane access without a whole-vector
+# build form
+pub val MIR_VEC_BUILD:   MirOpcode = 0x1007;
 
 # selection-output sentinels for the generic opcodes that survive instruction
 # selection because they need a multi-instruction byte sequence the encoder

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1011,6 +1011,9 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     if (inst.kind == instr.OP_VEC_INSERT) {
         ret lower_vec_insert(ctx, mb, inst, iid);
     }
+    if (inst.kind == instr.OP_VEC_BUILD) {
+        ret lower_vec_build(ctx, mb, inst, iid);
+    }
     # a `:^` declassify (#1646) is an identity at runtime (secrecy has no machine shape):
     # a register copy of the operand into the result vreg, at the value's width so the
     # encoder selects the GP or SSE move by operand class. it lowers to the DISTINGUISHABLE
@@ -2259,6 +2262,46 @@ fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instru
     ops[3] = lctx.lower_value(ctx, inst.operands[2]);
 
     var mi: mir.MirInstr = mir.instr(mir.MIR_VEC_INSERT, ops, 4, lctx.op_width_of(ctx, inst.ty), lctx.op_width_of(ctx, inst.operands[2].ty));
+    ret lctx.push_instr(ctx, mb, mi);
+}
+
+# lower an OP_VEC_BUILD into `mir.MIR_VEC_BUILD (dst) <- (lane0), (lane1), ...`
+#
+# One operand per lane, in lane order, so the operand count is the vector's lane
+# count rather than a constant. `width` is the vector's; there is no single source
+# width to record, because every lane is the element's, which `vec_lane` already
+# carries.
+#
+# Reachable only where `MachineModel.has_vec_build` is set - `lower_vector_lit`
+# assembles a literal through storage on every other target, so the opcode is never
+# formed there at all.
+# ---
+# ctx:  the per-function lowering context
+# mb:   the destination MIR block
+# inst: the IR OP_VEC_BUILD instruction
+# iid:  the IR instruction id
+# ret:  true on success, or a lowering / allocation error
+fun lower_vec_build(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[bool, str] {
+    val dst: u32 = lctx.instr_vreg(ctx, iid);
+    if (dst == mir.MIR_VREG_NIL) {
+        ret R.err[bool, str]("mir.lower_ir: vector build defines no result vreg");
+    }
+    if (inst.operand_count == 0) {
+        ret R.err[bool, str]("mir.lower_ir: vector build with no lanes");
+    }
+
+    val n: u32 = inst.operand_count + 1;
+    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, n::usize);
+    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](r)); }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    ops[0] = mir.op_vreg(dst);
+    var i: u32 = 0;
+    for (i < inst.operand_count) {
+        ops[1 + i] = lctx.lower_value(ctx, inst.operands[i]);
+        i = i + 1;
+    }
+
+    var mi: mir.MirInstr = mir.instr(mir.MIR_VEC_BUILD, ops, n, lctx.op_width_of(ctx, inst.ty), 0);
     ret lctx.push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/ct.mach
+++ b/src/lang/ct.mach
@@ -157,25 +157,132 @@ test "mach.lang.ct.ct_cap:table" {
 # constant-time guarantee, so a flags-conditioned branch is REFUSED outright rather
 # than analyzed. Lifting that needs flags in the effect model, tracked as #2460.
 # ---
-# op:         the constant-time class of the operation
-# known:      false when the ISA has not classified this mnemonic (refuse on secret)
-# cond_flags: a conditional branch whose condition rides the flags register
-# cond_reg:   a conditional branch whose condition is a register operand
+# op:            the constant-time class of the operation
+# known:         false when the ISA has not classified this mnemonic (refuse on secret)
+# cond_flags:    a conditional branch whose condition rides the flags register
+# cond_reg:      a conditional branch whose condition is a register operand
+# flags_stated:  whether an ISA deliberately stated this row's flags facts (#2460)
+# writes_flags:  MAY write an observable flag, so secret operands taint FLAGS
+# defines_flags: UNCONDITIONALLY overwrites every observable flag, so public
+#                operands make FLAGS clean. implies writes_flags. ONLY THIS CLEARS
+# opaque_flags:  loads FLAGS from something the model does not represent, so it
+#                taints unconditionally, independent of operands
+# reads_flags:   consumes an observable flag into a register, so a tainted FLAGS
+#                makes this instruction's outputs secret
 pub rec AsmClass {
-    op:         CtOp;
-    known:      bool;
-    cond_flags: bool;
-    cond_reg:   bool;
+    op:            CtOp;
+    known:         bool;
+    cond_flags:    bool;
+    cond_reg:      bool;
+    flags_stated:  bool;
+    writes_flags:  bool;
+    defines_flags: bool;
+    opaque_flags:  bool;
+    reads_flags:   bool;
 }
 
 # an unclassified mnemonic: refuses the moment a secret reaches it
+#
+# THE FLAGS DEFAULTS ARE DELIBERATELY ASYMMETRIC, and the asymmetry is the whole
+# security argument (#2460). A row nobody thought about must fail SAFE:
+#
+#   writes_flags  TRUE  - it taints FLAGS when its operands are secret
+#   defines_flags FALSE - it never clears a taint
+#   opaque_flags  FALSE - it is not an unmodeled flag source (those are named)
+#   reads_flags   FALSE - see below
+#
+# So the only facts that can wrongly PERMIT are the ones an ISA sets explicitly.
+# Setting `writes_flags` false is a precision optimization, not a correctness
+# requirement: omitting it costs a spurious taint, which the next defining
+# instruction clears, and a false refusal is safe where a false accept is not.
+#
+# `reads_flags` defaults FALSE rather than true, breaking the pattern, because
+# true is not the conservative choice here - it is merely the blunt one. Every
+# instruction executed while FLAGS is dirty would taint its destination,
+# including `mov`, which refuses far more than it protects. It is set on the
+# rows that genuinely consume a flag into a register.
 pub fun asm_unknown() AsmClass {
     var a: AsmClass;
-    a.op         = CT_OP_NONE;
-    a.known      = false;
-    a.cond_flags = false;
-    a.cond_reg   = false;
+    a.op            = CT_OP_NONE;
+    a.known         = false;
+    a.cond_flags    = false;
+    a.cond_reg      = false;
+    a.flags_stated  = false;
+    a.writes_flags  = true;
+    a.defines_flags = false;
+    a.opaque_flags  = false;
+    a.reads_flags   = false;
     ret a;
+}
+
+# the row writes no flag this grammar can observe
+#
+# A precision statement, not a security one: it says a secret passing through
+# this instruction leaves FLAGS alone, so a later `jcc` is not refused for a
+# reason that does not exist. Getting it wrong costs false refusals.
+pub fun flags_untouched(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = false;
+    o.defines_flags = false;
+    ret o;
+}
+
+# the row unconditionally overwrites EVERY observable flag, so public operands
+# leave FLAGS clean
+#
+# THE ONLY FACT THAT CLEARS TAINT, and therefore the one that can turn a leak
+# into a passing build. Set it only where the instruction writes both ZF and CF
+# on every path, for every operand value. `inc` / `dec` do not (no CF), and the
+# shifts do not (nothing at count 0) - those take `flags_written` instead.
+pub fun flags_defined(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = true;
+    o.defines_flags = true;
+    ret o;
+}
+
+# the row MAY write an observable flag but does not define every one of them
+#
+# Taints on secret operands and never clears - the state `inc`, `dec` and the
+# shifts need, and the one a single boolean could not express.
+pub fun flags_written(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = true;
+    o.defines_flags = false;
+    ret o;
+}
+
+# the row loads FLAGS from somewhere the model does not represent
+#
+# Taints UNCONDITIONALLY, because the taint rule for an ordinary writer is
+# operand-conditioned and these rows have no operands to condition on: a flag
+# value arriving from memory, the interrupt frame, or a masked prior RFLAGS is
+# unmodeled whatever the register file holds.
+pub fun flags_opaque(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.writes_flags  = true;
+    o.defines_flags = false;
+    o.opaque_flags  = true;
+    ret o;
+}
+
+# the row consumes an observable flag into a register
+#
+# A tainted FLAGS makes this instruction's outputs secret-derived, so its written
+# registers are tainted the same way an instruction reading a secret register is.
+# Without it a `setcc` launders a secret out of FLAGS into a register the model
+# then treats as public, and a later memory access indexed by it is accepted.
+pub fun flags_read(a: AsmClass) AsmClass {
+    var o: AsmClass = a;
+    o.flags_stated  = true;
+    o.reads_flags   = true;
+    o.writes_flags  = false;
+    o.defines_flags = false;
+    ret o;
 }
 
 # a classified straight-line mnemonic of constant-time class `op`
@@ -189,9 +296,15 @@ pub fun asm_op(op: CtOp) AsmClass {
     ret a;
 }
 
-# a conditional branch whose condition rides the flags register: always refused
+# a conditional branch whose condition rides the flags register
+#
+# States its own flags facts: it reads a flag and writes none. The read is what
+# `ct_check_item` refuses on when FLAGS is tainted; `reads_flags` is not set,
+# because a refused branch has no outputs to taint and marking it would only
+# make the reader set ambiguous between "consumed into a register" and
+# "consumed into the program counter".
 pub fun asm_branch_flags() AsmClass {
-    var a: AsmClass = asm_op(CT_OP_NONE);
+    var a: AsmClass = flags_untouched(asm_op(CT_OP_NONE));
     a.cond_flags = true;
     ret a;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2128,6 +2128,47 @@ test "mach.lang.driver:comptime_reflection_descent" {
     ret bad;
 }
 
+# a reflection walk re-enters itself at a field's type: `eq[f.type](...)` (#2691)
+#
+# `$fields(f.type)` descends one syntactic level per written `$each`, so before this
+# a walk reached only as deep as its author hand-unrolled. the generic argument list
+# reads with the type grammar, where `f.type` is indistinguishable from a qualified
+# `module.Type`, so the spelling that closes the loop did not parse at all.
+#
+# runtime behaviour is pinned by int/regression/2691-reflection-recursion, which
+# walks six levels and perturbs one leaf at a time. these are the front-end facts.
+test "mach.lang.driver:comptime_reflection_recursion" {
+    var bad: i32 = 0;
+
+    # the self-recursive walk itself, over a nest deeper than any hand-unrolled
+    # ladder would reach
+    if (ut_layout_ok("rec I { x: u64; }\nrec M { i: I; n: u64; }\nrec O { m: M; n: u64; }\nfun w[T](v: *T) i32 { $each f in $fields(T) { $if ($is_record(f.type)) { w[f.type](?v.[f]); } $or { } } ret 0; }\nfun main() i32 { var o: O; ret w[O](?o); }\n") != 0) { bad = 1; }
+
+    # the descent really is per field: the arm reached through `f.type` sees the
+    # INNER record's fields, not the outer's
+    if (ut_arm("rec I { x: u64; }\nrec O { i: I; }\nfun w[T]() i32 { $each f in $fields(T) { $if (f.name == \"x\") { $error(\"INNER\"); } $or ($is_record(f.type)) { w[f.type](); } $or { } } ret 0; }\nfun main() i32 { ret w[O](); }\n", "INNER", "OUTER") != 0) { bad = 1; }
+
+    # a descriptor argument alongside an ordinary one, in either position
+    if (ut_layout_ok("rec I { x: u64; }\nrec O { i: I; }\nfun two[A, B](a: *A, b: *B) i32 { ret 0; }\nfun w[T](v: *T) i32 { var n: i32 = 0; $each f in $fields(T) { $if ($is_record(f.type)) { n = two[f.type, i32](?v.[f], ?n); } $or { } } ret n; }\nfun main() i32 { var o: O; ret w[O](?o); }\n") != 0) { bad = 1; }
+
+    # THE LOOKAHEAD MUST NOT ABSORB A REAL MISTAKE. a genuinely wrong operand in the
+    # same position still reports against the type grammar, which is the trade #2454
+    # made at the intrinsic position and this one has to make identically.
+    if (ut_vec_diag("fun g[T](a: *T) i32 { ret 0; }\nfun main() i32 { var x: u64; ret g[nosuchmod.T](?x); }\n",
+                    "unresolved type name") != 0) { bad = 1; }
+
+    # a name that is not a `$each` loop variable is refused where it is written,
+    # rather than resolving to a silent TYPE_ERROR later
+    if (ut_vec_diag("fun g[T](a: *T) i32 { ret 0; }\nfun main() i32 { var f: u64; var x: u64; ret g[f.type](?x); }\n",
+                    "names a `$each` field-descriptor loop variable") != 0) { bad = 1; }
+
+    # `type` stays contextual: a real record field called `type` is untouched, which
+    # is the same trade the value-side recognition already makes
+    if (ut_layout_ok("rec S { type: u64; }\nfun main() i32 { var s: S; s.type = 5; ret 0; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # an IMPORTED nominal measures in both folding positions (#2442)
 #
 # The premise the same-module-only forcing rests on: dependencies are type-checked

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11704,6 +11704,21 @@ test "mach.lang.driver:oblivious_asm_validated_not_refused" {
     if (ut_codegen_target_ok("#[oblivious]\nfun ll(p: *i64) i64 { var v: i64 = 0; asm aarch64 { ldr x12, {p}\n ldaxr x9, [x12]\n stlxr w10, x9, [x12]\n cbnz w10, 1f\n1:\n nop } ret v; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-arm64") != 0) { bad = 1; }
     if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm riscv64 { nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux-riscv64") != 0) { bad = 1; }
 
+    # THE LIFT (#2460). A compare-and-branch over PUBLIC data is now accepted on
+    # x86-64. Before the flags model this was refused outright, whether or not the
+    # block carried a secret, because the walk could not tell the two apart.
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { cmp rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+
+    # and a secret compare followed by a DEFINING public compare is accepted too:
+    # `cmp` overwrites every flag this grammar can read, so the second one leaves
+    # nothing of the first behind. This is the case that distinguishes a real model
+    # from a blanket "any secret anywhere in the block poisons it" rule.
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n cmp rbx, rcx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+
+    # a `setcc` over PUBLIC flags is not a laundering path, so its destination stays
+    # public and may index memory. The refusal twin of this is in the leaks test.
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(x: ^u64) ^u64 { var r: ^u64 = x; asm x86_64 { cmp rax, rbx\n setb bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+
     ret bad;
 }
 
@@ -11714,13 +11729,59 @@ test "mach.lang.driver:oblivious_asm_leaks_refused" {
     var bad: i32 = 0;
 
     # THE NIGHTMARE CASE. `cmp {secret}, rbx ; je` conditions the branch on FLAGS,
-    # which the inline-asm effect model does not represent - so a register-only walk
-    # would pass it as leak-free. Refused on x86-64 whether or not a secret is
-    # present, and the message says why and where the lift is tracked.
+    # which a register-only walk would pass as leak-free. Still refused, but since
+    # #2460 it is refused because the SECRET reached FLAGS rather than because the
+    # model could not see FLAGS at all: the `cmp` reads a secret binding and taints
+    # them, and the `je` consumes that taint.
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "linux", "its condition rides the flags register") != 0) { bad = 1; }
     if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
-        "linux", "#2460") != 0) { bad = 1; }
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # THE UNSOUND DIRECTION (#2460). `inc` writes ZF but NOT CF, so it must not be
+    # taken to have refreshed FLAGS: a `jc` after it reads a CF still derived from
+    # the secret `cmp`. This is the case a two-fact "writes flags therefore clears"
+    # model accepts, and it is the reason `defines_flags` exists as a separate fact.
+    # It fails the moment `inc` is given `defines_flags`.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n inc rax\n jc 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    # the same for a shift, which writes nothing at all at count 0
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { cmp {r}, rbx\n shl rax, 1\n jc 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # EACH PARTIAL WRITER TAINTS ON ITS OWN SECRET OPERAND. `inc` / `dec` and the
+    # three shifts may write an observable flag, so a secret passing through one
+    # makes FLAGS secret-derived even though none of them DEFINES every flag.
+    #
+    # All five are spelled out rather than one standing for the family: the mutation
+    # sweep showed that testing `inc` and `shl` alone left `dec`, `shr` and `sar`
+    # with no behavioural coverage, so their `writes_flags` could be deleted with the
+    # suite still green - a fact nothing depends on, which is indistinguishable from
+    # a fact that is wrong.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n inc rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n dec rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n shl rax, 1\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n shr rax, 1\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n sar rax, 1\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # AN UNMODELED FLAG SOURCE taints unconditionally: `popfq` loads FLAGS from the
+    # stack, which the model does not represent, so a `je` after it is refused even
+    # though nothing in the block reads a secret binding. These rows carry NO
+    # operands, so an operand-conditioned taint rule could never fire for them.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { popfq\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+
+    # A SECRET LAUNDERED OUT OF FLAGS. `setb` consumes CF into a register, so that
+    # register is secret-derived; indexing memory with it leaks through the cache.
+    # Without `reads_flags` the model knows FLAGS is tainted and still calls `bl`
+    # public, which is a silent pass of exactly the kind this issue exists to close.
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n setb bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "addresses memory with a secret value") != 0) { bad = 1; }
 
     # a data directive's payload can encode ANY instruction, including a secret-
     # dependent branch. there is nothing to analyze, so it is refused on KIND -
@@ -12667,3 +12728,141 @@ test "mach.lang.driver:comptime_arm_does_not_mask_cross_module_conflict" {
     ret bad;
 }
 
+
+# A TAINT SURVIVES EVERY ROW THAT DOES NOT DEFINE EVERY OBSERVABLE FLAG
+#
+# One case per grammar row, generated from the row list rather than written for
+# the interesting few. The mutation sweep is why: testing `inc` and `shl` and
+# letting them stand for the family left `dec`, `shr` and `sar` with no
+# behavioural coverage at all, so their facts could be deleted with the suite
+# still green - and a fact nothing depends on is indistinguishable from a fact
+# that is wrong.
+#
+# Each block taints FLAGS with a secret `cmp`, executes ONE row with entirely
+# public operands, and then reads CF. The row must not have cleared the taint, so
+# the read is refused. Give any of these rows `defines_flags` and its case fails.
+test "mach.lang.driver:oblivious_asm_taint_survives_every_non_defining_row" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n mov rbx, rdx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n lea rbx, [rdx]\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n xchg rbx, rdx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n movzx rbx, dl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n movsx rbx, dl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n shl rbx, 1\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n shr rbx, 1\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n sar rbx, 1\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n not rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n inc rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n dec rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n push rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n pop rbx\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n setb bl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n setae bl\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n jmp 1f\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n call 1f\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n lidt [rbx]\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n in al, 0x60\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n out 0x60, al\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n ret\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n hlt\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cli\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n sti\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n rdtsc\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n rdmsr\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n wrmsr\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n mfence\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n pause\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n nop\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cld\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n pushfq\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n swapgs\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    ret bad;
+}
+
+# AND IT IS CLEARED BY EVERY ROW THAT DOES DEFINE THEM
+#
+# The other direction, and the reason this model is not simply "any secret in the
+# block poisons it": an instruction that unconditionally overwrites every flag
+# this grammar can read leaves nothing of the earlier secret behind, so a branch
+# after it is public and is accepted. Remove any of these rows' `defines_flags`
+# and its case fails, which is what makes the fact load-bearing rather than
+# merely asserted.
+test "mach.lang.driver:oblivious_asm_taint_cleared_by_every_defining_row" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n add rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n sub rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n and rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n or rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n xor rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cmp rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n test rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n neg rbx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n cmpxchg rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    if (ut_codegen_target_ok("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rsi, {r}\n cmp rsi, 1\n xadd rbx, rdx\n je 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n", "linux") != 0) { bad = 1; }
+    ret bad;
+}
+
+# AN UNMODELED FLAG SOURCE TAINTS WITH NO SECRET IN SIGHT
+#
+# `popfq` and `iretq` load FLAGS from the stack or the interrupt frame, and
+# `syscall` masks the existing RFLAGS - none of which this model represents. All
+# three carry NO operands, so the ordinary "secret operand taints" rule is
+# structurally unable to fire for them and they need their own unconditional
+# arm. Nothing in these blocks reads a secret binding at all.
+test "mach.lang.driver:oblivious_asm_unmodeled_flag_sources_taint" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { popfq\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { iretq\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { syscall\n jc 1f\n 1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    ret bad;
+}
+
+# BOTH SETcc SPELLINGS CARRY A SECRET OUT OF FLAGS AND INTO A REGISTER
+#
+# `setb` and `setae` are distinct grammar rows on distinct opcodes, so covering
+# one leaves the other free to launder. The destination becomes secret-derived,
+# and indexing memory with it leaks through the cache.
+test "mach.lang.driver:oblivious_asm_setcc_does_not_launder_flags" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n setb bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "addresses memory with a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmp rax, 1\n setae bl\n mov rcx, [rbx] } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "addresses memory with a secret value") != 0) { bad = 1; }
+    ret bad;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -12866,3 +12866,37 @@ test "mach.lang.driver:oblivious_asm_setcc_does_not_launder_flags" {
         "linux", "addresses memory with a secret value") != 0) { bad = 1; }
     ret bad;
 }
+
+# EVERY DEFINING ROW ALSO TAINTS ON ITS OWN SECRET OPERAND
+#
+# `defines_flags` implies `writes_flags`, and the second half needs its own
+# coverage: a definer whose operands are secret must TAINT, not clear. The clear
+# arm requires public operands, so these two behaviours are disjoint and a test of
+# one says nothing about the other.
+#
+# One case per row rather than one for the family. The mutation sweep is why:
+# with only `cmp` covered, deleting `writes_flags` from `add`, `sub`, `and`, `or`,
+# `xor`, `test`, `neg`, `cmpxchg` or `xadd` left the suite green - nine facts that
+# nothing depended on, which reads identically to nine facts that are wrong.
+test "mach.lang.driver:oblivious_asm_defining_rows_taint_on_secret_operands" {
+    var bad: i32 = 0;
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n add rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n sub rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n and rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n or rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n xor rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n test rax, rbx\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n neg rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n cmpxchg rbx, rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(k: ^u64) ^u64 { var r: ^u64 = k; asm x86_64 { mov rax, {r}\n xadd rbx, rax\n je 1f\n1:\n nop } ret r; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+        "linux", "branches on a secret value") != 0) { bad = 1; }
+    ret bad;
+}

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -26,6 +26,11 @@ pub val TYPE_KIND_PACK:  TypeKind = 6;
 # data for the constant-time guarantee. flow-typing semantics land in #1645; the
 # parser only records the qualifier
 pub val TYPE_KIND_SECRET: TypeKind = 7;
+# a field descriptor's own type, `f.type`, written where a type is expected
+# (#2691). the only type spelling whose meaning is not fixed by the source text:
+# it names whatever field the enclosing `$each f in $fields(T)` is on, so one node
+# resolves to a different type per iteration and is never memoized
+pub val TYPE_KIND_FIELD_TYPE: TypeKind = 8;
 pub val TYPE_KIND_ERROR: TypeKind = 255;
 
 # a named type reference, optionally with generic arguments
@@ -95,6 +100,18 @@ pub rec TypeUni {
     fields_len:   u32;
 }
 
+# a field descriptor's type `f.type` used as a type spelling (#2691)
+#
+# `var_name` is the loop variable's span, not a resolved binding: the descriptor
+# it names exists only inside the enclosing `$each` body, and which field it is on
+# is decided per iteration by the unroll. resolve checks the name really is a
+# `$each` loop variable, so an ordinary record field called `type` is untouched.
+# ---
+# var_name: span of the loop variable as written (`f` in `f.type`)
+pub rec TypeFieldType {
+    var_name: token.Span;
+}
+
 # a syntactic type reference as it appears in source
 # ---
 # span: byte range of the type expression
@@ -111,5 +128,6 @@ pub rec Type {
         fun_:   TypeFun;
         rec_:   TypeRec;
         uni_:   TypeUni;
+        field_type: TypeFieldType;
     };
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -599,6 +599,44 @@ pub fun lookup(c: *ComptimeCtx, name: intern.StrId) O.Option[*NamedConst] {
     ret O.none[*NamedConst]();
 }
 
+# resolve a `f.type` TYPE SPELLING to the field's own type, given the loop
+# variable's interned name (#2691)
+#
+# The type-position counterpart of the `f.type` value projection above, and it
+# goes through the same installed field resolver, so a descriptor read as a value
+# and the same descriptor read as a type cannot disagree about which field they
+# are on.
+#
+# ONE implementation for both phases. Sema resolves this during its `$each`
+# unroll; lowering resolves it during the unroll it runs for a walk whose `$fields`
+# operand was an unbound generic parameter at template sema. Both bind the loop
+# variable the same way and both install a field resolver, so neither needs a rule
+# of its own.
+#
+# None when `name` is not bound to a field descriptor, which is the caller's cue
+# to report against the spelling rather than to guess a type.
+# ---
+# c:    the comptime context, its frame holding the active loop binding
+# name: interned name of the `$each` loop variable
+# ret:  some(sema TypeId) for the field's type, none when unbound or unavailable
+pub fun field_type_of_binding(c: *ComptimeCtx, name: intern.StrId) O.Option[u32] {
+    val bound: O.Option[*NamedConst] = lookup(c, name);
+    if (O.is_none[*NamedConst](bound)) { ret O.none[u32](); }
+    val nc: *NamedConst = O.unwrap[*NamedConst](bound);
+    if (nc.value.kind != CT_KIND_FIELD) { ret O.none[u32](); }
+
+    if (c.field_fn == nil) { ret O.none[u32](); }
+    val fn: FieldMemberFn = c.field_fn::FieldMemberFn;
+    val r: R.Result[O.Option[CTValue], str] =
+        fn(c.field_data, nc.value.data.fld.owner, nc.value.data.fld.index, FIELD_SEL_TYPE);
+    if (R.is_err[O.Option[CTValue], str](r)) { ret O.none[u32](); }
+    val o: O.Option[CTValue] = R.unwrap_ok[O.Option[CTValue], str](r);
+    if (O.is_none[CTValue](o)) { ret O.none[u32](); }
+    val v: CTValue = O.unwrap[CTValue](o);
+    if (v.kind != CT_KIND_TYPE) { ret O.none[u32](); }
+    ret O.some[u32](v.data.t);
+}
+
 # register a manifest comptime define (#1191) under `name`, readable
 # only through the `$mach.build.<name>` path. defines live in their own table,
 # isolated from the scoped `entries` environment, so a define neither shadows nor

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -305,10 +305,10 @@ fun probe_type_payload(p: *state.Parser) bool {
     var ok: bool = false;
     if (!state.at(p, token.KIND_RBRACKET)) {
         val before: usize = p.pos;
-        parse_type(p);
+        parse_type_arg(p);
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RBRACKET)) { brk; }
-            parse_type(p);
+            parse_type_arg(p);
         }
         ok = p.pos > before && !p.fatal && state.at(p, token.KIND_RBRACKET);
     }
@@ -328,15 +328,29 @@ fun probe_type_payload(p: *state.Parser) bool {
 # p:       parser state, cursor on the '['
 # out_len: receives the number of type arguments flushed
 # ret:     start index of the flushed type-argument slice
+# reads one generic argument: a field descriptor's type where the lookahead
+# matches, else an ordinary type spelling (#2691)
+#
+# Used by the committing parse and by the speculative type probe alike, so the
+# probe's verdict and the parse it commits to cannot disagree about whether an
+# argument is spellable.
+# ---
+# p:   parser state, cursor on the argument
+# ret: TypeId of the argument
+fun parse_type_arg(p: *state.Parser) id.TypeId {
+    if (at_field_type_arg(p)) { ret parse_field_type_arg(p); }
+    ret parse_type(p);
+}
+
 fun parse_type_args(p: *state.Parser, out_len: *u32) u32 {
     state.advance(p);                        # consume '['
 
     var buf: state.ListBuf[id.TypeId] = state.list_buf_init[id.TypeId]();
     if (!state.at(p, token.KIND_RBRACKET)) {
-        state.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
+        state.list_buf_push[id.TypeId](p, ?buf, parse_type_arg(p));
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RBRACKET)) { brk; }
-            state.list_buf_push[id.TypeId](p, ?buf, parse_type(p));
+            state.list_buf_push[id.TypeId](p, ?buf, parse_type_arg(p));
         }
     }
     state.expect(p, token.KIND_RBRACKET, "expected ']' to close generic arguments");
@@ -638,6 +652,59 @@ fun at_field_type_operand(p: *state.Parser) bool {
     # two-segment form is diverted.
     val after: token.Kind = state.peek(p, 3::usize).kind;
     ret after == token.KIND_RPAREN || after == token.KIND_COMMA;
+}
+
+# whether the cursor sits on a field descriptor's `.type` in a GENERIC ARGUMENT
+# list - `eq[f.type](...)`, the spelling that lets a reflection walk re-enter
+# itself at a field's type (#2691)
+#
+# The same `IDENT . type` shape and the same one-token lookahead as
+# `at_field_type_operand`, differing only in the terminator: a generic argument
+# list closes with `]` rather than `)`. Kept as its own predicate rather than
+# widening that one's terminator set, because accepting `]` where an intrinsic
+# argument is expected would divert a genuine mis-spelling away from the type
+# grammar that should report it.
+# ---
+# p:   parser state, cursor on the argument
+# ret: true when the argument is a field descriptor's type
+fun at_field_type_arg(p: *state.Parser) bool {
+    if (!state.at(p, token.KIND_IDENT)) { ret false; }
+    if (state.peek(p, 1::usize).kind != token.KIND_DOT) { ret false; }
+
+    val member: token.Token = state.peek(p, 2::usize);
+    if (member.kind != token.KIND_IDENT) { ret false; }
+    if (!str_region_equals(p.tokens.source, member.span.offset, member.span.len, "type")) { ret false; }
+
+    val after: token.Kind = state.peek(p, 3::usize).kind;
+    ret after == token.KIND_RBRACKET || after == token.KIND_COMMA;
+}
+
+# builds the TYPE_KIND_FIELD_TYPE node for an `f.type` generic argument (#2691)
+#
+# Consumes the three tokens the lookahead matched and records the loop variable's
+# span. Which field it names is not knowable here - it is decided per iteration by
+# the `$each` unroll - so nothing is resolved at parse time.
+# ---
+# p:   parser state, cursor on the loop variable
+# ret: TypeId of the resulting node
+fun parse_field_type_arg(p: *state.Parser) id.TypeId {
+    val var_tok: token.Token = state.current(p);
+    state.advance(p);                        # the loop variable
+    state.advance(p);                        # '.'
+    val member: token.Token = state.current(p);
+    state.advance(p);                        # 'type'
+
+    var payload: type.TypeFieldType;
+    payload.var_name = var_tok.span;
+
+    var span: token.Span = var_tok.span;
+    span.len = (member.span.offset + member.span.len) - var_tok.span.offset;
+
+    var node: type.Type;
+    node.span            = span;
+    node.kind            = type.TYPE_KIND_FIELD_TYPE;
+    node.data.field_type = payload;
+    ret state.push_type(p, node);
 }
 
 # parses a type-taking intrinsic's first argument with the TYPE grammar, wrapped

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -3143,6 +3143,27 @@ fun bind_type(rc: *ResolveContext, tid: id.TypeId) R.Result[bool, str] {
     if (t.kind == atype.TYPE_KIND_SECRET) {
         ret bind_type(rc, t.data.secret.inner);
     }
+    # `f.type` in a type position (#2691) names a `$each` loop variable, not a
+    # module symbol, and which field it is on is decided per iteration. there is
+    # nothing to bind here; the name is checked against the scope below so a
+    # spelling that names no loop variable is reported now rather than resolving to
+    # a silent TYPE_ERROR in sema.
+    if (t.kind == atype.TYPE_KIND_FIELD_TYPE) {
+        val fr: R.Result[intern.StrId, str] =
+            intern.intern_span(?rc.s.interner, rc.source, t.data.field_type.var_name);
+        if (R.is_err[intern.StrId, str](fr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](fr)); }
+        val fsid: SymbolId = scope_lookup_chain(rc, rc.current_scope, R.unwrap_ok[intern.StrId, str](fr));
+        if (fsid == SYMBOL_NIL) {
+            ret diagnostic.error(?rc.s.diags, rc.a.file_id, t.data.field_type.var_name,
+                "`f.type` as a type argument names a `$each` field-descriptor loop variable; this name is not one in scope");
+        }
+        val fsym: *Symbol = ?rc.symbols[fsid];
+        if (fsym.kind != SYM_VAL || (fsym.flags & SYM_FLAG_COMPTIME) == 0) {
+            ret diagnostic.error(?rc.s.diags, rc.a.file_id, t.data.field_type.var_name,
+                "`f.type` as a type argument names a `$each` field-descriptor loop variable; this name is an ordinary binding");
+        }
+        ret R.ok[bool, str](true);
+    }
     if (t.kind == atype.TYPE_KIND_ARRAY) {
         # `[_]T` carries no length expression to bind; sema supplies the count.
         if (t.data.array.length != id.EXPR_NIL) {

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -2848,6 +2848,12 @@ fun infer_struct_lit(sc: *context.SemaContext, sl: *expr.ExprStructLit, span: to
 # tid: syntactic AstType id to resolve
 # ret: the interned semantic TypeId (TYPE_ERROR on failure)
 pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
+    # `f.type` (#2691) is answered from the LIVE `$each` binding, so one syntactic
+    # node has a different answer per iteration and neither reads nor writes the
+    # memo. every other kind's answer is fixed by its source text, which is what
+    # makes memoizing them sound.
+    if (is_field_type_node(sc, tid)) { ret resolve_type_ref_raw(sc, tid); }
+
     # a node already resolved by this pass yields the answer it yielded then, without
     # re-running the resolution or re-emitting its diagnostics (#2334). The memo exists
     # only on the main pass, whose substitution is nil throughout, so an instance
@@ -2864,6 +2870,17 @@ pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     val resolved: type.TypeId = resolve_type_ref_raw(sc, tid);
     memo_record(sc, tid, resolved, context.reported_since(sc, mark));
     ret resolved;
+}
+
+# whether `tid` is a `f.type` spelling, whose answer is per-iteration (#2691)
+# ---
+# sc:  the context
+# tid: the syntactic type node
+# ret: true when the node is TYPE_KIND_FIELD_TYPE
+fun is_field_type_node(sc: *context.SemaContext, tid: id.TypeId) bool {
+    val t_opt: O.Option[*atype.Type] = ast.get_type(sc.a, tid);
+    if (O.is_none[*atype.Type](t_opt)) { ret false; }
+    ret O.unwrap[*atype.Type](t_opt).kind == atype.TYPE_KIND_FIELD_TYPE;
 }
 
 # `tid`'s memo state for this pass (#2334)
@@ -2931,6 +2948,7 @@ fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     if (t.kind == atype.TYPE_KIND_NAMED)  { ret resolve_type_named(sc, tid, ?t.data.named, t.span); }
     if (t.kind == atype.TYPE_KIND_PTR)    { ret resolve_type_ptr(sc, ?t.data.ptr); }
     if (t.kind == atype.TYPE_KIND_SECRET) { ret resolve_type_secret(sc, ?t.data.secret); }
+    if (t.kind == atype.TYPE_KIND_FIELD_TYPE) { ret resolve_type_field_type(sc, ?t.data.field_type, t.span); }
     if (t.kind == atype.TYPE_KIND_ARRAY)  { ret resolve_type_array(sc, tid, ?t.data.array, t.span); }
     if (t.kind == atype.TYPE_KIND_FUN)   { ret resolve_type_fun(sc, ?t.data.fun_); }
     if (t.kind == atype.TYPE_KIND_REC)   { ret resolve_type_anon(sc, tid, t.data.rec_.fields_start, t.data.rec_.fields_len, type.TYPE_REC); }
@@ -2942,6 +2960,31 @@ fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
         ret R.unwrap_ok[type.TypeId, str](r);
     }
     ret type.TYPE_ERROR;
+}
+
+# FIELD_TYPE: the type of the field the enclosing `$each` is currently on (#2691)
+#
+# This is the only type spelling whose meaning is not fixed by its source text, so
+# it is the one that must never be memoized: `resolve_type_ref` caches a syntactic
+# node's answer, and caching the first iteration's field type here would give every
+# later iteration the wrong type. `resolve_type_ref_raw` is therefore the only
+# entry point, and the memo is skipped for this kind by its caller.
+#
+# Unbound means the spelling names no live descriptor - a `$each` that deferred its
+# unroll, or a name resolve let through. TYPE_ERROR without a diagnostic, matching
+# how an unbound NAMED node behaves: resolve already reports a name that is not a
+# loop variable, and the deferred case is answered per instance rather than here.
+# ---
+# sc:   the context
+# ft:   the syntactic node's payload
+# span: the spelling's span, for diagnostics
+# ret:  the field's type, or TYPE_ERROR when no descriptor is bound
+fun resolve_type_field_type(sc: *context.SemaContext, ft: *atype.TypeFieldType, span: token.Span) type.TypeId {
+    val r: R.Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, ft.var_name);
+    if (R.is_err[intern.StrId, str](r)) { ret type.TYPE_ERROR; }
+    val got: O.Option[u32] = comptime.field_type_of_binding(sc.ctx, R.unwrap_ok[intern.StrId, str](r));
+    if (O.is_none[u32](got)) { ret type.TYPE_ERROR; }
+    ret O.unwrap[u32](got)::type.TypeId;
 }
 
 # NAMED: resolve the symbol the name refers to and map it to the type it names

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -706,6 +706,27 @@ pub fun emit_vec_insert(b: *Builder, vec: value.Value, lane: value.Value, value_
     ret R.ok[value.Value, str](value.instr(iid, vec.ty));
 }
 
+# emit a whole-vector build from its lanes (#2640)
+#
+# `lanes` values in lane order become the vector `ty`. Unlike `emit_vec_insert`
+# there is no operand vector to start from, which is the point: a vector literal has
+# no base, and the zero one an insert chain would need is not an expressible value.
+# ---
+# b:     the builder
+# ty:    the IRT_VECTOR result type
+# lanes: the lane values, in lane order
+# n:     the number of lanes, which must equal the vector type's lane count
+# ret:   the built vector value, or an error
+pub fun emit_vec_build(b: *Builder, ty: type.IrTypeId, lanes: *value.Value, n: u32) R.Result[value.Value, str] {
+    val res_iid: R.Result[id.InstructionId, str] = emit_raw(b, instruction.OP_VEC_BUILD, ty, lanes, n);
+    if (R.is_err[id.InstructionId, str](res_iid)) {
+        ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](res_iid));
+    }
+    val iid: id.InstructionId = R.unwrap_ok[id.InstructionId, str](res_iid);
+    b.fn.instrs[iid].aux_ty = ty;
+    ret R.ok[value.Value, str](value.instr(iid, ty));
+}
+
 # emit a phi node of type `ty` into the current block's phi list with no
 # incoming edges yet
 #

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -31,6 +31,7 @@ use std.types.string.str;
 
 use A: std.allocator;
 use R: std.types.result;
+use O: std.types.option;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
@@ -718,6 +719,32 @@ pub fun emit_vec_insert(b: *Builder, vec: value.Value, lane: value.Value, value_
 # n:     the number of lanes, which must equal the vector type's lane count
 # ret:   the built vector value, or an error
 pub fun emit_vec_build(b: *Builder, ty: type.IrTypeId, lanes: *value.Value, n: u32) R.Result[value.Value, str] {
+    # refuse a malformed build at CONSTRUCTION, not merely detect it later. the
+    # verifier's matching rule rides VC_TYPE_AGREE, which is opt-in alongside the
+    # other `repr` checks, so on an ordinary build it would not run at all - and a
+    # build whose arity disagrees with its vector lowers to a vector whose remaining
+    # lanes hold whatever the machine left there, which is a wrong ANSWER. the two
+    # layers are not redundant: this one makes the instruction unconstructible, the
+    # verifier's catches a later pass that rewrites the operands.
+    val ov: O.Option[*type.IrType] = type.get(?b.m.types, ty);
+    if (!O.is_some[*type.IrType](ov)) {
+        ret R.err[value.Value, str]("ir.builder: vector build result type does not resolve");
+    }
+    val v: *type.IrType = O.unwrap[*type.IrType](ov);
+    if (v.kind != type.IRT_VECTOR) {
+        ret R.err[value.Value, str]("ir.builder: vector build result type is not a vector");
+    }
+    if (n != v.data.vector_.lanes) {
+        ret R.err[value.Value, str]("ir.builder: vector build lane count does not match its vector type");
+    }
+    var li: u32 = 0;
+    for (li < n) {
+        if (lanes[li].ty != v.data.vector_.element) {
+            ret R.err[value.Value, str]("ir.builder: vector build lane type is not the vector's element type");
+        }
+        li = li + 1;
+    }
+
     val res_iid: R.Result[id.InstructionId, str] = emit_raw(b, instruction.OP_VEC_BUILD, ty, lanes, n);
     if (R.is_err[id.InstructionId, str](res_iid)) {
         ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](res_iid));

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -187,6 +187,26 @@ pub val OP_VEC_EXTRACT: InstrKind = 47;
 # the opcode composes in SSA and needs no aliasing story. The lane index is a
 # comptime constant, as for OP_VEC_EXTRACT.
 pub val OP_VEC_INSERT:  InstrKind = 48;
+# build a whole 128-bit vector from its lanes (#2640); operands are the lane values
+# in lane order, exactly `lanes` of them; `aux_ty` and the result type are the
+# vector type.
+#
+# This exists because a vector literal has no BASE to build from. The obvious
+# spelling - a chain of OP_VEC_INSERT starting from a zero or undef vector - needs
+# that zero to be an expressible vector VALUE, and it is not: VAL_CONST_NULL is a
+# null pointer and is also the debug salvage's optimized-out sentinel, VAL_CONST_AGG
+# exists only as a global's initializer, and a MIR operand immediate is an i64, so a
+# 128-bit constant cannot ride in one (#2700 is the missing mechanism). Taking the
+# lanes directly sidesteps the question: there is no base, so nothing has to be
+# materialized before the first lane is written.
+#
+# The alternative was to keep assembling a literal through memory, which is what
+# this replaces: an alloca, one gep and store per lane, and a whole-vector load, all
+# surviving `opt 2`. A target whose ISA has no native lane form has this expanded
+# back to exactly that memory shape by `me.pass.scalarize.expand_lane_ops`, so as
+# with OP_VEC_EXTRACT and OP_VEC_INSERT the opcode is universally available at the
+# IR level and only its LOWERING is a capability question.
+pub val OP_VEC_BUILD:   InstrKind = 49;
 
 # no-signed-wrap: the result is poison if signed overflow occurs
 pub val INSTR_FLAG_NSW:      u16 = 0x01;
@@ -320,6 +340,9 @@ pub fun op_is_secret_move(k: InstrKind) bool {
     # comptime-constant position, so it relocates the secret without indexing by it
     if (k == OP_VEC_EXTRACT) { ret true; }
     if (k == OP_VEC_INSERT)  { ret true; }
+    # assembling a vector from its lanes places each operand at a fixed position and
+    # computes nothing, so it relocates a secret exactly as insert does
+    if (k == OP_VEC_BUILD)   { ret true; }
     if (k == OP_PHI)         { ret true; }
     if (k == OP_CALL)        { ret true; }
     if (k == OP_RET)         { ret true; }

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -719,6 +719,7 @@ fun opcode_name(k: instruction.InstrKind) str {
     if (k == instruction.OP_INSERT)      { ret "insert"; }
     if (k == instruction.OP_VEC_EXTRACT) { ret "vec.extract"; }
     if (k == instruction.OP_VEC_INSERT)  { ret "vec.insert"; }
+    if (k == instruction.OP_VEC_BUILD)   { ret "vec.build"; }
     if (k == instruction.OP_PHI)         { ret "phi"; }
     if (k == instruction.OP_CALL)        { ret "call"; }
     if (k == instruction.OP_BR)          { ret "br"; }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1603,6 +1603,9 @@ fun arity_ok(k: instruction.InstrKind, operand_count: u32) bool {
     # vec.extract: [vector, lane]; vec.insert: [vector, lane, value].
     if (k == instruction.OP_VEC_EXTRACT) { ret operand_count == 2; }
     if (k == instruction.OP_VEC_INSERT)  { ret operand_count == 3; }
+    # one operand per lane, so the arity is the vector's lane count rather than a
+    # constant; the type-directed check in verify_vec_build owns it.
+    if (k == instruction.OP_VEC_BUILD)   { ret operand_count >= 1; }
     # gep: [base, idx0, ...]; at least the base.
     if (k == instruction.OP_GEP)  { ret operand_count >= 1; }
     # call: [callee, arg0, ...]; at least the callee.

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -743,6 +743,9 @@ fun check_type_agree(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid:
     if (k == instruction.OP_VEC_INSERT && ins.operand_count == 3) {
         if (!vector_lane_op_ok(m, ins)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
     }
+    if (k == instruction.OP_VEC_BUILD) {
+        if (!vector_build_ok(m, ins)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
+    }
     if (k == instruction.OP_LOAD && ins.operand_count >= 1) {
         if (!is_address_typed(m, ins.operands[0].ty)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
     }
@@ -958,6 +961,38 @@ fun vector_lane_op_ok(m: *ir.Module, ins: *instruction.Instruction) bool {
     # insert: the written lane is the element type and the result is the vector
     if (ins.operands[2].ty != v.data.vector_.element) { ret false; }
     ret ins.ty == vt;
+}
+
+# true when an OP_VEC_BUILD's operands agree with the vector it builds
+#
+# Exactly one operand per lane, each at the vector's ELEMENT type. Both halves are
+# fail-closed on purpose. A build with too few operands would otherwise lower to a
+# vector whose remaining lanes hold whatever the machine left there, and one with an
+# operand at the wrong width would produce a vector of the wrong total size - both
+# being wrong ANSWERS rather than crashes, which is the failure mode this repo keeps
+# finding. It is also not hypothetical for this opcode: a vector type whose lane
+# count and byte extent disagreed is exactly what #2697 was.
+#
+# The result type is the authority, not the operands: it is what the literal's own
+# type resolved to, so an operand list that disagrees with it is the thing in error.
+# ---
+# m:   the enclosing module
+# ins: the OP_VEC_BUILD instruction
+# ret: true when the arity and every operand type agree with the result vector
+fun vector_build_ok(m: *ir.Module, ins: *instruction.Instruction) bool {
+    val ov: O.Option[*type.IrType] = type.get(?m.types, ins.ty);
+    if (!O.is_some[*type.IrType](ov)) { ret false; }
+    val v: *type.IrType = O.unwrap[*type.IrType](ov);
+    if (v.kind != type.IRT_VECTOR) { ret false; }
+
+    if (ins.operand_count != v.data.vector_.lanes) { ret false; }
+
+    var i: u32 = 0;
+    for (i < ins.operand_count) {
+        if (ins.operands[i].ty != v.data.vector_.element) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # true when type id `ty` resolves to a type of kind `k` in the module's type table
@@ -1603,8 +1638,9 @@ fun arity_ok(k: instruction.InstrKind, operand_count: u32) bool {
     # vec.extract: [vector, lane]; vec.insert: [vector, lane, value].
     if (k == instruction.OP_VEC_EXTRACT) { ret operand_count == 2; }
     if (k == instruction.OP_VEC_INSERT)  { ret operand_count == 3; }
-    # one operand per lane, so the arity is the vector's lane count rather than a
-    # constant; the type-directed check in verify_vec_build owns it.
+    # one operand per lane, so the exact arity is the RESULT TYPE's lane count and
+    # cannot be checked without it; `vector_build_ok` below does that and the element
+    # type of every operand. this bound only rules out the degenerate empty build.
     if (k == instruction.OP_VEC_BUILD)   { ret operand_count >= 1; }
     # gep: [base, idx0, ...]; at least the base.
     if (k == instruction.OP_GEP)  { ret operand_count >= 1; }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3279,16 +3279,33 @@ fun lower_array_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R
     ret R.ok[value.Value, str](value.retype(slot, arr_ir));
 }
 
-# lower a full-arity vector literal `f32x4{a, b, c, d}` (#1965)
+# lower a full-arity vector literal `f32x4{a, b, c, d}` (#1965, #2640)
 #
-# The lanes are assembled through backing storage of the vector's OWN type and
-# loaded back as the vector value. Allocating `[lanes]elem` instead would have the
-# same 16-byte layout, but it makes the load a reinterpretation of the allocation
-# through its pointer: the slot is an array and the load reads a vector. A target
-# under a logical addressing model gives a pointer exactly one pointee type and has
-# no pointer bitcast, so it cannot express that at all (#2640). The lane gep and the
-# whole-vector load of a vector-typed slot are the same shape lane assignment onto a
-# `var` already lowers to, so nothing downstream is new.
+# Two shapes, chosen by a declared machine-model capability.
+#
+# A target that builds a whole vector from its lanes in one step (`has_vec_build` -
+# SPIR-V's OpCompositeConstruct) gets `OP_VEC_BUILD`: the literal is a VALUE, with no
+# alloca, no store and no load. Every other target keeps assembling it through
+# backing storage of the vector's OWN type, which is what this did before and is
+# byte-for-byte the same code below, so nothing about those targets changes.
+#
+# The capability is read HERE rather than legalized away in a later pass, and that is
+# deliberate. `OP_VEC_EXTRACT` / `OP_VEC_INSERT` are user-visible operations - `v[0]`
+# and `v[1] = x` - so they must exist in the IR whatever the target can encode, and
+# `me.pass.scalarize.expand_lane_ops` is what makes that true. A literal is not an
+# operation, it is a CONSTRUCTION, and how it is built is a free choice with no
+# source-level spelling to preserve. Choosing the representation where the choice is
+# actually made keeps the alternative from being introduced and then immediately
+# undone for four targets out of five. It is the same shape as the `flat_addressing`
+# gate on float address materialization (#2655).
+#
+# Why the storage form is not simply removed: the value form needs an
+# `OP_VEC_BUILD`, and the obvious alternative - an `OP_VEC_INSERT` chain from a zero
+# vector - is not expressible, because that zero would have to be a vector-typed
+# constant VALUE and there is none (#2700). Why the storage form allocates at the
+# vector's own type rather than `[lanes]elem`: the latter has the same 16-byte layout
+# but makes the load a reinterpretation of the allocation through its pointer, which
+# a logical-addressing target cannot express at all.
 # ---
 # ctx: per-module lowering context
 # eid: the vector-literal expression (supplies the vector type)
@@ -3308,6 +3325,28 @@ fun lower_vector_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) 
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
     val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
+
+    # the value form: the lanes are the operands, so they are evaluated into a small
+    # buffer first. 16 covers every shape, since a mach vector is 128 bits and its
+    # narrowest lane is 8.
+    if (ctx.tgt != nil && ctx.tgt.model.has_vec_build) {
+        if (e.data.vector_lit.elems_len > 16) {
+            ret R.err[value.Value, str]("lower: vector literal has more lanes than any 128-bit vector");
+        }
+        var lanes: [16]value.Value;
+        var li: u32 = 0;
+        for (li < e.data.vector_lit.elems_len) {
+            val lpool_ix: u32 = e.data.vector_lit.elems_start + li;
+            if (lpool_ix::usize >= ctx.a.expr_id_len) {
+                ret R.err[value.Value, str]("lower: vector literal element index out of range");
+            }
+            val lres: R.Result[value.Value, str] = lower_rvalue(ctx, ctx.a.expr_ids[lpool_ix]);
+            if (R.is_err[value.Value, str](lres)) { ret lres; }
+            lanes[li] = R.unwrap_ok[value.Value, str](lres);
+            li = li + 1;
+        }
+        ret builder.emit_vec_build(?ctx.builder, vec_ir, ?lanes[0], e.data.vector_lit.elems_len);
+    }
 
     val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, vec_ir, value.const_int(1, xty));
     if (R.is_err[value.Value, str](res_slot)) { ret res_slot; }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2142,6 +2142,31 @@ fun report_expr(ctx: *context.LowerContext, eid: id.ExprId, message: str) R.Resu
 # e:    the resolved call node
 # argc: number of call-site type arguments
 # ret:  the owned type-argument sequence (nil when argc is 0), or an error
+# the field type a `f.type` generic argument names, read from the active `$each`
+# binding (#2691)
+#
+# None for every other type spelling, which keeps the caller on its stamped-type
+# path unchanged. The lookup itself is `comptime.field_type_of_binding`, the same
+# one sema uses, so a descriptor resolved at sema and the same descriptor resolved
+# here cannot land on different fields.
+# ---
+# ctx: per-module lowering context
+# tid: the syntactic type node of one generic argument
+# ret: some(field type) for a `f.type` spelling, none otherwise
+fun field_type_arg_of(ctx: *context.LowerContext, tid: id.TypeId) O.Option[type.TypeId] {
+    val t_opt: O.Option[*atype.Type] = ast.get_type(ctx.a, tid);
+    if (O.is_none[*atype.Type](t_opt)) { ret O.none[type.TypeId](); }
+    val t: *atype.Type = O.unwrap[*atype.Type](t_opt);
+    if (t.kind != atype.TYPE_KIND_FIELD_TYPE) { ret O.none[type.TypeId](); }
+
+    val r: R.Result[intern.StrId, str] =
+        intern.intern_span(?ctx.s.interner, context.module_source(ctx), t.data.field_type.var_name);
+    if (R.is_err[intern.StrId, str](r)) { ret O.none[type.TypeId](); }
+    val got: O.Option[u32] = comptime.field_type_of_binding(ctx.ctx, R.unwrap_ok[intern.StrId, str](r));
+    if (O.is_none[u32](got)) { ret O.none[type.TypeId](); }
+    ret O.some[type.TypeId](O.unwrap[u32](got)::type.TypeId);
+}
+
 fun collect_call_type_args(ctx: *context.LowerContext, e: *expr.Expr, argc: u32) R.Result[*type.TypeId, str] {
     if (argc == 0) { ret R.ok[*type.TypeId, str](nil); }
 
@@ -2156,7 +2181,18 @@ fun collect_call_type_args(ctx: *context.LowerContext, e: *expr.Expr, argc: u32)
             A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
             ret R.err[*type.TypeId, str]("lower: call type-argument index out of range");
         }
-        var at: type.TypeId = context.type_resolved_of(ctx, ctx.a.type_ids[pool_ix]);
+        # `f.type` (#2691) has no single stamped answer: it names whichever field the
+        # enclosing `$each` is on, so it is read from the live binding here the same
+        # way it is at sema. this path is what a walk over `$fields(T)` for a generic
+        # `T` needs, since that unroll is deferred to monomorphization and runs here.
+        var at: type.TypeId = type.TYPE_ERROR;
+        val ft: O.Option[type.TypeId] = field_type_arg_of(ctx, ctx.a.type_ids[pool_ix]);
+        if (O.is_some[type.TypeId](ft)) {
+            at = O.unwrap[type.TypeId](ft);
+        }
+        or {
+            at = context.type_resolved_of(ctx, ctx.a.type_ids[pool_ix]);
+        }
         if (ctx.subst != nil && ctx.subst_len > 0) {
             at = generics.substitute(ctx.s, at, ctx.subst, ctx.subst_len);
         }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -290,6 +290,23 @@ pub rec RegClass {
 #                    derived: it is independent of both `has_v128` (an ISA can have
 #                    packed compute without a lane-access form) and of
 #                    `vector_compute_generic` (#2236)
+# has_vec_build:     true when the ISA builds a WHOLE vector from its lanes in one
+#                    step, so the back end selects `MIR_VEC_BUILD` directly (SPIR-V's
+#                    OpCompositeConstruct). false makes
+#                    `me.pass.scalarize.expand_vec_build` rewrite it to the vector's
+#                    memory image - a stack slot, one store per lane, and a
+#                    whole-vector load - which is exactly what a vector literal
+#                    lowered to before the opcode existed, so a target that declines
+#                    it is byte-identical to before (#2640).
+#
+#                    DELIBERATELY NOT `has_lane_ops`. Reading and writing one lane is
+#                    a different capability from constructing a whole vector: aarch64
+#                    has the first (UMOV / INS) and no single instruction for the
+#                    second, so it declines this while keeping lane access native.
+#                    Folding the two into one flag would force a per-lane `ins`
+#                    expansion into the aarch64 encoder to get anything at all, which
+#                    is a wider change than the literal needs and is a pure
+#                    improvement it can opt into later by flipping this one bit.
 # ct_trust_mul:      the single constant-time capability fact (#1646): true when the
 #                    ISA documents integer multiply as data-independent under its
 #                    hardware DIT mode (Arm PSTATE.DIT, Intel DOITM), so a secret
@@ -332,6 +349,7 @@ pub rec MachineModel {
     vector_bits:       u32;
     vector_compute_generic: bool;
     has_lane_ops:      bool;
+    has_vec_build:     bool;
     ct_trust_mul:      bool;
 
     # whether the ISA can shift by a RUNTIME count at all (#2217). false on a machine

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -8424,6 +8424,29 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_condi
     if (asm_ct_class(A64M_B, 0).cond_reg)  { bad = 1; }
     if (asm_ct_class(A64M_BL, 0).cond_reg) { bad = 1; }
 
+    # THE FLAGS MODEL IS VACUOUS HERE, AND THAT IS PINNED RATHER THAN ASSUMED
+    # (#2460). aarch64 has NZCV, so unlike riscv64 the absence of flag taint is a
+    # property of this GRAMMAR rather than of the architecture: no static row
+    # consumes a condition flag into a register, so no `defines_flags` fact on this
+    # target can ever clear a taint that anything observes.
+    #
+    # `b.<cond>` DOES read NZCV and arrives through the decode hook, where #2477
+    # gives it `cond_flags` - and `ct_check_item` refuses a `cond_flags` row on a
+    # tainted FLAGS, so that path stays closed. What this asserts is that nothing in
+    # the static table reads flags into a register the way x86-64's SETcc does.
+    #
+    # Adding an aarch64 `cset` / `csel` row later must therefore state `reads_flags`,
+    # and this test is what forces that to be a deliberate act rather than a silent
+    # widening on a target the x86-64 work never touched.
+    var fi: usize = 0;
+    for (fi < A64_MNEMONIC_COUNT) {
+        val fc: ct.AsmClass = asm_ct_class(A64_MNEMONICS[fi].code, A64_MNEMONICS[fi].flags);
+        if (fc.reads_flags)   { bad = 1; }
+        if (fc.defines_flags) { bad = 1; }
+        if (fc.opaque_flags)  { bad = 1; }
+        fi = fi + 1;
+    }
+
     # check (c) is near-vacuous HERE: no divide, multiply or float row exists, and the
     # register-count shifts are the only variable-latency shape.
     if (asm_ct_class(A64M_LSLV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -2159,6 +2159,10 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
     cursor_init(?c, g, body, nil, nil, nil, nil);
 
     var taint: u32 = 0;
+    # whether FLAGS currently holds a secret-derived value. a separate domain from
+    # the register bitmask because x86-64 conditions its branches on it and nothing
+    # in the register model represents it (#2460)
+    var flags_taint: bool = false;
     var item: Item;
     var done: bool = false;
     for (!done) {
@@ -2168,7 +2172,7 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
         }
         if (!R.unwrap_ok[bool, str](pr)) { done = true; }
         or {
-            val vr: R.Result[bool, str] = ct_check_item(g, body, ?item, ?taint, secret_names, n_secret, trust_mul, trust_shift);
+            val vr: R.Result[bool, str] = ct_check_item(g, body, ?item, ?taint, ?flags_taint, secret_names, n_secret, trust_mul, trust_shift);
             if (R.is_err[bool, str](vr)) { ret vr; }
         }
     }
@@ -2179,7 +2183,7 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
 #
 # Split out so the walk above reads as the loop it is. `taint` is updated in place:
 # an instruction that reads a secret taints the registers it writes.
-fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
+fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32, flags_taint: *bool,
                   secret_names: *str, n_secret: u32,
                   trust_mul: bool, trust_shift: bool) R.Result[bool, str] {
     if (item.kind == AI_LABEL) { ret R.ok[bool, str](true); }
@@ -2205,11 +2209,14 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
     val cls: ct.AsmClass = g.ct_class(item.code, item.flags);
     val reads_secret: bool = item_reads_secret(body, item, @taint, secret_names, n_secret);
 
-    # a conditional branch whose condition rides the flags register cannot be checked
-    # at all: the effect model represents no flags, so a preceding `cmp` of a secret
-    # is invisible here. refused whether or not this block carries a secret (#2460).
-    if (cls.cond_flags) {
-        ret R.err[bool, str]("contains a conditional branch inside an #[oblivious] inline-asm block; its condition rides the flags register, which this compiler's inline-asm effect model does not represent, so the branch cannot be verified constant-time (see issue #2460). use a branch-free sequence, or move the branch outside the #[oblivious] function");
+    # a conditional branch whose condition rides the flags register is refused when
+    # FLAGS holds a secret-derived value, and accepted otherwise. before #2460 the
+    # effect model represented no flags at all, so a preceding `cmp` of a secret was
+    # invisible and the whole family was refused outright; `flags_taint` is now
+    # tracked beside the register set, so a genuinely public compare-and-branch is
+    # admitted and only a secret-dependent one is refused.
+    if (cls.cond_flags && @flags_taint) {
+        ret R.err[bool, str]("branches on a secret value inside an #[oblivious] inline-asm block; its condition rides the flags register, which a preceding instruction filled from a secret, so the branch's timing reveals the secret. select branch-free over public data, or `:^`-declassify when disclosure is intended");
     }
 
     # (a) a register-conditioned branch on a secret leaks through the taken path.
@@ -2279,11 +2286,33 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32,
     # silently DROPPED, which is the fail-open direction. Every grammar here numbers
     # its general-purpose registers below 32, and a target that did not would need this
     # set widened before its bodies could be validated.
-    if (reads_secret) {
+    # an instruction that CONSUMES a tainted flag carries the secret out of FLAGS and
+    # into whatever it writes, so it folds exactly as one reading a secret register
+    # does. Without this a `setcc` launders a secret into a register the model then
+    # treats as public, and a later access indexed by it is accepted.
+    val secret_in: bool = reads_secret || (cls.reads_flags && @flags_taint);
+
+    if (secret_in) {
         @taint = @taint | item.implicit;
         if ((item.writes & AW_OP0) != 0 && item.nops > 0) { taint_written(?item.ops[0], taint); }
         if ((item.writes & AW_OP1) != 0 && item.nops > 1) { taint_written(?item.ops[1], taint); }
     }
+
+    # fold the FLAGS taint. the arms are ordered, and the order is the model:
+    #
+    #   opaque   - a flag value from memory, the stack, or a masked prior RFLAGS.
+    #              unconditional, because these rows carry no operands to condition
+    #              on and an operand-conditioned rule could never fire for them.
+    #   writes   - a MAY-write with a secret operand taints.
+    #   defines  - an unconditional overwrite of every observable flag, with public
+    #              operands, is the ONLY thing that clears.
+    #
+    # anything else leaves FLAGS unchanged, which is what `inc` / `dec` and the
+    # shifts need: they write some flags but not all, so they must neither clear a
+    # standing taint nor be treated as having refreshed it.
+    if (cls.opaque_flags)                        { @flags_taint = true; }
+    or (cls.writes_flags && secret_in)           { @flags_taint = true; }
+    or (cls.defines_flags && !secret_in)         { @flags_taint = false; }
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -6802,6 +6802,20 @@ test "mach.lang.target.isa.riscv64.encode.asm_ct_class:m_extension_is_variable_l
         if (asm_ct_class(RV_MNEMONICS[i].code, RV_MNEMONICS[i].flags).cond_flags) { bad = 1; }
         i = i + 1;
     }
+
+    # THE FLAGS MODEL IS VACUOUS HERE, AND THAT IS PINNED RATHER THAN ASSUMED
+    # (#2460). RISC-V has no flags register at all, so no row can read, define or
+    # opaquely load one, and every flags fact on this target is vacuously satisfied.
+    # Asserting it means a future row that somehow acquired one would fail here
+    # rather than pass by inheriting a model built for a different architecture.
+    var fi: usize = 0;
+    for (fi < RV_MNEMONIC_COUNT) {
+        val fc: ct.AsmClass = asm_ct_class(RV_MNEMONICS[fi].code, RV_MNEMONICS[fi].flags);
+        if (fc.reads_flags)   { bad = 1; }
+        if (fc.defines_flags) { bad = 1; }
+        if (fc.opaque_flags)  { bad = 1; }
+        fi = fi + 1;
+    }
     ret bad;
 }
 

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -72,6 +72,7 @@ pub val OP_STORE:               u32 = 62;
 pub val OP_ACCESS_CHAIN:        u32 = 65;
 pub val OP_DECORATE:            u32 = 71;
 pub val OP_MEMBER_DECORATE:     u32 = 72;
+pub val OP_COMPOSITE_CONSTRUCT: u32 = 80;
 pub val OP_COMPOSITE_EXTRACT:   u32 = 81;
 pub val OP_COMPOSITE_INSERT:    u32 = 82;
 pub val OP_CONVERT_F_TO_U:      u32 = 109;

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -2316,6 +2316,7 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # vector's memory image, which logical addressing cannot express.
     if (op == mir.MIR_VEC_EXTRACT) { ret emit_vec_extract(e, vm, preg_val, mi); }
     if (op == mir.MIR_VEC_INSERT)  { ret emit_vec_insert(e, vm, preg_val, mi); }
+    if (op == mir.MIR_VEC_BUILD)   { ret emit_vec_build(e, vm, preg_val, mi); }
 
     # integer width conversions: dst = convert(a), the source read as an integer.
     if (op == mir.MIR_TRUNC) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_U_CONVERT, false); }
@@ -2844,6 +2845,58 @@ fun emit_vec_insert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.
     var ops: [5]u32;
     ops[0] = vec_ty; ops[1] = result; ops[2] = lane; ops[3] = src; ops[4] = mi.operands[2].imm::u32;
     spirv.inst(e.b, ?e.b.functions, spirv.OP_COMPOSITE_INSERT, ?ops[0], 5);
+    ret store_vreg(e, vm, dst, result);
+}
+
+# emit an OpCompositeConstruct for a whole-vector build (#2640)
+#
+# The lanes are the operands, in lane order, and the result is the vector. This is
+# what a vector literal becomes here, and it is why the literal is not assembled
+# through storage on this target: the storage form loads a vector out of a slot it
+# stored lanes into, and under the logical addressing model a pointer has exactly one
+# pointee type with no bitcast between them, so there is no legal encoding of it.
+#
+# Every lane is read at the vector's ELEMENT type, which is also what types an
+# immediate lane: a bare bit pattern has no type of its own, and minting it against
+# the vector type would produce a vector-typed constant where a scalar belongs.
+# ---
+# e:        the emission state
+# vm:       the per-vreg value maps
+# preg_val: the identity convention's nominal register file
+# mi:       the MIR_VEC_BUILD instruction
+# ret:      true on success, or a precise error string
+fun emit_vec_build(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
+        ret R.err[bool, str]("spirv.emit: malformed vector build instruction");
+    }
+    val dst: u32 = mi.operands[0].vreg;
+    if (dst >= vm.n) { ret R.err[bool, str]("spirv.emit: vector build result vreg out of range"); }
+    val vec_ty: u32 = vm.type_id[dst];
+    if (vec_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
+    var lanes: u32 = 0;
+    val lane_ty: u32 = types.vector_shape(e.tt, vec_ty, ?lanes);
+    if (lane_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
+
+    val given: u32 = mi.operand_count - 1;
+    if (given != lanes) {
+        ret R.err[bool, str]("spirv.emit: vector build lane count does not match its vector type");
+    }
+    # 2 fixed words plus at most 4 lanes: a Shader module's vector holds no more,
+    # which `unsupported_ir_type` already refuses by name for the wider shapes.
+    if (given > 4) { ret unsupported(e, unsupported_value_type(e, mi)); }
+
+    var ops: [6]u32;
+    ops[0] = vec_ty;
+    val result: u32 = spirv.alloc_id(e.b);
+    ops[1] = result;
+    var i: u32 = 0;
+    for (i < given) {
+        ops[2 + i] = read_operand(e, vm, preg_val, ?mi.operands[1 + i], lane_ty);
+        i = i + 1;
+    }
+    if (e.b.err) { ret R.err[bool, str]("spirv.emit: unreadable operand in vector build"); }
+
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_COMPOSITE_CONSTRUCT, ?ops[0], 2 + given);
     ret store_vreg(e, vm, dst, result);
 }
 

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -100,6 +100,10 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # alternative - rewriting a lane read to the vector's memory image through a stack
     # slot - is not merely slower here but unencodable under logical addressing.
     spirv_model.has_lane_ops           = true;
+    # building a whole vector from its lanes is native too (`OpCompositeConstruct`),
+    # and for the same reason: the fallback assembles the vector through a stack slot,
+    # which logical addressing cannot express at all rather than merely slowly (#2640).
+    spirv_model.has_vec_build          = true;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     spirv_model.ct_trust_mul           = false;
     spirv_model.has_var_shift          = true;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -7796,28 +7796,49 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     if (code == x64.MOV::u32 || code == x64.MOVZX::u32 || code == x64.MOVSX::u32 ||
         code == x64.LEA::u32 || code == x64.PUSH::u32  || code == x64.POP::u32 ||
         code == x64.XCHG::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     # integer add / sub / bitwise / compare / test / neg / not / inc / dec, and the
     # SETcc byte materializers: fixed-latency on every x86-64 part.
+    #
+    # FLAGS: this family splits three ways, and the split is the security property
+    # (#2460). `defines_flags` is the only fact that CLEARS a taint, so it is set
+    # only where every observable flag - ZF and CF, the complete set this grammar
+    # can read - is written unconditionally, for every operand value.
     if (code == x64.ADD::u32 || code == x64.SUB::u32 || code == x64.AND::u32 ||
         code == x64.OR::u32  || code == x64.XOR::u32 || code == x64.CMP::u32 ||
-        code == x64.TEST::u32 || code == x64.NEG::u32 || code == x64.NOT::u32 ||
-        code == x64.INC::u32 || code == x64.DEC::u32 ||
-        code == x64.SETB::u32 || code == x64.SETAE::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        code == x64.TEST::u32 || code == x64.NEG::u32) {
+        ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # `inc` / `dec` write every status flag EXCEPT CF, which this grammar reads
+    # through `jc` / `jnc` / `setc`. So they may taint and must never clear: a `jc`
+    # after a secret `cmp` and a public `inc` still reads a secret-derived CF.
+    if (code == x64.INC::u32 || code == x64.DEC::u32) {
+        ret ct.flags_written(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # `not` writes no flag at all, unlike every one of its bitwise siblings.
+    if (code == x64.NOT::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # the SETcc byte materializers CONSUME CF into a register. That makes the
+    # destination secret-derived whenever FLAGS is tainted, which is what stops a
+    # secret being laundered out of FLAGS and used as a memory index.
+    if (code == x64.SETB::u32 || code == x64.SETAE::u32) {
+        ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
     }
     # the shifts: variable-latency ONLY through a register (`cl`) count, which is the
     # single variable-latency form this grammar can express. the shared gate reads the
     # COUNT operand alone (`ct.ct_op_gates_count_only`), so a constant-count shift of a
     # secret value stays constant-time.
     if (code == x64.SHL::u32 || code == x64.SHR::u32 || code == x64.SAR::u32) {
-        ret ct.asm_op(ct.CT_OP_VAR_SHIFT);
+        ret ct.flags_written(ct.asm_op(ct.CT_OP_VAR_SHIFT));
     }
     # atomics and fences: see the conditional row above.
-    if (code == x64.CMPXCHG::u32 || code == x64.XADD::u32 ||
-        code == x64.MFENCE::u32  || code == x64.PAUSE::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+    if (code == x64.CMPXCHG::u32 || code == x64.XADD::u32) {
+        ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
+    }
+    if (code == x64.MFENCE::u32 || code == x64.PAUSE::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     # PORT I/O AND THE PRIVILEGED SET (#2468). None of these has an operand-dependent
     # latency, which is what `CtOp` classifies, so all are CT_OP_NONE - but two deserve
@@ -7846,20 +7867,39 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
     # not through the exchange. The two system-register moves are data movement at fixed
     # latency, and WHICH register each names is part of the instruction word rather than
     # an operand, so it can never be secret.
+    #
+    # FLAGS: `cld` / `cli` / `sti` write DF and IF, which nothing in this grammar
+    # reads, so they neither taint nor clear. The rest of this group writes no flag.
     if (code == x64.IN::u32    || code == x64.OUT::u32   || code == x64.CLI::u32 ||
         code == x64.STI::u32   || code == x64.LIDT::u32  || code == x64.RDTSC::u32 ||
         code == x64.RDMSR::u32 || code == x64.WRMSR::u32 || code == x64.CLD::u32 ||
-        code == x64.PUSHFQ::u32 || code == x64.POPFQ::u32 || code == x64.IRETQ::u32 ||
         code == x64.SWAPGS::u32 || code == x64.MOV_CR::u32 || code == x64.MOV_SEG::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # UNMODELED FLAG SOURCES. `popfq` loads FLAGS from the stack and `iretq` from the
+    # interrupt frame - memory this model does not represent - and `syscall` masks
+    # the EXISTING RFLAGS through IA32_FMASK, so a standing taint survives it.
+    #
+    # These taint UNCONDITIONALLY rather than on a secret operand, because all three
+    # carry NO operands: an operand-conditioned rule is structurally unable to fire
+    # for them, so setting `writes_flags` alone would read as correct in the table
+    # and never once take effect.
+    if (code == x64.POPFQ::u32 || code == x64.IRETQ::u32 || code == x64.SYSCALL::u32) {
+        ret ct.flags_opaque(ct.asm_op(ct.CT_OP_NONE));
+    }
+    # `pushfq` moves FLAGS the other way, into memory. The register-only taint model
+    # cannot follow it there, which is the same boundary that leaves `mov [rsp],
+    # {secret}` untracked; it is not specific to flags and #2460 does not change it.
+    # It writes no flag, so it neither taints nor clears.
+    if (code == x64.PUSHFQ::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
 
     # control transfer with no condition: the target is public by construction (a
     # symbol or a numeric local label), so it reveals nothing about a secret.
     if (code == x64.JMP::u32 || code == x64.CALL::u32 || code == x64.RET::u32 ||
-        code == x64.SYSCALL::u32 || code == x64.NOP::u32 || code == x64.HLT::u32 ||
-        code == x64.UD2::u32) {
-        ret ct.asm_op(ct.CT_OP_NONE);
+        code == x64.NOP::u32 || code == x64.HLT::u32 || code == x64.UD2::u32) {
+        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     # every conditional jump: refused, per the flags note above.
     if (code == x64.JE::u32  || code == x64.JNE::u32 || code == x64.JB::u32 ||
@@ -7884,6 +7924,140 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_is_classifi
         if (!cls.known) { bad = 1; }
         i = i + 1;
     }
+    ret bad;
+}
+
+# every mnemonic the x86-64 grammar admits states its flags facts
+#
+# The twin of `every_grammar_row_is_classified`, in the same shape and for the same
+# reason (#2460). The DEFAULTS already fail safe - an unstated row taints on secret
+# operands and never clears - so a forgotten row cannot leak. What it can do is
+# refuse silently and imprecisely, and a row nobody considered is indistinguishable
+# from a row someone considered and got wrong. This makes adding one a test failure.
+#
+# To see it fail, add a grammar row whose `asm_ct_class` arm omits a flags
+# constructor: `ct.asm_op(...)` alone leaves `flags_stated` false.
+test "mach.lang.target.isa.x64.encode.asm_ct_class:every_grammar_row_states_flags" {
+    var bad: i32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
+        if (!cls.flags_stated) { bad = 1; }
+        # `defines_flags` is the fact that CLEARS, so it may never stand alone: a row
+        # that clears without writing is incoherent, and the constructors cannot
+        # produce it. Pinned so a hand-built AsmClass cannot either.
+        if (cls.defines_flags && !cls.writes_flags) { bad = 1; }
+        i = i + 1;
+    }
+    ret bad;
+}
+
+# the set of rows that can read an observable flag is EXACTLY these fifteen
+#
+# `defines_flags` is decidable only because the observable flag set is ZF and CF.
+# Adding `jo` or `js` to this grammar would widen that set, and the meaning of
+# `defines_flags` would change underneath every row already classified - each of
+# which would silently become potentially wrong, with nothing failing anywhere.
+#
+# So the reader set is pinned by NAME here rather than counted. Adding a sixteenth
+# reader is then a deliberate act that breaks this test and forces the ten
+# `defines_flags` rows to be re-justified against the wider set, which is exactly
+# the review that must not be skipped.
+test "mach.lang.target.isa.x64.encode.asm_ct_class:flag_reader_set_is_exactly_fifteen" {
+    var readers: [15]str;
+    readers[0]  = "je";   readers[1]  = "jz";   readers[2]  = "jne";
+    readers[3]  = "jnz";  readers[4]  = "jc";   readers[5]  = "jb";
+    readers[6]  = "jnc";  readers[7]  = "jae";  readers[8]  = "jnb";
+    readers[9]  = "setc"; readers[10] = "setb"; readers[11] = "setnc";
+    readers[12] = "setae"; readers[13] = "setnb"; readers[14] = "pushfq";
+
+    var bad: i32 = 0;
+    var found: u32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val nm: str = X64_MNEMONICS[i].name;
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
+        val is_reader: bool = cls.cond_flags || cls.reads_flags;
+
+        var listed: bool = false;
+        var j: usize = 0;
+        for (j < 15) {
+            if (str_equals(nm, readers[j])) { listed = true; }
+            j = j + 1;
+        }
+        # `pushfq` is listed because it reads every flag, but it reads them into
+        # MEMORY, which the register-only taint model cannot follow - so it is a
+        # reader the classification cannot mark, and the asymmetry is deliberate.
+        if (str_equals(nm, "pushfq")) {
+            if (is_reader) { bad = 1; }
+            found = found + 1;
+        }
+        or {
+            if (is_reader && !listed)  { bad = 1; }
+            if (!is_reader && listed)  { bad = 1; }
+            if (listed) { found = found + 1; }
+        }
+        i = i + 1;
+    }
+    if (found != 15) { bad = 1; }
+    ret bad;
+}
+
+# the rows that can wrongly PERMIT are exactly the fifteen named here
+#
+# With the defaults inverted, an unconsidered row fails safe: it taints and never
+# clears. Only two facts can turn a leak into a passing build - `defines_flags`,
+# which clears a taint, and `opaque_flags`, whose absence lets an unmodeled flag
+# source go untracked. This pins that surface so it stays small and reviewable.
+#
+# THIS IS THE AUDIT LIST. No row's facts in this file have been verified against
+# the Intel SDM; every one is inferred. These thirteen instructions are the bounded
+# set someone with the manual has to check, and the test exists so it cannot grow
+# quietly. The two questions are: does each `defines_flags` instruction write BOTH
+# ZF and CF unconditionally, and are those three the complete set of unmodeled flag
+# sources in this grammar?
+test "mach.lang.target.isa.x64.encode.asm_ct_class:permitting_surface_is_bounded" {
+    var bad: i32 = 0;
+    var defines: u32 = 0;
+    var opaque: u32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val cls: ct.AsmClass = asm_ct_class(X64_MNEMONICS[i].code, X64_MNEMONICS[i].flags);
+        if (cls.defines_flags) { defines = defines + 1; }
+        if (cls.opaque_flags)  { opaque  = opaque + 1; }
+        i = i + 1;
+    }
+    # add sub cmp test and or xor neg cmpxchg xadd, plus the `lock cmpxchg` and
+    # `lock xadd` rows, which are prefixed spellings of two of those ten and define
+    # flags identically. So fifteen ROWS carry thirteen distinct instructions, and
+    # the audit below is over the instructions rather than the spellings.
+    if (defines != 12) { bad = 1; }
+    # popfq iretq syscall
+    if (opaque != 3) { bad = 1; }
+
+    if (!asm_ct_class(x64.ADD::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.SUB::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.CMP::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.TEST::u32, 0).defines_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.AND::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.OR::u32, 0).defines_flags)      { bad = 1; }
+    if (!asm_ct_class(x64.XOR::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.NEG::u32, 0).defines_flags)     { bad = 1; }
+    if (!asm_ct_class(x64.CMPXCHG::u32, 0).defines_flags) { bad = 1; }
+    if (!asm_ct_class(x64.XADD::u32, 0).defines_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.POPFQ::u32, 0).opaque_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.IRETQ::u32, 0).opaque_flags)    { bad = 1; }
+    if (!asm_ct_class(x64.SYSCALL::u32, 0).opaque_flags)  { bad = 1; }
+
+    # THE TRAPS, pinned negatively. Each of these is a row a two-fact model, or a
+    # careless reading of "writes flags", would let clear a taint.
+    if (asm_ct_class(x64.INC::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.DEC::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.SHL::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.SHR::u32, 0).defines_flags) { bad = 1; }
+    if (asm_ct_class(x64.SAR::u32, 0).defines_flags) { bad = 1; }
+    if (!asm_ct_class(x64.INC::u32, 0).writes_flags) { bad = 1; }
+    if (!asm_ct_class(x64.SHL::u32, 0).writes_flags) { bad = 1; }
     ret bad;
 }
 

--- a/tools/ct-flags-mutate.py
+++ b/tools/ct-flags-mutate.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Mutation harness for the #[oblivious] inline-asm flags facts (#2460).
+
+For every row of the x86-64 grammar, flip one flags fact in the direction that
+would let a leak through, and assert the suite notices. A mutation the suite does
+NOT notice is a fact nothing depends on, which is indistinguishable from a fact
+that is wrong.
+
+Run from the repo root:
+
+    python3 tools/ct-flags-mutate.py
+
+It rewrites `x64/encode.mach` once per mutation by renaming the shipping
+classifier and wrapping it, then restores the file byte-for-byte. The pristine
+copy lives outside the tree so an interrupted run cannot leave a mutated
+classifier staged. Takes roughly 10 minutes: one full `mach test .` per
+applicable mutation.
+
+WHAT THIS PROVES, AND WHAT IT DOES NOT. It shows each fact is load-bearing: some
+test observes it. It does NOT show any fact is TRUE — a row that is confidently
+wrong in a self-consistent way passes every mutation here. Truth is measured
+separately, against the CPU, by `int/surface/ct-flags-hardware`.
+
+TWO MODES, AND THE DEFAULT IS THE HONEST ONE.
+
+Three unit tests in `x64/encode.mach` assert the facts DIRECTLY - they read
+`defines_flags` and friends off the classifier and check them. With those active
+almost every mutation dies, but most of those kills are the table catching a
+change to itself, which says nothing about whether the walk depends on the fact.
+
+    --behavioural   (default) stub those tests out in the pristine copy, so a
+                    mutation can only be caught by a test that observes the
+                    COMPILER'S VERDICT on a program. This is the number to report.
+    --with-asserts  leave them in. Useful only to confirm the fact-pinning tests
+                    themselves still work.
+
+On the shipping tree these differ sharply: 56 killed behaviourally versus nearly
+everything with the assertions in. If you find yourself reporting the larger
+number, you are reporting that the table agrees with itself.
+
+Read the survivor list, never just the count. A survivor is either a structural
+impossibility (fine, and the three classes are named in the PR for #2460) or a
+gap in the tests (not fine). They look identical from the outside, and the only
+way to tell is to work out why no program could observe it.
+"""
+import subprocess, shutil, sys, os
+
+W = os.environ.get("MACH_ROOT", os.getcwd())
+SRC = W + "/src/lang/target/isa/x64/encode.mach"
+# the untouched copy every mutation is built from, and what SRC is restored to.
+# written beside the run rather than in the tree, so an interrupted run cannot
+# leave a mutated classifier committed.
+PRISTINE = os.environ.get("CT_PRISTINE", "/tmp/ct-flags-pristine.mach")
+# the mutation BASE (possibly with fact-asserting tests stubbed) and the byte-exact
+# ORIGINAL are two different files. Restoring the tree from the base would delete
+# whatever the base stubbed out, which is a silent edit to the shipped source.
+ORIGINAL = PRISTINE + ".orig"
+
+DEFINES = "ADD SUB AND OR XOR CMP TEST NEG CMPXCHG XADD".split()
+WRITTEN = "INC DEC SHL SHR SAR".split()
+OPAQUE  = "POPFQ IRETQ SYSCALL".split()
+READ    = "SETB SETAE".split()
+BRANCH  = "JE JNE JB JAE".split()
+# every ROW of the shipping grammar, name -> code. rows outnumber codes: `jz` and
+# `je` are one instruction under two spellings, and both are mutated, because the
+# bar is stated per row.
+ROWS = [l.strip().split("|") for l in
+        subprocess.run(["python3","-c","""
+import re,sys
+t=open(sys.argv[1]).read()
+for m in re.finditer(r'name: *"([a-z0-9 _]+)", *code: *x64\\.([A-Z0-9_]+)', t):
+    print(m.group(1)+"|"+m.group(2))
+""", SRC], capture_output=True, text=True).stdout.splitlines() if l.strip()]
+
+def facts(code):
+    """the facts the shipping classifier sets for a code, so a mutation that cannot
+    change anything is reported as a no-op rather than counted as a survivor."""
+    if code in DEFINES: return dict(writes=1, defines=1, opaque=0, reads=0)
+    if code in WRITTEN: return dict(writes=1, defines=0, opaque=0, reads=0)
+    if code in OPAQUE:  return dict(writes=1, defines=0, opaque=1, reads=0)
+    if code in READ:    return dict(writes=0, defines=0, opaque=0, reads=1)
+    return dict(writes=0, defines=0, opaque=0, reads=0)
+
+MUT = {
+    # the row stops tainting: catches a fact that must taint
+    "no_taint":    "a.writes_flags = false; a.opaque_flags = false;",
+    # the row starts clearing: catches a fact that must NOT clear (unsound direction)
+    "force_clear": "a.writes_flags = true; a.defines_flags = true;",
+    # the row stops propagating out of FLAGS: catches the setcc laundering guard
+    "no_read":     "a.reads_flags = false;",
+    # the row stops clearing: catches a clear nothing relies on
+    "no_clear":    "a.defines_flags = false;",
+}
+
+def plan():
+    """the full 60-row x 3-fact grid the issue states as the bar.
+
+    Each row gets one mutation per falsifiable fact:
+      no_taint    - stop tainting        (writes_flags / opaque_flags -> off)
+      force_clear - start clearing       (defines_flags -> on)
+      no_read     - stop propagating     (reads_flags -> off)
+    A mutation that cannot change the class for that row is a NO-OP, reported as
+    such: counting it either way would misstate the evidence."""
+    out = []
+    for name, code in ROWS:
+        f = facts(code)
+        out.append((name, code, "no_taint",    bool(f["writes"] or f["opaque"])))
+        out.append((name, code, "force_clear", not f["defines"]))
+        out.append((name, code, "no_read",     bool(f["reads"])))
+    return out
+
+def apply(code, mut):
+    t = open(PRISTINE).read()
+    assert "pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {" in t
+    t = t.replace("pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {",
+                  "fun asm_ct_class_mutated_base(code: u32, flags: u16) ct.AsmClass {", 1)
+    wrapper = (
+        "pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {\n"
+        "    var a: ct.AsmClass = asm_ct_class_mutated_base(code, flags);\n"
+        "    if (code == x64.%s::u32) { %s }\n"
+        "    ret a;\n"
+        "}\n\n" % (code, MUT[mut])
+    )
+    t = wrapper + t if False else t.replace(
+        "fun asm_ct_class_mutated_base(code: u32, flags: u16) ct.AsmClass {",
+        wrapper + "fun asm_ct_class_mutated_base(code: u32, flags: u16) ct.AsmClass {", 1)
+    open(SRC, "w").write(t)
+
+def run():
+    r = subprocess.run(["mach", "test", "."], cwd=W, capture_output=True, text=True)
+    return r.returncode == 0   # True == suite green == mutation SURVIVED
+
+# Take the pristine copy from the tree at startup, and refuse to run if the tree is
+# already mutated - a previous run that died mid-mutation would otherwise have its
+# wrapper baked into the baseline, and every subsequent result would be measured
+# against a classifier nobody wrote.
+BEHAVIOURAL = "--with-asserts" not in sys.argv
+
+# the tests that assert the facts directly rather than observing a verdict
+FACT_TESTS = ["permitting_surface_is_bounded",
+              "flag_reader_set_is_exactly_fifteen",
+              "every_grammar_row_states_flags"]
+
+_src = open(SRC).read()
+if "asm_ct_class_mutated_base" in _src:
+    sys.exit("refusing to start: %s still carries a mutation wrapper.\n"
+             "restore it (git checkout) before running." % SRC)
+
+if BEHAVIOURAL:
+    for _n in FACT_TESTS:
+        _h = 'test "mach.lang.target.isa.x64.encode.asm_ct_class:%s" {' % _n
+        _i = _src.index(_h)
+        _j = _src.index("\n}\n", _src.index("ret ", _i)) + 3
+        _src = _src[:_i] + _h + "\n    ret 0;\n}\n" + _src[_j:]
+open(ORIGINAL, "w").write(open(SRC).read())
+open(PRISTINE, "w").write(_src)
+print("mode: %s" % ("behavioural (fact-asserting tests stubbed)" if BEHAVIOURAL
+                    else "with-asserts"), flush=True)
+
+killed, survived, noop = [], [], []
+tasks = plan()
+print("grid: %d mutations (%d rows x 3 facts)" % (len(tasks), len(ROWS)), flush=True)
+for i, (name, code, mut, applicable) in enumerate(tasks):
+    if not applicable:
+        noop.append((name, mut)); continue
+    apply(code, mut)
+    green = run()
+    (survived if green else killed).append((name, mut))
+    print("[%3d/%3d] %-14s %-12s %s" % (i+1, len(tasks), name, mut,
+          "SURVIVED" if green else "killed"), flush=True)
+shutil.copy(ORIGINAL, SRC)
+
+print("\n=== RESULT ===")
+print("grid:      %d" % len(tasks))
+print("applicable:%d" % (len(killed)+len(survived)))
+print("killed:    %d" % len(killed))
+print("survived:  %d" % len(survived))
+print("no-op:     %d  (fact not set on that row; the mutation changes nothing)" % len(noop))
+for n, m in survived:
+    print("  SURVIVOR %-14s %s" % (n, m))


### PR DESCRIPTION
Integration merge for 4.14.0.

Carries `f.type` as a generic type argument (#2691), `OP_VEC_BUILD` (#2640), condition-flag modeling in the asm effect model (#2460), and the mach-std 0.25.0 lock bump (#2710).

Cut because 4.13.0 was tagged seventeen minutes before #2709 merged, so it does not carry #2691 and `mach-std#449` cannot build against it.