### PR TITLE
fix(link): emit and resolve the riscv64 psABI hi/lo pair spelling

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -2723,8 +2723,14 @@ dis_case_objects() {
     tool=$(resolve_objdump) || {
         echo "int: $who: llvm-objdump not found (install the 'llvm' package)" >&2; return 2
     }
+    # riscv64 defines a `.Lpcrel_hi.N` label at every `auipc` that starts a psABI
+    # hi/lo pair (mach#2828), and objdump prints one as a `<name>:` line exactly like
+    # a function start. it is an address INSIDE a function, not a new one, so every
+    # scan below that attributes instructions to the enclosing symbol would otherwise
+    # split one function into a dozen. dropped here, once, rather than in each scan.
     find "$objdir" -name '*.o' | sort | while IFS= read -r o; do
-        "$tool" -d --no-show-raw-insn ${extra:+"$extra"} "$o"
+        "$tool" -d --no-show-raw-insn ${extra:+"$extra"} "$o" \
+            | grep -v '^[0-9a-f]\{1,\} <\.Lpcrel_hi\.[0-9]\{1,\}>:$'
     done
 }
 
@@ -2773,12 +2779,13 @@ produce_float_emit() {
 # that names nothing does the same. Neither can pass by accident.
 #
 # The two lists are not required to be EQUAL, and the golden is per-target because of
-# it: how many instructions spell one reference, and how many relocation records cover
-# them, are both the ISA's business. riscv64 is the case in point - `la sym` is an
-# auipc/addi pair carrying `%pcrel_hi` and `%pcrel_lo`, which is two of each, while
-# `call sym` is an auipc/jalr pair the printer names twice and a single
-# `R_RISCV_CALL_PLT` covers. Both are right; what the pairing catches is a name
-# appearing on one side and not the other.
+# it: how many instructions spell one reference, and how many relocation records NAME
+# it, are both the ISA's business. riscv64 is the case in point - `la sym` is an
+# auipc/addi pair the printer names twice, but only the auipc's `%pcrel_hi` names the
+# symbol: the `%pcrel_lo` names the LABEL at that auipc, which is the psABI spelling
+# (mach#2828), so one reference reaches `reloc` once. `call sym` is an auipc/jalr pair
+# the printer names twice and a single `R_RISCV_CALL_PLT` covers. All of these are
+# right; what the pairing catches is a name appearing on one side and not the other.
 #
 # The program's own answer is reported too: the asm loads and calls through those
 # symbols, so a reference that reached the wrong one is a wrong number as well as

--- a/int/surface/asm-symbol-operands/expect.linux-riscv64.txt
+++ b/int/surface/asm-symbol-operands/expect.linux-riscv64.txt
@@ -1,3 +1,3 @@
 print=iasm_counter iasm_counter iasm_other iasm_other iasm_target iasm_target
-reloc=iasm_counter iasm_counter iasm_other iasm_other iasm_target
+reloc=iasm_counter iasm_other iasm_target
 probe=21

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -585,8 +585,16 @@ fun pack_text(s: *session.Session, image: *of.ObjectImage, enc: *encode.EncoderO
 
 # register every encoder symbol mark against the `.text` section
 #
-# Each mark is a function entry point (or an exposed inline-asm label) defined at
-# a known text offset. A mark naming a defined IR function is given GLOBAL
+# Each mark is an address defined in the encoded text at a known offset. The MARK
+# states what kind of symbol it is and this loop carries that through unchanged: it
+# used to OR in `SYM_OBJ_FLAG_FUNCTION` for every mark, which was true only because
+# every mark happened to be a function entry, and stopped being true the moment
+# riscv64 began defining `.Lpcrel_hi` labels at its `auipc` sites (#2828). A
+# fabricated type is worse than a missing one - a label typed STT_FUNC misleads every
+# consumer that asks what a symbol is, and here it made the psABI pair normalizer
+# refuse to recognize its own labels.
+#
+# A mark naming a defined IR function is given GLOBAL
 # linkage so the whole-program linker can resolve cross-module references to it
 # (every function symbol name is now globally unique - module-path-mangled, or an
 # exempted literal like `main` / `_start` - so global linkage cannot collide). A
@@ -609,7 +617,7 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
     for (i < enc.symbol_count) {
         val mark: *encode.SymbolMark = ?enc.symbols[i];
 
-        var flags: u32 = mark.flags | of.SYM_OBJ_FLAG_FUNCTION;
+        var flags: u32 = mark.flags;
         if (function_is_defined(irmod, mark.name)) {
             flags = flags | of.SYM_OBJ_FLAG_GLOBAL;
         }

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -1027,6 +1027,7 @@ rec BlockOffset {
 # syms:        symbol marks
 # sym_count:   number of symbol marks
 # sym_cap:     capacity of `syms`
+# pcrel_label_count: per-module ordinal for `%pcrel_hi` labels
 # relocs:      pending relocations
 # reloc_count: number of relocations
 # reloc_cap:   capacity of `relocs`
@@ -1057,6 +1058,10 @@ pub rec EncodeState {
     syms:        *SymbolMark;
     sym_count:   u32;
     sym_cap:     u32;
+    # ordinal for `%pcrel_hi` labels, per module. separate from `sym_count` because
+    # it names labels only, so the spelling of one does not shift when an unrelated
+    # symbol is added
+    pcrel_label_count: u32;
     relocs:      *PendingReloc;
     reloc_count: u32;
     reloc_cap:   u32;
@@ -1447,6 +1452,32 @@ pub fun intern_const(st: *EncodeState, bytes: *u8, len: u32, kind: u8) R.Result[
     st.consts[st.const_count].sym   = R.unwrap_ok[intern.StrId, str](res_sym);
     st.const_count = st.const_count + 1;
     ret R.ok[intern.StrId, str](st.consts[st.const_count - 1].sym);
+}
+
+# intern a per-module local label name, `<prefix><ordinal>`
+#
+# The one place a local label's NAME is spelled. A local symbol's name only has to be
+# unique within its own object: a relocation against one resolves through `(module,
+# symbol index)` and never by name across objects (`linker.local_symbol_target`,
+# #2520), and STB_LOCAL says the same thing to a foreign linker. So a per-module
+# ordinal is enough, and the same ordinal appearing in every object is correct rather
+# than a collision.
+# ---
+# st:      the encode state supplying the interner
+# prefix:  the label prefix, including its trailing dot
+# ordinal: the per-module ordinal to append
+# ret:     the interned name, or an interning error
+pub fun intern_local_label(st: *EncodeState, prefix: str, ordinal: u32) R.Result[intern.StrId, str] {
+    var name: [64]u8;
+    val plen: usize = str_len(prefix);
+    if (plen + 24 >= 64) {
+        ret R.err[intern.StrId, str]("encode: local label prefix is too long to spell");
+    }
+    var k: usize = 0;
+    for (k < plen) { name[k] = prefix[k]::u8; k = k + 1; }
+    k = put_decimal(?name[0], k, ordinal::usize);
+    name[k] = 0;
+    ret intern.intern(st.interner, (?name[0])::str);
 }
 
 # intern a scalar float bit pattern, the shape every target's float-immediate
@@ -1849,6 +1880,7 @@ pub fun state_blank(st: *EncodeState, alloc: *A.Allocator) {
     st.buf         = buf_init(alloc);
     st.syms        = nil;
     st.sym_count   = 0;
+    st.pcrel_label_count = 0;
     st.sym_cap     = 0;
     st.relocs      = nil;
     st.reloc_count = 0;
@@ -1891,6 +1923,7 @@ fun state_dnit(st: *EncodeState) {
     }
     st.syms      = nil;
     st.sym_count = 0;
+    st.pcrel_label_count = 0;
     st.sym_cap   = 0;
     if (st.relocs != nil && st.reloc_cap > 0) {
         A.deallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize);

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -3056,6 +3056,40 @@ fun atom_resume_offset(dst: u32, end: u32, section_align: u32) u32 {
 }
 
 # physical relocation shape supplied by the active ISA's relocatable-object seam
+# whether a symbol is object-private and named by no relocation in its own module
+#
+# An object-private symbol is resolved by (module, symbol index) and never by name
+# (#2520), so the ONLY thing that can address one is a relocation in the same module.
+# A local no relocation names is therefore unreachable, whatever it sits inside.
+#
+# Relocations sourced from a debug section do not count, for the same reason the atom
+# reference index skips them: debug information DESCRIBES code and must never be what
+# keeps code alive, or the `-g` link retains bodies the plain link discards (#2572).
+#
+# Scans the module's relocations rather than consulting a precomputed set: this is
+# asked only about a symbol that falls inside a duplicate weak body, which is rare,
+# and a set would have to be built for every link to serve those few questions.
+# ---
+# m:  the module owning both the symbol and the relocations that could name it
+# sy: index of the symbol within that module
+# ret: true when the symbol is local and nothing in the module names it
+fun unreferenced_local(m: *of.ObjectImage, sy: u32) bool {
+    if (sy >= m.symbol_count) { ret false; }
+    val sym: *of.Symbol = ?m.symbols[sy];
+    if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0) { ret false; }
+    if (sym.section == of.SECTION_EXTERNAL)        { ret false; }
+    var ri: u32 = 0;
+    for (ri < m.reloc_count) {
+        val r: *of.Relocation = ?m.relocations[ri];
+        if (r.sym == sy
+            && !(r.section < m.section_count && m.sections[r.section].kind == of.SK_DEBUG)) {
+            ret false;
+        }
+        ri = ri + 1;
+    }
+    ret true;
+}
+
 fun atom_reloc_traits(r: *of.Relocation, section: *of.Section,
                       arch: *isa.IsaVTable,
                       codegen_image: bool) rel.RelocTraits {
@@ -3507,16 +3541,25 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         if (end <= start) { ci = ci + 1; cnt; }
 
         # a second symbol entry or nonzero extent overlapping the candidate may
-        # remain addressable from live code. The sole exception is COFF's exact
-        # synthetic section anchor for a full COMDAT carrier; relocation
-        # reachability through that anchor is audited below.
+        # remain addressable from live code. Two exceptions: COFF's exact synthetic
+        # section anchor for a full COMDAT carrier, whose relocation reachability is
+        # audited below, and an object-private symbol NOTHING addresses, which cannot
+        # be reached by definition (`unreferenced_local`).
+        #
+        # The second exists because a producer may define interior labels that exist
+        # only to be consumed before this point. riscv64 defines a `.Lpcrel_hi` label
+        # at every `auipc` starting a psABI pair, and the pair collapse rewrites every
+        # reference to one away before the link reads a relocation (#2828); without
+        # this, one such label inside a duplicate weak body kept the whole body alive
+        # and the -g link then described it with a second, contradictory DIE.
         var safe: bool = true;
         var sy: u32 = 0;
         for (sy < modules[cm].symbol_count) {
             if (sy != cy) {
                 val other: *of.Symbol = ?modules[cm].symbols[sy];
                 if (other.section == sym.section
-                    && !atom_is_carrier_anchor(?modules[cm], sym, other, start, end)) {
+                    && !atom_is_carrier_anchor(?modules[cm], sym, other, start, end)
+                    && !unreferenced_local(?modules[cm], sy)) {
                     if (other.offset >= start && other.offset < end) { safe = false; }
                     if (other.size > 0) {
                         val other_end: u64 = other.offset::u64 + other.size::u64;
@@ -10808,15 +10851,23 @@ test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
     ret 0;
 }
 
-# a second symbol inside a losing function interval keeps that interval live;
-# this is the conservative control for an exposed local/shared label that a live
-# relocation could still address
+# a second symbol inside a losing function interval keeps that interval live WHEN
+# SOMETHING NAMES IT - the conservative control for an exposed local label a live
+# relocation could still address - and does NOT when nothing does. The pair is the
+# test: a local is resolved by index and never by name, so a relocation in its own
+# module is the only thing that can reach one, and a rule that ignored that kept every
+# duplicate weak body alive the moment riscv64 began defining a `.Lpcrel_hi` label at
+# each `auipc` inside one (#2828)
 test "mach.lang.be.linker.atom_plan:shared_symbol_retains_loser" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    if (x64 == nil) { ret 1; }
 
     val dup: intern.StrId = lt_name(?s, "dup$u64");
     val local: intern.StrId = lt_name(?s, "inside_label");
@@ -10839,19 +10890,37 @@ test "mach.lang.be.linker.atom_plan:shared_symbol_retains_loser" {
     b_syms[0].name = dup; b_syms[0].section = 0; b_syms[0].offset = 0;
     b_syms[0].size = 0; b_syms[0].flags = weak_flags;
     b_syms[1].name = local; b_syms[1].section = 0; b_syms[1].offset = 4;
-    b_syms[1].size = 0; b_syms[1].flags = of.SYM_OBJ_FLAG_FUNCTION;
+    b_syms[1].size = 0; b_syms[1].flags = 0;
+
+    # module b names its own interior label from its own text: that reference is what
+    # makes the label reachable, and the label is what makes the body unsafe to drop
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
+    relocs[0].sym = 1; relocs[0].addend = 0;
 
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "a"), ?a_sec[0], 1, ?a_syms[0], 1,
                        nil::*of.Relocation, 0);
     mods[1] = lt_image(?s, lt_name(?s, "b"), ?b_sec[0], 1, ?b_syms[0], 2,
-                       nil::*of.Relocation, 0);
+                       ?relocs[0], 1);
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val pr: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](pr) || plan.active || plan.drop_count != 0) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
+
+    # the SAME shape with nothing naming the label: unreachable, so the duplicate body
+    # goes. this is the riscv64 `.Lpcrel_hi` case, whose references are all rewritten
+    # away by the pair collapse before the link reads a relocation
+    init_atom_plan(?plan);
+    mods[1] = lt_image(?s, lt_name(?s, "b"), ?b_sec[0], 1, ?b_syms[0], 2,
+                       nil::*of.Relocation, 0);
+    val ur: R.Result[bool, str] =
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
+    if (R.is_err[bool, str](ur) || !plan.active || plan.drop_count != 1) { ret 1; }
+    free_atom_plan(?alloc, ?plan);
     ret 0;
 }
 
@@ -10864,6 +10933,11 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val x64: *isa.IsaVTable = lt_isa(?reg, "x86_64");
+    if (x64 == nil) { ret 1; }
 
     val dup: intern.StrId = lt_name(?s, "sized$u64");
     val cover: intern.StrId = lt_name(?s, "cover");
@@ -10891,16 +10965,22 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     b_syms[1].name = cover; b_syms[1].section = 0; b_syms[1].offset = 16;
     b_syms[1].size = 0; b_syms[1].flags = 0;
 
+    # module b names `cover` from its own text, so it is a reachable local and the
+    # covering-extent arm below is testing the extent rather than an unreferenced label
+    var relocs: [1]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 0; relocs[0].kind = of.RK_PC32;
+    relocs[0].sym = 1; relocs[0].addend = 0;
+
     var mods: [2]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "a"), ?a_sec[0], 1, ?a_syms[0], 1,
                        nil::*of.Relocation, 0);
     mods[1] = lt_image(?s, lt_name(?s, "b"), ?b_sec[0], 1, ?b_syms[0], 2,
-                       nil::*of.Relocation, 0);
+                       ?relocs[0], 1);
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
     val sized: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](sized) || !plan.active || plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].start != 0 || plan.drops[0].end != 8
         || plan.sections[1].live_len != 8) { ret 1; }
@@ -10920,7 +11000,7 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     b_syms[1].offset = 0;
     b_syms[1].size = 16;
     val covered: R.Result[bool, str] =
-        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
+        build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
     if (R.is_err[bool, str](covered) || plan.active) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -589,6 +589,20 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                  out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
                  image_options: of.ImageOptions) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
+    # put every input into the form the appliers resolve, before anything reads a
+    # relocation, and for EVERY input regardless of provenance: an image parsed from
+    # a foreign `.o` and an image handed straight over from codegen arrive here by
+    # different routes and must leave here the same shape (#2828). Skipped for a
+    # relocatable output, which carries its relocations through unresolved and so
+    # must keep the format's own spelling.
+    if (mode != LINK_RELOCATABLE && modules != nil) {
+        var ni: u32 = 0;
+        for (ni < module_count) {
+            val nr: R.Result[bool, str] = rel.normalize_image(tgt.isa, ?modules[ni]);
+            if (R.is_err[bool, str](nr)) { ret R.err[bool, str](R.unwrap_err[bool, str](nr)); }
+            ni = ni + 1;
+        }
+    }
     val mf_r: R.Result[u32, str] = image_machine_flags(s, tgt, modules, module_count);
     if (R.is_err[u32, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[u32, str](mf_r)); }
     var opts: of.ImageOptions = image_options;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -1107,12 +1107,21 @@ pub rec ModuleEmitter {
 #                 ELF writer reads it to stamp a `.riscv.attributes`-style
 #                 ISA-string section so external tools decode the full instruction
 #                 set; nil for an arch that emits none
+# normalize_image: OPTIONAL capability - put one whole image into the form this
+#                 arch's `apply_reloc` resolves, before anything reads its
+#                 relocations (cast back to `of.reloc.NormalizeImageFn`). Declared
+#                 by an arch whose object format spells a relocation relative to
+#                 ANOTHER relocation rather than to its own target - riscv's hi/lo
+#                 pairs - so the collapse happens once, at link time, for an image
+#                 read from a file and an image handed straight over from codegen
+#                 alike. nil for an arch whose relocations already stand alone
 pub rec RelocSeam {
     apply_reloc:    *u8;
     reloc_traits:   *u8;
     elf_reloc_type: *u8;
     elf_attributes: *u8;
-    machine_flags:  *u8;
+    machine_flags:   *u8;
+    normalize_image: *u8;
 }
 
 # the ISA runtime-dispatch interface
@@ -1301,15 +1310,15 @@ pub fun module_emitter(emit_module: *u8) ModuleEmitter {
 # `elf_reloc_type`.
 #
 # The optional capabilities are left at their zero default here and added afterwards
-# through `with_elf_attributes` / `with_machine_flags`: nil is the zero value for an
-# erased fn ptr, so a bare `var` already leaves them absent before the setters run.
+# through the `with_*` setters: nil is the zero value for an erased fn ptr, so a bare
+# `var` already leaves each one absent before any setter runs.
 # ---
 # apply_reloc:    the relocation applier, erased (`of.reloc.ApplyRelocFn`)
 # reloc_traits:   the relocation-traits source, erased
 #                 (`of.reloc.RelocTraitsFn`)
 # elf_reloc_type: the abstract-kind to ELF-type map, erased (the ELF writer's
 #                 `ElfRelocTypeFn`)
-# ret:            the contract, with its optional capability unset
+# ret:            the contract, with its optional capabilities unset
 pub fun reloc_seam(apply_reloc: *u8, reloc_traits: *u8,
                    elf_reloc_type: *u8) RelocSeam {
     var s: RelocSeam;
@@ -1396,6 +1405,19 @@ pub fun machine_flags(tgt_isa: *IsaVTable, float_arg_bits: u32,
     if (!emits_relocations(tgt_isa))        { ret 0; }
     if (tgt_isa.reloc.machine_flags == nil) { ret 0; }
     ret tgt_isa.reloc.machine_flags::MachineFlagsFn(float_arg_bits, has_compressed);
+}
+
+# declare the optional whole-image relocation normalizer
+#
+# Without it the linker resolves an image's relocations exactly as they arrive, which
+# is right for every arch whose relocations name their own target. An arch that spells
+# one relocation relative to another declares this so the collapse happens once, for
+# every image, rather than in whichever reader an image happened to come through.
+# ---
+# s: the relocatable-object contract to extend
+# f: the normalizer, erased (`of.reloc.NormalizeImageFn`)
+pub fun with_normalize_image(s: *RelocSeam, f: *u8) {
+    s.normalize_image = f;
 }
 
 # compose an ISA vtable for a REGISTER MACHINE
@@ -2071,11 +2093,14 @@ test "mach.lang.target.isa.reloc_seam:required_then_optional" {
     if (s.apply_reloc == nil)    { ret 1; }
     if (s.reloc_traits == nil)   { ret 1; }
     if (s.elf_reloc_type == nil) { ret 1; }
-    if (s.elf_attributes != nil) { ret 1; }
+    if (s.elf_attributes != nil)  { ret 1; }
+    if (s.normalize_image != nil) { ret 1; }
 
     var hook: u8;
     with_elf_attributes(?s, ?hook);
     if (s.elf_attributes == nil) { ret 1; }
+    with_normalize_image(?s, ?hook);
+    if (s.normalize_image == nil) { ret 1; }
 
     # an arch whose relocatable objects are not ELF passes a deliberate nil for the
     # ELF map and still owes the applier

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -116,7 +116,7 @@ pub fun encode_mos6502(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirModu
 fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
 
-    val res_sym: R.Result[bool, str] = enc.push_symbol(st, f.name, fn_base, 0);
+    val res_sym: R.Result[bool, str] = enc.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](res_sym)) { ret res_sym; }
 
     var bi: u32 = 0;

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1577,6 +1577,13 @@ fun emit_pcrel_hi(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i
     ret encode.push_reloc(st, pos, of.RK_PCREL_HI20, sym, addend);
 }
 
+# the object-symbol flags a `%pcrel_hi` label carries: none. it is a local, untyped
+# address inside `.text`, neither a function nor a data object, which is exactly what
+# the psABI's `.Lpcrel_hiN` is and what a foreign linker matches on. `be.codegen`
+# carries a mark's flags through verbatim, so "no flags" survives to the object as
+# STB_LOCAL/STT_NOTYPE rather than being upgraded to a function
+val PCREL_LABEL_FLAGS: u32 = 0;
+
 # record the low half of a pc-relative pair, `<op> rd, %pcrel_lo(sym)(rs1)`, against the
 # `auipc` that materialized the high half
 #
@@ -1605,11 +1612,50 @@ fun push_pcrel_lo(st: *encode.EncodeState, lo_pos: u32, kind: of.RelocKind,
     for (i > 0) {
         i = i - 1;
         if (st.relocs[i].kind == of.RK_PCREL_HI20 && st.relocs[i].sym == sym) {
-            val fold: i32 = (lo_pos - st.relocs[i].offset)::i32;
-            ret encode.push_reloc(st, lo_pos, kind, sym, st.relocs[i].addend + fold);
+            val hi_off: u32 = st.relocs[i].offset;
+            val lr: R.Result[intern.StrId, str] = pcrel_hi_label(st, hi_off);
+            if (R.is_err[intern.StrId, str](lr)) {
+                ret R.err[bool, str](R.unwrap_err[intern.StrId, str](lr));
+            }
+            ret encode.push_reloc(st, lo_pos, kind, R.unwrap_ok[intern.StrId, str](lr), 0);
         }
     }
     ret R.err[bool, str]("encode: riscv64 pc-relative low-12 names a symbol no preceding 'auipc rd, %pcrel_hi(sym)' in this .text materialized");
+}
+
+# the local label naming the `auipc` at `hi_off`, defining it on first use
+#
+# One label per auipc, shared by every low half that pairs with it: a second low half
+# reaching the same auipc finds the existing definition rather than defining a rival
+# one at the same offset. The lookup is by OFFSET, not by name, because "which auipc"
+# is what the label means.
+#
+# The name only has to be unique within the object, for the same reason `.Lconst.N`
+# does: a relocation against a LOCAL symbol resolves against its own module's
+# definition through `(module, symbol index)` and never by name across objects
+# (`linker.local_symbol_target`, #2520), and STB_LOCAL says the same thing to a
+# foreign linker. So `.Lpcrel_hi.0` appearing in every object in the link is correct
+# rather than a collision.
+# ---
+# st:     the encode state whose symbol array holds the labels
+# hi_off: byte offset of the auipc within `.text`
+# ret:    the label's interned name, or an allocation error
+fun pcrel_hi_label(st: *encode.EncodeState, hi_off: u32) R.Result[intern.StrId, str] {
+    var i: u32 = 0;
+    for (i < st.sym_count) {
+        if (st.syms[i].offset == hi_off && st.syms[i].flags == PCREL_LABEL_FLAGS
+            && st.syms[i].name != intern.STR_NIL) {
+            ret R.ok[intern.StrId, str](st.syms[i].name);
+        }
+        i = i + 1;
+    }
+    val nr: R.Result[intern.StrId, str] = encode.intern_local_label(st, ".Lpcrel_hi.", st.pcrel_label_count);
+    if (R.is_err[intern.StrId, str](nr)) { ret nr; }
+    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](nr);
+    st.pcrel_label_count = st.pcrel_label_count + 1;
+    val sr: R.Result[bool, str] = encode.push_symbol(st, name, hi_off, PCREL_LABEL_FLAGS);
+    if (R.is_err[bool, str](sr)) { ret R.err[intern.StrId, str](R.unwrap_err[bool, str](sr)); }
+    ret R.ok[intern.StrId, str](name);
 }
 
 # a symbol address as an rvalue (the `la` / lea equivalent) - `auipc rd, %pcrel_hi(sym)`

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -4935,6 +4935,25 @@ fun tbuf_interned(st: *encode.EncodeState, alloc: *A.Allocator, itn: *intern.Int
     st.interner = itn;
 }
 
+# whether `name` is a `%pcrel_hi` label mark defined at text offset `off`
+#
+# The psABI property every low-half assertion below rests on: a low half names a
+# label, and that label sits at the offset its paired `auipc` was written to.
+# ---
+# st:   the encode state holding the symbol marks
+# name: the interned name the low half's relocation carries
+# off:  the text offset the paired high half patches
+# ret:  true when a label mark of that name is defined at that offset
+fun label_at(st: *encode.EncodeState, name: intern.StrId, off: u32) bool {
+    var i: u32 = 0;
+    for (i < st.sym_count) {
+        if (st.syms[i].name == name && st.syms[i].offset == off
+            && st.syms[i].flags == PCREL_LABEL_FLAGS) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # the R/I/S/U-type packers are byte-exact against `llvm-mc -triple=riscv64
 # --show-encoding`. registers a0/a1/a2 = x10/x11/x12
 test "mach.lang.target.isa.riscv64.encode:rtype_itype_stype_utype_packers" {
@@ -5084,7 +5103,8 @@ test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
-    tbuf(?st, ?alloc);
+    var itn: intern.Interner;
+    tbuf_interned(?st, ?alloc, ?itn);
     st.alloc       = ?alloc;
     st.relocs      = nil;
     st.reloc_count = 0;
@@ -5615,7 +5635,8 @@ test "mach.lang.target.isa.riscv64.encode:global_la_sequences" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
-    tbuf(?st, ?alloc);
+    var itn: intern.Interner;
+    tbuf_interned(?st, ?alloc, ?itn);
     st.alloc       = ?alloc;
     st.relocs      = nil;
     st.reloc_count = 0;
@@ -5635,7 +5656,10 @@ test "mach.lang.target.isa.riscv64.encode:global_la_sequences" {
         if (st.relocs[0].sym != sym)                 { bad = 1; }
         if (st.relocs[1].kind != of.RK_PCREL_LO12_I) { bad = 1; }
         if (st.relocs[1].offset != 4)                { bad = 1; }
-        if (st.relocs[1].sym != sym)                 { bad = 1; }
+        # the low half names the label at the auipc, never the target (the psABI
+        # spelling), and that label is defined at the high half's offset
+        if (st.relocs[1].sym == sym)                 { bad = 1; }
+        if (!label_at(?st, st.relocs[1].sym, 0))     { bad = 1; }
     }
 
     # folded-global load (width 8): auipc t0,0 (0x00000297) ; ld a0,0(t0) (0x0002B503).
@@ -7764,10 +7788,12 @@ test "mach.lang.target.isa.riscv64.encode:float_constant_materialization" {
     or {
         if (st.relocs[0].kind != of.RK_PCREL_HI20)   { bad = 1; }
         if (st.relocs[1].kind != of.RK_PCREL_LO12_I) { bad = 1; }
-        # both halves name the SAME entry: the linker measures the low half from
-        # the auipc that carries the matching high half
-        if (st.relocs[0].sym != st.relocs[1].sym)  { bad = 1; }
+        # the psABI spelling: the HIGH half names the pool entry, and the LOW half
+        # names a local label defined at the high half's own offset, which is how the
+        # linker (and every other toolchain's) finds the auipc it must measure from
         if (st.relocs[0].sym != st.consts[0].sym)  { bad = 1; }
+        if (st.relocs[1].sym == st.consts[0].sym)  { bad = 1; }
+        if (!label_at(?st, st.relocs[1].sym, st.relocs[0].offset)) { bad = 1; }
     }
     if (st.consts[0].len != 8 || st.consts[0].align != 8) { bad = 1; }
     or {

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -297,6 +297,9 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the `e_flags` derivation, declared beside the arch string because the two are
     # claims about the same ISA and have to agree about the C extension
     isa.with_machine_flags(?riscv64_reloc, riscv64_machine_flags::*u8);
+    # the psABI hi/lo pair collapse, which every riscv64 image needs before anything
+    # resolves a relocation in it
+    isa.with_normalize_image(?riscv64_reloc, reloc.resolve_riscv_pcrel_pairs::*u8);
 
     # elf_machine 243 is EM_RISCV
     riscv64_vtable = isa.machine_isa(isa.ARCH_RISCV64, "riscv64", 243, 8,

--- a/src/lang/target/isa/riscv64/reloc.mach
+++ b/src/lang/target/isa/riscv64/reloc.mach
@@ -36,6 +36,7 @@ use std.types.size.usize;
 
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.target.of;
 use mach.lang.target.of.bin;
 use rel: mach.lang.target.of.reloc;
@@ -339,4 +340,70 @@ pub fun resolve_riscv_pcrel_pairs(img: *of.ObjectImage) R.Result[bool, str] {
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# the psABI pair collapse rewrites ONLY the psABI spelling, carries the high half's
+# whole fact (symbol AND addend), folds the low half's distance back to the auipc into
+# the addend so `S + A - P` measures from the auipc's pc, and is idempotent - a second
+# pass over an already-collapsed image must not fold the distance in twice.
+#
+# The shapes it must leave alone are asserted beside the one it rewrites, because
+# "collapsed everything" and "collapsed the right thing" look identical on an image
+# that only contains pairs: a low half naming a typed symbol is this compiler's own
+# pre-#2828 spelling, and a low half carrying its own addend is not a label reference
+# at all. Both are read back unchanged.
+test "mach.lang.target.isa.riscv64.reloc.resolve_riscv_pcrel_pairs:collapse_and_leave_alone" {
+    var syms: [3]of.Symbol;
+    # 0: the label at the auipc - local, untyped, in the section the low half patches
+    syms[0].name = 0::intern.StrId; syms[0].section = 1; syms[0].offset = 0x40;
+    syms[0].size = 0; syms[0].flags = 0; syms[0].fallback = 0;
+    # 1: the real target the high half names
+    syms[1].name = 1::intern.StrId; syms[1].section = 2; syms[1].offset = 0;
+    syms[1].size = 8; syms[1].flags = of.SYM_OBJ_FLAG_OBJECT; syms[1].fallback = 0;
+    # 2: a TYPED symbol at the same offset as the label, which is not a label
+    syms[2].name = 2::intern.StrId; syms[2].section = 1; syms[2].offset = 0x40;
+    syms[2].size = 4; syms[2].flags = of.SYM_OBJ_FLAG_FUNCTION; syms[2].fallback = 0;
+
+    var rels: [4]of.Relocation;
+    # the auipc, 24 bytes before its low half, naming the target with a real addend
+    rels[0].section = 1; rels[0].offset = 0x40; rels[0].kind = of.RK_PCREL_HI20;
+    rels[0].sym = 1; rels[0].addend = 0x18;
+    # the psABI low half: names the label, carries no addend
+    rels[1].section = 1; rels[1].offset = 0x58; rels[1].kind = of.RK_PCREL_LO12_I;
+    rels[1].sym = 0; rels[1].addend = 0;
+    # a low half naming a TYPED symbol - not a label reference, left alone
+    rels[2].section = 1; rels[2].offset = 0x5C; rels[2].kind = of.RK_PCREL_LO12_S;
+    rels[2].sym = 2; rels[2].addend = 0;
+    # a low half naming the label but carrying its own addend - also not the spelling
+    rels[3].section = 1; rels[3].offset = 0x60; rels[3].kind = of.RK_PCREL_LO12_I;
+    rels[3].sym = 0; rels[3].addend = 4;
+
+    var img: of.ObjectImage;
+    img.symbols = ?syms[0];     img.symbol_count = 3;
+    img.relocations = ?rels[0]; img.reloc_count = 4;
+
+    val r1: R.Result[bool, str] = resolve_riscv_pcrel_pairs(?img);
+    if (R.is_err[bool, str](r1)) { ret 1; }
+
+    # the collapsed low half now names the TARGET, and its addend is the high half's
+    # addend plus the 0x18 it sits past the auipc
+    if (img.relocations[1].sym != 1)         { ret 1; }
+    if (img.relocations[1].addend != 0x30)   { ret 1; }
+    # the high half is untouched
+    if (img.relocations[0].sym != 1)         { ret 1; }
+    if (img.relocations[0].addend != 0x18)   { ret 1; }
+    # neither non-psABI shape moved
+    if (img.relocations[2].sym != 2)         { ret 1; }
+    if (img.relocations[2].addend != 0)      { ret 1; }
+    if (img.relocations[3].sym != 0)         { ret 1; }
+    if (img.relocations[3].addend != 4)      { ret 1; }
+
+    # idempotent: the rewritten low half no longer names a label at a high-half site,
+    # so a second pass leaves the whole image exactly as it is
+    val r2: R.Result[bool, str] = resolve_riscv_pcrel_pairs(?img);
+    if (R.is_err[bool, str](r2))             { ret 1; }
+    if (img.relocations[1].sym != 1)         { ret 1; }
+    if (img.relocations[1].addend != 0x30)   { ret 1; }
+
+    ret 0;
 }

--- a/src/lang/target/isa/riscv64/reloc.mach
+++ b/src/lang/target/isa/riscv64/reloc.mach
@@ -31,6 +31,7 @@
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
+use std.types.string.str;
 use std.types.size.usize;
 
 use R: std.types.result;
@@ -278,4 +279,64 @@ test "mach.lang.target.isa.riscv64.reloc.apply_reloc:overflow_rejection" {
     if (R.unwrap_err[bool, rel.RelocError](o4) != rel.RELOC_UNSUPPORTED) { ret 1; }
 
     ret 0;
+}
+
+# resolve every riscv64 pc-relative low-12 relocation against the `auipc` it pairs
+# with, rewriting it into the self-contained form the appliers resolve
+#
+# This arch's `normalize_image` hook, so it runs for EVERY image regardless of
+# provenance rather than only for one the ELF reader parsed. The psABI does not put
+# the TARGET on a `R_RISCV_PCREL_LO12_I/_S`; it puts a label whose address is the
+# paired `auipc`, and the target is read off the `R_RISCV_PCREL_HI20` at that label.
+# Both this compiler's own emission and every other toolchain's spell it that way, so
+# there is ONE rule here and no per-producer discriminator.
+#
+# The rewrite adopts the paired high half's symbol and addend, and folds the
+# intra-section distance back to the auipc into the addend, so `S + A - P` measured
+# from the low half's own patch site names the auipc's pc. Idempotent by construction:
+# a rewritten relocation no longer names a label at a high-half site, so a second pass
+# leaves it alone.
+#
+# Callers must NOT run this when relocations are being carried through to a
+# relocatable output rather than resolved: the rewritten form is this compiler's
+# internal one, and writing it back out would un-conform the object.
+# ---
+# img: the image whose low-12 relocations are resolved in place
+# ret: ok(true) once every pair is resolved, or the reason one could not be
+pub fun resolve_riscv_pcrel_pairs(img: *of.ObjectImage) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < img.reloc_count) {
+        val k: of.RelocKind = img.relocations[i].kind;
+        if (k != of.RK_PCREL_LO12_I && k != of.RK_PCREL_LO12_S) { i = i + 1; cnt; }
+        val si: u32 = img.relocations[i].sym;
+        if (si == of.SYMBOL_NONE || si >= img.symbol_count) { i = i + 1; cnt; }
+
+        # the label is an untyped local defined in the section the low half patches,
+        # carrying no addend, at an offset a high half patches. anything else is not
+        # the psABI spelling and is left exactly as read.
+        val lsec: u32 = img.symbols[si].section;
+        val loff: u32 = img.symbols[si].offset;
+        val typed: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK
+                       | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION
+                       | of.SYM_OBJ_FLAG_OBJECT;
+        if ((img.symbols[si].flags & typed) != 0)  { i = i + 1; cnt; }
+        if (img.relocations[i].addend != 0)        { i = i + 1; cnt; }
+        if (lsec != img.relocations[i].section)    { i = i + 1; cnt; }
+
+        var hi: u32 = 0;
+        var found: bool = false;
+        for (hi < img.reloc_count) {
+            if (img.relocations[hi].kind == of.RK_PCREL_HI20
+                && img.relocations[hi].section == lsec
+                && img.relocations[hi].offset == loff) { found = true; brk; }
+            hi = hi + 1;
+        }
+        if (!found) { i = i + 1; cnt; }
+
+        img.relocations[i].sym = img.relocations[hi].sym;
+        img.relocations[i].addend = img.relocations[hi].addend
+            + (img.relocations[i].offset::i64) - (loff::i64);
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -473,15 +473,6 @@ fun section_flags_for(kind: of.SectionKind) u64 {
     ret f;
 }
 
-# the ELF symbol type for an abstract section kind; functions live in text
-# ---
-# kind: the abstract section kind the symbol is defined in
-# ret:  the ELF STT_* symbol type
-fun symbol_type_for(kind: of.SectionKind) u8 {
-    if (kind == of.SK_TEXT) { ret STT_FUNC; }
-    ret STT_OBJECT;
-}
-
 # count the relocations in an image that patch a given section
 # ---
 # img:     the object image to scan
@@ -594,10 +585,14 @@ fun write_symbol(buf: *u8, sym_off: usize, str_off: usize, str_pos: *usize,
     @str_pos = @str_pos + bin.write_str(buf, str_off + @str_pos, bin.resolve_name(img.interner, img.symbols[idx].name));
     bin.write_u32_le(buf, sym_off, name_pos::u32);
 
+    # the IMAGE says what a symbol is, and a symbol that names no type is STT_NOTYPE,
+    # which is what ELF means by "untyped". This used to fall back to the section's
+    # kind, so every symbol defined in `.text` came out STT_FUNC whether or not it was
+    # a function - and a `.Lpcrel_hi` label is precisely an untyped address inside
+    # `.text` (#2828). Every producer now states the type it means.
     var sym_type: u8 = STT_NOTYPE;
     var sec_idx: u16 = 0;
     if (img.symbols[idx].section != of.SECTION_EXTERNAL && img.symbols[idx].section < img.section_count) {
-        sym_type = symbol_type_for(img.sections[img.symbols[idx].section].kind);
         sec_idx = (img.symbols[idx].section + 1)::u16;
     }
     if ((img.symbols[idx].flags & of.SYM_OBJ_FLAG_FUNCTION) != 0) { sym_type = STT_FUNC; }
@@ -4764,70 +4759,6 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     }
 
     A.deallocate[i32](alloc, sec_map, e_shnum::usize);
-    if (e_machine == EM_RISCV) { ret pair_riscv_pcrel_lo12(out); }
-    ret R.ok[bool, str](true);
-}
-
-# rewrite every riscv64 pc-relative low-12 relocation this object spells the psABI
-# way into the self-contained form the rest of the compiler resolves
-#
-# The psABI does not put the TARGET on a `R_RISCV_PCREL_LO12_I/_S`. It puts a label
-# whose address is the paired `auipc`, and the target is read off the
-# `R_RISCV_PCREL_HI20` relocation sitting AT that address. Not following that
-# indirection does not merely misplace the displacement, it LOSES the target: the low
-# half's symbol resolves to the auipc itself, so the whole computation becomes a
-# statement about where two instructions sit. Every such relocation in every foreign
-# object resolved wrongly, at every hi/lo distance - adjacent halves included, where
-# it collapsed to a flat zero that looked like a rule holding (mach#2797).
-#
-# Both facts the low half needs are recovered here, at the boundary where the psABI
-# spelling is the only spelling: the paired high half's symbol and addend become this
-# relocation's own, and the distance back to that auipc is folded into the addend, so
-# the applier measures from the plain patch site and re-derives no pairing. A low half
-# whose symbol is not the site of a high half is this back end's own emission, which
-# already carries both facts, and is left exactly as read.
-# ---
-# out: the parsed image whose riscv64 relocations are normalized in place
-# ret: ok(true), or the reason a low half could not be paired
-fun pair_riscv_pcrel_lo12(out: *of.ObjectImage) R.Result[bool, str] {
-    var i: u32 = 0;
-    for (i < out.reloc_count) {
-        val k: of.RelocKind = out.relocations[i].kind;
-        if (k != of.RK_PCREL_LO12_I && k != of.RK_PCREL_LO12_S) { i = i + 1; cnt; }
-        val si: u32 = out.relocations[i].sym;
-        if (si == of.SYMBOL_NONE || si >= out.symbol_count) { i = i + 1; cnt; }
-
-        # the label form is recognized by everything the psABI requires of it at once,
-        # so this back end's own emission cannot be mistaken for it: an untyped local
-        # label (never a function or data symbol), defined in the very section the low
-        # half patches, carrying no addend of its own, at an offset a high half patches.
-        # a low half naming a real target - a function through `la`, a pooled constant -
-        # fails at least the type and addend conditions and is left alone.
-        val lsec: u32 = out.symbols[si].section;
-        val loff: u32 = out.symbols[si].offset;
-        val lflags: u32 = out.symbols[si].flags;
-        val typed: u32 = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK
-                       | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_FUNCTION
-                       | of.SYM_OBJ_FLAG_OBJECT;
-        if ((lflags & typed) != 0)              { i = i + 1; cnt; }
-        if (out.relocations[i].addend != 0)     { i = i + 1; cnt; }
-        if (lsec != out.relocations[i].section) { i = i + 1; cnt; }
-
-        var hi: u32 = 0;
-        var found: bool = false;
-        for (hi < out.reloc_count) {
-            if (out.relocations[hi].kind == of.RK_PCREL_HI20
-                && out.relocations[hi].section == lsec
-                && out.relocations[hi].offset == loff) { found = true; brk; }
-            hi = hi + 1;
-        }
-        if (!found) { i = i + 1; cnt; }
-
-        out.relocations[i].sym = out.relocations[hi].sym;
-        out.relocations[i].addend = out.relocations[hi].addend
-            + (out.relocations[i].offset::i64) - (loff::i64);
-        i = i + 1;
-    }
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/target/of/reloc.mach
+++ b/src/lang/target/of/reloc.mach
@@ -21,10 +21,12 @@
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.string.str;
 use std.types.size.usize;
 
 use R: std.types.result;
 
+use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.of.bin;
 
@@ -285,4 +287,44 @@ pub fun apply_pcrel64(dst: *u8, patch_off: u32, sec_len: u32,
     }
     bin.write_u64_le(dst, patch_off::usize, encoded);
     ret R.ok[bool, RelocError](true);
+}
+
+# the concrete signature the erased `isa.RelocSeam.normalize_image` pointer is cast
+# back to before it is called
+#
+# Erased on the seam for the import direction, like every other member: its parameter
+# names `of.ObjectImage`, and `of` imports `isa`.
+# ---
+# ret: ok(true) once the image is normalized, or the reason it could not be
+pub def NormalizeImageFn: fun(*of.ObjectImage) R.Result[bool, str];
+
+# put one image into the form this compiler's relocation appliers resolve
+#
+# THE ONE PLACE THIS HAPPENS, FOR EVERY IMAGE REGARDLESS OF PROVENANCE. An arch whose
+# object format spells a relocation relative to ANOTHER relocation - riscv's hi/lo
+# pairs, where the low half names a label at its `auipc` rather than the target -
+# needs that spelling collapsed before anything resolves it, and every image needs it
+# equally: one read from a foreign `.o` and one handed straight over from codegen are
+# the same problem.
+#
+# It is a link-time step rather than a format-reader one for exactly that reason. When
+# the riscv chase lived in the ELF reader, a link that went through a file resolved
+# correctly and a link that went straight from codegen produced a flat zero
+# displacement, which is the #2797 defect reintroduced from the emission side and
+# invisible to any test that touched disk (#2828).
+#
+# Callers must NOT run this when relocations are being carried through to a
+# relocatable output rather than resolved: the normalized form is this compiler's
+# internal one, and writing it back out would un-conform the object.
+#
+# An arch that declares no hook needs no normalization, which is not a failure.
+# ---
+# tgt_isa: the target ISA vtable supplying the hook
+# img:     the image to normalize in place
+# ret:     ok(true) once normalized, or the reason it could not be
+pub fun normalize_image(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage) R.Result[bool, str] {
+    if (tgt_isa == nil)                       { ret R.ok[bool, str](true); }
+    if (!isa.emits_relocations(tgt_isa))      { ret R.ok[bool, str](true); }
+    if (tgt_isa.reloc.normalize_image == nil) { ret R.ok[bool, str](true); }
+    ret tgt_isa.reloc.normalize_image::NormalizeImageFn(img);
 }


### PR DESCRIPTION
Refs #2828. First of two PRs against that issue: this one makes mach's riscv64 objects carry the psABI hi/lo spelling and collapses the two spellings the reader used to accept into one rule. `.riscv.attributes` merging follows in a second PR against the same issue.

## What was wrong

The RISC-V psABI does not put the target on a `R_RISCV_PCREL_LO12_I/_S`. It puts a label whose address is the paired `auipc`, and the target is read off the `R_RISCV_PCREL_HI20` sitting at that label. mach emitted the other spelling (low half names the target directly) and its reader chased the psABI one, so:

- `ld.lld` could not link a mach-produced riscv64 object at all
- the chase lived in the ELF reader, which an image handed straight from codegen to the linker never passes through

Those two are one problem. Fixing the emission without moving the chase reintroduces #2797 from the emission side, and only for in-memory links: a build that went through a file resolved correctly and a build that did not produced a flat displacement. I confirmed that before fixing it - the in-memory case segfaults.

## Shape

- `isa.RelocSeam` gains an optional `normalize_image` hook. An arch whose object format spells one relocation relative to ANOTHER declares it; every other arch declares nothing and is unaffected.
- The linker runs it over every input once, before anything reads a relocation, and skips it for `LINK_RELOCATABLE`, which must keep the format's own spelling.
- riscv64 declares it beside its appliers. One rule, no per-producer discriminator.
- riscv64 codegen mints one `.Lpcrel_hi.N` label per `auipc` and points every low half that pairs with it at that label.

Two places fabricated a symbol type rather than reading one, and both were true only while every text symbol happened to be a function entry: `be.codegen.pack_symbols` OR-ed `SYM_OBJ_FLAG_FUNCTION` into every mark, and the ELF writer fell back to the defining section's kind. A mark now states its own type and an untyped symbol is written `STT_NOTYPE`, which is what a `.Lpcrel_hi` label is.

## The second commit is not incidental

Dropping a duplicate weak function refused whenever any other symbol sat inside its interval. Once every `auipc` inside such a body carried a label, no duplicate weak body was ever dropped again, and the `-g` link described a discarded body with a second contradictory DIE instead of tombstoning it (`regression/2759-riscv64-fbreg-bias` caught this, reporting `varloc_fbreg_unbacked=1`).

The rule is now: a local symbol nothing names cannot keep anything alive. A local is resolved by index and never by name (#2520), so a relocation in its own module is the only thing that can reach one. Debug-sourced relocations do not count, for the same reason the atom reference index already skips them (#2572).

## Acceptance, hand-run

`ld.lld` over the 31 objects of `int/surface/riscv-pcrel-pair` plus its clang probe.

Before (compiler built from `dev` at 5e772dee):

```
ld.lld: error: .../case/main.o:(.text+0x70): R_RISCV_PCREL_LO12 relocation points to a symbol '.Lc.00000000' in a different section '.rodata'
ld.lld: error: .../case/main.o:(.text+0xd0): R_RISCV_PCREL_LO12 relocation points to a symbol '.Lconst.0' in a different section '.rodata.cst'
... 228 PCREL_LO12 errors, no binary produced
```

After (this branch):

```
$ ld.lld -o lldbin @objs.txt probe.o -e _start --static --error-limit=0
$ qemu-riscv64 ./lldbin
doubles n=4 125 250 375 500
longs=47531
scale=25 100 1250
stored longs=121931 doubles=2500
```

Zero `PCREL_LO12` errors and the right values, not merely a link that completed.

## Object-size delta

Same 31 objects, same sources, debug profile:

| | bytes |
| --- | --- |
| dev | 268184 |
| this branch | 276240 |
| delta | +8056 (+3.00%) |

215 `.Lpcrel_hi` labels, 37.5 bytes each: a 24-byte `Elf64_Sym` plus its name in `.strtab`. Objects only; the labels are local and do not reach a linked image.

## Verification

- `mach test .` 1353 passed, 0 failed. New: `resolve_riscv_pcrel_pairs:collapse_and_leave_alone` (collapse, the two non-psABI shapes it must leave alone, idempotency) and a second arm on `atom_plan:shared_symbol_retains_loser` (a named interior local still retains, an unnamed one does not).
- `int` full sweeps green on linux, linux-arm64 and linux-riscv64.
- Self-host fixpoint, each stage into a freshly removed `out/`: `stage3 == stage4` byte-identical.

No `int` case added; the freeze holds. Two `int` files changed for the new symbol class: the shared disassembly helper drops `.Lpcrel_hi` label lines, which objdump prints exactly like a function start, and `asm-symbol-operands` records that one riscv64 reference now reaches the relocation list once rather than twice - which is the psABI change being observed, not worked around.
