### PR TITLE
fix(sema): refuse a constant index outside a statically known length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### A constant out-of-bounds index is refused, on every target (#2751)
+`var xs: [4]i32; ret xs[9];` compiled cleanly on x86-64, aarch64 and riscv64, and on SPIR-V emitted an `OpAccessChain` with `%uint_9` into a four-element array that `spirv-val` did not catch either. The length is part of the type and the index is a constant, so the violation was decidable with no analysis at all. It had simply never been asked.
+
+Sema now asks it, keyed on `type.element_count` — the one definition of "how many elements a type holds", the same answer `$length_of` gives. Keying on the count rather than on the syntax is what makes the spellings free: a `def` alias, an array field of a generic instance, an array nested in a record or in another array, and a `^`-qualified array all name the same interned array type, and all get the same refusal. A vector's lane count is a statically known length too and now takes the identical rule and the identical message, replacing the vector-only wording it had before.
+
+The diagnostic names the index, the type and the length: ``index 9 is out of bounds for `[4]i32` of length 4``.
+
+Scope is deliberate. Only a **constant** index against a **fixed** length is checked, which needs no dataflow. A runtime index is not checked, and a pointer is not checked at all — `*T` carries no length to measure against.
+
+Folding the index now decides on **resolution identity** rather than on name text. The comptime environment is keyed by name, so a block-local `var n` that shares its name with a module-level `val n` used to fold to the module constant. That was already visible on the vector path, where `v[n]` with a local `n = 1` was reported as an out-of-bounds lane against a module-level `n = 9`; it now reports the dynamic-lane refusal it should always have given, and an array indexed by such a local is correctly left alone rather than refused. The runtime-binding rule the `$if` gate check already carried is now one shared definition.
+
 ### Added
 
 #### A constant pool, so a float constant is loaded rather than rebuilt (#2248, #2700)

--- a/doc/language/expressions.md
+++ b/doc/language/expressions.md
@@ -40,6 +40,10 @@ val x:     i64 = p.x;            # record field
 val first: i64 = a[0];           # array index
 ```
 
+An index the compiler can fold is bounds-checked against a statically known
+length — a fixed array's `N`, a vector's lane count — see
+[types.md](types.md).
+
 ## Function calls
 
 ```mach

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -109,8 +109,10 @@ var z: i32x4;                   # every lane is 0
 ```
 
 **Lane access** `v[i]` reads or writes a single lane. The index must be a
-comptime constant in `[0, lanes)` and is bounds-checked at compile time; a
-dynamic (runtime) lane index is not supported in this increment.
+comptime constant in `[0, lanes)`; a dynamic (runtime) lane index is not
+supported in this increment. The bound is the same compile-time rule an array
+gets, reported the same way — `v[4]` on a `u32x4` is `index 4 is out of bounds
+for `u32x4` of length 4`.
 
 ```mach
 var v: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
@@ -143,6 +145,26 @@ val v: i64  = @p;       # dereference reads through it
 val a: [4]i64    = [4]i64{1, 2, 3, 4};
 val g: [2][2]i64 = [2][2]i64{ [2]i64{1, 2}, [2]i64{3, 4} };
 ```
+
+**Constant indices are bounds-checked at compile time.** `N` is part of the
+type, so an index the compiler can fold must land in `[0, N)`:
+
+```mach
+var xs: [4]i32;
+val a: i32 = xs[3];             # ok
+val b: i32 = xs[4];             # error: index 4 is out of bounds for `[4]i32` of length 4
+val c: i32 = xs[-1];            # error: index -1 is out of bounds ...
+```
+
+The rule is keyed on the length the type carries, not on how the array was
+spelled, so a `def` alias, an array field of a generic instance, an array nested
+in a record or in another array, and a `^`-qualified array are all checked the
+same way. It is exactly the length `$length_of` reports
+([comptime-intrinsics.md](comptime-intrinsics.md)), and a vector's lane count
+takes the identical rule.
+
+Only a **constant** index is checked. A runtime index is not, and a pointer is
+not indexed against any length at all — `*T` carries none.
 
 ## Function type
 

--- a/int/regression/2751-const-index-bounds/case.conf
+++ b/int/regression/2751-const-index-bounds/case.conf
@@ -1,0 +1,13 @@
+# #2751: a constant index outside a fixed length reached code generation on every
+# target, and on SPIR-V produced an `OpAccessChain` with `%uint_9` into a
+# four-element array that `spirv-val` accepted. the refusal is in sema, so the
+# observable is the diagnostic set: a build that emits nothing is the point.
+#
+# the fixture carries every spelling that reaches the same interned array type -
+# alias, generic instance field, nested aggregate, `^`-qualified - because a check
+# keyed on the expression rather than on the type passes the plain form and misses
+# all of them. the in-bounds neighbours are in the same file: if the rule were a
+# hardcoded bound rather than the type's length, they would land in the golden too.
+run: build-fails
+targets: linux
+profiles: debug

--- a/int/regression/2751-const-index-bounds/expect.linux.txt
+++ b/int/regression/2751-const-index-bounds/expect.linux.txt
@@ -1,0 +1,9 @@
+error: index 9 is out of bounds for `[4]i32` of length 4
+error: index 4 is out of bounds for `[4]i32` of length 4
+error: index -1 is out of bounds for `[4]i32` of length 4
+error: index 4 is out of bounds for `[4]i32` of length 4
+error: index 8 is out of bounds for `[8]i64` of length 8
+error: index 3 is out of bounds for `[3]i32` of length 3
+error: index 3 is out of bounds for `[3]i32` of length 3
+error: index 6 is out of bounds for `^[4]i32` of length 4
+error: index 4 is out of bounds for `u32x4` of length 4

--- a/int/regression/2751-const-index-bounds/mach.toml
+++ b/int/regression/2751-const-index-bounds/mach.toml
@@ -1,0 +1,24 @@
+[project]
+id = "case"
+version = "1.0.0"
+src = "src"
+out = "out"
+
+[target.linux]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+

--- a/int/regression/2751-const-index-bounds/src/main.mach
+++ b/int/regression/2751-const-index-bounds/src/main.mach
@@ -1,0 +1,60 @@
+# a constant index outside a statically known length is refused before any target
+# sees it, and the in-bounds neighbour of each is not
+
+def Buf: [4]i32;
+
+rec Box[T] { xs: [8]T; }
+
+rec Nest { inner: [3]i32; }
+
+fun plain() i32 {
+    var xs: [4]i32;
+    ret xs[3] + xs[0] + xs[9];
+}
+
+fun boundary() i32 {
+    var xs: [4]i32;
+    ret xs[4];
+}
+
+fun low() i32 {
+    var xs: [4]i32;
+    ret xs[-1];
+}
+
+fun alias() i32 {
+    var b: Buf;
+    ret b[3] + b[4];
+}
+
+fun generic() i64 {
+    var b: Box[i64];
+    ret b.xs[7] + b.xs[8];
+}
+
+fun nested() i32 {
+    var v: Nest;
+    ret v.inner[2] + v.inner[3];
+}
+
+fun grid() i32 {
+    var g: [2][3]i32;
+    ret g[1][2] + g[1][3];
+}
+
+fun secret(s: ^[4]i32) ^i32 {
+    ret s[6];
+}
+
+fun lane(v: u32x4) u32 {
+    ret v[3] + v[4];
+}
+
+# a runtime index and a pointer carry no decidable bound, and stay accepted
+fun dynamic(i: u64, p: *i32) i32 {
+    var xs: [4]i32;
+    ret xs[i] + p[99];
+}
+
+#[symbol("main")]
+fun main() i32 { ret 0; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1697,9 +1697,9 @@ test "mach.lang.driver:vector_negative_diagnostics" {
     # non-comptime lane index (dynamic)
     if (ut_vec_diag("fun main(argc: i64, argv: **u8) i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val x: f32 = a[argc]; ret 0; }\n",
         "dynamic lane index not supported") != 0) { bad = 1; }
-    # out-of-bounds constant lane index
+    # out-of-bounds constant lane index: the same bound an array is measured by (#2751)
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val x: f32 = a[4]; ret 0; }\n",
-        "vector lane index out of bounds") != 0) { bad = 1; }
+        "index 4 is out of bounds for `f32x4` of length 4") != 0) { bad = 1; }
     # vector %
     if (ut_vec_diag("fun main() i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 2, 3, 4}; val c: i32x4 = a % b; ret 0; }\n",
         "vector `%` is not supported") != 0) { bad = 1; }
@@ -1717,7 +1717,7 @@ test "mach.lang.driver:vector_negative_diagnostics" {
         "positional-brace literal requires a vector type") != 0) { bad = 1; }
     # a negative constant lane index.
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val x: f32 = a[-1]; ret 0; }\n",
-        "index must be non-negative") != 0) { bad = 1; }
+        "index -1 is out of bounds for `f32x4` of length 4") != 0) { bad = 1; }
     # scalar<->vector mixing in the reversed operand order (scalar on the left).
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val s: f32 = 1.0; val c: f32x4 = s + a; ret 0; }\n",
         "mismatch") != 0) { bad = 1; }
@@ -1728,6 +1728,95 @@ test "mach.lang.driver:vector_negative_diagnostics" {
         "not in the increment-1 operator table") != 0) { bad = 1; }
     if (ut_vec_diag("fun main() i32 { val a: i8x16 = i8x16{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}; val b: i8x16 = i8x16{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; val c: i8x16 = a << b; ret 0; }\n",
         "vector shift") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# a CONSTANT index outside a statically known element count is refused (#2751)
+#
+# Each needle carries the index, the type and the length, so a hit cannot come
+# from a different diagnostic and cannot come from a hardcoded bound: three
+# lengths (3, 4, 8) with the boundary index of each is what separates a real rule
+# from `> 4`. The spellings matter as much as the lengths -- an alias, a generic
+# instance's field, a nested aggregate and a `^`-qualified array all reach the
+# same interned array type, and a check keyed on the expression that reached it
+# rather than on the type would pass the plain form and miss every one of these.
+test "mach.lang.driver:const_index_out_of_bounds" {
+    var bad: i32 = 0;
+
+    # the boundary: on a [4], index 4 is refused and index 3 is not
+    if (ut_vec_diag("fun f() i32 { var xs: [4]i32; ret xs[4]; }\nfun main() i32 { ret 0; }\n",
+        "index 4 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
+    if (!ut_sema_clean("fun f() i32 { var xs: [4]i32; ret xs[3]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # index 0 is in bounds for a non-empty array, and is not confused with the bound
+    if (!ut_sema_clean("fun f() i32 { var xs: [4]i32; ret xs[0]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # a different length moves the boundary with it
+    if (ut_vec_diag("fun f() i32 { var xs: [3]i32; ret xs[3]; }\nfun main() i32 { ret 0; }\n",
+        "index 3 is out of bounds for `[3]i32` of length 3") != 0) { bad = 1; }
+    if (!ut_sema_clean("fun f() i32 { var xs: [3]i32; ret xs[2]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (ut_vec_diag("fun f() i32 { var xs: [8]i32; ret xs[8]; }\nfun main() i32 { ret 0; }\n",
+        "index 8 is out of bounds for `[8]i32` of length 8") != 0) { bad = 1; }
+    if (!ut_sema_clean("fun f() i32 { var xs: [8]i32; ret xs[7]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a length-1 array: index 1 is past the end, index 0 is not
+    if (ut_vec_diag("fun f() i32 { var xs: [1]i32; ret xs[1]; }\nfun main() i32 { ret 0; }\n",
+        "index 1 is out of bounds for `[1]i32` of length 1") != 0) { bad = 1; }
+    if (!ut_sema_clean("fun f() i32 { var xs: [1]i32; ret xs[0]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # far past the end, the shape the issue was filed on
+    if (ut_vec_diag("fun f() i32 { var xs: [4]i32; ret xs[9]; }\nfun main() i32 { ret 0; }\n",
+        "index 9 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
+    # a negative constant is out of bounds at the low end
+    if (ut_vec_diag("fun f() i32 { var xs: [4]i32; ret xs[-1]; }\nfun main() i32 { ret 0; }\n",
+        "index -1 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
+
+    # SPELLINGS. a `def` alias names the same interned array
+    if (ut_vec_diag("def Buf: [4]i32;\nfun f() i32 { var b: Buf; ret b[4]; }\nfun main() i32 { ret 0; }\n",
+        "index 4 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
+    if (!ut_sema_clean("def Buf: [4]i32;\nfun f() i32 { var b: Buf; ret b[3]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a generic instance's array field, per instantiation
+    if (ut_vec_diag("rec Box[T] { xs: [4]T; }\nfun f() i64 { var b: Box[i64]; ret b.xs[7]; }\nfun main() i32 { ret 0; }\n",
+        "index 7 is out of bounds for `[4]i64` of length 4") != 0) { bad = 1; }
+    if (!ut_sema_clean("rec Box[T] { xs: [4]T; }\nfun f() i64 { var b: Box[i64]; ret b.xs[3]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # an array nested inside a record
+    if (ut_vec_diag("rec N { inner: [3]i32; }\nfun f() i32 { var v: N; ret v.inner[5]; }\nfun main() i32 { ret 0; }\n",
+        "index 5 is out of bounds for `[3]i32` of length 3") != 0) { bad = 1; }
+    # an array nested inside an array
+    if (ut_vec_diag("fun f() i32 { var g: [2][3]i32; ret g[1][3]; }\nfun main() i32 { ret 0; }\n",
+        "index 3 is out of bounds for `[3]i32` of length 3") != 0) { bad = 1; }
+    if (ut_vec_diag("fun f() i32 { var g: [2][3]i32; ret g[2][0]; }\nfun main() i32 { ret 0; }\n",
+        "index 2 is out of bounds for `[2][3]i32` of length 2") != 0) { bad = 1; }
+    # a `^`-qualified array is measured through the wrapper, as `$length_of` is
+    if (ut_vec_diag("fun f(s: ^[4]i32) i32 { ret s[6]::i32; }\nfun main() i32 { ret 0; }\n",
+        "index 6 is out of bounds for `^[4]i32` of length 4") != 0) { bad = 1; }
+    # a vector's lane count is a statically known length too, and takes the same rule
+    if (ut_vec_diag("fun f(v: u32x4) u32 { ret v[4]; }\nfun main() i32 { ret 0; }\n",
+        "index 4 is out of bounds for `u32x4` of length 4") != 0) { bad = 1; }
+    if (ut_vec_diag("fun f(v: i8x16) i8 { ret v[16]; }\nfun main() i32 { ret 0; }\n",
+        "index 16 is out of bounds for `i8x16` of length 16") != 0) { bad = 1; }
+
+    # a folded constant EXPRESSION, and a module-level constant, are both indices
+    if (ut_vec_diag("fun f() i32 { var xs: [4]i32; ret xs[2 + 2]; }\nfun main() i32 { ret 0; }\n",
+        "index 4 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
+    if (ut_vec_diag("val K: u64 = 5;\nfun f() i32 { var xs: [4]i32; ret xs[K]; }\nfun main() i32 { ret 0; }\n",
+        "index 5 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
+    if (!ut_sema_clean("val K: u64 = 3;\nfun f() i32 { var xs: [4]i32; ret xs[K]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # NOT decidable here, and so NOT refused: a runtime index, and a pointer,
+    # which carries no length to measure against
+    if (!ut_sema_clean("fun f(i: u64) i32 { var xs: [4]i32; ret xs[i]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("fun f(p: *i32) i32 { ret p[99]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # the comptime env is keyed by NAME, so a local that SHADOWS a module constant
+    # must not be folded: `n` here is 1 at runtime and the access is legal
+    if (!ut_sema_clean("val N: u64 = 9;\nfun f() i32 { var xs: [4]i32; var N: u64 = 1; ret xs[N]; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # the same shadow on a vector is a DYNAMIC lane, not an out-of-bounds one
+    if (ut_vec_diag("val N: u64 = 9;\nfun f(v: u32x4) u32 { var N: u64 = 1; ret v[N]; }\nfun main() i32 { ret 0; }\n",
+        "dynamic lane index not supported") != 0) { bad = 1; }
+
+    # the assignment target is an index too
+    if (ut_vec_diag("fun f() i32 { var xs: [4]i32; xs[4] = 1; ret 0; }\nfun main() i32 { ret 0; }\n",
+        "index 4 is out of bounds for `[4]i32` of length 4") != 0) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1840,6 +1840,33 @@ fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32
     ret R.ok[bool, str](true);
 }
 
+# whether a resolved symbol denotes a RUNTIME binding, decided on resolution
+# identity rather than on name text
+#
+# ONE definition because the comptime environment is keyed by NAME: a block-local
+# `val`/`var` or a non-`$` parameter that happens to share a name with a
+# module-level constant folds to that constant, so every site that decides
+# whether an identifier may be folded has to ask the same question. A second
+# enumeration of this rule would drift, and the two sites it serves - the `$if`
+# gate shadowing check and the constant index bound (#2751) - disagree loudly
+# when it does: one miscompiles a gate, the other refuses a legal access.
+#
+# Module scope is what makes a `val` foldable, `$` is what makes a parameter
+# foldable, and everything else (a function, an import, a type name) is not a
+# value binding at all and is left to the evaluator.
+# ---
+# sym: the resolved symbol
+# ret: true when the symbol names storage decided at runtime
+pub fun symbol_is_runtime(sym: *Symbol) bool {
+    if (sym.kind == SYM_VAL || sym.kind == SYM_VAR) {
+        ret (sym.flags & SYM_FLAG_MODULE) == 0;
+    }
+    if (sym.kind == SYM_PARAM) {
+        ret (sym.flags & SYM_FLAG_COMPTIME) == 0;
+    }
+    ret false;
+}
+
 # walks a folded (non-param) `$if` gate and rejects any
 # leaf identifier that resolves to a runtime binding whose NAME also names a
 # comptime constant in the env. the comptime fold is name-keyed, so such a gate
@@ -1873,16 +1900,7 @@ fun check_gate_shadowing(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str
     if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret R.ok[bool, str](true); }
     val sym: *Symbol = ?rc.symbols[sid];
 
-    # runtime by resolution identity: a block-local val/var, or a non-`$`
-    # parameter. module-scope vals, imports, and comptime params are foldable.
-    var runtime: bool = false;
-    if (sym.kind == SYM_VAL || sym.kind == SYM_VAR) {
-        runtime = (sym.flags & SYM_FLAG_MODULE) == 0;
-    }
-    if (sym.kind == SYM_PARAM) {
-        runtime = (sym.flags & SYM_FLAG_COMPTIME) == 0;
-    }
-    if (!runtime) { ret R.ok[bool, str](true); }
+    if (!symbol_is_runtime(sym)) { ret R.ok[bool, str](true); }
 
     val id_r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, e.span);
     if (R.is_err[intern.StrId, str](id_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](id_r)); }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -402,6 +402,135 @@ pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.T
     ret O.some[type.TypeId](elem);
 }
 
+# GATE (#2751): a CONSTANT index outside a STATICALLY KNOWN element count
+#
+# A fixed array's length and a vector's lane count are both part of the type, so
+# an index the compiler can fold is decidable here on every target with no
+# dataflow at all. Keyed on `type.element_count`, which is the ONE definition of
+# "how many elements a type holds" and the same answer `$length_of` gives, so an
+# array and a vector cannot drift into different bounds rules and a `^` wrapper
+# is seen through by exactly the rule that makes `$length_of(^[4]u8)` four.
+#
+# Keying on the count rather than on the syntax is what makes the alias, the
+# generic field and the nested-aggregate spellings free: `def Buf: [4]i32;` and
+# `Box[i64].xs` both name the same interned array type, and the count is read off
+# that type rather than off the expression that reached it.
+#
+# A pointer is deliberately NOT covered: `*T` carries no length, so `p[9]` has
+# nothing to be measured against. A non-constant index is likewise out of scope,
+# that one needs dataflow.
+# ---
+# sc:     the active sema context
+# object: the indexed object's type
+# idx:    the index expression
+# span:   source range of the access
+# ret:    true when the access is in bounds or not decidable here, false (with a
+#         diagnostic) when a folded index falls outside the element count
+pub fun check_const_index(sc: *context.SemaContext, object: type.TypeId, idx: id.ExprId, span: token.Span) bool {
+    val n_opt: O.Option[u32] = type.element_count(?sc.s.types, object);
+    if (O.is_none[u32](n_opt)) { ret true; }
+
+    val cv_opt: O.Option[comptime.CTValue] = const_index_value(sc, idx);
+    if (O.is_none[comptime.CTValue](cv_opt)) { ret true; }
+
+    val n:  u32              = O.unwrap[u32](n_opt);
+    val cv: comptime.CTValue = O.unwrap[comptime.CTValue](cv_opt);
+
+    if (!comptime.ct_is_negative(cv) && cv.data.i:~u64 < n::u64) { ret true; }
+
+    report_index_oob(sc, span, cv, object, n);
+    ret false;
+}
+
+# the constant value of an index expression, or none when this layer cannot
+# decide it
+#
+# Folds through `comptime.eval`, but only once resolution identity has said that
+# no leaf names a runtime binding. The comptime environment is keyed by NAME, so
+# a block-local `var n` that shares its name with a module-level `val n` folds to
+# the module constant, and a bound rule that trusted the fold would refuse a
+# legal access against a value the program never reads.
+# ---
+# sc:  the active sema context
+# eid: the index expression
+# ret: some(value) for a decidable integer index, none otherwise
+pub fun const_index_value(sc: *context.SemaContext, eid: id.ExprId) O.Option[comptime.CTValue] {
+    if (eid == id.EXPR_NIL)                { ret O.none[comptime.CTValue](); }
+    if (references_runtime_binding(sc, eid)) { ret O.none[comptime.CTValue](); }
+
+    val cr: R.Result[comptime.CTValue, str] =
+        comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+    if (R.is_err[comptime.CTValue, str](cr)) { ret O.none[comptime.CTValue](); }
+
+    val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](cr);
+    if (cv.kind != comptime.CT_KIND_INT) { ret O.none[comptime.CTValue](); }
+    ret O.some[comptime.CTValue](cv);
+}
+
+# walks `eid` reporting whether any leaf identifier resolves to a runtime binding
+# ---
+# sc:  the active sema context
+# eid: the expression to walk (EXPR_NIL terminates it)
+# ret: true when any leaf names storage decided at runtime
+fun references_runtime_binding(sc: *context.SemaContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_none[*expr.Expr](opt_expr)) { ret false; }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](opt_expr);
+
+    if (e.kind == expr.EXPR_KIND_IDENT) {
+        val opt_sym: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
+        if (O.is_none[*resolve.Symbol](opt_sym)) { ret false; }
+        ret resolve.symbol_is_runtime(O.unwrap[*resolve.Symbol](opt_sym));
+    }
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        ret references_runtime_binding(sc, e.data.binary.lhs)
+         || references_runtime_binding(sc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret references_runtime_binding(sc, e.data.unary.operand);
+    }
+    ret false;
+}
+
+# report `index N is out of bounds for `T` of length L` at `span`
+#
+# degrades to a static message on any allocation failure so the refusal always
+# lands.
+# ---
+# sc:     the active sema context
+# span:   source range of the access
+# cv:     the folded index
+# object: the indexed object's type
+# n:      its element count
+fun report_index_oob(sc: *context.SemaContext, span: token.Span, cv: comptime.CTValue, object: type.TypeId, n: u32) {
+    val res_type: R.Result[str, str] = type_to_str(sc, object);
+    if (R.is_err[str, str](res_type)) {
+        report(sc, span, "index out of bounds for the element count");
+        ret;
+    }
+    val type_str: str = R.unwrap_ok[str, str](res_type);
+
+    var res_msg: R.Result[str, str] = R.err[str, str]("unformatted");
+    if (cv.int_unsigned) {
+        res_msg = format.sprint(sc.s.alloc, "index {} is out of bounds for `{}` of length {}",
+            cv.data.i:~u64, type_str, n);
+    }
+    or {
+        res_msg = format.sprint(sc.s.alloc, "index {} is out of bounds for `{}` of length {}",
+            cv.data.i, type_str, n);
+    }
+    if (R.is_err[str, str](res_msg)) {
+        report(sc, span, "index out of bounds for the element count");
+        type_str_free(sc, type_str);
+        ret;
+    }
+    val msg: str = R.unwrap_ok[str, str](res_msg);
+    report(sc, span, msg);
+    A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
+    type_str_free(sc, type_str);
+}
+
 # GATE (#2191): reject a value used as a MEMORY ADDRESS whose own type is secret
 #
 # The address half of the leakage model's memory rule, and the exact counterpart of

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -2692,9 +2692,13 @@ fun infer_index(sc: *context.SemaContext, ix: *expr.ExprIndex, span: token.Span)
     val it: type.TypeId = infer_expr(sc, ix.index);
     if (ot == type.TYPE_ERROR || it == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
-    # lane access `v[i]` on a vector: the index must be a comptime constant in
-    # bounds, and the result is the lane scalar (#1965). a dynamic index is a
-    # defined error, deferred by design (a memory round-trip breaks 1:1 on SSE2).
+    # BOUNDS (#2751): asked before the vector split so an array and a vector get
+    # the identical rule off the identical element count.
+    if (!check.check_const_index(sc, ot, ix.index, span)) { ret type.TYPE_ERROR; }
+
+    # lane access `v[i]` on a vector: the index must be a comptime constant, and
+    # the result is the lane scalar (#1965). a dynamic index is a defined error,
+    # deferred by design (a memory round-trip breaks 1:1 on SSE2).
     if (type.is_vector(?sc.s.types, ot)) {
         ret infer_vector_lane(sc, ix, ot, span);
     }
@@ -2704,8 +2708,13 @@ fun infer_index(sc: *context.SemaContext, ix: *expr.ExprIndex, span: token.Span)
     ret O.unwrap[type.TypeId](r);
 }
 
-# lane access on a vector: demand a comptime-constant, in-bounds index and yield
-# the lane scalar, joining any secrecy on the vector onto the result (#1965)
+# lane access on a vector: demand a comptime-constant index and yield the lane
+# scalar, joining any secrecy on the vector onto the result (#1965)
+#
+# The BOUND is not asked here: `check.check_const_index` has already refused an
+# out-of-range lane against the same element count an array is measured by, so
+# this only enforces the extra rule a vector carries, that the index be constant
+# at all.
 # ---
 # sc:   sema context
 # ix:   the index payload
@@ -2713,27 +2722,13 @@ fun infer_index(sc: *context.SemaContext, ix: *expr.ExprIndex, span: token.Span)
 # span: the index span for diagnostics
 # ret:  the lane scalar TypeId, or TYPE_ERROR
 fun infer_vector_lane(sc: *context.SemaContext, ix: *expr.ExprIndex, ot: type.TypeId, span: token.Span) type.TypeId {
-    val base:      type.TypeId = type.strip_secret(?sc.s.types, ot);
-    val lanes:     u32         = type.vector_lanes(?sc.s.types, base);
+    val base:      type.TypeId   = type.strip_secret(?sc.s.types, ot);
     val lane_kind: type.TypeKind = type.vector_element(?sc.s.types, base);
-    val lane_ty:   type.TypeId = prim_or_error(sc, lane_kind);
+    val lane_ty:   type.TypeId   = prim_or_error(sc, lane_kind);
 
-    val cr: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, ix.index, ?sc.s.interner);
-    if (R.is_err[comptime.CTValue, str](cr)) {
+    val cv_opt: O.Option[comptime.CTValue] = check.const_index_value(sc, ix.index);
+    if (O.is_none[comptime.CTValue](cv_opt)) {
         context.report(sc, span, "dynamic lane index not supported: a vector lane index must be a comptime constant");
-        ret type.TYPE_ERROR;
-    }
-    val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](cr);
-    if (cv.kind != comptime.CT_KIND_INT) {
-        context.report(sc, span, "dynamic lane index not supported: a vector lane index must be a comptime constant");
-        ret type.TYPE_ERROR;
-    }
-    if (comptime.ct_is_negative(cv)) {
-        context.report(sc, span, "vector lane index out of bounds: index must be non-negative");
-        ret type.TYPE_ERROR;
-    }
-    if (cv.data.i:~u64 >= lanes::u64) {
-        context.report(sc, span, "vector lane index out of bounds for the lane count");
         ret type.TYPE_ERROR;
     }
 


### PR DESCRIPTION
Closes #2751

## The rule

A constant index against a **statically known element count** must land in `[0, count)`.

The check is keyed on `type.element_count`, which is the ONE definition of "how many elements a type holds" and the same answer `$length_of` gives (#2536). That choice is the whole point:

- **Arrays and vectors cannot drift.** A vector's lane count is a decided length, not an incidental one, so it takes the identical rule off the identical predicate. The vector-only bounds wording it had before is gone, replaced by the shared message. What stays vector-specific is the extra rule a vector carries, that the index be constant at all.
- **The spellings are free.** `def Buf: [4]i32;`, `Box[i64].xs`, an array nested in a record, an array nested in an array, and `^[4]i32` all name the same interned array type, and the count is read off that type rather than off the expression that reached it. A check keyed on the syntax passes the plain form and misses every one of these, which is the shape that looks correct in review.

The diagnostic names the index, the type and the length:

```
error: index 9 is out of bounds for `[4]i32` of length 4
```

Deliberately **not** covered: a runtime index (needs dataflow) and a pointer (`*T` carries no length to measure against). Both are pinned by positive tests, not left to assumption.

## A second defect, found on the way

Folding the index now decides on **resolution identity** rather than on name text.

The comptime environment is keyed by name, so a block-local `var n` that shares its name with a module-level `val n` folds to the module constant. That is not hypothetical, it was already firing on `dev`:

```mach
val N: u64 = 9;
fun g(v: u32x4) u32 {
    var N: u64 = 1;
    ret v[N];          # dev: "vector lane index out of bounds for the lane count"
}
```

`N` is 1 there. The diagnostic was reporting a bound against a value the program never reads. It now gives the dynamic-lane refusal it should always have given, and an array indexed by such a local is correctly left alone rather than refused, which is what the same bug would have cost on the new array rule.

The runtime-binding rule already existed twice (resolve's `$if` gate shadowing check, and the sema gate walk). It now has one definition, `resolve.symbol_is_runtime`, shared by the gate check and the new bound.

## Evidence

**Every refusal was proven to fire, and to fail without the patch.** Both new/changed unit tests fail against a compiler built from `origin/dev` @ `96c251f3` and pass against this branch:

```
$ ./mach-dev test .   # origin/dev compiler, this branch's tests
  FAIL  mach.lang.driver:vector_negative_diagnostics
  FAIL  mach.lang.driver:const_index_out_of_bounds
1285 passed, 2 failed, 1287 total
```

The int case is the same story, blessed under the patch and diffed against the baseline compiler, which produces one line where the golden has nine.

**Not a hardcoded bound.** The unit test uses lengths 1, 3, 4 and 8, and for each one asserts the boundary index is refused *and* that boundary minus one is clean. Index 0 is asserted in bounds separately, and a negative constant is asserted out of bounds at the low end. The int fixture puts the in-bounds neighbour of every refusal in the same file, so the golden's nine lines are also proof that nothing legal was swept up.

**Runs.**

- `mach test .` — 1287 passed, 0 failed.
- `int/run.sh --target linux --deps pin` — all cases passed.
- `int/run.sh --target linux-arm64` under qemu locally: 4 failures, all pre-existing and host-environmental (`c-variadic`, `narrow-stack-args` build their C probe with the host `cc`), identical on the baseline compiler. **The native aarch64 leg is CI's** — `linux-arm64` on `ubuntu-24.04-arm` is a `pr`-cadence row in `int/targets.conf`, so it runs here.
- Self-host fixpoint: stage2 byte-identical to stage3, self-built against self-built.
  `18018025c8913c63a24c0b06d78104de0d48457b8557568a780497b579947e49`

**The compiler's own source does not trip the new check.** The stage2 build of this tree, mach-std included, is clean. There is no constant out-of-bounds index in it.

## Docs

`doc/language/types.md` states the rule under Array with the spellings it covers and the two cases it deliberately does not, and the vector Lane access paragraph now points at the shared bound instead of describing its own. `doc/language/expressions.md` cross-references from the index-access section. `CHANGELOG.md` under `## [Unreleased]`.
