### PR TITLE
codegen: move a sub-width vector to memory in one instruction where the ISA has one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The two paths computed one fact in two places and agreed only by accident. The h
 
 ### Added
 
+#### A sub-width vector crosses to memory in one instruction where the ISA has one, instead of always going through a scratch slot (#2716)
+`i32x2` and `f32x2` cost a stack frame, a 16-byte scratch slot, a whole-register spill and a chunk walk through a GP register to move eight bytes. `copy_i32x2` on x86-64 was 13 instructions and a 32-byte frame; it is now 5 instructions and **no frame**, one `movsd` each way.
+
+Which widths can cross between a **vector register** and memory in one instruction is a declared per-ISA capability (`vec_mem_widths`), read only through `isa.moves_vector_memory`. x86-64 has `movss`/`movsd`/`movups` at 4, 8 and 16; aarch64 has `ldr`/`str` at the S, D and Q views. A width listed there also promises that a load of it **zeroes the lanes above it**, which is what lets the direct load keep the guarantee the scratch round trip provided: the lanes a type does not have read as a defined 0 rather than as frame residue.
+
+The 12-byte shapes stay on the scratch path, and that is the finding rather than a gap: the issue proposed gating on lane alignment, a predicate that is **true for every shape mach can spell** (every lane width is a power of two no greater than 8, so the greedy 8/4/2/1 walk is lane-aligned by induction — its `i16x7` counterexample is arithmetically wrong, the 4-byte chunk at offset 8 covering lanes 4 and 5 exactly). A vacuous guard would have licensed a chunked direct access that neither baseline can encode: `pinsrd`/`pextrd` are SSE4.1 against an SSE2 baseline, and aarch64's single-structure `ld1 {v0.s}[2]` is a form this encoder does not emit yet. Both are pure additions later; until then the round trip covers those shapes, on a declared capability rather than by accident.
+
+Asserted on the emitted code (`int/surface/vector-subwidth-direct`, frame verdicts per shape per leg), because the lanes were already right — a run-and-compare case cannot see this at all.
 #### A shader can bind and sample a texture (#2794)
 The GPU decorator set covered `#[input]`, `#[output]`, `#[builtin]`, `#[uniform]` and `#[storage]`, and none of them declares an image. A shader that reads a texture could not be written at all, which is the remaining blocker for porting boom's shaders off GLSL - every one of them samples a texture.
 

--- a/int/surface/vector-subwidth-direct/case.conf
+++ b/int/surface/vector-subwidth-direct/case.conf
@@ -1,0 +1,45 @@
+# the DIRECT vector-memory access for sub-width shapes (#2716), read out of the
+# emitted code rather than out of the result.
+#
+# #2697 carries a vector narrower than the vector register between the register and
+# memory through a register-width SCRATCH SLOT, walking it in 8/4/2/1 chunks. That is
+# correct for every shape and costs a frame, a slot and a round trip through a GP
+# register. Where ONE instruction moves the whole footprint to or from a vector
+# register, that instruction is the access, and the function stops needing a frame at
+# all - which is exactly what this case reads.
+#
+# WHY THE FRAME IS THE OBSERVABLE. Each function here does nothing but copy one
+# vector field, so its only stack use is the scratch. `frameless` therefore means the
+# scratch is gone and `framed` means it is still there, and neither can be produced by
+# accident. The lanes are NOT the observable: the scratch round trip computes exactly
+# the right lanes, which is why `int/surface/vector-subwidth` stays green either way
+# and cannot see this at all. That case asserts the values; this one asserts the shape.
+#
+# WHY THE VERDICTS DIFFER PER LEG, and why that is the point rather than an
+# embarrassment. Which widths cross between a vector register and memory in one
+# instruction is an INSTRUCTION-SET fact, and the three ISAs genuinely differ:
+#
+#   linux (x86_64)   MOVSS / MOVSD / MOVUPS give 4, 8 and 16. A 12-byte `i32x3` needs
+#                    `pinsrd` / `pextrd`, which are SSE4.1 against an SSE2 baseline,
+#                    so it stays framed.
+#   linux-arm64      LDR / STR take B, H, S, D and Q views of one V register, so 1, 2,
+#                    4, 8 and 16 all qualify. 12 still does not: it would need the
+#                    single-structure `ld1 {v0.s}[2]` form, which the encoder does not
+#                    emit yet.
+#   linux-riscv64    no vector register file at all, so nothing crosses and every
+#                    vector is scalarized into memory. every verdict here is framed,
+#                    and that is the correct answer rather than a gap.
+#
+# THIS IS WHY THE ISSUE'S PREFERRED CANDIDATE WAS NOT IMPLEMENTED. It proposed taking
+# the direct path wherever the chunk boundaries fall on lane boundaries - a predicate
+# that is TRUE FOR EVERY SHAPE mach can spell, since every lane width is a power of
+# two no greater than 8 and the greedy 8/4/2/1 walk is therefore lane-aligned by
+# induction. Its `i16x7` counterexample does not hold either: the 4-byte chunk at
+# offset 8 covers lanes 4 and 5 exactly. A guard that cannot fail reads as protection
+# and gives none, and it would have licensed a chunked direct access on x86-64 that no
+# SSE2 instruction can encode.
+#
+# release only: a debug build spills enough that nothing is frameless to observe.
+run: frame-elision
+profiles: release
+targets: linux linux-arm64 linux-riscv64

--- a/int/surface/vector-subwidth-direct/expect.linux-arm64.txt
+++ b/int/surface/vector-subwidth-direct/expect.linux-arm64.txt
@@ -1,0 +1,14 @@
+arch=aarch64
+copy_f32x2 frameless
+copy_f32x3 framed
+copy_i16x2 frameless
+copy_i16x4 frameless
+copy_i16x7 framed
+copy_i32x2 frameless
+copy_i32x3 framed
+copy_i32x4 frameless
+copy_i8x2 framed
+copy_i8x3 framed
+copy_i8x4 frameless
+copy_i8x8 frameless
+main framed

--- a/int/surface/vector-subwidth-direct/expect.linux-riscv64.txt
+++ b/int/surface/vector-subwidth-direct/expect.linux-riscv64.txt
@@ -1,0 +1,14 @@
+arch=riscv64
+copy_f32x2 framed
+copy_f32x3 framed
+copy_i16x2 framed
+copy_i16x4 framed
+copy_i16x7 framed
+copy_i32x2 framed
+copy_i32x3 framed
+copy_i32x4 framed
+copy_i8x2 framed
+copy_i8x3 framed
+copy_i8x4 framed
+copy_i8x8 framed
+main framed

--- a/int/surface/vector-subwidth-direct/expect.linux.txt
+++ b/int/surface/vector-subwidth-direct/expect.linux.txt
@@ -1,0 +1,14 @@
+arch=x86_64
+copy_f32x2 frameless
+copy_f32x3 framed
+copy_i16x2 frameless
+copy_i16x4 frameless
+copy_i16x7 framed
+copy_i32x2 frameless
+copy_i32x3 framed
+copy_i32x4 frameless
+copy_i8x2 framed
+copy_i8x3 framed
+copy_i8x4 frameless
+copy_i8x8 frameless
+main framed

--- a/int/surface/vector-subwidth-direct/mach.toml
+++ b/int/surface/vector-subwidth-direct/mach.toml
@@ -1,0 +1,41 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed out root, not the usual {target.name}/{profile.name} template: the
+# frame-elision producer disassembles the per-module objects this build leaves
+# behind, so their path must be the same on every leg. run.sh wipes out/int before
+# and after each build, so one target's objects can never be read on another's run.
+out = "out/int/build"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/vector-subwidth-direct/src/main.mach
+++ b/int/surface/vector-subwidth-direct/src/main.mach
@@ -1,0 +1,103 @@
+# The direct vector-memory access for sub-width shapes (#2716).
+#
+# Every function is a bare field copy of one vector shape, so its only possible stack
+# use is the scratch slot the round trip needs. `frameless` in the golden means the
+# access was one instruction against the real address; `framed` means the round trip
+# is still there, which is the correct answer for a shape no single instruction moves.
+#
+# The shapes are grouped by footprint, because the footprint is what the capability is
+# keyed on - not the lane width, not the lane count, and not lane alignment.
+#
+# Each copy is reached through a module-scope function-pointer hook, exactly as
+# `frame-elision` does it: a function the inliner folds into its caller emits no
+# prologue at all, and its verdict would vanish from the golden rather than fail it.
+
+use std.runtime;
+use std.types.size.usize;
+
+# ONE BYTE and TWO BYTES: nothing on x86-64, which has no 1- or 2-byte XMM move; one
+# LDR B / LDR H on aarch64.
+rec B2  { v: i8x2; }
+rec B3  { v: i8x3; }
+rec H2  { v: i16x2; }
+
+# FOUR BYTES: MOVSS on x86-64, LDR S on aarch64.
+rec S4  { v: i8x4; }
+
+# EIGHT BYTES: MOVSD on x86-64, LDR D on aarch64. This is `vec2`, the shape after
+# `vec3` and `vec4` a program is most likely to have a lot of.
+rec D8a { v: i32x2; }
+rec D8b { v: f32x2; }
+rec D8c { v: i16x4; }
+rec D8d { v: i8x8; }
+
+# TWELVE BYTES: the shape the issue was filed about, and the one no baseline here
+# moves in a single instruction in either direction. It stays framed on every leg,
+# which is the finding the issue's own preferred design would have got wrong.
+rec T12  { v: i32x3; }
+rec T12f { v: f32x3; }
+
+# FOURTEEN BYTES: the issue's `i16x7`. Also no single move, also still framed.
+rec X14 { v: i16x7; }
+
+# SIXTEEN BYTES: fills the register, so this path is not reached at all - the whole
+# vector moves as one MOVUPS / LDR Q the way it always has. Here so a change that
+# broke the register-filling shapes cannot look like one that improved the narrow ones.
+rec Q16 { v: i32x4; }
+
+pub fun copy_i8x2(d: *B2, s: *B2)     { d.v = s.v; }
+pub fun copy_i8x3(d: *B3, s: *B3)     { d.v = s.v; }
+pub fun copy_i16x2(d: *H2, s: *H2)    { d.v = s.v; }
+pub fun copy_i8x4(d: *S4, s: *S4)     { d.v = s.v; }
+pub fun copy_i32x2(d: *D8a, s: *D8a)  { d.v = s.v; }
+pub fun copy_f32x2(d: *D8b, s: *D8b)  { d.v = s.v; }
+pub fun copy_i16x4(d: *D8c, s: *D8c)  { d.v = s.v; }
+pub fun copy_i8x8(d: *D8d, s: *D8d)   { d.v = s.v; }
+pub fun copy_i32x3(d: *T12, s: *T12)  { d.v = s.v; }
+pub fun copy_f32x3(d: *T12f, s: *T12f){ d.v = s.v; }
+pub fun copy_i16x7(d: *X14, s: *X14)  { d.v = s.v; }
+pub fun copy_i32x4(d: *Q16, s: *Q16)  { d.v = s.v; }
+
+def CopyB2:  fun(*B2, *B2);
+def CopyB3:  fun(*B3, *B3);
+def CopyH2:  fun(*H2, *H2);
+def CopyS4:  fun(*S4, *S4);
+def CopyD8a: fun(*D8a, *D8a);
+def CopyD8b: fun(*D8b, *D8b);
+def CopyD8c: fun(*D8c, *D8c);
+def CopyD8d: fun(*D8d, *D8d);
+def CopyT12: fun(*T12, *T12);
+def CopyT12f: fun(*T12f, *T12f);
+def CopyX14: fun(*X14, *X14);
+def CopyQ16: fun(*Q16, *Q16);
+
+# the indirection that keeps every copy above out of line
+var hook_i8x2:  CopyB2  = copy_i8x2;
+var hook_i8x3:  CopyB3  = copy_i8x3;
+var hook_i16x2: CopyH2  = copy_i16x2;
+var hook_i8x4:  CopyS4  = copy_i8x4;
+var hook_i32x2: CopyD8a = copy_i32x2;
+var hook_f32x2: CopyD8b = copy_f32x2;
+var hook_i16x4: CopyD8c = copy_i16x4;
+var hook_i8x8:  CopyD8d = copy_i8x8;
+var hook_i32x3: CopyT12 = copy_i32x3;
+var hook_f32x3: CopyT12f = copy_f32x3;
+var hook_i16x7: CopyX14 = copy_i16x7;
+var hook_i32x4: CopyQ16 = copy_i32x4;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var b2: B2;   var b2d: B2;   hook_i8x2(?b2d, ?b2);
+    var b3: B3;   var b3d: B3;   hook_i8x3(?b3d, ?b3);
+    var h2: H2;   var h2d: H2;   hook_i16x2(?h2d, ?h2);
+    var s4: S4;   var s4d: S4;   hook_i8x4(?s4d, ?s4);
+    var d8a: D8a; var d8ad: D8a; hook_i32x2(?d8ad, ?d8a);
+    var d8b: D8b; var d8bd: D8b; hook_f32x2(?d8bd, ?d8b);
+    var d8c: D8c; var d8cd: D8c; hook_i16x4(?d8cd, ?d8c);
+    var d8d: D8d; var d8dd: D8d; hook_i8x8(?d8dd, ?d8d);
+    var t12: T12; var t12d: T12; hook_i32x3(?t12d, ?t12);
+    var t12f: T12f; var t12fd: T12f; hook_f32x3(?t12fd, ?t12f);
+    var x14: X14; var x14d: X14; hook_i16x7(?x14d, ?x14);
+    var q16: Q16; var q16d: Q16; hook_i32x4(?q16d, ?q16);
+    ret 0;
+}

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -938,6 +938,24 @@ pub fun store_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOp
     if (mem_w > reg_w) {
         ret R.err[bool, str]("mir.context.store_subwidth_vector: vector wider than the target's vector register; an over-width vector's placement is a split, not a single move");
     }
+    # THE DIRECT STORE (#2716): when one instruction moves exactly this footprint out
+    # of a vector register, that instruction IS the store - no scratch slot, no chunk
+    # walk, no GP register in the middle. `f32x2` and `i32x2` become one MOVSD or one
+    # `str d`, where they used to be a spill, two chunk copies and a slot.
+    #
+    # ASKED OF THE TARGET, not derived from the size. Whether a width crosses between
+    # a vector register and memory is an instruction-set fact and nothing else
+    # predicts it: 12 bytes is as lane-aligned as 8 and no baseline here moves it.
+    if (isa.moves_vector_memory(?ctx.tgt.model, mem_w::u32)) {
+        val dr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (R.is_err[*mir.MirOperand, str](dr)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](dr)); }
+        val dops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](dr);
+        dops[0] = dest;
+        dops[1] = value;
+        var di: mir.MirInstr = mir.instr(mir.MIR_STORE, dops, 2, mem_w, mem_w);
+        di.vec_lane = vec_lane_for_type(ctx, ty);
+        ret push_instr(ctx, mb, di);
+    }
     # the scratch is the REGISTER's width and the vector's own alignment, so the
     # whole-register spill into it is a legal aligned access.
     val align: u32 = ir_type.byte_align(ctx.types, ty, ctx.tgt);
@@ -1008,6 +1026,24 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
     val reg_w: u8 = op_width_of(ctx, ty);
     if (mem_w > reg_w) {
         ret R.err[bool, str]("mir.context.load_subwidth_vector: vector wider than the target's vector register; an over-width vector's placement is a split, not a single move");
+    }
+    # THE DIRECT LOAD (#2716), the mirror of the store's, and it satisfies BOTH of the
+    # reasons the scratch exists rather than only the obvious one. It reads exactly
+    # the object's own bytes, so an object ending at a page boundary does not fault;
+    # and the lanes past the footprint come back DEFINED ZERO, because zeroing them is
+    # part of what a target promises by declaring the width at all (`movss` / `movsd`
+    # and `ldr s` / `ldr d` all clear the bits above their operand). A width whose
+    # narrow load merged into the destination would leave frame residue in the lanes
+    # the type does not have, which is the leak this path must not open.
+    if (isa.moves_vector_memory(?ctx.tgt.model, mem_w::u32)) {
+        val dr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (R.is_err[*mir.MirOperand, str](dr)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](dr)); }
+        val dops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](dr);
+        dops[0] = dst;
+        dops[1] = src;
+        var di: mir.MirInstr = mir.instr(mir.MIR_LOAD, dops, 2, mem_w, mem_w);
+        di.vec_lane = vec_lane_for_type(ctx, ty);
+        ret push_instr(ctx, mb, di);
     }
     val align: u32 = ir_type.byte_align(ctx.types, ty, ctx.tgt);
     val skr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -394,6 +394,22 @@ pub val VECTOR_BITS_128: u32 = 128;
 # rather than as an unset field.
 pub val VECTOR_LANES_UNBOUNDED: u32 = 0;
 
+# no width crosses between a vector register and memory in one instruction (#2716)
+#
+# The `vec_mem_widths` a target declares when it has no vector register file at all
+# (rv64gc, mos6502) or when it has no addressable memory for one to cross to
+# (SPIR-V's logical addressing). Every sub-width access on such a target is the
+# scratch round trip, or is not reached at all.
+pub val VEC_MEM_NONE: u32 = 0;
+
+# the widths a 128-bit SIMD unit with scalar-float sublanes moves to and from memory
+#
+# 4, 8 and 16: `movss` / `movsd` / `movups` on x86-64, and the S / D / Q views of one
+# V register on aarch64. Spelled as the sum of the widths because `vec_mem_widths` is
+# a mask whose bit for a width IS that width, so the declaration reads as the list it
+# is.
+pub val VEC_MEM_4_8_16:  u32 = 4 + 8 + 16;
+
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;
@@ -443,6 +459,38 @@ pub rec MachineModel {
     vector_compute_generic: bool;
     has_lane_ops:      bool;
     has_vec_build:     bool;
+
+    # the widths, in bytes, this ISA moves between a VECTOR REGISTER and MEMORY in one
+    # instruction, as a bitmask whose bit for a width IS that width (#2716)
+    #
+    # A declared capability, and a different question from every other vector fact
+    # here: `has_v128` is whether packed compute exists, `has_lane_ops` is whether a
+    # lane crosses between a vector register and a GP one, and this is which widths
+    # cross between a vector register and memory. x86-64 has MOVSS / MOVSD / MOVUPS at
+    # 4, 8 and 16; aarch64 has LDR / STR at the S, D and Q views of one V register.
+    #
+    # THE CONTRACT A TARGET SIGNS BY DECLARING A WIDTH: a LOAD of that width into a
+    # vector register leaves the lanes above it DEFINED ZERO. Both ISAs satisfy it
+    # (MOVSS / MOVSD zero the bits above their operand; an `ldr s` / `ldr d` zeroes the
+    # upper half of the V register), and it is not decoration - the sub-width path
+    # exists partly so the lanes a type does not have read as 0 rather than as frame
+    # residue, which is a leak question and not a tidiness one. An ISA whose narrow
+    # vector load MERGES into the destination must not list that width here.
+    #
+    # IT DESCRIBES WHAT THE BACK END EMITS, not what the architecture has. aarch64 also
+    # has B and H views, so 1 and 2 bytes would qualify on paper - and declaring them
+    # while the encoder has no float memory form at those widths would turn an `i8x2`
+    # copy into an internal compiler error rather than into a faster one.
+    #
+    # WHAT IT DOES NOT PROMISE is a chunked walk. A footprint this set does not cover
+    # in ONE move still takes the scratch round trip, because moving a chunk to or
+    # from a vector register AT AN OFFSET is a third capability again - `pinsrd` is
+    # SSE4.1 against an SSE2 baseline, and aarch64's `ld1 {v0.s}[2]` is a form the
+    # encoder does not emit yet. So `i32x2` and `f32x2` are one move and `i32x3` is
+    # still the round trip, which is the opposite of what #2716 assumed when it
+    # reasoned from lane alignment rather than from the instruction set.
+    vec_mem_widths:    u32;
+
     ct_trust_mul:      bool;
 
     # whether the ISA can shift by a RUNTIME count at all (#2217). false on a machine
@@ -611,6 +659,42 @@ pub fun packed_lane_cap(m: *MachineModel, lane_bits: u32) u32 {
     val w: u32 = packed_extent(m, lane_bits);
     if (w == 0) { ret 0; }
     ret w / lane_bits;
+}
+
+# the `vec_mem_widths` bit for a width in bytes, or 0 when the width is not one this
+# encoding describes
+#
+# Widths are powers of two from 1 to 16, which is every width a vector register moves
+# at on any ISA here. Anything else answers 0 and therefore never matches, so a caller
+# handing over a 12-byte footprint gets "no" rather than an out-of-range shift.
+fun vec_mem_bit(bytes: u32) u32 {
+    if (bytes == 1)  { ret 1; }
+    if (bytes == 2)  { ret 2; }
+    if (bytes == 4)  { ret 4; }
+    if (bytes == 8)  { ret 8; }
+    if (bytes == 16) { ret 16; }
+    ret 0;
+}
+
+# THE DIRECT-ACCESS QUESTION (#2716): can this target move `bytes` between a vector
+# register and memory in ONE instruction
+#
+# The single door onto `vec_mem_widths`, so no caller reads the mask itself and no
+# caller re-derives the width set from `vector_bits` - which is the mistake that would
+# claim a 12-byte move on a 16-byte register.
+#
+# False means the scratch round trip, which is correct on every target and is what
+# every shape used before this existed. So a target that declares nothing here loses
+# no correctness and only pays the round trip, which is why the default is empty.
+# ---
+# m:     the target's machine model
+# bytes: the footprint to move
+# ret:   true when one instruction moves exactly that many bytes to or from a vector
+#        register, zeroing the lanes above it on a load
+pub fun moves_vector_memory(m: *MachineModel, bytes: u32) bool {
+    val b: u32 = vec_mem_bit(bytes);
+    if (b == 0) { ret false; }
+    ret (m.vec_mem_widths & b) != 0;
 }
 
 # the concrete signature the erased `RegMachine.asm_clobbers` pointer is cast back to

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -258,6 +258,20 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no lane-count ceiling: this vector unit is described completely by its register
     # width, so the lane count follows from the width and the lane size (#2749)
     arm64_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
+    # LDR / STR at the S, D and Q views of one V register cross to memory at 4, 8 and
+    # 16 bytes, and each zeroes the lanes above its operand on a load, which is the
+    # contract this field carries (#2716).
+    #
+    # THE FIELD DESCRIBES WHAT THE BACK END EMITS, NOT WHAT THE ISA HAS, and aarch64
+    # is where the two differ. The architecture also has B and H views, so 1 and 2
+    # bytes would qualify on paper - but this encoder has no float memory form at
+    # those widths and refuses them, so declaring them here would turn an `i8x2` copy
+    # into an internal compiler error rather than into a faster one. The same holds
+    # one step further out: the single-structure `ld1 {v0.s}[2]` forms would cover a
+    # chunked walk at an OFFSET, which is what a 12-byte vector needs, and they are
+    # absent here for the same reason. Both are pure additions whenever the encoder
+    # grows the forms; until then the scratch round trip covers those shapes.
+    arm64_model.vec_mem_widths  = isa.VEC_MEM_4_8_16;
     arm64_packed_gaps[0].op = isa.VEC_OP_MUL; arm64_packed_gaps[0].is_float = false; arm64_packed_gaps[0].lane_bits = 64;
     arm64_model.packed_gaps     = ?arm64_packed_gaps[0];
     arm64_model.packed_gap_len  = 1;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -125,6 +125,8 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no lane-count ceiling: this vector unit is described completely by its register
     # width, so the lane count follows from the width and the lane size (#2749)
     mos6502_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
+    # no vector register file, so nothing crosses between one and memory (#2716)
+    mos6502_model.vec_mem_widths  = isa.VEC_MEM_NONE;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -295,6 +295,8 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no lane-count ceiling: this vector unit is described completely by its register
     # width, so the lane count follows from the width and the lane size (#2749)
     riscv64_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
+    # no vector register file, so nothing crosses between one and memory (#2716)
+    riscv64_model.vec_mem_widths  = isa.VEC_MEM_NONE;
     riscv64_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -103,6 +103,9 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # authority folds the two bounds, so 8-bit lanes report a 32-bit packed form and a
     # wider shape realizes as the scalar expansion rather than as a refusal.
     spirv_model.max_vector_lanes       = types.MAX_VECTOR_COMPONENTS;
+    # logical addressing: a value has no byte footprint and no register to cross from,
+    # so the question this field answers does not arise here (#2716)
+    spirv_model.vec_mem_widths         = isa.VEC_MEM_NONE;
     # no packed-form gaps (#2726): SPIR-V's arithmetic opcodes are defined over
     # vectors of any component type and count, so `OpIMul` covers every lane width a
     # machine ISA has to special-case. The empty list is a statement about the target,

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -310,6 +310,12 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no lane-count ceiling: this vector unit is described completely by its register
     # width, so the lane count follows from the width and the lane size (#2749)
     x64_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
+    # MOVSS / MOVSD / MOVUPS cross between an XMM register and memory at 4, 8 and 16
+    # bytes, and the two narrow forms zero the lanes above their operand on a load,
+    # which is the contract this field carries (#2716). 12 is deliberately absent:
+    # covering it needs `pinsrd` / `pextrd`, which are SSE4.1 and this baseline is
+    # SSE2, so a 12-byte vector still takes the scratch round trip.
+    x64_model.vec_mem_widths  = isa.VEC_MEM_4_8_16;
     x64_packed_gaps[0].op = isa.VEC_OP_MUL; x64_packed_gaps[0].is_float = false; x64_packed_gaps[0].lane_bits = 8;
     x64_packed_gaps[1].op = isa.VEC_OP_MUL; x64_packed_gaps[1].is_float = false; x64_packed_gaps[1].lane_bits = 32;
     x64_packed_gaps[2].op = isa.VEC_OP_MUL; x64_packed_gaps[2].is_float = false; x64_packed_gaps[2].lane_bits = 64;


### PR DESCRIPTION
Closes #2716

## What

#2697 carries a vector narrower than the vector register between the register and memory through a register-width **scratch slot**, walking the object's own bytes in 8/4/2/1 chunks through a GP register. That is correct for every shape and costs a frame, a slot and a round trip to move eight bytes.

Where **one instruction** moves the whole footprint between a vector register and memory, that instruction is now the access. Measured, x86-64 release:

```
copy_i32x2, before: 13 instructions, 32-byte frame
copy_i32x2, after:   5 instructions, no frame   (movsd in, movsd out)
```

Which widths those are is a declared per-ISA capability, `vec_mem_widths`, read only through `isa.moves_vector_memory`. x86-64 and aarch64 both declare 4, 8 and 16. A target that declares nothing keeps the round trip and loses no correctness, which is why the default is empty.

**Declaring a width also signs a contract**: a load of it leaves the lanes above it *defined zero*. That is what lets the direct load keep the guarantee the scratch provided - the lanes a type does not have read as 0 rather than as frame residue, which the round trip's own comment records as a leak concern rather than a tidiness one. `movss` / `movsd` and `ldr s` / `ldr d` all satisfy it; an ISA whose narrow vector load merges must not list the width.

## This is candidate (3), and the issue's preferred (2) is unimplementable as written

The issue prefers a **lane-alignment predicate**. Enumerated exhaustively, that predicate is **true for every shape mach can spell**: every lane width is a power of two no greater than 8, so the greedy 8/4/2/1 walk is lane-aligned by induction. Its `i16x7` counterexample is arithmetically wrong - 14 bytes walks as 8 + 4 + 2, and the 4-byte chunk at offset 8 covers lanes 4 and 5 *exactly*, because 8 is a multiple of 2.

A guard that cannot fail reads as protection and gives none. Worse here, it would have licensed a **chunked** direct access, which is a different capability again: writing a chunk to a vector register at an offset needs `pinsrd` / `pextrd` (SSE4.1, against an SSE2 baseline) or aarch64's single-structure `ld1 {v0.s}[2]` (a form this encoder does not emit). So the 12-byte `i32x3` the issue was filed about **stays on the scratch path** - the opposite of what it assumed - and `i32x2` / `f32x2` are the shapes that win.

Both missing forms are pure additions later. The capability is where they get declared when they land.

## Testing

`int/surface/vector-subwidth-direct` asserts the **emitted shape** (frame verdict per footprint per leg), not the lanes: the lanes were already right, so a run-and-compare case is vacuously green against this whole change. Blessed on all three ELF legs, and the verdicts differ per leg because the instruction sets differ - riscv64 has no vector register file, so every shape there is framed.

Built a compiler from unpatched `dev` and ran the case against it: six shapes go `frameless` -> `framed`.

- `mach test .`: 1304 passed, 0 failed
- `int/run.sh --target linux`: all cases passed
- `int/run.sh --target linux-arm64 --runmode qemu`: all vector cases passed
- self-host fixpoint: stage2 == stage3 byte-identically, each stage built into a freshly removed `out/`