### PR TITLE
chore(release): 4.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.17.0] - 2026-08-08
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.16.0"
+version = "4.17.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Cuts 4.17.0. Bumps `mach.toml` and promotes `[Unreleased]` to `## [4.17.0] - 2026-08-08`. **45 entries.**

## Release-candidate verification

Run twice, independently, on the final tree.

**#2795 `PT_LOAD` non-overlap** - 18 combos (3 ELF ISAs x 2 profiles x static/PIE/shared), no overlapping pair in any image. Independently confirmed on a self-hosted x86-64 binary: 6 segments, 0 overlaps, both profiles.

**#2772/#2807 `.symtab` mid-function resolution** - same 18 combos, no `-g`, `addr2line -f` on `st_value + st_size/2` resolving to the correct dotted name every time. Independently confirmed: 7173 `FUNC` symbols, 6/6 mid-function addresses resolving at both profiles. Mid-function rather than entry point is the point, since an entry address is the one a broken symbol table still gets right.

**Self-host fixpoint** - `stage3 == stage4` byte-identical, each stage built into a freshly removed `out/`, re-run independently on the final commit.

**`mach test .`** - 1364 passed, 0 failed.

**`int`** - linux 310/310, linux-arm64 163/163, linux-riscv64 pass in CI (3m17s), windows and pinned-linux pass.

**#2847's `.Lpcrel_hi.N` locals do not reach a linked image** - confirmed on all 6 riscv64 images, and confirmed the check has teeth by finding the labels genuinely present in `--emit obj` output. Independently confirmed on a cross-built riscv64 image: zero matches in `.symtab`.

**#2813 visible in the artifact** - `file` reports `UCB RISC-V, double-float ABI` on a cross-built riscv64 image, where the header previously claimed soft-float.

One verification gap, stated rather than papered over: three riscv64 `int` cases (`c-variadic`, `narrow-stack-args`, `riscv-pcrel-pair`) cannot run on an Arch host, because `cc.sh` refuses before mach's compiler runs when no riscv64 cross-libc is present. They pass in CI, which installs `libc6-dev-riscv64-cross`. The refusal is the guard added this cycle working as designed, and it names the package and the `MACH_RISCV64_SYSROOT` override.

## What is in it

Three defects live on shipped targets, all found by sweeps framed as cleanup and all confirmed by execution rather than by tracing:

- **#2838** - a sub-128-bit vector stored to a global on aarch64 wrote a general-purpose register that never held the value. A regression from #2716, so unreleased, but it would have shipped here.
- **#2818** - mos6502 reserved eight-byte stack slots and spill slots on a one-byte machine.
- **#2835** - const-aggregate pointer leaves relocated at 8 bytes regardless of pointer width, breaking mos6502 outright and silently corrupting any future 4-byte-pointer target.

Plus riscv64 objects becoming psABI-conformant so a foreign linker will accept them (#2828, first half), riscv64 variadic floats reaching the integer bank (#2771), SPIR-V cross-module calls (#2823), `.symtab` reaching PIE and shared objects (#2807), and a build readout whose numbers are now correct and whose rows partition the wall exactly (#2816, #2847).

## Not in it

- **#2828's `.riscv.attributes` half** is deliberately held. It is a known gap rather than a regression, and it needs a `SHT_RISCV_ATTRIBUTES` reader, a ULEB128 subsection parser, and an ISA-string merger. The issue stays open and its changelog entry says so.
- **#2778** (RV32) and **#2843** (SPIR-V interface globals) are tracked, not started.