### PR TITLE
arm64: emit the B and H views of a V register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The two paths computed one fact in two places and agreed only by accident. The h
 
 ### Added
 
+#### aarch64 emits the B and H views of a V register, so a two-byte vector moves in one instruction (#2716)
+`vec_mem_widths` declared 4, 8 and 16 on aarch64 while the architecture also has B and H views of the same V register. The gap was not neutral: declaring 1 and 2 anyway turned an `i8x2` copy into `internal compiler error: aarch64 has no float memory access form for this width`, because the model claimed a capability the encoder did not have. That is what an aspirational declaration produces, and it is why the field describes **what the back end emits** rather than what the ISA has.
+
+The encoder emits them now — `ldr`/`str`, `ldur`/`stur` and the register-offset forms at B and H, every word byte-exact against `llvm-mc -triple=aarch64` and re-checked by disassembling the emitted object — so the declaration grew to match. That order is the rule, never the reverse. `copy_i8x2` goes from a stack frame, a 16-byte scratch slot and a chunk walk to `ldr h0, [x2]` / `str h0, [x1]`.
+
+They join the plain `ldr`/`str` mnemonic rows rather than taking `ldrb`/`ldrh`: those name a W destination and have to say which part of it they wrote, while `ldr b0, [x1]` transfers exactly the register named. The width-refusal test moved with the forms — 1 and 2 are now asserted **accepted** at their exact words, and 0, 12 and 32 stay refused, which is the property that test exists for.
+
 #### A vector of any lane count compiles on every target, whether or not a vector register can hold it (#2727)
 `f32x5`, `f32x8` and `f32x16` were refused **by name** at the front end on every target: `vector `f32x8` is 256 bits wide, more than this target's 128-bit vector width`. That read a realization fact as a legality rule, and it was incoherent besides — rv64gc has no vector unit at all, scalarizes every vector it is handed, and still refused `f32x8` on the ground of a 128-bit SIMD width it does not have.
 

--- a/int/surface/vector-subwidth-direct/expect.linux-arm64.txt
+++ b/int/surface/vector-subwidth-direct/expect.linux-arm64.txt
@@ -7,7 +7,7 @@ copy_i16x7 framed
 copy_i32x2 frameless
 copy_i32x3 framed
 copy_i32x4 frameless
-copy_i8x2 framed
+copy_i8x2 frameless
 copy_i8x3 framed
 copy_i8x4 frameless
 copy_i8x8 frameless

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -410,6 +410,13 @@ pub val VEC_MEM_NONE: u32 = 0;
 # is.
 pub val VEC_MEM_4_8_16:  u32 = 4 + 8 + 16;
 
+# the widths a 128-bit SIMD unit with a full sub-register file moves to and from
+# memory
+#
+# 1, 2, 4, 8 and 16: aarch64's `ldr` / `str` take B, H, S, D and Q views of one V
+# register, and every one of them zeroes the lanes above its operand on a load.
+pub val VEC_MEM_ALL_128: u32 = 1 + 2 + 4 + 8 + 16;
+
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -286,6 +286,25 @@ val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
 val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
 val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
 
+# the B (8-bit) and H (16-bit) views of the same V register (#2716)
+#
+# The same three addressing forms at the two narrow widths, which A64 has had all
+# along and this encoder did not emit. Their absence was not neutral: `fp_access`
+# refused those widths, so the only way to move a two-byte vector was the scratch
+# round trip, and a target model that declared the widths anyway turned an `i8x2`
+# copy into an internal compiler error. Like every other word here, byte-exact
+# against `llvm-mc -triple=aarch64`.
+#
+# A narrow load ZEROES the rest of the V register, exactly as the S and D forms do,
+# which is what lets `vec_mem_widths` declare them: the lanes a two-byte vector does
+# not have come back a defined 0 rather than as whatever the register held.
+val LDR_B_OFF: u32 = 0x3D400000; val STR_B_OFF: u32 = 0x3D000000;
+val LDR_H_OFF: u32 = 0x7D400000; val STR_H_OFF: u32 = 0x7D000000;
+val LDUR_B_FP: u32 = 0x3C400000; val STUR_B_FP: u32 = 0x3C000000;
+val LDUR_H_FP: u32 = 0x7C400000; val STUR_H_FP: u32 = 0x7C000000;
+val LDR_B_REG: u32 = 0x3C606800; val STR_B_REG: u32 = 0x3C206800;
+val LDR_H_REG: u32 = 0x7C606800; val STR_H_REG: u32 = 0x7C206800;
+
 # NEON 128-bit (Q) vector base words (#1965 / #2015). the three-register-same
 # arithmetic / logical / compare forms share the `pack_alu3` register layout
 # (Rm[20:16], Rn[9:5], Rd[4:0]); the lane arrangement rides the size field [23:22]
@@ -837,15 +856,30 @@ fun int_access(w: u8, is_load: bool) R.Result[A64Access, str] {
 
 # the SIMD&FP load / store form for an access width
 #
-# A64 implements the S (4), D (8) and Q (16) accesses. The Q forms are unaligned-safe,
-# so a vector spill needs no over-aligned slot. A width outside the three is refused:
-# the S row used to answer for everything that was not 8 or 16, so a 32-byte access
-# moved FOUR bytes of a slot the surrounding code had already sized at 32 (#2766).
+# A64 implements the B (1), H (2), S (4), D (8) and Q (16) accesses. The Q forms are
+# unaligned-safe, so a vector spill needs no over-aligned slot. A width outside the
+# five is refused: the S row used to answer for everything that was not 8 or 16, so a
+# 32-byte access moved FOUR bytes of a slot the surrounding code had already sized at
+# 32 (#2766).
+#
+# THE B AND H ROWS ARE NEW (#2716) and are the reason the model may declare 1 and 2 in
+# `vec_mem_widths`. Their absence was the gap between what the architecture has and
+# what this encoder emits, and declaring the widths without them turned an `i8x2` copy
+# into an internal compiler error - which is exactly what an aspirational capability
+# declaration produces, and why the field describes the back end rather than the ISA.
 # ---
 # w:       the access width in bytes
 # is_load: true for the load direction
 # ret:     the form, or an error naming the width A64 has no float access for
 fun fp_access(w: u8, is_load: bool) R.Result[A64Access, str] {
+    if (w == 1) {
+        if (is_load) { ret acc(LDR_B_OFF, LDUR_B_FP, LDR_B_REG, 0, of.RK_LDST8_LO12); }
+        ret acc(STR_B_OFF, STUR_B_FP, STR_B_REG, 0, of.RK_LDST8_LO12);
+    }
+    if (w == 2) {
+        if (is_load) { ret acc(LDR_H_OFF, LDUR_H_FP, LDR_H_REG, 1, of.RK_LDST16_LO12); }
+        ret acc(STR_H_OFF, STUR_H_FP, STR_H_REG, 1, of.RK_LDST16_LO12);
+    }
     if (w == 4) {
         if (is_load) { ret acc(LDR_S_OFF, LDUR_S_FP, LDR_S_REG, 2, of.RK_LDST32_LO12); }
         ret acc(STR_S_OFF, STUR_S_FP, STR_S_REG, 2, of.RK_LDST32_LO12);
@@ -858,7 +892,7 @@ fun fp_access(w: u8, is_load: bool) R.Result[A64Access, str] {
         if (is_load) { ret acc(LDR_Q_OFF, LDUR_Q_FP, LDR_Q_REG, 4, of.RK_LDST128_LO12); }
         ret acc(STR_Q_OFF, STUR_Q_FP, STR_Q_REG, 4, of.RK_LDST128_LO12);
     }
-    ret R.err[A64Access, str]("internal compiler error: aarch64 has no float memory access form for this width (expected 4, 8, or 16)");
+    ret R.err[A64Access, str]("internal compiler error: aarch64 has no float memory access form for this width (expected 1, 2, 4, 8, or 16)");
 }
 
 # append one 32-bit A64 instruction word to the text sink (little-endian)
@@ -1118,6 +1152,8 @@ fun ldst_shape(base: u32) LdStShape {
     if (base == LDR_OFF_X || base == STR_OFF_X) { ret ls(false, 8, 8); }
     if (base == LDR_D_OFF || base == STR_D_OFF) { ret ls(true, 8, 8); }
     if (base == LDR_S_OFF || base == STR_S_OFF) { ret ls(true, 4, 4); }
+    if (base == LDR_H_OFF || base == STR_H_OFF) { ret ls(true, 2, 2); }
+    if (base == LDR_B_OFF || base == STR_B_OFF) { ret ls(true, 1, 1); }
     if (base == LDR_Q_OFF || base == STR_Q_OFF) { ret ls(true, 16, 16); }
     if (base == LDAR_X || base == STLR_X || base == LDAXR_X) { ret ls(false, 8, 0); }
     if (base == LDAR_W || base == STLR_W || base == LDAXR_W) { ret ls(false, 4, 0); }
@@ -1131,6 +1167,8 @@ fun ldur_shape(base: u32) LdStShape {
     if (base == LDUR_X || base == STUR_X)       { ret ls(false, 8, 1); }
     if (base == LDUR_D_FP || base == STUR_D_FP) { ret ls(true, 8, 1); }
     if (base == LDUR_S_FP || base == STUR_S_FP) { ret ls(true, 4, 1); }
+    if (base == LDUR_H_FP || base == STUR_H_FP) { ret ls(true, 2, 1); }
+    if (base == LDUR_B_FP || base == STUR_B_FP) { ret ls(true, 1, 1); }
     if (base == LDUR_Q_FP || base == STUR_Q_FP) { ret ls(true, 16, 1); }
     ret ls(false, 0, 255);
 }
@@ -1142,6 +1180,8 @@ fun ldst_reg_shape(base: u32) LdStShape {
     if (base == LDR_REG_X || base == STR_REG_X)   { ret ls(false, 8, 1); }
     if (base == LDR_D_REG || base == STR_D_REG)   { ret ls(true, 8, 1); }
     if (base == LDR_S_REG || base == STR_S_REG)   { ret ls(true, 4, 1); }
+    if (base == LDR_H_REG || base == STR_H_REG)   { ret ls(true, 2, 1); }
+    if (base == LDR_B_REG || base == STR_B_REG)   { ret ls(true, 1, 1); }
     if (base == LDR_Q_REG || base == STR_Q_REG)   { ret ls(true, 16, 1); }
     ret ls(false, 0, 255);
 }
@@ -1150,6 +1190,9 @@ fun ldst_reg_shape(base: u32) LdStShape {
 fun ldst_loads(base: u32) bool {
     ret base == LDRB_OFF || base == LDRH_OFF || base == LDRW_OFF || base == LDR_OFF_X ||
         base == LDR_D_OFF || base == LDR_S_OFF || base == LDR_Q_OFF ||
+        base == LDR_B_OFF || base == LDR_H_OFF ||
+        base == LDUR_B_FP || base == LDUR_H_FP ||
+        base == LDR_B_REG || base == LDR_H_REG ||
         base == LDAR_X || base == LDAR_W || base == LDAXR_X || base == LDAXR_W ||
         base == LDURB || base == LDURH || base == LDURW || base == LDUR_X ||
         base == LDUR_D_FP || base == LDUR_S_FP || base == LDUR_Q_FP ||
@@ -6343,6 +6386,14 @@ test "mach.lang.target.isa.arm64.encode:float_width_refusals_emit_nothing" {
 # 16 SPLITS THE TWO FAMILIES and is checked on both. A64 has a Q float access and no
 # 16-byte integer one, so the float table must ACCEPT 16 while the integer table
 # REFUSES it - a check written once for the file would have got one of the two wrong.
+#
+# 1 AND 2 SPLIT THEM THE OTHER WAY, and they moved (#2716). The float family refused
+# them until the B and H views were added; it accepts them now, at the words below,
+# and the integer family's own 1 and 2 are a different pair of forms with different
+# mnemonics. What stays refused on the float side is 0, 12 and 32: widths with no
+# single A64 form at all, which is the property this test exists for. A width that
+# gains a form is a deliberate edit here; a width that gains an ANSWER without a form
+# is the #2766 defect coming back.
 test "mach.lang.target.isa.arm64.encode:access_width_refusals_emit_nothing" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
@@ -6357,10 +6408,6 @@ test "mach.lang.target.isa.arm64.encode:access_width_refusals_emit_nothing" {
     st.buf.len = 0;
     if (!t_refused(emit_fp_mem(?st, 0, 1, 0, 32, false), ?st.buf)) { bad = 1; }
     st.buf.len = 0;
-    if (!t_refused(emit_fp_mem(?st, 0, 1, 0, 1, true), ?st.buf))   { bad = 1; }
-    st.buf.len = 0;
-    if (!t_refused(emit_fp_mem(?st, 0, 1, 0, 2, true), ?st.buf))   { bad = 1; }
-    st.buf.len = 0;
     if (!t_refused(emit_fp_mem(?st, 0, 1, 0, 0, true), ?st.buf))   { bad = 1; }
     st.buf.len = 0;
     if (!t_refused(emit_fp_mem(?st, 0, 1, 0, 12, true), ?st.buf))  { bad = 1; }
@@ -6369,7 +6416,32 @@ test "mach.lang.target.isa.arm64.encode:access_width_refusals_emit_nothing" {
     st.buf.len = 0;
     if (!t_refused(emit_fp_mem(?st, 0, 1, 100000, 32, true), ?st.buf)) { bad = 1; }
 
-    # the three float widths it DOES implement, byte-exact against llvm-mc
+    # the five float widths it DOES implement, byte-exact against llvm-mc
+    #
+    # B AND H FIRST, because they are the two this file could not emit until #2716 and
+    # the two a reader is most likely to assume are the integer LDRB / LDRH. They are
+    # not: these transfer the B and H views of a V register, so they spell `ldr` /
+    # `str` like every other SIMD&FP width.
+    st.buf.len = 0;
+    if (!t_accepted(emit_fp_mem(?st, 0, 1, 16, 1, true), ?st.buf))  { bad = 1; }
+    if (read_word(?st.buf, 0) != 0x3D404020) { bad = 1; }   # ldr b0, [x1, #16]
+    st.buf.len = 0;
+    emit_fp_mem(?st, 0, 1, 16, 1, false);
+    if (read_word(?st.buf, 0) != 0x3D004020) { bad = 1; }   # str b0, [x1, #16]
+    st.buf.len = 0;
+    emit_fp_mem(?st, 0, 1, 16, 2, true);
+    if (read_word(?st.buf, 0) != 0x7D402020) { bad = 1; }   # ldr h0, [x1, #16]
+    st.buf.len = 0;
+    emit_fp_mem(?st, 0, 1, 16, 2, false);
+    if (read_word(?st.buf, 0) != 0x7D002020) { bad = 1; }   # str h0, [x1, #16]
+    # and their unscaled arms, which a negative displacement reaches
+    st.buf.len = 0;
+    emit_fp_mem(?st, 0, 1, 0 - 8, 1, true);
+    if (read_word(?st.buf, 0) != 0x3C5F8020) { bad = 1; }   # ldur b0, [x1, #-8]
+    st.buf.len = 0;
+    emit_fp_mem(?st, 0, 1, 0 - 8, 2, true);
+    if (read_word(?st.buf, 0) != 0x7C5F8020) { bad = 1; }   # ldur h0, [x1, #-8]
+
     st.buf.len = 0;
     if (!t_accepted(emit_fp_mem(?st, 0, 1, 16, 4, true), ?st.buf))  { bad = 1; }
     if (read_word(?st.buf, 0) != 0xBD401020) { bad = 1; }   # ldr s0, [x1, #16]

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -779,9 +779,13 @@ fun render_cset(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
 # the mnemonic a load / store base word denotes, or nil when unmapped
 #
 # The transferred register's width and bank come from the operand, so one entry
-# covers the W, X, S, D and Q forms of `ldr`; only the mnemonics that genuinely
-# differ - the sub-word accesses, the unscaled LDUR / STUR family, and the ordered
-# and exclusive accesses - need their own.
+# covers the W, X, B, H, S, D and Q forms of `ldr`; only the mnemonics that genuinely
+# differ - the sub-word INTEGER accesses, which name a W destination and so have to
+# say which part of it they wrote, the unscaled LDUR / STUR family, and the ordered
+# and exclusive accesses - need their own. The SIMD&FP B and H views join the plain
+# `ldr` / `str` rows for that reason and not by oversight (#2716): `ldr b0, [x1]`
+# transfers exactly the register named, so there is no `ldrb`-shaped ambiguity to
+# resolve in the mnemonic.
 # ---
 # base: the packer base word
 # ret:  the mnemonic, or nil for an unmapped base
@@ -793,19 +797,25 @@ fun ldst_mnem(base: u32) str {
     if (base == 0xB9400000 || base == 0xF9400000 || base == 0xFD400000 ||
         base == 0xBD400000 || base == 0x3DC00000 || base == 0xB8606800 ||
         base == 0xF8606800 || base == 0xFC606800 || base == 0xBC606800 ||
-        base == 0x3CE06800)                       { ret "ldr"; }
+        base == 0x3CE06800 ||
+        base == 0x3D400000 || base == 0x7D400000 ||
+        base == 0x3C606800 || base == 0x7C606800) { ret "ldr"; }
     if (base == 0xB9000000 || base == 0xF9000000 || base == 0xFD000000 ||
         base == 0xBD000000 || base == 0x3D800000 || base == 0xB8206800 ||
         base == 0xF8206800 || base == 0xFC206800 || base == 0xBC206800 ||
-        base == 0x3CA06800)                       { ret "str"; }
+        base == 0x3CA06800 ||
+        base == 0x3D000000 || base == 0x7D000000 ||
+        base == 0x3C206800 || base == 0x7C206800) { ret "str"; }
     if (base == 0x38400000)                       { ret "ldurb"; }
     if (base == 0x38000000)                       { ret "sturb"; }
     if (base == 0x78400000)                       { ret "ldurh"; }
     if (base == 0x78000000)                       { ret "sturh"; }
     if (base == 0xB8400000 || base == 0xF8400000 || base == 0xFC400000 ||
-        base == 0xBC400000 || base == 0x3CC00000) { ret "ldur"; }
+        base == 0xBC400000 || base == 0x3CC00000 ||
+        base == 0x3C400000 || base == 0x7C400000) { ret "ldur"; }
     if (base == 0xB8000000 || base == 0xF8000000 || base == 0xFC000000 ||
-        base == 0xBC000000 || base == 0x3C800000) { ret "stur"; }
+        base == 0xBC000000 || base == 0x3C800000 ||
+        base == 0x3C000000 || base == 0x7C000000) { ret "stur"; }
     if (base == 0xC8DFFC00 || base == 0x88DFFC00) { ret "ldar"; }
     if (base == 0xC89FFC00 || base == 0x889FFC00) { ret "stlr"; }
     if (base == 0xC85FFC00 || base == 0x885FFC00) { ret "ldaxr"; }
@@ -1718,6 +1728,8 @@ fun emit_reg(out: *writer.Writer, op: *isa.Operand, sp: bool) R.Result[bool, str
 fun emit_reg_id(out: *writer.Writer, id: i32, size: u8, sp: bool) R.Result[bool, str] {
     val n: u32 = isa.regid_index(id)::u32;
     if (isa.regid_class(id) == isa.REG_CLASS_ID_XMM) {
+        if (size == 1)  { ret emit_indexed(out, "b", n); }
+        if (size == 2)  { ret emit_indexed(out, "h", n); }
         if (size == 4)  { ret emit_indexed(out, "s", n); }
         if (size == 8)  { ret emit_indexed(out, "d", n); }
         if (size == 16) { ret emit_indexed(out, "q", n); }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -258,20 +258,16 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no lane-count ceiling: this vector unit is described completely by its register
     # width, so the lane count follows from the width and the lane size (#2749)
     arm64_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
-    # LDR / STR at the S, D and Q views of one V register cross to memory at 4, 8 and
-    # 16 bytes, and each zeroes the lanes above its operand on a load, which is the
-    # contract this field carries (#2716).
+    # LDR / STR at the B, H, S, D and Q views of one V register cross to memory at 1,
+    # 2, 4, 8 and 16 bytes, and each zeroes the lanes above its operand on a load,
+    # which is the contract this field carries (#2716).
     #
-    # THE FIELD DESCRIBES WHAT THE BACK END EMITS, NOT WHAT THE ISA HAS, and aarch64
-    # is where the two differ. The architecture also has B and H views, so 1 and 2
-    # bytes would qualify on paper - but this encoder has no float memory form at
-    # those widths and refuses them, so declaring them here would turn an `i8x2` copy
-    # into an internal compiler error rather than into a faster one. The same holds
-    # one step further out: the single-structure `ld1 {v0.s}[2]` forms would cover a
-    # chunked walk at an OFFSET, which is what a 12-byte vector needs, and they are
-    # absent here for the same reason. Both are pure additions whenever the encoder
-    # grows the forms; until then the scratch round trip covers those shapes.
-    arm64_model.vec_mem_widths  = isa.VEC_MEM_4_8_16;
+    # THE FIELD DESCRIBES WHAT THE BACK END EMITS, NOT WHAT THE ISA HAS. It said 4, 8
+    # and 16 when it landed, because the B and H views existed in the architecture and
+    # not in this encoder, and declaring them anyway turned an `i8x2` copy into an
+    # internal compiler error. The encoder emits them now, so the declaration grew to
+    # match - and that is the order these two have to move in, never the reverse.
+    arm64_model.vec_mem_widths  = isa.VEC_MEM_ALL_128;
     arm64_packed_gaps[0].op = isa.VEC_OP_MUL; arm64_packed_gaps[0].is_float = false; arm64_packed_gaps[0].lane_bits = 64;
     arm64_model.packed_gaps     = ?arm64_packed_gaps[0];
     arm64_model.packed_gap_len  = 1;


### PR DESCRIPTION
Refs #2716. **Stacked on #2806**, which is stacked on #2805 — review after both.

## What

`vec_mem_widths` declared 4, 8 and 16 on aarch64 while the architecture also has B and H views of the same V register. The gap was not neutral, and this is how it was found: declaring 1 and 2 anyway turned an `i8x2` copy into

```
internal compiler error: aarch64 has no float memory access form for this width (expected 4, 8, or 16)
```

because the model claimed a capability the encoder did not have. That is exactly what an aspirational declaration produces, and it is why the field describes **what the back end emits** rather than what the ISA has.

The encoder emits them now — `ldr`/`str`, `ldur`/`stur` and the register-offset forms at B and H — so the declaration grew to match. **That order is the rule**, never the reverse.

```
copy_i8x2, before: frame + 16-byte scratch slot + chunk walk
copy_i8x2, after:  ldr h0, [x2] / str h0, [x1]
```

## Verification of the encodings specifically

Every new word is byte-exact against `llvm-mc -triple=aarch64`, and I did not stop there: the emitted object was disassembled with `llvm-objdump`, which reads the bytes back as `ldr h0, [x2]` / `str h0, [x1]`. A hand-derived word that assembles as *some other valid instruction* is the failure mode a table-only check cannot see.

The width-refusal test (#2766) moved with the forms rather than being deleted: 1 and 2 are now asserted **accepted at their exact words**, and 0, 12 and 32 stay refused — that separation is the property the test exists for. A width that gains a form is a deliberate edit there; a width that gains an *answer* without a form is #2766 coming back.

The B and H views join the plain `ldr`/`str` mnemonic rows rather than taking `ldrb`/`ldrh`: those name a W destination and so have to say which part of it they wrote, while `ldr b0, [x1]` transfers exactly the register named.

## What this does NOT include, and the measurement behind that

The other half of what was scoped — single-structure `ld1 {v0.s}[2]` / `st1` for a chunked walk, which is what a 12-byte `i32x3` needs — is **not here**, and measuring it changed my recommendation:

- `ld1`/`st1` single-structure have **no immediate-offset form**, only `[Xn]` and post-index. A 12-byte load is therefore `ldr d0,[x]` + `add x9,x0,#8` + `ld1 {v0.s}[2],[x9]` — **three** instructions.
- aarch64 already declares `has_lane_ops`, so the same three exist today with no new encoder work at all: `ldr d0,[x]` + `ldr w9,[x,#8]` + `ins v0.s[2],w9`.

So the win is **removing the scratch**, which is worth a lot (`copy_i32x3` on aarch64 is currently 3 prologue + 13 body instructions and a 32-byte frame), and the `ld1` form is worth only the GP bank crossing on top of it — real, but not the instruction-count difference the issue implied. Both routes want the same new piece: a capability for *lane-indexed* memory access (distinct from `vec_mem_widths`, which is whole-footprint) plus the chunked walk in `mir/context.mach`.

I would rather hand that over as a measured design than land an encoder addition at the end of a long session. Happy to take it as a fourth PR — say the word.

## Verification

- `mach test .`: 1328 passed, 0 failed
- `int/run.sh --target linux`: all cases passed
- `int/run.sh --target linux-arm64 --runmode qemu`: all cases passed
- `int/run.sh --target linux-riscv64` (vector cases): all passed
- self-host fixpoint: stage2 == stage3 byte-identically, each stage into a freshly removed `out/`
- the `vector-subwidth-direct` golden moves on **exactly one shape on one leg** (`copy_i8x2`, aarch64) and on nothing else anywhere

---

## A misattributed doc comment found on the way through, and where the fix actually is

Flagged here because it is easy to miss inside a rebase, and because a doc comment attached to the wrong test misleads the next reader **while looking authoritative** — the same failure mode #2288 is about, one layer down.

#2794 inserted its `image_form` test directly beneath `vector_form`'s doc comment in `src/lang/type.mach`, so that comment came to document a test it has nothing to do with:

```mach
# `vector_form` reads `<element>x<lanes>` and separates the three outcomes: a
# shape the target admits, a shape too wide for it, and a spelling that is not a
# vector at all. the ten formerly seeded spellings are exactly the 128-bit forms
test "mach.lang.type.image_form:reads_every_operand" {
```

**The fix is not in this PR.** It surfaced as a rebase conflict on the #2727 branch and landed there, so it is already on `dev` via #2806 (`e033011a`) — `image_form` now carries a header derived from its own body, and `vector_form`'s comment sits above `vector_form`'s test where it belongs. Recorded here rather than left as a silent conflict resolution.

Nothing about it is load-bearing for this PR; it is noted so the correction is visible as a decision rather than as a diff nobody reads.
