### PR TITLE
Revert "display source names instead of linkage names"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-#### Compiler output names functions the way the source spells them, not the way the linker does
-An `ir.Function` has carried two names for a while: `name`, the mangled linkage symbol, and `disp`, the bare source spelling. The house rule is to prefer `disp` and fall back to `name`, and the DWARF `DW_AT_name` producer, the IR verifier, the SPIR-V entry point and the `#[oblivious]` sema diagnostic all followed it. Everything else printed the symbol, so `--emit-ir` read `fn @_M4case4mainN5add32`, the `simd = "require"` refusal read ``in '_M4case4mainN5add32'``, and a regalloc failure, a constant-time refusal, an encoder ICE and every `--emit-asm` function heading did the same. None of those names anything a reader can find in a source file.
-
-The preference now has exactly one definition per layer - `ir.function_display` and `mir.function_display` - and every producer of text a person reads goes through one of them. The mangled symbol survives only where it IS the identity: an object symbol, a relocation, a linker diagnostic, and the `#[oblivious]` note that deliberately names one generic instantiation among many.
-
-Reaching the back end took a real change rather than a lookup: `EncodeFunctionFn`, the constant-time validator and regalloc all take a `mir.MirFunction` and no IR handle, so `MirFunction` now carries `disp` itself, stamped at lowering exactly as `oblivious` and `naked` already are. Widening those interfaces to carry a mid-end structure so a diagnostic could spell a name would have been the wrong direction.
-
-Two dumps keep both names, because in both the symbol is still load-bearing. `--emit-ir` writes `fn @add32(...): i32 symbol "_M4demo4mainN10echoI3i32E"` - source names are not unique across generic instantiations, and the header is where they are told apart. `--emit-asm` writes `# add32 (_M4case4mainN5add32):`, since the listing carries no `.globl` and that comment is the only place a function's identity appears in it. The heading's format is now defined once in `be/codegen/encode.mach` rather than three times, once per ISA printer.
-
-Display only: the compiler was built before and after and used to compile itself for all six targets, and the emitted binaries are byte-identical on every one.
-
-#### `int`'s shell demangler was a third copy of the mangling scheme, and disagreed with the other two
-`int/lib/produce.sh` carried the same ~18-line awk `demangle()` twice, hardcoding the `_M` prefix, the `N` separator and the length-prefixed-run grammar - a transcription of `src/lang/me/lower/mangle.mach` that agreed with it by accident. It mishandled the generic form, returning `unwrapI3ptrE` for `_M3std9allocatorN6unwrapI3ptrE`, and the value-instance `K...E` form did not exist to it at all.
-
-There is now one `_demangle_awk` definition, prepended to both scanners' programs, and a scheme change needs exactly that one shell edit. It parses the module path as the run of length-prefixed segments it is, takes the name as the run after `N`, and drops the `I...E` / `K...E` instance suffix - which is what these per-source-function shape observables want, and is written down as a limit rather than left to be discovered.
-
 #### A C `[step]` cross-builds for its leg instead of silently assuming the host toolchain targets it (#2741)
 `int/surface/narrow-stack-args` and `int/surface/c-variadic` shelled out to the bare host `cc` to build a probe object, which happens to target the leg on every CI runner (each builds natively) but not on a developer cross-building locally - `mach --target linux-arm64` on an x86-64 host still ran the host's x86-64 `cc`, silently linking an x86-64 object into an aarch64 image. That surfaced as `error: relocation 'plt32' to 'float_tail' overflows` on narrow-stack-args and a qemu `Illegal instruction` on c-variadic, neither of which names its actual cause.
 

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -138,50 +138,6 @@
 _produce_lib_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 _flat_loader_bin=
 
-# _demangle_awk — the awk `demangle(s)` function every shape-observable scanner uses,
-# defined ONCE and prepended to each scanner's program.
-#
-# This is a transcription of the mangling scheme, which lives in
-# src/lang/me/lower/mangle.mach. A transcription is a second copy of a rule, and a
-# second copy agrees with the first by accident until it does not - so there is exactly
-# one of it here, and a scheme change needs exactly this one shell edit. Do not inline
-# it back into a scanner.
-#
-# The scheme (mangle.mach's header comment is the authority):
-#   ordinary  `_M<len><seg>...N<len><name>`
-#   generic   `_M<len><seg>...N<len><name>I<encoded type args>E`
-#   value     `_M<len><seg>...N<len><name>K<encoded comptime values>E`
-# The module path is a run of length-prefixed segments; `N` terminates it; the bare
-# source name is the length-prefixed run immediately after it.
-#
-# WHAT IT DOES NOT COVER, deliberately:
-#   - the `I...E` / `K...E` instance suffix is DROPPED, not decoded. every instance of
-#     one generic therefore demangles to the same bare name. these observables count
-#     emitted shape per source function, which is what that collapse gives them; a
-#     scanner that needs to tell two instantiations apart must not use this.
-#   - an `ext fun` or `#[symbol(...)]` name is not mangled at all and has no `_M`
-#     prefix, so it is returned unchanged, which is correct.
-#   - anything that does not parse as the grammar above is returned unchanged rather
-#     than guessed at.
-_demangle_awk='
-    function demangle(s,   i, len) {
-        if (substr(s, 1, 2) != "_M") { return s }
-        i = 3
-        while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) {
-            len = 0
-            while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) { len = len * 10 + substr(s, i, 1); i++ }
-            i += len
-        }
-        if (substr(s, i, 1) != "N") { return s }
-        i++
-        if (substr(s, i, 1) !~ /[0-9]/) { return s }
-        len = 0
-        while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) { len = len * 10 + substr(s, i, 1); i++ }
-        if (len == 0) { return s }
-        return substr(s, i, len)
-    }
-'
-
 # qemu_bin <target> — the qemu-user interpreter for a harness target, keyed by ISA
 # rather than sliced from the name. linux-riscv64's name suffix happens to match its
 # qemu-user binary (qemu-riscv64), but linux-arm64's does not (qemu-aarch64, never
@@ -2488,7 +2444,23 @@ produce_const_pool() {
 
 # const_pool_scan — read a `-d -r` disassembly on stdin and print the pool observable
 const_pool_scan() {
-    awk "$_demangle_awk"'
+    awk '
+    function demangle(s,   i, len, c, out) {
+        if (substr(s, 1, 2) != "_M") { return s }
+        i = 3
+        out = ""
+        while (i <= length(s)) {
+            c = substr(s, i, 1)
+            if (c == "N") { i++; continue }
+            if (c !~ /[0-9]/) { return s }
+            len = 0
+            while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) { len = len * 10 + substr(s, i, 1); i++ }
+            out = substr(s, i, len)
+            i += len
+        }
+        if (out == "") { return s }
+        return out
+    }
     /file format/ {
         if      ($0 ~ /x86-64/)   { isa = "x86_64" }
         else if ($0 ~ /aarch64/)  { isa = "aarch64" }
@@ -2601,7 +2573,23 @@ vector_lanes_scan() { emit_scan lanes; }
 #               ordinary integer loads and stores, so both facts are 0 - the
 #               target's own golden, not an exemption.
 emit_scan() {
-    awk -v mode="$1" "$_demangle_awk"'
+    awk -v mode="$1" '
+    function demangle(s,   i, len, c, out) {
+        if (substr(s, 1, 2) != "_M") { return s }
+        i = 3
+        out = ""
+        while (i <= length(s)) {
+            c = substr(s, i, 1)
+            if (c == "N") { i++; continue }
+            if (c !~ /[0-9]/) { return s }
+            len = 0
+            while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) { len = len * 10 + substr(s, i, 1); i++ }
+            out = substr(s, i, len)
+            i += len
+        }
+        if (out == "") { return s }
+        return out
+    }
     function packed(m, rest) {
         if (isa == "x86_64") {
             if (m ~ /^(movup[sd]|movap[sd]|movdq[au])$/) { return 1 }

--- a/int/surface/vector-mul-scalar-shortfall/expect.linux-arm64.txt
+++ b/int/surface/vector-mul-scalar-shortfall/expect.linux-arm64.txt
@@ -1,1 +1,1 @@
-error: simd = "require": vector multiply on 64-bit lanes in 'mul64' would scalarize on aarch64 (target has no packed form for this operation at this lane width); set simd = "scalarize" to build with the scalar expansion
+error: simd = "require": vector multiply on 64-bit lanes in '_M4case4mainN5mul64' would scalarize on aarch64 (target has no packed form for this operation at this lane width); set simd = "scalarize" to build with the scalar expansion

--- a/int/surface/vector-mul-scalar-shortfall/expect.linux-riscv64.txt
+++ b/int/surface/vector-mul-scalar-shortfall/expect.linux-riscv64.txt
@@ -1,1 +1,1 @@
-error: simd = "require": vector multiply on 64-bit lanes in 'mul64' would scalarize on riscv64 (target has no 128-bit SIMD); set simd = "scalarize" to build with the scalar expansion
+error: simd = "require": vector multiply on 64-bit lanes in '_M4case4mainN5mul64' would scalarize on riscv64 (target has no 128-bit SIMD); set simd = "scalarize" to build with the scalar expansion

--- a/int/surface/vector-mul-scalar-shortfall/expect.linux.txt
+++ b/int/surface/vector-mul-scalar-shortfall/expect.linux.txt
@@ -1,1 +1,1 @@
-error: simd = "require": vector multiply on 64-bit lanes in 'mul64' would scalarize on x86_64 (target has no packed form for this operation at this lane width); set simd = "scalarize" to build with the scalar expansion
+error: simd = "require": vector multiply on 64-bit lanes in '_M4case4mainN5mul64' would scalarize on x86_64 (target has no packed form for this operation at this lane width); set simd = "scalarize" to build with the scalar expansion

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -147,7 +147,7 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
         val f: *mir.MirFunction = ?m.functions[i];
         if (f.oblivious) {
             if (unverifiable) {
-                ret R.err[bool, str](unverifiable_msg(m.alloc, m.interner, mir.function_display(f), tgt.isa.name));
+                ret R.err[bool, str](unverifiable_msg(m.alloc, m.interner, f.name, tgt.isa.name));
             }
             val res: R.Result[bool, str] = validate_function(tgt, f, m.interner, m.alloc);
             if (R.is_err[bool, str](res)) { ret res; }
@@ -357,7 +357,7 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
     # (a) a conditional branch whose condition is secret leaks through the taken path.
     if (mi.opcode == mir.MIR_CBR) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
-            ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                 "uses a secret value as a conditional-branch condition; the branch decides the taken path, so its timing reveals the secret. select branch-free (a masked select) over public data, or `:^`-declassify the value when disclosure is intended"));
         }
     }
@@ -366,7 +366,7 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
     # vreg for an indirect one).
     if (mi.opcode == mir.MIR_CALL) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
-            ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                 "calls through a secret function pointer; the branch target, hence the taken path and its timing, depends on the secret. dispatch on public data, or `:^`-declassify the pointer when disclosure is intended"));
         }
     }
@@ -374,11 +374,11 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
     # two compared values in operands 0 and 1; checked defensively so a future placement stays sound.
     if (mir.is_fused_cbr(mi.opcode)) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
-            ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                 "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:^`-declassify when disclosure is intended"));
         }
         if (mi.operand_count >= 2 && operand_secret(?mi.operands[1], vt, nv, pt, np)) {
-            ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                 "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:^`-declassify when disclosure is intended"));
         }
     }
@@ -388,11 +388,11 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
         val op: *mir.MirOperand = ?mi.operands[k];
         if (op.kind == mir.MIR_OP_MEM) {
             if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv && vt[op.vreg]) {
-                ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+                ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                     "uses a secret value as a memory address; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:^`-declassify the pointer when disclosure is intended"));
             }
             if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) {
-                ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+                ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                     "uses a secret value as a memory index; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:^`-declassify the index when disclosure is intended"));
             }
         }
@@ -404,7 +404,7 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
         val cap: ct.CtCap = ct.ct_cap(cop);
         if (!ct.target_provides(tgt.model.ct_trust_mul, tgt.model.ct_trust_var_shift, cap)) {
             if (ct_secret_operand(mi, cop, vt, nv, pt, np)) {
-                ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f), ct_op_detail(cop)));
+                ret R.err[bool, str](leak_msg(alloc, interner, f.name, ct_op_detail(cop)));
             }
         }
     }
@@ -432,7 +432,7 @@ fun check_asm(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt: *
     # payload is worse: there is no body to walk, so accepting it would certify a
     # block this validator never read.
     if (tgt.arch == nil || tgt.arch.asm_ct_scan == nil || mi.asm_block == nil) {
-        ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f),
+        ret R.err[bool, str](leak_msg(alloc, interner, f.name,
             "contains inline assembly, which cannot be verified constant-time and is not permitted in a #[oblivious] function; express the operation with the constant-time primitives, or move it to a non-oblivious function and `:^`-declassify at the boundary"));
     }
     val blk: *mir.MirAsm = mi.asm_block;
@@ -468,7 +468,7 @@ fun check_asm(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt: *
     if (names != nil) { A.deallocate[str](alloc, names, blk.bind_count::usize); }
 
     if (R.is_err[bool, str](r)) {
-        ret R.err[bool, str](leak_msg(alloc, interner, mir.function_display(f), R.unwrap_err[bool, str](r)));
+        ret R.err[bool, str](leak_msg(alloc, interner, f.name, R.unwrap_err[bool, str](r)));
     }
     ret R.ok[bool, str](true);
 }
@@ -577,10 +577,6 @@ fun stable(alloc: *A.Allocator, interner: *intern.Interner, buf: str, fallback: 
 }
 
 # the function's source name, or "<unknown>" when unresolved
-#
-# `id` is a DISPLAY id (`mir.function_display`), not a linkage symbol: this refusal is
-# read by the author of the `#[oblivious]` function, who is looking for it in a source
-# file.
 fun fn_name(interner: *intern.Interner, id: intern.StrId) str {
     val o: O.Option[str] = intern.lookup(interner, id);
     if (O.is_some[str](o)) { ret O.unwrap[str](o); }

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -514,10 +514,7 @@ pub val ASM_NOTE_BYTES_WIDTH: usize = 4;
 # kind:  ASM_NOTE_INST / ASM_NOTE_FUNC / ASM_NOTE_BLOCK / ASM_NOTE_BYTES
 # off:   `.text` byte offset of the note's first byte (ASM_NOTE_INST, ASM_NOTE_BYTES)
 # inst:  the emitted machine instruction (ASM_NOTE_INST)
-# name:  the function's mangled linkage symbol (ASM_NOTE_FUNC)
-# disp:  the function's bare source name (ASM_NOTE_FUNC), or STR_NIL when it has none.
-#        both are carried because the heading shows both: the source name is what the
-#        reader is looking for, the symbol is what an object dump will agree with
+# name:  the function's interned name (ASM_NOTE_FUNC)
 # id:    the block id (ASM_NOTE_BLOCK)
 # bytes: the payload slice, `ASM_NOTE_BYTES_WIDTH` bytes (ASM_NOTE_BYTES)
 pub rec AsmNote {
@@ -525,59 +522,8 @@ pub rec AsmNote {
     off:   u32;
     inst:  isa.Inst;
     name:  intern.StrId;
-    disp:  intern.StrId;
     id:    u32;
     bytes: [ASM_NOTE_BYTES_WIDTH]u8;
-}
-
-# write the `--emit-asm` heading that introduces one function
-#
-# `# <source name>:` normally, and `# <source name> (<linkage symbol>):` when the two
-# differ, which is the generic instantiation and the `#[symbol(...)]` override. The
-# listing carries no `.globl` directive, so this comment is the ONLY place a function's
-# identity appears in the assembly text: showing the source name alone would take the
-# symbol an object dump agrees with out of the listing, and showing the symbol alone is
-# what made the listing hard to read. Defined here rather than in each ISA's printer so
-# the three arches cannot drift into three headings.
-# ---
-# out:      destination writer
-# interner: resolves both ids
-# name:     the mangled linkage symbol
-# disp:     the bare source name, or STR_NIL when the function has none
-# ret:      true on success, or the write error
-pub fun emit_function_heading(out: *writer.Writer, interner: *intern.Interner, name: intern.StrId, disp: intern.StrId) R.Result[bool, str] {
-    val shown: intern.StrId = mir.display_of(name, disp);
-    val rn: R.Result[usize, str] = format.write_str(out, "\n# ");
-    if (R.is_err[usize, str](rn)) { ret R.err[bool, str](R.unwrap_err[usize, str](rn)); }
-    val rs: R.Result[bool, str] = emit_interned(out, interner, shown);
-    if (R.is_err[bool, str](rs)) { ret rs; }
-    if (shown != name) {
-        val ro: R.Result[usize, str] = format.write_str(out, " (");
-        if (R.is_err[usize, str](ro)) { ret R.err[bool, str](R.unwrap_err[usize, str](ro)); }
-        val rl: R.Result[bool, str] = emit_interned(out, interner, name);
-        if (R.is_err[bool, str](rl)) { ret rl; }
-        val rc: R.Result[usize, str] = format.write_str(out, ")");
-        if (R.is_err[usize, str](rc)) { ret R.err[bool, str](R.unwrap_err[usize, str](rc)); }
-    }
-    val re: R.Result[usize, str] = format.write_str(out, ":\n");
-    if (R.is_err[usize, str](re)) { ret R.err[bool, str](R.unwrap_err[usize, str](re)); }
-    ret R.ok[bool, str](true);
-}
-
-# write one interned id, failing when it does not resolve
-# ---
-# out:      destination writer
-# interner: the interner that resolves the id
-# id:       the interned string id
-# ret:      true on success, or an error
-fun emit_interned(out: *writer.Writer, interner: *intern.Interner, id: intern.StrId) R.Result[bool, str] {
-    val opt: O.Option[str] = intern.lookup(interner, id);
-    if (O.is_none[str](opt)) {
-        ret R.err[bool, str]("--emit-asm: a function name did not resolve in the interner");
-    }
-    val rw: R.Result[usize, str] = format.write_str(out, O.unwrap[str](opt));
-    if (R.is_err[usize, str](rw)) { ret R.err[bool, str](R.unwrap_err[usize, str](rw)); }
-    ret R.ok[bool, str](true);
 }
 
 # initial capacity of a sink's note buffer
@@ -614,7 +560,6 @@ pub fun note_blank() AsmNote {
     n.off  = 0;
     n.inst = isa.inst_blank();
     n.name = intern.STR_NIL;
-    n.disp = intern.STR_NIL;
     n.id   = 0;
     ret n;
 }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -1038,18 +1038,6 @@ pub rec MirFrame {
 # a function in MIR form - blocks, the virtual-register table, and frame layout
 # ---
 # name:           interned function symbol name
-# disp:           the bare source name, mirroring the IR function's `disp` and stamped
-#                 at lowering the same way `oblivious` and `naked` are. `name` is the
-#                 mangled linkage symbol: right for an object symbol, a relocation or
-#                 an assembly label, wrong in a sentence a person reads. every back-end
-#                 producer of such a sentence - the regalloc failure, the constant-time
-#                 refusal, the encoder ICE, the `-S` function heading - resolves
-#                 `function_display` instead. carried on the MIR rather than looked up
-#                 in the IR module because the back end's interfaces (`EncodeFunctionFn`,
-#                 the ct validator, regalloc) take a MirFunction and no IR handle, and
-#                 widening them to carry a mid-end structure so a diagnostic can spell a
-#                 name is the wrong direction. pure display metadata, read by nothing
-#                 that decides a byte. STR_NIL when the function has no source spelling.
 # blocks:         MIR blocks; blocks[0] is the entry block (owned)
 # block_count:    number of blocks
 # block_cap:      allocated capacity for blocks
@@ -1082,7 +1070,6 @@ pub rec MirFrame {
 #                 fact, so it belongs to the function, not to the laid-out `frame`.
 pub rec MirFunction {
     name:        intern.StrId;
-    disp:        intern.StrId;
 
     blocks:      *MirBlock;
     block_count: u32;
@@ -1097,33 +1084,6 @@ pub rec MirFunction {
     callee_mask_fp: u32;
     oblivious:      bool;
     naked:          bool;
-}
-
-# the name to SHOW for a MIR function: its bare source spelling when it has one, else
-# its mangled linkage symbol
-#
-# The back-end twin of `ir.function_display`, and the single definition of the
-# preference for every back-end producer of human-facing text. A caller that needs the
-# LINKAGE identity - the object symbol, a relocation target, an assembly label - reads
-# `name` directly and must not come through here.
-# ---
-# f:   the function
-# ret: the StrId to resolve for display
-pub fun function_display(f: *MirFunction) intern.StrId {
-    ret display_of(f.name, f.disp);
-}
-
-# the preference itself, over a name / disp pair detached from any function
-#
-# The asm sink buffers a heading as a pair of ids rather than a function pointer, so it
-# needs the rule without the function; this is the one definition both forms resolve.
-# ---
-# name: the mangled linkage symbol
-# disp: the bare source name, or STR_NIL when there is none
-# ret:  the StrId to resolve for display
-pub fun display_of(name: intern.StrId, disp: intern.StrId) intern.StrId {
-    if (disp != intern.STR_NIL) { ret disp; }
-    ret name;
 }
 
 # the source spelling of a MIR opcode, for a diagnostic that has to say WHICH

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -184,9 +184,6 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     mf.oblivious           = (fn.flags & ir.FN_FLAG_OBLIVIOUS) != 0;
     # the #[naked] seed for #2198, read by `frame.omits_frame`.
     mf.naked               = (fn.flags & ir.FN_FLAG_NAKED) != 0;
-    # the bare source name, so a back-end diagnostic can name the function the way the
-    # source spells it without reaching back into the IR module for it.
-    mf.disp                = fn.disp;
 
     # extern / body-less functions lower to an empty mir.MirFunction shell.
     if ((fn.flags & ir.FN_FLAG_EXTERN) != 0 || fn.block_count == 0) {

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -326,7 +326,7 @@ rec AllocCtx {
 # the allocating function's source name, or "<unknown>" when unresolved
 fun ctx_fn_name(ctx: *AllocCtx) str {
     if (ctx.interner == nil) { ret "<unknown>"; }
-    val nm: O.Option[str] = intern.lookup(ctx.interner, mir.function_display(ctx.f));
+    val nm: O.Option[str] = intern.lookup(ctx.interner, ctx.f.name);
     if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
     ret "<unknown>";
 }

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -321,14 +321,10 @@ pub rec Block {
 # spv_op:      the opcode within `spv_set`, resolved by `spirvop.opcode_of`; a core
 #              opcode for SPV_SET_CORE, an extended instruction number otherwise.
 #              meaningless when `spv_set` is SPV_SET_NONE
-# disp:        bare source name of the function. inert display metadata like `loc`
-#              (#1689): the machine-code path never reads it, so nothing it decides
-#              can reach the emitted bytes. every producer of text a HUMAN reads -
-#              the `-g` DWARF `DW_AT_name`, `--emit-ir`, and every diagnostic that
-#              names a function - resolves it through `function_display`, so the
-#              mangled linkage name appears only where it IS the identity (a linker
-#              symbol, a relocation, a named generic instantiation). STR_NIL for a
-#              synthesized function with no source spelling
+# disp:        bare source name of the function. inert debug metadata like `loc`
+#              (#1689): the machine-code path never reads it; only the `-g` DWARF
+#              producer does, for a readable DW_AT_name instead of the mangled linkage
+#              name. STR_NIL for a synthesized function with no source spelling
 # ret_sem:     semantic return type (`mach.lang.type`, which keeps the integer
 #              signedness the IR type erases). inert debug metadata read only by the
 #              `-g` DWARF producer, for an accurate return base type; TYPE_NIL for a
@@ -845,24 +841,6 @@ pub fun function_lookup(m: *Module, name: intern.StrId) O.Option[u32] {
     val res_idx: R.Result[*u32, str] = map.get[intern.StrId, u32](?m.fn_by_name, ?key);
     if (R.is_ok[*u32, str](res_idx)) { ret O.some[u32](@R.unwrap_ok[*u32, str](res_idx)); }
     ret O.none[u32]();
-}
-
-# the name to SHOW for a function: its bare source spelling when it has one, else
-# its mangled linkage symbol
-#
-# The single definition of the preference every human-facing producer follows -
-# `--emit-ir`, the DWARF `DW_AT_name`, the verifier's messages, the scalarize
-# `require` refusal, the SPIR-V entry point. A synthesized function carries no source
-# spelling, so the linkage name is the only name it has and the fallback is not an
-# error path. Callers that need the LINKAGE identity - a relocation, an object symbol,
-# a note naming one generic instantiation among many - read `name` directly and must
-# not come through here.
-# ---
-# fn:  the function
-# ret: the StrId to resolve for display
-pub fun function_display(fn: *Function) intern.StrId {
-    if (fn.disp != intern.STR_NIL) { ret fn.disp; }
-    ret fn.name;
 }
 
 # record `name -> idx` in the module's global index. only user and extern globals

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -130,7 +130,7 @@ pub fun print_global(out: *writer.Writer, m: *ir.Module, g: *ir.Global, interner
 pub fun print_function(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, interner: *intern.Interner) R.Result[bool, str] {
     val res_head: R.Result[bool, str] = emit_str(out, "  fn @");
     if (R.is_err[bool, str](res_head)) { ret res_head; }
-    val res_name: R.Result[bool, str] = emit_name(out, interner, ir.function_display(fn));
+    val res_name: R.Result[bool, str] = emit_name(out, interner, fn.name);
     if (R.is_err[bool, str](res_name)) { ret res_name; }
     val res_open: R.Result[bool, str] = emit_str(out, "(");
     if (R.is_err[bool, str](res_open)) { ret res_open; }
@@ -165,19 +165,6 @@ pub fun print_function(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, int
     if (R.is_err[bool, str](res_close)) { ret res_close; }
     val res_ret: R.Result[bool, str] = print_signature_ret(out, m, fn.sig);
     if (R.is_err[bool, str](res_ret)) { ret res_ret; }
-
-    # the header shows the source name, which is not unique: every instantiation of a
-    # generic shares one. name the linkage symbol here, and only here, so the dump
-    # still distinguishes them and stays greppable against an object file. omitted
-    # when the two agree, which is the common non-generic case.
-    if (ir.function_display(fn) != fn.name) {
-        val res_sym: R.Result[bool, str] = emit_str(out, " symbol \"");
-        if (R.is_err[bool, str](res_sym)) { ret res_sym; }
-        val res_lnk: R.Result[bool, str] = emit_name(out, interner, fn.name);
-        if (R.is_err[bool, str](res_lnk)) { ret res_lnk; }
-        val res_end: R.Result[bool, str] = emit_str(out, "\"");
-        if (R.is_err[bool, str](res_end)) { ret res_end; }
-    }
 
     if ((fn.flags & ir.FN_FLAG_EXTERN) != 0) {
         ret emit_str(out, " extern\n");
@@ -372,9 +359,7 @@ pub fun print_value(out: *writer.Writer, m: *ir.Module, v: *value.Value, interne
         val res_sigil: R.Result[bool, str] = emit_str(out, "@");
         if (R.is_err[bool, str](res_sigil)) { ret res_sigil; }
         if (v.data.fn_ix < m.function_len) {
-            # the same name the definition header leads with, so a reference and its
-            # definition still read as the same function
-            ret emit_name(out, interner, ir.function_display(?m.functions[v.data.fn_ix]));
+            ret emit_name(out, interner, m.functions[v.data.fn_ix].name);
         }
         ret emit_u64(out, v.data.fn_ix::u64);
     }

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -174,9 +174,6 @@ fun produces_vector(m: *ir.Module, inst: *instruction.Instruction) bool {
 # per-target (#2726): "multiply would scalarize" is not actionable on a target that
 # packs the same multiply one lane width down, so the diagnostic names the width the
 # gap is at.
-# fn_name is the DISPLAY name (`ir.function_display`), not the linkage symbol: the
-# reader of the note or the `require` refusal is looking for the function in a source
-# file, and the mangled symbol does not appear in one.
 pub rec ScalarizeSite {
     fn_name:   intern.StrId;
     op:        instruction.InstrKind;
@@ -217,7 +214,7 @@ pub fun detect(m: *ir.Module, tgt: *target.Target, first: *ScalarizeSite) u32 {
                     val inst: *instruction.Instruction = ?fn.instrs[blk.instructions[ii]::u32];
                     if (is_operator(m, inst) && !vecform.realizes_packed(m, tgt, inst)) {
                         if (count == 0) {
-                            first.fn_name   = ir.function_display(fn);
+                            first.fn_name   = fn.name;
                             first.op        = inst.kind;
                             first.lane_bits = 0;
                             var d: vecform.LaneDesc;

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -268,7 +268,12 @@ pub fun vec(n: u32, bytes: u8) isa.Operand {
 # f:        the function whose encoding is starting
 # ret:      true on success, or the write error
 pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.MirFunction) R.Result[bool, str] {
-    ret enc.emit_function_heading(buf.asm.out, interner, f.name, f.disp);
+    val out: *writer.Writer = buf.asm.out;
+    val res_nl: R.Result[bool, str] = emit_str(out, "\n# ");
+    if (R.is_err[bool, str](res_nl)) { ret res_nl; }
+    val res_name: R.Result[bool, str] = emit_interned(out, interner, f.name);
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    ret emit_str(out, ":\n");
 }
 
 # render one block's local label

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -3191,7 +3191,6 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
     head.kind = encode.ASM_NOTE_FUNC;
     head.off  = st.buf.len::u32;
     head.name = f.name;
-    head.disp = f.disp;
     val rh: R.Result[bool, str] = encode.note_push(?st.buf, ?head);
     if (R.is_err[bool, str](rh)) { ret rh; }
 

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -83,7 +83,11 @@ pub fun render_notes(buf: *enc.ByteBuf) R.Result[bool, str] {
 # ret:      true on success, or the first write error
 fun render_note(out: *writer.Writer, interner: *intern.Interner, n: *enc.AsmNote) R.Result[bool, str] {
     if (n.kind == enc.ASM_NOTE_FUNC) {
-        ret enc.emit_function_heading(out, interner, n.name, n.disp);
+        val res_open: R.Result[bool, str] = emit_str(out, "\n# ");
+        if (R.is_err[bool, str](res_open)) { ret res_open; }
+        val res_name: R.Result[bool, str] = emit_name(out, interner, n.name);
+        if (R.is_err[bool, str](res_name)) { ret res_name; }
+        ret emit_str(out, ":\n");
     }
     if (n.kind == enc.ASM_NOTE_BLOCK) {
         val res_label: R.Result[bool, str] = emit_block(out, n.id);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2926,7 +2926,7 @@ fun named_message(alloc: *A.Allocator, interner: *intern.Interner, prefix: str, 
 
 # the encoder function's source name, or "<unknown>" when unresolved
 fun enc_fn_name(st: *enc.EncodeState, f: *mir.MirFunction) str {
-    val fno: O.Option[str] = intern.lookup(st.interner, mir.function_display(f));
+    val fno: O.Option[str] = intern.lookup(st.interner, f.name);
     if (O.is_some[str](fno)) { ret O.unwrap[str](fno); }
     ret "<unknown>";
 }

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -65,7 +65,12 @@ pub fun emit_header(out: *writer.Writer) R.Result[bool, str] {
 # f:        the function whose encoding is starting
 # ret:      true on success, or the write error
 pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.MirFunction) R.Result[bool, str] {
-    ret enc.emit_function_heading(buf.asm.out, interner, f.name, f.disp);
+    val out: *writer.Writer = buf.asm.out;
+    val res_nl: R.Result[bool, str] = emit_str(out, "\n# ");
+    if (R.is_err[bool, str](res_nl)) { ret res_nl; }
+    val res_name: R.Result[bool, str] = emit_name(out, interner, f.name);
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    ret emit_str(out, ":\n");
 }
 
 # render one block's local label


### PR DESCRIPTION
Reverts #2785 in full, at the owner's direction.

The change was dispatched on a misreading. The owner had said explicitly that mangled names in diagnostics and IR were **not** something they were reacting to, and I treated it as the motivation anyway. The display method was fine as it was. What they actually want changed is the **mangling scheme itself**, which is separate in-progress work.

All four parts go back: the IR printer, the diagnostic sites, the `--emit-asm` headings, and `MirFunction`'s `disp` field with the shared `function_display` helpers.

One design objection worth recording, since it argues the revert is right on the merits and not only on scope: making the bare source name primary in IR meant two `echo` functions from different modules both printed `@echo`, with the distinguishing linkage name demoted to a trailing `symbol "..."` clause. For IR specifically, where the common task is correlating a function to its object symbol or its emitted assembly, that is arguably worse than what it replaced.

Verified on this branch: `mach test .` **1297 passed, 0 failed**, and the `vector-mul-scalar-shortfall` goldens are back to `'_M4case4mainN5mul64'`.

The shell-demangler deduplication in `int/lib/produce.sh` goes back with it. That one was a genuine improvement, one copy of the grammar instead of two, and is worth re-landing on its own if anyone wants it.