### PR TITLE
fix(int): pin mach-shader instead of floating it, so spirv-ext-inst and spirv-shader-only test mach rather than mach-shader's main

### DIFF
--- a/int/deps.lock
+++ b/int/deps.lock
@@ -6,5 +6,5 @@
 
 [dep.mach-shader]
 url = "https://github.com/briar-systems/mach-shader"
-ref = "branch/main"
+ref = "commit/a0581755753abb6d4ca99d2946b2b973af3d0ddf"
 commit = "a0581755753abb6d4ca99d2946b2b973af3d0ddf"

--- a/int/surface/spirv-ext-inst/case.conf
+++ b/int/surface/spirv-ext-inst/case.conf
@@ -12,3 +12,15 @@
 run: spirv-shader
 targets: linux
 build-target: spirv
+
+# mach-shader is pinned in mach.toml (commit/, not branch/main), deliberately,
+# unlike every other int dependency (#2827). the golden here names three specific
+# exports - normalize, length, distance - and mach-shader's 0.1.0 release dropped
+# all three, so under the harness's default `--deps float` this case went red on
+# every ordinary mach PR that touched none of this: the exact shape #2592 fixed
+# for mach-std, applied to a dependency the root manifest does not cover. pinned
+# to a0581755753abb6d4ca99d2946b2b973af3d0ddf, the commit immediately before that
+# release, where the three exports still exist. if someone deliberately advances
+# this pin past 0.1.0, this case's golden (and mach-shader's own math module) may
+# need updating together - advancing it silently would reintroduce exactly the
+# gap this note exists to prevent.

--- a/int/surface/spirv-ext-inst/mach.toml
+++ b/int/surface/spirv-ext-inst/mach.toml
@@ -38,6 +38,13 @@ need = []
 # check is a call ACROSS A MODULE BOUNDARY into a real published library, which is
 # where the substitution has to happen, since a SPIR-V module is compiled per mach
 # module and a shader module may declare no linkage to call out through.
+#
+# pinned rather than branch/main (#2827): this case's own golden names specific
+# exports (normalize/length/distance) that mach-shader's 0.1.0 release dropped, so
+# floating turns this case red on an ordinary mach PR that touched none of this -
+# exactly the shape #2592 fixed for mach-std. see case.conf for the rationale and
+# spirv-shader-only's identical pin (check-deps.sh requires every case naming a dep
+# to agree on its ref).
 [dep.mach-shader]
 git = "https://github.com/briar-systems/mach-shader"
-ref = "branch/main"
+ref = "commit/a0581755753abb6d4ca99d2946b2b973af3d0ddf"

--- a/int/surface/spirv-shader-only/case.conf
+++ b/int/surface/spirv-shader-only/case.conf
@@ -14,3 +14,11 @@
 # decision until someone gives the library a body; this case is what makes it hold.
 run: build-fails
 targets: linux
+
+# mach-shader is pinned in mach.toml (commit/, not branch/main), matching
+# spirv-ext-inst (#2827): check-deps.sh requires every case naming a dep to agree
+# on its url and ref, and that sibling case's golden names exports mach-shader's
+# 0.1.0 release dropped, so it is pinned before that release. this case's own
+# assertion (a link failure on a non-SPIR-V target) does not depend on which
+# functions shader.math exports, so it would tolerate floating on its own - it is
+# pinned only to satisfy the shared-ref agreement, not because it needs to be.

--- a/int/surface/spirv-shader-only/mach.toml
+++ b/int/surface/spirv-shader-only/mach.toml
@@ -28,6 +28,12 @@ targets = ["*"]
 link = []
 need = []
 
+# pinned rather than branch/main (#2827): the sibling spirv-ext-inst case's golden
+# names exports mach-shader's 0.1.0 release dropped, and check-deps.sh requires
+# every case naming a dep to agree on its ref, so this one is pinned to the same
+# commit even though its own assertion (a link failure on a non-SPIR-V target)
+# does not depend on which functions shader.math exports. see spirv-ext-inst's
+# mach.toml and case.conf for the rationale.
 [dep.mach-shader]
 git = "https://github.com/briar-systems/mach-shader"
-ref = "branch/main"
+ref = "commit/a0581755753abb6d4ca99d2946b2b973af3d0ddf"


### PR DESCRIPTION
## Summary
- `spirv-ext-inst`'s golden names three exports (`normalize`/`length`/`distance`) that mach-shader's `0.1.0` release dropped, so under the harness's default `--deps float` the case went red on every ordinary mach PR that touched none of it - the same shape #2592 fixed for `mach-std`, but for a dependency the root manifest does not cover at all.
- `int/deps.lock` already pinned a working commit (`a058175`), but the PR lane deliberately floats by default, so that pin was never consulted there.
- Both cases declaring `mach-shader` (`spirv-ext-inst`, `spirv-shader-only`) now pin it directly in their own `mach.toml` (`ref = "commit/a058175..."`, immediately before the `0.1.0` release) rather than `branch/main` - `check-deps.sh` requires every case naming a dep to agree on its ref, so both moved together even though `spirv-shader-only`'s own assertion does not depend on which functions `shader.math` exports.
- `int/deps.lock` regenerated via `update-deps.sh` to match.
- Audited every int case for the same shape: the whole suite declares exactly two distinct git dep names - `mach-std` (~46 cases, covered by the root `mach.lock`, deliberately floating per `ci.yml`'s own PR-lane design) and `mach-shader` (these two, now pinned). No other case has this exposure.
- Note for whoever deliberately advances this pin past `0.1.0`: `spirv-ext-inst`'s golden (and `mach-shader`'s own math module) may need updating together, or the case goes back to failing against a release that dropped what it asserts.

## Test plan
- [x] `check-target-matrix.sh` and `check-deps.sh` clean
- [x] `mach test .` - 1336/1336
- [x] Full `int/run.sh` on `linux`, default (`--deps float`) mode - all green, including `spirv-ext-inst`
- [x] Full `int/run.sh --deps pin` on `linux` (the release-gate lane) - all green

Closes #2827