### PR TITLE
fix(comptime): decide an identifier on resolution identity, not on its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### A comptime identifier names the declaration it resolves to, not the spelling (#2764)
+The comptime environment is keyed by **name**, and `comptime.eval_ident` looked a bare identifier up in it directly. Resolution identity was never consulted, so a binding was matched by what it is called rather than by which declaration it is. A block-local `val N` shadowing a module-level `val N = 9` therefore read back the **module** constant: `var xs: [N]i64;` under a runtime local `N` compiled as `[9]i64`, and the out-of-bounds diagnostic it later raised named a length the source never wrote.
+
+The evaluator now decides each identifier on the symbol the resolver bound to it. Every pass that owns a name-resolution map installs the same hook, and all of them answer from **one** function, `resolve.symbol_is_runtime`.
+
+That collapses the two rules that existed to compensate for the old reading. `resolve.check_gate_shadowing` is **removed**: it caught a case the evaluator would otherwise get wrong, and there is no such case left to catch. The constant index bound (#2751) no longer walks its operand for runtime leaves before folding, because the fold now fails on them by itself. `sema`'s `$if` gate walk keeps its per-kind diagnostics — a reader needs to hear "parameter" for a parameter and "value" for a binding — but delegates the decision.
+
+Consolidating them surfaced a disagreement the copies had been hiding. An `$each` loop variable is a **comptime** binding that resolve declares as a `SYM_VAL` bearing the comptime flag, and a rule keyed only on module scope classified it as runtime. The constant index bound consequently declined to decide any index driven by one, so `xs[e]` over an element out of range compiled clean and read past the array. It is now refused. `$` marks a comptime binding whatever its kind, and the rule says so once.
+
+A comptime binding that shadows a module constant still resolves innermost-first, which is the half of this that had to be preserved rather than changed: a `$param` or an `$each` variable named after a module constant denotes the inner one.
+
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/doc/language/comptime.md
+++ b/doc/language/comptime.md
@@ -67,6 +67,44 @@ A comptime **parameter** is referenced by its bare name (no `$`); every comptime
 position — sema and lowering both defer to the evaluator's single verdict rather
 than each carrying their own.
 
+## Which binding a name denotes
+
+An identifier in the comptime channel denotes the declaration it resolves to,
+under the ordinary scoping rules — never whichever binding happens to share its
+spelling. A block-scoped binding shadows an outer one of the same name here
+exactly as it does at runtime:
+
+```mach
+val N: i64 = 9;
+
+fun f(k: i64) i64 {
+    val N: i64 = k;      # shadows the module constant
+    var xs: [N]i64;      # error: array length is not a comptime constant
+    ret xs[0];
+}
+```
+
+The inner `N` is decided at runtime, so it has no comptime value, and the
+constant it shadows is not what the expression names. Reading such a name in a
+comptime position is refused:
+
+> identifier names a runtime binding, so it has no comptime value
+
+A binding marked `$` — a comptime value parameter, an `$each` loop variable —
+*is* a comptime binding, and shadows an outer name of its own spelling in the
+same way. Inside the `$each` below the name `N` is the element, not the 9:
+
+```mach
+val N:  i64    = 9;
+val ES: [2]i64 = [2]i64{1, 2};
+
+fun g() i64 {
+    var s: i64 = 0;
+    $each N in ES { s = s + N; }   # 3, not 18
+    ret s;
+}
+```
+
 ## What's not in the channel
 
 - No reflection-via-`$<Type>.*` subtree. Types are not first-class

--- a/int/regression/2764-comptime-ident-identity/case.conf
+++ b/int/regression/2764-comptime-ident-identity/case.conf
@@ -1,0 +1,14 @@
+# #2764: `comptime.eval_ident` folded an identifier by NAME against a name-keyed
+# environment, so a block-local binding shadowing a module constant read back the
+# constant - a plausible value, no diagnostic. the refusal is in the frontend, so
+# the observable is the diagnostic set.
+#
+# the fixture puts ONE rule in front of every consumer that reads it - the array
+# length in a type position, the constant index bound (#2751), the same two
+# through a generic instance, and the `$if` gate - with the module `N` and the
+# local `N` carrying different values. each line of the golden names which of the
+# two the compiler read, so a consumer that disagreed with the others changes the
+# golden rather than passing quietly.
+run: build-fails
+targets: linux
+profiles: debug

--- a/int/regression/2764-comptime-ident-identity/expect.linux.txt
+++ b/int/regression/2764-comptime-ident-identity/expect.linux.txt
@@ -1,0 +1,3 @@
+error: cannot infer type: array length is not a comptime constant
+error: cannot infer type: array length is not a comptime constant
+error: index 5 is out of bounds for `[4]i64` of length 4

--- a/int/regression/2764-comptime-ident-identity/mach.toml
+++ b/int/regression/2764-comptime-ident-identity/mach.toml
@@ -1,0 +1,24 @@
+[project]
+id = "case2764a"
+version = "1.0.0"
+src = "src"
+out = "out"
+
+[target.linux]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+

--- a/int/regression/2764-comptime-ident-identity/src/main.mach
+++ b/int/regression/2764-comptime-ident-identity/src/main.mach
@@ -1,0 +1,67 @@
+# every consumer of the runtime-binding rule reads the same answer, because there
+# is only one place left that decides it
+#
+# the comptime environment is keyed by NAME, so an identifier folded by spelling
+# names whichever binding happens to share it. the two `N`s below carry different
+# values on purpose: the module one is 9, the local one is not a constant at all,
+# and the diagnostic each function raises names WHICH of them the compiler read.
+
+val N:  i64    = 9;
+val ES: [2]i64 = [2]i64{0, 5};
+
+# a block-local `val` shadowing the module constant. the length must refuse - a
+# block-local binding has no value before the program runs - and the refusal is
+# the one line this function contributes. reading the NAME instead makes the array
+# `[9]i64`, at which point `xs[100]` is measured against a length the source never
+# wrote and the golden names 9.
+fun shadowed_length(k: i64) i64 {
+    val N: i64 = k;
+    var xs: [N]i64;
+    ret xs[100];
+}
+
+# the same shadowing binding reaching the constant index bound (#2751). that rule
+# no longer walks for runtime leaves of its own: it folds and inherits the
+# evaluator's answer, so its silence here is the two sites agreeing that this `N`
+# is the local. were the fold still name-keyed it would decide 9 against a
+# four-element array and add a second line below.
+fun shadowed_index(k: i64) i64 {
+    val N: i64 = k;
+    var xs: [4]i64;
+    ret xs[N];
+}
+
+# the SAME shadowing, through a generic instance: an instance body is typed under
+# its own substitution and folded again at monomorphization, so it reaches the
+# rule by a different path and has to reach the same answer.
+fun shadowed_generic[T](k: i64) i64 {
+    val N: i64 = k;
+    var xs: [N]T;
+    ret xs[100]::i64;
+}
+
+# the other direction of the same rule. an `$each` loop variable is a COMPTIME
+# binding - resolve marks it `$` - so every consumer must decide it rather than
+# decline. the bound check therefore refuses element 5 against a four-element
+# array; a rule keyed only on module scope called this binding runtime and let the
+# out-of-range access through with no diagnostic at all.
+fun each_index() i64 {
+    var xs: [4]i64;
+    var s:  i64 = 0;
+    $each e in ES { s = s + xs[e]; }
+    ret s;
+}
+
+# the gate consumer, over that same comptime binding: it folds per element and
+# says nothing. its silence is the third site agreeing.
+fun each_gate() i64 {
+    var s: i64 = 0;
+    $each e in ES {
+        $if (e == 5) { s = s + 1; }
+        $or          { }
+    }
+    ret s;
+}
+
+#[symbol("main")]
+fun main() i32 { ret 0; }

--- a/int/regression/2764-gate-runtime-binding/case.conf
+++ b/int/regression/2764-gate-runtime-binding/case.conf
@@ -1,0 +1,12 @@
+# #2764: a `$if` gate over a runtime binding is refused by the EVALUATOR, on the
+# resolution identity of each leaf, rather than by a shadowing guard sitting in
+# front of a name-keyed fold. the refusal is in the frontend, so the observable is
+# the diagnostic set.
+#
+# the last function carries a runtime binding whose name is NOT also a comptime
+# constant: the removed guard fired only on a name collision, so that shape and
+# the four above it reached two different diagnostics. one rule owes them one
+# answer, and the golden is where a second rule would show up again.
+run: build-fails
+targets: linux
+profiles: debug

--- a/int/regression/2764-gate-runtime-binding/expect.linux.txt
+++ b/int/regression/2764-gate-runtime-binding/expect.linux.txt
@@ -1,0 +1,5 @@
+error: identifier names a runtime binding, so it has no comptime value
+error: identifier names a runtime binding, so it has no comptime value
+error: identifier names a runtime binding, so it has no comptime value
+error: identifier names a runtime binding, so it has no comptime value
+error: identifier names a runtime binding, so it has no comptime value

--- a/int/regression/2764-gate-runtime-binding/mach.toml
+++ b/int/regression/2764-gate-runtime-binding/mach.toml
@@ -1,0 +1,24 @@
+[project]
+id = "case2764b"
+version = "1.0.0"
+src = "src"
+out = "out"
+
+[target.linux]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+

--- a/int/regression/2764-gate-runtime-binding/src/main.mach
+++ b/int/regression/2764-gate-runtime-binding/src/main.mach
@@ -1,0 +1,42 @@
+# a `$if` gate over a binding that is decided at runtime is refused, and the
+# refusal comes from the evaluator rather than from a guard standing in front of it
+#
+# the module `N` is 9 and every local `N` below is something else, so a gate folded
+# by NAME would take the `9` arm - silently, with no diagnostic, in whichever arm
+# the source did not write. each shape reaches the gate by a different route: a
+# block-local `val`, a runtime parameter, and both again inside a generic template.
+
+val N: i64 = 9;
+
+fun local_gate(k: i64) i64 {
+    val N: i64 = k;
+    $if (N == 9) { ret 900; }
+    $or          { ret 1; }
+}
+
+fun param_gate(N: i64) i64 {
+    $if (N == 9) { ret 900; }
+    $or          { ret 1; }
+}
+
+fun local_gate_generic[T](k: i64, v: T) i64 {
+    val N: i64 = k;
+    $if (N == 9) { ret 900; }
+    $or          { ret 1; }
+}
+
+fun param_gate_generic[T](N: i64, v: T) i64 {
+    $if (N == 9) { ret 900; }
+    $or          { ret 1; }
+}
+
+# a runtime binding whose name is NOT also a comptime constant fails the same way
+# for the same reason. the old shadowing guard fired only on a name collision, so
+# this one reached a different diagnostic; one rule gives it one answer.
+fun unshadowed_gate(q: i64) i64 {
+    $if (q == 9) { ret 900; }
+    $or          { ret 1; }
+}
+
+#[symbol("main")]
+fun main() i32 { ret 0; }

--- a/int/regression/2764-shadowed-comptime-binding/expect.txt
+++ b/int/regression/2764-shadowed-comptime-binding/expect.txt
@@ -1,0 +1,4 @@
+param=1 2
+generic=3 3
+each=3
+gate=3

--- a/int/regression/2764-shadowed-comptime-binding/mach.toml
+++ b/int/regression/2764-shadowed-comptime-binding/mach.toml
@@ -1,0 +1,57 @@
+[project]
+id = "case2764c"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2764-shadowed-comptime-binding/src/main.mach
+++ b/int/regression/2764-shadowed-comptime-binding/src/main.mach
@@ -1,0 +1,61 @@
+# a COMPTIME binding shadowing a module constant of the same name folds to the
+# inner binding, and the value each row prints says which one was read
+#
+# this is the half of #2764 that must survive the fix. deciding an identifier on
+# resolution identity settles WHETHER a name may fold; which of several comptime
+# bindings it then denotes is still innermost-wins, and a `$param` or an `$each`
+# loop variable named after a module constant has to shadow it exactly as a local
+# shadows an outer local. the module `N` is 9 and no call below supplies 9, so a
+# fold that reached past the inner binding prints 900 on every row.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+val N:  i64    = 9;
+val ES: [2]i64 = [2]i64{1, 2};
+
+# a comptime value parameter named after the module constant.
+fun by_param($N: i64) i64 {
+    $if (N == 9) { ret 900; }
+    $or          { ret N; }
+}
+
+# through a generic instance: an instance body is emitted from lowering against
+# its ORIGIN module's comptime context, which is exactly where the module `N` is
+# bound, so this is the shape most exposed to reading the outer binding. the loop
+# variable shadows it per element and the gate folds against the element.
+fun by_generic[T](v: T) i64 {
+    var s: i64 = 0;
+    $each N in ES {
+        $if (N == 9) { s = s + 900; }
+        $or          { s = s + N; }
+    }
+    ret s;
+}
+
+# an `$each` loop variable named after the module constant, read as a value.
+fun by_each() i64 {
+    var s: i64 = 0;
+    $each N in ES { s = s + N; }
+    ret s;
+}
+
+# and the same loop variable inside a `$if` gate, folded per element.
+fun by_each_gate() i64 {
+    var s: i64 = 0;
+    $each N in ES {
+        $if (N == 9) { s = s + 900; }
+        $or          { s = s + N; }
+    }
+    ret s;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("param={} {}",   by_param(1),          by_param(2));
+    p.printlnf("generic={} {}", by_generic[i64](0),  by_generic[u8](0u8));
+    p.printlnf("each={}",       by_each());
+    p.printlnf("gate={}",       by_each_gate());
+    ret 0;
+}

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -2229,7 +2229,8 @@ test "mach.lang.editor.resolve:repeated_resets_diags" {
     ret 0;
 }
 
-# a runtime local shadowing a module const is rejected in a $if gate, not folded (#1249)
+# a runtime local shadowing a module const is rejected in a $if gate, not folded
+# (#1249, #2764)
 test "mach.lang.editor.resolve:local_shadows_comptime_const" {
     var alloc: A.Allocator;
     val res_session: R.Result[session.Session, str] = t_session(?alloc);
@@ -2238,17 +2239,18 @@ test "mach.lang.editor.resolve:local_shadows_comptime_const" {
     var es: EditorSession = init(?s);
 
     # `N` is a module comptime const; the runtime local `N` shadows it. the
-    # comptime env is name-keyed, so the gate fold silently succeeds against the
-    # module const 4 while the resolver bound the ident to the local - resolve
-    # must reject the gate on resolution identity instead of miscompiling it.
+    # comptime env is name-keyed, so a fold that read the name would silently
+    # succeed against the module const 4 while the resolver bound the ident to
+    # the local. the EVALUATOR now decides the leaf on resolution identity, so
+    # the refusal is the evaluator's own - there is no separate shadowing guard.
     val res_fid: R.Result[source.FileId, str] = open(?es, "shadow.mach",
         "pub val N: i64 = 4;\nfun g(x: i64) i64 {\n    val N: i64 = x;\n    $if (N > 2) { ret 1; }\n    ret 0;\n}\n");
     if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))        { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "shadows a comptime constant")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](res_resolve))     { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "names a runtime binding")) { dnit(?es); session.dnit(?s); ret 1; }
 
     dnit(?es);
     session.dnit(?s);
@@ -2271,8 +2273,8 @@ test "mach.lang.editor.resolve:param_shadows_comptime_const" {
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))        { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "shadows a comptime constant")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](res_resolve))     { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "names a runtime binding")) { dnit(?es); session.dnit(?s); ret 1; }
 
     dnit(?es);
     session.dnit(?s);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -217,6 +217,31 @@ pub val FIELD_SEL_OFFSET: u8 = 2;
 # installs this hook with `set_field_resolver`
 pub def FieldMemberFn: fun(ptr, u32, u32, u8) R.Result[O.Option[CTValue], str];
 
+# decides a bare identifier expression by RESOLUTION IDENTITY: true when the name
+# denotes a runtime binding (a block-local `val`/`var`, a non-`$` parameter), false
+# when it denotes a comptime one or has no resolution at all.
+#
+# The comptime environment is keyed by NAME, so without this the evaluator answers
+# "which declaration is this" by spelling: a block-local `var N` shadowing a
+# module-level `val N` folds to the MODULE constant, silently, with a plausible
+# value (#2764). `eval` owns the identifier dispatch but cannot depend on name
+# resolution without an import cycle, so every pass that owns a resolution map
+# installs this hook with `set_ident_resolver` and answers from the one shared
+# rule, `resolve.symbol_is_runtime`. A context with no hook (the driver's load-time
+# module walk, the editor's single-buffer analysis) sees only module-level names,
+# where no shadowing binding exists to confuse.
+#
+# The first argument is the installer's opaque context; the second is the IDENT
+# expression id, valid in the ast eval is currently walking.
+pub def IdentBindingFn: fun(ptr, id.ExprId) bool;
+
+# surfaced when an identifier resolves to a runtime binding. distinct from the
+# not-in-scope message: the name IS bound, just not to anything with a value
+# before the program runs, and a same-named comptime constant it shadows is not
+# what the expression denotes
+pub val COMPTIME_IDENT_RUNTIME_MSG: str =
+    "identifier names a runtime binding, so it has no comptime value";
+
 # the questions a comptime type query answers about one already-resolved type
 # (#2128). `eval` holds no type universe, so the typed layer installs the answer
 # with `set_type_query_resolver`, the same shape as the field-member hook above.
@@ -321,6 +346,10 @@ pub def FrameMark: u32;
 #                 type-identity token, or nil when no resolver is installed (every
 #                 pass before lowering)
 # type_data:      opaque context passed to type_fn (the *LowerContext)
+# ident_fn:       erased IdentBindingFn deciding whether a bare identifier names a
+#                 runtime binding, or nil when the evaluating pass owns no name
+#                 resolution (the driver's load walk, the editor's host context)
+# ident_data:     opaque context passed to ident_fn (the pass's own context record)
 pub rec ComptimeCtx {
     alloc:          *A.Allocator;
     target_os_id:   u32;
@@ -355,6 +384,8 @@ pub rec ComptimeCtx {
     field_data:     ptr;
     query_fn:       *u8;
     query_data:     ptr;
+    ident_fn:       *u8;
+    ident_data:     ptr;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
@@ -427,6 +458,10 @@ pub fun init(
     c.type_data      = nil;
     c.field_fn       = nil;
     c.field_data     = nil;
+    c.query_fn       = nil;
+    c.query_data     = nil;
+    c.ident_fn       = nil;
+    c.ident_data     = nil;
     ret c;
 }
 
@@ -479,6 +514,19 @@ pub fun set_field_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 pub fun set_type_query_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.query_fn   = fn;
     c.query_data = data;
+}
+
+# install (or clear) the identifier-binding resolver `eval` consults before it
+# folds a bare identifier (#2764). the pass that owns the module's name resolution
+# installs it; passing `nil` for both clears it, which restores the name-keyed
+# reading and is only correct where no local binding can exist
+# ---
+# c:    the comptime context
+# fn:   erased IdentBindingFn, or nil to clear
+# data: opaque context handed back to `fn`
+pub fun set_ident_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.ident_fn   = fn;
+    c.ident_data = data;
 }
 
 # bind the manifest-derived project metadata, the selected
@@ -746,7 +794,7 @@ pub fun eval(
     if (k == expr.EXPR_KIND_UNARY)  { ret eval_unary(c, a, source, ?node.data.unary, interner); }
 
     if (k == expr.EXPR_KIND_IDENT) {
-        val r_id: R.Result[CTValue, str] = eval_ident(c, source, node.span, interner);
+        val r_id: R.Result[CTValue, str] = eval_ident(c, source, e, node.span, interner);
         if (R.is_err[CTValue, str](r_id)) { ret r_id; }
         val v_id: CTValue = R.unwrap_ok[CTValue, str](r_id);
         # a `$each x in ARR` loop variable binds to a CONST_ELEM descriptor; fold a
@@ -2027,15 +2075,28 @@ fun apply_int_shift(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue
 # resolves a bare identifier expression (no `$` prefix). language-level
 # boolean literals `true` and `false` are short-circuited; everything else
 # must have been registered as a comptime constant by the driver
+#
+# WHICH declaration the name denotes is decided by the installed ident resolver,
+# never by the name itself (#2764). The environment below is keyed by name, so
+# consulting it first would answer for whichever binding happens to share the
+# spelling - and a block-local binding shadowing a module constant reads back the
+# constant, with no error to say so. The identity question is therefore asked
+# BEFORE the environment is touched, and a runtime binding stops here.
 fun eval_ident(
     c:        *ComptimeCtx,
     source:   str,
+    e:        id.ExprId,
     span:     token.Span,
     interner: *intern.Interner
 ) R.Result[CTValue, str] {
     val text: View = span_text(source, span);
     if (view_eq_str(text, "true"))  { ret bool_value(true); }
     if (view_eq_str(text, "false")) { ret bool_value(false); }
+
+    if (c.ident_fn != nil) {
+        val ident_of: IdentBindingFn = c.ident_fn::IdentBindingFn;
+        if (ident_of(c.ident_data, e)) { ret R.err[CTValue, str](COMPTIME_IDENT_RUNTIME_MSG); }
+    }
 
     val id_r: R.Result[intern.StrId, str] = intern.intern_span(interner, source, span);
     if (R.is_err[intern.StrId, str](id_r)) {
@@ -2118,7 +2179,7 @@ fun eval_const_elem_member(
     val obj: *expr.Expr = O.unwrap[*expr.Expr](obj_opt);
     if (obj.kind != expr.EXPR_KIND_IDENT)                                     { ret O.none[R.Result[CTValue, str]](); }
 
-    val obj_r: R.Result[CTValue, str] = eval_ident(c, source, obj.span, interner);
+    val obj_r: R.Result[CTValue, str] = eval_ident(c, source, object_eid, obj.span, interner);
     if (R.is_err[CTValue, str](obj_r))                                        { ret O.none[R.Result[CTValue, str]](); }
     val ov: CTValue = R.unwrap_ok[CTValue, str](obj_r);
     if (ov.kind != CT_KIND_CONST_ELEM)                                        { ret O.none[R.Result[CTValue, str]](); }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -524,6 +524,11 @@ fun init_context(
         memory.fill[SymbolId](rc.decl_symbol, SYMBOL_NIL, a.decl_len);
     }
 
+    # install last, once expr_resolved exists: from here on every fold this pass
+    # runs decides an identifier on the declaration bound to it (#2764). cleared by
+    # dnit_context, which every exit from `resolve` reaches, so the borrowed ctx
+    # never keeps a dangling ResolveContext pointer.
+    comptime.set_ident_resolver(ctx, comptime_ident_is_runtime::*u8, rc::ptr);
     ret R.ok[bool, str](true);
 }
 
@@ -531,6 +536,7 @@ fun init_context(
 # ---
 # rc: the context to tear down
 fun dnit_context(rc: *ResolveContext) {
+    if (rc.ctx != nil) { comptime.set_ident_resolver(rc.ctx, nil, nil); }
     var i: u32 = 0;
     for (i < rc.scope_len) {
         val sc: *Scope = ?rc.scopes[i];
@@ -1815,17 +1821,14 @@ fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32
     var bi: u32 = 0;
     for (bi < branches_len) {
         val br: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + bi];
-        # resolve the gate's identifiers before folding it, recording each leaf's
-        # resolution identity, then reject any leaf whose binding the name-keyed
-        # fold would silently misread (a runtime local/param shadowing a comptime
-        # constant). eval failures themselves are reported by
-        # comptime_branch_active; this check covers exactly the case where the
-        # fold SUCCEEDS against the wrong binding.
+        # resolve the gate's identifiers before folding it, so each leaf's
+        # resolution identity is recorded by the time the installed ident resolver
+        # is asked for it. a leaf naming a runtime binding then fails the fold on
+        # identity, and comptime_branch_active reports that failure - there is no
+        # second rule here to keep in step with the evaluator's (#2764).
         if (br.cond != id.EXPR_NIL) {
             val rce: R.Result[bool, str] = bind_expr(rc, br.cond);
             if (R.is_err[bool, str](rce)) { ret rce; }
-            val rcs: R.Result[bool, str] = check_gate_shadowing(rc, br.cond);
-            if (R.is_err[bool, str](rcs)) { ret rcs; }
         }
         val take_r: R.Result[bool, str] = comptime_branch_active(rc, br);
         if (R.is_err[bool, str](take_r)) { ret take_r; }
@@ -1843,72 +1846,47 @@ fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32
 # whether a resolved symbol denotes a RUNTIME binding, decided on resolution
 # identity rather than on name text
 #
-# ONE definition because the comptime environment is keyed by NAME: a block-local
+# THE definition. The comptime environment is keyed by NAME, so a block-local
 # `val`/`var` or a non-`$` parameter that happens to share a name with a
-# module-level constant folds to that constant, so every site that decides
-# whether an identifier may be folded has to ask the same question. A second
-# enumeration of this rule would drift, and the two sites it serves - the `$if`
-# gate shadowing check and the constant index bound (#2751) - disagree loudly
-# when it does: one miscompiles a gate, the other refuses a legal access.
+# module-level constant would otherwise read back that constant - which is the
+# defect this answers (#2764). `comptime.eval_ident` asks it through the ident
+# resolver every pass installs, so the evaluator, the `$if` gate diagnostics, and
+# the constant index bound (#2751) all decide the same question from this one
+# function rather than from three enumerations of it.
 #
-# Module scope is what makes a `val` foldable, `$` is what makes a parameter
-# foldable, and everything else (a function, an import, a type name) is not a
-# value binding at all and is left to the evaluator.
+# `$` marks a comptime binding whatever its kind: a `$param`, and the `$each` loop
+# variable, which resolve declares as a SYM_VAL bearing SYM_FLAG_COMPTIME and which
+# a rule keyed only on module scope therefore misread as runtime. Module scope is
+# what makes an unmarked `val` foldable, and everything else (a function, an import,
+# a type name) is not a value binding at all and is left to the evaluator.
 # ---
 # sym: the resolved symbol
 # ret: true when the symbol names storage decided at runtime
 pub fun symbol_is_runtime(sym: *Symbol) bool {
+    if ((sym.flags & SYM_FLAG_COMPTIME) != 0) { ret false; }
     if (sym.kind == SYM_VAL || sym.kind == SYM_VAR) {
         ret (sym.flags & SYM_FLAG_MODULE) == 0;
     }
-    if (sym.kind == SYM_PARAM) {
-        ret (sym.flags & SYM_FLAG_COMPTIME) == 0;
-    }
-    ret false;
+    ret sym.kind == SYM_PARAM;
 }
 
-# walks a folded (non-param) `$if` gate and rejects any
-# leaf identifier that resolves to a runtime binding whose NAME also names a
-# comptime constant in the env. the comptime fold is name-keyed, so such a gate
-# folds against the constant while the resolver bound the ident to the runtime
-# local / parameter - a silent wrong-arm miscompile. a runtime ident whose name
-# is not in the env is left alone: the fold fails on it and
-# comptime_branch_active reports that failure, so reporting here would
-# duplicate it. reports at the offending leaf's span
+# the identifier-binding resolver resolve installs on the module's ComptimeCtx (a
+# comptime.IdentBindingFn), so a gate folded during binding reads the declaration
+# the resolver just bound rather than whatever shares the spelling. leaves reach
+# this already recorded: bind_expr runs over a gate before comptime_branch_active
+# folds it. an unrecorded or out-of-range leaf answers false, leaving the evaluator
+# to report the name as not a constant
 # ---
-# rc:  resolver state for the module being resolved
-# eid: the gate expression to walk
-# ret: ok(true), or a reported shadowing error
-fun check_gate_shadowing(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
-    if (eid == id.EXPR_NIL) { ret R.ok[bool, str](true); }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret R.ok[bool, str](true); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
-
-    if (e.kind == expr.EXPR_KIND_BINARY) {
-        val rl: R.Result[bool, str] = check_gate_shadowing(rc, e.data.binary.lhs);
-        if (R.is_err[bool, str](rl)) { ret rl; }
-        ret check_gate_shadowing(rc, e.data.binary.rhs);
-    }
-    if (e.kind == expr.EXPR_KIND_UNARY) {
-        ret check_gate_shadowing(rc, e.data.unary.operand);
-    }
-    if (e.kind != expr.EXPR_KIND_IDENT) { ret R.ok[bool, str](true); }
-
-    if (rc.expr_resolved == nil) { ret R.ok[bool, str](true); }
+# data: the *ResolveContext, erased to a ptr by the installer
+# eid:  the IDENT expression id, valid in this module's ast
+# ret:  true when the identifier names a runtime binding
+fun comptime_ident_is_runtime(data: ptr, eid: id.ExprId) bool {
+    val rc: *ResolveContext = data::*ResolveContext;
+    if (rc == nil || rc.expr_resolved == nil) { ret false; }
+    if (eid == id.EXPR_NIL || eid::u32 >= rc.a.expr_len::u32) { ret false; }
     val sid: SymbolId = rc.expr_resolved[eid];
-    if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret R.ok[bool, str](true); }
-    val sym: *Symbol = ?rc.symbols[sid];
-
-    if (!symbol_is_runtime(sym)) { ret R.ok[bool, str](true); }
-
-    val id_r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, e.span);
-    if (R.is_err[intern.StrId, str](id_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](id_r)); }
-    val nc: O.Option[*comptime.NamedConst] = comptime.lookup(rc.ctx, R.unwrap_ok[intern.StrId, str](id_r));
-    if (O.is_none[*comptime.NamedConst](nc)) { ret R.ok[bool, str](true); }
-
-    ret diagnostic.error(?rc.s.diags, rc.a.file_id, e.span,
-        "comptime branch condition references a runtime binding that shadows a comptime constant");
+    if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret false; }
+    ret symbol_is_runtime(?rc.symbols[sid]);
 }
 
 # reports whether any arm gate of a `$if` chain references a comptime value

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -111,6 +111,15 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_init));
     }
 
+    # install the identifier-binding resolver for the WHOLE pass, not for a window:
+    # every fold this pass runs - an array length in a type position, a `$if` gate,
+    # a constant index bound - has to decide an identifier on the declaration it
+    # resolves to, and a window would leave whichever fold fell outside it reading
+    # by name (#2764). cleared on every exit below so the borrowed ctx never keeps a
+    # dangling `sc` pointer.
+    val scp_ident: *context.SemaContext = ?sc;
+    comptime.set_ident_resolver(ctx, context.comptime_ident_is_runtime::*u8, scp_ident::ptr);
+
     # install the module-member resolver so `comptime.eval` can fold an imported
     # `pub val` referenced in a type position - an array length like `[a.CAP]u8` -
     # exactly as a local `val` folds (#2081). every syntactic type node, including a
@@ -199,6 +208,7 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_reval));
     }
 
+    comptime.set_ident_resolver(ctx, nil, nil);
     ret build_result(?sc);
 }
 
@@ -643,9 +653,12 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     val saved_td:  ptr                  = octx.type_data;
     val saved_qfn: *u8                  = octx.query_fn;
     val saved_qd:  ptr                  = octx.query_data;
+    val saved_ifn: *u8                  = octx.ident_fn;
+    val saved_id:  ptr                  = octx.ident_data;
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, tscp::ptr);
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, tscp::ptr);
     comptime.set_type_query_resolver(octx, infer.resolve_type_query::*u8, tscp::ptr);
+    comptime.set_ident_resolver(octx, context.comptime_ident_is_runtime::*u8, tscp::ptr);
     tsc.inst_site     = site;
     tsc.inst_site_set = true;
     val res: R.Result[bool, str] = infer_stmt(?tsc, d.data.fun_.body, ret_ty);
@@ -653,6 +666,7 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     comptime.set_field_resolver(octx, saved_ffn, saved_fd);
     comptime.set_type_resolver(octx, saved_tfn, saved_td);
     comptime.set_type_query_resolver(octx, saved_qfn, saved_qd);
+    comptime.set_ident_resolver(octx, saved_ifn, saved_id);
 
     free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);
     free_typeids(sc.s.alloc, scratch_decl, oa.decl_len);
@@ -972,6 +986,7 @@ fun source_text_of(s: *session.Session, a: *ast.Ast) str {
 # ---
 # sc: the context to tear down
 fun dnit_context(sc: *context.SemaContext) {
+    if (sc.ctx != nil) { comptime.set_ident_resolver(sc.ctx, nil, nil); }
     if (sc.expr_type != nil && sc.a.expr_len > 0) {
         A.deallocate[type.TypeId](sc.s.alloc, sc.expr_type, sc.a.expr_len);
     }
@@ -2586,26 +2601,25 @@ fun check_comptime_gate(sc: *context.SemaContext, eid: id.ExprId) {
         # evaluator folds directly; leave it to the evaluator.
         if (O.is_none[*resolve.Symbol](opt_sym)) { ret; }
         val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
-        if (sym.kind == resolve.SYM_PARAM) {
-            if ((sym.flags & resolve.SYM_FLAG_COMPTIME) == 0) {
+        # whether the name denotes runtime storage is `resolve.symbol_is_runtime`'s
+        # question, asked here exactly as the evaluator asks it, so this gate walk
+        # cannot drift from what `comptime.eval` will actually do with the same leaf
+        # (#2764). only the WORDING is local: the reader needs to hear "parameter"
+        # for a parameter and "value" for a binding.
+        if (resolve.symbol_is_runtime(sym)) {
+            if (sym.kind == resolve.SYM_PARAM) {
                 check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime parameter '", sym.name, "'", "comptime `$if` gate cannot reference a runtime parameter");
-            }
-            ret;
-        }
-        # a `val` / imported binding is foldable ONLY if it actually resolves to a
-        # comptime constant. a runtime block-local `val n = f();` is SYM_VAL but not
-        # foldable - and the comptime env is name-keyed, so folding it would
-        # spuriously succeed against a same-named MODULE const it shadows (a real
-        # miscompile of the gate). decide on resolution identity first: only a
-        # module-scope val (or an import) reaches the fold test; a block-local val
-        # is rejected outright regardless of any name collision.
-        if (sym.kind == resolve.SYM_VAL || sym.kind == resolve.SYM_IMPORTED) {
-            val is_module: bool = sym.kind == resolve.SYM_IMPORTED
-                                || (sym.flags & resolve.SYM_FLAG_MODULE) != 0;
-            if (!is_module) {
-                check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime value '", sym.name, "'", "comptime `$if` gate cannot reference a runtime value");
                 ret;
             }
+            check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime value '", sym.name, "'", "comptime `$if` gate cannot reference a runtime value");
+            ret;
+        }
+        # a comptime parameter is foldable per call site, never here.
+        if (sym.kind == resolve.SYM_PARAM) { ret; }
+        # a `val` / imported binding survives the identity test but is still foldable
+        # only if it actually resolves to a comptime constant, so a module-scope
+        # `val n = f();` is rejected by the fold rather than by the rule above.
+        if (sym.kind == resolve.SYM_VAL || sym.kind == resolve.SYM_IMPORTED) {
             val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
             if (R.is_err[comptime.CTValue, str](res_eval) && !check.imported_module_const_sym(sc, sym)) {
                 check.report_named(sc, e.span, "comptime `$if` gate cannot reference runtime value '", sym.name, "'", "comptime `$if` gate cannot reference a runtime value");

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -445,18 +445,18 @@ pub fun check_const_index(sc: *context.SemaContext, object: type.TypeId, idx: id
 # the constant value of an index expression, or none when this layer cannot
 # decide it
 #
-# Folds through `comptime.eval`, but only once resolution identity has said that
-# no leaf names a runtime binding. The comptime environment is keyed by NAME, so
-# a block-local `var n` that shares its name with a module-level `val n` folds to
-# the module constant, and a bound rule that trusted the fold would refuse a
-# legal access against a value the program never reads.
+# Folds through `comptime.eval` and trusts the result. The evaluator decides each
+# identifier on resolution identity (#2764), so a block-local `var n` sharing its
+# name with a module-level `val n` fails the fold instead of reading back the
+# module constant - and this rule no longer needs a walk of its own to protect
+# itself from the evaluator. A second walk here would be a second place for the
+# runtime-binding rule to live, which is exactly what #2751 had to work around.
 # ---
 # sc:  the active sema context
 # eid: the index expression
 # ret: some(value) for a decidable integer index, none otherwise
 pub fun const_index_value(sc: *context.SemaContext, eid: id.ExprId) O.Option[comptime.CTValue] {
-    if (eid == id.EXPR_NIL)                { ret O.none[comptime.CTValue](); }
-    if (references_runtime_binding(sc, eid)) { ret O.none[comptime.CTValue](); }
+    if (eid == id.EXPR_NIL) { ret O.none[comptime.CTValue](); }
 
     val cr: R.Result[comptime.CTValue, str] =
         comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
@@ -465,32 +465,6 @@ pub fun const_index_value(sc: *context.SemaContext, eid: id.ExprId) O.Option[com
     val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](cr);
     if (cv.kind != comptime.CT_KIND_INT) { ret O.none[comptime.CTValue](); }
     ret O.some[comptime.CTValue](cv);
-}
-
-# walks `eid` reporting whether any leaf identifier resolves to a runtime binding
-# ---
-# sc:  the active sema context
-# eid: the expression to walk (EXPR_NIL terminates it)
-# ret: true when any leaf names storage decided at runtime
-fun references_runtime_binding(sc: *context.SemaContext, eid: id.ExprId) bool {
-    if (eid == id.EXPR_NIL) { ret false; }
-    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](opt_expr)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](opt_expr);
-
-    if (e.kind == expr.EXPR_KIND_IDENT) {
-        val opt_sym: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
-        if (O.is_none[*resolve.Symbol](opt_sym)) { ret false; }
-        ret resolve.symbol_is_runtime(O.unwrap[*resolve.Symbol](opt_sym));
-    }
-    if (e.kind == expr.EXPR_KIND_BINARY) {
-        ret references_runtime_binding(sc, e.data.binary.lhs)
-         || references_runtime_binding(sc, e.data.binary.rhs);
-    }
-    if (e.kind == expr.EXPR_KIND_UNARY) {
-        ret references_runtime_binding(sc, e.data.unary.operand);
-    }
-    ret false;
 }
 
 # report `index N is out of bounds for `T` of length L` at `span`

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -926,6 +926,25 @@ pub fun symbol_for_expr(sc: *SemaContext, eid: id.ExprId) O.Option[*resolve.Symb
     ret symbol_by_id(sc, sid);
 }
 
+# the identifier-binding resolver sema installs on the module's ComptimeCtx (a
+# comptime.IdentBindingFn), so every fold this pass runs - an array length in a
+# type position, a `$if` gate, a constant index bound - decides an identifier on the
+# declaration it resolves to rather than on its spelling (#2764). answers from
+# `resolve.symbol_is_runtime`, the one definition of the rule. `data` is the
+# *SemaContext driving the evaluation; reading its `rr` live keeps the answer
+# correct across the transient contexts the instance episodes build
+# ---
+# data: the *SemaContext, erased to a ptr by the installer
+# eid:  the IDENT expression id, valid in the active module's ast
+# ret:  true when the identifier names a runtime binding
+pub fun comptime_ident_is_runtime(data: ptr, eid: id.ExprId) bool {
+    val sc: *SemaContext = data::*SemaContext;
+    if (sc == nil || eid == id.EXPR_NIL) { ret false; }
+    val opt_sym: O.Option[*resolve.Symbol] = symbol_for_expr(sc, eid);
+    if (O.is_none[*resolve.Symbol](opt_sym)) { ret false; }
+    ret resolve.symbol_is_runtime(O.unwrap[*resolve.Symbol](opt_sym));
+}
+
 # the Symbol a NAMED AstType resolves to, via the resolve result's type_resolved
 # table
 # ---

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -531,9 +531,10 @@ fun context_origin_bind(lc: *context.LowerContext, s: *session.Session, origin: 
     comptime_resolvers_install(octx, lc);
 }
 
-# installs the member / type / field comptime resolvers against `octx`, routing
-# each back to `lc` so `comptime.eval` folds `alias.CONST` paths, `$type_of(...)`
-# gates, and `$each` field descriptors against the context's active module
+# installs the member / type / field / ident comptime resolvers against `octx`,
+# routing each back to `lc` so `comptime.eval` folds `alias.CONST` paths,
+# `$type_of(...)` gates, `$each` field descriptors, and bare identifiers against
+# the context's active module
 # ---
 # octx: the comptime context to install resolvers on
 # lc:   the lowering context the resolvers read live
@@ -542,6 +543,7 @@ fun comptime_resolvers_install(octx: *comptime.ComptimeCtx, lc: *context.LowerCo
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, lc::ptr);
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, lc::ptr);
     comptime.set_type_query_resolver(octx, context.resolve_type_query::*u8, lc::ptr);
+    comptime.set_ident_resolver(octx, context.comptime_ident_is_runtime::*u8, lc::ptr);
 }
 
 # restores the home module's phase inputs after an instance drain (the body

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -384,6 +384,9 @@ pub fun init_context(
     comptime.set_field_resolver(ctx, resolve_field_member::*u8, lc::ptr);
     # install the type-query resolver so a `$is_record` / `$type_name` gate folds here.
     comptime.set_type_query_resolver(ctx, resolve_type_query::*u8, lc::ptr);
+    # install the identifier-binding resolver so a gate folded here reads the
+    # declaration each leaf resolves to rather than its spelling (#2764).
+    comptime.set_ident_resolver(ctx, comptime_ident_is_runtime::*u8, lc::ptr);
 
     lc.locals      = map.init[resolve.SymbolId, value.Value](s.alloc, map.hash_u32, map.eq_u32);
     lc.local_names = map.init[intern.StrId, LocalBinding](s.alloc, map.hash_u32, map.eq_u32);
@@ -467,6 +470,7 @@ pub fun dnit_context(lc: *LowerContext) {
         comptime.set_type_resolver(lc.ctx, nil, nil);
         comptime.set_field_resolver(lc.ctx, nil, nil);
         comptime.set_type_query_resolver(lc.ctx, nil, nil);
+        comptime.set_ident_resolver(lc.ctx, nil, nil);
     }
     map.dnit[intern.StrId, LocalBinding](?lc.local_names);
     map.dnit[resolve.SymbolId, value.Value](?lc.locals);
@@ -603,6 +607,30 @@ pub fun resolve_module_member_const(data: ptr, eid: id.ExprId) R.Result[O.Option
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
     ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](nc).value));
+}
+
+# the identifier-binding resolver lowering installs on every ComptimeCtx it
+# evaluates against (a comptime.IdentBindingFn)
+#
+# Lowering is where a `$param`-gated `$if` finally folds, and a body it folds may
+# hold a runtime local that shares a name with a module constant. Answering that by
+# spelling selects an arm the program never asked for, silently (#2764), so the
+# question goes to `resolve.symbol_is_runtime` like everywhere else. `data` is the
+# *LowerContext driving the evaluation; reading its `rr` live keeps the answer
+# correct across the instance drains that swap the active module - the same reason
+# the member resolver reads it live
+# ---
+# data: the *LowerContext, erased to a ptr by the installer
+# eid:  the IDENT expression id, valid in the active module's ast
+# ret:  true when the identifier names a runtime binding
+pub fun comptime_ident_is_runtime(data: ptr, eid: id.ExprId) bool {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil || eid == id.EXPR_NIL) { ret false; }
+    val rr: *resolve.ResolveResult = lc.rr;
+    if (rr == nil || rr.expr_resolved == nil || eid::u32 >= rr.expr_count) { ret false; }
+    val sid: resolve.SymbolId = rr.expr_resolved[eid];
+    if (sid == resolve.SYMBOL_NIL || sid::u32 >= rr.symbol_count) { ret false; }
+    ret resolve.symbol_is_runtime(?rr.symbols[sid]);
 }
 
 # the type-comparison operand resolver lowering installs on every ComptimeCtx it


### PR DESCRIPTION
Closes #2764

## What was wrong

`comptime.eval_ident` resolved a bare identifier by **name text** against the name-keyed comptime environment. Resolution identity was never consulted, so a binding was matched by what it is called rather than by which declaration it is.

The live wrong answer, reproduced on `origin/dev` @ `2b1a0464`:

```mach
val N: i64 = 9;

fun f(k: i64) i64 {
    val N: i64 = k;      # runtime local, shadows the module constant
    var xs: [N]i64;      # folds to [9]i64
    ret xs[100];
}
```

```
dev:  error: index 100 is out of bounds for `[9]i64` of length 9
```

The diagnostic names a length the source never wrote, against a value the expression does not denote. The array-length type position was the one consumer that no compensating rule stood in front of, so it was still silently wrong at HEAD.

## What changed

`ComptimeCtx` gains an ident resolver (`IdentBindingFn`), installed by every pass that owns a name-resolution map — resolve, sema, lowering, including the origin-module swaps the instance drains perform. `eval_ident` asks it **before** it touches the environment, so identity decides whether a name may fold and the environment only says what it folds to.

All of them answer from one function, `resolve.symbol_is_runtime`.

### The compensating rules folded in

| site | before | after |
|---|---|---|
| `resolve.symbol_is_runtime` | the shared definition (#2751) | **the** definition, corrected |
| `resolve.check_gate_shadowing` | a defensive guard over the defect | **removed** — the case it caught cannot arise |
| `check.const_index_value` | walked its operand for runtime leaves before folding | folds and inherits the evaluator's answer; its private walk is gone |
| `sema`'s `$if` gate walk | a third enumeration, with `SYM_IMPORTED` | delegates the decision, keeps only its per-kind wording |

`check_gate_shadowing` became **unnecessary**, not merely correct: a gate leaf naming a runtime binding now fails the fold on identity, and `comptime_branch_active` reports that failure. It is deleted rather than demoted.

### A disagreement the copies were hiding

Consolidating them surfaced a real defect in the shared rule. An `$each` loop variable is a **comptime** binding, which resolve declares as a `SYM_VAL` bearing `SYM_FLAG_COMPTIME`; a rule keyed only on module scope called it runtime. So the #2751 index bound declined to decide any index driven by one:

```mach
val ES: [2]i64 = [2]i64{0, 5};
fun g() i64 {
    var xs: [4]i64;
    var s: i64 = 0;
    $each e in ES { s = s + xs[e]; }   # element 5 into a 4-element array
    ret s;
}
```

On `dev` this compiles clean and reads past the array. It is now refused. `$` marks a comptime binding whatever its kind, and the rule says so once.

## Tests

Three integration cases, all reproduced against a compiler built from `origin/dev` first.

- `int/regression/2764-comptime-ident-identity` — **build-fails.** Puts the one rule in front of every consumer that reads it (array length in a type position, the constant index bound, both again through a generic instance, and the `$each` gate) with the module `N` = 9 and the local `N` carrying something else. Each golden line names which of the two was read, so a consumer that disagreed changes the golden rather than passing quietly. Against `origin/dev` the golden diff is the wrong answer, spelled out:
  ```
  -error: cannot infer type: array length is not a comptime constant
  -error: cannot infer type: array length is not a comptime constant
  -error: index 5 is out of bounds for `[4]i64` of length 4
  +error: index 100 is out of bounds for `[9]i64` of length 9
  +error: index 100 is out of bounds for `[9]T` of length 9
  ```
  The `index 5` line is the `$each` disagreement above: absent on `dev` entirely.

- `int/regression/2764-gate-runtime-binding` — **build-fails.** A `$if` gate over a runtime binding through five routes, including one whose name is *not* also a comptime constant. The removed guard fired only on a name collision, so on `dev` those five shapes get two different diagnostics; one rule owes them one answer. Fails against `origin/dev` on the golden.

- `int/regression/2764-shadowed-comptime-binding` — **exec.** The half that had to be preserved: a `$param` and an `$each` variable named after a module constant fold to the **inner** binding, pinned with the two carrying different values (module 9, never supplied by any call), through a generic instance and inside a `$if` gate. Passes on `dev` too, by design — it guards the fix rather than proving it.

The two editor unit tests that pinned `check_gate_shadowing`'s message now assert the evaluator's own refusal.

## Verification

- `mach test .` — 1296 passed, 0 failed
- `int` `--target linux --deps pin` — all cases passed
- `int` `--target linux-arm64 --runmode qemu` — 4 failures (`surface/c-variadic`, `surface/narrow-stack-args`), **identical on `origin/dev`**; both are artifacts of hosting the aarch64 leg under qemu on an x86-64 box with a host C toolchain, not regressions. The native aarch64 leg is CI's, per targets.conf.
- Self-host fixpoint: stage1 = stage2 = stage3, `sha256 09d562ade72e0879f1f9772967b25b256bc1556dce6bbd10db1713f519296a23`

## The compiler's own source

It does not rely on the buggy behaviour anywhere: the tree builds clean under the fix and reaches the byte-identical fixpoint, and so does `mach-std`. Worth stating explicitly, since a self-hosting compiler that had leaned on the name-text reading would have had to be edited before it could compile itself.