### PR TITLE
fix(verify): check a conversion's result width against its own opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### The IR verifier now checks that a conversion is well-*typed* for its own opcode, not merely well-*formed* (#2808)
+The verifier constrained a conversion's **arity** - `OP_TRUNC` / `OP_SEXT` / `OP_ZEXT` / `OP_BITCAST` all sit in the "exactly one operand" bucket - and `VC_TYPE_AGREE` covered operand agreement for binary ops, branch conditions, load/store/gep bases and `ret` against the signature. Nothing related a conversion's **result width** to its operand's, so it checked that a conversion was well-formed and never that it meant what its opcode says. A width-changing `BITCAST`, a `TRUNC` whose result is *wider* than its operand, a `SEXT` / `ZEXT` whose result is *narrower*, and any of the three at *equal* widths were all accepted.
+
+`instruction.mach` states each of these relations on the opcode itself - `OP_BITCAST` is documented as a "same-size bit reinterpretation" - so every one of them is a self-inconsistency in the IR's own type model. #2373 shipped exactly that: `bitcast i32 %p0: i8`, a four-times width change, with `--verify-ir` exiting 0 on the reproducer, reaching users as a `^i8 -1` widening to `255` and a widened `^u8` reading uninitialized register residue.
+
+New violation class `VC_CONVERT_WIDTH`, and it is **always on** rather than gated behind `--verify-ir`: the widths ride on the instruction and its operand with no dataflow needed, and a conversion is exactly where a front-end classification error lands, so it names the site (function, and `path:line:col`) instead of letting the defect reach codegen.
+
+A width the type table alone cannot state is deliberately **not judged**. `type.bit_width` answers 0 - meaning *unknown*, not zero-width - for a pointer, a function type, an aggregate and void, and a pair with an unknown side is skipped. This is not laxity, it is the arm that makes the rule shippable: a `::` cast between a pointer and an integer lowers to a `BITCAST` whose pointer width is the *target's*, which the verifier does not carry, and guessing it turns correct programs into violations. Removing that guard fails the standard library's own `raw_fill` on the first build, which is how it was confirmed rather than assumed.
+
+Because the rule is always on, its blast radius is proven by a clean self-host plus the whole int corpus on all three register targets, not by a fixture set. Each relation is separately mutation-tested: the backwards direction refused, the right direction clean, varying only the widths.
+
 #### Every static ELF carried two PT_LOAD segments claiming the same address (#2795)
 The static writer mapped the ELF header and program-header table **at** `segs[0].vaddr`; the PIE and dynamic writers mapped them one page **below** it. So every static executable mach has ever produced had two `PT_LOAD` segments covering the same virtual address - the header block and `.text` both at `0x400000` - on all three ELF targets.
 

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -306,6 +306,37 @@ pub fun is_float_scalar(t: *IrTypeTable, id: IrTypeId) bool {
     ret O.unwrap[*IrType](opt_get).kind == IRT_FLOAT;
 }
 
+# the bit width of a type, or 0 when it has none this table alone can state
+#
+# A conversion opcode's contract is a relation between its operand's width and its
+# result's - a TRUNC narrows, a SEXT / ZEXT widens, a BITCAST keeps - and checking
+# that relation needs a width the verifier can obtain with no target in hand. An
+# IRT_INT / IRT_FLOAT carries its width on the type; a vector's is its lanes times its
+# element's.
+#
+# Everything else answers 0, meaning UNKNOWN rather than zero-width: a pointer's width
+# is the target's, and an aggregate's is a layout computation. A caller compares two
+# widths only when both are non-zero, so an unknown never manufactures a verdict - the
+# ptr / int bitcasts a `::` cast lowers to stay unjudged rather than wrongly flagged.
+# ---
+# t:   the table
+# id:  the IrTypeId to measure
+# ret: the width in bits, or 0 when this table cannot state one
+pub fun bit_width(t: *IrTypeTable, id: IrTypeId) u32 {
+    val opt_get: O.Option[*IrType] = get(t, id);
+    if (O.is_none[*IrType](opt_get)) { ret 0; }
+    val ir: *IrType = O.unwrap[*IrType](opt_get);
+    if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) { ret ir.data.bits; }
+    if (ir.kind == IRT_VECTOR) {
+        val opt_el: O.Option[*IrType] = get(t, ir.data.vector_.element);
+        if (O.is_none[*IrType](opt_el)) { ret 0; }
+        val el: *IrType = O.unwrap[*IrType](opt_el);
+        if (el.kind != IRT_INT && el.kind != IRT_FLOAT) { ret 0; }
+        ret el.data.bits * ir.data.vector_.lanes;
+    }
+    ret 0;
+}
+
 # whether a type is a vector (#1965)
 #
 # The single classifier the backend consults to route a vector value to the

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -111,6 +111,28 @@ pub val VC_CALL_ARG_TYPE:   VerifyCheck = 14;
 # in combination, which review does not catch and only an invariant does
 pub val VC_BITCAST_CLASS:   VerifyCheck = 15;
 
+# a conversion's result width contradicts its own opcode: a BITCAST that changes
+# width, a TRUNC / FP_TRUNC whose result is not narrower than its operand, or a SEXT
+# / ZEXT / FP_EXT whose result is not wider. The verifier constrained conversion
+# ARITY - all of these sit in the "exactly one operand" bucket - and VC_TYPE_AGREE
+# covers operand agreement for binary ops, branch conditions, load/store/gep bases
+# and `ret`, but nothing related a conversion's result width to its operand's, so
+# every one of these was accepted (#2373, epic #2288). That defect emitted
+# `bitcast i32 %p0: i8` - a four-times width change through an opcode
+# `instruction.mach` documents as a SAME-SIZE bit reinterpretation - and shipped as
+# a `^i8 -1` widening to 255 and a widened `^u8` reading uninitialized register
+# residue, with `--verify-ir` exiting 0 on the reproducer.
+#
+# The widths come from `type.bit_width`, which answers 0 for anything it cannot state
+# without a target, and a pair with an unknown side is not judged: a `::` cast between
+# a pointer and an integer lowers to a BITCAST whose pointer width is the target's, and
+# guessing it would turn a correct program into a violation. What is checked is what is
+# checkable from the type table alone, which is every case the opcode's own
+# documentation constrains. Always on: the widths ride on the instruction and its
+# operand with no dataflow needed, and a conversion is exactly where a front-end
+# classification error lands, so it names the site instead of reaching codegen
+pub val VC_CONVERT_WIDTH:   VerifyCheck = 16;
+
 # one invariant failure, located as precisely as the failing check allows
 # ---
 # function: index into Module.functions
@@ -215,6 +237,7 @@ pub fun describe(check: VerifyCheck) str {
     if (check == VC_DANGLING_ID)     { ret "dangling id: a block list names an out-of-range instruction id"; }
     if (check == VC_TYPE_AGREE)      { ret "type agreement: operand types violate the opcode's typing contract"; }
     if (check == VC_CALL_ARG_TYPE)   { ret "call argument typing: a call argument's type disagrees with the callee's declared parameter"; }
+    if (check == VC_CONVERT_WIDTH)   { ret "conversion width: a conversion's result width contradicts its opcode (a bitcast must keep the width, a truncation must narrow, an extension must widen)"; }
     ret "unknown verification check";
 }
 
@@ -658,7 +681,44 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
     if (R.is_err[bool, str](res_bc)) { ret res_bc; }
     val res_call: R.Result[bool, str] = check_call_arg_types(m, ins, fi, bid, iid, r);
     if (R.is_err[bool, str](res_call)) { ret res_call; }
+    val res_cw: R.Result[bool, str] = check_convert_width(m, ins, fi, bid, iid, r);
+    if (R.is_err[bool, str](res_cw)) { ret res_cw; }
     ret R.ok[bool, str](true);
+}
+
+# VC_CONVERT_WIDTH: a conversion's result width must satisfy its own opcode
+#
+# `instruction.mach` states each relation on the opcode itself - TRUNC "to a narrower
+# width", SEXT / ZEXT "to a wider width", BITCAST "same-size" - and nothing enforced
+# any of them, so a conversion could be well-FORMED (right arity, resolvable types)
+# and not well-TYPED for the opcode it names. #2373 shipped exactly that.
+#
+# An unknown width on either side is not a verdict. `type.bit_width` answers 0 for a
+# pointer, a function, an aggregate and void, and the ptr/int BITCAST a `::` cast
+# lowers to is the common shape that lands there - judging it would require the
+# target's pointer width, which the verifier does not carry.
+# ---
+# m:   the module (type table)
+# ins: the instruction to check
+# ret: ok(true) once checked, or an allocation error from `push`
+fun check_convert_width(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport) R.Result[bool, str] {
+    val k: instruction.InstrKind = ins.kind;
+    val narrows: bool = k == instruction.OP_TRUNC || k == instruction.OP_FP_TRUNC;
+    val widens:  bool = k == instruction.OP_SEXT  || k == instruction.OP_ZEXT
+                     || k == instruction.OP_FP_EXT;
+    val keeps:   bool = k == instruction.OP_BITCAST;
+    if (!narrows && !widens && !keeps) { ret R.ok[bool, str](true); }
+    if (ins.operand_count < 1)         { ret R.ok[bool, str](true); }
+
+    val src: type.IrTypeId = (?ins.operands[0]).ty;
+    val sw:  u32 = type.bit_width(?m.types, src);
+    val dw:  u32 = type.bit_width(?m.types, ins.ty);
+    if (sw == 0 || dw == 0) { ret R.ok[bool, str](true); }
+
+    if (narrows && dw < sw) { ret R.ok[bool, str](true); }
+    if (widens  && dw > sw) { ret R.ok[bool, str](true); }
+    if (keeps   && dw == sw) { ret R.ok[bool, str](true); }
+    ret push(r, fi, bid, iid, VC_CONVERT_WIDTH);
 }
 
 # VC_TYPE_RESOLVE: the per-opcode auxiliary type slot must resolve in the type
@@ -2164,6 +2224,143 @@ test "mach.lang.me.ir.verify.check_bitcast_class:same_class_accepted" {
     if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
 
     if (t_count(?env, false, false, VC_BITCAST_CLASS) != 0) { ret 1; }
+    ret 0;
+}
+
+# a BITCAST that changes width is refused, and one that keeps it is not (#2373)
+#
+# The exact shape that shipped: `bitcast i32 %p0: i8`, a four-times width change
+# through an opcode `instruction.mach` documents as a same-size reinterpretation. The
+# verifier exited 0 on it, so it reached codegen as a `^i8 -1` widening to 255 and a
+# widened `^u8` reading uninitialized register residue.
+#
+# The two arms differ ONLY in the destination width, which is the property under test:
+# an assertion that some violation was recorded would be satisfied by any malformed
+# operand, and this pair cannot be.
+test "mach.lang.me.ir.verify.check_convert_width:bitcast_must_keep_width" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    val i8r: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, 8);
+    if (R.is_err[type.IrTypeId, str](i8r)) { ret 1; }
+    val i8ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](i8r);
+    val i32r: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, 32);
+    if (R.is_err[type.IrTypeId, str](i32r)) { ret 1; }
+    val i32ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](i32r);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+
+    val narrow: value.Value = value.const_int(1, i8ty);
+    val bad: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, narrow, i32ty);
+    if (R.is_err[value.Value, str](bad)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_count(?env, false, false, VC_CONVERT_WIDTH) != 1) { ret 1; }
+    # always on: the repr run sees the same one violation, not a second.
+    if (t_count(?env, false, true,  VC_CONVERT_WIDTH) != 1) { ret 1; }
+
+    # the nearest correct program: the same bitcast at equal widths - a signedness
+    # flip or pointer retype - which the tree is full of and must stay clean.
+    var ok_env: TEnv;
+    if (!t_env(?ok_env)) { ret 1; }
+    val o32r: R.Result[type.IrTypeId, str] = type.intern_int(?ok_env.m.types, 32);
+    if (R.is_err[type.IrTypeId, str](o32r)) { ret 1; }
+    val o32ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](o32r);
+    val ob0: id.BlockId = t_block(?ok_env);
+    builder.set_block(?ok_env.bld, ob0);
+    val good: R.Result[value.Value, str] = builder.emit_bitcast(?ok_env.bld, value.const_int(1, o32ty), o32ty);
+    if (R.is_err[value.Value, str](good)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?ok_env.bld))) { ret 1; }
+    if (t_count(?ok_env, false, false, VC_CONVERT_WIDTH) != 0) { ret 1; }
+    ret 0;
+}
+
+# a TRUNC must narrow and an extension must widen, in that direction and no other
+#
+# Each row is its own opcode because the rule is stated per opcode, and each is paired
+# with the same opcode applied the right way round. A verifier that keyed on "the
+# widths differ" rather than on the DIRECTION would pass every one of these.
+test "mach.lang.me.ir.verify.check_convert_width:direction_per_opcode" {
+    var bad: i32 = 0;
+    # backwards: trunc widening, sext / zext narrowing
+    if (t_convert(instruction.OP_TRUNC, 8,  32) != 1) { bad = 1; }
+    if (t_convert(instruction.OP_SEXT,  32, 8)  != 1) { bad = 1; }
+    if (t_convert(instruction.OP_ZEXT,  32, 8)  != 1) { bad = 1; }
+    # equal widths are wrong for all three: a conversion that changes nothing is not
+    # the opcode it names, and this is the arm a `<` / `<=` slip would lose.
+    if (t_convert(instruction.OP_TRUNC, 32, 32) != 1) { bad = 1; }
+    if (t_convert(instruction.OP_SEXT,  32, 32) != 1) { bad = 1; }
+    if (t_convert(instruction.OP_ZEXT,  32, 32) != 1) { bad = 1; }
+
+    # the right way round: clean, and these are the shapes the whole tree emits
+    if (t_convert(instruction.OP_TRUNC, 32, 8)  != 0) { bad = 1; }
+    if (t_convert(instruction.OP_SEXT,  8,  32) != 0) { bad = 1; }
+    if (t_convert(instruction.OP_ZEXT,  8,  32) != 0) { bad = 1; }
+    ret bad;
+}
+
+# emits one integer conversion in a fresh module and counts VC_CONVERT_WIDTH
+#
+# `from` and `to` are bit widths; the pair is the only thing that varies between a
+# row that must be refused and its correct twin.
+# ---
+# k:    the conversion opcode
+# from: the operand's width in bits
+# to:   the result's width in bits
+# ret:  the violation count, or -1 on a harness failure
+fun t_convert(k: instruction.InstrKind, from: u32, to: u32) i64 {
+    var env: TEnv;
+    if (!t_env(?env)) { ret -1; }
+
+    val fr: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, from);
+    if (R.is_err[type.IrTypeId, str](fr)) { ret -1; }
+    val fty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](fr);
+    val tr: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, to);
+    if (R.is_err[type.IrTypeId, str](tr)) { ret -1; }
+    val tty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](tr);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+    val src: value.Value = value.const_int(1, fty);
+
+    var e: R.Result[value.Value, str] = R.err[value.Value, str]("unset");
+    if (k == instruction.OP_SEXT) { e = builder.emit_sext(?env.bld, src, tty); }
+    or (k == instruction.OP_ZEXT) { e = builder.emit_zext(?env.bld, src, tty); }
+    or                            { e = builder.emit_trunc(?env.bld, src, tty); }
+    if (R.is_err[value.Value, str](e)) { ret -1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret -1; }
+
+    ret t_count(?env, false, false, VC_CONVERT_WIDTH);
+}
+
+# a width the type table alone cannot state is not judged
+#
+# A `::` cast between a pointer and an integer lowers to a BITCAST whose pointer side
+# is the TARGET's width, which the verifier does not carry. Guessing it would turn a
+# correct program into a violation, so the pair is skipped - and this is the arm that
+# keeps the rule from being unshippable rather than merely strict.
+test "mach.lang.me.ir.verify.check_convert_width:unknown_width_not_judged" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    val pr: R.Result[type.IrTypeId, str] = type.intern_ptr(?env.m.types);
+    if (R.is_err[type.IrTypeId, str](pr)) { ret 1; }
+    val pty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](pr);
+    val i8r: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, 8);
+    if (R.is_err[type.IrTypeId, str](i8r)) { ret 1; }
+    val i8ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](i8r);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+
+    # an i8 into a pointer: the widths certainly differ on every target mach has, and
+    # the verifier still must not say so, because it cannot know the pointer's.
+    val bc: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, value.const_int(1, i8ty), pty);
+    if (R.is_err[value.Value, str](bc)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_count(?env, false, false, VC_CONVERT_WIDTH) != 0) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #2808. Part of epic #2288.

## What was wrong

`--verify-ir` constrained a conversion's **arity** — `OP_TRUNC` / `OP_SEXT` / `OP_ZEXT` / `OP_BITCAST` all sit in the "exactly one operand" bucket — and `VC_TYPE_AGREE` covered operand agreement for binary ops, branch conditions, load/store/gep bases and `ret` against the signature. Nothing related a conversion's **result width** to its operand's, so the verifier checked that a conversion was well-*formed* and never that it was well-*typed for its own opcode*.

`instruction.mach` states each relation on the opcode itself:

```mach
# integer truncation to a narrower width; operands [operand]
pub val OP_TRUNC:       InstrKind = 21;
...
# same-size bit reinterpretation; operands [operand]
pub val OP_BITCAST:     InstrKind = 30;
```

and none of it was enforced. #2373 emitted, and `--verify-ir` accepted, `bitcast i32 %p0: i8` — a four-times width change through the same-size opcode — exiting 0 on the reproducer and shipping as a `^i8 -1` widening to `255` and a widened `^u8` reading uninitialized register residue.

This is also the counterexample to the framing that had been converging on #2288 (*"`--verify-ir` models types and order, and is strong on both"*). This one **is** a lie about types, on the side the tally assumed was strong.

## The rule

New violation class `VC_CONVERT_WIDTH`, **always on** rather than gated behind `--verify-ir` — the pipeline's entry/exit verification runs on every build, so this is enforced on every compile. The widths ride on the instruction and its operand with no dataflow needed, and a conversion is exactly where a front-end classification error lands, so it names the site (function, `path:line:col`) instead of letting the defect reach codegen.

Enforced: `TRUNC` / `FP_TRUNC` must narrow, `SEXT` / `ZEXT` / `FP_EXT` must widen, `BITCAST` must keep. **Equal widths are refused for all of them** — a conversion that changes nothing is not the opcode it names, and that is the arm a `<` vs `<=` slip would lose.

## The half that makes it shippable

`type.bit_width` is a new query that answers **0 meaning unknown**, not zero-width, for anything the type table alone cannot state: a pointer (whose width is the target's), a function type, an aggregate, void, and an image handle. A pair with an unknown side is **not judged**.

This is not laxity. A `::` cast between a pointer and an integer lowers to a `BITCAST` whose pointer side the verifier cannot size — it carries no target — and guessing it turns correct programs into violations. Confirmed by removing the guard rather than by reasoning about it: the build then fails on the standard library's own `raw_fill` on the first module.

```
error: conversion width: a conversion's result width contradicts its opcode
(a bitcast must keep the width, a truncation must narrow, an extension must widen)
(in std.memory.raw_fill, at ./dep/mach-std/src/memory.mach:28:24)
```

## Blast radius

The issue deliberately kept this off #2373's fix because a new violation class has to be clean across all existing IR — every pass that synthesizes a conversion. Since the rule is always on, that is proven by running, not by inspection:

- self-host clean, and `mach build . --verify-ir` over the whole compiler exits 0
- the whole int corpus on **all three register targets**: `linux`, `linux-arm64`, `linux-riscv64` — all cases passed
- self-host fixpoint, stage2 == stage3 byte-identical, each stage into a freshly removed `out/`

## Verification

Each rule is paired with the same opcode applied the right way round, varying only the widths, so a verifier that keyed on "the widths differ" rather than on the *direction* fails:

| opcode | refused | accepted |
|---|---|---|
| `TRUNC` | 8 → 32, 32 → 32 | 32 → 8 |
| `SEXT` | 32 → 8, 32 → 32 | 8 → 32 |
| `ZEXT` | 32 → 8, 32 → 32 | 8 → 32 |
| `BITCAST` | i8 → i32 (#2373's exact shape) | i32 → i32 |
| `BITCAST` | — | i8 → ptr (unknown width, not judged) |

Three live strips, each independently mutated out and each independently killed:

- `keeps && dw == sw` → `keeps` (accept every bitcast) → `check_convert_width:bitcast_must_keep_width` fails
- `<` → `<=` and `>` → `>=` (accept equal widths) → `check_convert_width:direction_per_opcode` fails
- dropping the unknown-width guard → the build fails on `std.memory.raw_fill`, before any test runs

- `mach test .` — 1331 passed, 0 failed
- `bash int/run.sh --target linux ./m`, plus `linux-arm64` (qemu) and `linux-riscv64` — all cases passed
- self-host fixpoint — byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6L67517WpZTPQDhtMsuJ2
