### PR TITLE
fix(sema): disambiguate a diagnostic naming two types that spell the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ The message cost a day of investigation before anything was fixed. It named the 
 Which message a user saw was decided by accident, too: the same broken program read `undefined symbol` on a link with no shared library in it and the false `not among the link's dependencies` the moment any unrelated one joined. Two different statements about one program, one of them untrue, selected by something neither of them mentions.
 
 The driver's single walk over the link inputs now records each entry's logical name and whether it resolved static or dynamic, and the linker reads that one account rather than inferring the link from the half it was handed. A failed pin resolves to one of two truthful statements - the library is in the link **as a static input**, which defines symbols rather than importing them, so the symbol is undefined; or the library is genuinely nowhere in the effective link set, in which case the refusal stands and now lists what the link does provide. Both paths that can reach a failed pin call one decision function, so the wording no longer depends on the link's shape: the two int cases that differ only by an unrelated dynamic dependency assert **byte-identical** goldens, and a third holds the genuine refusal so the fix cannot become a blanket permit.
+#### A type mismatch between two same-named types from different modules said `expected P, found P` (#2288)
+A nominal type is interned by `(origin, decl)` and rendered by its bare name, so `rec P` declared in two modules produced exactly this:
+
+```
+error: type mismatch: expected P, found P
+```
+
+The two types are genuinely different and the diagnostic could not show it - the message names the defect and tells the reader nothing about it. That is the failure this epic exists for, arriving in a diagnostic rather than in a dump.
+
+The disambiguation is a property of the **pair**, not of either type, so it lives at the reporting site rather than in the type renderer: qualifying every nominal at every site would make every ordinary diagnostic noisier to fix a case that is rare. When the two renderings collide, the note names each side's defining module instead of the cast advice, which could not apply between two unrelated records anyway:
+
+```
+error: type mismatch: expected P, found P
+  = note: these are two different types that share the name `P`: the first is declared in `dcase.main`, the second in `dcase.lib`
+```
+
+Every diagnostic that names two types routes through **one** decision point, so this is not a patch at one message site. It reaches the assignment mismatch, the `:~` size mismatch (which collapsed the same way - `P (16 bytes) vs P (1 bytes)`), and `incompatible operand types`, whose collision is unreachable today only because aggregate arithmetic and `==` are refused before the message is built. A generic instance is disambiguated too, since `Box[u8]` from two modules renders identically for the same reason.
+
+Found while auditing the surfaces #2288 lists, by producing both sides of each distinction and diffing rather than by reading the printer. The rest of the type renderer came out clean under the same treatment: secret against public (`^u32` / `u32`), generic arguments, vector lane signedness (`i32x4` / `u32x4`), aggregate against scalar at equal width (`[8]u8` / `i64`), packed against unpacked, over-aligned against natural, and function arity all render distinguishably.
+
+Alongside it, `ut_diag_note_has` - the note-reading sibling of the test harness's `ut_diag_has`, which scans a diagnostic's `message` only. A note is a separate field, so until now **no test in the tree could assert anything about a note's text** and every note the compiler attaches was unpinned. That is the same asymmetry #2297 found between `ut_lower_ok` and the sink-reading helpers, arriving through a different door, and it is worth stating plainly: two arms of this change's own test, written against `ut_diag_has` with a bare module name as the needle, passed against the unpatched compiler because some unrelated note in the same compile mentioned that module. They assert the surrounding phrase now, and all five arms fail without the fix.
+
 #### The IR verifier now checks that a conversion is well-*typed* for its own opcode, not merely well-*formed* (#2808)
 The verifier constrained a conversion's **arity** - `OP_TRUNC` / `OP_SEXT` / `OP_ZEXT` / `OP_BITCAST` all sit in the "exactly one operand" bucket - and `VC_TYPE_AGREE` covered operand agreement for binary ops, branch conditions, load/store/gep bases and `ret` against the signature. Nothing related a conversion's **result width** to its operand's, so it checked that a conversion was well-formed and never that it meant what its opcode says. A width-changing `BITCAST`, a `TRUNC` whose result is *wider* than its operand, a `SEXT` / `ZEXT` whose result is *narrower*, and any of the three at *equal* widths were all accepted.
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -583,6 +583,30 @@ fun ut_diag_has(d: *diagnostic.DiagList, needle: str) bool {
     ret false;
 }
 
+# whether some error diagnostic's `= note:` line contains `needle`
+#
+# The note-reading sibling of `ut_diag_has`, which scans `message` only. A note is
+# a separate owned field on the Diag, so until this existed NO test in the tree
+# could assert anything about a note's text, and every note the compiler attaches
+# was unpinned - a whole category of diagnostic content the test surface could not
+# observe. That is the same asymmetry #2297 found between `ut_lower_ok` and the
+# sink-reading helpers, arriving through a different door, and it is why the
+# assertions below name notes explicitly rather than settling for the message.
+# ---
+# d:      the diagnostic sink to scan
+# needle: a substring the expected note must contain
+# ret:    true when some error diagnostic carries a note containing `needle`
+fun ut_diag_note_has(d: *diagnostic.DiagList, needle: str) bool {
+    var i: usize = 0;
+    for (i < d.len) {
+        if (d.items[i].severity == diagnostic.SEVERITY_ERROR
+            && d.items[i].note != nil
+            && ut_str_contains(d.items[i].note, needle)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # build a one-file project from `src` (as main.mach), run resolve + sema, and
 # return the project so a test can inspect p.s.diags. the caller tears down the
 # project and session
@@ -6857,6 +6881,124 @@ test "mach.lang.driver:addr_of_cross_module_generic_rejected" {
     project.dnit_project(?p2);
     session.dnit(?s2);
     ret bad;
+}
+
+# a diagnostic naming TWO types disambiguates them when both render as the same
+# string (#2288)
+#
+# A nominal is interned by `(origin, decl)` and rendered by its bare name, so `rec P`
+# declared in two modules produced `type mismatch: expected P, found P` - a diagnostic
+# that reports the defect and cannot represent it, which is the failure class #2288
+# exists for. The types differ; the message could not show it.
+#
+# Every arm asserts the NOTE's text through `ut_diag_note_has`, not the message: the
+# message legitimately still reads `expected P, found P`, because both types really
+# are spelled `P`, and it is the note that carries the distinction. Reading the
+# message here would assert nothing.
+#
+# Both directions are covered, because the disambiguation must be a property of the
+# COLLIDING PAIR and not something every two-type diagnostic now carries.
+test "mach.lang.driver:same_name_type_mismatch_names_its_modules" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+    val need: str = "two different types that share the name";
+    val a_src: str = "pub rec P { a: u8; }\npub rec Other { a: u8; }\npub rec Box[T] { a: T; }\n";
+
+    # `P` in the entry module against `P` in module `a`: the two spellings collide.
+    bad = bad | 1 * ut_pair_note(?alloc, "use a: uniontest.a;\nrec P { a: u8; }\nfun main() i64 { var x: P; var y: a.P; x = y; ret 0; }\n", a_src, need);
+    # ...and it names BOTH modules, so the note locates each side rather than only
+    # announcing that they differ. The needles carry the surrounding phrase rather
+    # than the bare module name on purpose: a bare `uniontest.a` is satisfied by any
+    # other note in the same compile that happens to mention the module, and both of
+    # these arms passed against the unpatched compiler when written that way -
+    # asserting nothing, which is the exact defect class this epic is about.
+    bad = bad | 2 * ut_pair_note(?alloc, "use a: uniontest.a;\nrec P { a: u8; }\nfun main() i64 { var x: P; var y: a.P; x = y; ret 0; }\n", a_src, "the first is declared in `uniontest.main`");
+    bad = bad | 4 * ut_pair_note(?alloc, "use a: uniontest.a;\nrec P { a: u8; }\nfun main() i64 { var x: P; var y: a.P; x = y; ret 0; }\n", a_src, "the second in `uniontest.a`");
+
+    # the same collision through a GENERIC INSTANCE, which renders as `Box[u8]` on
+    # both sides for the same reason - a different type kind reaching the same rule.
+    bad = bad | 8 * ut_pair_note(?alloc, "use a: uniontest.a;\nrec Box[T] { a: T; }\nfun main() i64 { var x: Box[u8]; var y: a.Box[u8]; x = y; ret 0; }\n", a_src, need);
+
+    # A SECOND MESSAGE SITE, not just the assignment mismatch. The `:~` size
+    # mismatch (`report_reinterpret_mismatch`) names two types the same way and
+    # collapsed identically - `P (16 bytes) vs P (1 bytes)`. Both route through one
+    # decision point, which is what stops the fix being a per-message patch.
+    #
+    # The third member of the family, `report_typed2`'s `incompatible operand types`,
+    # routes through the same point but has no reachable collision today: its two
+    # types would have to be nominals, and aggregate arithmetic and `==` are both
+    # refused before the operand-type message is built. It is wired up rather than
+    # tested, deliberately, so the next operand-typed message inherits the rule.
+    bad = bad | 16 * ut_pair_note(?alloc, "use a: uniontest.a;\nrec P { a: u8; b: u64; }\nfun cast(x: P) a.P { ret x:~a.P; }\nfun main() i64 { ret 0; }\n", a_src, need);
+
+    ret bad;
+}
+
+# THE ARM THAT MUST NOT BE LOST: a diagnostic naming two types that do NOT collide
+# keeps its ordinary note and must not pick up the disambiguation (#2288)
+#
+# Same shape, same two modules, one identifier changed - so a rule that fired on
+# "two nominal types" rather than on "two types that render the same" fails here.
+# The mismatch itself is asserted first: a case that stopped producing one would
+# satisfy the absence check vacuously, which is the trap a refusal test falls into.
+test "mach.lang.driver:distinct_name_type_mismatch_keeps_its_note" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+    val need: str = "two different types that share the name";
+    val a_src: str = "pub rec P { a: u8; }\npub rec Other { a: u8; }\npub rec Box[T] { a: T; }\n";
+
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, ?alloc,
+        "use a: uniontest.a;\nrec P { a: u8; }\nfun main() i64 { var x: P; var y: a.Other; x = y; ret 0; }\n", a_src);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (!ut_diag_has(?s.diags, "type mismatch: expected P, found Other"))      { bad = 1; }
+    if (!ut_diag_note_has(?s.diags, "mach has no implicit widening"))          { bad = 1; }
+    if (ut_diag_note_has(?s.diags, need))                                     { bad = 1; }
+    project.dnit_project(?p);
+    session.dnit(?s);
+
+    # two PRIMITIVES have no declaring module at all, and must degrade to the
+    # ordinary note rather than to a half-written sentence naming nothing.
+    val sr2: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr2)) { ret 1; }
+    var s2: session.Session = R.unwrap_ok[session.Session, str](sr2);
+    val pr2: R.Result[project.Project, outcome.Fail] = ut_sema2(?s2, ?alloc,
+        "fun main() i64 { var x: u8; var y: i64; x = y; ret 0; }\n", a_src);
+    if (R.is_err[project.Project, outcome.Fail](pr2)) { session.dnit(?s2); ret 1; }
+    var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr2);
+    if (!ut_diag_has(?s2.diags, "type mismatch: expected u8, found i64"))      { bad = 1; }
+    if (!ut_diag_note_has(?s2.diags, "mach has no implicit widening"))         { bad = 1; }
+    if (ut_diag_note_has(?s2.diags, need))                                     { bad = 1; }
+    project.dnit_project(?p2);
+    session.dnit(?s2);
+    ret bad;
+}
+
+# compiles a two-module project and reports whether some error carries a note
+# containing `needle`
+# ---
+# alloc:  allocator for the session
+# main_s: the entry module's source
+# a_src:  module `a`'s source
+# needle: a substring the expected note must contain
+# ret:    0 when the note is present, else 1
+fun ut_pair_note(alloc: *A.Allocator, main_s: str, a_src: str, needle: str) i32 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, alloc, main_s, a_src);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var rc: i32 = 1;
+    if (ut_diag_note_has(?s.diags, needle)) { rc = 0; }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret rc;
 }
 
 # a generic instance is nameable as a VALUE: `f[i64]` types as the INSTANTIATED

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -24,6 +24,7 @@ use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -1034,7 +1035,7 @@ pub fun report_typed2(sc: *context.SemaContext, span: token.Span, prefix: str, a
         ret;
     }
     val msg: str = R.unwrap_ok[str, str](res_msg);
-    report(sc, span, msg);
+    report_types_pair(sc, span, msg, a, b, a_str, b_str, "");
     A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
     type_str_free(sc, a_str);
     type_str_free(sc, b_str);
@@ -1343,11 +1344,117 @@ fun report_mismatch(sc: *context.SemaContext, span: token.Span, expected: type.T
         ret;
     }
     val msg: str = R.unwrap_ok[str, str](res_msg);
-    report_note(sc, span, msg, note);
+
+    # TWO DISTINCT TYPES THAT SPELL THE SAME (#2288). A nominal is interned by
+    # `(origin, decl)` and rendered by its bare name, so `rec P` in two modules
+    # produces `type mismatch: expected P, found P` - a message that names the
+    # defect and tells the reader nothing, which is this repo's diagnostic-surface
+    # failure exactly. The types are different and the diagnostic could not show it.
+    #
+    # The ambiguity is a property of the PAIR, not of either type, which is why the
+    # fix is here and not in the renderer: qualifying every nominal everywhere would
+    # make every ordinary diagnostic noisier to fix a case that is rare. When the two
+    # spellings collide, the note names each side's defining module instead of the
+    # cast advice, which cannot apply between two unrelated records anyway.
+    report_types_pair(sc, span, msg, expected, actual, expected_str, actual_str, note);
 
     A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
     type_str_free(sc, expected_str);
     type_str_free(sc, actual_str);
+}
+
+# report an assembled message that names TWO types, disambiguating them when their
+# two renderings are the same string (#2288)
+#
+# THE ONE DECISION POINT for the whole two-type diagnostic family, so a message
+# added later inherits the disambiguation instead of collapsing the way the first
+# one did. A nominal is interned by `(origin, decl)` and rendered by its bare name,
+# so `rec P` declared in two modules produces `type mismatch: expected P, found P` -
+# a diagnostic that reports the defect and cannot represent it.
+#
+# The ambiguity is a property of the PAIR, not of either type, which is why this is
+# not a change to the renderer: qualifying every nominal at every site would make
+# every ordinary diagnostic noisier to fix a case that is rare.
+#
+# Degrades to `note` (or to a bare report when `note` is empty) when either side has
+# no module to name - a primitive, a generic parameter, a function type, or a nominal
+# whose origin did not resolve - so a pair that collided for some other reason still
+# reports with its ordinary advice rather than with a half-written sentence.
+# ---
+# sc:    the active sema context
+# span:  source range to pin the diagnostic to
+# msg:   the assembled message, already carrying both rendered types
+# a:     the first type named in `msg`
+# b:     the second type named in `msg`
+# a_str: `a` as rendered into `msg`
+# b_str: `b` as rendered into `msg`
+# note:  the note to attach when the pair is not ambiguous; "" for no note
+fun report_types_pair(sc: *context.SemaContext, span: token.Span, msg: str,
+                      a: type.TypeId, b: type.TypeId, a_str: str, b_str: str, note: str) {
+    if (a == b || !str_equals(a_str, b_str)) {
+        report_pair_plain(sc, span, msg, note);
+        ret;
+    }
+
+    val am: intern.StrId = declaring_module_fqn(sc, a);
+    val bm: intern.StrId = declaring_module_fqn(sc, b);
+    if (am == intern.STR_NIL || bm == intern.STR_NIL) {
+        report_pair_plain(sc, span, msg, note);
+        ret;
+    }
+    val ao: O.Option[str] = intern.lookup(?sc.s.interner, am);
+    val bo: O.Option[str] = intern.lookup(?sc.s.interner, bm);
+    if (O.is_none[str](ao) || O.is_none[str](bo)) {
+        report_pair_plain(sc, span, msg, note);
+        ret;
+    }
+
+    val res_n: R.Result[str, str] = format.sprint(sc.s.alloc,
+        "these are two different types that share the name `{}`: the first is declared in `{}`, the second in `{}`",
+        a_str, O.unwrap[str](ao), O.unwrap[str](bo));
+    if (R.is_err[str, str](res_n)) {
+        report_pair_plain(sc, span, msg, note);
+        ret;
+    }
+    val n: str = R.unwrap_ok[str, str](res_n);
+    report_note(sc, span, msg, n);
+    A.deallocate[char](sc.s.alloc, n, str_len(n) + 1);
+}
+
+# report `msg`, attaching `note` only when there is one
+# ---
+# sc:   the active sema context
+# span: source range to pin the diagnostic to
+# msg:  the assembled message
+# note: the note to attach, or "" for none
+fun report_pair_plain(sc: *context.SemaContext, span: token.Span, msg: str, note: str) {
+    if (str_len(note) == 0) {
+        report(sc, span, msg);
+        ret;
+    }
+    report_note(sc, span, msg, note);
+}
+
+# the FQN of the module that declares `t`'s nominal, or STR_NIL when it has none
+#
+# A generic instance is answered by the declaration it instantiates, so
+# `lib.Box[i32]` and `main.Box[i32]` - which also render identically - name their
+# own modules. Every other kind has no declaring module and answers STR_NIL.
+# ---
+# sc: the active sema context
+# t:  the type to locate
+# ret: the interned module FQN, or STR_NIL
+fun declaring_module_fqn(sc: *context.SemaContext, t: type.TypeId) intern.StrId {
+    val opt: O.Option[*type.Type] = type.get(?sc.s.types, t);
+    if (O.is_none[*type.Type](opt)) { ret intern.STR_NIL; }
+    val ty: *type.Type = O.unwrap[*type.Type](opt);
+    if (ty.kind == type.TYPE_REC || ty.kind == type.TYPE_UNI) {
+        ret session.module_fqn(sc.s, ty.data.nominal.origin);
+    }
+    if (ty.kind == type.TYPE_INSTANCE) {
+        ret session.module_fqn(sc.s, ty.data.instance.target_origin);
+    }
+    ret intern.STR_NIL;
 }
 
 # report a `literal <v> is out of range for <T> (<min>..<max>)` diagnostic
@@ -1489,7 +1596,7 @@ fun report_reinterpret_mismatch(sc: *context.SemaContext, span: token.Span, from
         ret;
     }
     val msg: str = R.unwrap_ok[str, str](res_msg);
-    report(sc, span, msg);
+    report_types_pair(sc, span, msg, from, to, from_str, to_str, "");
 
     A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
     type_str_free(sc, from_str);


### PR DESCRIPTION
Part of epic #2288.

## What was wrong

A nominal type is interned by `(origin, decl)` and rendered by its bare name, so `rec P` declared in two modules produced exactly this on `dev`:

```
error: type mismatch: expected P, found P
  --> ./src/main.mach:12:5
   |
12 |     x = y;
   |     ^^^^^
   |
   = note: mach has no implicit widening; cast the value with `value::Type`
```

The two types are genuinely different and the diagnostic could not show it. The message names the defect and tells the reader nothing about it, and the note is actively wrong — no cast relates two unrelated records. This is #2288's thesis in one line: the surface you reach for cannot represent the thing it exists to report.

Found by auditing the epic's "diagnostics that print a type or a value: can two distinct things print identically?" bullet the way the bar asks — producing both sides of each distinction and diffing, not reading the printer.

## What was already fine

Worth recording, since the bar asks for the table and not just the fix. Every one of these renders distinguishably, checked by producing both:

| distinction | renders as |
|---|---|
| secret vs public | `^u32` / `u32` |
| generic arguments | `Box[i32]` / `Box[u32]` |
| vector lane signedness | `i32x4` / `u32x4` |
| aggregate vs scalar at equal width | `[8]u8` / `i64` |
| packed vs unpacked | `Q` / `R` (distinct nominals) |
| over-aligned vs natural | `S` / `R` |
| function arity | `fun(i64) i64` / `fun(i64, i64) i64` |

One collapse in the sweep, which is this PR.

## The fix, and where it lives

The ambiguity is a property of the **pair**, not of either type. That is why this is not a change to the type renderer: qualifying every nominal at every site would make every ordinary diagnostic noisier to fix a case that is rare. When the two renderings collide, the note names each side's defining module instead of the cast advice.

```
error: type mismatch: expected P, found P
  = note: these are two different types that share the name `P`: the first is declared in `dcase.main`, the second in `dcase.lib`
```

**One decision point for the whole family**, per the duplicate-policy concern raised on this: `report_types_pair` is the single place that decides, and the assignment mismatch, the `:~` size mismatch and `incompatible operand types` all route through it. So a two-type message added later inherits the rule instead of collapsing the way the first one did.

The `:~` site collapsed identically and is fixed by the same change — `bit reinterpret requires equal-size types: P (16 bytes) vs P (1 bytes)` now carries the note. `incompatible operand types` is wired up but has **no reachable collision today**: its two types would have to be nominals, and aggregate arithmetic and `==` are both refused before that message is built. It is connected deliberately rather than tested, and the test says so.

A pair with no module to name — two primitives, a generic parameter, a function type — degrades to the ordinary note rather than to a half-written sentence.

## A harness gap found on the way, and it bit this change's own test

`ut_diag_has` scans a diagnostic's `message` only. A note is a **separate owned field** on the `Diag`, so until this PR **no test in the tree could assert anything about a note's text**, and every note the compiler attaches was unpinned. That is the same asymmetry #2297 found between `ut_lower_ok` and the sink-reading helpers, arriving through a different door.

It is not hypothetical. Two arms of this change's own test, written with a bare module name as the needle, **passed against the unpatched compiler** — some unrelated note in the same compile mentions the module, so they asserted nothing. Both now assert the surrounding phrase (`the first is declared in \`uniontest.main\``), and `ut_diag_note_has` is added as the note-reading sibling.

I have not filed this separately; it is stated here and in the helper's own comment. If you want it tracked as its own audit finding on #2288, say so.

## Verification

Each of the five arms contributes a distinct bit to the exit code, so a failure names which one. Against a compiler built from **unpatched** `check.mach` with the tests kept:

```
FAIL  mach.lang.driver:same_name_type_mismatch_names_its_modules  (exit 31)
```

`31` is all five arms — the same-name note absent, both module-naming arms absent, the generic-instance collision absent, and the `:~` collision absent. Before tightening, the same run gave `25`, i.e. the two module-naming arms passed vacuously; that is what prompted the harness work above.

The over-firing guard, `distinct_name_type_mismatch_keeps_its_note`, passes on **both** compilers by design: same shape, same two modules, one identifier changed, so a rule that fired on "two nominal types" rather than on "two types that render the same" fails it. It asserts the mismatch is still produced before asserting the note is absent, so it cannot pass vacuously. Two primitives are covered there too.

- `mach test .` — 1336 passed, 0 failed
- `bash int/run.sh --target linux ./m` — all cases passed
- self-host fixpoint — stage2 == stage3 byte-identical, each stage built into a freshly removed `out/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6L67517WpZTPQDhtMsuJ2
