### PR TITLE
docs(int): record that two run.sh invocations against one checkout race

### DIFF
--- a/int/run.sh
+++ b/int/run.sh
@@ -71,6 +71,12 @@
 # answers the question while the log exists, and "what did the run that cut this tag
 # build against" is asked afterwards. CI uploads the file.
 #
+# NOT SAFE TO RUN CONCURRENTLY. two invocations against one checkout - even for
+# different --target values - race on the same per-case out/ directories and can
+# produce a wrong result, including a spurious PASS. no guard here (this suite is
+# being rebuilt; run isolation belongs in that design, not patched into this
+# one) - run a second target from a second checkout instead.
+#
 # `--runmode qemu` only reaches a leg qemu-user can actually load: qemu_bin() in
 # lib/produce.sh names the ELF-only rule and the three targets that can never
 # work under it (#2453) - passing `qemu` for one of those fails loudly with that


### PR DESCRIPTION
## Summary
- Two independent reports today confirmed `int/run.sh` isn't safe to run concurrently: two invocations against one checkout, even for different `--target` values, race on the shared per-case `out/` directories. Worst case is a spurious PASS (invisible), not just a spurious FAIL.
- `int/` is being rebuilt, so this does not add a lock or any code path - it's a one-line record of the constraint where the next person hits it, and a note that run isolation belongs in the rebuild's design.

## Test plan
- [x] `bash -n int/run.sh` - syntax clean
- [x] Ran a case through it - unaffected, comment-only change