### PR TITLE
fix(codegen): read the machine word from MachineModel in the shared backend, and gate float ops out of width splitting

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -23,9 +23,18 @@
 # allocation, no vreg added, no block rebuilt. The output is therefore byte-
 # identical to a build without this pass on every wide-native target; only a
 # target that declares a narrow ALU or no multiply (the 8-bit mos6502 declares
-# both: `max_alu_width = 1`, `has_mul = false`) drives the rewrite. A 128-bit
-# vector instruction (`vec_lane != 0`) is never legalized here: it is the vector
-# path's responsibility and was already legalized (or rejected) in the middle end.
+# both: `max_alu_width = 1`, `has_mul = false`) drives the rewrite.
+#
+# WHAT IS NEVER LEGALIZED HERE: anything riding the FLOAT / VECTOR REGISTER BANK.
+# This pass splits a value into integer lanes and threads carries between them, which
+# is meaningful only for a value the INTEGER ALU computes. A float unit's width is an
+# independent fact - rv32d has 64-bit f-registers on a 32-bit machine - so `f64`
+# operations there are native at `lane_width` 4, and splitting one into integer lanes
+# would move the value out of the float bank entirely. A 128-bit vector was always
+# excluded (it is the vector path's responsibility and was already legalized or
+# rejected in the middle end). A SCALAR float was not, which was invisible while every
+# target's ALU covered every scalar and a silent miscompile on the first one whose does
+# not (#2818). Both are now the one gate `instr_rides_fp_bank` states.
 #
 # THE MODEL. A wide value is one vreg; the pass splits it into
 # `width / max_alu_width` native-width LANE vregs (lane 0 the least significant),
@@ -272,7 +281,7 @@ fun function_needs_legalize(f: *mir.MirFunction, mach: *Machine) bool {
 # mach: the machine facts (native lane width, pointer width, shift/multiply capability)
 # ret:  true when the instruction needs legalization
 fun instr_needs_legalize(f: *mir.MirFunction, mi: *mir.MirInstr, mach: *Machine) bool {
-    if (instr_is_vector(f, mi)) { ret false; }
+    if (instr_rides_fp_bank(f, mi)) { ret false; }
     if (mi.width > mach.lane_width || mi.src_width > mach.lane_width) { ret true; }
     if (!mach.var_shift && is_shift(mi.opcode)) { ret true; }
     if (!mach.has_mul && mi.opcode == mir.MIR_MUL) { ret true; }
@@ -306,18 +315,44 @@ fun instr_has_value_base(mi: *mir.MirInstr) bool {
     ret false;
 }
 
-# whether an instruction rides the 128-bit vector bank (via its lane descriptor or
-# any vector-flagged vreg operand)
+# whether an instruction rides the FLOAT / VECTOR REGISTER BANK, via its lane
+# descriptor or any non-GP vreg operand
+#
+# THE GATE IS THE BANK, NOT THE OPCODE, AND NOT THE WIDTH (#2818). This pass splits a
+# value into INTEGER lanes and threads carries between them, which is meaningful only
+# for a value the integer ALU computes. A value in the float bank is computed by a
+# separate unit whose width has nothing to do with `max_alu_width` - rv32d's
+# f-registers are 64 bits wide on a 32-bit machine - so an `f64` register copy at
+# `lane_width` 4 is a single native `fmv.d`, and splitting it into two 4-byte integer
+# lane moves is a SILENT MISCOMPILE: the lane vregs are GP-class, so the value leaves
+# the float bank and the reassembled halves are not the float. Exactly the shape of
+# #2777, where a move width taken from the machine word rather than the value's own
+# type emitted `fmv.d.x` for an `f32` and NaN-boxed every soft-float `f32` into a NaN.
+#
+# The vector flag alone was the gate before, which excluded a 16-byte vector and
+# admitted a scalar float - invisible while every target's word was 8 and no scalar
+# was ever wider than its ALU, and a wrong answer the moment a target declares a
+# 4-byte word. The register CLASS is the authority both cases share: `vreg_is_fp` is
+# the same fact instruction selection reads to identify a float register copy, and a
+# vector vreg is FP-class too. The `vector` flag is still honored because the phi /
+# merge move splice in `mir.lower` carries a 16-byte width without stamping vec_lane.
+#
+# A TARGET WITH NO FLOAT BANK IS UNAFFECTED. mos6502 declares one register class, so
+# a soft-float `f64` there rides GP vregs, answers false here, and is split by this
+# pass exactly as it was - which is the whole reason mos6502 can have floats at all.
 # ---
 # f:  the MIR function owning the vreg table
 # mi: the instruction to test
-# ret: true when the instruction is a vector op
-fun instr_is_vector(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
+# ret: true when the instruction's values ride the float / vector bank
+fun instr_rides_fp_bank(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
     if (mi.vec_lane != mir.VEC_LANE_NONE) { ret true; }
     var k: u32 = 0;
     for (k < mi.operand_count) {
         val op: *mir.MirOperand = ?mi.operands[k];
-        if (op.kind == mir.MIR_OP_VREG && op.vreg < f.vreg_count && f.vregs[op.vreg].vector) { ret true; }
+        if (op.kind == mir.MIR_OP_VREG && op.vreg < f.vreg_count) {
+            if (f.vregs[op.vreg].vector)    { ret true; }
+            if (mir.vreg_is_fp(f, op.vreg)) { ret true; }
+        }
         k = k + 1;
     }
     ret false;
@@ -402,7 +437,10 @@ fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *L
             # lanes off `mi.width` here would split that boolean into as many lanes as
             # the operands have and leave every consumer - which reads it at its own
             # native width - naming a vreg the expansion no longer defines.
-            if (!instr_is_vector(f, mi) && mir.instr_defines_shape(mi) &&
+            # the PLANNER and the needs-legalize GATE read one authority (#2818): a
+            # value the gate excludes must get no lanes here, or the plan describes a
+            # split the rewriter never performs.
+            if (!instr_rides_fp_bank(f, mi) && mir.instr_defines_shape(mi) &&
                 !mir.is_cmp_opcode(mi.opcode) &&
                 mi.width > maw && mi.operand_count > 0 &&
                 mi.operands[0].kind == mir.MIR_OP_VREG) {
@@ -3236,5 +3274,83 @@ test "mach.lang.be.codegen.legalize:rejects_a_shift_at_a_non_power_of_two_width"
     t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, 3, mir.op_vreg(2));
     var mach: Machine = t_mach(1, 2);
     if (!R.is_err[bool, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    ret 0;
+}
+
+# A SCALAR FLOAT IS NEVER SPLIT INTO INTEGER LANES (#2818).
+#
+# The gate excluded only VECTORS, which is indistinguishable from excluding the whole
+# float bank while every target's ALU covers every scalar - no scalar op is ever wider
+# than the lane, so the clause never fired for a float and the omission could not show.
+# At `lane_width` 4 it fires: an `f64` register copy is a plain `MIR_MOV` of width 8,
+# and splitting it produces two 4-byte moves between GP-CLASS lane vregs, so the value
+# leaves the float bank and the halves are not the float. A silent miscompile, the same
+# shape as #2777, and the reason the assertion is inertness rather than a diagnostic:
+# an `f64` move at `lane_width` 4 is a single native instruction (rv32d's `fmv.d`),
+# because a float unit's width is independent of the integer ALU's.
+#
+# THE CONTROLS ARE WHAT MAKE THIS TEST MEAN ANYTHING. The identical function over
+# GP-class vregs at the identical machine MUST still split - otherwise inertness would
+# prove only that the fixture legalizes nothing - and the float function must still be
+# split on a machine with no float bank at all, which is how mos6502 has floats.
+test "mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # v0 <- v1, both f64, on a machine whose integer ALU is 4 bytes wide.
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    f.vregs[0].class = mir.REG_CLASS_GP + 1;   # the float bank
+    f.vregs[1].class = mir.REG_CLASS_GP + 1;
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 1);
+    var mv: [2]mir.MirOperand;
+    mv[0] = mir.op_vreg(0); mv[1] = mir.op_vreg(1);
+    t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?mv[0], 2, 8);
+    f.blocks = ?b; f.block_count = 1;
+
+    val before_ptr:   *mir.MirInstr = b.instrs;
+    val before_count: u32           = b.instr_count;
+    val before_vregs: u32           = f.vreg_count;
+
+    var mach: Machine = t_mach(4, 4);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (R.is_err[bool, str](r))        { ret 1; }
+    if (b.instrs != before_ptr)        { ret 1; }  # not reallocated
+    if (b.instr_count != before_count) { ret 1; }  # still one native move
+    if (f.vreg_count != before_vregs)  { ret 1; }  # no integer lanes planned
+
+    # CONTROL 1: the same move over GP-class vregs at the same machine DOES split, so
+    # the inertness above is the gate and not a fixture that legalizes nothing.
+    var gf: mir.MirFunction;
+    t_vregs(?alloc, ?gf, 2);
+    var gb: mir.MirBlock;
+    t_block(?alloc, ?gb, 1);
+    var gi: [2]mir.MirOperand;
+    gi[0] = mir.op_vreg(0); gi[1] = mir.op_imm(0x0102030405060708);
+    t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?gi[0], 2, 8);
+    gf.blocks = ?gb; gf.block_count = 1;
+
+    val gr: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?gf);
+    if (R.is_err[bool, str](gr))   { ret 1; }
+    if (gb.instr_count != 2)       { ret 1; }  # two 4-byte lane moves
+    if (gf.vreg_count <= 2)        { ret 1; }  # lane vregs were planned
+
+    # CONTROL 2: a target with NO float bank declares one register class, so a
+    # soft-float value rides GP vregs and is split exactly as before - which is the
+    # whole reason mos6502 can compute with floats at all. Same shape as control 1,
+    # asserted separately because it is the case the gate must NOT catch.
+    var sf: mir.MirFunction;
+    t_vregs(?alloc, ?sf, 2);
+    var sb: mir.MirBlock;
+    t_block(?alloc, ?sb, 1);
+    t_instr(?alloc, ?sb, 0, mir.MIR_MOV, ?gi[0], 2, 8);
+    sf.blocks = ?sb; sf.block_count = 1;
+
+    var m8: Machine = t_mach(1, 2);
+    val sr: R.Result[bool, str] = legalize_function(?alloc, ?m8, ?sf);
+    if (R.is_err[bool, str](sr)) { ret 1; }
+    if (sb.instr_count != 8)     { ret 1; }  # eight byte lanes
+    if (sf.vreg_count <= 2)      { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -451,17 +451,18 @@ fun slot_has_stack_piece(slot: *abi.ParamSlot) bool {
 
 # the outgoing stack bytes a split slot's stack chunk(s) consume
 #
-# Each PIECE_STACK chunk occupies an eight-byte-granular outgoing slot sized from its
-# byte width; the sum is the slot's stack footprint above its register chunks.
+# Each PIECE_STACK chunk occupies a word-granular outgoing slot sized from its byte
+# width, and the sum is the slot's stack footprint above its register chunks.
 # ---
+# tgt:  the resolved target, supplying the outgoing-slot granularity
 # slot: the classified slot
 # ret:  the outgoing stack bytes the slot's stack chunks consume
-fun split_stack_bytes(slot: *abi.ParamSlot) i64 {
+fun split_stack_bytes(tgt: *target.Target, slot: *abi.ParamSlot) i64 {
     var total: i64 = 0;
     var i: u32 = 0;
     for (i < slot.piece_count) {
         if (slot.pieces[i].kind == abi.PIECE_STACK) {
-            total = total + context.stack_slot_bytes(slot.pieces[i].width::u64);
+            total = total + context.stack_slot_bytes(tgt, slot.pieces[i].width::u64);
         }
         i = i + 1;
     }
@@ -503,49 +504,65 @@ fun round_up_i64(value: i64, align: u64) i64 {
 # the alignment in bytes a stack-passed argument's slot rounds to
 #
 # A by-value stack slot (CLASS_STACK) rounds to the value's natural alignment,
-# clamped to the eight-byte outgoing-slot granularity; a by-reference spill
-# (CLASS_STACK_BYREF) holds only an eight-byte pointer, so it rounds to eight
-# regardless of the aggregate's alignment. On x86 every stack argument is
-# <=8-aligned, so this is always eight and the round-up is identity; AAPCS64 honors
-# a 16-byte-aligned by-value argument.
+# clamped up to the outgoing-slot granularity. A by-reference spill
+# (CLASS_STACK_BYREF) holds only a pointer, so it rounds to the pointer's alignment
+# regardless of the aggregate's. On x86 every stack argument is <=8-aligned, so this
+# is always eight and the round-up is identity, and AAPCS64 honors a 16-byte-aligned
+# by-value argument.
 #
-# `natural` drops the eight-byte clamp for a by-value slot, leaving the value's own
+# `natural` drops the granularity clamp for a by-value slot, leaving the value's own
 # alignment: the Apple arm64 rule for a FIXED argument, where a `u32` is 4-aligned and
 # a `u8` 1-aligned rather than both being 8-aligned (#2598). A by-reference spill is
-# unaffected either way - the pointer it holds is genuinely 8 bytes and 8-aligned.
+# unaffected either way - the pointer it holds is genuinely pointer-sized and
+# pointer-aligned.
+#
+# THREE QUANTITIES, NOT ONE EIGHT (#2818). The by-reference clause reads
+# `pointer_width` because the thing being aligned IS A POINTER, and the by-value clamp
+# reads `gpr_width` because it is the outgoing-slot granularity - the same authority
+# `context.stack_slot_bytes` sizes the slot with, so the cursor a caller aligns and
+# the footprint it then advances by cannot disagree, which is the asymmetry that
+# produced #2777. They are equal on every target this compiler ships and are not the
+# same question: a machine with a pointer narrower or wider than its word separates
+# them, and reading one for the other would be right by accident until it was not.
 # ---
+# tgt:     the resolved target, supplying the pointer width and the machine word
 # class:   the slot's classification (CLASS_STACK, CLASS_STACK_BYREF, or CLASS_VEC_STACK_BYREF)
 # align:   the value's natural alignment in bytes
 # natural: whether this argument's slot takes the value's natural alignment with no minimum
 # ret:     the slot's stack alignment in bytes
-fun stack_arg_align(class: abi.ParamClass, align: u64, natural: bool) u64 {
-    # both by-reference stack spills carry only an 8-byte pointer, so they round to 8
-    # regardless of the referent's alignment (CLASS_VEC_STACK_BYREF's referent is the
+fun stack_arg_align(tgt: *target.Target, class: abi.ParamClass, align: u64, natural: bool) u64 {
+    # both by-reference stack spills carry only a pointer, so they round to the pointer's
+    # width regardless of the referent's alignment (CLASS_VEC_STACK_BYREF's referent is the
     # spilled vector temp, aligned at its own frame slot, not this outgoing pointer slot).
-    if (class == abi.CLASS_STACK_BYREF)     { ret 8; }
-    if (class == abi.CLASS_VEC_STACK_BYREF) { ret 8; }
+    val ptr:  u64 = tgt.model.pointer_width::u64;
+    val word: u64 = tgt.model.gpr_width::u64;
+    if (class == abi.CLASS_STACK_BYREF)     { ret ptr; }
+    if (class == abi.CLASS_VEC_STACK_BYREF) { ret ptr; }
     if (natural)                            { ret align; }
-    if (align < 8)                          { ret 8; }
+    if (align < word)                       { ret word; }
     ret align;
 }
 
 # the outgoing stack bytes one by-value stack argument consumes
 #
-# The convention's rule is an eight-byte-granular slot (`context.stack_slot_bytes`): a
+# The convention's rule is a word-granular slot (`context.stack_slot_bytes`): a
 # value narrower than the machine word still consumes a whole slot. `natural` selects
 # the Apple arm64 FIXED-argument rule instead, where the argument consumes exactly its
 # own size and the next one packs against it, so two `i32`s land at [sp+0] and [sp+4].
 #
-# It is asked per ARGUMENT rather than read off the target, because Apple runs both
-# rules at once: a variadic tail argument keeps the eight-byte slot on the very target
-# where a fixed one does not, so the caller passes which rule this argument is under.
+# The RULE is asked per ARGUMENT rather than read off the target, because Apple runs
+# both at once: a variadic tail argument keeps the word-granular slot on the very
+# target where a fixed one does not, so the caller passes which rule this argument is
+# under. The GRANULARITY the rule then applies is a target fact and comes from the
+# model.
 # ---
+# tgt:     the resolved target, supplying the outgoing-slot granularity
 # size:    the argument's value size in bytes (from its ABI ParamSlot)
 # natural: whether this argument's slot takes its natural size with no minimum
 # ret:     the outgoing stack bytes the argument consumes
-fun stack_arg_bytes(size: u64, natural: bool) i64 {
+fun stack_arg_bytes(tgt: *target.Target, size: u64, natural: bool) i64 {
     if (natural) { ret size::i64; }
-    ret context.stack_slot_bytes(size);
+    ret context.stack_slot_bytes(tgt, size);
 }
 
 # whether one argument's outgoing stack slot takes its natural size and alignment
@@ -750,18 +767,20 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         # its natural size (Apple arm64) packs it against its neighbour rather than
         # rounding both the alignment and the footprint up to eight.
         if (is_stack_slot_class(slot.class)) {
-            stack_off   = round_up_i64(stack_off, stack_arg_align(slot.class, pal, fixed_natural));
+            stack_off   = round_up_i64(stack_off, stack_arg_align(ctx.tgt, slot.class, pal, fixed_natural));
             slot.offset = stack_off;
-            stack_off   = stack_off + stack_arg_bytes(slot.size, fixed_natural);
+            stack_off   = stack_off + stack_arg_bytes(ctx.tgt, slot.size, fixed_natural);
         } or {
             advance_arg_cursors(?slot, ?gp_used, ?fp_used);
             # a register-plus-stack split also reserves an outgoing stack slot for its
             # stack chunk: assign the running offset as the chunk's stack base and
-            # advance past it (eight-byte-granular), so the next argument clears it.
+            # advance past it (word-granular), so the next argument clears it. the
+            # cursor rounds to the same machine word `split_stack_bytes` sizes each
+            # chunk to, so the two cannot disagree (#2818).
             if (slot_has_stack_piece(?slot)) {
-                stack_off   = round_up_i64(stack_off, 8);
+                stack_off   = round_up_i64(stack_off, ctx.tgt.model.gpr_width::u64);
                 slot.offset = stack_off;
-                stack_off   = stack_off + split_stack_bytes(?slot);
+                stack_off   = stack_off + split_stack_bytes(ctx.tgt, ?slot);
             }
         }
 
@@ -1034,13 +1053,14 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             if (ctx.tgt.variadic_args_on_stack) { slot = stack_only_tail_slot(slot); }
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
-            # a register-plus-stack split's tail stack chunk is eight-byte-granular.
+            # a register-plus-stack split's tail stack chunk is word-granular, rounded
+            # to the same machine word `split_stack_bytes` sizes it to (#2818).
             # the tail is never under the natural-size rule: Apple arm64 keeps the
-            # eight-byte minimum here even though a fixed argument there does not (#2598).
+            # word-granular minimum here even though a fixed argument there does not (#2598).
             if (is_stack_slot_class(slot.class)) {
-                stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal, false));
+                stack_off = round_up_i64(stack_off, stack_arg_align(ctx.tgt, slot.class, aal, false));
             } or (slot_has_stack_piece(?slot)) {
-                stack_off = round_up_i64(stack_off, 8);
+                stack_off = round_up_i64(stack_off, ctx.tgt.model.gpr_width::u64);
             }
             soff = stack_off;
         }
@@ -1098,12 +1118,12 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         # advances each assigned register's bank; a stack slot advances the offset.
         if (pidx >= layout.param_count) {
             if (is_stack_slot_class(slot.class)) {
-                stack_off = stack_off + stack_arg_bytes(slot.size, false);
+                stack_off = stack_off + stack_arg_bytes(ctx.tgt, slot.size, false);
             } or {
                 advance_arg_cursors(?slot, ?gp_used, ?fp_used);
                 # a split tail also consumes its stack chunk's outgoing slot.
                 if (slot_has_stack_piece(?slot)) {
-                    stack_off = stack_off + split_stack_bytes(?slot);
+                    stack_off = stack_off + split_stack_bytes(ctx.tgt, ?slot);
                 }
             }
         }
@@ -2036,20 +2056,85 @@ test "mach.lang.be.codegen.mir.abi.sret_reserves_gp" {
     ret 0;
 }
 
+# a machine model with the given word and pointer widths, for the width tests below
+# ---
+# tgt:  the target to fill
+# word: the machine word in bytes
+# ptr:  the pointer width in bytes
+fun test_model(tgt: *target.Target, word: u32, ptr: u32) {
+    tgt.model.gpr_width     = word;
+    tgt.model.pointer_width = ptr;
+}
+
 # a stack argument offset rounds up to its slot alignment
 test "mach.lang.be.codegen.mir.abi:stack_arg_alignment" {
+    var tgt: target.Target;
+    test_model(?tgt, 8, 8);
+
     # an 8-aligned argument at an already-8-aligned cursor is identity (the x86 path).
     if (round_up_i64(8, 8) != 8) { ret 1; }
     if (round_up_i64(0, 8) != 0) { ret 1; }
     # a 16-aligned by-value argument rounds the cursor up to 16 (the AAPCS64 path).
     if (round_up_i64(8, 16) != 16)  { ret 1; }
     if (round_up_i64(24, 16) != 32) { ret 1; }
-    # a by-reference spill holds an 8-byte pointer, so it rounds to 8 regardless of
-    # the aggregate's natural alignment.
-    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16, false) != 8) { ret 1; }
-    # a by-value slot honors the value's alignment, clamped to the 8-byte minimum.
-    if (stack_arg_align(abi.CLASS_STACK, 16, false) != 16) { ret 1; }
-    if (stack_arg_align(abi.CLASS_STACK, 4, false) != 8)   { ret 1; }
+    # a by-reference spill holds a pointer, so it rounds to the pointer width regardless
+    # of the aggregate's natural alignment.
+    if (stack_arg_align(?tgt, abi.CLASS_STACK_BYREF, 16, false) != 8) { ret 1; }
+    # a by-value slot honors the value's alignment, clamped to the word minimum.
+    if (stack_arg_align(?tgt, abi.CLASS_STACK, 16, false) != 16) { ret 1; }
+    if (stack_arg_align(?tgt, abi.CLASS_STACK, 4, false) != 8)   { ret 1; }
+    ret 0;
+}
+
+# THE OUTGOING-SLOT GRANULARITY IS THE MACHINE WORD, AND THE BY-REFERENCE ALIGNMENT IS
+# THE POINTER WIDTH (#2818).
+#
+# Every target this compiler ships makes both eight, so a test on any of them cannot
+# tell a model read from a hardcoded literal - which is exactly the defect this issue
+# closes. The divergence is therefore constructed: a synthetic model whose word is 4,
+# and a second whose word and POINTER DISAGREE, so a site reading the wrong one of the
+# two is caught rather than silently agreeing.
+test "mach.lang.be.codegen.mir.abi:stack_slot_granularity_is_the_machine_word" {
+    var w8: target.Target;
+    test_model(?w8, 8, 8);
+    var w4: target.Target;
+    test_model(?w4, 4, 4);
+
+    # the by-value clamp is the WORD: a 4-byte argument fills a whole slot on both
+    # machines, and the slot is a different size on each.
+    if (stack_arg_align(?w8, abi.CLASS_STACK, 4, false) != 8) { ret 1; }
+    if (stack_arg_align(?w4, abi.CLASS_STACK, 4, false) != 4) { ret 1; }
+    if (stack_arg_bytes(?w8, 4, false) != 8) { ret 1; }
+    if (stack_arg_bytes(?w4, 4, false) != 4) { ret 1; }
+    if (stack_arg_bytes(?w8, 1, false) != 8) { ret 1; }
+    if (stack_arg_bytes(?w4, 1, false) != 4) { ret 1; }
+    # a value WIDER than the word still rounds to a whole number of slots.
+    if (stack_arg_bytes(?w4, 9, false) != 12) { ret 1; }
+    # and the value's own alignment still wins when it exceeds the word.
+    if (stack_arg_align(?w4, abi.CLASS_STACK, 16, false) != 16) { ret 1; }
+
+    # THE BY-REFERENCE SIDE READS THE POINTER, NOT THE WORD. A model where the two
+    # differ is the only thing that can tell them apart: a site reading gpr_width for
+    # the hidden pointer's alignment answers 4 here and must answer 2.
+    var split: target.Target;
+    test_model(?split, 4, 2);
+    if (stack_arg_align(?split, abi.CLASS_STACK_BYREF, 16, false) != 2)     { ret 1; }
+    if (stack_arg_align(?split, abi.CLASS_VEC_STACK_BYREF, 16, false) != 2) { ret 1; }
+    # while the by-value clamp on the same model is still the word.
+    if (stack_arg_align(?split, abi.CLASS_STACK, 1, false) != 4) { ret 1; }
+
+    # THE PLACEMENT SIDE AND THE FOOTPRINT SIDE AGREE, which is the asymmetry that
+    # produced #2777. Walk three 4-byte arguments on the 4-byte-word machine: each
+    # fills exactly one slot and the cursor never needs a round-up.
+    var off: i64 = 0;
+    var n:   u32 = 0;
+    for (n < 3) {
+        off = round_up_i64(off, stack_arg_align(?w4, abi.CLASS_STACK, 4, false));
+        if (off != (n * 4)::i64) { ret 1; }
+        off = off + stack_arg_bytes(?w4, 4, false);
+        n = n + 1;
+    }
+    if (off != 12) { ret 1; }
     ret 0;
 }
 
@@ -2061,23 +2146,26 @@ test "mach.lang.be.codegen.mir.abi:stack_arg_alignment" {
 # together - keeping either one alone still misplaces the third argument - so both are
 # asserted against the exact offsets clang emits for the issue's repro.
 test "mach.lang.be.codegen.mir.abi:natural_stack_args_pack_a_narrow_argument" {
+    var tgt: target.Target;
+    test_model(?tgt, 8, 8);
+
     # alignment: the value's own, with no clamp. a u8 argument is 1-aligned here and
     # 8-aligned under the base rule.
-    if (stack_arg_align(abi.CLASS_STACK, 4, true) != 4) { ret 1; }
-    if (stack_arg_align(abi.CLASS_STACK, 1, true) != 1) { ret 1; }
+    if (stack_arg_align(?tgt, abi.CLASS_STACK, 4, true) != 4) { ret 1; }
+    if (stack_arg_align(?tgt, abi.CLASS_STACK, 1, true) != 1) { ret 1; }
     # a 16-aligned by-value aggregate is 16-aligned under BOTH rules: natural size is
     # not "no alignment", it is the value's own.
-    if (stack_arg_align(abi.CLASS_STACK, 16, true) != 16) { ret 1; }
+    if (stack_arg_align(?tgt, abi.CLASS_STACK, 16, true) != 16) { ret 1; }
     # a by-reference spill is exempt under both: the pointer it holds really is 8/8.
-    if (stack_arg_align(abi.CLASS_STACK_BYREF, 16, true) != 8) { ret 1; }
+    if (stack_arg_align(?tgt, abi.CLASS_STACK_BYREF, 16, true) != 8) { ret 1; }
 
     # footprint: exactly the value's size, so the next argument packs against it.
-    if (stack_arg_bytes(4, true) != 4) { ret 1; }
-    if (stack_arg_bytes(1, true) != 1) { ret 1; }
-    if (stack_arg_bytes(8, true) != 8) { ret 1; }
+    if (stack_arg_bytes(?tgt, 4, true) != 4) { ret 1; }
+    if (stack_arg_bytes(?tgt, 1, true) != 1) { ret 1; }
+    if (stack_arg_bytes(?tgt, 8, true) != 8) { ret 1; }
     # and the convention's rule is untouched where it applies.
-    if (stack_arg_bytes(4, false) != 8) { ret 1; }
-    if (stack_arg_bytes(1, false) != 8) { ret 1; }
+    if (stack_arg_bytes(?tgt, 4, false) != 8) { ret 1; }
+    if (stack_arg_bytes(?tgt, 1, false) != 8) { ret 1; }
 
     # the access width follows the slot: a machine-word store into a 4-byte slot would
     # write over the argument packed at the next offset.
@@ -2092,13 +2180,13 @@ test "mach.lang.be.codegen.mir.abi:natural_stack_args_pack_a_narrow_argument" {
     var boff: i64 = 0;
     var n:    u32 = 0;
     for (n < 3) {
-        off = round_up_i64(off, stack_arg_align(abi.CLASS_STACK, 4, true));
-        boff = round_up_i64(boff, stack_arg_align(abi.CLASS_STACK, 4, false));
+        off = round_up_i64(off, stack_arg_align(?tgt, abi.CLASS_STACK, 4, true));
+        boff = round_up_i64(boff, stack_arg_align(?tgt, abi.CLASS_STACK, 4, false));
         if (n == 0 && (off != 0 || boff != 0))   { ret 1; }
         if (n == 1 && (off != 4 || boff != 8))   { ret 1; }
         if (n == 2 && (off != 8 || boff != 16))  { ret 1; }
-        off  = off + stack_arg_bytes(4, true);
-        boff = boff + stack_arg_bytes(4, false);
+        off  = off + stack_arg_bytes(?tgt, 4, true);
+        boff = boff + stack_arg_bytes(?tgt, 4, false);
         n = n + 1;
     }
     if (off != 12 || boff != 24) { ret 1; }

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -538,18 +538,32 @@ pub fun clamp_alu_width(alu_min_width: u32, w: u8) u8 {
 
 # the outgoing-region footprint of one stack-passed argument
 #
-# SysV passes each stack argument in an eight-byte-granular slot (a value
-# smaller than eight bytes still consumes a full slot), so round the value size
-# up to the eight-byte boundary. Mirrors the `[rbp + 16 + off]` layout the
+# Every convention this compiler targets passes a stack argument in a WORD-GRANULAR
+# slot - a value smaller than the machine word still consumes a whole one - so the
+# value size rounds up to the machine word. Mirrors the `[rbp + 16 + off]` layout the
 # callee reads.
+#
+# THE MACHINE WORD, NOT A CONSTANT EIGHT (#2818). SysV names the unit an "eightbyte"
+# and AAPCS64 an eight-byte slot, but the quantity both are naming is the machine
+# word: the RISC-V psABI states it as XLEN, and i386 SysV and rv32 ilp32 both make it
+# four. A literal eight here agrees with the word on every target this compiler ships
+# today and becomes a silent over-reservation - a callee reading its arguments at the
+# wrong displacements - on the first target whose word is narrower.
+#
+# THE SINGLE AUTHORITY FOR THE GRANULARITY, read by both halves of the placement
+# policy: this sizes the slot and `abi.stack_arg_align` aligns the cursor to it, and
+# the two disagreeing is what produced #2777. Anything asking a DIFFERENT question -
+# how wide a pointer is, how wide this value is - must read that quantity instead and
+# not this one.
 # ---
+# tgt:  the resolved target, supplying the machine word
 # size: the argument's value size in bytes (from its ABI ParamSlot)
-# ret:  the eight-byte-aligned slot size in bytes
-pub fun stack_slot_bytes(size: u64) i64 {
+# ret:  the word-aligned slot size in bytes
+pub fun stack_slot_bytes(tgt: *target.Target, size: u64) i64 {
+    val word: u64 = tgt.model.gpr_width::u64;
     var n: u64 = size;
-    if (n == 0) { n = 8; }
-    n = (n + 7) & ~7::u64;
-    ret n::i64;
+    if (n == 0) { n = word; }
+    ret round_up_word(n, word)::i64;
 }
 
 # lower an SSA Value reference to a MIR operand
@@ -981,7 +995,7 @@ pub fun store_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOp
     # copy the object's own bytes out of the scratch, 8/4/2/1 at a time.
     var off: i64 = 0;
     for (off::u32 < mem_w::u32) {
-        val chunk: u8 = copy_chunk_width((mem_w::u32 - off::u32)::u64);
+        val chunk: u8 = copy_chunk_width(ctx.tgt, (mem_w::u32 - off::u32)::u64);
 
         val tr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
         if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
@@ -1058,7 +1072,7 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
     # defined zero rather than frame residue.
     var zoff: i64 = 0;
     for (zoff::u32 < reg_w::u32) {
-        val zc: u8 = copy_chunk_width((reg_w::u32 - zoff::u32)::u64);
+        val zc: u8 = copy_chunk_width(ctx.tgt, (reg_w::u32 - zoff::u32)::u64);
         val zs: R.Result[bool, str] = push_store_chunk(ctx, mb, mir.op_mem_slot(sk, zoff), mir.op_imm(0), zc);
         if (R.is_err[bool, str](zs)) { ret zs; }
         zoff = zoff + zc::i64;
@@ -1067,7 +1081,7 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
     # gather the object's own bytes into the scratch.
     var off: i64 = 0;
     for (off::u32 < mem_w::u32) {
-        val chunk: u8 = copy_chunk_width((mem_w::u32 - off::u32)::u64);
+        val chunk: u8 = copy_chunk_width(ctx.tgt, (mem_w::u32 - off::u32)::u64);
 
         val tr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
         if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
@@ -1131,18 +1145,28 @@ pub fun subwidth_vector_memory(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
     ret mem_width_of(ctx, ty) != op_width_of(ctx, ty);
 }
 
-# the widest 8/4/2/1 chunk that fits in `remaining` bytes
+# the widest chunk that fits in `remaining` bytes, capped at the machine word
 #
 # The single granularity rule every byte-exact copy in the backend walks by, so an
 # aggregate memcpy, a sub-width vector's scratch round trip, and the scratch zero-fill
 # cannot drift apart on the tail.
+#
+# CAPPED AT THE MACHINE WORD, NOT AT EIGHT (#2818). Each chunk travels through a
+# SCRATCH GENERAL-PURPOSE REGISTER - load into it, store out of it - so the widest
+# chunk the walk can move is the widest value that register holds, which is the
+# machine word. The ladder used to start at a literal eight, which equals the word on
+# every 64-bit target and asks a four-byte-word machine to move a chunk it has no
+# register for.
 # ---
+# tgt:       the resolved target, supplying the machine word
 # remaining: the bytes left to copy
 # ret:       the chunk width in bytes
-pub fun copy_chunk_width(remaining: u64) u8 {
-    if (remaining >= 8) { ret 8; }
-    if (remaining >= 4) { ret 4; }
-    if (remaining >= 2) { ret 2; }
+pub fun copy_chunk_width(tgt: *target.Target, remaining: u64) u8 {
+    var w: u64 = tgt.model.gpr_width::u64;
+    for (w > 1) {
+        if (remaining >= w) { ret w::u8; }
+        w = w / 2;
+    }
     ret 1;
 }
 
@@ -1252,7 +1276,7 @@ pub fun copy_aggregate(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperan
 
     var off: i64 = 0;
     for (off::u64 < size) {
-        val chunk: u8 = copy_chunk_width(size - off::u64);
+        val chunk: u8 = copy_chunk_width(ctx.tgt, size - off::u64);
 
         val res_tmp: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
         if (R.is_err[u32, str](res_tmp)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_tmp)); }
@@ -1297,18 +1321,29 @@ pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32, ty
 # keyed on its vreg id
 #
 # frame.run assigns it an offset and the encoder forms `[rbp + offset]` for the
-# stored halves. The size is rounded up to the eight-byte register-store
-# granularity (each incoming half is stored as a full GP register) so a sub-word
-# aggregate's spill never overruns the slot.
+# stored halves. The size and alignment are the MACHINE WORD, because each incoming
+# half is stored as a full GP register: a slot sized or aligned below the width of
+# the store that fills it is overrun by that store (#2818).
 # ---
 # ctx:      the lowering context
 # value_id: the vreg id owning the slot
 # size:     the aggregate size in bytes
 # ret:      true on success, or an allocation error
 pub fun add_spill_slot(ctx: *LowerCtx, value_id: u32, size: u64) R.Result[bool, str] {
-    var padded: u64 = (size + 7) & ~7::u64;
-    if (padded == 0) { padded = 8; }
-    ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, padded::u32, 8, mir.SLOT_TY_NIL);
+    val word: u64 = ctx.tgt.model.gpr_width::u64;
+    var padded: u64 = round_up_word(size, word);
+    if (padded == 0) { padded = word; }
+    ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, padded::u32, word::u32, mir.SLOT_TY_NIL);
+}
+
+# round `n` up to the next multiple of the machine word (a power of two, or 1)
+# ---
+# n:    the byte count to round
+# word: the machine word in bytes
+# ret:  the smallest multiple of `word` that is >= `n`
+fun round_up_word(n: u64, word: u64) u64 {
+    if (word <= 1) { ret n; }
+    ret (n + word - 1) & ~(word - 1);
 }
 
 # back an aggregate call's result vreg with a caller-owned stack region and
@@ -1442,9 +1477,10 @@ fun gp_class_index(tgt: *target.Target) u32 {
 # result-storage region (the natural alignment of the returned type)
 #
 # A 16-byte-aligned aggregate result lands on its required boundary. The size is
-# rounded up to the eight-byte register-store granularity so a 9-16 byte
-# RAX:RDX or <=8 byte single-register return writing full GP registers never
-# overruns the slot.
+# rounded up to the MACHINE WORD, the register-store granularity, so a two-register
+# or single-register return writing full GP registers never overruns the slot. The
+# same quantity `add_spill_slot` pads to, and for the same reason (#2818): the
+# alignment is the CALLER'S (the returned type's own), the padding is the machine's.
 # ---
 # ctx:      the lowering context
 # value_id: the slot-key vreg owning the slot
@@ -1454,7 +1490,7 @@ fun gp_class_index(tgt: *target.Target) u32 {
 pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) R.Result[bool, str] {
     var al: u32 = align;
     if (al == 0) { al = 1; }
-    var sz: u32 = ((size + 7) & ~7::u64)::u32;
+    var sz: u32 = round_up_word(size, ctx.tgt.model.gpr_width::u64)::u32;
     if (sz == 0) { sz = al; }
     ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, sz, al, mir.SLOT_TY_NIL);
 }
@@ -1546,12 +1582,64 @@ fun inst3(ctx: *LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode, op0: mir.Mir
     ret push_instr(ctx, mb, mi);
 }
 
-# size=0 treated as 8; 1..8 all round up to 8; 9 rounds to 16
+# THE SLOT GRANULARITY IS THE MACHINE WORD, NOT EIGHT (#2818).
+#
+# size=0 is treated as one whole slot, anything up to the word rounds to the word, and a
+# value wider than the word rounds to a whole number of slots. Asserted on TWO models
+# whose words differ, because every target this compiler ships makes the word 8, and a
+# test that only ever asks an 8-byte-word machine cannot distinguish a model read from
+# the literal it replaced.
 test "mach.lang.be.codegen.mir.context.stack_slot_bytes" {
-    if (stack_slot_bytes(0) != 8)  { ret 1; }
-    if (stack_slot_bytes(1) != 8)  { ret 1; }
-    if (stack_slot_bytes(8) != 8)  { ret 1; }
-    if (stack_slot_bytes(9) != 16) { ret 1; }
+    var w8: target.Target;
+    w8.model.gpr_width = 8;
+    if (stack_slot_bytes(?w8, 0) != 8)  { ret 1; }
+    if (stack_slot_bytes(?w8, 1) != 8)  { ret 1; }
+    if (stack_slot_bytes(?w8, 8) != 8)  { ret 1; }
+    if (stack_slot_bytes(?w8, 9) != 16) { ret 1; }
+
+    var w4: target.Target;
+    w4.model.gpr_width = 4;
+    if (stack_slot_bytes(?w4, 0) != 4)  { ret 1; }
+    if (stack_slot_bytes(?w4, 1) != 4)  { ret 1; }
+    if (stack_slot_bytes(?w4, 4) != 4)  { ret 1; }
+    if (stack_slot_bytes(?w4, 5) != 8)  { ret 1; }
+    if (stack_slot_bytes(?w4, 9) != 12) { ret 1; }
+
+    # the 8-bit machine: every slot is one byte and the round-up is identity.
+    var w1: target.Target;
+    w1.model.gpr_width = 1;
+    if (stack_slot_bytes(?w1, 0) != 1) { ret 1; }
+    if (stack_slot_bytes(?w1, 3) != 3) { ret 1; }
+    ret 0;
+}
+
+# THE COPY CHUNK IS CAPPED AT THE MACHINE WORD (#2818), because the chunk travels
+# through a scratch GP register and cannot be wider than one.
+#
+# The 8-byte-word ladder is the 8/4/2/1 walk this always was. The 4-byte-word one is
+# the assertion a hardcoded ladder cannot pass, since it must never ask for the 8-byte
+# move that machine has no register for.
+test "mach.lang.be.codegen.mir.context.copy_chunk_width" {
+    var w8: target.Target;
+    w8.model.gpr_width = 8;
+    if (copy_chunk_width(?w8, 16) != 8) { ret 1; }
+    if (copy_chunk_width(?w8, 8) != 8)  { ret 1; }
+    if (copy_chunk_width(?w8, 7) != 4)  { ret 1; }
+    if (copy_chunk_width(?w8, 3) != 2)  { ret 1; }
+    if (copy_chunk_width(?w8, 1) != 1)  { ret 1; }
+
+    var w4: target.Target;
+    w4.model.gpr_width = 4;
+    if (copy_chunk_width(?w4, 16) != 4) { ret 1; }
+    if (copy_chunk_width(?w4, 8) != 4)  { ret 1; }
+    if (copy_chunk_width(?w4, 5) != 4)  { ret 1; }
+    if (copy_chunk_width(?w4, 3) != 2)  { ret 1; }
+    if (copy_chunk_width(?w4, 1) != 1)  { ret 1; }
+
+    var w1: target.Target;
+    w1.model.gpr_width = 1;
+    if (copy_chunk_width(?w1, 16) != 1) { ret 1; }
+    if (copy_chunk_width(?w1, 1) != 1)  { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2508,7 +2508,7 @@ fun lower_store_aggregate(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.I
     val size: u32 = ir_type.byte_size(ctx.types, inst.operands[0].ty, ctx.tgt);
     var off: i64 = 0;
     for (off::u32 < size) {
-        val chunk: u8 = lctx.copy_chunk_width((size - off::u32)::u64);
+        val chunk: u8 = lctx.copy_chunk_width(ctx.tgt, (size - off::u32)::u64);
 
         val src: mir.MirOperand = agg_pointer_mem(ctx, inst.operands[0], off);
         val dst: mir.MirOperand = agg_pointer_mem(ctx, inst.operands[1], off);
@@ -2577,7 +2577,7 @@ fun lower_memzero(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
 
     var off: i64 = 0;
     for (off::u32 < size) {
-        val chunk: u8 = lctx.copy_chunk_width((size - off::u32)::u64);
+        val chunk: u8 = lctx.copy_chunk_width(ctx.tgt, (size - off::u32)::u64);
 
         val dst: mir.MirOperand = agg_pointer_mem(ctx, inst.operands[0], off);
         val st: R.Result[bool, str] = lctx.push_store_chunk(ctx, mb, dst, mir.op_imm(0), chunk);

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2920,33 +2920,49 @@ fun spill_vreg(ctx: *AllocCtx, v: u32) R.Result[bool, str] {
     if (mv.spill_slot >= 0) { ret R.ok[bool, str](true); }
     mv.assigned = mir.MIR_VREG_NIL;
 
-    val size: u32 = class_width(?ctx.ranges[v]);
+    val size: u32 = class_width(ctx, ?ctx.ranges[v]);
     val sr: R.Result[i32, str] = add_spill_slot(ctx, v, size);
     if (R.is_err[i32, str](sr)) { ret R.err[bool, str](R.unwrap_err[i32, str](sr)); }
     mv.spill_slot = R.unwrap_ok[i32, str](sr);
     ret R.ok[bool, str](true);
 }
 
-# the spill-slot byte width for a range's register class - 8 bytes
-# for a GP value, 16 for a float / vector value
+# the spill-slot byte width for a range's register class: the model's spill-move width
+# for a GP value, the 128-bit vector register for a float / vector one
+#
+# THE GP ARM IS `ctx.spill_width`, NOT A LITERAL EIGHT (#2818). A spill slot exists to
+# hold exactly what the spill MOVE writes into it, and that width is already a declared
+# model fact read a few lines away - so a literal here was a second copy of a
+# parameterised decision, and the two already disagreed on mos6502, whose spill move is
+# one byte while every GP slot reserved eight.
+#
+# THE NON-GP ARM IS NOT THE MACHINE WORD AND IS DELIBERATELY LEFT LITERAL. Sixteen is
+# the VECTOR REGISTER's width, a third quantity again (`model.vector_bits / 8`) that
+# happens to be 16 on every target with a vector bank here. Substituting the word or
+# the spill width into it would be the same conflation this issue exists to stop, and
+# parameterising it properly is a separate change with its own byte-movement risk, on
+# any target whose vector register is not 128 bits.
 # ---
+# ctx: the allocation context, supplying the model's spill-move width
 # lr:  the live range whose register class sets the width
 # ret: the spill-slot width in bytes
-fun class_width(lr: *LiveRange) u32 {
+fun class_width(ctx: *AllocCtx, lr: *LiveRange) u32 {
     if (lr.reg_class != REG_CLASS_GP) { ret 16; }
-    ret 8;
+    ret ctx.spill_width::u32;
 }
 
 # the spill-slot alignment for a spilled vreg: 16 bytes for a 128-bit vector (so its
-# MOVAPS reload is aligned), 8 bytes otherwise. keyed on the vreg's `vector` flag, so
-# scalar GP / float spill layout is unchanged and byte-identical (#2014)
+# MOVAPS reload is aligned), the model's spill-move width otherwise. keyed on the
+# vreg's `vector` flag, so scalar GP / float spill layout is unchanged and
+# byte-identical (#2014). the non-vector arm reads the same model fact `class_width`
+# sizes the slot with, so a slot cannot be aligned below the store that fills it (#2818)
 # ---
 # ctx:      the allocation context
 # value_id: the spilled vreg id
-# ret:      the slot alignment in bytes (8 or 16)
+# ret:      the slot alignment in bytes
 fun spill_slot_align(ctx: *AllocCtx, value_id: u32) u32 {
     if (value_id < ctx.f.vreg_count && ctx.f.vregs[value_id].vector) { ret 16; }
-    ret 8;
+    ret ctx.spill_width::u32;
 }
 
 # append a SLOT_SPILL frame slot keyed on a vreg id and return

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11436,9 +11436,18 @@ val UT_MOS_MEM:   usize = 0x10000;
 val UT_MOS_CODE:  u32   = 0x0200;   # where `.text` loads, clear of the zero page
 val UT_MOS_ARGS:  u32   = 0xF000;   # the incoming argument block the frame pointer names
 val UT_MOS_STORE: u32   = 0xF100;   # the caller's result storage the hidden pointer names
-# the mos6502 convention rounds a stack argument to an eight-byte slot, so the second
-# parameter of `f(v, n)` begins here whatever the scalar's width
-val UT_MOS_ARG1:  u32   = 8;
+# THE SECOND PARAMETER'S OFFSET IS DERIVED, NOT PINNED (#2818). An outgoing stack
+# argument occupies a slot rounded up to the MACHINE WORD, and the 6502's word is one
+# byte, so a scalar packs against its neighbour and `n` begins exactly where `v` ends.
+# This read `8` while `context.stack_slot_bytes` rounded to a hardcoded eight, which is
+# the x86-64 slot the 6502 never had - the harness held a second copy of the compiler's
+# constant and agreed with it by construction rather than by checking it.
+# ---
+# nbytes: the scalar's byte width
+# ret:    the byte offset of `n` within the incoming argument block
+fun ut_mos_arg1(nbytes: u32) u32 {
+    ret nbytes;
+}
 
 # append `text` to `buf` at `w`, returning the new length (test helper)
 fun ut_app(buf: *u8, w: usize, text: str) usize {
@@ -11577,7 +11586,7 @@ fun ut_mos_run(mem: *u8, off: u32, nbytes: u32,
     var k: u32 = 0;
     for (k < nbytes) {
         mem[(UT_MOS_ARGS + k)::usize]                = ((v >> (k * 8)::u64) & 0xFF)::u8;
-        mem[(UT_MOS_ARGS + UT_MOS_ARG1 + k)::usize]  = ((n >> (k * 8)::u64) & 0xFF)::u8;
+        mem[(UT_MOS_ARGS + ut_mos_arg1(nbytes) + k)::usize]  = ((n >> (k * 8)::u64) & 0xFF)::u8;
         k = k + 1;
     }
 


### PR DESCRIPTION
Closes #2818.

Twelve width decisions in shared backend code answered "how wide is the machine word" with a literal `8`, plus the `legalize` float-bank gate. Each site now reads `MachineModel`, and the judgement of **which quantity each literal was actually answering** is recorded at the site, because they are not all the same question.

## The motivation, in the codebase's own words

`src/lang/target/abi/riscv.mach:24` already documents the fact: *"slot granularity. 64 across the lp64 family, 32 across ilp32"*, and `:211` says *"XLEN in bytes (8 for lp64\*, 4 for ilp32\*)"*.

The ABI layer has written it down. The shared lowerer never asked it. That is the whole defect: a second copy of one decision, with the correct copy already present, agreeing by accident because every target mach ships today makes both eight. Credit to `rv32` for finding it while sweeping for RV32 blockers.

**To be plain about risk: none of this miscompiles a shipped target.** Every literal is correct today. What makes it the highest-value item in that sweep is the failure mode when it stops being correct: a program that compiles, links, runs, and passes wrong arguments across a foreign boundary, certified green by a test that shares the assumption.

## The 12 sites, and what each was really asking

Taxonomy: **(a)** the machine word / slot granularity, **(b)** the pointer width, **(c)** the value's own width.

### `be/codegen/mir/context.mach`

| # | Site | Was asking | Now reads |
|---|---|---|---|
| 1 | `stack_slot_bytes` size round-up and its `size == 0` default | (a) | `gpr_width` |
| 2 | `copy_chunk_width` ladder cap | (a) | `gpr_width` |
| 3 | `add_spill_slot` size padding | (a) | `gpr_width` |
| 4 | `add_spill_slot` slot alignment | (a) | `gpr_width` |
| 5 | `add_spill_slot_aligned` size padding | (a) | `gpr_width` |

Site 2's reason is sharper than "granularity" and worth stating: the chunk travels through a **scratch GP register**, load into it and store out of it, so the widest chunk the walk can move is the widest value that register holds. A 4-byte-word machine was being asked for a move it has no register for.

Site 5 is the clean illustration that these are separable: its **alignment** stays the caller's, question (c), while only its **padding** is the machine's. That asymmetry is correct and now documented.

### `be/codegen/mir/abi.mach`

| # | Site | Was asking | Now reads |
|---|---|---|---|
| 6 | `stack_arg_align`, `CLASS_STACK_BYREF` | **(b)** | `pointer_width` |
| 7 | `stack_arg_align`, `CLASS_VEC_STACK_BYREF` | **(b)** | `pointer_width` |
| 8 | `stack_arg_align`, `if (align < 8) ret 8` | (a) | `gpr_width` |
| 9 | fixed-parameter split-chunk cursor `round_up_i64(stack_off, 8)` | (a) | `gpr_width` |
| 10 | variadic-tail split-chunk cursor `round_up_i64(stack_off, 8)` | (a) | `gpr_width` |

**Sites 6-8 are the taxonomy in miniature: one function, one literal, two different questions.** The by-reference clauses align a *pointer* — the doc comment said so all along, "holds only an eight-byte pointer" — while the floor three lines below is the *outgoing-slot granularity*. Substituting one authority into both would have been the same defect wearing a fix's clothes.

Sites 9 and 10 now round to the same word `stack_slot_bytes` sizes each chunk to, so the cursor a caller aligns and the footprint it then advances by cannot disagree. That asymmetry is what produced #2777.

### `be/codegen/regalloc.mach`

| # | Site | Was asking | Now reads |
|---|---|---|---|
| 11 | `class_width`, GP arm | (a), as the spill-move width | `ctx.spill_width` |
| 12 | `spill_slot_align`, non-vector arm | (a) | `ctx.spill_width` |

These were **already inconsistent on a shipped target before this PR**. `regalloc.mach:537` sets `ctx.spill_width = tgt.model.spill_width` and the spill store/reload MOVs use it correctly, so on mos6502 (`spill_width` 1) every GP slot reserved eight bytes for a move that writes one. A parameterised fact and an unparameterised one, four lines apart, disagreeing.

### The `legalize` float gate

`instr_needs_legalize` excluded only **vector** ops from width splitting, never **float** ones. At `lane_width` 4 an `f64` register copy is a plain `MIR_MOV` of width 8, split into two 4-byte **integer** lane moves between GP-class lane vregs — so the value leaves the float bank entirely and the reassembled halves are not the float. Silent miscompile, and the exact mirror of #2777.

The gate is now the register **bank** (`instr_rides_fp_bank`), which strictly subsumes the vector flag, since a vector vreg is FP-class too. `mir.vreg_is_fp` is the same authority instruction selection already reads to identify a float register copy.

The **lane planner** now reads the same gate, so a plan cannot describe a split the rewriter never performs — the placement/capture symmetry the issue asked for.

A target with **no** float bank is unaffected: mos6502 declares one register class, a soft-float value rides GP vregs, and it splits exactly as before. That is why mos6502 can have floats at all, and it is asserted as a control.

## Sites that look like the machine word and are NOT

More valuable than the list above, because this is the part a future reader gets wrong. **None of these were changed.**

| Site | What the `8` (or `16`) actually is | Why substituting the word would be wrong |
|---|---|---|
| `riscv64/encode.mach` `save_callee_fp`, width 8 per callee-saved f register | **float register width** (FLEN/8) | Stays 8 under RV32D, becomes 4 under RV32F. Tracks FLEN, never XLEN. |
| `riscv64/encode.mach` `frame_total` `align16` | **`model.stack_align`** | 16 under both lp64 and ilp32d. Never the word. |
| `regalloc.mach` `class_width`, non-GP arm, 16 | **vector register width** (`vector_bits / 8`) | A third quantity again. Left literal, documented, and flagged as needing its own change with its own byte-movement check. |
| `abi/riscv.mach:550-560` `callee_saved_v` size 8 | **float register width** | rv32's finding, same class as `save_callee_fp`. Not touched — that file is owned by other agents. |

## What is deliberately NOT in this PR

**The riscv64 prologue/epilogue frame geometry (9 sites).** Two reasons, and the first is the better one:

1. Several of those `8`s are not the machine word at all (see the table above). Substituting `gpr_width` into `save_callee_fp` or `align16` would create a **new** instance of the defect this PR closes, while looking like the fix.
2. For the ones that genuinely are the word, a model read there does not produce a working RV32 encoder anyway: `emit_mem_access` at width 8 selects `sd`, which RV32 has no form for. The encoder fork has to land with it.

Handed to `rv32` on `feat/2778-riscv32` with the per-site judgement, which is worth more to it than the substitution.

**`target/abi.mach:713-716` and `:743`** (`piece_for_reg` / `make_slot` chunking a two-register aggregate at the word). Correctly identified as (a), and the prose at `:704-707` states the assumption out loud. Left out because `make_slot` is a pure constructor with no model in scope, so parameterising it means threading a word through **109 call sites across 9 files**, six of them convention classifiers including `abi/riscv.mach`, which two other agents are inside right now. That is a collision, not a hard problem. Filed separately.

## Evidence

### The tests fail against the unpatched compiler

Not "a test exists" — each one was run both ways. `int/` is frozen, so all coverage is in `mach test .`.

**Float gate.** Reverting only the `mir.vreg_is_fp` clause reproduces the pre-fix gate:

```
=== unpatched gate ===
  FAIL  mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes  (exit 1)
0 passed, 1 failed, 1 total

=== patched gate ===
mach.lang.be.codegen.legalize     1 ok    334us
1 passed, 0 failed, 1 total
```

The test asserts **inertness** for an `f64` `MIR_MOV` at `lane_width` 4, with two controls that are what make it mean anything: the identical function over **GP-class** vregs at the identical machine must still split into two lane moves, and the same function on a machine with **no float bank** must still split into eight byte lanes. Without those, inertness would prove only that the fixture legalizes nothing.

**Machine word.** Pinning `gpr_width` and `pointer_width` back to the literal `8` and rebuilding:

```
=== literal-8 build ===
  mach.lang.be.codegen.mir.context.stack_slot_bytes                        (exit 1)
  mach.lang.be.codegen.mir.context.copy_chunk_width                        (exit 1)
  mach.lang.be.codegen.mir.abi:stack_slot_granularity_is_the_machine_word  (exit 1)
0 passed, 3 failed

=== model-read build ===
mach.lang.be.codegen.mir.context.stack_slot_bytes                          1 ok
mach.lang.be.codegen.mir.context.copy_chunk_width                          1 ok
mach.lang.be.codegen.mir.abi:stack_slot_granularity_is_the_machine_word    1 ok
3 passed, 0 failed
```

### The word and the value width genuinely differ

**mach ships no target where they differ, so this is constructed, and the PR says so rather than claiming coverage it does not have.** Each test asserts against synthetic `MachineModel`s:

- `stack_slot_bytes` and `copy_chunk_width` at words **8, 4 and 1**. A 4-byte-word machine must never be handed the 8-byte move it has no register for, which is the assertion a hardcoded ladder cannot pass.
- `stack_slot_granularity_is_the_machine_word` additionally builds a model where the **word is 4 and the pointer is 2**. That is the only thing that can separate sites 6-8: a site reading `gpr_width` for the hidden pointer's alignment answers 4 and must answer 2. Without a model where they disagree, both readings pass.
- The placement side and footprint side are walked together over three arguments on the 4-byte-word machine, pinning that they agree.

### Byte identity

Compiler built before and after, each compiling the full mach project across three targets at both profiles:

```
linux-x86_64/debug:    223 files (222 objects) compared, 0 differ
linux-x86_64/release:  223 files (222 objects) compared, 0 differ
linux-arm64/debug:     223 files (222 objects) compared, 0 differ
linux-arm64/release:   223 files (222 objects) compared, 0 differ
linux-riscv64/debug:   223 files (222 objects) compared, 0 differ
linux-riscv64/release: 223 files (222 objects) compared, 0 differ
TOTAL: 1338 files, 1332 objects, 0 differing
```

### mos6502 DOES change, and correctly

The one place where the literal `8` was **not** a no-op, and it took a full run to find.

mos6502 has `gpr_width = 1`, so its outgoing stack arguments now pack tightly instead of each consuming an 8-byte slot that machine never had, and its GP spill slots reserve the one byte the spill move writes. Both sides of the compiler agree on the new layout, and it is verified **by executing the emitted bytes on the reference 6502 core**, not by reading them.

The only thing that broke was `driver/tests.mach`, which held `UT_MOS_ARG1 = 8` for the second parameter's offset — **the same defect one level up**, a test harness carrying its own copy of the compiler's constant and therefore agreeing with it by construction rather than checking it. It now derives the offset.

### `mach test .`

```
1339 passed, 0 failed, 1339 total
```

### `int`

Filtered to the ABI, float, aggregate and stack-argument cases, all three legs, both profiles. `--runmode qemu` for the non-native legs.

- `linux`: all passed
- `linux-arm64`: all passed
- `linux-riscv64`: all passed, including `2777-riscv-abi-lp64`, `lp64d` and `lp64f`

### Self-host fixpoint

Each stage built into a **freshly removed `out/`**:

```
stage2: cdef8e4ae4949be9  5877760 bytes
stage3: 53df5f42b8f498c3  6465968 bytes
stage4: 53df5f42b8f498c3  6465968 bytes
FIXPOINT: stage3 == stage4
stage2 != stage3 (expected: stage1 is the released 4.16.0, not this branch)
```
