### PR TITLE
fix(diag): audit the three assembly printers, and name the two fields whose omission read as a different instruction

### DIFF
--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -938,8 +938,20 @@ fun neon_is_bitwise(base: u32) bool {
 
 # the lane arrangement a NEON operation renders at
 #
-# A 128-bit vector holds sixteen bytes, so the element width fixes the lane count.
-# The bitwise forms are fixed at the byte arrangement.
+# The element width alone, mirroring `encode.neon_size` - the SAME projection of the
+# descriptor the encoder packs into the word's size field. The descriptor's LANE COUNT
+# is deliberately not read: this renders the instruction that was emitted, and the
+# emitted word is a Q form naming sixteen bytes whatever count the operation carried.
+#
+# So a two-lane and a four-lane f32 operation render the same line, and that is
+# correct here - they also ENCODE the same word. The collapse is real and it is the
+# encoder's: `neon_size` derives the arrangement from the element width alone, so
+# arm64 emits the four-lane form for every sub-128-bit vector (#2838, the aarch64 twin
+# of the SPIR-V defect #2743 fixed). Asserting the count here would refuse to print an
+# instruction the object really contains, which hides the evidence rather than the
+# defect. The surface that can show the distinction is the IR type, not the `.s`.
+#
+# The bitwise forms are fixed at the byte arrangement - their size bits are opcode.
 # ---
 # base: the packer base word
 # lane: the lane descriptor, in `mir.MirInstr.vec_lane`'s encoding

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -127,7 +127,29 @@ fun render_inst(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst) 
 
     val res_ops: R.Result[bool, str] = render_operands(out, interner, mi);
     if (R.is_err[bool, str](res_ops)) { ret res_ops; }
+    val res_rm: R.Result[bool, str] = emit_str(out, rounding_operand(mi.opcode::inst.MachOp));
+    if (R.is_err[bool, str](res_rm)) { ret res_rm; }
     ret emit_str(out, "\n");
+}
+
+# the explicit rounding-mode operand a float conversion spells
+#
+# The rounding mode is a FIELD OF THE WORD, and an assembler fills it from the operand
+# or, when there is none, from the form's default - which for the float-to-integer
+# converts is the DYNAMIC mode read out of `fcsr`. This encoder emits those converts
+# round-toward-zero, mach's defined cast rule, so a line printed without the operand
+# reassembles to a different instruction than the one beside it in the object and
+# disagrees with every disassembly of it. Naming the mode is what makes the two agree.
+#
+# Only that family needs one. The float arithmetic and the remaining converts already
+# encode the mode the assembler defaults to for their form - dynamic where the result
+# may round, round-to-nearest where it cannot - so an operand there would be noise.
+# ---
+# op:  the concrete instruction
+# ret: the trailing operand text, empty for a form that needs none
+fun rounding_operand(op: inst.MachOp) str {
+    if (op >= inst.FCVT_W_S && op <= inst.FCVT_LU_D) { ret ", rtz"; }
+    ret "";
 }
 
 # render an instruction's operands, left to right
@@ -702,6 +724,52 @@ test "mach.lang.target.isa.riscv64.printer.names:abi_mnemonics" {
     if (!str_equals(fp_name(10), "fa0"))  { ret 1; }
     if (!str_equals(fp_name(31), "ft11")) { ret 1; }
     if (!str_equals(fp_name(99), "f?"))   { ret 1; }
+    ret 0;
+}
+
+# a float conversion names the rounding mode it encodes, so the line reassembles to
+# the word it came from
+#
+# The mode is a field of the word and an assembler fills it from this operand or,
+# without one, from the form's default. The float-to-integer converts default to the
+# DYNAMIC mode, and this encoder emits them round-toward-zero, so the line without the
+# operand named a different instruction than the one in the object - `objdump` prints
+# `fcvt.w.s a0,fa0,rtz` for the same four bytes. The int-to-float direction is the
+# control: it encodes the mode its form already defaults to and takes no operand, so a
+# printer appending one unconditionally would be wrong in the other direction.
+test "mach.lang.target.isa.riscv64.printer.render_inst:rounding_mode_is_named" {
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = test_sink_write;
+
+    val a0:  isa.Operand = isa.make_reg(10, 8);
+    val fa0: isa.Operand = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, 10), 8);
+
+    var f2i: isa.Inst = isa.inst_blank();
+    f2i.opcode = inst.FCVT_W_S::u16;
+    f2i.size   = 4;
+    f2i.dst    = a0;
+    f2i.src1   = fa0;
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, nil, ?f2i)))         { ret 1; }
+    if (!str_equals(test_sink_text(), "  fcvt.w.s a0, fa0, rtz\n")) { ret 1; }
+
+    var i2f: isa.Inst = isa.inst_blank();
+    i2f.opcode = inst.FCVT_S_W::u16;
+    i2f.size   = 4;
+    i2f.dst    = fa0;
+    i2f.src1   = a0;
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, nil, ?i2f)))      { ret 1; }
+    if (!str_equals(test_sink_text(), "  fcvt.s.w fa0, a0\n")) { ret 1; }
+
+    # the whole float-to-integer family names it, not just the one form
+    if (!str_equals(rounding_operand(inst.FCVT_LU_D), ", rtz")) { ret 1; }
+    if (!str_equals(rounding_operand(inst.FCVT_W_D), ", rtz"))  { ret 1; }
+    # and nothing outside it does - a float add takes the dynamic mode it defaults to
+    if (!str_equals(rounding_operand(inst.FADD_D), ""))   { ret 1; }
+    if (!str_equals(rounding_operand(inst.FCVT_S_D), "")) { ret 1; }
+    if (!str_equals(rounding_operand(inst.FMV_X_W), "")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -132,6 +132,14 @@ fun render_inst(buf: *enc.ByteBuf, mi: *isa.Inst) R.Result[bool, str] {
         if (R.is_err[bool, str](res_lock)) { ret res_lock; }
     }
 
+    # the REP prefix is what makes a string operation a loop over rcx rather than a
+    # single element, and the encoder emits its own byte for it: a repeated `movsb`
+    # printed as a plain one names a different instruction, not a shorter one
+    if ((mi.flags & x64.FLAG_REP::u16) != 0) {
+        val res_rep: R.Result[bool, str] = emit_str(out, "rep ");
+        if (R.is_err[bool, str](res_rep)) { ret res_rep; }
+    }
+
     # a packed compare spells its imm8 predicate into the mnemonic (`cmpltps`), which
     # is how the instruction disassembles; the generic form plus a bare predicate
     # number would not correspond to the object line for line
@@ -767,6 +775,45 @@ test "mach.lang.target.isa.x64.printer.render_inst:freestanding_surface" {
     i6.dst    = isa.make_reg(x64.RAX, 4);
     i6.src1   = isa.make_mem(x64.RCX, 0, -1, 0, 2);
     bad = bad | rendered_is(?buf, ?i6, "movzx eax, word [rcx]");
+
+    enc.buf_dnit(?buf);
+    ret bad;
+}
+
+# a prefix the encoder emits a byte for changes the instruction, so two words that
+# differ only in one must not print the same line
+#
+# The prefix bits ride `flags`, not the opcode, so a printer that reads only the
+# opcode renders the prefixed and unprefixed forms identically - a repeated string
+# move as a single-element one, an atomic read-modify-write as a plain one. Both
+# directions are pinned here by rendering the pair, because a claim that a field is
+# printed is worth nothing without the state that would have collided with it.
+test "mach.lang.target.isa.x64.printer.render_inst:prefixes_are_part_of_the_instruction" {
+    var alloc: A.Allocator;
+    var buf: enc.ByteBuf;
+    var w: writer.Writer;
+    var sink: enc.AsmSink;
+    test_sink_buf_init(?buf, ?alloc, ?w, ?sink);
+
+    var bad: i32 = 0;
+
+    # `A4` and `F3 A4` are two instructions; only the flag tells them apart
+    var mov: isa.Inst = isa.inst_blank();
+    mov.opcode = x64.MOVSB;
+    mov.size   = 1;
+    bad = bad | rendered_is(?buf, ?mov, "movsb");
+    mov.flags  = x64.FLAG_REP::u16;
+    bad = bad | rendered_is(?buf, ?mov, "rep movsb");
+
+    # the atomic pair, whose LOCK byte is what the operation's guarantee rests on
+    var add: isa.Inst = isa.inst_blank();
+    add.opcode = x64.ADD;
+    add.size   = 8;
+    add.dst    = isa.make_mem(x64.RCX, 0, -1, 0, 8);
+    add.src1   = isa.make_reg(x64.RAX, 8);
+    bad = bad | rendered_is(?buf, ?add, "add qword [rcx], rax");
+    add.flags  = x64.FLAG_LOCK::u16;
+    bad = bad | rendered_is(?buf, ?add, "lock add qword [rcx], rax");
 
     enc.buf_dnit(?buf);
     ret bad;


### PR DESCRIPTION
Closes #2821.

## The surface named in the issue does not exist

There is no `--emit-mir` flag. `mach/src/cli/args.mach` declares `--emit-asm` and `--emit-ir` and nothing else, and no MIR dumper exists anywhere in the tree. The three files the issue means by "the per-ISA MIR printers" are `isa/{x64,arm64,riscv64}/printer.mach`, and since #2187 none of them walks the MIR: each renders the `isa.Inst` its own encoder built, at the moment it emitted the bytes. mos6502 has no printer at all.

That changes the audit's question, and for the better. The issue asks "is there a distinction the compiler can produce that this surface cannot show?" - a question about MIR. Since the printers render the encoder's output, the sharper question is **does a printed line name the instruction that is in the object?** A line that names a different instruction is a wrong claim; a MIR distinction that two identical instructions cannot show is the encoder's problem, not the printer's. Both were found, and they needed opposite treatment.

## Table: every field and operand kind, with a verdict

`isa.Operand` (shared by x86-64 and riscv64; aarch64's `printer.Inst` carries the same operand payloads).

| Field / kind | x86-64 | aarch64 | riscv64 |
|---|---|---|---|
| `kind` = OPK_NONE | correct (renders nothing, no separator) | correct | correct |
| `kind` = OPK_REG | correct | correct | correct |
| `kind` = OPK_IMM | correct | correct | correct |
| `kind` = OPK_MEM | correct | correct | correct |
| `kind` = OPK_LABEL | correct | correct | correct |
| `kind` = OPK_SYM | correct | correct | correct |
| unmodelled kind | correct (hard error) | correct (hard error) | correct (hard error) |
| `reg` bank (GP vs float) | correct, off the composite id's class tag | correct | correct |
| `reg` index out of range | n/a (table total) | n/a | **explicitly unknown** (`x?` / `f?`) |
| `size` on a register | correct (`al`/`ax`/`eax`/`rax`, `b`/`h`/`s`/`d`/`q`) | correct | n/a (RV64 names are width-free) |
| `size` on a memory operand | correct (`byte`/`word`/`dword`/`qword`/`xmmword`) | n/a (width rides the mnemonic) | n/a |
| `imm` value and sign | correct | correct (hex, decimal for bit positions) | correct |
| `imm` as a system-register number | correct (`cr2`, `ds`; reserved numbers are a hard error) | correct (sysreg + pstate field names) | correct (bare CSR number, which is the assembler's form) |
| `base` in a MEM | correct, incl. the RIP and absolute forms | correct | correct |
| `index` / `scale` in a MEM | correct (`*2`/`*4`/`*8`; `*1` elided as a disassembler does) | correct | n/a (no scaled index) |
| `disp` in a MEM | correct, incl. the negative form | correct, incl. pre/post-index writeback | correct |
| `disp` under a `sym_mod` | **omitted**, and the placeholder is documented as zero | **omitted**, same | **omitted**, same |
| `sym_id` | correct | correct | correct |
| symbol ADDEND (`MirOperand.sym_off`) | **ambiguous** - dropped at `mir_to_operand`, never reaches the operand | **ambiguous** - same | **ambiguous** - same |
| `sym_mod` | n/a (x86-64 has none) | correct (`:lo12:`, `:got:`, `:got_lo12:`; page-high is bare, as `adrp` spells it) | correct (`%pcrel_hi`, `%pcrel_lo`, `%got_pcrel_hi`) |
| `label` name | correct | correct | correct |
| block-target label | correct, incl. the block-0 disambiguation via the MIR operand | correct (`TGT_BLOCK`) | correct |
| expansion-internal label | **explicitly unknown** (`<internal>`) | correct (`.+N`, a real distance) | correct (`.+N`) |
| inline-asm numeric local label | correct (`1f`/`1b`) | correct | correct |

`isa.Inst` / `printer.Inst`.

| Field | x86-64 | aarch64 | riscv64 |
|---|---|---|---|
| `opcode` / `base` mnemonic | correct, total (unmapped = hard error) | correct, total | correct, total |
| disassembler aliases | correct (`movd` by width, packed-compare predicates) | correct (`mov`/`cmp`/`neg`/`mvn`/`lsr`/`uxtb`/`sxtw`/`mul`/`cset`) | n/a by design (no pseudo-instructions) |
| `size` fallback when an operand carries none | correct | correct | correct |
| `flags` LOCK | correct | n/a | n/a |
| `flags` REP | **ambiguous** -> FIXED | n/a | n/a |
| `flags` REX_W / 16BIT | correct (they only restate the operand width, which is printed) | n/a | n/a |
| `flags` INDIRECT | correct (disambiguated by the operand kind, which differs) | n/a | n/a |
| `flags` acquire / release | n/a | n/a | correct (`.aq` / `.rl` / `.aqrl`) |
| `flags` condition code | n/a | correct (`b.<cc>`, `cset <cc>`, inverted where the encoding is) | n/a (the condition is the opcode) |
| `flags` pair writeback | n/a | correct (`]!` and the outside-brackets post-index) | n/a |
| `flags` label flavour | n/a | correct | correct |
| rounding mode (a real field of the word) | n/a | n/a | **omitted, read as a different value** -> FIXED |
| `vec_lane` element width | n/a (no lane count in the mnemonic) | correct | n/a |
| `vec_lane` LANE COUNT | n/a | see below - **not the printer's** | n/a |
| `vec_lane` lane index | n/a | correct (`v3.s[2]`, missing index is a hard error) | n/a |
| `clobbers` | omitted, and correctly - it produces no text and no bytes | omitted, same | omitted, same |
| `src_line` / `src_file` | omitted, and correctly - `--emit-asm` is not a line-table view | omitted, same | omitted, same |
| MIR `secret` / `writes_secret` taint | **structurally unshowable** - see below | same | same |
| MIR `inline_site`, `dbg_bindings` | **structurally unshowable** - same | same | same |

Two verdicts need their reasoning, not just a cell.

**The secret taint and the other MIR-only metadata.** These do not reach the printer and cannot: a printer that renders the encoder's output can only show what is in the instruction, and secrecy leaves no trace in the bytes - a `^`-free build is byte-identical by design. Per the issue's own bar, the surface that CAN show it is named rather than patched: it is the #1648 constant-time validator, which re-derives the taint over the lowered MIR and is the thing to extend if the taint needs a readout. Printing it in the `.s` would put a second, independently-derived taint beside the bytes - the drift #2197 found five instances of.

**The aarch64 lane count.** `f32x2` and `f32x4` addition print the identical line. They also ENCODE the identical word - the object holds `4e21d402`, `fadd v2.4s`, for both. The printer is right about the object; the encoder is wrong about the MIR. I fixed this in the printer first, and the disassembly proved the fix wrong: it made `--emit-asm` refuse to print an instruction the object really contains, which hides the evidence rather than the defect. Reverted, comment corrected to say so, and the real defect filed as **#2838** (critical) - which also disproves #2742's premise that "the defect is invisible on every machine target", the reasoning that kept anyone from looking.

## The two fixes, each with the states that collided

### riscv64: the rounding mode

The encoder emits every float-to-integer convert round-toward-zero (`encode.mach:2644`, `emit_r(st, OPC_OP_FP, RM_RTZ, ...)`). The printer named no mode, and an assembler reading the line back fills that field from the form's default, which is DYNAMIC. So the line was a different instruction from the one beside it in the object.

Before (`--emit-asm`, `linux-riscv64`):
```
# fcvt2.main.conv:
.0:
  fcvt.w.s a1, fa0
  fcvt.l.d a2, fa1
  fcvt.d.w ft0, a0
```
After:
```
  fcvt.w.s a1, fa0, rtz
  fcvt.l.d a2, fa1, rtz
  fcvt.d.w ft0, a0
```

The object, unchanged in both:
```
$ llvm-objdump -d out/linux-riscv64/debug/obj/fcvt2/main.o
   0: c00515d3     	fcvt.w.s	a1, fa0, rtz
   4: c2259653     	fcvt.l.d	a2, fa1, rtz
```

And the two states, assembled:
```
$ llvm-mc -triple=riscv64 -mattr=+f,+d -show-encoding
	fcvt.w.s	a1, fa0            # encoding: [0xd3,0x75,0x05,0xc0]   <- what the old line meant
	fcvt.w.s	a1, fa0, rtz       # encoding: [0xd3,0x15,0x05,0xc0]   <- what is in the object
```
`funct3` 7 versus 1. Not a shorter spelling of the same instruction - a different one.

`fcvt.d.w` correctly keeps no operand, and that is the control: appending one unconditionally would be wrong in the other direction. I checked every float form the encoder emits against `llvm-mc`'s default for that form rather than assuming:

| form | encoder | assembler default | verdict |
|---|---|---|---|
| `fcvt.{w,wu,l,lu}.{s,d}` | RTZ (1) | dyn (7) | **diverged - fixed** |
| `fcvt.d.w` / `fcvt.d.wu` | RNE (0) | 0 (exact, no rm operand) | agrees |
| `fcvt.s.w` / `fcvt.s.wu` / `fcvt.{s,d}.{l,lu}` | DYN (7) | dyn (7) | agrees |
| `fcvt.s.d` | DYN (7) | dyn (7) | agrees |
| `fcvt.d.s` | RNE (0) | 0 (exact) | agrees |
| `fadd/fsub/fmul/fdiv.{s,d}` | DYN (7) | dyn (7) | agrees |
| `fmv.x.w` and the other `fmv` forms | 0 | 0 (the field is not a mode) | agrees |

So exactly one family gains an operand, and `rounding_operand` covers exactly that range.

### x86-64: the REP prefix

`FLAG_REP` rides `flags` beside `FLAG_LOCK`, and `encode_x64`'s `MOVSB` arm emits an `F3` byte for it. The printer rendered LOCK and not REP, so `A4` and `F3 A4` printed the same line. Latent - `x64.MOVSB` is defined and encoded but nothing currently selects it - so this is a collapse fixed before it can be reached, not one observed in the wild. Stated plainly rather than dressed up.

Before / after, from the unit test's own two states:
```
movsb          <- flags = 0
movsb          <- flags = FLAG_REP      (before)
rep movsb      <- flags = FLAG_REP      (after)
```

## How the before/after was obtained

No goldens added, no `int/` cases added, per the freeze. Each collapse was demonstrated by hand and then pinned by a unit test in `mach test .`.

The by-hand method: with the production change reverted but the new tests in place, I flipped each test's expectation to the OLD output and ran `mach test .`. All 1340 passed - which is the proof that the two states collided, not an assertion that they might have. Restoring the production change and the correct expectations, all pass again. The riscv64 case additionally has the `llvm-mc` / `llvm-objdump` evidence above, which is stronger than either.

The two new unit tests each render BOTH states and assert they differ, because "the field is now printed" pins nothing - it is the collision that has to be excluded.

## Verification

- `mach test .` - 1338 passed, 0 failed (two of the three printers gain a test; the arm64 pair was removed with the reverted change).
- `int/run.sh --target linux --filter 'asm-symbol-operands'` - PASS. This is #2788's case, the nearest neighbour.
- `int/run.sh --target linux-riscv64 --runmode qemu --filter 'asm-symbol-operands'` - PASS. The riscv64 leg is the one this PR changes.
- `int/run.sh --target linux --filter '26*'` - 15 cases PASS, debug and release.
- `int linux` is otherwise red on every branch from the unrelated mach-shader drift fixed by #2830; not touched here.

**No emitted byte moves.** Argued and then checked. Only the three `printer.mach` files change, and a printer runs only under `--emit-asm` off the encoder's sink; it emits no bytes and its `sink_claim` accounting is unchanged. Checked by building the compiler from `origin/dev` and from this branch and diffing the whole `out/` tree for each target:

```
linux-x86_64   IDENTICAL
linux-arm64    IDENTICAL
linux-riscv64  IDENTICAL
```

**Self-host fixpoint**, each stage into a freshly removed `out/`:

```
rm -rf out; mach build . -o s1
rm -rf out; ./s1 build . -o s2
rm -rf out; ./s2 build . -o s3
rm -rf out; ./s3 build . -o s4
cmp s3 s4   ->  stage3 == stage4
```
`s2 == s3` as well on this seed.

## Filed rather than fixed

- **#2838** (bug, critical, aarch64) - a sub-128-bit vector is miscompiled: the four-lane arrangement for every lane-wise operation, and a store that transfers `x2` when the value is in `v2`. Found by this audit, disproves #2742's premise, and is codegen rather than diagnostics.
- **#2839** (problem, all three register targets) - `--emit-asm` drops a symbol reference's addend, so `&g.lo` and `&g.hi` print the same line while the objects relocate against different addends. Demonstrated on all three with disassembly. Split out because the fix needs `isa.Operand` to gain a field and three encoders to carry it, which is outside the printers and inside code other work is touching.
