### PR TITLE
int: drive a real gdb session over DWARF, not just verify it structurally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,12 +326,16 @@ jobs:
       # spirv-val (#2245), and spirv-ext-inst additionally DISASSEMBLES it with
       # spirv-dis to assert the instructions the emitter produced, which the
       # validator's verdict cannot show (#2688) - both binaries ship in the same
-      # spirv-tools package. all run on the Linux legs.
+      # spirv-tools package. debugger-gdb (int/surface/debugger-gdb, #2756) goes
+      # further than validation and drives gdb over the artifact directly; its own
+      # case.conf scopes it to `linux` only (the leg this was hand-verified on), but
+      # gdb is installed on every Linux leg here, matching the other validators,
+      # since `linux-arm64` runs it natively too and a future case could name it.
       - name: install artifact validators
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm binutils spirv-tools
+          sudo apt-get install -y llvm binutils spirv-tools gdb
 
       # the seed lands on PATH via GITHUB_PATH, which only takes effect in later
       # steps, so the fetch and the build are separate (as in the build lanes).
@@ -397,7 +401,7 @@ jobs:
       - name: install artifact validators
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm binutils spirv-tools
+          sudo apt-get install -y llvm binutils spirv-tools gdb
       - name: fetch released mach
         uses: ./.github/actions/seed-mach
       - name: build the from-source compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.16.0] - 2026-08-08
+## [Unreleased]
+
+### Added
+
+#### A real gdb session drives the DWARF the compiler emits (#2756)
+`int/surface/debuginfo` proves the `-g` image is structurally valid (`llvm-dwarfdump --verify` clean, `addr2line` round-trips); it cannot prove the DWARF describes the right thing, because a location list can be valid and still name a register the value has already left. Nothing in the harness drove an actual debugger, so that half of debug info was never checked.
+
+`int/surface/debugger-gdb` now does: one `gdb --batch` session per `opt` level breaks on a call inlined at release only (`#[inline]`, which the debug pipeline's no-inlining-pass makes a real call there instead) and reads its parameter back from whatever register or stack slot the location list names, breaks mid-loop on a local that stays register-resident for the whole loop and reads a running sum this case's own case.conf computes by hand, and confirms a local that is written and never read carries no location at either profile - "optimized out" is the correct answer there, not a gap. A single `step` off a loop body line is asserted to land on the condition check, then back into the body, by source line rather than instruction count.
+
+Scoped to the `linux` leg only: gdb is what a Linux runner carries (no lldb here), and this is the one leg whose result was read by hand against the source. `linux-arm64` runs gdb natively in CI and could plausibly carry this case too, but that leg's session was never exercised or hand-verified, so it - along with `linux-riscv64` (qemu-user has no ptrace story a host gdb can attach through), `windows`, and both `darwin` legs - stays explicitly unverified rather than assumed to work.
 
 ### Added
 

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -2202,6 +2202,134 @@ produce_debuginfo() {
     done
 }
 
+# produce_gdb_session <runmode> <target> <nog_binary> <g_binary>
+# the BEHAVIOURAL debugger observable (#2756): int/surface/debuginfo proves the `-g`
+# image is structurally valid; it cannot prove gdb reports the right thing when a
+# user actually breaks into it. this producer drives one real `gdb --batch` session
+# over the `-g` artifact and normalizes its transcript into stop/frame/value facts -
+# every one of them read off the fixture by hand before it went into the golden (see
+# int/surface/debugger-gdb/src/main.mach and case.conf for the arithmetic).
+#
+# a missing gdb is a hard error, the same contract produce_debuginfo already uses for
+# its own validators (llvm-dwarfdump, addr2line, ...): every runner this case's
+# case.conf names (`linux` only - see that file for why the others are not) is
+# expected to carry one, so a silent skip would hide a real coverage gap instead of
+# reporting it.
+#
+# gdb's own text is not the observable: it carries a pid in the exit line, a
+# `Breakpoint N` or `Breakpoint N.M` counter that depends on how many candidate
+# addresses gdb resolved for a source line (an inlined body and its dead out-of-line
+# twin both claim the same line, so this varies between profiles for reasons that
+# have nothing to do with correctness), and - a real gap this case does NOT assert
+# on - the caller frame's OWN argument list, which this compiler currently populates
+# from unrelated inlined locals rather than `main`'s real parameters (found while
+# building this case; tracked separately, not asserted here because it is not what
+# #2756 asks this case to prove). the gdb script below prints a `SENTINEL:<name>`
+# echo ahead of each fact so the normalizer below can key off it instead of gdb's own
+# formatting, and extracts only the function name and source line from a frame
+# line, never its argument list.
+produce_gdb_session() {
+    g=$4
+    command -v gdb >/dev/null 2>&1 || {
+        echo "int: gdb-session: gdb not found (install the 'gdb' package)" >&2; return 2
+    }
+
+    gdbtmp=$(mktemp -d)
+    script=$gdbtmp/session.gdb
+    cat >"$script" <<'GDBEOF'
+set debuginfod enabled off
+set pagination off
+break main.mach:11
+break main.mach:20
+break main.mach:27
+run
+echo SENTINEL:addone_stop\n
+frame 0
+echo SENTINEL:addone_v\n
+print v
+echo SENTINEL:addone_caller\n
+frame 1
+continue
+continue
+continue
+continue
+continue
+echo SENTINEL:accum_total\n
+print total
+echo SENTINEL:accum_i\n
+print i
+echo SENTINEL:step1\n
+step
+echo SENTINEL:step2\n
+step
+delete 2
+continue
+echo SENTINEL:dead_stop\n
+frame 0
+echo SENTINEL:dead_v\n
+print v
+echo SENTINEL:dead_unused\n
+print unused
+echo SENTINEL:dead_caller\n
+frame 1
+continue
+GDBEOF
+
+    transcript=$gdbtmp/transcript.txt
+    gdb --batch -q -x "$script" "$g" >"$transcript" 2>&1
+
+    # the program's own stdout is ground truth for the values gdb is asked to read
+    # back: a=addone's result, b=accumulate's, c=deadlocal's. cross-checking it
+    # against the golden's hand-computed values is what would catch a normalizer
+    # bug that made every gdb-side assertion vacuously agree with itself.
+    stdout=$(grep -E '^[abc]=[0-9]+$' "$transcript" | paste -sd, -)
+    echo "program_stdout=$stdout"
+    if grep -q 'exited normally' "$transcript"; then
+        echo "exit=normal"
+    else
+        echo "exit=abnormal"
+    fi
+
+    # state machine over the transcript: a `SENTINEL:<name>` line names the fact the
+    # NEXT matching line carries. frame lines (`_stop`/`_caller`) yield two facts,
+    # function and line, deliberately excluding the argument list (see header). a
+    # `print` result is the text after `$N = `. a `step` target is the source line
+    # number gdb echoes ahead of the line's own text.
+    cur=
+    while IFS= read -r line; do
+        case "$line" in
+            SENTINEL:*) cur=${line#SENTINEL:}; continue ;;
+        esac
+        [ -n "$cur" ] || continue
+        case "$cur" in
+            *_stop|*_caller)
+                m=$(printf '%s\n' "$line" | sed -E -n 's/^#[01]  (0x[0-9a-f]+ in )?([A-Za-z_][A-Za-z0-9_]*) \(.*\) at .*:([0-9]+)$/\2 \3/p')
+                if [ -n "$m" ]; then
+                    echo "${cur}_func=${m% *}"
+                    echo "${cur}_line=${m#* }"
+                    cur=
+                fi
+                ;;
+            step1|step2)
+                m=$(printf '%s\n' "$line" | sed -E -n 's/^([0-9]+)\t.*/\1/p')
+                if [ -n "$m" ]; then
+                    echo "${cur}_line=$m"
+                    cur=
+                fi
+                ;;
+            *)
+                m=$(printf '%s\n' "$line" | sed -E -n 's/^\$[0-9]+ = (.*)$/\1/p')
+                if [ -n "$m" ]; then
+                    echo "${cur}=$m"
+                    cur=
+                fi
+                ;;
+        esac
+    done <"$transcript"
+
+    rm -rf "$gdbtmp"
+}
+
 # resolve_objdump — print an llvm-objdump on PATH, preferring the unversioned name
 # and falling back to the highest-versioned one (ubuntu ships llvm-objdump-NN, from
 # the same `llvm` package as llvm-dwarfdump). llvm-objdump decodes every ISA mach
@@ -2760,6 +2888,7 @@ produce() {
         flat-loader) produce_flat_loader "$@" ;;
         built)       produce_built "$@" ;;
         debuginfo)   produce_debuginfo "$@" ;;
+        gdb-session) produce_gdb_session "$@" ;;
         spirv-val)   produce_spirv_val "$@" ;;
         spirv-val-vulkan) produce_spirv_val_vulkan "$@" ;;
         spirv-shader) produce_spirv_shader "$@" ;;

--- a/int/run.sh
+++ b/int/run.sh
@@ -397,11 +397,13 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
     # the golden is shared across build-targets for target-independent observables (exec,
     # the relro-fault guard, and the panic-exit guard, whose outputs are all
     # target-independent; debuginfo, whose two facts — validator-clean and additive —
-    # hold identically on every ELF ISA) and per-build-target for structural producers
-    # (their fact is format-specific).
+    # hold identically on every ELF ISA; gdb-session, whose stop/frame/value facts are
+    # verified by hand to read identically at both opt levels and, were a second ELF
+    # leg ever added to its case.conf, would hold there too) and per-build-target for
+    # structural producers (their fact is format-specific).
     case "$case_run" in
-        exec|relro-fault|panic-exit|debuginfo|varloc-fbreg) golden="$dir/expect.txt" ;;
-        *)                                                 golden="$dir/expect.$build_target.txt" ;;
+        exec|relro-fault|panic-exit|debuginfo|varloc-fbreg|gdb-session) golden="$dir/expect.txt" ;;
+        *)                                                             golden="$dir/expect.$build_target.txt" ;;
     esac
 
     # once per case, not per profile: `dep pull` honors the lock left by the first
@@ -512,7 +514,7 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
             # compiler / target / profile / flags, plus `-g`) and hand its path to the
             # producer as an extra argument. every other producer inspects only `$bin`.
             gbin=
-            if [ "$case_run" = debuginfo ] || [ "$case_run" = varloc-fbreg ]; then
+            if [ "$case_run" = debuginfo ] || [ "$case_run" = varloc-fbreg ] || [ "$case_run" = gdb-session ]; then
                 gbin="$dir/out/int/prog-g$exe"
                 if ! (cd "$dir" && $buildcc build . --target "$build_target" --profile "$profile" $case_build_flags -g -o "out/int/prog-g$exe") >"$tmp/build-g.log" 2>&1; then
                     echo "FAIL $flabel (build -g)"

--- a/int/surface/debugger-gdb/case.conf
+++ b/int/surface/debugger-gdb/case.conf
@@ -1,0 +1,35 @@
+# behavioural case (#2756): drives a real gdb batch session over the `-g` artifact
+# and asserts on where it stops, which frame it reports, and what a local reads
+# back as - not on the encoding, which int/surface/debuginfo already checks
+# structurally. every fact below was read off this file's own program by hand
+# before it went into the golden (see src/main.mach's header for the values):
+#
+#   addone(41)     -> a breakpoint on `val r = v + 1` stops inside `addone`
+#                      (a real call in debug, an inlined body in release - #[inline]
+#                      forces it at release only, since the debug pipeline runs no
+#                      inlining pass) with `v` reading 41, and the caller frame is
+#                      `main` at the call's own source line.
+#   accumulate(10) -> five iterations into the loop, `total` (0+1+2+3+4) is 10 and
+#                      `i` is 4, both register-resident the whole time in both
+#                      profiles (no spill), so a live register value is what gets
+#                      read back, not a stack slot.
+#   deadlocal(4)   -> `unused` is written and never read, so its DIE carries no
+#                      DW_AT_location in either profile - "optimized out" is the
+#                      correct answer, not a gap to fill in.
+#   single-step    -> `step` off the loop body's assignment line lands on the
+#                      condition check, then back into the body - source-level
+#                      stepping, not a raw instruction count.
+#
+# scoped to `linux` only, deliberately: gdb is what this environment has (no lldb),
+# and a native x86_64 runner is the one leg this repo can drive it on and read the
+# result by hand. linux-arm64 runs gdb NATIVELY in CI (ubuntu-24.04-arm, real
+# hardware) and could plausibly carry this same case, but a foreign-arch gdb
+# session was never exercised or hand-verified here and this repo's own convention
+# (int/run.sh's header) is not to claim a leg on the strength of a leg that passed
+# for an unrelated reason - so linux-arm64, linux-riscv64 (qemu-user has no ptrace
+# story a host gdb can attach through), windows, and both darwin legs remain
+# UNVERIFIED by a real debugger. a missing gdb on the linux leg itself is a hard
+# error here, the same contract int/surface/debuginfo already uses for its own
+# validators, because every runner this case targets is expected to carry one.
+run: gdb-session
+targets: linux

--- a/int/surface/debugger-gdb/expect.txt
+++ b/int/surface/debugger-gdb/expect.txt
@@ -1,0 +1,17 @@
+program_stdout=a=42,b=45,c=5
+exit=normal
+addone_stop_func=addone
+addone_stop_line=11
+addone_v=41
+addone_caller_func=main
+addone_caller_line=33
+accum_total=10
+accum_i=4
+step1_line=18
+step2_line=19
+dead_stop_func=deadlocal
+dead_stop_line=27
+dead_v=4
+dead_unused=<optimized out>
+dead_caller_func=main
+dead_caller_line=35

--- a/int/surface/debugger-gdb/mach.toml
+++ b/int/surface/debugger-gdb/mach.toml
@@ -1,0 +1,32 @@
+[project]
+id = "dbggdbcase"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.dbggdbcase]
+kind = "bin"
+entry = "main.mach"
+out = "bin/dbggdbcase"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/debugger-gdb/src/main.mach
+++ b/int/surface/debugger-gdb/src/main.mach
@@ -1,0 +1,40 @@
+# debugger-behaviour fixture (#2756). rationale and hand-computed values live in
+# this case's case.conf. LINE NUMBERS ARE LOAD-BEARING: int/lib/produce.sh's
+# produce_gdb_session sets `break main.mach:<N>` by exact source line, so inserting
+# or removing a line above `fun addone` requires updating those breakpoints too.
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+#[inline]
+fun addone(v: i64) i64 {
+    val r: i64 = v + 1;
+    ret r;
+}
+
+fun accumulate(n: i64) i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    for (i < n) {
+        total = total + i;
+        i = i + 1;
+    }
+    ret total;
+}
+
+fun deadlocal(v: i64) i64 {
+    val unused: i64 = v * 3;
+    ret v + 1;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    val base: i64 = 40 + argc:~i64;
+    val a: i64 = addone(base);
+    val b: i64 = accumulate(10 + argc:~i64 - 1);
+    val c: i64 = deadlocal(3 + argc:~i64);
+    p.printlnf("a={}", a);
+    p.printlnf("b={}", b);
+    p.printlnf("c={}", c);
+    ret 0;
+}


### PR DESCRIPTION
## Summary
- structural validation (`int/surface/debuginfo`) proves the `-g` image is well-formed; it cannot prove the DWARF describes the right thing, since a location list can be valid and still name a register the value already left
- `int/surface/debugger-gdb` drives a real `gdb --batch` session per `opt` level and asserts on where it stops, which frame it reports, and what a local reads back as: an inlined-only-at-release breakpoint, a register-live loop local read against a hand-computed sum, and a local that is genuinely optimized out
- scoped to the `linux` leg only, the one this was hand-verified on by driving gdb interactively against the fixture; `linux-arm64`, `linux-riscv64`, `windows`, and both `darwin` legs are named as unverified in the case's own `case.conf`, not silently assumed to work
- building this caught two real DWARF defects at the debug profile (opt=0), invisible to `--verify`/`addr2line` because both artifacts are well-formed and simply wrong: filed as #2779, linked to this issue as context, not a blocker

## Test plan
- [x] `mach test .` — 1296 passed, 0 failed
- [x] `int/lib/check-target-matrix.sh` — 454 case×leg pairs OK
- [x] `int/lib/check-deps.sh` — 100 git dep declarations OK
- [x] `int/run.sh --target linux ./m` — full suite green, including the new case at both profiles
- [x] `int/run.sh --target linux-arm64 --runmode qemu ./m` — full suite green except two pre-existing, unrelated failures (`c-variadic`, `narrow-stack-args`) reproduced identically on a clean `origin/dev` worktree, confirming they predate this branch
- [x] teeth proven two ways: (1) perturbing `expect.txt`'s `accum_total` value causes a diff FAIL on both profiles; (2) removing `#[inline]` from the fixture (a real behavior change) causes both profiles to FAIL with a materially different transcript
- [x] every golden value hand-computed and cross-checked against an interactive `gdb` session before being blessed (see case.conf's comment block for the arithmetic)

Closes #2756
