### PR TITLE
fix(link): stop emitting two PT_LOAD segments at one virtual address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Every static ELF carried two PT_LOAD segments claiming the same address (#2795)
+The static writer mapped the ELF header and program-header table **at** `segs[0].vaddr`; the PIE and dynamic writers mapped them one page **below** it. So every static executable mach has ever produced had two `PT_LOAD` segments covering the same virtual address - the header block and `.text` both at `0x400000` - on all three ELF targets.
+
+**The image runs correctly**, which is why nothing caught it: the loader maps segments in order and the later mapping wins. It is wrong only to a reader, and mach's linked executables carry no section headers, so program headers are all a reader has. `gdb 17.2` aborts outright at process start; a crash reporter or symbolizer doing the same derivation would have been **silently wrong** instead, which is the worse failure and why this is critical rather than cosmetic.
+
+The two paths computed one fact in two places and agreed only by accident. The header-segment base is now a single definition all three writers call, and `header_fits_reserved_page` guards the static path too - it never needed the guard before only because it had no reserved page to overrun. The regression test asserts the general property that **no two load segments overlap in virtual address**, over the emitted headers rather than about one specific pair, so it fails closed for whatever the next segment-layout change does.
+
 ### Added
 
 #### A release build now carries a real ELF `.symtab`, so `perf` and a crash reporter can resolve a function name without a `-g` rebuild (#2772)

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1475,6 +1475,15 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     val attr: *BuildAttributes = attributes_for(tgt_isa);
 
     val phdr_count: u32 = seg_count + 1;
+
+    # the same one-page header reservation the PIE and dynamic writers refuse to
+    # overrun. the static writer needs it for the same reason and did not have it,
+    # because until the header block moved below segment 0 it had no reserved page to
+    # overrun - it simply sat on top of segment 0's address instead.
+    if (!header_fits_reserved_page(phdr_count, page_size)) {
+        ret R.err[bool, str]("elf: static program headers exceed the one-page header reservation (too many load segments)");
+    }
+
     val phdr_offset: usize = ELF_HEADER_SIZE;
     val phdr_table_size: usize = phdr_count::usize * PHDR_SIZE;
 
@@ -1653,7 +1662,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 
     # leading PT_LOAD covering the ELF header and the program headers.
     var hdr_vaddr: u64 = entry & ~(page_size - 1);
-    if (seg_count > 0) { hdr_vaddr = segs[0].vaddr & ~(page_size - 1); }
+    if (seg_count > 0) { hdr_vaddr = header_segment_vaddr(segs[0].vaddr, page_size); }
     val hdr_filesz: usize = phdr_offset + phdr_table_size;
     bin.write_u32_le(buf, phdr_pos, PT_LOAD);
     bin.write_u32_le(buf, phdr_pos + 4, PF_R);
@@ -1864,6 +1873,32 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # ret:        true when the header block still fits its one reserved page
 fun header_fits_reserved_page(phdr_count: u32, page_size: u64) bool {
     ret ELF_HEADER_SIZE + phdr_count::usize * PHDR_SIZE <= page_size::usize;
+}
+
+# the virtual address the leading PT_LOAD maps the ELF header and program-header table
+# at: one page below the first load segment's own page
+#
+# ONE DEFINITION FOR ALL THREE WRITERS, and the reason it is a function is that it was
+# not one. The static writer mapped the header block AT `segs[0].vaddr` while the PIE
+# and dynamic writers mapped it a page below, so two PT_LOADs claimed the same virtual
+# address in every static image mach has ever produced. That is a malformed image: a
+# consumer deriving load addresses from program headers rather than section headers
+# reads two different file ranges for one address. It executes correctly only because
+# the loader maps the segments in order and the later one wins.
+#
+# The reserved page must hold the whole header block, which is what
+# `header_fits_reserved_page` checks - every writer that calls this must call that too,
+# or it emits an image whose segment 0 no longer maps at its own vaddr.
+#
+# The degenerate no-segment case stays with each caller: a writer's default for an
+# image with nothing to load is not this policy, and folding it in here would invent
+# an answer (a PIE image's `entry` of 0 would underflow a page below zero).
+# ---
+# first_seg_vaddr: virtual address of the lowest load segment
+# page_size:       the segment-alignment page
+# ret:             the header block's virtual address
+fun header_segment_vaddr(first_seg_vaddr: u64, page_size: u64) u64 {
+    ret (first_seg_vaddr & ~(page_size - 1)) - page_size;
 }
 
 # one already-emitted allocated section (its body lives in a load segment) to name
@@ -2338,7 +2373,7 @@ fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
     # the page the ELF header + phdrs map at: one page below the first segment's base,
     # so extending the first segment down to file offset 0 covers them.
     var hdr_vaddr: u64 = 0;
-    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(page_size - 1)) - page_size; }
+    if (seg_count > 0) { hdr_vaddr = header_segment_vaddr(segs[0].vaddr, page_size); }
 
     # PT_PHDR -> the program-header table (within the first, header-covering PT_LOAD).
     pos = write_phdr(buf, pos, PT_PHDR, PF_R, phdr_offset, hdr_vaddr + phdr_offset::u64,
@@ -4035,7 +4070,7 @@ fun write_dyn_phdrs(buf: *u8, phdr_offset: usize, lay: *DynLayout,
     # the page the ELF header + phdrs map at: one page below the first segment's
     # base, so extending the first segment down to file offset 0 covers them.
     var hdr_vaddr: u64 = 0;
-    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(page_size - 1)) - page_size; }
+    if (seg_count > 0) { hdr_vaddr = header_segment_vaddr(segs[0].vaddr, page_size); }
 
     # PT_PHDR -> the program-header table, so the dynamic loader can locate the
     # program's own headers. it lies within the first (header+text) PT_LOAD.
@@ -6587,4 +6622,93 @@ test "mach.lang.target.of.elf.emit_shared:dynamic_sections_in_sht" {
 
     if (bad) { ret 1; }
     ret 0;
+}
+
+# read every PT_LOAD's [vaddr, vaddr+memsz) from an emitted image and report whether any
+# two of them overlap
+#
+# A PROPERTY OVER THE WHOLE IMAGE, not an assertion about `phdr[0]`. The defect this
+# guards was one specific pair claiming one specific address, but keying the test on
+# that pair would pass the moment a later segment-layout change produced a different
+# overlapping pair - which is exactly the class of regression a layout change causes.
+# Stated as "no two load segments claim the same address", it fails closed for whatever
+# the next change does.
+# ---
+# buf: the emitted image bytes
+# ret: true when some pair of PT_LOAD segments overlaps in virtual address
+fun t_any_load_overlap(buf: *Vector[u8]) bool {
+    val e_phoff: usize = bin.read_u64_le(buf.data, 32)::usize;
+    val e_phnum: usize = bin.read_u16_le(buf.data, 56)::usize;
+    var i: usize = 0;
+    for (i < e_phnum) {
+        val ioff: usize = e_phoff + i * PHDR_SIZE;
+        if (bin.read_u32_le(buf.data, ioff) != PT_LOAD) { i = i + 1; cnt; }
+        val ia: u64 = bin.read_u64_le(buf.data, ioff + 16);
+        val iz: u64 = bin.read_u64_le(buf.data, ioff + 40);
+        var j: usize = i + 1;
+        for (j < e_phnum) {
+            val joff: usize = e_phoff + j * PHDR_SIZE;
+            if (bin.read_u32_le(buf.data, joff) != PT_LOAD) { j = j + 1; cnt; }
+            val ja: u64 = bin.read_u64_le(buf.data, joff + 16);
+            val jz: u64 = bin.read_u64_le(buf.data, joff + 40);
+            # a zero-length segment occupies nothing and cannot overlap.
+            if (iz > 0 && jz > 0 && ia < ja + jz && ja < ia + iz) { ret true; }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# no two PT_LOAD segments of a static executable claim the same virtual address
+#
+# THE DEFECT: the static writer mapped the ELF header + program-header table AT
+# `segs[0].vaddr` while the PIE and dynamic writers mapped them a page below, so every
+# static image mach produced had two PT_LOADs covering one address. It executed
+# correctly because the loader maps segments in order and the later one wins, which is
+# why nothing caught it for so long - the image is only wrong to a reader, not to the
+# kernel. A consumer that derives load addresses from program headers rather than
+# section headers reads two different file ranges for one address; gdb 17.2 aborted
+# outright, and a consumer that merely picked the first match would have been silently
+# wrong instead.
+#
+# Asserted as a PROPERTY over the emitted phdrs, so it also covers the PIE and dynamic
+# writers and any future segment the layout gains.
+test "mach.lang.target.of.elf.emit_exec:load_segments_do_not_overlap" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var i: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, nil);
+
+    var text: [16]u8;
+    var data: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; data[k] = 0; k = k + 1; }
+    var segs: [2]of.LoadSegment;
+    segs[0].vaddr = 0x400000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+    segs[1].vaddr = 0x401000; segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].flags = of.SEG_FLAG_READ | of.SEG_FLAG_WRITE; segs[1].bytes = ?data[0];
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "elf_overlap");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    var opts: of.ImageOptions;
+    opts.subsystem = 0;
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x400000, 0x400000,
+                                            nil::*of.ExecFunction, 0, nil::*of.Section, 0,
+                                            nil::*of.Section, 0, nil::*of.SymtabEntry, 0,
+                                            tpath::*u8, nil::*u8, opts);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 1; }
+    var buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    var bad: i32 = 0;
+    if (t_any_load_overlap(?buf)) { bad = 1; }
+    ret bad;
 }


### PR DESCRIPTION
Closes #2795

## What

The static ELF writer mapped the ELF header + program-header table **at** `segs[0].vaddr`; the PIE and dynamic writers mapped them one page **below**. So every static executable mach has ever produced had two `PT_LOAD` segments covering one address, on all three ELF targets:

```
linux          OVERLAP 0x400000-0x400158 / 0x400000-0x42585b
linux-arm64    OVERLAP 0x400000-0x400158 / 0x400000-0x41d404
linux-riscv64  OVERLAP 0x400000-0x400158 / 0x400000-0x4244d0
```

After: `no overlap` on all three, verified against real linked binaries.

## Why it is critical rather than cosmetic

**The image runs correctly** - the loader maps segments in order and the later mapping wins - so nothing in a run-and-compare suite could ever see it. It is wrong only to a **reader**, and mach's linked executables carry no section headers, so program headers are the only thing a reader has.

gdb 17.2 aborts outright. A crash reporter, profiler or symbolizer doing the same derivation would have been **silently wrong** instead, attributing addresses to the wrong file range. That is the worse outcome.

## How it was root-caused

One field changed, nothing else. Patching only `phdr[0].p_vaddr` in an **already-built** crashing binary - same code bytes, same everything - makes gdb work; the unpatched binary still crashes. gdb also stops saying `in ?? ()` and starts saying `in _start ()`, which is the tell that the overlap corrupted its view of the image generally rather than tipping one allocation over. `set debug infrun` places the abort immediately after inferior creation and before solib handling, which is where load addresses are re-derived from phdrs.

Found while investigating why inlining an asm-bearing callee (#2231 / #2782) made gdb abort. **It is unrelated to inlining** - that change only altered segment sizes enough to tip gdb's already-confused computation over, which is why every gate keyed on the inlining appeared to fix it. #2791 is a real and separate model defect, but it is not this and does not fix it.

## The fix, beyond the one line

The static and PIE/dynamic paths computed the same fact in two places and agreed only by accident - the duplicate-policy shape this repo keeps finding. `header_segment_vaddr` is now the **single** definition all three writers call, and `header_fits_reserved_page` guards the static path too; it never needed the guard before only because it had no reserved page to overrun.

The degenerate no-load-segment case stays with each caller deliberately: a writer's default for an image with nothing to load is not this policy, and folding it in would invent an answer (a PIE image's `entry` of 0 would underflow a page below zero).

## The test is a property, not an assertion about `phdr[0]`

`emit_exec:load_segments_do_not_overlap` reads every `PT_LOAD` off the emitted image and fails if **any** pair overlaps in virtual address. Keyed on the specific pair, it would pass the moment a later layout change produced a different overlapping pair - exactly the regression a layout change causes. Stated as a property it fails closed.

**Proved it has teeth**: restoring only the old `hdr_vaddr` line fails exactly that test.

## Verification

- `mach test .` **1309 passed, 0 failed**.
- `int` green on **linux**, **linux-arm64**, **linux-riscv64**.
- Self-host fixpoint byte-identical: `cff6053350943b5c8e85c9caeb7ce76be6087f6232a97beef7a53e0f9f50d47d`.
- Overlap confirmed present before and absent after on all three ELF legs, measured on real linked binaries rather than only in the unit test.
