### PR TITLE
fix(codegen): carry a symbol reference's addend into the machine operand

### DIFF
--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -98,6 +98,11 @@ pub rec Register {
 # unrelated flags have already silently landed on the same bit. A target consumes
 # these rather than extending them; a genuinely new modifier is a change here, with
 # every caller visible.
+#
+# `Operand.sym_addend` belongs to the reference for the same reason and by the same
+# argument (#2839). It is the OFFSET half of what a modifier is the prefix half of,
+# and both exist so a rendered line names the address the instruction computes rather
+# than the symbol it starts from.
 pub def SymModifier: u8;
 pub val SYM_MOD_NONE:     SymModifier = 0;  # the reference is unmodified
 pub val SYM_MOD_PCREL_HI: SymModifier = 1;  # rv64 `%pcrel_hi`, aarch64 `adrp` page-high
@@ -122,6 +127,8 @@ pub val SYM_MOD_GOT_LO:   SymModifier = 4;  # aarch64 `:got_lo12:`
 # label:   label name for OPK_LABEL
 # sym_mod: the relocation modifier a symbol reference carries (SYM_MOD_NONE for an
 #          unmodified reference and for every non-symbol operand)
+# sym_addend: the symbol addend this operand's TEXT must spell (0 for an operand
+#          whose text spells none, and for every non-symbol operand). see below
 pub rec Operand {
     kind:    OperandKind;
     size:    u8;
@@ -134,6 +141,7 @@ pub rec Operand {
     sym_id:  u32;
     label:   str;
     sym_mod: SymModifier;
+    sym_addend: i32;
 }
 
 # a single machine instruction in the target-agnostic model
@@ -1832,6 +1840,10 @@ fun operand_blank(kind: OperandKind, size: u8) Operand {
     # every operand starts unmodified, so a target that never forms a symbol address
     # as a pair reads SYM_MOD_NONE by construction rather than by leaving a field unset
     op.sym_mod = SYM_MOD_NONE;
+    # and starts spelling no addend, so an operand whose text carries none - every
+    # non-symbol operand, and the halves of a pair that do not own the constant - is
+    # right by construction rather than by a caller remembering to clear it (#2839)
+    op.sym_addend = 0;
     ret op;
 }
 
@@ -1848,6 +1860,43 @@ fun operand_blank(kind: OperandKind, size: u8) Operand {
 pub fun make_sym_mod(sym_id: u32, size: u8, mod: SymModifier) Operand {
     var op: Operand = make_sym(sym_id, size);
     op.sym_mod = mod;
+    ret op;
+}
+
+# build a symbol-reference operand carrying a relocation modifier and the addend its
+# text must spell
+#
+# THE ADDEND IS WHAT THE LINE MUST SAY, NOT WHAT THE OPERAND CAME FROM AND NOT WHAT
+# THE RELOCATION HOLDS (#2839). Those three are the same number at most sites and
+# differ at two real ones, so naming the question is the whole point:
+#
+#   - riscv64's `%pcrel_lo` half records `hi_addend + distance back to its auipc`,
+#     because the low 12 is measured from the auipc's pc. That is a PAIRING fact, not
+#     a symbol constant, and the constant is owned by the `%pcrel_hi` half. So the low
+#     half spells 0 and the high half spells the offset, which is also what an
+#     assembler reads back.
+#   - aarch64's GOT pair relocates with addend 0 whatever the reference's offset,
+#     because a GOT relocation cannot carry one - the slot holds the symbol's base and
+#     a nonzero offset rides a trailing `add`. Both GOT lines spell 0, and the `add`
+#     that follows says the rest.
+#
+# So a caller passes the offset the ASSEMBLER would need on THIS line, and a half of a
+# sequence that states the constant elsewhere passes 0 deliberately.
+#
+# UNREAD BY EVERY ENCODER, exactly as `sym_id` is. That is what makes this field
+# provably byte-neutral rather than argued to be: the relocation's addend keeps coming
+# from the MIR operand on the path it always did, and this is a second, parallel carry
+# for the text. The two must not be merged - putting the addend in `disp` would reach
+# the memory-operand encoders and move bytes.
+# ---
+# sym_id: symbol id resolved by the linker
+# size:   reference width in bytes
+# mod:    the relocation modifier (one of SYM_MOD_*)
+# addend: the symbol addend this operand's text must spell (0 when it spells none)
+# ret:    an Operand with kind OPK_SYM
+pub fun make_sym_addend(sym_id: u32, size: u8, mod: SymModifier, addend: i32) Operand {
+    var op: Operand = make_sym_mod(sym_id, size, mod);
+    op.sym_addend = addend;
     ret op;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1053,7 +1053,10 @@ fun emit_addsub_imm(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, imm12:
 
 # emit an ADD (immediate) word whose immediate is a symbol's low twelve bits,
 # filled by the linker
-fun emit_addsub_imm_sym(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, sym: intern.StrId, mod: u8) {
+# `addend` is the symbol offset this line's text must spell, which is the offset the
+# paired relocation carries here and 0 on the GOT path, where the slot holds the
+# symbol's base and a nonzero offset rides a trailing `add` instead (#2839)
+fun emit_addsub_imm_sym(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, sym: intern.StrId, mod: u8, addend: i32) {
     emit_word(st, pack_addsub_imm(base, rd, rn, 0, 0));
     if (!noting(st)) { ret; }
     var w: u8 = 4;
@@ -1062,6 +1065,7 @@ fun emit_addsub_imm_sym(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, sy
     i.dst     = printer.gp(rd, w);
     i.src1    = printer.gp(rn, w);
     i.src2    = isa.make_sym(sym::u32, w);
+    i.src2.sym_addend = addend;
     i.sym_mod = mod;
     printer.note_inst(?st.buf, ?i);
 }
@@ -1229,7 +1233,7 @@ fun emit_ldst(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm12: u32) 
 
 # emit a scaled unsigned-offset load / store whose displacement is a symbol's low
 # twelve bits, filled by the linker
-fun emit_ldst_sym(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, sym: intern.StrId, mod: u8) {
+fun emit_ldst_sym(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, sym: intern.StrId, mod: u8, addend: i32) {
     emit_word(st, pack_ldst(base, rt, rn, 0));
     if (!noting(st)) { ret; }
     val s: LdStShape = ldst_shape(base);
@@ -1238,7 +1242,8 @@ fun emit_ldst_sym(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, sym: int
         ret;
     }
     var mem: isa.Operand = isa.make_mem(printer.gp_id(rn), 0, -1, 0, s.w);
-    mem.sym_id = sym::u32;
+    mem.sym_id     = sym::u32;
+    mem.sym_addend = addend;
     var i: printer.Inst = printer.inst(printer.FORM_LDST, base);
     i.sym_mod = mod;
     val reg: isa.Operand = shaped_reg(s.fp, rt, s.w);
@@ -1388,11 +1393,12 @@ fun emit_branch_block(st: *encode.EncodeState, base: u32, rt: u32, has_rt: bool,
 }
 
 # emit a branch whose destination is a symbol the linker resolves
-fun emit_branch_sym(st: *encode.EncodeState, base: u32, sym: intern.StrId) {
+fun emit_branch_sym(st: *encode.EncodeState, base: u32, sym: intern.StrId, addend: i32) {
     emit_word(st, base);
     if (!noting(st)) { ret; }
     var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
     i.src2   = isa.make_sym(sym::u32, 0);
+    i.src2.sym_addend = addend;
     i.target = printer.TGT_SYM;
     printer.note_inst(?st.buf, ?i);
 }
@@ -1433,12 +1439,13 @@ fun emit_branch_reg(st: *encode.EncodeState, base: u32, rn: u32) {
 }
 
 # emit an ADRP page-address word with a placeholder page delta
-fun emit_adrp(st: *encode.EncodeState, rd: u32, sym: intern.StrId, mod: u8) {
+fun emit_adrp(st: *encode.EncodeState, rd: u32, sym: intern.StrId, mod: u8, addend: i32) {
     emit_word(st, pack_adrp(rd));
     if (!noting(st)) { ret; }
     var i: printer.Inst = printer.inst(printer.FORM_ADRP, ADRP_BASE);
     i.dst     = printer.gp(rd, 8);
     i.src1    = isa.make_sym(sym::u32, 0);
+    i.src1.sym_addend = addend;
     i.sym_mod = mod;
     printer.note_inst(?st.buf, ?i);
 }
@@ -1822,7 +1829,7 @@ fun scale_shift(scale: u8) R.Result[u32, str] {
 # ADD or LDR/STR `:lo12:` low half naming the same symbol
 fun emit_adrp_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i32) R.Result[bool, str] {
     val pos: u32 = st.buf.len::u32;
-    emit_adrp(st, rd, sym, printer.MOD_PCREL_HI);
+    emit_adrp(st, rd, sym, printer.MOD_PCREL_HI, addend);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PAGE21, sym, addend);
 }
 
@@ -1837,7 +1844,7 @@ fun emit_global_addr(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, rd, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_addsub_imm_sym(st, ADDI_X, rd, rd, symop.sym, printer.MOD_PCREL_LO);
+    emit_addsub_imm_sym(st, ADDI_X, rd, rd, symop.sym, printer.MOD_PCREL_LO, symop.sym_off);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, symop.sym, symop.sym_off);
 }
 
@@ -1857,7 +1864,7 @@ fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, w
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, a.scaled, rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO);
+    emit_ldst_sym(st, a.scaled, rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO, symop.sym_off);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), a.lo12, symop.sym, symop.sym_off);
 }
 
@@ -1891,7 +1898,7 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, a.scaled, rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO);
+    emit_ldst_sym(st, a.scaled, rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO, symop.sym_off);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), a.lo12, symop.sym, symop.sym_off);
 }
 
@@ -1903,7 +1910,7 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
 # it with the `ldr :got_lo12:` low half that dereferences the slot
 fun emit_adrp_got_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId) R.Result[bool, str] {
     val pos: u32 = st.buf.len::u32;
-    emit_adrp(st, rd, sym, printer.MOD_GOT_HI);
+    emit_adrp(st, rd, sym, printer.MOD_GOT_HI, 0);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_PAGE21, sym, 0);
 }
 
@@ -1913,6 +1920,10 @@ fun emit_adrp_got_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId) R.R
 # address, which the dynamic loader bound through an R_AARCH64_GLOB_DAT. a nonzero
 # addend rides a trailing `add Xd, Xd, #off` (the slot addresses the symbol base
 # only). this is the imported-data analogue of the absolute emit_global_addr
+#
+# SO NEITHER GOT LINE SPELLS AN ADDEND, and that is a statement rather than a gap
+# (#2839): the `add` below says the rest, and a `:got:sym+8` would name an
+# instruction the assembler turns into different bytes than these
 fun emit_global_addr_got(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R.Result[bool, str] {
     if (symop.sym == intern.STR_NIL) {
         ret R.err[bool, str]("encode: GOT address-of has no resolved symbol name");
@@ -1922,7 +1933,7 @@ fun emit_global_addr_got(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperan
     val pos: u32 = st.buf.len::u32;
     # a GOT slot is a pointer, so this LDR is a doubleword whatever the access width
     # the caller goes on to use it at.
-    emit_ldst_sym(st, LDR_OFF_X, rd, rd, symop.sym, printer.MOD_GOT_LO);
+    emit_ldst_sym(st, LDR_OFF_X, rd, rd, symop.sym, printer.MOD_GOT_LO, 0);
     val pr: R.Result[bool, str] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, symop.sym, 0);
     if (R.is_err[bool, str](pr)) { ret pr; }
     if (symop.sym_off != 0) { emit_add_imm(st, rd, rd, symop.sym_off::i64); }
@@ -1986,7 +1997,7 @@ fun encode_call(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] 
             ret R.err[bool, str]("encode: direct call has no resolved symbol name");
         }
         val pos: u32 = st.buf.len::u32;
-        emit_branch_sym(st, BL_BASE, callee.sym);
+        emit_branch_sym(st, BL_BASE, callee.sym, callee.sym_off);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, callee.sym, callee.sym_off);
     }
     val rr: R.Result[i32, str] = req_gpr(callee);
@@ -2609,7 +2620,7 @@ fun emit_fp_const(st: *encode.EncodeState, vd: u32, bits: u64, width: u8) R.Resu
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, sym, 0);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, a.scaled, vd, SCRATCH0, sym, printer.MOD_PCREL_LO);
+    emit_ldst_sym(st, a.scaled, vd, SCRATCH0, sym, printer.MOD_PCREL_LO, 0);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), a.lo12, sym, 0);
 }
 
@@ -5177,7 +5188,7 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
         if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
         val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
         val pos: u32 = st.buf.len::u32;
-        emit_addsub_imm_sym(st, sel(use64, ADDI_X, ADDI_W), rd.reg::u32, rn.reg::u32, sid, printer.MOD_PCREL_LO);
+        emit_addsub_imm_sym(st, sel(use64, ADDI_X, ADDI_W), rd.reg::u32, rn.reg::u32, sid, printer.MOD_PCREL_LO, 0);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, sid, 0);
     }
     if (a64_is_sp(rd) || a64_is_sp(rn) || a64_is_sp(op3)) {
@@ -5234,7 +5245,7 @@ fun a64_emit_call(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.
     if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
     val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
-    emit_branch_sym(st, BL_BASE, sid);
+    emit_branch_sym(st, BL_BASE, sid, 0);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
 }
 
@@ -5248,7 +5259,7 @@ fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, i
         if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
         val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
         val pos: u32 = st.buf.len::u32;
-        emit_branch_sym(st, B_BASE, sid);
+        emit_branch_sym(st, B_BASE, sid, 0);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
     }
 
@@ -5302,10 +5313,10 @@ fun a64_emit_ldst(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.
         if (mem.mod == isa.SYM_MOD_GOT_LO) {
             if (!is_load || w != 8) { ret R.err[bool, str]("encode: inline-asm ':got_lo12:' offset takes a 64-bit load"); }
             # a GOT slot is a pointer: the doubleword form whatever `w` says.
-            emit_ldst_sym(st, LDR_OFF_X, rt.reg::u32, mem.reg::u32, sid, printer.MOD_GOT_LO);
+            emit_ldst_sym(st, LDR_OFF_X, rt.reg::u32, mem.reg::u32, sid, printer.MOD_GOT_LO, 0);
             ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, sid, 0);
         }
-        emit_ldst_sym(st, acf.scaled, rt.reg::u32, mem.reg::u32, sid, printer.MOD_PCREL_LO);
+        emit_ldst_sym(st, acf.scaled, rt.reg::u32, mem.reg::u32, sid, printer.MOD_PCREL_LO, 0);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), acf.lo12, sid, 0);
     }
     if ((mem.flags & iasm.AOF_HAS_INDEX) != 0) {

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -1893,7 +1893,40 @@ fun emit_interned(out: *writer.Writer, interner: *intern.Interner, id: intern.St
 # op:       the operand carrying the symbol id
 # ret:      true on success, or an error
 fun emit_sym(out: *writer.Writer, interner: *intern.Interner, op: *isa.Operand) R.Result[bool, str] {
-    ret emit_interned(out, interner, op.sym_id::intern.StrId);
+    val res_name: R.Result[bool, str] = emit_interned(out, interner, op.sym_id::intern.StrId);
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    ret emit_addend(out, op.sym_addend);
+}
+
+# append a symbol reference's addend as `+N` / `-N`, or nothing when it is zero
+#
+# The offset half of naming an address (#2839). Without it `&g.lo` and `&g.hi`
+# rendered the identical `adrp x0, g` / `add x0, x0, :lo12:g` pair while the objects
+# relocated against `g` and `g+8`. AArch64 spells the offset after the name and
+# inside the modifier's scope (`:lo12:g+8`), which is what the assembler reads back.
+#
+# A ZERO ADDEND PRINTS NOTHING rather than `+0`, because `g` is the spelling an
+# assembler produces for the same relocation - and on the GOT path the zero is load
+# bearing: the slot holds the symbol's base and a nonzero offset rides a trailing
+# `add`, so `:got:g+8` would name an instruction that assembles to different bytes.
+#
+# BARE DECIMAL, NOT `emit_dec_imm`. That helper prefixes `#`, which is how AArch64
+# spells an IMMEDIATE OPERAND - `g+#8` is not an address expression any assembler
+# reads, so the `#` would reintroduce the divergence in a new spelling.
+# ---
+# out:    destination writer
+# addend: the addend to spell
+# ret:    true on success, or the first write error
+fun emit_addend(out: *writer.Writer, addend: i32) R.Result[bool, str] {
+    if (addend == 0) { ret R.ok[bool, str](true); }
+    if (addend < 0) {
+        val res_neg: R.Result[bool, str] = emit_str(out, "-");
+        if (R.is_err[bool, str](res_neg)) { ret res_neg; }
+        ret emit_u64(out, (0 - addend::i64)::u64);
+    }
+    val res_pos: R.Result[bool, str] = emit_str(out, "+");
+    if (R.is_err[bool, str](res_pos)) { ret res_pos; }
+    ret emit_u64(out, addend::u64);
 }
 
 # a fixed capture buffer the rendering tests write into, and its writer
@@ -2183,6 +2216,94 @@ test "mach.lang.target.isa.arm64.printer.render_inst:unmapped_base_is_an_error" 
     note_inst(?buf, ?i);
     if (!buf.asm.failed) { bad = 1; }
 
+    enc.buf_dnit(?buf);
+    ret bad;
+}
+
+# TWO DIFFERENT ADDRESSES INSIDE ONE OBJECT RENDER AS TWO DIFFERENT LINES (#2839)
+#
+# `&g.lo` and `&g.hi` lower to the same symbol at addends 0 and 8, and the objects
+# relocate against `g` and `g+8` (`R_AARCH64_ADR_PREL_PG_HI21 g` versus `g+0x8`). The
+# rendering dropped the addend, so both functions printed the identical
+# `adrp x0, g` / `add x0, x0, :lo12:g` pair - the `.s` stating that two functions
+# compute the same address, which is a wrong claim rather than a missing detail.
+#
+# ASSERTING THE PAIR IS THE POINT. A test that only checked the addend "is printed"
+# would say nothing about the collapse, so both lines are named exactly and the
+# zero-addend one is pinned to have no `+0`.
+#
+# BOTH HALVES SPELL IT on the absolute path, because both relocations carry it and
+# both `adrp Xd, g+8` and `add Xd, Xd, :lo12:g+8` are what an assembler reads back.
+# That is the opposite of RISC-V, where the high half owns the constant alone, and
+# the difference is a property of the two ABIs rather than of this printer.
+#
+# THE GOT PATH SPELLS NONE, and that zero is load bearing rather than absent: a GOT
+# relocation cannot carry an addend, the slot holds the symbol's base, and a nonzero
+# offset rides a trailing `add`. A `:got:g+8` would name an instruction that
+# assembles to different bytes than the object holds.
+#
+# AND THE SPELLING IS BARE DECIMAL. `emit_dec_imm` prefixes `#`, which is how AArch64
+# writes an IMMEDIATE OPERAND, so `g+#8` would be an address expression no assembler
+# reads - the same divergence in a new spelling. Asserted because the first cut of
+# this change emitted exactly that.
+test "mach.lang.target.isa.arm64.printer.render_inst:a_symbol_addend_is_part_of_the_address" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+
+    var itn: intern.Interner = intern.init(?alloc);
+    val gr: R.Result[intern.StrId, str] = intern.intern(?itn, "g");
+    if (R.is_err[intern.StrId, str](gr)) { ret 1; }
+    val g: intern.StrId = R.unwrap_ok[intern.StrId, str](gr);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = test_sink_write;
+    var sink: enc.AsmSink = enc.sink_init(?w, ?itn);
+    buf.asm = ?sink;
+
+    var bad: i32 = 0;
+
+    # the high half of `&g.lo` and of `&g.hi`.
+    # the base words are `encode.mach`'s ADRP_BASE and ADDI_X, spelled here because
+    # the printer is what is under test and reads only the word it is handed.
+    var adrp_lo: Inst = inst(FORM_ADRP, 0x90000000);
+    adrp_lo.dst     = gp(0, 8);
+    adrp_lo.src1    = isa.make_sym(g::u32, 0);
+    adrp_lo.sym_mod = MOD_PCREL_HI;
+    bad = bad | rendered_is(?buf, ?adrp_lo, "adrp x0, g");
+
+    var adrp_hi: Inst = adrp_lo;
+    adrp_hi.src1.sym_addend = 8;
+    bad = bad | rendered_is(?buf, ?adrp_hi, "adrp x0, g+8");
+
+    # a negative addend spells its own sign rather than a `+-8`.
+    var adrp_neg: Inst = adrp_lo;
+    adrp_neg.src1.sym_addend = 0 - 8;
+    bad = bad | rendered_is(?buf, ?adrp_neg, "adrp x0, g-8");
+
+    # the low half carries it too on the absolute path, so the two lines of one pair
+    # agree with each other and with the two relocations.
+    var add_lo: Inst = inst(FORM_ADDSUB_IMM, 0x91000000);
+    add_lo.dst     = gp(0, 8);
+    add_lo.src1    = gp(0, 8);
+    add_lo.src2    = isa.make_sym(g::u32, 8);
+    add_lo.sym_mod = MOD_PCREL_LO;
+    bad = bad | rendered_is(?buf, ?add_lo, "add x0, x0, :lo12:g");
+
+    var add_hi: Inst = add_lo;
+    add_hi.src2.sym_addend = 8;
+    bad = bad | rendered_is(?buf, ?add_hi, "add x0, x0, :lo12:g+8");
+
+    # the GOT half spells none, whatever the reference's own offset - the trailing
+    # `add` the encoder emits says the rest.
+    var got: Inst = inst(FORM_ADRP, 0x90000000);
+    got.dst     = gp(0, 8);
+    got.src1    = isa.make_sym(g::u32, 0);
+    got.sym_mod = MOD_GOT_HI;
+    bad = bad | rendered_is(?buf, ?got, "adrp x0, :got:g");
+
+    intern.dnit(?itn);
     enc.buf_dnit(?buf);
     ret bad;
 }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -999,22 +999,37 @@ fun note_local_target(st: *encode.EncodeState, number: u64, fwd: bool) {
 # then an `addi` / load / store taking `%pcrel_lo(sym)` - and the two halves take
 # different relocations and different text. The modifier rides the operand carrying
 # the symbol, so each half renders as the assembler would spell it.
+#
+# THE HIGH HALF OWNS THE ADDEND AND THE LOW HALF SPELLS NONE (#2839). The pair
+# materializes ONE address, so exactly one of the two states its constant, and on
+# RISC-V it is the `%pcrel_hi`: `push_pcrel_lo` records the low half's relocation as
+# `hi_addend + the distance back to its auipc`, which is a PAIRING fact rather than a
+# symbol constant, and an assembler reading `%pcrel_lo` takes the offset from the
+# auipc it pairs with. So a caller passes the symbol's offset on the high half and 0
+# on the low one, and 0 there is a statement rather than a gap.
+#
+# Both branches set the field. The memory-operand branch edits three fields of an
+# already-buffered slot in place, so a field it did not set would keep whatever the
+# instruction's own emitter left there rather than a default - which is exactly how a
+# new field goes missing on one path only.
 # ---
-# st:  encoder driver state (its buffer carries the sink)
-# sym: the referenced symbol
-# mod: the relocation modifier the half takes
-fun note_sym_target(st: *encode.EncodeState, sym: intern.StrId, mod: isa.SymModifier) {
+# st:     encoder driver state (its buffer carries the sink)
+# sym:    the referenced symbol
+# mod:    the relocation modifier the half takes
+# addend: the symbol addend this half's text must spell (0 for a half that spells none)
+fun note_sym_target(st: *encode.EncodeState, sym: intern.StrId, mod: isa.SymModifier, addend: i32) {
     val op: *isa.Operand = last_target(st);
     if (op == nil) { ret; }
     if (op.kind == isa.OPK_MEM) {
         # an address field that is part of a memory operand keeps its base register
         # and takes the symbol in place of its displacement
-        op.sym_id  = sym::u32;
-        op.sym_mod = mod;
-        op.disp    = 0;
+        op.sym_id     = sym::u32;
+        op.sym_mod    = mod;
+        op.disp       = 0;
+        op.sym_addend = addend;
         ret;
     }
-    @op = isa.make_sym_mod(sym::u32, 8, mod);
+    @op = isa.make_sym_addend(sym::u32, 8, mod, addend);
 }
 
 # read the 32-bit little-endian word at `pos` in the text sink
@@ -1548,7 +1563,7 @@ fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.M
 fun emit_pcrel_hi(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i32) R.Result[bool, str] {
     val pos: u32 = st.buf.len::u32;
     emit_u(st, OPC_AUIPC, rd, 0);
-    note_sym_target(st, sym, isa.SYM_MOD_PCREL_HI);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_HI, addend);
     ret encode.push_reloc(st, pos, of.RK_PCREL_HI20, sym, addend);
 }
 
@@ -1599,7 +1614,7 @@ fun emit_global_addr(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
     emit_i(st, OPC_OP_IMM, F3_ADD, rd, rd, 0);   # addi rd, rd, %pcrel_lo(sym)
-    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO, 0);
     ret push_pcrel_lo(st, lo_pos, of.RK_PCREL_LO12_I, symop.sym);
 }
 
@@ -1618,7 +1633,7 @@ fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, w
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
     emit_i(st, OPC_LOAD, R.unwrap_ok[u32, str](f3r), rt, SCRATCH, 0);
-    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO, 0);
     ret push_pcrel_lo(st, lo_pos, of.RK_PCREL_LO12_I, symop.sym);
 }
 
@@ -1648,7 +1663,7 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
     emit_s(st, OPC_STORE, R.unwrap_ok[u32, str](f3r), SCRATCH, rt, 0);
-    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO, 0);
     ret push_pcrel_lo(st, lo_pos, of.RK_PCREL_LO12_S, symop.sym);
 }
 
@@ -2030,9 +2045,9 @@ fun encode_call(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] 
         }
         val pos: u32 = st.buf.len::u32;
         emit_u(st, OPC_AUIPC, RRA, 0);
-        note_sym_target(st, callee.sym, isa.SYM_MOD_PCREL_HI);
+        note_sym_target(st, callee.sym, isa.SYM_MOD_PCREL_HI, callee.sym_off);
         emit_i(st, OPC_JALR, F3_ADD, RRA, RRA, 0);
-        note_sym_target(st, callee.sym, isa.SYM_MOD_PCREL_LO);
+        note_sym_target(st, callee.sym, isa.SYM_MOD_PCREL_LO, 0);
         ret encode.push_reloc(st, pos, of.RK_PLT32, callee.sym, callee.sym_off);
     }
     val rr: R.Result[i32, str] = req_gpr(callee);
@@ -2333,7 +2348,7 @@ fun emit_fp_const(st: *encode.EncodeState, vd: u32, bits: i64, width: u8) R.Resu
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
     emit_i(st, OPC_LOAD_FP, R.unwrap_ok[u32, str](f3r), vd, SCRATCH, 0);
-    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO, 0);
     ret push_pcrel_lo(st, lo_pos, of.RK_PCREL_LO12_I, sym);
 }
 
@@ -4632,7 +4647,7 @@ fun rv_emit_pcrel_lo(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item,
     val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
     emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), 0);
-    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO, 0);
     ret push_pcrel_lo(st, pos, of.RK_PCREL_LO12_I, sym);
 }
 
@@ -4647,7 +4662,7 @@ fun rv_emit_la(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Res
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
     emit_i(st, OPC_OP_IMM, F3_ADD, rd, rd, 0);
-    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO, 0);
     ret push_pcrel_lo(st, lo_pos, of.RK_PCREL_LO12_I, sym);
 }
 
@@ -4661,9 +4676,9 @@ fun rv_emit_call(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item, lin
     val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
     emit_u(st, OPC_AUIPC, link, 0);
-    note_sym_target(st, sym, isa.SYM_MOD_PCREL_HI);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_HI, 0);
     emit_i(st, OPC_JALR, F3_ADD, ret_reg, link, 0);
-    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO, 0);
     ret encode.push_reloc(st, pos, of.RK_PLT32, sym, 0);
 }
 

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -39,6 +39,7 @@
 # error naming the opcode. Silent degradation is what let the old divergence go
 # unnoticed, so there is no fallback text anywhere in this module.
 
+use std.allocator.page;
 use std.format;
 use std.io.writer;
 use std.types.bool.bool;
@@ -48,6 +49,7 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
 
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -309,12 +311,44 @@ fun emit_target(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst, 
 # op:       the symbol-carrying operand
 # ret:      true on success, or an error
 fun emit_sym(out: *writer.Writer, interner: *intern.Interner, op: *isa.Operand) R.Result[bool, str] {
-    if (op.sym_mod == isa.SYM_MOD_NONE) { ret emit_name(out, interner, op.sym_id::intern.StrId); }
+    if (op.sym_mod == isa.SYM_MOD_NONE) {
+        val res_bare: R.Result[bool, str] = emit_name(out, interner, op.sym_id::intern.StrId);
+        if (R.is_err[bool, str](res_bare)) { ret res_bare; }
+        ret emit_addend(out, op.sym_addend);
+    }
     val res_open: R.Result[bool, str] = emit_str(out, modifier_text(op.sym_mod));
     if (R.is_err[bool, str](res_open)) { ret res_open; }
     val res_name: R.Result[bool, str] = emit_name(out, interner, op.sym_id::intern.StrId);
     if (R.is_err[bool, str](res_name)) { ret res_name; }
+    # INSIDE THE PARENS, because the modifier applies to the whole address: an
+    # assembler reads `%pcrel_hi(g+8)` and would read `%pcrel_hi(g)+8` as an
+    # arithmetic expression on the relocated value, which is a different thing
+    val res_add: R.Result[bool, str] = emit_addend(out, op.sym_addend);
+    if (R.is_err[bool, str](res_add)) { ret res_add; }
     ret emit_str(out, ")");
+}
+
+# append a symbol reference's addend as `+N` / `-N`, or nothing when it is zero
+#
+# The offset half of naming an address (#2839). Without it `&g.lo` and `&g.hi`
+# rendered the identical line while the objects relocated against `g` and `g+8`, so
+# the `.s` said two functions computed the same address. A ZERO ADDEND PRINTS
+# NOTHING rather than `+0`, because `g` is the spelling an assembler produces for the
+# same relocation and the artifact has to match what the object holds.
+# ---
+# out:    destination writer
+# addend: the addend to spell
+# ret:    true on success, or the first write error
+fun emit_addend(out: *writer.Writer, addend: i32) R.Result[bool, str] {
+    if (addend == 0) { ret R.ok[bool, str](true); }
+    if (addend < 0) {
+        val res_neg: R.Result[bool, str] = emit_str(out, "-");
+        if (R.is_err[bool, str](res_neg)) { ret res_neg; }
+        ret emit_i64(out, 0 - addend::i64);
+    }
+    val res_pos: R.Result[bool, str] = emit_str(out, "+");
+    if (R.is_err[bool, str](res_pos)) { ret res_pos; }
+    ret emit_i64(out, addend::i64);
 }
 
 # the RISC-V assembler spelling of a relocation modifier, with its opening paren
@@ -806,5 +840,87 @@ test "mach.lang.target.isa.riscv64.printer.mnemonic:opcode_names" {
     # an opcode outside the surface has no name, so the render fails rather than
     # inventing one
     if (mnemonic(inst.MOP_NONE) != nil) { ret 1; }
+    ret 0;
+}
+
+# TWO DIFFERENT ADDRESSES INSIDE ONE OBJECT RENDER AS TWO DIFFERENT LINES (#2839)
+#
+# `&g.lo` and `&g.hi` lower to the same symbol at addends 0 and 8, and the objects
+# relocate against `g` and `g+8` (`R_RISCV_PCREL_HI20 g` versus `g+0x8`). The
+# rendering dropped the addend, so both functions printed the identical
+# `auipc a0, %pcrel_hi(g)` - the `.s` stating that two functions compute the same
+# address, which is a wrong claim rather than a missing detail.
+#
+# ASSERTING THE PAIR IS THE POINT. A test that only checked the addend "is printed"
+# would say nothing about the collapse, so both lines are named exactly and the
+# zero-addend one is pinned to have no `+0`.
+#
+# THE OFFSET GOES INSIDE THE PARENS, and only on the HIGH half. `%pcrel_hi(g+8)` is
+# what an assembler reads back, and `%pcrel_hi(g)+8` would be arithmetic on the relocated
+# value, a different thing. And the low half spells NOTHING, because the pair
+# materializes one address and the high half owns its constant - `push_pcrel_lo`
+# records the low half's relocation as the high addend plus its own distance back to
+# the auipc, which is a pairing fact and not a symbol offset. A `%pcrel_lo(g+8)` here
+# would double-count the constant, so the zero is load bearing and is asserted.
+test "mach.lang.target.isa.riscv64.printer.render_inst:a_symbol_addend_is_part_of_the_address" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    val gr: R.Result[intern.StrId, str] = intern.intern(?itn, "g");
+    if (R.is_err[intern.StrId, str](gr)) { ret 1; }
+    val g: intern.StrId = R.unwrap_ok[intern.StrId, str](gr);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = test_sink_write;
+
+    # the high half of `&g.lo` and of `&g.hi`.
+    var hi_lo: isa.Inst = isa.inst_blank();
+    hi_lo.opcode = inst.AUIPC::u16;
+    hi_lo.size   = 8;
+    hi_lo.dst    = isa.make_reg(10, 8);
+    hi_lo.src1   = isa.make_sym_addend(g::u32, 8, isa.SYM_MOD_PCREL_HI, 0);
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, ?itn, ?hi_lo)))                { intern.dnit(?itn); ret 1; }
+    if (!str_equals(test_sink_text(), "  auipc a0, %pcrel_hi(g)\n"))       { intern.dnit(?itn); ret 1; }
+
+    var hi_hi: isa.Inst = hi_lo;
+    hi_hi.src1 = isa.make_sym_addend(g::u32, 8, isa.SYM_MOD_PCREL_HI, 8);
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, ?itn, ?hi_hi)))                { intern.dnit(?itn); ret 1; }
+    if (!str_equals(test_sink_text(), "  auipc a0, %pcrel_hi(g+8)\n"))     { intern.dnit(?itn); ret 1; }
+
+    # a negative addend spells its own sign rather than a `+-8`.
+    var hi_neg: isa.Inst = hi_lo;
+    hi_neg.src1 = isa.make_sym_addend(g::u32, 8, isa.SYM_MOD_PCREL_HI, 0 - 8);
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, ?itn, ?hi_neg)))               { intern.dnit(?itn); ret 1; }
+    if (!str_equals(test_sink_text(), "  auipc a0, %pcrel_hi(g-8)\n"))     { intern.dnit(?itn); ret 1; }
+
+    # THE LOW HALF OF BOTH SPELLS NO ADDEND. Its own relocation carries one, and it is
+    # not this symbol's offset - the high half already stated that.
+    var lo_half: isa.Inst = isa.inst_blank();
+    lo_half.opcode = inst.ADDI::u16;
+    lo_half.size   = 8;
+    lo_half.dst    = isa.make_reg(10, 8);
+    lo_half.src1   = isa.make_reg(10, 8);
+    lo_half.src2   = isa.make_sym_addend(g::u32, 8, isa.SYM_MOD_PCREL_LO, 0);
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, ?itn, ?lo_half)))              { intern.dnit(?itn); ret 1; }
+    if (!str_equals(test_sink_text(), "  addi a0, a0, %pcrel_lo(g)\n"))    { intern.dnit(?itn); ret 1; }
+
+    # an unmodified reference carries its addend too - the field is the reference's,
+    # not the modifier's.
+    var bare: isa.Inst = isa.inst_blank();
+    bare.opcode = inst.AUIPC::u16;
+    bare.size   = 8;
+    bare.dst    = isa.make_reg(10, 8);
+    bare.src1   = isa.make_sym(g::u32, 8);
+    bare.src1.sym_addend = 8;
+    test_sink_reset();
+    if (R.is_err[bool, str](render_inst(?w, ?itn, ?bare)))                 { intern.dnit(?itn); ret 1; }
+    if (!str_equals(test_sink_text(), "  auipc a0, g+8\n"))                { intern.dnit(?itn); ret 1; }
+
+    intern.dnit(?itn);
     ret 0;
 }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5381,8 +5381,18 @@ fun mir_to_operand(f: *mir.MirFunction, op: *mir.MirOperand, width: u8) R.Result
         # address value, and as a direct CALL/JMP target (whose encoder emits a rel32
         # and ignores the base / size). the symbol id rides along in `sym_id` so
         # `--emit-asm` can name the target; no encoder reads it.
+        #
+        # AND THE ADDEND RIDES WITH IT (#2839). Naming the symbol alone made `&g.lo`
+        # and `&g.hi` render the identical line while relocating against `g` and
+        # `g+8`, so the `.s` said two functions computed the same address. `sym_off`
+        # is the whole difference between a field address, a constant index into a
+        # global, and a bare `&g` - `mir.context.fold_offset` puts a constant offset
+        # there rather than materializing an add - so a text that drops it states
+        # something false rather than something incomplete. Unread by the encoder,
+        # exactly as `sym_id` is.
         var sym: isa.Operand = isa.make_mem(-1, 0, -1, 0, width);
-        sym.sym_id = op.sym;
+        sym.sym_id     = op.sym;
+        sym.sym_addend = op.sym_off;
         ret R.ok[isa.Operand, str](sym);
     }
     if (op.kind == mir.MIR_OP_BLOCK) {
@@ -6329,6 +6339,12 @@ fun x64_to_isa(op: *iasm.Operand, size: u8, sym: intern.StrId) isa.Operand {
     if (op.kind == iasm.AOP_IMM) { ret isa.make_imm(op.imm, size); }
     if (op.kind == iasm.AOP_MEM) {
         if ((op.flags & iasm.AOF_MEM_SYM) != 0) {
+            # NO ADDEND, AND NOT BY OMISSION (#2839). `x64_mem` accepts a bare name in
+            # brackets only, refusing `[sym + 8]` outright ("valid only without a
+            # displacement term"), and the relocation this operand takes is pushed with
+            # addend 0. So the operand spells none because the shape HAS none, which is
+            # a different fact from the compiler-emitted path above and is why it is
+            # written down rather than left to look like the same oversight.
             var m: isa.Operand = isa.make_mem(-1, 0, -1, 0, size);
             m.sym_id = sym::u32;
             ret m;

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -250,7 +250,7 @@ fun render_operand_body(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand) R.Re
     if (op.kind == isa.OPK_IMM && mi.opcode == x64.MOV_SEG) { ret emit_segreg(out, op.imm); }
     if (op.kind == isa.OPK_IMM)   { ret emit_i64(out, op.imm); }
     if (op.kind == isa.OPK_MEM)   { ret render_mem(buf, mi, op); }
-    if (op.kind == isa.OPK_SYM)   { ret emit_sym(out, buf.asm.interner, op.sym_id); }
+    if (op.kind == isa.OPK_SYM)   { ret emit_sym(out, buf.asm.interner, op); }
     if (op.kind == isa.OPK_LABEL) { ret render_label(buf, op); }
 
     ret R.err[bool, str]("--emit-asm: instruction operand has no renderable kind");
@@ -285,7 +285,7 @@ fun render_mem(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand) R.Result[bool
     if (op.base < 0) {
         val res_rip: R.Result[bool, str] = emit_str(out, "rip + ");
         if (R.is_err[bool, str](res_rip)) { ret res_rip; }
-        val res_sym: R.Result[bool, str] = emit_sym(out, buf.asm.interner, op.sym_id);
+        val res_sym: R.Result[bool, str] = emit_sym(out, buf.asm.interner, op);
         if (R.is_err[bool, str](res_sym)) { ret res_sym; }
         ret emit_str(out, "]");
     }
@@ -636,18 +636,38 @@ fun emit_name(out: *writer.Writer, interner: *intern.Interner, id: intern.StrId)
     ret emit_str(out, O.unwrap[str](opt_name));
 }
 
-# write a symbol reference's name, failing when the id does not resolve
+# write a symbol reference's name and the addend it must spell, failing when the id
+# does not resolve
+#
+# TAKES THE OPERAND, NOT THE ID (#2839). Both call sites - the bare `OPK_SYM` arm and
+# the rip-relative memory form - name the same reference, so both read the addend from
+# one place rather than each reconstructing it. Without it `&g.lo` and `&g.hi` rendered
+# the identical `lea rax, qword [rip + g]` while the objects relocated against `g` and
+# `g+8`, so the `.s` said two functions computed the same address.
+#
+# A ZERO ADDEND PRINTS NOTHING rather than `+0`, because `g` is the spelling an
+# assembler produces for the same relocation and the artifact has to match the object.
 # ---
 # out:      destination writer
 # interner: the interner that resolves the id to text
-# id:       the symbol's interned string id
+# op:       the symbol-carrying operand
 # ret:      true on success, or an error
-fun emit_sym(out: *writer.Writer, interner: *intern.Interner, id: u32) R.Result[bool, str] {
-    val opt_name: O.Option[str] = intern.lookup(interner, id::intern.StrId);
+fun emit_sym(out: *writer.Writer, interner: *intern.Interner, op: *isa.Operand) R.Result[bool, str] {
+    val opt_name: O.Option[str] = intern.lookup(interner, op.sym_id::intern.StrId);
     if (O.is_none[str](opt_name)) {
         ret R.err[bool, str]("--emit-asm: a symbol reference did not resolve in the interner");
     }
-    ret emit_str(out, O.unwrap[str](opt_name));
+    val res_name: R.Result[bool, str] = emit_str(out, O.unwrap[str](opt_name));
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    if (op.sym_addend == 0) { ret R.ok[bool, str](true); }
+    if (op.sym_addend < 0) {
+        val res_neg: R.Result[bool, str] = emit_str(out, "-");
+        if (R.is_err[bool, str](res_neg)) { ret res_neg; }
+        ret emit_i64(out, 0 - op.sym_addend::i64);
+    }
+    val res_pos: R.Result[bool, str] = emit_str(out, "+");
+    if (R.is_err[bool, str](res_pos)) { ret res_pos; }
+    ret emit_i64(out, op.sym_addend::i64);
 }
 
 # a fixed capture buffer the rendering tests write into, and its writer
@@ -852,6 +872,71 @@ test "mach.lang.target.isa.x64.printer.render_inst:unmapped_sysreg_is_an_error" 
     test_sink_len = 0;
     if (!R.is_err[bool, str](render_inst(?buf, ?i2))) { bad = 1; }
 
+    enc.buf_dnit(?buf);
+    ret bad;
+}
+
+# TWO DIFFERENT ADDRESSES INSIDE ONE OBJECT RENDER AS TWO DIFFERENT LINES (#2839)
+#
+# `&g.lo` and `&g.hi` lower to the same symbol at addends 0 and 8, and the objects
+# relocate against `g` and `g+8`. The rendering dropped the addend, so both functions
+# printed `lea rax, qword [rip + g]` - the `.s` stating that two functions compute the
+# same address, which is a wrong claim rather than a missing detail.
+#
+# ASSERTING THE PAIR IS THE POINT. A test that only checked the addend "is printed"
+# would pass against a renderer that printed it for one operand shape and not the
+# other, and would say nothing at all about the collapse. What has to be pinned is
+# that the two states are DISTINGUISHABLE, so both lines are named exactly and the
+# zero-addend one is pinned to have no `+0` - the spelling an assembler produces for
+# that relocation, and the one the object's own disassembly shows.
+test "mach.lang.target.isa.x64.printer.render_inst:a_symbol_addend_is_part_of_the_address" {
+    var alloc: A.Allocator;
+    var buf: enc.ByteBuf;
+    var w: writer.Writer;
+    var sink: enc.AsmSink;
+    test_sink_buf_init(?buf, ?alloc, ?w, ?sink);
+
+    var itn: intern.Interner = intern.init(?alloc);
+    val gr: R.Result[intern.StrId, str] = intern.intern(?itn, "g");
+    if (R.is_err[intern.StrId, str](gr)) { enc.buf_dnit(?buf); ret 1; }
+    val g: intern.StrId = R.unwrap_ok[intern.StrId, str](gr);
+    sink.interner = ?itn;
+    buf.asm       = ?sink;
+
+    var bad: i32 = 0;
+
+    # the rip-relative memory form both `&g.lo` and `&g.hi` lower to.
+    var lo: isa.Inst = isa.inst_blank();
+    lo.opcode = x64.LEA;
+    lo.size   = 8;
+    lo.dst    = isa.make_reg(x64.RAX, 8);
+    lo.src1   = isa.make_mem(-1, 0, -1, 0, 8);
+    lo.src1.sym_id = g::u32;
+    bad = bad | rendered_is(?buf, ?lo, "lea rax, qword [rip + g]");
+
+    var hi: isa.Inst = lo;
+    hi.src1.sym_addend = 8;
+    bad = bad | rendered_is(?buf, ?hi, "lea rax, qword [rip + g+8]");
+
+    # a negative addend spells its own sign rather than a `+-8`.
+    var neg: isa.Inst = lo;
+    neg.src1.sym_addend = 0 - 8;
+    bad = bad | rendered_is(?buf, ?neg, "lea rax, qword [rip + g-8]");
+
+    # the bare OPK_SYM arm reads the same field, so the two operand shapes cannot
+    # drift apart - which is what putting the addend on the operand rather than
+    # reconstructing it per shape is for.
+    var call_lo: isa.Inst = isa.inst_blank();
+    call_lo.opcode = x64.CALL;
+    call_lo.size   = 8;
+    call_lo.src1   = isa.make_sym(g::u32, 8);
+    bad = bad | rendered_is(?buf, ?call_lo, "call g");
+
+    var call_hi: isa.Inst = call_lo;
+    call_hi.src1.sym_addend = 8;
+    bad = bad | rendered_is(?buf, ?call_hi, "call g+8");
+
+    intern.dnit(?itn);
     enc.buf_dnit(?buf);
     ret bad;
 }


### PR DESCRIPTION
Closes #2839.

`--emit-asm` rendered a symbol reference by name and dropped its addend, so `&g.lo` and `&g.hi` printed the identical line on all three register targets while the objects relocated against `g` and `g+8`. `isa.Operand` gains `sym_addend`, the three encoders carry it, and the three printers spell it in each assembler's own grammar.

## The field, and what it actually means

`isa.Operand.sym_addend`, beside `sym_id` and `sym_mod`. The `SymModifier` doc's own argument covers it without extension:

> The modifier belongs to the symbol REFERENCE, not to the instruction — an instruction may carry more than one operand, and it is the operand that is relocated.

An addend belongs to the reference for the same reason. It is the offset half of what a modifier is the prefix half of.

**Diagnostics-only by construction, read by no encoder**, exactly as `sym_id` is. That is what makes the change provably byte-neutral rather than argued to be: the relocation's addend keeps coming from the MIR operand on the path it always did, and this is a second, parallel carry for the text. The two are not merged — putting the addend in `disp` would reach `encode_mem_operand` and move bytes.

### It is what THIS LINE must spell, not the operand's offset and not the relocation's addend

The three coincide at most sites, which is exactly why the question has to be named. They diverge at two real ones, and both are load-bearing:

| Site | Relocation addend | What the line spells | Why |
|---|---|---|---|
| riscv64 `%pcrel_hi` | `sym_off` | `%pcrel_hi(g+8)` | owns the pair's constant |
| riscv64 `%pcrel_lo` | `hi_addend + distance back to its auipc` | `%pcrel_lo(g)` | that addend is a **pairing** fact, not a symbol constant. `push_pcrel_lo` folds the distance in so the linker resolves the low half from the relocation alone. `%pcrel_lo(g+8)` would double-count the offset the high half already stated |
| aarch64 absolute `adrp` / `add` / `ldr` | `sym_off` on both halves | `g+8` and `:lo12:g+8` | both relocations carry it, both spellings assemble back |
| aarch64 GOT `:got:` / `:got_lo12:` | always 0 | no addend | a GOT relocation cannot carry one. The slot holds the symbol's base and a nonzero offset rides a **trailing `add`**, so `:got:g+8` would name an instruction that assembles to different bytes than the object holds |
| x86-64 inline asm `[sym]` | 0 | no addend | `x64_mem` refuses `[sym + 8]` at the parse. The shape **has** no addend, which is a different fact from the compiler-emitted path and is written down so it does not read as the same oversight |

So a caller passes what an assembler would need on that line, and a half of a sequence that states the constant elsewhere passes `0` deliberately. Every one of those sites carries the reason where it sits.

## One source, not three

- **x86-64**: `emit_sym` now takes the **operand** rather than the id, so the bare `OPK_SYM` arm and the rip-relative memory form read one field instead of each reconstructing it. The x64 printer never read `sym_mod` at all, which is the standing precedent for a printer quietly ignoring an operand field.
- **riscv64**: `note_sym_target` gains the addend and sets it on **both** branches. The `OPK_MEM` branch edits three fields of an already-buffered slot in place, so a field it did not set would keep whatever `build_inst` left there rather than a default — the shape a new field goes missing in on one path only.
- **aarch64**: threaded through `emit_adrp`, `emit_addsub_imm_sym`, `emit_ldst_sym` and `emit_branch_sym`. aarch64 keeps `sym_mod` on its own `printer.Inst`, but the addend goes on the operand, because the operand is what is relocated and putting it on the instruction would recreate the per-target copy this change exists to remove.

## Copy-by-field audit

The caution from `of.ObjectImage` / `obj.rehome_remap`, where a new field was silently dropped on the parallel-codegen path only. **`isa.Operand` has no equivalent**, checked before relying on propagation:

- Every constructor funnels through one `operand_blank`, and `Inst` through one `inst_blank`. The new field is zeroed once and is neutral at every site by construction. This is already enforced: `isa/tests.mach` is a source-scanning census that fails the build if a censused record is declared bare outside a permitted set.
- **No field-by-field rebuild of an `Operand` or `Inst` exists anywhere in `src/`.** No serialize, no hash, no equality that enumerates fields. Every bulk copy is a whole-struct assignment.
- `obj.rehome_remap` rebuilds `of.ObjectImage` field by field, but only touches `machine_flags`, `Section`, `Symbol` and `Relocation`. By the time a worker image is rehomed the instructions are already bytes, so **the parallel path carries no Operand risk**.
- The census's own header records what it cannot see: a write into an *existing slot*. That blind spot has exactly one instance for this field, riscv64's `note_sym_target`, and it is handled above.
- `isa/asm.mach`'s `asm.Operand` is a different record (the parse-time superset). Untouched, and the inline-asm paths that feed it are the ones documented above as having no addend to carry.

## Evidence

### The collision is demonstrated, not asserted

With **production reverted** (the three printers made to ignore the field) and every expectation in the new tests **flipped to the old output**:

```
1355 passed, 0 failed, 1355 total
```

All three flipped tests pass, which is the proof that the two operand states genuinely printed identically. The ambiguity was real rather than hypothesised.

The complementary direction, production reverted with the **correct** expectations:

```
failures:
  mach.lang.target.isa.arm64.printer.render_inst:a_symbol_addend_is_part_of_the_address    (exit 1)
  mach.lang.target.isa.riscv64.printer.render_inst:a_symbol_addend_is_part_of_the_address  (exit 1)
  mach.lang.target.isa.x64.printer.render_inst:a_symbol_addend_is_part_of_the_address      (exit 1)
0 passed, 3 failed, 3 total
```

Each test asserts the **pair** — both lines named exactly, and the zero-addend one pinned to have no `+0`. Asserting only that the addend "is printed" would pass against a renderer that printed it for one operand shape and not the other and would say nothing at all about the collapse. Also pinned: a negative addend spells `g-8` rather than `g+-8`, the riscv64 low half spells none, and the aarch64 GOT half spells none.

### Hand-run, the issue's repro

**Before**

```
=== linux-x86_64 ===                        === linux-arm64 ===                        === linux-riscv64 ===
# repro.main.addr_lo:                       # repro.main.addr_lo:                      # repro.main.addr_lo:
  lea rax, qword [rip + repro.main.g]         adrp x0, repro.main.g                      auipc a0, %pcrel_hi(repro.main.g)
                                              add x0, x0, :lo12:repro.main.g             addi a0, a0, %pcrel_lo(repro.main.g)
# repro.main.addr_hi:                       # repro.main.addr_hi:                      # repro.main.addr_hi:
  lea rax, qword [rip + repro.main.g]         adrp x0, repro.main.g                      auipc a0, %pcrel_hi(repro.main.g)
                                              add x0, x0, :lo12:repro.main.g             addi a0, a0, %pcrel_lo(repro.main.g)
```

**After**

```
=== linux-x86_64 ===                        === linux-arm64 ===                        === linux-riscv64 ===
# repro.main.addr_lo:                       # repro.main.addr_lo:                      # repro.main.addr_lo:
  lea rax, qword [rip + repro.main.g]         adrp x0, repro.main.g                      auipc a0, %pcrel_hi(repro.main.g)
                                              add x0, x0, :lo12:repro.main.g             addi a0, a0, %pcrel_lo(repro.main.g)
# repro.main.addr_hi:                       # repro.main.addr_hi:                      # repro.main.addr_hi:
  lea rax, qword [rip + repro.main.g+8]       adrp x0, repro.main.g+8                    auipc a0, %pcrel_hi(repro.main.g+8)
                                              add x0, x0, :lo12:repro.main.g+8           addi a0, a0, %pcrel_lo(repro.main.g)
```

Each matches the issue's Expected, in the spelling that target's assembler reads back.

One spelling bug caught in the process and pinned by a test: the first cut used aarch64's `emit_dec_imm`, which prefixes `#`, producing `adrp x0, g+#8`. `#` is how AArch64 spells an **immediate operand**, not part of an address expression, so that would have reintroduced the same divergence in a new spelling.

### Byte identity

```
linux-x86_64/debug:    224 files = 223 objects + 1 linked, 0 differ
linux-x86_64/release:  224 files = 223 objects + 1 linked, 0 differ
linux-arm64/debug:     224 files = 223 objects + 1 linked, 0 differ
linux-arm64/release:   224 files = 223 objects + 1 linked, 0 differ
linux-riscv64/debug:   224 files = 223 objects + 1 linked, 0 differ
linux-riscv64/release: 224 files = 223 objects + 1 linked, 0 differ
TOTAL: 1344 files = 1338 objects + 6 binaries, 0 differing
```

### `mach test .`

```
1355 passed, 0 failed, 1355 total
```

Three new tests. No `int/` case — the freeze holds.

### Self-host fixpoint

Each stage built into a **freshly removed `out/`**:

```
stage2: 82d0b41eacd43e5d  5931008 bytes
stage3: 04a8340d51e6ceaf  6525504 bytes
stage4: 04a8340d51e6ceaf  6525504 bytes
FIXPOINT: stage3 == stage4
stage2 != stage3 (expected: stage1 is the released 4.16.0, not this branch)
```
