### PR TITLE
fix(ir): render float constants in shortest round-trippable decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ The refusal itself is unchanged. Its diagnostic and `doc/language/decorators.md`
 
 ### Fixed
 
+#### `--emit-ir` shows a float constant, not its truncated integer magnitude (#2753)
+Every float constant in an IR dump rendered as the integer part of its magnitude, so the surface could not show any distinction living below the decimal point, at the top of the range, or at the bottom of it. `1.5` and `1.75` both printed `f1`. A positive infinity printed `f9223372036854775808`, which is also what the finite value 2^63 printed, so an infinity read as a plausible finite number and the two were indistinguishable. The smallest denormal printed `f0`.
+
+The middle end never lost any of this: `me/pass/cse.mach` value-numbers float constants by bit pattern and `me/pass/algebraic.mach` declines to fold `x + 0.0`, precisely so the IR keeps IEEE distinctions apart. Only the view collapsed them, which matters because a dump is what someone reads when they already suspect a float bug and the fraction is the evidence.
+
+Constants now render through `std.format.write_f64` in shortest round-trippable decimal, so `f1.5`, `f1.75`, `f5e-324` and `f9.223372036854776e18` are each themselves, and the non-finite classes spell themselves as `finf`, `f-inf` and `fnan` rather than borrowing an integer. A NaN whose payload is not the canonical quiet one renders its full bit pattern as `fnan:0x…`, since a payload is a distinction the middle end keeps too. Signed zero still renders `f-0` and `f0`, which #2274 established.
+
+The reason recorded in the code for the old rendering - that std had no float formatter - had gone stale; `printer.mach` already imported `std.format`. The unit test that pinned `-1.5` to `f-1` and `2.5` to `f2` was enforcing the defect rather than any intended behaviour, and now pins the real rendering across the IEEE classes, built from bit patterns rather than decimal literals. Objects are byte-identical: this moves nothing but the dump.
+
 #### An over-aligned stack local is over-aligned at run time (#2735)
 `#[align(32)]` and above worked on a global and did nothing on a local. The slot's offset was a correct multiple of the requested alignment, but it was measured from the frame pointer, and the only alignment that reaches the frame pointer is the ABI's 16-byte call boundary. So the address was a multiple of 32 exactly when the process stack happened to start on one, which depends on the environment block and therefore changes between runs of the same binary. `$size_of` already reported the padded size, so the storage was sized for a promise the placement did not keep.
 

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -23,6 +23,11 @@
 # as `phi <ty> [bb0 %0: i32, bb1 %3: i32, ...]`. Per-instruction modifier flags
 # render as opcode suffixes (`add.nsw`, `load.volatile`).
 #
+# Float constants render as `f` followed by the shortest round-trippable decimal
+# (`f1.5`, `f1.75`, `f5e-324`), with `finf` / `f-inf` / `f-0` for the classes an
+# integer magnitude cannot spell and `fnan:0x<bits>` for a NaN whose payload is
+# not the canonical quiet one.
+#
 # Every value operand at a use site carries its own IR type as a `<value>: <ty>`
 # suffix, so a mis-typed operand (an aggregate passed as a bare pointer) is
 # visible without chasing def-use chains. An extern declaration renders its
@@ -328,20 +333,9 @@ pub fun print_value(out: *writer.Writer, m: *ir.Module, v: *value.Value, interne
         ret emit_u64(out, v.data.int_lit);
     }
     if (v.kind == value.VAL_CONST_FLOAT) {
-        # std has no float formatter; print the truncated integer magnitude
-        # tagged `f` so the dump stays readable (it is not reloadable anyway).
-        # the sign comes off the IEEE sign bit, not `f < 0.0`, so a negative zero
-        # prints `f-0` rather than reading as `+0.0` (#2274) -- the two are
-        # distinct constants the middle end deliberately keeps apart.
         val res_tag: R.Result[bool, str] = emit_str(out, "f");
         if (R.is_err[bool, str](res_tag)) { ret res_tag; }
-        val f: f64 = v.data.float_lit;
-        if (float.f64_signbit(f)) {
-            val res_sign: R.Result[bool, str] = emit_str(out, "-");
-            if (R.is_err[bool, str](res_sign)) { ret res_sign; }
-            ret emit_u64(out, float.f64_neg(f)::u64);
-        }
-        ret emit_u64(out, f::u64);
+        ret emit_f64(out, v.data.float_lit);
     }
     if (v.kind == value.VAL_CONST_NULL) {
         ret emit_str(out, "null");
@@ -752,6 +746,32 @@ fun emit_u64(out: *writer.Writer, n: u64) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
+# write a float constant in shortest round-trippable decimal
+#
+# `write_f64` spells both signed zeros and both infinities itself, so every IEEE
+# class but NaN renders distinguishably through it - including the `f-0` that
+# #2274 established. NaN payloads it collapses to `nan`, and the middle end keeps
+# them apart (cse.mach value-numbers float constants by bit pattern), so anything
+# other than the canonical quiet NaN renders as its full bit pattern instead.
+# ---
+# out: destination writer
+# f:   the value to write
+# ret: ok(true) on success, or the write error
+fun emit_f64(out: *writer.Writer, f: f64) R.Result[bool, str] {
+    val bits: u64 = float.f64_bits(f);
+    if (((bits >> 52) & 0x7FF) == 0x7FF && (bits & 0xFFFFFFFFFFFFF) != 0) {
+        if (bits == 0x7FF8000000000000) { ret emit_str(out, "nan"); }
+        val res_tag: R.Result[bool, str] = emit_str(out, "nan:0x");
+        if (R.is_err[bool, str](res_tag)) { ret res_tag; }
+        val res_hex: R.Result[usize, str] = format.write_hex_u64(out, bits, false);
+        if (R.is_err[usize, str](res_hex)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_hex)); }
+        ret R.ok[bool, str](true);
+    }
+    val res: R.Result[usize, str] = format.write_f64(out, f);
+    if (R.is_err[usize, str](res)) { ret R.err[bool, str](R.unwrap_err[usize, str](res)); }
+    ret R.ok[bool, str](true);
+}
+
 # write an interned name, or `<?name>` when the id does not resolve
 # ---
 # out:      destination writer
@@ -808,12 +828,16 @@ fun float_renders_as(m: *ir.Module, f: f64, ty: type.IrTypeId, want: str) i32 {
     ret 0;
 }
 
-# the two zeros are DISTINCT constants and must render distinctly
+# float constants the middle end keeps apart must render apart
 #
-# The sign came off `f < 0.0`, which is false for -0.0, so a dump showed both as
-# `f0` (#2274) - hiding the difference cse.mach value-numbers float constants by
-# bit pattern to preserve, and algebraic.mach declines to fold `x + 0.0` over.
-test "mach.lang.me.ir.printer.print_value:signed_zero" {
+# cse.mach value-numbers float constants by bit pattern and algebraic.mach
+# declines to fold `x + 0.0`, so the IR carries every IEEE distinction. The
+# printer used to collapse them onto a truncated integer magnitude (#2753):
+# `1.5` and `1.75` both rendered `f1`, an infinity rendered as a plausible finite
+# `f9223372036854775808`, and the smallest denormal rendered `f0`. Before that it
+# also collapsed the two zeros (#2274). Operands are built from IEEE-754 bit
+# patterns rather than decimal literals so each case names the value it pins.
+test "mach.lang.me.ir.printer.print_value:float_rendering" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
@@ -823,11 +847,30 @@ test "mach.lang.me.ir.printer.print_value:signed_zero" {
     if (R.is_err[type.IrTypeId, str](res_ty)) { ret 1; }
     val ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_ty);
 
+    val pos_inf: f64 = float.bits_f64(0x7FF0000000000000);
+    val neg_inf: f64 = float.f64_neg(pos_inf);
+    # 0x43E0000000000000 is 2^63, the finite value an infinity used to print as
+    val two_63:  f64 = float.bits_f64(0x43E0000000000000);
+    val denorm:  f64 = float.bits_f64(1);
+    val qnan:    f64 = float.bits_f64(0x7FF8000000000000);
+    val pnan:    f64 = float.bits_f64(0x7FF8000000000001);
+
     var bad: i32 = 0;
     bad = bad | float_renders_as(?m, -0.0, ty, "f-0");
     bad = bad | float_renders_as(?m, 0.0, ty, "f0");
-    # the magnitude of a negative value is unaffected
-    bad = bad | float_renders_as(?m, -1.5, ty, "f-1");
-    bad = bad | float_renders_as(?m, 2.5, ty, "f2");
+    # the fraction is the evidence in a float bug, so it survives to the dump
+    bad = bad | float_renders_as(?m, 1.5, ty, "f1.5");
+    bad = bad | float_renders_as(?m, 1.75, ty, "f1.75");
+    bad = bad | float_renders_as(?m, -1.5, ty, "f-1.5");
+    bad = bad | float_renders_as(?m, 2.5, ty, "f2.5");
+    # an infinity announces itself instead of borrowing a finite magnitude
+    bad = bad | float_renders_as(?m, pos_inf, ty, "finf");
+    bad = bad | float_renders_as(?m, neg_inf, ty, "f-inf");
+    bad = bad | float_renders_as(?m, two_63, ty, "f9.223372036854776e18");
+    # 2^-1074, the smallest positive value, is not zero
+    bad = bad | float_renders_as(?m, denorm, ty, "f5e-324");
+    # a NaN payload is a distinction too, so only the canonical quiet one is bare
+    bad = bad | float_renders_as(?m, qnan, ty, "fnan");
+    bad = bad | float_renders_as(?m, pnan, ty, "fnan:0x7ff8000000000001");
     ret bad;
 }


### PR DESCRIPTION
Closes #2753. Part of #2288.

## Before, on the unpatched compiler

Built `origin/dev` @ `6991413e`, one function per constant, `--emit-ir` on `linux-x86_64`:

```
ret f1: f64                       # 1.5
ret f1: f64                       # 1.75
ret f9223372036854775808: f64     # +inf
ret f-9223372036854775808: f64    # -inf
ret f9223372036854775808: f64     # 9223372036854775808.0, a finite value
ret f0: f64                       # 5.0e-324, the smallest denormal
ret f0: f64                       # 0.0
ret f-0: f64                      # -0.0
ret f0: f64                       # 0.1
ret f1: f32                       # 1.25
```

Three collapses, exactly as the issue reports: `1.5` = `1.75`, `+inf` = the finite 2^63, denormal = zero.

## After

```
ret f1.5: f64
ret f1.75: f64
ret finf: f64
ret f-inf: f64
ret f9.223372036854776e18: f64
ret f5e-324: f64
ret f0: f64
ret f-0: f64
ret f0.1: f64
ret f1.25: f32
```

Every distinction the middle end keeps is now visible, and `f-0` / `f0` still differ, so #2274 is not regressed.

## What changed

`print_value` now renders a float constant through `std.format.write_f64` in shortest round-trippable decimal. That function already spells both signed zeros and both infinities, so the only class it collapses is NaN, whose payloads `cse.mach` value-numbers apart. A NaN whose bits are not the canonical quiet `0x7FF8000000000000` therefore renders `fnan:0x<bits>` rather than a bare `fnan`.

The stated reason for the old rendering, "std has no float formatter", was stale: `printer.mach` already imported `std.format`.

## The test that pinned the defect

`print_value:signed_zero` asserted `-1.5 -> "f-1"` and `2.5 -> "f2"`, which made a missing distinction look intended. It is replaced by `print_value:float_rendering`, which pins the real rendering across the IEEE classes. Operands are built from bit patterns (`float.bits_f64(0x7FF0000000000000)`, `float.bits_f64(1)`, `float.bits_f64(0x43E0000000000000)`) rather than decimal literals, and every expectation was derived from IEEE-754 before the code was run, not captured from output.

Mutation-checked: grafting the new test onto the pristine `origin/dev` printer fails it.

```
FAIL  mach.lang.me.ir.printer.print_value:float_rendering  ./src/lang/me/ir/printer.mach:820  (exit 1)
```

## Verification

- No golden moves. There are no `.ir` goldens in `int/`, and nothing outside `printer.mach` referenced the old test.
- Objects byte-identical. Built the repro project with a compiler from pristine `origin/dev` and with this branch's compiler; `diff -r` over the whole output tree reports no difference. This moves nothing but the dump.
- `mach test .`: 1288 passed, 0 failed.
- `int/run.sh --target linux --deps pin`: all cases passed.
- Self-host fixpoint holds, stage2 == stage3 == `6c3f4461064c517e4b20e33a16fce310d7db7307b6661d3cf22120d69db43ebd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6L67517WpZTPQDhtMsuJ2