### PR TITLE
fix(abi): place a riscv64 variadic float in the integer bank

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-user
 
+      # linux-riscv64 is the only leg whose runner is not its own ISA, so it is the
+      # only one that reaches int/lib/cc.sh's CROSS path in CI - and a cross build
+      # needs the target's libc headers as soon as a case's C probe includes one.
+      # c-variadic's does (#2771), and without these clang resolved the runner's own
+      # x86-64 /usr/include instead. keyed on the target rather than the runmode:
+      # this package is riscv64's, and a future qemu leg of another ISA needs its
+      # own, not this one. cc.sh names the same path in its --sysroot.
+      - name: install riscv64 cross libc headers
+        if: matrix.target == 'linux-riscv64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libc6-dev-riscv64-cross
+
       # the host-side validators the structural cases inspect artifacts with, all
       # reading the target artifact regardless of the runner's own ISA. debuginfo
       # (int/surface/debuginfo) verifies the emitted DWARF with llvm-dwarfdump and

--- a/int/lib/cc.sh
+++ b/int/lib/cc.sh
@@ -19,7 +19,9 @@
 # (native build, including every CI runner), and fall back to a cross-capable
 # `clang -target <triple>` only when it does not (a local cross-build). Either
 # path only ever needs to emit an object (`-c`) - mach does the link itself -
-# so `clang -target` needs no sysroot or cross-linker to be sufficient.
+# so the cross path needs no cross LINKER. It does need the target's libc
+# HEADERS the moment a probe includes one, which is what the riscv64 branch's
+# `--sysroot` supplies; see the triple table below.
 #
 # usage: cc.sh <compiler args...>  (same argv a bare `cc` would take)
 #
@@ -56,15 +58,27 @@ if [ "$(host_isa)" = "$MACH_TARGET_ISA" ] && [ "$(host_os)" = "$MACH_TARGET_OS" 
 fi
 
 # cross build: the host cannot produce this leg's ISA/OS natively, so route
-# through clang with an explicit target triple. compile-only (-c) needs no
-# sysroot or cross-linker for any of these, verified against every
-# targets.conf leg (mach#2741) - only a case that asked cc.sh to LINK a full
-# binary would need one, and none does today.
+# through clang with an explicit target triple.
+#
+# COMPILE-ONLY NEEDS NO CROSS LINKER. It DOES need the target's libc headers as
+# soon as a probe includes one, and this file used to claim otherwise - "needs no
+# sysroot or cross-linker for any of these, verified against every targets.conf
+# leg (mach#2741)". That claim was verified against a set that could not disprove
+# it: `c-variadic` was exempt on linux-riscv64, so no probe that cross-built here
+# had ever included a libc header. Un-exempting it (mach#2771) reached the case
+# that falsifies it, and clang resolved the HOST's /usr/include/stdint.h while
+# targeting riscv64 - failing inside it on a file no case mentions
+# ("bits/libc-header-start.h file not found", a multiarch host's glibc looking for
+# its own arch subdirectory). Silently succeeding would have been worse: an object
+# compiled against the wrong architecture's libc headers, which is the same class
+# of quiet divergence mach#2741 named. So the riscv64 branch names a sysroot, and
+# no branch pretends the headers are free.
 #
 # extend this table exactly when targets.conf gains a leg (same axis
 # check-target-matrix.sh already enforces one block per [target.*] on).
 triple=
 extra=
+sysroot_arg=
 case "$MACH_TARGET_OS-$MACH_TARGET_ISA" in
     linux-x86_64)    triple=x86_64-linux-gnu ;;
     linux-aarch64)   triple=aarch64-linux-gnu ;;
@@ -105,9 +119,27 @@ case "$MACH_TARGET_OS-$MACH_TARGET_ISA" in
     #                                  hits the exact same ADD32/SUB32 pairing.
     # suppressing emission at the compiler is the fix, not teaching mach's reader
     # relocation arithmetic it will never otherwise need (mach#2741).
+    #
+    # ...and a SYSROOT, because this is the one leg CI cross-builds: linux-riscv64
+    # is the only targets.conf row whose runner is not its own ISA, so it is the
+    # only leg whose probes need target libc headers in CI. `--sysroot` alone is
+    # sufficient and is what makes the resolution honest - clang finds
+    # <sysroot>/include and stops searching the host's /usr/include, so a probe
+    # either compiles against riscv64's own headers or fails naming the one it
+    # wanted. The path is where Ubuntu's `libc6-dev-riscv64-cross` installs, which
+    # ci.yml installs on this leg; MACH_RISCV64_SYSROOT overrides it for a host
+    # that keeps its cross headers elsewhere. Absent, the build stops here naming
+    # the package rather than falling back to the host's headers, which is exactly
+    # the silent wrong-headers outcome this exists to prevent.
     linux-riscv64)
         triple=riscv64-linux-gnu
+        sysroot=${MACH_RISCV64_SYSROOT:-/usr/riscv64-linux-gnu}
+        if [ ! -d "$sysroot/include" ]; then
+            echo "cc.sh: cross-building linux-riscv64 needs riscv64 libc headers, and none are at '$sysroot/include' - install Ubuntu's libc6-dev-riscv64-cross (or your distro's riscv64-linux-gnu glibc headers) and point MACH_RISCV64_SYSROOT at it if it lands elsewhere. compiling against the host's headers instead would emit an object built to the wrong architecture's libc (mach#2741, mach#2771)" >&2
+            exit 1
+        fi
         extra="-march=rv64gc -mabi=lp64d -mno-relax -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-jump-tables"
+        sysroot_arg=$sysroot
         ;;
     windows-x86_64)  triple=x86_64-pc-windows-msvc ;;
     darwin-x86_64)   triple=x86_64-apple-darwin ;;
@@ -125,8 +157,10 @@ fi
 
 # $extra is deliberately unquoted: it is always either empty or a fixed set of
 # single-word flags built above, never user input, so word-splitting it here is
-# the intended expansion, not a quoting bug.
-clang -target "$triple" $extra "$@" || exit $?
+# the intended expansion, not a quoting bug. the sysroot is the opposite - it can
+# come from MACH_RISCV64_SYSROOT - so it rides its own quoted expansion, present
+# only for a branch that set one.
+clang -target "$triple" ${sysroot_arg:+--sysroot="$sysroot_arg"} $extra "$@" || exit $?
 
 # the -mabi/-march pin above is a REQUEST, and a toolchain that does not honour it
 # fails silently in the direction that looks like a mach bug: a soft-float probe

--- a/int/surface/c-variadic/case.conf
+++ b/int/surface/c-variadic/case.conf
@@ -10,12 +10,11 @@
 # compile the probe object through int/lib/cc.sh when the runner's own `cc` can't
 # target the leg (mach#2741), and both match the golden.
 #
-# exempt linux-riscv64: builds and runs cleanly through the same cc.sh path, but
-# every variadic float/double argument comes back as 0 - a real mach bug in
-# riscv64's lp64 variadic-float lowering, exactly the class of divergence this
-# case exists to catch, newly reachable now that cc.sh can cross-build the probe
-# for this leg at all. Tracked as #2771; re-enable once that lands rather than
-# reporting a wrong value as a pass.
+# linux-riscv64 runs since #2771. the RISC-V psABI passes an UNNAMED float in an
+# integer register even under the hard-float members, so the riscv family declares
+# `variadic_float_bits = 0` and the tail classifier routes every variadic float to
+# the a bank the probe's `va_arg` actually reads. before that the caller placed
+# them in fa0-fa7 and every float came back as flat 0.
 #
 # exempt windows: `[step]` now runs there (#2578/#2587 fixed it), but this case has
 # not yet been verified against the windows-latest runner's own C toolchain (does it
@@ -24,4 +23,4 @@
 # tail float duplicated into its integer register) is otherwise exercised only by
 # the compiler's own unit tests.
 run: exec
-exempt: linux-riscv64 windows
+exempt: windows

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1006,8 +1006,28 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             soff = slot.offset;
         } or {
             val aal: u64  = type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
-            val afl: bool = context.value_is_float(ctx, av.ty);
+            var afl: bool = context.value_is_float(ctx, av.ty);
             val avec: bool = context.value_is_vector(ctx, av.ty);
+            # AN UNNAMED FLOAT RIDES THE FLOAT BANK ONLY AS WIDE AS THE CONVENTION'S
+            # VARIADIC RULE ALLOWS (#2771). The classifier answers for a named
+            # argument, and the two rules disagree: the RISC-V psABI passes a tail
+            # float in an INTEGER register under every member, including the
+            # hard-float ones whose named floats ride fa0-fa7, so a tail double
+            # classified as float lands in a register the callee's `va_arg` never
+            # reads and the callee sees a flat 0 rather than a crash. Ask the model,
+            # then hand the classifier the question it can answer: a float the bank
+            # will not carry is placed by the integer rule, which is a cross-bank
+            # move of its raw bits into the `a` register or its stack slot. 64 on
+            # every AMD64 / AAPCS64 convention, so this is identity there.
+            if (afl) {
+                var vafl: abi.VaModel;
+                val vfr: R.Result[bool, str] = abi_va_model(ctx.tgt, ?vafl);
+                if (R.is_err[bool, str](vfr)) {
+                    sig_layout_free(ctx, ?layout);
+                    ret vfr;
+                }
+                if (!abi.variadic_float_in_fp_bank(?vafl, asz)) { afl = false; }
+            }
             # a variadic tail aggregate is classified as integer eightbytes (mask 0),
             # never as an HFA (members 0), and with no flattened-aggregate descriptor
             # (agg_none): the va_arg read path walks the GP register-save / overflow
@@ -1017,14 +1037,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             # MS passes an __m128 vararg by reference too, so a tail vector at an ext
             # boundary marshals exactly like a fixed one (#2058).
             #
-            # THE SCALAR FLOAT FLAG `afl` IS PASSED THROUGH UNCHANGED, which is right
-            # for every convention that reaches here and wrong for one that does not.
-            # Under the RISC-V hard-float members an unnamed float is passed AS IF
-            # INTEGER, unlike a named one -- so a tail float classified here would take
-            # an fa register the callee never reads. That rule is not implemented, and
-            # the RISC-V family accordingly REFUSES a C-variadic call outright rather
-            # than placing one wrongly: `abi_va_model` errors on its nil `va_model`
-            # before this loop's result can be emitted (#2777).
+            # THE SCALAR FLOAT FLAG `afl` IS THE ONE INPUT THE VARIADIC RULE CHANGES,
+            # and it is answered just above from the convention's own model rather
+            # than assumed to match the named rule (#2771).
             slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, avec, is_ext, gp_used, fp_used, 0, 0, abi.agg_none());
             # a platform that passes the WHOLE variadic tail on the stack (Apple arm64,
             # and only there) overrides the convention's placement here: the classifier

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -312,8 +312,9 @@ pub def RetPassingFn: fun(u64, u64, bool, u8, bool, bool, u8, u8, AggLayout) Par
 pub def RegFileFn: fun(*isa.Register) i32;
 
 # return the convention's `VaModel`: the call-ABI facts the backend's call
-# lowering dispatches on (the conservative vector-count register and the win64
-# tail-float duplication). the erased `va_model` pointer is cast back to this
+# lowering dispatches on (the conservative vector-count register, the win64
+# tail-float duplication, and the unnamed-float bank width). the erased `va_model`
+# pointer is cast back to this
 # ---
 # ret: the convention's call-ABI variadic model
 pub def VaModelFn: fun() VaModel;
@@ -597,9 +598,10 @@ pub rec SigLayout {
 
 # variadic-ABI call-side model kinds. the C-style varargs callee surface was
 # removed in v2.0.0, so the model now carries only what the call path needs for
-# ABI-conformant calls: the conservative vector-count register and the win64
-# tail-float duplication. read from the ABI vtable's `va_model`; the backend never
-# branches on the convention id
+# ABI-conformant calls: the conservative vector-count register, the win64
+# tail-float duplication, and the width of an unnamed float the float bank carries.
+# read from the ABI vtable's `va_model`; the backend never branches on the
+# convention id
 pub val VA_MODEL_REG_SAVE: u8 = 0;  # SysV: vector-count register (AL), no float duplication
 pub val VA_MODEL_HOME:     u8 = 1;  # win64: tail float duplicated into its GP reg, no vector count
 
@@ -616,10 +618,86 @@ pub val VA_MODEL_HOME:     u8 = 1;  # win64: tail float duplicated into its GP r
 #                   a call uses (SysV's AL/RAX), or -1 when the convention encodes
 #                   no vector count (win64); the pre-call vector-count move is
 #                   emitted only when this is non-negative
+# variadic_float_bits: the widest SCALAR FLOAT, in bits, an UNNAMED (variadic-tail)
+#                   argument rides a FLOAT register in -- 0 when no unnamed float
+#                   ever does, whatever the convention does with a NAMED one.
+#
+#                   THE UNNAMED TWIN OF `AbiVTable.float_arg_bits`, AND A SEPARATE
+#                   FACT BECAUSE THE TWO DISAGREE (#2771). Under the RISC-V psABI's
+#                   hard-float members a named double rides fa0 while an unnamed
+#                   double of the same type rides a0, so one number cannot answer
+#                   both questions and a tail float classified by the named rule
+#                   lands in a register the callee's `va_arg` never reads -- which
+#                   the callee sees as a flat 0, not as a crash. 64 on the AMD64 and
+#                   AAPCS64 conventions, whose tail floats ride the vector bank
+#                   exactly like their named ones; 0 across the RISC-V family.
+#
+#                   A WIDTH RATHER THAN A BOOL for the same reason its named twin
+#                   is: the rule is `width * 8 <= variadic_float_bits`, so "no
+#                   unnamed float in the bank" is that rule at 0 rather than a
+#                   branch beside it, and a member that carried f32 but not f64
+#                   needs no new case.
 pub rec VaModel {
-    kind:             u8;
-    float_dup_gp:     bool;
-    vector_count_reg: i32;
+    kind:                u8;
+    float_dup_gp:        bool;
+    vector_count_reg:    i32;
+    variadic_float_bits: u32;
+}
+
+# build a convention's variadic model, every fact supplied
+#
+# Positional for the reason `abi_vtable` is: a convention that forgets a fact is an
+# arity error at build time rather than a zero, and a zero `variadic_float_bits`
+# reads as the written-down "no unnamed float rides the float bank" that only the
+# RISC-V family means.
+# ---
+# kind:                one of VA_MODEL_*
+# float_dup_gp:        true when a tail float is duplicated into its integer register
+# vector_count_reg:    the vector-count register, or -1
+# variadic_float_bits: the widest unnamed scalar float carried in the float bank
+# ret:                 the assembled model
+pub fun va_model_make(kind: u8, float_dup_gp: bool, vector_count_reg: i32,
+                      variadic_float_bits: u32) VaModel {
+    var m: VaModel;
+    m.kind                = kind;
+    m.float_dup_gp        = float_dup_gp;
+    m.vector_count_reg    = vector_count_reg;
+    m.variadic_float_bits = variadic_float_bits;
+    ret m;
+}
+
+# whether an unnamed float of `width` bytes rides the convention's float bank
+#
+# The one comparison the tail classifier asks, so no caller re-derives it and no
+# convention grows a second spelling of the same rule.
+# ---
+# m:     the convention's variadic model
+# width: the scalar float's width in bytes
+# ret:   true when it rides a float register
+pub fun variadic_float_in_fp_bank(m: *VaModel, width: u64) bool {
+    if (m.variadic_float_bits == 0) { ret false; }
+    ret (width * 8) <= m.variadic_float_bits::u64;
+}
+
+# the unnamed-float rule is a WIDTH, so "never" is that rule at 0
+#
+# The same shape as `AbiVTable.float_arg_bits` and for the same reason: a convention
+# that carried an unnamed f32 but not an unnamed f64 needs no case of its own, and
+# the RISC-V family's "never" is not a branch beside the comparison but the
+# comparison at zero.
+test "mach.lang.target.abi.variadic_float_in_fp_bank:is_the_declared_width" {
+    val never: VaModel = va_model_make(VA_MODEL_REG_SAVE, false, -1, 0);
+    if (variadic_float_in_fp_bank(?never, 4)) { ret 1; }
+    if (variadic_float_in_fp_bank(?never, 8)) { ret 1; }
+    val single: VaModel = va_model_make(VA_MODEL_REG_SAVE, false, -1, 32);
+    if (!variadic_float_in_fp_bank(?single, 4)) { ret 1; }
+    if (variadic_float_in_fp_bank(?single, 8))  { ret 1; }
+    val both: VaModel = va_model_make(VA_MODEL_HOME, true, 0, 64);
+    if (!variadic_float_in_fp_bank(?both, 4)) { ret 1; }
+    if (!variadic_float_in_fp_bank(?both, 8)) { ret 1; }
+    if (!both.float_dup_gp)                   { ret 1; }
+    if (both.kind != VA_MODEL_HOME)           { ret 1; }
+    ret 0;
 }
 
 # construct a fresh ABI registry with every slot empty

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -428,17 +428,16 @@ pub fun callee_saved(out: *isa.Register) i32 {
 # return the AAPCS64 call-side variadic-ABI model
 #
 # AArch64 encodes no caller vector-count register, so `vector_count_reg` is -1 (the
-# pre-call vector-count move is never emitted) and `float_dup_gp` is false. The
-# full AArch64 `va_list` callee surface is a separate, deferred concern; nothing
-# here carries it.
+# pre-call vector-count move is never emitted) and `float_dup_gp` is false. An
+# UNNAMED float rides the V bank exactly like a named one, so the unnamed width is
+# the named 64 -- Apple's "the whole tail goes on the stack" divergence is a
+# TARGET fact (`Target.variadic_args_on_stack`), applied after this placement, and
+# is not this convention's rule. The full AArch64 `va_list` callee surface is a
+# separate, deferred concern; nothing here carries it.
 # ---
 # ret: the AAPCS64 call-side variadic model
 pub fun va_model() abi.VaModel {
-    var m: abi.VaModel;
-    m.kind             = abi.VA_MODEL_REG_SAVE;
-    m.float_dup_gp     = false;
-    m.vector_count_reg = -1;
-    ret m;
+    ret abi.va_model_make(abi.VA_MODEL_REG_SAVE, false, -1, 64);
 }
 
 # build the AAPCS64 AbiVTable and install it into `reg`

--- a/src/lang/target/abi/mos6502.mach
+++ b/src/lang/target/abi/mos6502.mach
@@ -102,14 +102,10 @@ fun gp_arg_regs(out: *isa.Register) i32 {
 # the 6502 convention is caller-saved throughout: no callee-saved registers
 fun callee_saved(out: *isa.Register) i32 { ret 0; }
 
-# the call-side variadic model: the 6502 encodes no vector count and duplicates no
-# tail float
+# the call-side variadic model: the 6502 encodes no vector count, duplicates no
+# tail float, and has no float register bank at all, so no unnamed float rides one
 fun va_model() abi.VaModel {
-    var m: abi.VaModel;
-    m.kind             = abi.VA_MODEL_REG_SAVE;
-    m.float_dup_gp     = false;
-    m.vector_count_reg = -1;
-    ret m;
+    ret abi.va_model_make(abi.VA_MODEL_REG_SAVE, false, -1, 0);
 }
 
 # build and install the 6502 ABI vtable

--- a/src/lang/target/abi/riscv.mach
+++ b/src/lang/target/abi/riscv.mach
@@ -15,7 +15,7 @@
 # hard-float code. Nothing read the difference because the riscv64 leg runs under
 # qemu against mach's own code and links nothing foreign.
 #
-# THE FOUR FACTS, and why each is DECLARED rather than assumed. A classifier shaped
+# THE FIVE FACTS, and why each is DECLARED rather than assumed. A classifier shaped
 # around lp64 and lp64d alone silently inherits everything those two agree on, and
 # every one of those agreements is false for some other member:
 #
@@ -48,6 +48,13 @@
 #                 the `e` members are the reason the count is not a constant, and
 #                 because the ISA and the ABI must agree about it before either is
 #                 usable.
+#
+#   variadic_float_bits -- the same width for an UNNAMED (variadic-tail) argument.
+#                 0 across every member the psABI describes, where `flen_bits` gives
+#                 three different answers, which is the whole reason it is its own
+#                 fact: reusing `flen_bits` would put a tail double in fa0 under
+#                 lp64d and the callee's `va_arg` would read an untouched a register
+#                 (#2771).
 #
 # WHAT IS SHIPPED AND WHAT IS NOT. lp64, lp64f and lp64d are registered and
 # complete. `lp64e` and the whole ilp32 family are DESCRIBED by this contract but
@@ -92,7 +99,7 @@ var lp64d_vtable: abi.AbiVTable;
 # fp_arg_count:          float argument registers (8, and unreachable at flen_bits 0)
 # gp_callee_saved_count: callee-saved integer registers
 # fp_callee_saved_count: callee-saved float registers (full even under soft float)
-# variadic_float_bits:   the UNPOPULATED variadic rule; see VARIADIC_RULE_UNDECLARED
+# variadic_float_bits:   widest scalar float an UNNAMED argument rides in the fa bank
 pub rec RiscvAbi {
     id:                    u32;
     name:                  str;
@@ -105,35 +112,39 @@ pub rec RiscvAbi {
     gp_callee_saved_count: i32;
     fp_callee_saved_count: i32;
 
-    # THE VARIADIC RULE, DECLARED AND DELIBERATELY NOT POPULATED.
+    # THE VARIADIC RULE (#2771).
     #
-    # The widest scalar float an UNNAMED (variadic-tail) argument would ride in the
-    # fa bank. It is a fact OF A MEMBER exactly like `flen_bits` beside it, and it is
-    # a separate fact rather than a reuse of that one because the two genuinely
+    # The widest scalar float an UNNAMED (variadic-tail) argument rides in the fa
+    # bank. It is a fact OF A MEMBER exactly like `flen_bits` beside it, and it is a
+    # separate fact rather than a reuse of that one because the two genuinely
     # disagree: under lp64d a named double takes fa0 while an unnamed double of the
-    # same type takes a0, so one number cannot answer both questions. The soft-float
-    # members differ again, which is the multiplication this field exists to make
-    # visible rather than to hide.
+    # same type takes a0, so one number cannot answer both questions.
     #
-    # Every shipped member sets this to VARIADIC_RULE_UNDECLARED, and the family
-    # REFUSES a C-variadic call (its `va_model` is nil) rather than guessing. mach has
-    # no variadics of its own; the C-variadic `ext fun` CALL form has no user in mach
-    # or mach-std, and whether it survives at all is not settled. Populating a
-    # placement rule for a caller that may not exist would take the family from three
-    # descriptions to eleven, and a wrong rule is far more expensive to find than a
-    # refusal is to replace.
+    # THE PSABI ANSWERS 0 FOR EVERY MEMBER. The hardware floating-point calling
+    # convention disclaims variadics in two sentences -- "The remainder of this
+    # section applies only to named arguments. Variadic arguments are passed
+    # according to the integer calling convention." -- and it is stated in the
+    # HARD-FLOAT section precisely because the soft-float members had nothing to say:
+    # under lp64 every float already rides the integer bank. So the three shipped
+    # members agree at 0 while `flen_bits` gives three different answers, which is
+    # exactly why the two are separate fields.
     #
-    # To fill this in: give it a real width per member, add the reader that consults
-    # it, and give the family a non-nil `va_model` in the same change.
+    # A member reaching this file with a rule nobody has decided carries
+    # VARIADIC_RULE_UNDECLARED and is REFUSED REGISTRATION by `register` below,
+    # rather than defaulting into the 0 that the shipped members happen to want.
     variadic_float_bits:   u32;
 }
 
-# the value `variadic_float_bits` carries while the variadic rule is unbuilt
+# the value `variadic_float_bits` carries when a member's variadic rule is undecided
 #
 # Distinct from 0, which is a REAL answer meaning "no unnamed float ever rides the fa
-# bank" and happens to be the correct rule for the hard-float members. A sentinel
-# instead, so that a member left unpopulated cannot be mistaken for a member whose
-# rule was decided and written down.
+# bank" and is the written-down rule of all three shipped members. A sentinel
+# instead, so that a member nobody has decided cannot be mistaken for one whose rule
+# is 0, and so that the two are told apart by `register`, which refuses to install a
+# member still carrying it. Every member that exists today answers, and the sentinel
+# survives for the ones that do not: `lp64e` and the ilp32 family are described by
+# this contract and not registered, and a future member reaching a psABI corner
+# nobody has read is better refused at startup than placed by a neighbour's rule.
 pub val VARIADIC_RULE_UNDECLARED: u32 = 0xFFFFFFFF;
 
 # build a family-member descriptor, every fact supplied
@@ -146,7 +157,8 @@ pub val VARIADIC_RULE_UNDECLARED: u32 = 0xFFFFFFFF;
 # ret: the assembled descriptor
 pub fun rv_abi(id: u32, name: str, arch_id: u32, xlen_bits: u32, flen_bits: u32,
                int_reg_count: u32, gp_arg_count: i32, fp_arg_count: i32,
-               gp_callee_saved_count: i32, fp_callee_saved_count: i32) RiscvAbi {
+               gp_callee_saved_count: i32, fp_callee_saved_count: i32,
+               variadic_float_bits: u32) RiscvAbi {
     var v: RiscvAbi;
     v.id                    = id;
     v.name                  = name;
@@ -158,10 +170,7 @@ pub fun rv_abi(id: u32, name: str, arch_id: u32, xlen_bits: u32, flen_bits: u32,
     v.fp_arg_count          = fp_arg_count;
     v.gp_callee_saved_count = gp_callee_saved_count;
     v.fp_callee_saved_count = fp_callee_saved_count;
-    # not a constructor parameter: no member has a variadic rule, so there is nothing
-    # for a caller to supply. it becomes a parameter in the change that populates it,
-    # and every member is then forced to answer by the same arity rule as the rest.
-    v.variadic_float_bits   = VARIADIC_RULE_UNDECLARED;
+    v.variadic_float_bits   = variadic_float_bits;
     ret v;
 }
 
@@ -185,14 +194,14 @@ pub val RED_ZONE:    u32 = 0;
 # lp64: RV64 SOFT FLOAT. every floating-point argument and return rides an INTEGER
 # register. runs on any rv64, including one with no F or D extension at all
 pub fun v_lp64() RiscvAbi {
-    ret rv_abi(abi.ABI_LP64, "lp64", isa.ARCH_RISCV64, 64, 0, 32, 8, 8, 11, 12);
+    ret rv_abi(abi.ABI_LP64, "lp64", isa.ARCH_RISCV64, 64, 0, 32, 8, 8, 11, 12, 0);
 }
 
 # lp64f: RV64 with SINGLE-precision arguments in fa0-fa7. an f64 still rides the
 # integer bank, which is the case a hard-float / soft-float boolean cannot express.
 # requires the F extension
 pub fun v_lp64f() RiscvAbi {
-    ret rv_abi(abi.ABI_LP64F, "lp64f", isa.ARCH_RISCV64, 64, 32, 32, 8, 8, 11, 12);
+    ret rv_abi(abi.ABI_LP64F, "lp64f", isa.ARCH_RISCV64, 64, 32, 32, 8, 8, 11, 12, 0);
 }
 
 # lp64d: RV64 with SINGLE AND DOUBLE precision arguments in fa0-fa7. requires the D
@@ -200,7 +209,7 @@ pub fun v_lp64f() RiscvAbi {
 # linux default (`os.linux.linux_native_abi`) and the one a mach object must use to
 # link against any system library
 pub fun v_lp64d() RiscvAbi {
-    ret rv_abi(abi.ABI_LP64D, "lp64d", isa.ARCH_RISCV64, 64, 64, 32, 8, 8, 11, 12);
+    ret rv_abi(abi.ABI_LP64D, "lp64d", isa.ARCH_RISCV64, 64, 64, 32, 8, 8, 11, 12, 0);
 }
 
 # ------------------------------------------------------------------ derived facts
@@ -337,12 +346,15 @@ fun make_two_leaf_slot(agg: abi.AggLayout, nf: u32, fp0: i32, fp1: i32, gp0: i32
 # pair (splitting across the last register and the stack at the boundary), and a
 # scalar takes its bank then the stack.
 #
-# THIS CLASSIFIER ANSWERS FOR A NAMED ARGUMENT ONLY. The psABI's rule for an
-# UNNAMED (variadic-tail) argument differs -- under the hard-float members a tail
-# double rides a0-a7 rather than fa0-fa7 -- and that rule is deliberately not
-# implemented here. The family refuses a C-variadic call instead (a nil `va_model`),
-# so no caller can reach this function with a tail argument and receive a named
-# argument's answer. See `RiscvAbi.variadic_float_bits`.
+# THIS CLASSIFIER ANSWERS FOR A NAMED ARGUMENT, and an unnamed one reaches it
+# already reduced to the same question. The psABI's rule for an UNNAMED
+# (variadic-tail) argument differs -- under the hard-float members a tail double
+# rides a0-a7 rather than fa0-fa7 -- and that difference is carried by the member's
+# `variadic_float_bits` through its `va_model`: the call lowering asks the model
+# first and hands a tail float here with `is_float` already false, so the integer
+# arm below places it. `is_float` therefore means "this value rides the fa bank if
+# the member's width admits it", which is true of a named float and, across this
+# family, never true of an unnamed one.
 # ---
 # v:             the family member's declared facts
 # index:         zero-based logical argument position
@@ -561,25 +573,48 @@ pub fun callee_saved_v(v: RiscvAbi, out: *isa.Register) i32 {
     ret v.gp_callee_saved_count + v.fp_callee_saved_count;
 }
 
-# THE FAMILY DECLARES NO VARIADIC MODEL, SO A C-VARIADIC CALL IS REFUSED.
+# THE FAMILY'S VARIADIC MODEL, FOR ANY MEMBER (#2771)
 #
-# Every member registers a NIL `va_model`, which `mir.abi.abi_va_model` already
-# treats as "this convention cannot make a variadic call" and reports as a
-# diagnostic at the call rather than as a silently misplaced argument. That is the
-# whole of the family's variadic support, on purpose.
+# The member's own `variadic_float_bits`, handed to the call lowering, which asks it
+# one question per unnamed argument: does a float this wide ride the fa bank? At 0
+# the answer is always no, so a tail f32 or f64 is placed by the INTEGER rule -- an
+# `a` register, then the stack -- which is where the callee's `va_arg` reads it.
 #
-# WHY A REFUSAL RATHER THAN A RULE. The psABI's unnamed-argument placement differs
-# per member -- a tail double takes a0 under lp64d where a named one takes fa0, and
-# the soft-float members differ again -- so implementing it multiplies the family's
-# descriptions rather than adding to them. mach has no variadics of its own, and the
-# C-variadic `ext fun` call form it would serve has no user in mach or mach-std. A
-# refusal is exact, cannot be wrong at runtime, and is replaced by populating
-# `RiscvAbi.variadic_float_bits` and returning a real model from here.
+# The other two facts are the family's, not a member's. RISC-V encodes no caller
+# vector count (`vector_count_reg` -1, no pre-call move), and it duplicates nothing
+# into a second register: the tail float rides the integer bank INSTEAD of the fa
+# bank, not in addition to it, which is what makes win64's `float_dup_gp` false here
+# and the two rules different rather than variants of one.
+#
+# UNNAMED AGGREGATES need no fact of their own. The psABI passes a variadic
+# aggregate by the integer convention, and the call lowering already classifies a
+# tail aggregate with no HFA count and no flattened-leaf descriptor -- so the fa
+# flatten rules above are unreachable for one, and a `{f64}` that would ride fa0 as
+# a NAMED argument takes a0 as an unnamed one.
+#
+# THE PSABI'S OTHER VARIADIC CLAUSE IS NOT IMPLEMENTED, and it is a separate axis
+# from this one. The integer calling convention's single exception for variadics --
+# "Variadic arguments with 2xXLEN-bit alignment and size at most 2xXLEN bits are
+# passed in an aligned register pair (i.e., the first register in the pair is
+# even-numbered)" -- is a rule about the CURSOR, not about a value's class, so it
+# belongs where the tail cursor lives rather than here. It is reachable but has no
+# user: a 16-byte-aligned mach value on riscv64 is a 128-bit vector, which this
+# classifier passes by hidden reference, or an aggregate WRAPPING one, which is the
+# only shape that would land on the pair rule. The clause's other half -- once a
+# variadic argument goes on the stack every later one does too -- already holds
+# here, because a tail argument reaches the stack only with the integer bank spent
+# and the cursor never falls back.
 #
 # WHAT THIS DOES NOT AFFECT: mach's own `va: ...` parameter pack. That is expanded
 # at compile time into a fixed-arity call and never reaches the variadic call path,
 # which is why `printlnf` and the rest of the standard library's formatting keep
 # working on every RISC-V target.
+# ---
+# v:   the family member
+# ret: the member's call-side variadic model
+pub fun va_model_v(v: RiscvAbi) abi.VaModel {
+    ret abi.va_model_make(abi.VA_MODEL_REG_SAVE, false, -1, v.variadic_float_bits);
+}
 
 # ------------------------------------------------ per-member vtable installation
 
@@ -588,8 +623,8 @@ pub fun callee_saved_v(v: RiscvAbi, out: *isa.Register) i32 {
 # `AbiVTable`'s operation pointers are plain function pointers with a fixed,
 # architecture-neutral signature and no self parameter, so a shared implementation
 # cannot recover WHICH member it is serving from its arguments. Each member
-# therefore supplies three one-line thunks that name its own descriptor and forward
-# to the shared bodies above. That is the entire per-member cost: the classifier,
+# therefore supplies a handful of one-line thunks that name its own descriptor and
+# forward to the shared bodies above. That is the entire per-member cost: the classifier,
 # the flatten rules, the banks and the variadic rule are written once.
 #
 # The alternative -- widening every convention's classifier signature to carry a
@@ -611,6 +646,7 @@ fun lp64_ret(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool, is_ve
     ret classify_return_v(v_lp64(), size, align, is_float, fpe, is_agg, is_vec, hm, he, agg);
 }
 fun lp64_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_lp64(), out); }
+fun lp64_va() abi.VaModel  { ret va_model_v(v_lp64()); }
 fun lp64_cs(out: *isa.Register) i32      { ret callee_saved_v(v_lp64(), out); }
 
 fun lp64f_classify(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
@@ -627,6 +663,7 @@ fun lp64f_ret(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool, is_v
     ret classify_return_v(v_lp64f(), size, align, is_float, fpe, is_agg, is_vec, hm, he, agg);
 }
 fun lp64f_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_lp64f(), out); }
+fun lp64f_va() abi.VaModel { ret va_model_v(v_lp64f()); }
 fun lp64f_cs(out: *isa.Register) i32      { ret callee_saved_v(v_lp64f(), out); }
 
 fun lp64d_classify(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
@@ -643,7 +680,28 @@ fun lp64d_ret(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool, is_v
     ret classify_return_v(v_lp64d(), size, align, is_float, fpe, is_agg, is_vec, hm, he, agg);
 }
 fun lp64d_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_lp64d(), out); }
+fun lp64d_va() abi.VaModel { ret va_model_v(v_lp64d()); }
 fun lp64d_cs(out: *isa.Register) i32      { ret callee_saved_v(v_lp64d(), out); }
+
+# install one member's vtable, refusing a member whose variadic rule is undeclared
+#
+# The sentinel's reader. A descriptor still carrying VARIADIC_RULE_UNDECLARED has
+# not been read against the psABI, and installing it would hand the call lowering a
+# width of 0xFFFFFFFF -- "every unnamed float rides the fa bank" -- which is the one
+# answer no member gives. Refused by name instead, at startup, where it is a
+# programming error rather than a wrong argument at a call site.
+# ---
+# reg: the ABI registry to install into
+# v:   the member's declared facts
+# vt:  the member's assembled vtable
+# ret: ok(true) on success
+fun install(reg: *abi.AbiRegistry, v: RiscvAbi, vt: *abi.AbiVTable) R.Result[bool, str] {
+    if (v.variadic_float_bits == VARIADIC_RULE_UNDECLARED) {
+        ret R.err[bool, str]("mach.lang.target.abi.riscv: a family member declares no variadic float rule; read the psABI for it and give `variadic_float_bits` a width rather than registering it undecided");
+    }
+    abi.register(reg, vt);
+    ret R.ok[bool, str](true);
+}
 
 # install every registered member of the family into `reg`
 #
@@ -657,10 +715,17 @@ fun lp64d_cs(out: *isa.Register) i32      { ret callee_saved_v(v_lp64d(), out); 
 #
 # `float_arg_bits` is the member's own `flen_bits`, which is what makes the
 # extension check in `target.select_of` a comparison against the ISA's declared
-# FLEN rather than a table of convention names.
+# FLEN rather than a table of convention names. `va_model` is the member's own
+# variadic rule, through its own thunk, so a member whose unnamed-float width
+# differs from its neighbours' costs a descriptor number and nothing else.
+#
+# A member whose variadic rule is still VARIADIC_RULE_UNDECLARED is REFUSED here
+# rather than installed: the sentinel means nobody has read the psABI for it, and a
+# convention that cannot answer for an unnamed argument must not be reachable by a
+# manifest that names it. That refusal is the sentinel's one reader.
 # ---
 # reg: the ABI registry to install into
-# ret: ok(true) on success
+# ret: ok(true) on success, or an error naming a member with an undeclared rule
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     val vl:  RiscvAbi = v_lp64();
     lp64_vtable = abi.abi_vtable(
@@ -671,9 +736,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         gp_param_reg(vl, 0), true,
         true, true,
         vl.flen_bits,
-        nil
+        lp64_va::*u8
     );
-    abi.register(reg, ?lp64_vtable);
+    val rlp64: R.Result[bool, str] = install(reg, vl, ?lp64_vtable);
+    if (R.is_err[bool, str](rlp64)) { ret rlp64; }
 
     val vf: RiscvAbi = v_lp64f();
     lp64f_vtable = abi.abi_vtable(
@@ -684,9 +750,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         gp_param_reg(vf, 0), true,
         true, true,
         vf.flen_bits,
-        nil
+        lp64f_va::*u8
     );
-    abi.register(reg, ?lp64f_vtable);
+    val rlp64f: R.Result[bool, str] = install(reg, vf, ?lp64f_vtable);
+    if (R.is_err[bool, str](rlp64f)) { ret rlp64f; }
 
     val vd: RiscvAbi = v_lp64d();
     lp64d_vtable = abi.abi_vtable(
@@ -697,9 +764,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         gp_param_reg(vd, 0), true,
         true, true,
         vd.flen_bits,
-        nil
+        lp64d_va::*u8
     );
-    abi.register(reg, ?lp64d_vtable);
+    val rlp64d: R.Result[bool, str] = install(reg, vd, ?lp64d_vtable);
+    if (R.is_err[bool, str](rlp64d)) { ret rlp64d; }
 
     ret R.ok[bool, str](true);
 }
@@ -750,28 +818,93 @@ test "mach.lang.target.abi.riscv.classify_arg_v:same_double_three_banks" {
     ret 0;
 }
 
-# the family REFUSES a C-variadic call rather than placing one by the named rule
+# EVERY MEMBER PLACES AN UNNAMED FLOAT IN THE INTEGER BANK, AND SAYS SO (#2771)
 #
-# The refusal is the shipped behaviour, so it is asserted rather than left to be
-# discovered. Under the hard-float members an unnamed float would take an integer
-# register where a named one takes fa, so classifying a tail argument through
-# `classify_arg_v` would place it wrongly -- and a nil `va_model` is what stops that
-# call from being emitted at all.
-test "mach.lang.target.abi.riscv.register:refuses_c_variadic_rather_than_guessing" {
+# The one fact the psABI states for variadics, asserted at the width it is declared
+# at rather than at the placement it produces: 0 for all three, where `flen_bits`
+# gives 0 / 32 / 64. A member that copied `flen_bits` into this field -- the obvious
+# wrong fix -- fails here, and it fails on lp64d, the member the linux default
+# resolves to.
+test "mach.lang.target.abi.riscv.va_model_v:no_unnamed_float_rides_the_fa_bank" {
     var reg: abi.AbiRegistry = abi.registry_init();
     val r: R.Result[bool, str] = register(?reg);
     if (R.is_err[bool, str](r)) { ret 1; }
-    # a NIL va_model is the refusal: `mir.abi.abi_va_model` reports a diagnostic at a
-    # C-variadic call instead of letting one be emitted with named-argument placement.
-    # if a variadic rule is ever populated, this assertion is the thing that fails and
-    # points at the descriptor field that has to be filled in with it.
-    if (lp64_vtable.va_model  != nil) { ret 1; }
-    if (lp64f_vtable.va_model != nil) { ret 1; }
-    if (lp64d_vtable.va_model != nil) { ret 1; }
-    # and the rule really is unpopulated rather than accidentally decided as 0, which
-    # would read as a written-down "no unnamed float rides the fa bank".
-    if (v_lp64d().variadic_float_bits != VARIADIC_RULE_UNDECLARED) { ret 1; }
-    if (v_lp64().variadic_float_bits  != VARIADIC_RULE_UNDECLARED) { ret 1; }
+    # a real model now, so a C-variadic call is emitted rather than refused.
+    if (lp64_vtable.va_model  == nil) { ret 1; }
+    if (lp64f_vtable.va_model == nil) { ret 1; }
+    if (lp64d_vtable.va_model == nil) { ret 1; }
+
+    val md: abi.VaModel = va_model_v(v_lp64d());
+    if (md.variadic_float_bits != 0)          { ret 1; }
+    if (md.kind != abi.VA_MODEL_REG_SAVE)     { ret 1; }
+    # the tail float rides the integer bank INSTEAD of the fa bank, not as well as
+    # it, so nothing is duplicated and no vector count is encoded.
+    if (md.float_dup_gp)                      { ret 1; }
+    if (md.vector_count_reg != -1)            { ret 1; }
+    # neither width rides the bank, under the member that carries both when NAMED.
+    if (abi.variadic_float_in_fp_bank(?md, 4)) { ret 1; }
+    if (abi.variadic_float_in_fp_bank(?md, 8)) { ret 1; }
+    if (!float_in_fp_bank(v_lp64d(), 8))       { ret 1; }
+    val mf: abi.VaModel = va_model_v(v_lp64f());
+    if (mf.variadic_float_bits != 0)           { ret 1; }
+    if (abi.variadic_float_in_fp_bank(?mf, 4)) { ret 1; }
+    val ms: abi.VaModel = va_model_v(v_lp64());
+    if (ms.variadic_float_bits != 0)           { ret 1; }
+    ret 0;
+}
+
+# an UNNAMED float lands in the a bank, and an unnamed aggregate that would flatten
+# to fa registers as a NAMED argument lands there too
+#
+# The placement the model produces, asserted the way the call lowering asks for it:
+# a tail float arrives with `is_float` false (the model said no fa bank), and a tail
+# aggregate arrives with no HFA count and no leaf descriptor (the psABI passes a
+# variadic aggregate by the integer convention). Both under lp64d, the member whose
+# NAMED answers are the fa bank -- so each line differs from the named one beside it.
+test "mach.lang.target.abi.riscv.classify_arg_v:unnamed_float_takes_the_a_bank" {
+    val v: RiscvAbi = v_lp64d();
+    # a NAMED double takes fa0; the same double UNNAMED takes a0.
+    val named: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
+    if (named.class != abi.CLASS_FP)          { ret 1; }
+    val tail: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
+    if (tail.class != abi.CLASS_GP)           { ret 1; }
+    if (tail.reg   != REG_A0)                 { ret 1; }
+    # a {f64} that flattens to fa0 as a named argument takes a0 as an unnamed one.
+    val hfa: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, false, 0, true, false, false, 0, 0, 1, 8, abi.agg_none());
+    if (hfa.class != abi.CLASS_FP)            { ret 1; }
+    val tagg: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
+    if (tagg.class != abi.CLASS_GP)           { ret 1; }
+    if (tagg.reg   != REG_A0)                 { ret 1; }
+    # and the a bank is exhausted by unnamed floats exactly as by integers: the
+    # seventh tail double past a full bank goes to the stack, not to a spare fa.
+    val spill: abi.ParamSlot = classify_arg_v(v, 8, 8, 8, false, 0, false, false, false, 8, 0, 0, 0, abi.agg_none());
+    if (spill.class != abi.CLASS_STACK)       { ret 1; }
+    ret 0;
+}
+
+# a member that has not decided its variadic rule is REFUSED registration
+#
+# The sentinel's reader, asserted so it cannot quietly become dead code. This is what
+# a future `ilp32e` gets if it is added without reading the psABI's variadic clause
+# for it: a named error at startup rather than an unnamed float in fa0.
+test "mach.lang.target.abi.riscv.register:refuses_a_member_with_no_variadic_rule" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    var vt:  abi.AbiVTable = abi.abi_vtable(
+        abi.ABI_UNKNOWN, "ilp32e", isa.ARCH_RISCV64,
+        nil, nil, nil,
+        nil, nil,
+        STACK_ALIGN, RED_ZONE, 0,
+        REG_A0, true,
+        true, true,
+        0,
+        nil
+    );
+    val undecided: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "ilp32e", isa.ARCH_RISCV64, 32, 0, 16, 6, 0, 2, 0,
+                                     VARIADIC_RULE_UNDECLARED);
+    if (!R.is_err[bool, str](install(?reg, undecided, ?vt))) { ret 1; }
+    # and a decided one installs.
+    val decided: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "ilp32e", isa.ARCH_RISCV64, 32, 0, 16, 6, 0, 2, 0, 0);
+    if (R.is_err[bool, str](install(?reg, decided, ?vt)))    { ret 1; }
     ret 0;
 }
 
@@ -825,7 +958,7 @@ test "mach.lang.target.abi.riscv.classify_return_v:bank_matches_member" {
 test "mach.lang.target.abi.riscv.classify_arg_v:descriptor_facts_are_read" {
     # an ilp32 descriptor: XLEN 32, so the by-reference threshold is 8, not 16, and
     # a 16-byte aggregate goes by REFERENCE where lp64d passes it in a register pair.
-    val ilp32d: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "ilp32d", isa.ARCH_RISCV64, 32, 64, 32, 8, 8, 11, 12);
+    val ilp32d: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "ilp32d", isa.ARCH_RISCV64, 32, 64, 32, 8, 8, 11, 12, 0);
     if (max_reg_ret(ilp32d) != 8) { ret 1; }
     val big: abi.ParamSlot = classify_arg_v(ilp32d, 0, 16, 4, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (big.class != abi.CLASS_BYREF) { ret 1; }
@@ -843,7 +976,7 @@ test "mach.lang.target.abi.riscv.classify_arg_v:descriptor_facts_are_read" {
 
     # an lp64e descriptor: a 16-register integer file gives SIX argument registers,
     # so the seventh integer argument goes to the STACK where lp64d still has a6.
-    val lp64e: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "lp64e", isa.ARCH_RISCV64, 64, 0, 16, 6, 0, 2, 0);
+    val lp64e: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "lp64e", isa.ARCH_RISCV64, 64, 0, 16, 6, 0, 2, 0, 0);
     val a6: abi.ParamSlot = classify_arg_v(lp64e, 6, 8, 8, false, 0, false, false, false, 6, 0, 0, 0, abi.agg_none());
     if (a6.class != abi.CLASS_STACK) { ret 1; }
     val ok: abi.ParamSlot = classify_arg_v(v_lp64d(), 6, 8, 8, false, 0, false, false, false, 6, 0, 0, 0, abi.agg_none());

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -400,15 +400,12 @@ pub fun callee_saved(out: *isa.Register) i32 {
 # the SysV call-side variadic-ABI facts -- VA_MODEL_REG_SAVE
 #
 # SysV has no caller-side tail-float duplication (`float_dup_gp` false) and sets
-# the AL vector-count register before every variadic call.
+# the AL vector-count register before every variadic call. an UNNAMED float rides
+# the xmm bank exactly like a named one, so the unnamed width is the named 64.
 # ---
 # ret: the SysV call-side variadic model
 pub fun va_model() abi.VaModel {
-    var m: abi.VaModel;
-    m.kind             = abi.VA_MODEL_REG_SAVE;
-    m.float_dup_gp     = false;
-    m.vector_count_reg = VA_VECTOR_COUNT_REG;
-    ret m;
+    ret abi.va_model_make(abi.VA_MODEL_REG_SAVE, false, VA_VECTOR_COUNT_REG, 64);
 }
 
 # build the SysV AMD64 AbiVTable and install it into `reg`

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -405,15 +405,13 @@ pub fun shadow_space() u64 {
 #
 # win64 passes a tail float in both its XMM register and the matching integer
 # register (`float_dup_gp`), and encodes no vector count, so `vector_count_reg` is
-# -1 (no pre-call AL move).
+# -1 (no pre-call AL move). the tail float still RIDES the XMM bank at both widths
+# -- the duplication is in addition to it, not instead of it -- so the unnamed
+# width is the named 64.
 # ---
 # ret: the win64 call-side variadic model
 pub fun va_model() abi.VaModel {
-    var m: abi.VaModel;
-    m.kind             = abi.VA_MODEL_HOME;
-    m.float_dup_gp     = true;
-    m.vector_count_reg = -1;
-    ret m;
+    ret abi.va_model_make(abi.VA_MODEL_HOME, true, -1, 64);
 }
 
 # compute the positional argument slot from the running GP/FP usage counters


### PR DESCRIPTION
Closes #2818.

Twelve width decisions in shared backend code answered "how wide is the machine word" with a literal `8`, plus the `legalize` float-bank gate. Each site now reads `MachineModel`, and the judgement of **which quantity each literal was actually answering** is recorded at the site, because they are not all the same question.

## The motivation, in the codebase's own words

`src/lang/target/abi/riscv.mach:24` already documents the fact: *"slot granularity. 64 across the lp64 family, 32 across ilp32"*, and `:211` says *"XLEN in bytes (8 for lp64\*, 4 for ilp32\*)"*.

The ABI layer has written it down. The shared lowerer never asked it. That is the whole defect: a second copy of one decision, with the correct copy already present, agreeing by accident because every target mach ships today makes both eight. Credit to `rv32` for finding it while sweeping for RV32 blockers.

**To be plain about risk: none of this miscompiles a shipped target.** Every literal is correct today. What makes it the highest-value item in that sweep is the failure mode when it stops being correct: a program that compiles, links, runs, and passes wrong arguments across a foreign boundary, certified green by a test that shares the assumption.

## The 12 sites, and what each was really asking

Taxonomy: **(a)** the machine word / slot granularity, **(b)** the pointer width, **(c)** the value's own width.

### `be/codegen/mir/context.mach`

| # | Site | Was asking | Now reads |
|---|---|---|---|
| 1 | `stack_slot_bytes` size round-up and its `size == 0` default | (a) | `gpr_width` |
| 2 | `copy_chunk_width` ladder cap | (a) | `gpr_width` |
| 3 | `add_spill_slot` size padding | (a) | `gpr_width` |
| 4 | `add_spill_slot` slot alignment | (a) | `gpr_width` |
| 5 | `add_spill_slot_aligned` size padding | (a) | `gpr_width` |

Site 2's reason is sharper than "granularity" and worth stating: the chunk travels through a **scratch GP register**, load into it and store out of it, so the widest chunk the walk can move is the widest value that register holds. A 4-byte-word machine was being asked for a move it has no register for.

Site 5 is the clean illustration that these are separable: its **alignment** stays the caller's, question (c), while only its **padding** is the machine's. That asymmetry is correct and now documented.

### `be/codegen/mir/abi.mach`

| # | Site | Was asking | Now reads |
|---|---|---|---|
| 6 | `stack_arg_align`, `CLASS_STACK_BYREF` | **(b)** | `pointer_width` |
| 7 | `stack_arg_align`, `CLASS_VEC_STACK_BYREF` | **(b)** | `pointer_width` |
| 8 | `stack_arg_align`, `if (align < 8) ret 8` | (a) | `gpr_width` |
| 9 | fixed-parameter split-chunk cursor `round_up_i64(stack_off, 8)` | (a) | `gpr_width` |
| 10 | variadic-tail split-chunk cursor `round_up_i64(stack_off, 8)` | (a) | `gpr_width` |

**Sites 6-8 are the taxonomy in miniature: one function, one literal, two different questions.** The by-reference clauses align a *pointer* — the doc comment said so all along, "holds only an eight-byte pointer" — while the floor three lines below is the *outgoing-slot granularity*. Substituting one authority into both would have been the same defect wearing a fix's clothes.

Sites 9 and 10 now round to the same word `stack_slot_bytes` sizes each chunk to, so the cursor a caller aligns and the footprint it then advances by cannot disagree. That asymmetry is what produced #2777.

### `be/codegen/regalloc.mach`

| # | Site | Was asking | Now reads |
|---|---|---|---|
| 11 | `class_width`, GP arm | (a), as the spill-move width | `ctx.spill_width` |
| 12 | `spill_slot_align`, non-vector arm | (a) | `ctx.spill_width` |

These were **already inconsistent on a shipped target before this PR**. `regalloc.mach:537` sets `ctx.spill_width = tgt.model.spill_width` and the spill store/reload MOVs use it correctly, so on mos6502 (`spill_width` 1) every GP slot reserved eight bytes for a move that writes one. A parameterised fact and an unparameterised one, four lines apart, disagreeing.

### The `legalize` float gate

`instr_needs_legalize` excluded only **vector** ops from width splitting, never **float** ones. At `lane_width` 4 an `f64` register copy is a plain `MIR_MOV` of width 8, split into two 4-byte **integer** lane moves between GP-class lane vregs — so the value leaves the float bank entirely and the reassembled halves are not the float. Silent miscompile, and the exact mirror of #2777.

The gate is now the register **bank** (`instr_rides_fp_bank`), which strictly subsumes the vector flag, since a vector vreg is FP-class too. `mir.vreg_is_fp` is the same authority instruction selection already reads to identify a float register copy.

The **lane planner** now reads the same gate, so a plan cannot describe a split the rewriter never performs — the placement/capture symmetry the issue asked for.

A target with **no** float bank is unaffected: mos6502 declares one register class, a soft-float value rides GP vregs, and it splits exactly as before. That is why mos6502 can have floats at all, and it is asserted as a control.

## Sites that look like the machine word and are NOT

More valuable than the list above, because this is the part a future reader gets wrong. **None of these were changed.**

| Site | What the `8` (or `16`) actually is | Why substituting the word would be wrong |
|---|---|---|
| `riscv64/encode.mach` `save_callee_fp`, width 8 per callee-saved f register | **float register width** (FLEN/8) | Stays 8 under RV32D, becomes 4 under RV32F. Tracks FLEN, never XLEN. |
| `riscv64/encode.mach` `frame_total` `align16` | **`model.stack_align`** | 16 under both lp64 and ilp32d. Never the word. |
| `regalloc.mach` `class_width`, non-GP arm, 16 | **vector register width** (`vector_bits / 8`) | A third quantity again. Left literal, documented, and flagged as needing its own change with its own byte-movement check. |
| `abi/riscv.mach:550-560` `callee_saved_v` size 8 | **float register width** | rv32's finding, same class as `save_callee_fp`. Not touched — that file is owned by other agents. |

## What is deliberately NOT in this PR

**The riscv64 prologue/epilogue frame geometry (9 sites).** Two reasons, and the first is the better one:

1. Several of those `8`s are not the machine word at all (see the table above). Substituting `gpr_width` into `save_callee_fp` or `align16` would create a **new** instance of the defect this PR closes, while looking like the fix.
2. For the ones that genuinely are the word, a model read there does not produce a working RV32 encoder anyway: `emit_mem_access` at width 8 selects `sd`, which RV32 has no form for. The encoder fork has to land with it.

Handed to `rv32` on `feat/2778-riscv32` with the per-site judgement, which is worth more to it than the substitution.

**`target/abi.mach:713-716` and `:743`** (`piece_for_reg` / `make_slot` chunking a two-register aggregate at the word). Correctly identified as (a), and the prose at `:704-707` states the assumption out loud. Left out because `make_slot` is a pure constructor with no model in scope, so parameterising it means threading a word through **109 call sites across 9 files**, six of them convention classifiers including `abi/riscv.mach`, which two other agents are inside right now. That is a collision, not a hard problem. Filed separately.

## Evidence

### The tests fail against the unpatched compiler

Not "a test exists" — each one was run both ways. `int/` is frozen, so all coverage is in `mach test .`.

**Float gate.** Reverting only the `mir.vreg_is_fp` clause reproduces the pre-fix gate:

```
=== unpatched gate ===
  FAIL  mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes  (exit 1)
0 passed, 1 failed, 1 total

=== patched gate ===
mach.lang.be.codegen.legalize     1 ok    334us
1 passed, 0 failed, 1 total
```

The test asserts **inertness** for an `f64` `MIR_MOV` at `lane_width` 4, with two controls that are what make it mean anything: the identical function over **GP-class** vregs at the identical machine must still split into two lane moves, and the same function on a machine with **no float bank** must still split into eight byte lanes. Without those, inertness would prove only that the fixture legalizes nothing.

**Machine word.** Pinning `gpr_width` and `pointer_width` back to the literal `8` and rebuilding:

```
=== literal-8 build ===
  mach.lang.be.codegen.mir.context.stack_slot_bytes                        (exit 1)
  mach.lang.be.codegen.mir.context.copy_chunk_width                        (exit 1)
  mach.lang.be.codegen.mir.abi:stack_slot_granularity_is_the_machine_word  (exit 1)
0 passed, 3 failed

=== model-read build ===
mach.lang.be.codegen.mir.context.stack_slot_bytes                          1 ok
mach.lang.be.codegen.mir.context.copy_chunk_width                          1 ok
mach.lang.be.codegen.mir.abi:stack_slot_granularity_is_the_machine_word    1 ok
3 passed, 0 failed
```

### The word and the value width genuinely differ

**mach ships no target where they differ, so this is constructed, and the PR says so rather than claiming coverage it does not have.** Each test asserts against synthetic `MachineModel`s:

- `stack_slot_bytes` and `copy_chunk_width` at words **8, 4 and 1**. A 4-byte-word machine must never be handed the 8-byte move it has no register for, which is the assertion a hardcoded ladder cannot pass.
- `stack_slot_granularity_is_the_machine_word` additionally builds a model where the **word is 4 and the pointer is 2**. That is the only thing that can separate sites 6-8: a site reading `gpr_width` for the hidden pointer's alignment answers 4 and must answer 2. Without a model where they disagree, both readings pass.
- The placement side and footprint side are walked together over three arguments on the 4-byte-word machine, pinning that they agree.

### Byte identity

Compiler built before and after, each compiling the full mach project across three targets at both profiles:

```
linux-x86_64/debug:    223 files (222 objects) compared, 0 differ
linux-x86_64/release:  223 files (222 objects) compared, 0 differ
linux-arm64/debug:     223 files (222 objects) compared, 0 differ
linux-arm64/release:   223 files (222 objects) compared, 0 differ
linux-riscv64/debug:   223 files (222 objects) compared, 0 differ
linux-riscv64/release: 223 files (222 objects) compared, 0 differ
TOTAL: 1338 files, 1332 objects, 0 differing
```

### mos6502 DOES change, and correctly

The one place where the literal `8` was **not** a no-op, and it took a full run to find.

mos6502 has `gpr_width = 1`, so its outgoing stack arguments now pack tightly instead of each consuming an 8-byte slot that machine never had, and its GP spill slots reserve the one byte the spill move writes. Both sides of the compiler agree on the new layout, and it is verified **by executing the emitted bytes on the reference 6502 core**, not by reading them.

The only thing that broke was `driver/tests.mach`, which held `UT_MOS_ARG1 = 8` for the second parameter's offset — **the same defect one level up**, a test harness carrying its own copy of the compiler's constant and therefore agreeing with it by construction rather than checking it. It now derives the offset.

### `mach test .`

```
1339 passed, 0 failed, 1339 total
```

### `int`

Filtered to the ABI, float, aggregate and stack-argument cases, all three legs, both profiles. `--runmode qemu` for the non-native legs.

- `linux`: all passed
- `linux-arm64`: all passed
- `linux-riscv64`: all passed, including `2777-riscv-abi-lp64`, `lp64d` and `lp64f`

### Self-host fixpoint

Each stage built into a **freshly removed `out/`**:

```
stage2: cdef8e4ae4949be9  5877760 bytes
stage3: 53df5f42b8f498c3  6465968 bytes
stage4: 53df5f42b8f498c3  6465968 bytes
FIXPOINT: stage3 == stage4
stage2 != stage3 (expected: stage1 is the released 4.16.0, not this branch)
```
