### PR TITLE
feat(comptime): add $is_secret, the one type predicate about the wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### `$is_secret(T)`, so a reflection walk can act on secrecy instead of refusing it (#2694)
+Every comptime predicate asks about the shape **under** a `^`, so all of them answer false for a secret. `$is_record(^u64)` and `$is_record(u64)` were therefore the same answer, and a `std.derive` walk could only ever meet a secret field as a fallthrough it had to refuse. That is a refusal, not a decision, and it blocked all three things a derive actually wants: a formatter that redacts a secret field, a hash that refuses one (a data-dependent fold is a leak in the shape of a digest), and an equality that selects the constant-time comparison rather than the early-out whose timing is the secret.
+
+`$is_secret(T)` is the positive question, and it joins the predicate family exactly: comptime-only, one type operand, gate position, answered per instantiation inside a generic. It is the family's one exception to the stripping rule, and the exception is coherent rather than special-cased — the other three ask about the wrapped storage, this one asks about the wrapper. The doc's stripping table names it as such.
+
+The contract is **outermost only**, the same line the shape predicates already draw, so the four cannot disagree about what a type is. `^*u8` is true (the pointer is the secret), `*^u8` is false (a public address to secret storage), `[N]^u8` is false, `^^T` is true because `^^T` collapses to `^T`, and a record with a secret field is false — the field is secret, and `$is_secret(f.type)` is where a walk meets that.
+
+There is deliberately no transitive "contains a secret anywhere" query. Folding it in would make the common case wrong: a formatter gating on a transitive answer would redact a whole record over one field, and could not tell which. Where the transitive question is genuinely wanted through a reference it composes instead, `$is_secret($pointee_of(f.type))`. `$pointee_of(^*U)` stays refused, which is right — `$is_secret` has already answered true there and a walk should stop.
+
+A walk that skips a secret field is pinned by the flow rules rather than by convention: reading one into a public accumulator does not compile, so a gate that answers wrongly is a compile error rather than a silent disclosure. The regression case relies on exactly that.
+
 #### A constant pool, so a float constant is loaded rather than rebuilt (#2248, #2700)
 A constant wider than an ISA's immediate forms has to live in memory somewhere. Every back end here instead rebuilt one from instructions at every use, inside loop bodies included: x86-64 spent `movabs r11 ; movq xmm, r11` (two instructions, 15 bytes, and a general-purpose scratch) because SSE has no immediate form at all, aarch64 spent up to four `movz`/`movk` words plus a bank move, and riscv64 spent `emit_li`'s recursive shift-and-add - five to seven words for an arbitrary `f64`, since its widest immediate is 32 bits.
 

--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -44,7 +44,7 @@ neighboring links; start from the index below.
 - [comptime.md](comptime.md) — channel overview
 - [comptime-mach.md](comptime-mach.md) — `$mach.*` compiler-owned namespace
 - [decorators.md](decorators.md) — codegen decorators, `#[name]` (replaces the removed `$sym.attr` setters)
-- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$is_record`, `$is_union`, `$is_pointer`, `$type_name`, `$each`, `$error`
+- [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$length_of`, `$align_of`, `$offset_of`, `$type_of`, `$fields`, `$pointee_of`, `$is_record`, `$is_union`, `$is_pointer`, `$is_secret`, `$type_name`, `$each`, `$error`
 - [comptime-control.md](comptime-control.md) — `$if` / `$or`
 
 ## Low-level

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -136,27 +136,69 @@ and folds in a `$if` / `$or` gate:
 $is_record(T)           # T is a record (or an instance of one)
 $is_union(T)            # T is a union  (or an instance of one)
 $is_pointer(T)          # T is a reference: the raw `ptr` or a typed `*U`
+$is_secret(T)           # T is `^`-qualified at the outermost level
 ```
 
 They are **comptime-only** — a gate condition selects an arm, and there is no
 runtime boolean for one to become, so using a predicate as a value is an error.
 
 **`^` is a constructor, and a predicate answers about the outermost one.** `^Pair`
-is a secret, not a record, so all three answer false and a reflection walk refuses
-it instead of descending into secret storage. That is what keeps a predicate and
-`$fields` in agreement: `$fields(^Pair)` refuses, so a gate that called `^Pair` a
-record would send a walk into an operand the intrinsic then rejects.
+is a secret, not a record, so the three shape predicates answer false and a
+reflection walk refuses it instead of descending into secret storage. That is what
+keeps a predicate and `$fields` in agreement: `$fields(^Pair)` refuses, so a gate
+that called `^Pair` a record would send a walk into an operand the intrinsic then
+rejects.
 
-Outermost means outermost. `^*u8` is a secret pointer and answers false; `*^u8` is
-a **public** pointer to secret storage and is still a pointer, since the address is
-public. A generic instance answers as the declaration it instantiates, so `Box[i64]`
-is a record — which is the type a reflection loop actually meets — and `Box[^u64]`
-is a record too, because the instance is not itself secret; its field is, and the
-field is where a walk meets the question.
+Outermost means outermost. `^*u8` is a secret pointer and `$is_pointer` answers
+false; `*^u8` is a **public** pointer to secret storage and is still a pointer,
+since the address is public. A generic instance answers as the declaration it
+instantiates, so `Box[i64]` is a record — which is the type a reflection loop
+actually meets — and `Box[^u64]` is a record too, because the instance is not itself
+secret; its field is, and the field is where a walk meets the question.
 
-Because all three answer false for `^T`, "nothing classifies it" is itself a usable
-signal: a walk that gates on the three predicates and refuses the fallthrough
-refuses secrets without needing to ask about secrecy directly.
+`$is_secret` is the family's fourth member and its one **exception**, and the
+exception is coherent rather than special-cased: the other three ask about the shape
+*under* the wrapper, this one asks about the wrapper itself. It is what makes the
+other three's false readable — `$is_record(^Pair)` and `$is_record(u64)` are
+otherwise the same answer, so before this a library could only ever meet a secret as
+a fallthrough it had to refuse.
+
+```mach
+$each f in $fields(T) {
+    $if ($is_secret(f.type)) { ... }        # redact, refuse, or compare in constant time
+    $or { ... }                             # an ordinary public field
+}
+```
+
+`$is_secret` draws the outermost line in exactly the same place the shape predicates
+do, so the four cannot disagree about what a type is:
+
+| operand | `$is_secret` | why |
+|---|---|---|
+| `^u64`, `^Pair`, `^[4]u8` | true | `^` is outermost |
+| `^*u8` | true | a secret **pointer**: the address is the secret |
+| `^^T` | true | `^^T` collapses to `^T` |
+| `*^u8` | false | a **public** pointer to secret storage |
+| `[4]^u8` | false | a public array of secret elements |
+| `rec S { k: ^u64; }` | false | the record is public, its **field** is secret |
+| `Box[^u64]` | false | the instance is a record; its field is secret |
+| `u64`, `Pair`, `ptr` | false | no `^` anywhere |
+
+**It is not transitive, deliberately.** "Does this contain a secret anywhere" is a
+different question, and folding the two together would make the common case answer
+wrong: a `fmt` derive gating on a transitive answer would redact a whole record over
+one field, and could not tell which field to redact. The per-field question is the
+one a walk actually has, and `$is_secret(f.type)` is exactly it.
+
+Where the transitive question is genuinely wanted through a reference, it is
+**composed** rather than built in: `$is_secret($pointee_of(f.type))` says whether a
+pointer field points at secret storage. Note that `$pointee_of(^*U)` is refused, so
+there is no route through a secret pointer — which is correct, since `$is_secret` has
+already answered true for it and a walk should stop there.
+
+Because the shape predicates answer false for `^T`, "nothing classifies it" remains
+a usable signal on its own: a walk that gates on the three and refuses the
+fallthrough refuses secrets. `$is_secret` turns that refusal into a decision.
 
 ```mach
 rec Inner { x: u64; y: u64; }
@@ -250,6 +292,7 @@ about storage.**
 |---|---|
 | `$size_of` / `$length_of` / `$align_of` / `$offset_of` | yes — a secret occupies its base type's storage |
 | `$is_record` / `$is_union` / `$is_pointer` | no — `^T` is a secret, not a `T` |
+| `$is_secret` | no — and it is the one query *about* the `^` |
 | `$pointee_of` | no — `^*U` is a secret, and is refused rather than followed |
 | `$type_name` | no — the spelling is `^T` |
 | `$fields` | no — a secret record is refused, not walked |

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -700,12 +700,13 @@ intrinsic-call ::= comptime-ident call-args         (* $size_of(T), $fields(T), 
 mach-read      ::= comptime-ident { member }        (* $mach.build.os, $mach.arch.x86_64 *)
 ```
 
-- Intrinsic calls (`$size_of(T)`, `$align_of(T)`, `$offset_of(T, field)`,
-  `$type_of(e)`, `$fields(T)`, `$is_record(T)`, `$is_union(T)`,
-  `$is_pointer(T)`, `$type_name(T)`, `$error("msg")`) are syntactically a
-  `comptime-ident` callee with `call-args`.
-- The **type-taking** intrinsics — `$size_of`, `$align_of`, `$offset_of`,
-  `$fields` — parse their **first argument with the `type` production**, not the
+- Intrinsic calls (`$size_of(T)`, `$length_of(T)`, `$align_of(T)`,
+  `$offset_of(T, field)`, `$type_of(e)`, `$fields(T)`, `$is_record(T)`,
+  `$is_union(T)`, `$is_pointer(T)`, `$is_secret(T)`, `$type_name(T)`,
+  `$error("msg")`) are syntactically a `comptime-ident` callee with `call-args`.
+- The **type-taking** intrinsics — `$size_of`, `$length_of`, `$align_of`,
+  `$offset_of`, `$fields`, and the four predicates with `$type_name` — parse their
+  **first argument with the `type` production**, not the
   expression grammar, so the whole type language is spellable there:
   `$fields(Box[T])`, `$size_of(Pair[A, B])`, `$size_of(*T)`, `$size_of([4]u16)`,
   `$size_of(^u32)`, `$fields(mod.Rec)`. Every other argument is an ordinary
@@ -778,8 +779,8 @@ Doc-only (intended surface, not a distinct parser production):
   tag/path set — the parser accepts any `IDENT` / `$`-chain; the closed
   sets are enforced later (see [asm.md](asm.md),
   [comptime-mach.md](comptime-mach.md)).
-- The closed intrinsic set (`$size_of`, `$align_of`, `$offset_of`,
-  `$type_of`, `$fields`, `$is_record`, `$is_union`, `$is_pointer`,
+- The closed intrinsic set (`$size_of`, `$length_of`, `$align_of`, `$offset_of`,
+  `$type_of`, `$fields`, `$is_record`, `$is_union`, `$is_pointer`, `$is_secret`,
   `$type_name`, `$error`) — syntactically indistinguishable from any other
   `comptime-ident` call.
 - The closed decorator directive set (`symbol`, `library`, `inline`, `align`,

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -97,6 +97,52 @@ as well as the unrolled body itself — is re-typed per monomorphized instance, 
 a `T` that instantiates to a secret is gated exactly as the secret spelled out
 in full would be.
 
+## Asking about secrecy at comptime
+
+`$is_secret(T)` folds true when `T` is `^`-qualified **at the outermost level**,
+and false otherwise. It is a type predicate like `$is_record` / `$is_union` /
+`$is_pointer`: comptime-only, valid as a `$if` / `$or` gate condition, answered
+per instantiation inside a generic. The full reference is in
+[comptime-intrinsics.md](comptime-intrinsics.md).
+
+It exists because secrecy was otherwise invisible to a library. Every other
+predicate asks about the shape *under* the `^` and so answers false for every
+secret, which makes `$is_record(^u64)` and `$is_record(u64)` the same answer — a
+reflection walk could only ever meet a secret field as a fallthrough it had to
+refuse. `$is_secret` is the positive question, and it is what lets `std.derive`
+decide rather than refuse: a formatter redacts a secret field, a hash refuses one
+(a data-dependent fold is a leak in the shape of a digest), and an equality picks
+the constant-time comparison instead of the early-out whose timing *is* the
+secret.
+
+```mach
+rec Session { id: u64; key: ^[32]u8; }
+
+$each f in $fields(Session) {
+    $if ($is_secret(f.type)) { }            # redact: no read of `key` is emitted
+    $or { render(s.[f]); }
+}
+```
+
+**Outermost only**, the same line the rest of the family draws:
+
+- `^*u8` is secret — the pointer *is* the secret, which is the shape the
+  welded-storage rules exist for
+- `*^u8` is **not** — a public address to secret storage. Ask
+  `$is_secret($pointee_of(f.type))` for the pointee
+- `[N]^u8` is not — a public array whose elements are secret
+- a record with a secret field is not — the **field** is, and that is where a
+  walk meets the question
+
+There is deliberately no transitive "contains a secret anywhere" query. The
+per-field question is the one a walk actually has, and answering the transitive
+one in its place would make the common case wrong: a formatter would redact a
+whole record over one field and could not say which.
+
+Note that a walk which skips a secret field is pinned by the flow rules rather
+than by convention — reading one into a public accumulator does not compile, so a
+walk that gates wrongly is a compile error, not a silent disclosure.
+
 ## Downgrade with `:^`
 
 `:^` is the only way to remove `^`. It produces a new public value and never
@@ -418,6 +464,7 @@ refused rather than assumed.
 ## See also
 
 - [types.md](types.md) — the compound type grammar `^` qualifies
+- [comptime-intrinsics.md](comptime-intrinsics.md) — `$is_secret` and the rest of the type-predicate family
 - [operators.md](operators.md) — the `::` / `:~` casts that preserve secrecy
 - [decorators.md](decorators.md) — the `#[oblivious]` decorator reference
 - [grammar.md](grammar.md) — the formal grammar of `^` and `:^`

--- a/int/regression/2694-is-secret/expect.txt
+++ b/int/regression/2694-is-secret/expect.txt
@@ -1,0 +1,13 @@
+mixed public sum: 47
+mixed mask: 10
+all-public sum: 8
+all-public mask: 0
+all-secret sum: 0
+all-secret mask: 11
+classify ^u64: 2
+classify u64: 4
+classify Mixed: 1
+classify ^Mixed: 2
+classify *^u8: 3
+classify ^*u8: 2
+pointee of *^u8 is secret: 2

--- a/int/regression/2694-is-secret/mach.toml
+++ b/int/regression/2694-is-secret/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2694-is-secret/src/main.mach
+++ b/int/regression/2694-is-secret/src/main.mach
@@ -1,0 +1,87 @@
+# regression pin for #2694: a reflection walk can ask about secrecy positively
+#
+# Before this, secrecy was only ever observable as a REFUSAL. `$is_record(^u64)`
+# and `$is_record(u64)` both answer false, so a `std.derive` walk could only fall
+# into its error arm on a secret field - it could not skip one, could not select a
+# constant-time comparison for one, and could not tell a secret field from a scalar
+# it simply did not classify.
+#
+# The skip case is the load-bearing one, and it is pinned by CONSTRUCTION rather
+# than by inspection: the public accumulator is public, so if the gate answered
+# false for the secret field the walk would add `^u64` into a `u64` and sema would
+# refuse the program outright. This case running at all is the proof that no read
+# of the secret field was emitted; the printed sums are the proof that the walk
+# read exactly the public fields and nothing else.
+
+use std.runtime;
+use p: std.print;
+
+rec Mixed { a: u64; k: ^u64; b: u64; }
+rec AllPublic { a: u64; b: u64; }
+rec AllSecret { k: ^u64; j: ^u64; }
+
+# sums the PUBLIC fields, skipping every secret one. a gate that answered false for
+# `^u64` would put a secret in `total`, which does not compile.
+fun public_sum[T](v: *T) u64 {
+    var total: u64 = 0;
+    $each f in $fields(T) {
+        $if ($is_secret(f.type)) { }
+        $or { total = total + v.[f]; }
+    }
+    ret total;
+}
+
+# one decimal digit per field, 1 for secret and 0 for public, so two different
+# classifications cannot report the same number
+fun secrecy_mask[T]() u64 {
+    var acc: u64 = 0;
+    $each f in $fields(T) {
+        $if ($is_secret(f.type)) { acc = acc * 10 + 1; }
+        $or { acc = acc * 10; }
+    }
+    ret acc;
+}
+
+# the arm a walk takes for one type: exactly one of the two fires, which is what
+# separates "is a secret" from "is nothing the family classifies"
+fun classify[T]() u64 {
+    $if ($is_record(T)) { ret 1; }
+    $or {
+        $if ($is_secret(T)) { ret 2; }
+        $or {
+            $if ($is_pointer(T)) { ret 3; }
+            $or { ret 4; }
+        }
+    }
+}
+
+#[symbol("main")]
+pub fun main(argc: i64, argv: **u8) i64 {
+    var m: Mixed;
+    m.a = 7; m.k = 900; m.b = 40;
+    p.printf("mixed public sum: {}\n", public_sum[Mixed](?m));
+    p.printf("mixed mask: {}\n", secrecy_mask[Mixed]());
+
+    var ap: AllPublic;
+    ap.a = 3; ap.b = 5;
+    p.printf("all-public sum: {}\n", public_sum[AllPublic](?ap));
+    p.printf("all-public mask: {}\n", secrecy_mask[AllPublic]());
+
+    var as: AllSecret;
+    as.k = 1; as.j = 2;
+    p.printf("all-secret sum: {}\n", public_sum[AllSecret](?as));
+    p.printf("all-secret mask: {}\n", secrecy_mask[AllSecret]());
+
+    # outermost only, which is what separates this from "contains a secret"
+    p.printf("classify ^u64: {}\n", classify[^u64]());
+    p.printf("classify u64: {}\n", classify[u64]());
+    p.printf("classify Mixed: {}\n", classify[Mixed]());
+    p.printf("classify ^Mixed: {}\n", classify[^Mixed]());
+    p.printf("classify *^u8: {}\n", classify[*^u8]());
+    p.printf("classify ^*u8: {}\n", classify[^*u8]());
+
+    # the transitive question through a reference is composed, not built in
+    p.printf("pointee of *^u8 is secret: {}\n", classify[$pointee_of(*^u8)]());
+
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2058,6 +2058,77 @@ test "mach.lang.driver:comptime_type_predicates" {
     ret bad;
 }
 
+# `$is_secret(T)` is the one predicate that asks about the `^` WRAPPER rather than
+# about the type under it (#2694)
+#
+# The other predicates all answer false for a secret, which makes their false
+# indistinguishable from "not a record either" - so secrecy was only ever observable
+# as a refusal, and no reflection walk could act on it. This one is the positive
+# question, and its contract is OUTERMOST ONLY: the same line the family already
+# draws, so the two cannot disagree about what `^*u8` and `*^u8` are.
+#
+# The false cases carry the weight here. A predicate that answered true for anything
+# containing a secret would pass every true case below and be wrong in the way that
+# matters most: a `fmt` derive would redact a whole record over one field, and could
+# not tell which field to redact.
+test "mach.lang.driver:comptime_is_secret" {
+    var bad: i32 = 0;
+
+    # TRUE: `^` at the outermost level, over every shape it can wrap
+    if (ut_arm("fun main() i32 { $if ($is_secret(^u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_secret(^P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("uni U { a: u64; b: u32; }\nfun main() i32 { $if ($is_secret(^U)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # a SECRET POINTER: the address itself is the secret, which is the shape the
+    # welded-storage rules exist for
+    if (ut_arm("fun main() i32 { $if ($is_secret(^*u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_secret(^[4]u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # `^^T` collapses to `^T` at interning, so it answers exactly as `^T` does
+    if (ut_arm("fun main() i32 { $if ($is_secret(^^u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # FALSE: no `^` at all
+    if (ut_arm("fun main() i32 { $if ($is_secret(u64)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_secret(P)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_secret(ptr)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_secret(*u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+
+    # OUTERMOST ONLY, the three shapes that separate this from "contains a secret".
+    # a PUBLIC pointer to secret storage: the pointer is not the secret, the pointee
+    # is, and `$pointee_of` is the route to that question.
+    if (ut_arm("fun main() i32 { $if ($is_secret(*^u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($is_secret($pointee_of(*^u8))) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    # an array OF secrets is a public array whose elements are secret
+    if (ut_arm("fun main() i32 { $if ($is_secret([4]^u8)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    # a record with a secret FIELD is not itself secret; the field is where a walk
+    # meets the question, and it answers true there
+    if (ut_arm("rec S { k: ^u64; n: u64; }\nfun main() i32 { $if ($is_secret(S)) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    if (ut_arm("rec S { k: ^u64; }\nfun main() i32 { $each f in $fields(S) { $if ($is_secret(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec S { n: u64; }\nfun main() i32 { $each f in $fields(S) { $if ($is_secret(f.type)) { $error(\"Y\"); } $or { $error(\"N\"); } } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+    # a generic instance at a secret argument is a record whose field is secret, not
+    # a secret record - the same ruling `$is_record(Box[^u64])` already gives
+    if (ut_arm("rec Box[T] { v: T; }\nfun main() i32 { $if ($is_secret(Box[^u64])) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "N", "Y") != 0) { bad = 1; }
+
+    # AGREEMENT WITH THE REST OF THE FAMILY. `^P` is a secret and NOT a record, so
+    # exactly one of the two predicates fires. A walk that gates on both is what the
+    # issue asked for, and it only works if they do not both answer false.
+    if (ut_arm("rec P { a: u64; }\nfun main() i32 { $if ($is_record(^P)) { $error(\"REC\"); } $or { $if ($is_secret(^P)) { $error(\"SEC\"); } $or { $error(\"NEITHER\"); } } ret 0; }\n", "SEC", "NEITHER") != 0) { bad = 1; }
+
+    # PER INSTANTIATION, like the rest of the family: one template, opposite arms
+    if (ut_vec_diag("fun probe[T]() i32 { $if ($is_secret(T)) { $error(\"SEC\"); } $or { $error(\"PUB\"); } ret 0; }\nfun main() i32 { ret probe[^u64](); }\n", "SEC") != 0) { bad = 1; }
+    if (ut_vec_diag("fun probe[T]() i32 { $if ($is_secret(T)) { $error(\"SEC\"); } $or { $error(\"PUB\"); } ret 0; }\nfun main() i32 { ret probe[u64](); }\n", "PUB") != 0) { bad = 1; }
+    # both instances of ONE template, each taking its own arm. a predicate answered
+    # against the template placeholder instead would give both instances one answer.
+    if (ut_vec_diag("fun probe[T]() i32 { $if ($is_secret(T)) { $error(\"SEC\"); } $or { $error(\"PUB\"); } ret 0; }\nfun main() i32 { ret probe[^u64]() + probe[u64](); }\n", "SEC") != 0) { bad = 1; }
+    if (ut_vec_diag("fun probe[T]() i32 { $if ($is_secret(T)) { $error(\"SEC\"); } $or { $error(\"PUB\"); } ret 0; }\nfun main() i32 { ret probe[^u64]() + probe[u64](); }\n", "PUB") != 0) { bad = 1; }
+
+    # comptime-only, and one argument, exactly as the rest of the family
+    if (ut_vec_diag("fun main() i32 { val b: u8 = $is_secret(^u64); ret 0; }\n",
+                    "comptime type predicate is comptime-only") != 0) { bad = 1; }
+    if (ut_vec_diag("fun main() i32 { $if ($is_secret()) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n",
+                    "expected 1 argument") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # `$type_name(T)` yields the type's spelling, and it is the SAME spelling sema
 # prints in diagnostics - `typename.type_to_str` is the one authority, so a program
 # reading a name and an error reporting one cannot drift (#2128)

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -224,6 +224,10 @@ pub val TYPE_QUERY_IS_RECORD:  u8 = 0;  # a record, or an instance of one
 pub val TYPE_QUERY_IS_UNION:   u8 = 1;  # a union, or an instance of one
 pub val TYPE_QUERY_IS_POINTER: u8 = 2;  # the raw `ptr` or a typed `*T`
 pub val TYPE_QUERY_NAME:       u8 = 3;  # the type's spelling, as a string
+# the one query about the `^` WRAPPER rather than about the type under it (#2694).
+# the others answer about the wrapped shape and so answer false for every `^T`;
+# this one is what makes that false distinguishable from "not a record either".
+pub val TYPE_QUERY_IS_SECRET:  u8 = 4;
 
 # answers one TYPE_QUERY_* about a TypeId: a bool for the predicates, a string for
 # the name, or none when this context cannot answer (no resolver installed)
@@ -1412,6 +1416,7 @@ pub fun intrinsic_takes_type_operand(source: str, full: token.Span) bool {
      || view_eq_str(text, "is_record")
      || view_eq_str(text, "is_union")
      || view_eq_str(text, "is_pointer")
+     || view_eq_str(text, "is_secret")
      || view_eq_str(text, "type_name");
 }
 
@@ -1703,7 +1708,8 @@ fun eval_type_comparison(
 # `$type_of(...)` or type-name operand resolves through the installed type
 # resolver (#1472). errors when no resolver is installed, or when the operand has
 # no resolvable type identity
-# fold `$is_record(T)` / `$is_union(T)` / `$is_pointer(T)` / `$type_name(T)` (#2128)
+# fold `$is_record(T)` / `$is_union(T)` / `$is_pointer(T)` / `$is_secret(T)` /
+# `$type_name(T)` (#2128, #2694)
 #
 # These ask about the SHAPE of a type rather than its storage, which is what makes
 # them the missing half of reflection-driven generics: `$fields` can now descend
@@ -1728,6 +1734,7 @@ fun eval_type_query(
     if      (is_comptime_call(a, source, e, "is_record"))  { which = TYPE_QUERY_IS_RECORD; }
     or      (is_comptime_call(a, source, e, "is_union"))   { which = TYPE_QUERY_IS_UNION; }
     or      (is_comptime_call(a, source, e, "is_pointer")) { which = TYPE_QUERY_IS_POINTER; }
+    or      (is_comptime_call(a, source, e, "is_secret"))  { which = TYPE_QUERY_IS_SECRET; }
     or      (is_comptime_call(a, source, e, "type_name"))  { which = TYPE_QUERY_NAME; }
     or      { ret O.none[R.Result[CTValue, str]](); }
 
@@ -1760,11 +1767,12 @@ fun eval_type_query(
     ret O.some[R.Result[CTValue, str]](R.ok[CTValue, str](O.unwrap[CTValue](ans)));
 }
 
-# whether `eid` is one of the four comptime type queries (#2128)
+# whether `eid` is one of the comptime type queries (#2128, #2694)
 pub fun is_type_query_call(a: *ast.Ast, source: str, eid: id.ExprId) bool {
     if (is_comptime_call(a, source, eid, "is_record"))  { ret true; }
     if (is_comptime_call(a, source, eid, "is_union"))   { ret true; }
     if (is_comptime_call(a, source, eid, "is_pointer")) { ret true; }
+    if (is_comptime_call(a, source, eid, "is_secret"))  { ret true; }
     ret is_comptime_call(a, source, eid, "type_name");
 }
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -361,6 +361,35 @@ pub fun answer_type_query(s: *session.Session, tid: u32, which: u8) R.Result[O.O
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
 
+    # `$is_secret` IS THE ONE QUERY ABOUT THE WRAPPER (#2694), so it is answered
+    # ahead of the rule below rather than swallowed by it. The others ask about the
+    # shape UNDER the `^` and answer false for every secret, which makes their false
+    # indistinguishable from "not a record either"; this one closes that, and it is
+    # coherent rather than special-cased - the family's rule is that a query answers
+    # about the OUTERMOST constructor, and here the outermost constructor is the
+    # question.
+    #
+    # `type.is_secret` and not `type.carries_secret`: outermost only, the same line
+    # the shape predicates draw. `^*u8` is a secret pointer and answers true, `*^u8`
+    # is a PUBLIC pointer to secret storage and answers false, and a record with a
+    # secret field is not itself secret - its FIELD is, and `$is_secret(f.type)` is
+    # where a walk meets that. Folding the transitive question in would make the
+    # common case answer wrong: a `fmt` derive would redact a whole record over one
+    # field, and it could not tell which one.
+    #
+    # A bare generic parameter still defers: `T` may instantiate to `^u64`, so the
+    # answer exists per instance and not at the template. `^T` does not defer,
+    # because `^T` is secret whatever `T` turns out to be.
+    if (which == comptime.TYPE_QUERY_IS_SECRET) {
+        if (type.is_secret(?s.types, t)) {
+            ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_bool(true)));
+        }
+        if (type.shape_kind(?s.types, t) == type.TYPE_GENERIC_PARAM) {
+            ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+        }
+        ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_bool(false)));
+    }
+
     # `^` IS A CONSTRUCTOR, AND A PREDICATE ANSWERS ABOUT THE OUTERMOST ONE (#2692).
     # `^Rec` is a secret, not a record, so every predicate answers false and a
     # reflection walk refuses it rather than descending into secret storage. this is
@@ -2182,15 +2211,16 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
         ret type.TYPE_ERROR;
     }
 
-    # the type queries (#2128) take the same single type-naming argument and answer
-    # about its SHAPE rather than its storage: three bool predicates and the string
-    # `$type_name`. Typed here so the operand's expr_type is stamped for the
-    # resolver `comptime.eval` calls, exactly as the size/align path below does.
+    # the type queries (#2128, #2694) take the same single type-naming argument and
+    # answer about a type's SHAPE rather than its storage: four bool predicates and
+    # the string `$type_name`. Typed here so the operand's expr_type is stamped for
+    # the resolver `comptime.eval` calls, exactly as the size/align path below does.
     val is_rec_q:  bool = name == interned(sc, "is_record");
     val is_uni_q:  bool = name == interned(sc, "is_union");
     val is_ptr_q:  bool = name == interned(sc, "is_pointer");
+    val is_sec_q:  bool = name == interned(sc, "is_secret");
     val is_name_q: bool = name == interned(sc, "type_name");
-    if (is_rec_q || is_uni_q || is_ptr_q || is_name_q) {
+    if (is_rec_q || is_uni_q || is_ptr_q || is_sec_q || is_name_q) {
         if (c.args_len != 1) {
             context.report_numbered(sc, span, "a comptime type query: expected ", 1::usize, " argument(s)", "comptime type query: wrong number of arguments");
             ret type.TYPE_ERROR;
@@ -2203,7 +2233,7 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
         # `$type_name` is an ordinary value - a string, valid anywhere one is.
         if (is_name_q) { ret ptr_to(sc, prim_or_error(sc, type.TYPE_U8)); }
 
-        # the three predicates answer a comptime question and are folded by arm
+        # the four predicates answer a comptime question and are folded by arm
         # selection, so like a `$type_of` comparison they are gate-only: there is no
         # runtime boolean for one to become. Reported here rather than left to
         # surface as an opaque bare-comptime-ident error at lowering.

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -630,7 +630,8 @@ pub fun resolve_type_comparison_operand(data: ptr, eid: id.ExprId) R.Result[O.Op
 
 # the type-query resolver lowering installs on every ComptimeCtx it evaluates
 # against (a comptime.TypeQueryFn), so a `$is_record` / `$is_union` / `$is_pointer`
-# / `$type_name` gate deferred past sema still folds here (#2128)
+# / `$is_secret` / `$type_name` gate deferred past sema still folds here (#2128,
+# #2694)
 #
 # Delegates to `infer.answer_type_query`, the one implementation, so a predicate
 # folded during arm selection and the same predicate folded at monomorphization

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1484,7 +1484,7 @@ pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId,
 
     # `$type_name(T)` is a string rather than a measurement, so it folds through the
     # comptime channel (which owns the spelling) and materializes like any other
-    # folded CT_KIND_STR (#2128). The three type PREDICATES never reach here: they
+    # folded CT_KIND_STR (#2128). The type PREDICATES never reach here: they
     # are gate-only and consumed by arm selection, so a value position is already a
     # sema error.
     if (name == interned_literal(ctx, "type_name")) {


### PR DESCRIPTION
Closes #2694

## Built on the rule, not on the issue's description of it

The issue opens with "every comptime type query strips `^` before answering, by design". The triage comment is right that this is false on current `dev`: #2692 settled the rule the other way and `comptime-intrinsics.md` states it in a table. So the design here is not "everything strips, so secrecy is invisible" but the accurate and weaker statement: **nothing that could tell you strips, so secrecy is only ever observable as a refusal.**

`$is_record(^Pair)` answering false is indistinguishable from `$is_record(u64)` answering false. Every predicate asks about the shape *under* the `^`, so a `std.derive` walk can only ever fall into its error arm on a secret field. That is a refusal, not a decision, and it is what blocks all three things a derive actually wants: `fmt` redacting a secret field, `hash` refusing one (a data-dependent fold is a leak in the shape of a digest), and `eq` selecting the constant-time comparison rather than the early-out whose timing *is* the secret.

## The contract

`$is_secret(T)` folds true when `T` is `^`-qualified **at the outermost level**. It joins the predicate family exactly — comptime-only, one type operand, gate position, answered per instantiation inside a generic — and is the family's one exception to the stripping rule. The exception is coherent rather than special-cased: the other three ask about the wrapped storage, this one asks about the wrapper. The doc's stripping table now names it as such.

| operand | answer | why |
|---|---|---|
| `^u64`, `^Pair`, `^[4]u8` | true | `^` is outermost |
| `^*u8` | true | a secret **pointer** — the address is the secret |
| `^^T` | true | `^^T` collapses to `^T` at interning |
| `*^u8` | false | a **public** pointer to secret storage |
| `[4]^u8` | false | a public array of secret elements |
| `rec S { k: ^u64; }` | false | the record is public, its **field** is secret |
| `Box[^u64]` | false | the instance is a record; its field is secret |
| `u64`, `Pair`, `ptr` | false | no `^` anywhere |

### Nested secrets: why false, and not a refusal

The task asked whether a refusal would be better than a plausible wrong answer for the nested cases. It would not be, and the reason is the same one that decides the whole design.

**A record with one secret field is not secret, and answering false is not a wrong answer, it is the right one.** The question a walk has is per field. `$fields(S)` yields `k` with type `^u64`, and `$is_secret(f.type)` is true there — that is where the decision belongs. Answering true for `S` itself would make a `fmt` derive redact the whole record over one field, and it would still have no way to say *which* field. Refusing `S` would be worse again: `$is_record(S)` already answers true and a walk has to be able to ask about the container it is about to descend into.

**A pointer to secret storage is not secret, and the transitive question composes rather than being built in.** `$is_secret($pointee_of(*^u8))` is true, which is the honest route and keeps the two intrinsics from disagreeing. `$pointee_of(^*U)` stays refused (#2693), and that is right rather than a hole: `$is_secret` has already answered true for `^*U`, so a walk should stop there instead of following a secret address.

So there is deliberately no transitive "contains a secret anywhere" query. It is a different question, it is answerable by composition where it is genuinely wanted, and folding it into this one would make the common case wrong.

### The skip is pinned by the flow rules, not by convention

The acceptance list asks that a walk gating on `$is_secret(f.type)` and skipping the field emit no read of it. That is pinned by **construction** rather than by inspecting output: the regression fixture sums the public fields into a public `u64`, so if the gate answered false for the secret field the walk would add `^u64` into a `u64` and sema refuses the program outright (`type mismatch: expected u64, found ^u64`, verified). The case building at all is the proof; the printed sums are the proof it read exactly the public fields and nothing else.

## Evidence

**The tests fail without the patch.** Verified against a compiler built from `origin/dev` @ `6991413e` — the exact merge base, built fresh, not a stale binary:

```
$ ./mach-dev2 test .
  FAIL  mach.lang.driver:comptime_is_secret
1288 passed, 1 failed, 1289 total
```

The int case fails there too, with `function calls are not comptime-evaluable` — `$is_secret` is not an intrinsic on `dev`, so the call is read as an ordinary one.

**The refusal tests fire for the right reason.** `ut_arm` requires the expected marker to fire *and* the other marker to be absent, so a predicate that stopped folding entirely (type-checking every arm, both markers firing) fails rather than passes. The per-instantiation pair asserts both arms out of one template, which a template-placeholder answer could not produce.

**Runs.**

- `mach test .` — 1289 passed, 0 failed.
- `int/run.sh --target linux --deps pin` — all cases passed, full suite.
- `int/run.sh --target linux-arm64` under qemu, `269*` filter — `2694-is-secret` passes in both profiles. The **native** aarch64 leg is CI's: `linux-arm64` on `ubuntu-24.04-arm` is a `pr`-cadence row in `int/targets.conf`.
- Self-host fixpoint: stage2 byte-identical to stage3, self-built against self-built.
  `0fcea3c0c9c01ef9c2a74d8656bd8fed3bb8cd7ef5cfaad5a0b01fe2271ff13e`

## Docs

`comptime-intrinsics.md` adds `$is_secret` to the predicate list with the outermost-only table, the non-transitivity and the composed route, and the stripping table gains its row. `secrecy.md` states the rule where the secrecy model lives and cross-references back. `grammar.md`'s two closed-intrinsic lists gain it — and gain `$length_of` and `$pointee_of`, which had been added without updating those lists. `CHANGELOG.md` under `## [Unreleased]`.
