### PR TITLE
fix(ct): give the #[oblivious] asm walk a memory taint domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### A secret spilled to memory no longer launders past the `#[oblivious]` asm walk (#2706)
+The `#[oblivious]` inline-asm walk carried taint as a register bitmask with **no memory domain**, so a secret stored to the stack and reloaded came back in a register the model believed public. That defeated all three leak checks at once - a branch condition, a memory address, and a variable-latency operand:
+
+```
+mov rax, {r}
+mov [rsp], rax
+mov rbx, [rsp]
+mov rcx, [rbx]     # a secret-derived address, accepted
+```
+
+The direct form was always refused, which made the gate look sound while an ordinary spill walked through it. Memory is now the third taint domain beside the register set and the flags bit, shared across x86-64, aarch64 and riscv64 as the walk itself is.
+
+The domain is one bit for all of memory, and monotone. Per-slot tracking is not sound at this layer: `[rsp + k]` and `[rbp + j]` can name the same byte with nothing relating two base registers, and a slot key is an address rather than an extent, so overlapping accesses of different widths compare as different slots. The failure direction is over-refusal, never acceptance, and a body only loses by it if it stores a secret, reloads some other public value, and then leaks through what it reloaded.
+
+Note for anyone extending the walk: "does this instruction store" cannot be read from the `writes` mask, which names register operands. aarch64 `str` and riscv64 `sd` both declare `AW_NONE`, so a memory domain derived from that mask fires on x86-64 and silently passes every store on the other two targets.
+
 ## [4.14.0] - 2026-08-07
 
 ### Added

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -224,21 +224,38 @@ classification: `popfq`, `iretq` and `syscall` take their flags from the stack,
 the interrupt frame, or a masked prior RFLAGS, and no experiment of that shape can
 tell you where a value came *from*.
 
-**What the walk does not model is memory.** A secret spilled to the stack and
-reloaded comes back in a register the walk believes is public, and every check
-downstream of it is defeated:
+**Memory is the third taint domain**, beside the register set and the flags bit
+(#2706). A secret spilled to the stack and reloaded comes back **secret**:
 
 ```
 mov rax, {r}
 mov [rsp], rax
 mov rbx, [rsp]
-mov rcx, [rbx]     # a secret-derived address, accepted
+mov rcx, [rbx]     # error: addresses memory with a secret value
 ```
 
-The direct form of that — `mov rax, {r}` then `mov rbx, [rax]` — *is* refused, so
-the gate works and this path specifically escapes it. Taint is a register set with
-no memory domain, on every target, and closing it is tracked as #2706. Reading the
-flags model above as evidence that laundering is closed in general would be wrong.
+Before this domain existed the reload came back in a register the walk believed
+public, and all three checks downstream of it were defeated at once — a branch
+condition, a memory address, and a variable-latency operand alike. The direct form
+(`mov rax, {r}` then `mov rbx, [rax]`) was always refused, which made the gate look
+sound while an ordinary spill walked straight through it.
+
+The domain is **one bit covering all of memory**: either a secret has been stored in
+this body or it has not. That is coarser than it could be, and deliberately so. The
+obvious refinement — taint individual `[base + literal]` slots — is not sound here,
+because `[rsp + k]` and `[rbp + j]` can name the same byte with nothing in the walk
+relating two base registers, and because a slot key is an address rather than an
+extent, so an 8-byte store and an overlapping 4-byte load compare as different slots.
+Both would be laundering paths again.
+
+The bit is **monotone**: a later store of a public value does not clear it, since
+"the same slot" is precisely the question the domain cannot answer. So a body loses
+by this only if it stores a secret, later reloads some *other* public value, and then
+branches on, addresses with, or variable-latency operates on what it reloaded. The
+failure direction is refusal, never acceptance.
+
+A store through an address the walk cannot resolve needs no special case: there is no
+slot to fail to identify.
 
 The variable-latency check also bites unevenly: x86-64's and aarch64's asm grammars
 carry no divide, multiply or float instruction at all, so it reaches only their

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -8407,6 +8407,44 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:every_grammar_row_is_classi
 # both plain register operands, so the walk sees mechanically that the retry
 # conditions on CONTENTION status rather than on a taint. x86-64 cannot do this: its
 # `jcc` family conditions on FLAGS, which the effect model does not represent (#2460).
+# a secret spilled to memory and reloaded stays secret (#2706)
+#
+# The register bitmask carried no memory domain, so a store and a reload returned a
+# secret in a register the model believed public, defeating ALL THREE leak checks at
+# once.
+#
+# EVERY CASE IS RUN TWICE ON THE SAME BODY, once with the binding registered secret and
+# once with none registered. The secret run must be refused and the public run must be
+# accepted. That pairing is the whole point: an inline-asm body this grammar cannot
+# parse is refused as unverifiable, so a one-sided test would go green on a body that
+# never parsed, proving nothing. Two earlier drafts of this test did exactly that.
+#
+# THIS TARGET IS THE ONE THAT CATCHES A TARGET-SHAPED FIX. aarch64 `str` declares
+# `AW_NONE`, because the `writes` mask names REGISTER operands and a store writes no
+# register. A memory domain fed from that mask fires on x86-64's `mov [rsp], rax` and
+# silently passes every store here.
+test "mach.lang.target.isa.arm64.encode.asm_ct_scan:a_spill_does_not_launder_a_secret" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var bad: i32 = 0;
+
+    var names: [1]str;
+    names[0] = "r";
+
+    # (b) the reloaded secret reaches a memory address.
+    val addr: str = "ldr x0, {r}\nstr x0, [sp]\nldr x1, [sp]\nldr x2, [x1]";
+    if (!R.is_err[bool, str](asm_ct_scan(addr, ?names[0], 1, false, false, ?alloc))) { bad = bad + 1; }
+    if (R.is_err[bool, str](asm_ct_scan(addr, ?names[0], 0, false, false, ?alloc)))  { bad = bad + 2; }
+
+    # (a) the reloaded secret reaches a register-conditioned branch, the only
+    # conditional shape this grammar has statically.
+    val br: str = "ldr x0, {r}\nstr x0, [sp]\nldr x1, [sp]\ncbnz x1, 1f\n1:\nnop";
+    if (!R.is_err[bool, str](asm_ct_scan(br, ?names[0], 1, false, false, ?alloc)))   { bad = bad + 4; }
+    if (R.is_err[bool, str](asm_ct_scan(br, ?names[0], 0, false, false, ?alloc)))    { bad = bad + 8; }
+
+    ret bad;
+}
+
 test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_conditioned" {
     var bad: i32 = 0;
 

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -2109,9 +2109,12 @@ fun reg_tainted(taint: u32, r: i32) bool {
     ret (taint & (1::u32 << r::u32)) != 0;
 }
 
-# true when any operand of `item` carries a secret - a secret `{name}` binding, or a
-# register the walk has already tainted
-fun item_reads_secret(body: str, item: *Item, taint: u32, secret_names: *str, n_secret: u32) bool {
+# true when any operand of `item` carries a secret - a secret `{name}` binding, a
+# register the walk has already tainted, or any memory read once memory is tainted
+#
+# `mem_taint` is a SINGLE bit covering all of memory, and reading one memory operand
+# is enough. See `ct_scan` for why the domain has no finer resolution than that.
+fun item_reads_secret(body: str, item: *Item, taint: u32, mem_taint: bool, secret_names: *str, n_secret: u32) bool {
     var i: u32 = 0;
     for (i < item.nops) {
         val op: *Operand = ?item.ops[i::usize];
@@ -2120,7 +2123,38 @@ fun item_reads_secret(body: str, item: *Item, taint: u32, secret_names: *str, n_
         if (op.kind == AOP_MEM) {
             if (reg_tainted(taint, op.reg))   { ret true; }
             if (reg_tainted(taint, op.index)) { ret true; }
+            # a `{name}` binding substitutes to a fixed frame slot the compiler owns,
+            # not to a location this body can have stored a secret into, so it is not
+            # a read of the tainted memory domain. its secrecy is decided by
+            # `bind_is_secret` above.
+            if (mem_taint) { ret true; }
         }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# true when `item` has any memory operand at all
+#
+# THE `writes` MASK CANNOT ANSWER THIS AND MUST NOT BE USED FOR IT. `writes` names the
+# form's REGISTER OPERANDS, which is what the allocator needs: aarch64 `str x0, [x1]`
+# and riscv64 `sd a0, 0(sp)` both carry `AW_NONE`, because neither writes a register,
+# and both are stores. Deriving "is a store" from that mask produces a check that fires
+# on x86-64's `mov [rsp], rax` and silently passes every store on the other two targets.
+#
+# So the question asked here is the coarser, target-independent one: does this
+# instruction touch memory? An item that reads a secret and touches memory is treated
+# as having stored that secret. That over-taints a secret-reading LOAD, which only
+# refuses more, and it is the right trade at this domain's one-bit resolution.
+#
+# IT ALSO FAILS CLOSED ALONG THE GROWTH AXIS, which the alternative does not. A store
+# mnemonic added to any grammar later is covered the moment it parses a memory operand.
+# Had this been a per-mnemonic `stores` fact instead, a new row that forgot to set it
+# would launder secrets exactly as this issue describes, and nothing would report it.
+fun item_touches_memory(item: *Item) bool {
+    var i: u32 = 0;
+    for (i < item.nops) {
+        if (item.ops[i::usize].kind == AOP_MEM) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -2163,6 +2197,33 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
     # the register bitmask because x86-64 conditions its branches on it and nothing
     # in the register model represents it (#2460)
     var flags_taint: bool = false;
+    # whether ANY secret has been stored to memory in this body (#2706). the third
+    # domain, beside the register set and FLAGS, and the reason a spill no longer
+    # launders: before this, a secret stored and reloaded came back in a register the
+    # model believed public, defeating all three leak checks at once.
+    #
+    # ONE BIT FOR ALL OF MEMORY, AND THAT IS DELIBERATE. The obvious refinement -
+    # track `[base + literal]` slots and taint only those - is NOT SOUND here, for two
+    # independent reasons, and both have to be answered before any finer domain ships:
+    #
+    #   1. ALIASING ACROSS BASES. `[rsp + k]` and `[rbp + j]` can name the same byte,
+    #      and nothing in this walk knows the relationship between two base registers.
+    #      A per-base or per-slot set would miss a secret stored through one base and
+    #      reloaded through the other.
+    #   2. PARTIAL OVERLAP. A slot key is an address, not an extent. An 8-byte store to
+    #      `[rsp]` and a 4-byte load from `[rsp + 4]` overlap, and the parsed item does
+    #      not carry a reliable access width to compare.
+    #
+    # So the resolution the walk can actually justify is "memory holds a secret, or it
+    # does not". The cost is over-refusal, never under-refusal, and it is narrower than
+    # it first looks: a body only loses by this if it stores a secret AND later reloads
+    # some other public value AND then branches on, addresses with, or variable-latency
+    # operates on what it reloaded. The last of those is the thing an `#[oblivious]`
+    # body must not do regardless.
+    #
+    # MONOTONE - set once, never cleared. A later store of a PUBLIC value cannot clear
+    # it, because "the same slot" is exactly the question this domain cannot answer.
+    var mem_taint: bool = false;
     var item: Item;
     var done: bool = false;
     for (!done) {
@@ -2172,7 +2233,7 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
         }
         if (!R.unwrap_ok[bool, str](pr)) { done = true; }
         or {
-            val vr: R.Result[bool, str] = ct_check_item(g, body, ?item, ?taint, ?flags_taint, secret_names, n_secret, trust_mul, trust_shift);
+            val vr: R.Result[bool, str] = ct_check_item(g, body, ?item, ?taint, ?flags_taint, ?mem_taint, secret_names, n_secret, trust_mul, trust_shift);
             if (R.is_err[bool, str](vr)) { ret vr; }
         }
     }
@@ -2183,7 +2244,7 @@ pub fun ct_scan(g: *Grammar, body: str, secret_names: *str, n_secret: u32,
 #
 # Split out so the walk above reads as the loop it is. `taint` is updated in place:
 # an instruction that reads a secret taints the registers it writes.
-fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32, flags_taint: *bool,
+fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32, flags_taint: *bool, mem_taint: *bool,
                   secret_names: *str, n_secret: u32,
                   trust_mul: bool, trust_shift: bool) R.Result[bool, str] {
     if (item.kind == AI_LABEL) { ret R.ok[bool, str](true); }
@@ -2207,7 +2268,7 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32, flags_taint:
     }
 
     val cls: ct.AsmClass = g.ct_class(item.code, item.flags);
-    val reads_secret: bool = item_reads_secret(body, item, @taint, secret_names, n_secret);
+    val reads_secret: bool = item_reads_secret(body, item, @taint, @mem_taint, secret_names, n_secret);
 
     # a conditional branch whose condition rides the flags register is refused when
     # FLAGS holds a secret-derived value, and accepted otherwise. before #2460 the
@@ -2296,6 +2357,11 @@ fun ct_check_item(g: *Grammar, body: str, item: *Item, taint: *u32, flags_taint:
         @taint = @taint | item.implicit;
         if ((item.writes & AW_OP0) != 0 && item.nops > 0) { taint_written(?item.ops[0], taint); }
         if ((item.writes & AW_OP1) != 0 && item.nops > 1) { taint_written(?item.ops[1], taint); }
+        # and the MEMORY domain: an instruction that carries a secret and touches
+        # memory taints all of memory, so a later reload comes back secret instead of
+        # laundered public (#2706). the address is public here - a secret address was
+        # already refused by check (b) above - so this is about the VALUE, not the slot.
+        if (item_touches_memory(item)) { @mem_taint = true; }
     }
 
     # fold the FLAGS taint. the arms are ordered, and the order is the model:

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -6744,6 +6744,41 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
 #
 # Walks the shipping grammar table, so adding a mnemonic without classifying it fails
 # here rather than becoming a row `#[oblivious]` silently cannot use (#2230).
+# a secret spilled to memory and reloaded stays secret (#2706)
+#
+# The register bitmask carried no memory domain, so a store and a reload returned a
+# secret in a register the model believed public, defeating ALL THREE leak checks at
+# once.
+#
+# EVERY CASE IS RUN TWICE ON THE SAME BODY, once with the binding registered secret and
+# once with none registered. The secret run must be refused and the public run must be
+# accepted. That pairing is the whole point: an inline-asm body this grammar cannot
+# parse is refused as unverifiable, so a one-sided test would go green on a body that
+# never parsed, proving nothing. Two earlier drafts of this test did exactly that.
+#
+# riscv64 `sd` declares `AW_NONE` for the same reason aarch64 `str` does, so this
+# target and that one are what a `writes`-mask memory domain would silently miss.
+test "mach.lang.target.isa.riscv64.encode.asm_ct_scan:a_spill_does_not_launder_a_secret" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var bad: i32 = 0;
+
+    var names: [1]str;
+    names[0] = "r";
+
+    # (b) the reloaded secret reaches a memory address.
+    val addr: str = "ld a0, {r}\nsd a0, 0(sp)\nld a1, 0(sp)\nld a2, 0(a1)";
+    if (!R.is_err[bool, str](asm_ct_scan(addr, ?names[0], 1, false, false, ?alloc))) { bad = bad + 1; }
+    if (R.is_err[bool, str](asm_ct_scan(addr, ?names[0], 0, false, false, ?alloc)))  { bad = bad + 2; }
+
+    # (c) the reloaded secret reaches a variable-latency divide.
+    val lat: str = "ld a0, {r}\nsd a0, 0(sp)\nld a1, 0(sp)\ndiv a2, a3, a1";
+    if (!R.is_err[bool, str](asm_ct_scan(lat, ?names[0], 1, false, false, ?alloc)))  { bad = bad + 4; }
+    if (R.is_err[bool, str](asm_ct_scan(lat, ?names[0], 0, false, false, ?alloc)))   { bad = bad + 8; }
+
+    ret bad;
+}
+
 test "mach.lang.target.isa.riscv64.encode.asm_ct_class:every_grammar_row_is_classified" {
     var bad: i32 = 0;
     var i: usize = 0;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -6974,6 +6974,55 @@ test "mach.lang.target.isa.x64.encode.declared_raw_encodings:malformed_clauses_r
 # branches on a secret or divides in variable time, which is what this walk exists to
 # catch, so a declaration must buy allocation quality and never verification. Letting
 # an author declare past a security gate is #2288's failure exactly.
+# a secret spilled to memory and reloaded stays secret (#2706)
+#
+# The register bitmask carried no memory domain, so a store and a reload returned a
+# secret in a register the model believed public, defeating ALL THREE leak checks at
+# once.
+#
+# EVERY CASE IS RUN TWICE ON THE SAME BODY, once with the binding registered secret and
+# once with none registered. The secret run must be refused and the public run must be
+# accepted. That pairing is the whole point: an inline-asm body this grammar cannot
+# parse is refused as unverifiable, so a one-sided test would go green on a body that
+# never parsed, proving nothing. Two earlier drafts of this test did exactly that.
+test "mach.lang.target.isa.x64.encode.asm_ct_scan:a_spill_does_not_launder_a_secret" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var bad: i32 = 0;
+
+    var names: [1]str;
+    names[0] = "r";
+
+    # (b) the reloaded secret reaches a memory ADDRESS. this is the issue's reproducer.
+    val addr: str = "mov rax, {r}\nmov [rsp], rax\nmov rbx, [rsp]\nmov rcx, [rbx]";
+    if (!R.is_err[bool, str](asm_ct_scan(addr, ?names[0], 1, false, false, ?alloc)))  { bad = bad + 1; }
+    if (R.is_err[bool, str](asm_ct_scan(addr, ?names[0], 0, false, false, ?alloc)))   { bad = bad + 2; }
+
+    # (c) the reloaded secret reaches a variable-latency operation. a shift leaks
+    # through its COUNT, so the reloaded value is placed in the count operand.
+    val lat: str = "mov rax, {r}\nmov [rsp], rax\nmov rcx, [rsp]\nshl rdx, cl";
+    if (!R.is_err[bool, str](asm_ct_scan(lat, ?names[0], 1, false, false, ?alloc)))   { bad = bad + 4; }
+    if (R.is_err[bool, str](asm_ct_scan(lat, ?names[0], 0, false, false, ?alloc)))    { bad = bad + 8; }
+
+    # (a) the reloaded secret reaches a branch condition, through FLAGS.
+    val br: str = "mov rax, {r}\nmov [rsp], rax\nmov rbx, [rsp]\ncmp rbx, 1\njz 1f\n1:\nnop";
+    if (!R.is_err[bool, str](asm_ct_scan(br, ?names[0], 1, false, false, ?alloc)))    { bad = bad + 16; }
+    if (R.is_err[bool, str](asm_ct_scan(br, ?names[0], 0, false, false, ?alloc)))     { bad = bad + 32; }
+
+    # an ordinary PUBLIC spill and reload still compiles with the secret REGISTERED.
+    # without this the gate could be satisfied by refusing every body touching the
+    # stack, which is most of them, and everything above would still be green.
+    val pub: str = "mov [rsp], rax\nmov rbx, [rsp]\nmov rcx, [rbx]";
+    if (R.is_err[bool, str](asm_ct_scan(pub, ?names[0], 1, false, false, ?alloc)))    { bad = bad + 64; }
+
+    # a store through an address the walk cannot resolve taints memory just the same:
+    # the domain covers all of memory, so there is no slot to fail to identify.
+    val opaque: str = "mov rax, {r}\nmov [rdx + rsi * 8], rax\nmov rbx, [rsp]\nmov rcx, [rbx]";
+    if (!R.is_err[bool, str](asm_ct_scan(opaque, ?names[0], 1, false, false, ?alloc))) { bad = bad + 128; }
+
+    ret bad;
+}
+
 test "mach.lang.target.isa.x64.encode.asm_ct_scan:a_declaration_is_not_a_verification" {
     var alloc: A.Allocator;
     page.make(?alloc);


### PR DESCRIPTION
Closes #2706.

## The defect

The `#[oblivious]` inline-asm walk carried taint as a **register bitmask with no memory domain**. A secret stored to the stack and reloaded came back in a register the model believed public, defeating all three leak checks at once.

Confirmed on `dev` before touching anything, as a unit test whose exit code isolated the three facts: the direct case **is** refused, an ordinary public spill **does** compile, and the laundered case **is accepted**.

```
mov rax, {r}
mov [rsp], rax
mov rbx, [rsp]
mov rcx, [rbx]     # a secret-derived address, accepted
```

That the direct form was always refused is what made this survive: the gate looks sound right up until someone spills, which is the most ordinary thing an asm block does.

## The fix

Memory becomes the third taint domain beside the register set and the flags bit, folded in the same place and shared across x86-64, aarch64 and riscv64 exactly as the walk is.

**One bit for all of memory, and monotone.** The obvious refinement, tainting individual `[base + literal]` slots, is what the issue proposed and it is **not sound at this layer**:

1. **Aliasing across bases.** `[rsp + k]` and `[rbp + j]` can name the same byte and nothing here relates two base registers.
2. **Partial overlap.** A slot key is an address, not an extent. An 8-byte store to `[rsp]` and a 4-byte load from `[rsp + 4]` overlap, and the parsed item carries no reliable access width.

Either one is a laundering path again, so the resolution the walk can actually justify is "memory holds a secret, or it does not". The cost is over-refusal and it is narrow: a body loses only if it stores a secret, later reloads some *other* public value, and then branches on, addresses with, or variable-latency operates on what it reloaded. The last is what an `#[oblivious]` body must not do regardless.

## A trap worth naming

**Store-ness cannot be read from the `writes` mask.** That mask names REGISTER operands, which is what the allocator needs. aarch64 `str x0, [sp]` and riscv64 `sd a0, 0(sp)` both declare `AW_NONE` because neither writes a register. A memory domain derived from it fires on x86-64's `mov [rsp], rax` and **silently passes every store on the other two targets**.

My first draft did exactly that. The check asks the coarser target-independent question instead, which also fails closed along the growth axis: a store mnemonic added to any grammar later is covered the moment it parses a memory operand, whereas a per-mnemonic `stores` fact that a new row forgot to set would launder secrets with nothing reporting it.

## Verification

Every case is run **twice on the same body**, once with the binding registered secret and once with none registered. The secret run must be refused, the public run accepted. That pairing is load-bearing: an unparseable body is refused as unverifiable, so a one-sided test goes green on a body that never parsed.

Two earlier drafts of this test did exactly that, and both were caught by running the tests against the unpatched walk rather than by reading them:

- `div rbx` is not in the x86-64 grammar at all, and `.L0:` is not the label syntax (labels are numeric, `jz 1f` / `1:`). Both bodies failed to parse, so both "must be refused" assertions passed for the wrong reason.
- `mov x0, {r}` and `mv a0, {r}` do not parse in their grammars either, so the aarch64 and riscv64 tests passed **unpatched** while proving nothing. The public control did not cover the taint-source line.

With the paired structure, against the **unpatched** walk:

| target | exit | meaning |
|---|---|---|
| x86-64 | 149 | address, variable-latency, branch, and opaque-store all flip |
| aarch64 | 5 | address and register-conditioned branch flip |
| riscv64 | 5 | address and variable-latency divide flip |

Every public control stays clean on both walks, so no assertion is riding a parse failure.

- `mach test .` **1270 passed, 0 failed** (1267 baseline plus three)
- **Self-host fixpoint holds**: `mach build . -o a`, `./a build . -o b`, `./b build . -o c`, `cmp b c` identical (self-built against self-built)
- `doc/language/secrecy.md` rewritten: it previously documented this hole as open, and now states the domain, why it has no finer resolution, and what over-refusal costs