### PR TITLE
test(ct): tie the measured flags facts to the classifier

### DIFF
--- a/int/surface/ct-flags-hardware/expect.txt
+++ b/int/surface/ct-flags-hardware/expect.txt
@@ -8,6 +8,8 @@ xor ZF:defined CF:defined reads:0
 neg ZF:defined CF:defined reads:0
 neg0 ZF:defined CF:defined reads:0
 xadd ZF:defined CF:defined reads:0
+cmpxchgeq ZF:defined CF:defined reads:0
+cmpxchgne ZF:defined CF:defined reads:0
 inc ZF:defined CF:preserved reads:0
 dec ZF:defined CF:preserved reads:0
 shl1 ZF:defined CF:defined reads:0

--- a/int/surface/ct-flags-hardware/probe.c
+++ b/int/surface/ct-flags-hardware/probe.c
@@ -27,7 +27,7 @@
          __asm__ volatile ("push %[p]\n\tpopfq\n\t" INSN                       \
                            "\n\tpushfq\n\tpop %[o]"                            \
              : [o]"=&r"(_o), [d]"+r"(_d), [x]"+r"(_a), [y]"+r"(_b)             \
-             : [p]"r"((uint64_t)(PRE)) : "cc", "memory");                      \
+             : [p]"r"((uint64_t)(PRE)) : "cc", "memory", "rax");                      \
          (OUTF) = _o; (OUTD) = _d; } while (0)
 
 static const char *verdict(uint64_t hi, uint64_t lo, uint64_t bit) {
@@ -59,6 +59,12 @@ void ct_flags_probe(void) {
     W2("neg",     "neg %[x]",                  5, 0);
     W2("neg0",    "neg %[x]",                  0, 0);
     W2("xadd",    "xadd %[y], %[x]",           5, 3);
+    /* cmpxchg compares RAX against the destination, so RAX is part of the input and
+       both outcomes must be measured: the equal path stores the source and sets ZF,
+       the not-equal path loads the destination into RAX and clears it. A row that
+       defined flags on only one of its two paths would not be a definer at all. */
+    W2("cmpxchgeq", "mov %[x], %%rax\n\tcmpxchg %[y], %[x]", 5, 3);
+    W2("cmpxchgne", "mov $9, %%rax\n\tcmpxchg %[y], %[x]",   5, 3);
 
     /* the traps: partial writers that must NOT be read as defining */
     W2("inc",     "inc %[x]",                  5, 0);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -8061,6 +8061,176 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:permitting_surface_is_bounded
     ret bad;
 }
 
+# one row of `int/surface/ct-flags-hardware`'s golden, transcribed
+#
+# ---
+# code:   the grammar code the measured mnemonic belongs to
+# zf_def: the probe measured ZF as DEFINED rather than preserved
+# cf_def: the probe measured CF as DEFINED rather than preserved
+# reads:  the probe measured a destination difference between the two flag presets
+rec ProbedRow {
+    code:   u32;
+    zf_def: bool;
+    cf_def: bool;
+    reads:  bool;
+}
+
+fun probed(code: u32, zf: bool, cf: bool, reads: bool) ProbedRow {
+    var r: ProbedRow;
+    r.code = code; r.zf_def = zf; r.cf_def = cf; r.reads = reads;
+    ret r;
+}
+
+# what the CPU measured, transcribed from int/surface/ct-flags-hardware/expect.txt
+#
+# TRANSCRIBED, NOT COMPUTED. The int case runs the probe and diffs its own golden;
+# this array is a copy of that golden's verdicts, and copying is the one manual
+# step in the chain. A wrong copy is caught the next time the probe runs and its
+# golden disagrees, so the error is bounded and loud rather than silent.
+#
+# Several instructions appear more than once under different operands, and that is
+# the point for the count-dependent rows: `shl` at count 1 defines both flags and
+# at count 0 defines neither, so a single measurement of it would be a fact about
+# one operand rather than about the instruction.
+fun probed_rows(out: *ProbedRow) u32 {
+    out[0]  = probed(x64.ADD::u32,     true,  true,  false);
+    out[1]  = probed(x64.SUB::u32,     true,  true,  false);
+    out[2]  = probed(x64.CMP::u32,     true,  true,  false);
+    out[3]  = probed(x64.TEST::u32,    true,  true,  false);
+    out[4]  = probed(x64.AND::u32,     true,  true,  false);
+    out[5]  = probed(x64.OR::u32,      true,  true,  false);
+    out[6]  = probed(x64.XOR::u32,     true,  true,  false);
+    out[7]  = probed(x64.NEG::u32,     true,  true,  false);   # operand 5
+    out[8]  = probed(x64.NEG::u32,     true,  true,  false);   # operand 0, the CF edge
+    out[9]  = probed(x64.XADD::u32,    true,  true,  false);
+    out[10] = probed(x64.CMPXCHG::u32, true,  true,  false);   # equal path
+    out[11] = probed(x64.CMPXCHG::u32, true,  true,  false);   # not-equal path
+    out[12] = probed(x64.INC::u32,     true,  false, false);   # CF PRESERVED
+    out[13] = probed(x64.DEC::u32,     true,  false, false);   # CF PRESERVED
+    out[14] = probed(x64.SHL::u32,     true,  true,  false);   # count 1
+    out[15] = probed(x64.SHL::u32,     false, false, false);   # count 0, writes nothing
+    out[16] = probed(x64.SHR::u32,     false, false, false);   # count 0
+    out[17] = probed(x64.SAR::u32,     false, false, false);   # count 0
+    out[18] = probed(x64.NOT::u32,     false, false, false);
+    out[19] = probed(x64.MOV::u32,     false, false, false);
+    out[20] = probed(x64.LEA::u32,     false, false, false);
+    out[21] = probed(x64.XCHG::u32,    false, false, false);
+    out[22] = probed(x64.SETB::u32,    false, false, true);    # consumes CF
+    out[23] = probed(x64.SETAE::u32,   false, false, true);    # consumes CF
+    out[24] = probed(x64.JB::u32,      false, false, false);   # `jc`: see below
+    ret 25;
+}
+
+# the classification agrees with what the CPU does (#2460)
+#
+# The hardware case measures; this is what makes the measurement bear on the model.
+# Without it the golden and `asm_ct_class` agree by transcription and nothing forces
+# them to keep agreeing - two lists that happen to match today.
+#
+# EVERY ASSERTION IS A REFUTATION, and the one-sidedness is deliberate. The probe
+# runs an instruction on ONE set of operands; `defines_flags` claims something about
+# EVERY set. So a measurement can refute the fact and cannot confirm it:
+#
+#   measured NOT defining  ->  `defines_flags` must be FALSE   (a counterexample)
+#   measured defining      ->  says nothing; the fact may be false conservatively
+#
+# `shl` is why that matters rather than being pedantry: it measures as defining both
+# flags at count 1 and neither at count 0. Reading "measured defining" as "is a
+# definer" would classify it from the first measurement and reintroduce the exact
+# unsoundness this issue exists to close.
+#
+# The same shape holds for the other two facts. A measured read must be modelled,
+# because an unmodelled one is the laundering hole; an unmeasured read proves
+# nothing, since `jc` reads CF and leaves no register difference to see.
+test "mach.lang.target.isa.x64.encode.asm_ct_class:agrees_with_measured_hardware" {
+    var rows: [25]ProbedRow;
+    val n: u32 = probed_rows(?rows[0]);
+
+    var bad: i32 = 0;
+    var i: u32 = 0;
+    for (i < n) {
+        val r: *ProbedRow = ?rows[i];
+        val cls: ct.AsmClass = asm_ct_class(r.code, 0);
+
+        # a measured counterexample to "defines every observable flag" refutes
+        # `defines_flags`. this is the assertion that catches the `inc` / `dec` and
+        # count-0 shift unsoundness from the measurement rather than from a reading.
+        if (!(r.zf_def && r.cf_def) && cls.defines_flags) { bad = 1; }
+
+        # a measured flag write must be modelled as one: `writes_flags` false on a
+        # row the CPU shows writing would fail to taint on secret operands.
+        if ((r.zf_def || r.cf_def) && !cls.writes_flags) { bad = 1; }
+
+        # a measured read must be modelled, or the row launders a secret out of
+        # FLAGS into a register the walk then treats as public.
+        if (r.reads && !cls.reads_flags) { bad = 1; }
+
+        i = i + 1;
+    }
+    ret bad;
+}
+
+# every row on the permitting surface is either MEASURED or explicitly exempt
+#
+# The agreement test above checks the rows the probe covers. This checks that the
+# probe covers the rows that matter, which is the half that keeps the two lists
+# from drifting: without it, a grammar row added later with `defines_flags` and no
+# probe entry passes everything. `every_grammar_row_states_flags` would force it to
+# state a fact, and nothing would check the fact against the hardware.
+#
+# The exempt set is the three `opaque_flags` rows, and the exemption is not a
+# convenience. `popfq` PASSES the writer probe as "defines both" - the incoming
+# flags genuinely do not affect the result - and that answer is correct on its own
+# terms and wrong as a classification, because the value came from the stack.
+# Measuring them harder cannot help: `defines_flags` asks whether the flags were
+# overwritten FROM THIS INSTRUCTION'S OWN OPERANDS, and where a value came from is
+# structural. They are classified by reasoning, and this test pins that the exempt
+# set is exactly those three rather than a place to put anything inconvenient.
+#
+# To see it fail, give a new row `defines_flags` without adding it to `probed_rows`.
+test "mach.lang.target.isa.x64.encode.asm_ct_class:every_permitting_row_is_measured" {
+    var rows: [25]ProbedRow;
+    val n: u32 = probed_rows(?rows[0]);
+
+    var bad: i32 = 0;
+    var covered: u32 = 0;
+    var exempt: u32 = 0;
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val code: u32 = X64_MNEMONICS[i].code;
+        val cls: ct.AsmClass = asm_ct_class(code, X64_MNEMONICS[i].flags);
+
+        # the permitting surface: the facts that can turn a leak into a passing
+        # build. `writes_flags` is not among them - it only ever refuses more.
+        if (cls.defines_flags || cls.opaque_flags || cls.reads_flags) {
+            if (cls.opaque_flags) {
+                # exempt, and only these three may be
+                if (code != x64.POPFQ::u32 && code != x64.IRETQ::u32
+                    && code != x64.SYSCALL::u32) { bad = 1; }
+                exempt = exempt + 1;
+            }
+            or {
+                var found: bool = false;
+                var j: u32 = 0;
+                for (j < n) {
+                    if (rows[j].code == code) { found = true; }
+                    j = j + 1;
+                }
+                if (!found) { bad = 1; }
+                covered = covered + 1;
+            }
+        }
+        i = i + 1;
+    }
+
+    # the surface is 20 rows: 12 defining (ten instructions, two of them with a
+    # `lock` spelling as well), 5 SETcc readers, 3 opaque. Pinned so the set cannot
+    # grow or shrink without this test being revisited.
+    if (covered != 17) { bad = 1; }
+    if (exempt  != 3)  { bad = 1; }
+    ret bad;
+}
+
 # the classification says what the x86-64 grammar actually contains, not what a
 # reader might assume - the #2288 honesty bar applied to a security gate
 test "mach.lang.target.isa.x64.encode.asm_ct_class:variable_latency_surface" {


### PR DESCRIPTION
Discharges the verification gap recorded in #2460's final comment. Closes nothing.

## The gap

#2460 added a hardware probe that measures what each instruction does to the flags, and diffs its own golden. **Nothing connected that measurement to `asm_ct_class`.** The two agreed by transcription rather than by construction, so:

- a grammar row added later with a wrong fact and **no probe entry** passed everything
- `every_grammar_row_states_flags` forced such a row to *state* a fact; nothing checked the fact was right

## Two tests

**`agrees_with_measured_hardware`** transcribes the golden's verdicts and asserts the classifier does not contradict them.

Every assertion is a **refutation**, and the one-sidedness is the design rather than a shortcut. The probe runs one set of operands; `defines_flags` claims something about *every* set. So:

```
measured NOT defining  ->  defines_flags must be FALSE   (a counterexample)
measured defining      ->  says nothing; may be false conservatively
```

`shl` is why that matters: it measures as defining both flags at count 1 and neither at count 0. Reading "measured defining" as "is a definer" would classify it from the first measurement and reintroduce the exact unsoundness #2460 exists to close. The same shape holds for the other two facts — a measured read must be modelled, an unmeasured one proves nothing, since `jc` reads CF and leaves no register difference to see.

**`every_permitting_row_is_measured`** asserts the probe covers the permitting surface *exactly*, with the three `opaque_flags` rows as the only exemption.

This is the half that matters. Without it the first test only checks the rows someone remembered to probe — two lists that agree today with no mechanism keeping them agreeing, which is the original defect one level up.

## It found a real gap immediately

**`cmpxchg` carried `defines_flags` and had no probe entry at all.** It was on the audit surface, asserted, never measured. Both paths are now measured — the equal path and the not-equal path — since a row that defined flags on only one of them would not be a definer:

```
cmpxchgeq ZF:defined CF:defined reads:0
cmpxchgne ZF:defined CF:defined reads:0
```

## Demonstrated failing

**A fact contradicted by the measurement** — give `inc` `defines_flags`:
```
  asm_ct_class:permitting_surface_is_bounded       (exit 1)
  asm_ct_class:agrees_with_measured_hardware       (exit 1)
```

**A new audit row with no probe entry** — give `lidt` `defines_flags`:
```
  asm_ct_class:permitting_surface_is_bounded       (exit 1)
  asm_ct_class:every_permitting_row_is_measured    (exit 1)
```

**The case that shows the coverage test earns its place.** A maintainer adding a definer would naturally update `permitting_surface_is_bounded`, since that test names the rows. Doing exactly that — adding `lidt` as a definer *and* bumping the counts — leaves the surface test green:

```
  asm_ct_class:every_permitting_row_is_measured    (exit 1)
  oblivious_asm_taint_survives_every_non_defining_row  (exit 1)

1263 passed, 2 failed, 1265 total
```

Only the new test catches it. (The behavioural test fires too, but only because `lidt` genuinely should not clear; for a row that legitimately *is* a definer it would pass and the coverage test would stand alone.)

## What is still manual

Transcribing a verdict from the golden into `probed_rows`. That is the one remaining hand step, and it is bounded and loud: a wrong transcription is caught the next time the probe runs and its golden disagrees. The chain is now measurement → golden → transcription → classifier, with every link but the transcription mechanical.

The three `opaque_flags` rows stay a reasoned classification. `popfq` *passes* the writer probe as "defines both" — the incoming flags genuinely do not affect the result — and that answer is correct on its own terms and wrong as a classification, because the value came from the stack. Measuring harder cannot fix it: `defines_flags` asks whether the flags were overwritten from *this instruction's own operands*, and where a value came from is structural. The exempt set is pinned to exactly those three so it cannot become a place to put anything inconvenient.

## Verification

- `mach test .` green (1265/1265)
- `int/run.sh --target linux` green, including the re-blessed hardware case
- Self-host fixpoint holds