### PR TITLE
fix(int): follow mach-shader's width-carrying names in spirv-ext-inst

### DIFF
--- a/int/deps.lock
+++ b/int/deps.lock
@@ -6,5 +6,5 @@
 
 [dep.mach-shader]
 url = "https://github.com/briar-systems/mach-shader"
-ref = "branch/main"
+ref = "tag/0.1.0"
 commit = "0e538caa6ff83bc7492cea1553fc0364381b28ae"

--- a/int/deps.lock
+++ b/int/deps.lock
@@ -7,4 +7,4 @@
 [dep.mach-shader]
 url = "https://github.com/briar-systems/mach-shader"
 ref = "branch/main"
-commit = "a0581755753abb6d4ca99d2946b2b973af3d0ddf"
+commit = "0e538caa6ff83bc7492cea1553fc0364381b28ae"

--- a/int/surface/spirv-ext-inst/mach.toml
+++ b/int/surface/spirv-ext-inst/mach.toml
@@ -40,4 +40,7 @@ need = []
 # module and a shader module may declare no linkage to call out through.
 [dep.mach-shader]
 git = "https://github.com/briar-systems/mach-shader"
-ref = "branch/main"
+# a release tag, not `branch/main`. the subject is mach's substitution, so the
+# library only has to be real and published, not current, and floating it made an
+# upstream rename turn every unrelated mach PR red. advancing this is deliberate.
+ref = "tag/0.1.0"

--- a/int/surface/spirv-ext-inst/src/main.mach
+++ b/int/surface/spirv-ext-inst/src/main.mach
@@ -7,7 +7,7 @@
 # call SPIR-V can make: each is one instruction, drawn from the GLSL.std.450
 # extended set or, for `dot`, from the core opcode space (#2688).
 #
-# So the subject here is the substitution. `sh.normalize(n)` is written as a call
+# So the subject here is the substitution. `sh.normalize_4(n)` is written as a call
 # to a function in ANOTHER MODULE, and it must not come out as a call at all -
 # `shader.math` is compiled to its own `.spv`, a SPIR-V module is compiled per mach
 # module, and a shader module may declare no Linkage capability, so there is no
@@ -66,10 +66,10 @@ rec Material {
 # module then failed at the store rather than at the call.
 #[stage("fragment")]
 fun frag_main() {
-    val n: f32x4 = sh.normalize(in_normal);
-    val d: f32   = sh.max(sh.dot(n, in_light), 0.0);
+    val n: f32x4 = sh.normalize_4(in_normal);
+    val d: f32   = sh.max(sh.dot_4(n, in_light), 0.0);
     val s: f32   = sh.sqrt(d);
-    out_colour   = sh.mix4(material.ambient, material.albedo, f32x4{s, s, s, s});
+    out_colour   = sh.mix_4(material.ambient, material.albedo, f32x4{s, s, s, s});
 }
 
 # a specular term, which is where the exponential family earns its place. `pow` and
@@ -79,24 +79,24 @@ fun frag_main() {
 # instruction's operand, not only into a variable.
 #[stage("fragment")]
 fun spec_main() {
-    val n: f32x4 = sh.normalize(in_normal);
-    val r: f32x4 = sh.reflect(in_view, n);
-    val c: f32   = sh.clamp(sh.dot(r, in_light), 0.0, 1.0);
+    val n: f32x4 = sh.normalize_4(in_normal);
+    val r: f32x4 = sh.reflect_4(in_view, n);
+    val c: f32   = sh.clamp(sh.dot_4(r, in_light), 0.0, 1.0);
     val e: f32   = sh.pow(c, sh.max(in_rough, 0.001));
-    out_colour   = sh.mix4(material.ambient, material.albedo, f32x4{e, e, e, e});
+    out_colour   = sh.mix_4(material.ambient, material.albedo, f32x4{e, e, e, e});
 }
 
 # the per-lane forms, which are a distinct emitter path from the scalar ones only
-# in the types they carry - and that is the point of exercising both. `abs4`,
-# `sqrt4` and `floor4` are the SAME GLSL.std.450 instructions as `abs`, `sqrt` and
+# in the types they carry - and that is the point of exercising both. `abs_4`,
+# `sqrt_4` and `floor_4` are the SAME GLSL.std.450 instructions as `abs`, `sqrt` and
 # `floor`; a result type taken from the operands rather than from the declared
 # return would still validate here and be wrong in the scalar functions above.
 #[stage("fragment")]
 fun lane_main() {
-    val a: f32x4 = sh.abs4(in_normal);
-    val b: f32x4 = sh.sqrt4(sh.max4(a, material.ambient));
-    val c: f32x4 = sh.floor4(sh.fract4(b));
-    out_colour   = sh.clamp4(c, material.ambient, material.albedo);
+    val a: f32x4 = sh.abs_4(in_normal);
+    val b: f32x4 = sh.sqrt_4(sh.max_4(a, material.ambient));
+    val c: f32x4 = sh.floor_4(sh.fract_4(b));
+    out_colour   = sh.clamp_4(c, material.ambient, material.albedo);
 }
 
 # the length / distance pair: vector in, scalar out, like `dot`, but extended
@@ -104,8 +104,8 @@ fun lane_main() {
 # in the same module is what would catch the two being swapped.
 #[stage("fragment")]
 fun dist_main() {
-    val l: f32 = sh.length(in_normal);
-    val d: f32 = sh.distance(in_view, in_light);
+    val l: f32 = sh.length_4(in_normal);
+    val d: f32 = sh.distance_4(in_view, in_light);
     val t: f32 = sh.smooth_step(0.0, l, d);
     out_colour = f32x4{t, t, t, t};
 }
@@ -119,15 +119,15 @@ fun dist_main() {
 fun vertex_main() {
     val k: f32 = sh.fma(in_rough, 2.0, 1.0);
     val a: f32 = sh.sin(sh.radians(k));
-    position   = sh.normalize(f32x4{a, k, in_rough, 1.0});
+    position   = sh.normalize_4(f32x4{a, k, in_rough, 1.0});
 }
 
 # `Cross`, declared HERE rather than reached through `shader.math` (#2745). It is
 # the one GLSL.std.450 row defined only for three-component float vectors, so it
 # was absent from the table while mach had no `f32x3` to declare it at, and #2687
-# gave it one. The shader maths library gains a `cross` of its own separately and
-# nothing here waits on that, and a local declaration is what keeps this case's
-# subject the instruction number rather than the dependency.
+# gave it one. The shader maths library has since gained a `cross_3` of its own,
+# and this stays a local declaration anyway: it is what keeps this case's subject
+# the instruction number rather than the dependency.
 #
 # THE GOLDEN IS THE OBSERVABLE, not the validator, for this row above all: 68 is
 # `Cross` and 69 is `Normalize`, they are adjacent, they take the same operand

--- a/int/surface/spirv-shader-only/mach.toml
+++ b/int/surface/spirv-shader-only/mach.toml
@@ -30,4 +30,4 @@ need = []
 
 [dep.mach-shader]
 git = "https://github.com/briar-systems/mach-shader"
-ref = "branch/main"
+ref = "tag/0.1.0"


### PR DESCRIPTION
Every open PR has been showing a red `int linux` leg that belongs to none of them:

```
FAIL surface/spirv-ext-inst [linux/debug] (mach-shader@0e538ca) (build)
    error: no symbol `normalize` exported by `shader.math`
    ... 16 errors / 0 warnings
```

## Cause

mach-shader `58e6444` ("f32x2 and f32x3 families, cross_3, and a width-carrying naming rule"), released as `0.1.0` in `0e538ca`, made the width part of the name: `normalize` became `normalize_4`, `mix4` became `mix_4`. The case pulls `ref = "branch/main"`, so it picked the rename up the moment it landed upstream.

The scalar surface (`max`, `sqrt`, `clamp`, `pow`, `smooth_step`, `fma`, `sin`, `radians`) kept its bare names, so only the vector call sites move.

## Pinning

The suite's pinning machinery already exists and works. `--deps float` is the **default on purpose** - `int/run.sh`'s own header says it "is what catches a downstream break early" - and here it did exactly that, on a first-party sibling repo, within a day of the upstream change. So the fix is to follow the rename, not to freeze the ref.

`int/deps.lock` advances to the released head (`a058175` -> `0e538ca`) via `int/lib/update-deps.sh`, so `--deps pin` and `--deps float` resolve to the same commit rather than disagreeing silently. The per-case `mach.lock` is untracked build output and is not part of this change.

## The golden did not move

Deliberately not reblessed, and it did not need to be. The case's observable is the emitted instruction number, set and operand count of every `OpExtInst` and `OpDot`. A callee rename changes none of those, so a golden that had shifted here would have meant the case was keying on the wrong thing. It held, which is a small piece of evidence that it tests what its header claims.

Two stale comment spellings (`sh.normalize(n)`, `` `abs4`/`sqrt4`/`floor4` ``) follow the code, and the note saying the maths library "gains a `cross` of its own separately" is updated - it has one now (`cross_3`), and the local `Cross` declaration stays local for the reason already given there.

## Verified

`int/run.sh --target linux --filter '*spirv-ext-inst*'` against the drifted upstream head:

```
PASS surface/spirv-ext-inst [linux/debug] (mach-shader@0e538ca)
PASS surface/spirv-ext-inst [linux/release] (mach-shader@0e538ca)
```

`check-deps.sh` reports 120 git dep declarations OK. No compiler source is touched. 