### PR TITLE
fix(isa/arm64): pin the NEON integer-multiply arrangements and enforce the .2d hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,13 @@ The reach was not the real defect. The interface itself said *frame-pointer-rela
 
 **New refusal:** an inline-asm body that binds a `{name}` may not write the stack pointer, on targets that measure from it. The displacement is taken once at block entry, so the pointer must still be where it was. The whole block is judged rather than a prefix, because a backward branch reaches an earlier `{name}` again with the moved pointer. Move the stack adjustment out of the block, or drop the `{name}` and stage the address into a register.
 
+#### The NEON integer-multiply arrangement rule was wrong in both directions (#2721)
+`arm64/encode.mach` declared the `MUL (vector)` base word as "legal only on .8h (size 1)". NEON encodes that word at sizes 0/1/2 as `.16b` / `.8h` / `.4s` and leaves size 3 **unallocated**, so the comment forbade three arrangements the hardware has and omitted the one real constraint: there is no `mul v.2d`.
+
+The encoder was not wrong yet, because nothing selected the word at another size. That is exactly the #2037 shape — a base word plus a size field that *looks* general, with nothing pinning what each arrangement encodes — and a widening that trusted the word's apparent generality would emit `0x4EE29C20`, an invalid encoding, rather than refuse.
+
+Each permitted arrangement is now pinned byte-exact against the encoding definition, and `neon_3same_size_ok` makes the hole a fact the compiler enforces: a 64-bit integer lane multiply reaching the selector is a defined error emitting no bytes, proved by driving the selector directly rather than by arguing no caller reaches it.
+
 #### Field stores went through a second layout policy that no decorator could reach (#2715)
 `mir.lower_ir`'s `struct_field_offset` re-derived every field offset with its own `round_up` over each field's alignment, rather than calling `ir_type.byte_offset` like every other offset consumer. So a `#[packed]` record reported correct `$size_of`, `$align_of` and `$offset_of` — those go through the shared layout policy — while the code that actually **read and wrote the fields** placed them at the **natural** offsets, and nothing errored. A record whose fields fit its packed size wrote its last field past the end of its own storage.
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -294,7 +294,13 @@ val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
 val VFADD:   u32 = 0x4E20D400; val VFSUB:   u32 = 0x4EA0D400;
 val VFMUL:   u32 = 0x6E20DC00; val VFDIV:   u32 = 0x6E20FC00;
 val VADD:    u32 = 0x4E208400; val VSUB:    u32 = 0x6E208400;
-val VMUL:    u32 = 0x4E209C00;  # integer multiply, legal only on .8h (size 1)
+# integer multiply. `MUL (vector)` encodes sizes 0/1/2 as .16b/.8h/.4s and leaves
+# size 3 UNALLOCATED, so there is no `mul v.2d` word: 64-bit integer lanes are the
+# one real arrangement hole here, and every narrower lane width is legal. The
+# 64-bit-vector arrangements (.8b/.4h/.2s) are the Q=0 twins of these and this base
+# word does not reach them - it fixes Q=1, which is the only width mach selects.
+# `neon_3same_size_ok` enforces the hole rather than leaving it to a reader.
+val VMUL:    u32 = 0x4E209C00;
 val VAND:    u32 = 0x4E201C00; val VORR:    u32 = 0x4EA01C00; val VEOR: u32 = 0x6E201C00;
 # integer / float lane-wise compares producing native all-ones / all-zeros masks
 val VCMEQ:   u32 = 0x6E208C00;                                   # integer ==
@@ -2633,6 +2639,34 @@ fun neon_base(opcode: u32, is_float: bool) u32 {
     ret 0;
 }
 
+# whether NEON three-register-same base word `base` has an encoding at arrangement
+# `size` (integer 0=.16b, 1=.8h, 2=.4s, 3=.2d; float 0=.4s, 1=.2d)
+#
+# Keyed on the BASE WORD rather than the MIR opcode, because the hole is a property
+# of the encoding: adding another restricted word is one line here, next to the word
+# whose ARM ARM entry states the restriction.
+#
+# `MUL (vector)` is the only current hole - size 3 is unallocated, so a 64-bit
+# integer lane multiply has no word at all. Nothing routes one here: the packed-form
+# authority reports no packed integer multiply at 64-bit lanes on any target, so the
+# realization is the scalar expansion and this never fires from source. It is a
+# backstop against a future selector widening without re-deriving the arrangement,
+# which is #2037's failure exactly - a base word plus a general-looking size field
+# encoding an arrangement the hardware does not have, silently.
+fun neon_3same_size_ok(base: u32, size: u32) bool {
+    if (base == VMUL) { ret size != 3; }
+    ret true;
+}
+
+# the message for an arrangement a NEON three-register-same word cannot encode
+#
+# A compiler bug by construction, so it names the word and the arrangement the
+# selector asked for rather than anything a user could act on.
+fun neon_arrangement_err(base: u32, size: u32) str {
+    if (base == VMUL) { ret "encode: NEON integer multiply has no 64-bit lane arrangement (MUL (vector) leaves size 3 unallocated)"; }
+    ret "encode: NEON three-register-same word has no encoding at this arrangement";
+}
+
 # materialize a selected NEON vector data op `[dst, lhs(, rhs)]` (#2015)
 #
 # The arrangement (size) and the float-vs-integer form come from `mi.vec_lane`. A
@@ -2687,6 +2721,7 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     if (op == arm64.VEC_CMNE::u32) {
         var eqbase: u32 = VCMEQ;
         if (is_float) { eqbase = VFCMEQ; }
+        if (!neon_3same_size_ok(eqbase, size)) { ret R.err[bool, str](neon_arrangement_err(eqbase, size)); }
         emit_neon_3same(st, eqbase, size, rd, rn, rm, vl);
         emit_neon_2misc(st, VNOT, rd, rd);
     }
@@ -2696,7 +2731,9 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         # regardless of the lane width the descriptor carries.
         var eff_size: u32 = size;
         if (op == arm64.VEC_AND::u32 || op == arm64.VEC_ORR::u32 || op == arm64.VEC_EOR::u32) { eff_size = 0; }
-        emit_neon_3same(st, neon_base(op, is_float), eff_size, rd, rn, rm, vl);
+        val base: u32 = neon_base(op, is_float);
+        if (!neon_3same_size_ok(base, eff_size)) { ret R.err[bool, str](neon_arrangement_err(base, eff_size)); }
+        emit_neon_3same(st, base, eff_size, rd, rn, rm, vl);
     }
 
     if (to_slot) { ret emit_fp_slot_store(st, f, dst, rd, 16); }
@@ -8100,13 +8137,13 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
     if (pack_neon_3same(VFMUL, 0, 0, 0, 1) != 0x6E21DC00) { bad = 1; }
     if (pack_neon_3same(VFDIV, 0, 0, 0, 1) != 0x6E21FC00) { bad = 1; }
 
-    # integer add / sub across widths; multiply legal only on .8h.
+    # integer add / sub across widths. multiply has its own case below, since its
+    # arrangement set is not the full four.
     if (pack_neon_3same(VADD, 0, 0, 0, 1) != 0x4E218400) { bad = 1; }
     if (pack_neon_3same(VADD, 1, 0, 0, 1) != 0x4E618400) { bad = 1; }
     if (pack_neon_3same(VADD, 2, 0, 0, 1) != 0x4EA18400) { bad = 1; }
     if (pack_neon_3same(VADD, 3, 0, 0, 1) != 0x4EE18400) { bad = 1; }
     if (pack_neon_3same(VSUB, 0, 0, 0, 1) != 0x6E218400) { bad = 1; }
-    if (pack_neon_3same(VMUL, 1, 0, 0, 1) != 0x4E619C00) { bad = 1; }
 
     # logical (byte-agnostic, size 0) and the register move (ORR Vd,Vn,Vn alias).
     if (pack_neon_3same(VAND, 0, 0, 0, 1) != 0x4E211C00) { bad = 1; }
@@ -8162,6 +8199,46 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
     ret bad;
 }
 
+# every arrangement NEON `MUL (vector)` permits, byte-exact, plus the one it does
+# not (#2721)
+#
+# The expected words are DERIVED FROM THE ENCODING, not read back off this encoder:
+# `MUL (vector)` is `0 Q 001110 size 1 Rm 100111 Rn Rd`, so at Q=1 the word is
+# 0x4E209C00 | size<<22 | Rm<<16 | Rn<<5 | Rd, and each literal below is the
+# assembler's output for the named mnemonic. Asserting the packer against itself
+# would restate #2721 rather than catch it, and asserting only one arrangement is
+# how #2037's collapse hid: a base word plus a size field that LOOKS general, with
+# nothing pinning what each arrangement actually encodes.
+#
+# Rd=v3, Rn=v5, Rm=v7 are deliberately distinct and non-zero, so a transposed Rn/Rm
+# or a field at the wrong shift fails rather than cancelling out.
+test "mach.lang.target.isa.arm64.encode:neon_integer_multiply_arrangements" {
+    var bad: i32 = 0;
+
+    # mul v3.16b, v5.16b, v7.16b
+    if (pack_neon_3same(VMUL, 0, 3, 5, 7) != 0x4E279CA3) { bad = 1; }
+    # mul v3.8h, v5.8h, v7.8h
+    if (pack_neon_3same(VMUL, 1, 3, 5, 7) != 0x4E679CA3) { bad = 2; }
+    # mul v3.4s, v5.4s, v7.4s
+    if (pack_neon_3same(VMUL, 2, 3, 5, 7) != 0x4EA79CA3) { bad = 3; }
+
+    # the arrangement filter agrees with that set: sizes 0/1/2 encode, size 3 does
+    # not. `mul v.2d` is unallocated, so there is no word to compare against - the
+    # only correct behaviour is refusing to emit one.
+    if (!neon_3same_size_ok(VMUL, 0)) { bad = 4; }
+    if (!neon_3same_size_ok(VMUL, 1)) { bad = 5; }
+    if (!neon_3same_size_ok(VMUL, 2)) { bad = 6; }
+    if (neon_3same_size_ok(VMUL, 3))  { bad = 7; }
+
+    # the words that DO have all four arrangements are unaffected by the filter, so
+    # it is a hole in one encoding rather than a blanket 64-bit lane ban.
+    if (!neon_3same_size_ok(VADD, 3)) { bad = 8; }
+    if (!neon_3same_size_ok(VSUB, 3)) { bad = 9; }
+    if (!neon_3same_size_ok(VCMEQ, 3)) { bad = 10; }
+
+    ret bad;
+}
+
 # the NEON vector op selection (isel -> encode_neon) drives byte-exact words off
 # mi.vec_lane: the float-vs-integer form from the lane kind, the arrangement from
 # the element width, logical ops byte-agnostic (size 0), and the `!=` compare as an
@@ -8189,6 +8266,12 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_op_selection" {
     encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4EE2D420) { bad = 1; }
     mi.opcode = arm64.VEC_MUL::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 2); st.buf.len = 0;
     encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E629C20) { bad = 1; }
+    # VEC_MUL i8x16 -> MUL.16b and i32x4 -> MUL.4s: the arrangements #2721 found the
+    # comment forbidding and the selector unable to reach.
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E229C20) { bad = 1; }
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4EA29C20) { bad = 1; }
     mi.opcode = arm64.VEC_DIV::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4); st.buf.len = 0;
     encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6E22FC20) { bad = 1; }
 
@@ -8224,6 +8307,52 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_op_selection" {
     ops[0] = tvec(0); ops[1] = tvec(1);
     mi.opcode = arm64.VEC_NOT::u32; mi.operand_count = 2; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1); st.buf.len = 0;
     encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6E205820) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# a 64-bit integer lane multiply reaching the selector is a defined error, not a
+# word (#2721)
+#
+# Driven through `encode_neon` rather than argued from the callers, because the
+# whole point of the guard is to hold when a caller changes. `mul v.2d` does not
+# exist, so the failure this rejects is emitting SOME word - most likely the .2d
+# arrangement of a neighbouring opcode - and having it disassemble as something
+# plausible. Asserting the buffer stayed empty is what separates "refused" from
+# "emitted and then errored".
+#
+# Under the target-independent surface no source program reaches this: no target has
+# a packed integer multiply at 64-bit lanes, so `i64x2 * i64x2` realizes as the
+# scalar expansion everywhere. This is the backstop for a selector that widens
+# without re-deriving the arrangement.
+test "mach.lang.target.isa.arm64.encode:neon_integer_multiply_refuses_64bit_lanes" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
+    ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = tvec(2);
+
+    mi.opcode = arm64.VEC_MUL::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 8); st.buf.len = 0;
+    val r: R.Result[bool, str] = encode_neon(?st, ?f, ?mi);
+    if (!R.is_err[bool, str](r)) { bad = 1; }
+    if (st.buf.len != 0)         { bad = 2; }
+
+    # the same shape at every narrower lane width still encodes, so the guard is a
+    # hole in one arrangement and not a refusal of integer multiply.
+    st.buf.len = 0;
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4);
+    if (R.is_err[bool, str](encode_neon(?st, ?f, ?mi))) { bad = 3; }
+    if (st.buf.len != 4)                                { bad = 4; }
+
+    # and a 64-bit lane op that DOES have a .2d arrangement is untouched.
+    st.buf.len = 0;
+    mi.opcode = arm64.VEC_ADD::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 8);
+    if (R.is_err[bool, str](encode_neon(?st, ?f, ?mi))) { bad = 5; }
+    if (read_word(?st.buf, 0) != 0x4EE28420)            { bad = 6; }
 
     encode.buf_dnit(?st.buf);
     ret bad;


### PR DESCRIPTION
Closes #2721. Prerequisite for #2726.

## What was wrong

`arm64/encode.mach` declared the NEON integer-multiply base word as:

```mach
val VMUL: u32 = 0x4E209C00;  # integer multiply, legal only on .8h (size 1)
```

Wrong in both directions. `MUL (vector)` is `0 Q 001110 size 1 Rm 100111 Rn Rd`, and at Q=1 it encodes sizes 0/1/2 as `.16b` / `.8h` / `.4s`. Size 3 is **unallocated**, so there is no `mul v.2d`. The comment forbade three arrangements the hardware has and omitted the one real constraint.

The encoder was not wrong yet, because nothing selected the word at another size. That is exactly #2037's shape: a base word plus a size field that *looks* general, with nothing pinning what each arrangement actually encodes.

## Evidence, not argument

Removing `neon_3same_size_ok` and driving `encode_neon` with a 64-bit integer lane `VEC_MUL` makes the encoder emit `0x4EE29C20` and return ok. That word:

```
$ echo "0x20 0x9c 0xe2 0x4e" | llvm-mc -triple=aarch64 -disassemble
<stdin>:1:1: warning: invalid instruction encoding
```

So the pre-patch failure mode is a silently emitted invalid encoding, which is the thing #2721 was filed to prevent before anything reaches `.4s`.

## The fix

- **Comment corrected** to the real rule, stating the `.2d` hole and noting that the `.8b`/`.4h`/`.2s` arrangements are the Q=0 twins this base word does not reach.
- **Byte-exact assertions for every permitted arrangement**, derived from the encoding definition and cross-checked against `llvm-mc -triple=aarch64`, with `Rd=v3, Rn=v5, Rm=v7` deliberately distinct and non-zero so a transposed `Rn`/`Rm` or a field at the wrong shift fails rather than cancelling out:

  | arrangement | word |
  |---|---|
  | `mul v3.16b, v5.16b, v7.16b` | `0x4E279CA3` |
  | `mul v3.8h, v5.8h, v7.8h` | `0x4E679CA3` |
  | `mul v3.4s, v5.4s, v7.4s` | `0x4EA79CA3` |
  | `mul v3.2d, ...` | does not exist |

  Asserting the packer against itself would restate the defect rather than catch it, so the literals come from the encoding, not from a run of this encoder.

- **`neon_3same_size_ok` guards the selector**, keyed on the *base word* rather than the MIR opcode, because the hole is a property of the encoding: the constraint sits next to the word whose entry states it, and adding another restricted word is one line. `VADD` / `VSUB` / `VCMEQ` at `.2d` are asserted unaffected, so it is a hole in one encoding rather than a blanket 64-bit lane ban.

- **`encode_neon` now returns a defined error** for the unallocated arrangement, and the test drives the selector directly and asserts the buffer stayed empty — that is what separates "refused" from "emitted and then errored".

- **`MUL.16b` and `MUL.4s` added to the selection test**, so the arrangements the old comment forbade are now represented rather than merely unverified.

## Verification

Mutations, to prove the tests fail without the patch:

| mutation | result |
|---|---|
| `neon_3same_size_ok` always true | `neon_integer_multiply_arrangements` and `neon_integer_multiply_refuses_64bit_lanes` FAIL (the latter at the buffer-not-empty assertion — bytes were emitted) |
| `neon_size` collapsed to always 0 (#2037's arrangement collapse) | `neon_vector_op_selection` and `neon_integer_multiply_refuses_64bit_lanes` FAIL |

- `mach test .` — **1278 passed, 0 failed**
- self-host fixpoint holds, stage2 byte-identical to stage3: `3f19d2f1a8abf61710aa7e6ea5913a0891608c505142f0b42fc23038473a32fe`

Native aarch64 evidence comes from CI's `ubuntu-24.04-arm` leg; the host here is x86-64.