### PR TITLE
fix(link): derive and merge riscv64 build attributes instead of stamping a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### riscv64 images claimed an instruction set they did not have (#2828)
+`.riscv.attributes` carried an arch string taken from a per-ISA constant. A constant describes what mach's encoder emits, and an image is not what its encoder emits - it is that plus every object linked into it. A mach image containing a clang object built for `rv64gc` claimed no compressed extension and none of the z-extensions it actually held, so a disassembler configured from the image decoded its compressed float loads as `<unknown>`. This is the same class of false claim `e_flags` carried before #2813, one section over.
+
+Nothing states a string now. An image's claims are derived from the two facts that decide them - the resolved ABI and the emitted bytes - and a linked image's are merged from its inputs. `BuildAttributes` no longer has an arch field at all, so a constant is not merely unused but inexpressible.
+
+The merge rule is the arch's, because a union is right for the ISA string and wrong for everything else. Stack alignment must agree or the inputs cannot be linked. Unaligned access is a permission, so the image permits it if any input needed it. A privileged-spec disagreement leaves the image unable to state one, so it states none. A tag mach does not model survives only while every input that states it agrees. No shared layer can know which tag takes which rule, so the seam hands the arch the whole attribute body and reads none of it; the ELF layer keeps only the container, which the ARM EABI defines identically.
+
+`obj.rehome_remap` copies the body rather than aliasing it. Rehoming exists precisely because the source allocator is going away, so a field holding a pointer into it needs a copy and not an assignment - the note on that function now separates the two failure modes, since a missed scalar reverts to zero on the parallel path while a missed pointer segfaults somewhere else entirely.
+
 ## [4.17.0] - 2026-08-08
 
 ### Fixed

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -2918,16 +2918,16 @@ produce_riscv_pcrel() {
         echo "int: riscv-pcrel: no probe object at $probe" >&2; return 2
     fi
     "$tool" -d -r --no-show-raw-insn "$probe" | riscv_pcrel_label_scan
-    # --mattr=+c is still needed, but no longer for the reason it was added. e_flags
-    # now advertises the compressed extension the image contains (mach#2813 fixed
-    # that), and llvm-objdump decodes ordinary compressed instructions from it. The
-    # COMPRESSED FLOAT loads (`c.fld`) additionally need `c` in the `.riscv.attributes`
-    # arch string, which mach still derives from a per-ISA constant describing what
-    # its own encoder emits rather than from what the linked image ended up holding -
-    # the same shape of claim as e_flags was, one section over, and tracked as part of
-    # mach#2828 rather than accepted. Without this flag those loads decode as
+    # no --mattr override: the image now describes itself completely enough for the
+    # disassembler to configure itself. it needed one twice over - e_flags did not
+    # advertise the compressed extension the image contained (mach#2813), and the
+    # `.riscv.attributes` arch string was derived from a per-ISA constant describing
+    # what mach's own encoder emits rather than from what the linked image ended up
+    # holding, which is what the compressed FLOAT loads (`c.fld`) read (mach#2828).
+    # both are now derived from the image, so an override here would be hiding whether
+    # they still are. without a correct answer from one of them those loads decode as
     # `<unknown>` and the property silently measures nothing
-    "$tool" -d --mattr=+c --no-show-raw-insn "$bin" | riscv_pcrel_image_scan
+    "$tool" -d --no-show-raw-insn "$bin" | riscv_pcrel_image_scan
 }
 
 # riscv_pcrel_label_scan — read a `-d -r` object disassembly and report whether any

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -404,6 +404,19 @@ fun pack_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     # instead (#2813).
     image.machine_flags = isa.machine_flags(tgt.isa, tgt.abi.float_arg_bits, false);
 
+    # and the build-attribute body, from the same two facts and for the same reason:
+    # what this object CLAIMS about its instruction set has to be what it holds. the
+    # `false` is the compressed question again - this encoder emits none, and a linked
+    # image merges the claims of whatever was linked into it instead (#2828)
+    var attr_len: u32 = 0;
+    val attr_r: R.Result[*u8, str] = isa.build_attributes(tgt.isa, s.alloc,
+                                                         tgt.abi.float_arg_bits, false, ?attr_len);
+    if (R.is_err[*u8, str](attr_r)) {
+        ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](attr_r));
+    }
+    image.attributes = R.unwrap_ok[*u8, str](attr_r);
+    image.attributes_len = attr_len;
+
     # `#[section("...")]` decorators move individual functions out of the shared
     # `.text` into named sections. build one placement per sectioned function
     # (creating its section and copying the sectioned bytes out of the encoder

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -583,6 +583,51 @@ fun image_machine_flags(s: *session.Session, tgt: *target.Target,
     ret R.ok[u32, str](abi_bits | feature_bits);
 }
 
+# the merged build-attribute body for the image being written, folded from every input
+#
+# The `image_machine_flags` argument one section over, in the section next door: what
+# an image CLAIMS about its instruction set is the combination of what its inputs
+# claim, and a constant describing this compiler's encoder is wrong for every image a
+# foreign object was linked into (#2828).
+#
+# The fold is the ARCH's, one input at a time, because a union is the rule for the ISA
+# string and the wrong rule for everything else - two inputs disagreeing on stack
+# alignment cannot be linked at all, while a privileged-spec disagreement simply means
+# the image states none. No shared layer can know which tag takes which rule.
+#
+# An input that carries no attributes contributes nothing rather than erasing what the
+# others said: an object that claims nothing constrains nothing.
+# ---
+# s:            shared session (allocator)
+# tgt:          the resolved target, for the arch's fold
+# modules:      the input images
+# module_count: number of inputs
+# out_len:      out - the merged body's length in bytes
+# ret:          the owned merged body (nil when the arch defines none), or the reason
+#               two inputs cannot be combined
+fun image_attributes(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
+                     module_count: u32, out_len: *u32) R.Result[*u8, str] {
+    @out_len = 0;
+    if (!isa.declares_attributes(tgt.isa)) { ret R.ok[*u8, str](nil); }
+
+    var acc: *u8 = nil;
+    var acc_len: u32 = 0;
+    var i: u32 = 0;
+    for (i < module_count) {
+        if (modules[i].attributes == nil || modules[i].attributes_len == 0) { i = i + 1; cnt; }
+        var next_len: u32 = 0;
+        val mr: R.Result[*u8, str] = isa.merge_attributes(tgt.isa, s.alloc, acc, acc_len,
+                                                         modules[i].attributes,
+                                                         modules[i].attributes_len, ?next_len);
+        if (R.is_err[*u8, str](mr)) { ret mr; }
+        acc = R.unwrap_ok[*u8, str](mr);
+        acc_len = next_len;
+        i = i + 1;
+    }
+    @out_len = acc_len;
+    ret R.ok[*u8, str](acc);
+}
+
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
@@ -607,6 +652,11 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[u32, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[u32, str](mf_r)); }
     var opts: of.ImageOptions = image_options;
     opts.machine_flags = R.unwrap_ok[u32, str](mf_r);
+    var attr_len: u32 = 0;
+    val at_r: R.Result[*u8, str] = image_attributes(s, tgt, modules, module_count, ?attr_len);
+    if (R.is_err[*u8, str](at_r)) { ret R.err[bool, str](R.unwrap_err[*u8, str](at_r)); }
+    opts.attributes = R.unwrap_ok[*u8, str](at_r);
+    opts.attributes_len = attr_len;
     var local_atoms: AtomPlan;
     init_atom_plan(?local_atoms);
     var pre_atoms: *AtomPlan = nil;

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -57,6 +57,8 @@ pub fun init(a: *A.Allocator, interner: *intern.Interner, name: intern.StrId) R.
     # 0 is "this arch defines no machine flags", which is the truth for every arch
     # but riscv64; the back end overwrites it from the resolved ABI where it is not
     o.machine_flags = 0;
+    o.attributes = nil;
+    o.attributes_len = 0;
     ret R.ok[of.ObjectImage, str](o);
 }
 
@@ -376,6 +378,20 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
     # `of.ObjectImage` that nobody adds here is silently dropped for every
     # parallel-codegen build while a serial one keeps it (#2813)
     img.machine_flags = src.machine_flags;
+    # the attribute body is COPIED, not aliased. rehoming exists because the source
+    # image was built in an allocator that is about to go away, so a field holding a
+    # pointer into it has to be re-owned here or the destination image outlives its
+    # own bytes - which is what a dangling body did at object-write time
+    img.attributes = nil;
+    img.attributes_len = 0;
+    if (src.attributes != nil && src.attributes_len > 0) {
+        val ab: R.Result[*u8, str] = A.allocate[u8](dst_alloc, src.attributes_len::usize);
+        if (R.is_err[*u8, str](ab)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](ab)); }
+        val abuf: *u8 = R.unwrap_ok[*u8, str](ab);
+        memory.raw_copy(abuf::ptr, src.attributes::ptr, src.attributes_len::usize);
+        img.attributes = abuf;
+        img.attributes_len = src.attributes_len;
+    }
 
     if (src.section_count > 0) {
         val rs: R.Result[*of.Section, str] = A.allocate[of.Section](dst_alloc, src.section_count::usize);

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -342,13 +342,29 @@ fun remap_name(id: intern.StrId, base_len: usize, remap: *intern.StrId) intern.S
 # deep-copy an image built against a child interner into `dst_alloc`, remapping
 # every interned name into `dst_interner`'s id space
 #
-# EVERY FIELD OF `of.ObjectImage` MUST BE COPIED HERE EXPLICITLY. This rebuilds the
-# image field by field rather than assigning the record, so a field added to
-# `of.ObjectImage` that nobody adds here is dropped - and dropped ONLY on the
-# parallel path, while a serial build keeps it. That asymmetry is what makes the
-# omission expensive: the field's own unit tests pass, the serial build is correct,
-# and the defect appears only in a real parallel build as a value that silently
-# reverted to zero. `machine_flags` was lost exactly this way (#2813).
+# EVERY FIELD OF `of.ObjectImage` MUST BE COPIED HERE EXPLICITLY, AND A FIELD HOLDING
+# A POINTER NEEDS A COPY RATHER THAN AN ASSIGNMENT. This rebuilds the image field by
+# field rather than assigning the record, so a field added to `of.ObjectImage` that
+# nobody adds here is dropped - and dropped ONLY on the parallel path, while a serial
+# build keeps it. That asymmetry is what makes the omission expensive: the field's own
+# unit tests pass, the serial build is correct, and the defect appears only in a real
+# parallel build.
+#
+# The two ways to get it wrong fail differently, and the second is the one that reads
+# as unrelated:
+#
+#   a missed SCALAR field    silently reverts to zero. a wrong answer, on the parallel
+#                            path only. `machine_flags` was lost exactly this way
+#                            (#2813)
+#   a missed POINTER field   aliases memory that is about to be freed. not a wrong
+#                            answer but a segfault, and not here - at object-write
+#                            time, in a writer that has nothing to do with rehoming.
+#                            `attributes` was aliased exactly this way (#2828)
+#
+# THE TRAP IS AN INVERTED LIFETIME ASSUMPTION, so it is worth stating outright: the
+# source image does NOT outlive the rehomed one. Rehoming exists precisely because the
+# source allocator is going away, which is the opposite of the assumption that makes
+# aliasing look safe.
 #
 # A parallel-codegen worker builds its module's image in a private arena against a
 # child interner; this re-homes that image onto the destination (session)
@@ -372,16 +388,13 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
     val res_img: R.Result[of.ObjectImage, str] = init(dst_alloc, dst_interner, remap_name(src.name, base_len, remap));
     if (R.is_err[of.ObjectImage, str](res_img)) { ret res_img; }
     var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_img);
-    # the machine-flags word is a plain value with no interned id in it, so it copies
-    # straight across. it is copied EXPLICITLY rather than by struct assignment
-    # because this function rebuilds the image field by field, and a field added to
-    # `of.ObjectImage` that nobody adds here is silently dropped for every
-    # parallel-codegen build while a serial one keeps it (#2813)
+    # a scalar: no interned id in it, so it copies straight across. explicitly, for
+    # the reason the note above gives (#2813)
     img.machine_flags = src.machine_flags;
-    # the attribute body is COPIED, not aliased. rehoming exists because the source
-    # image was built in an allocator that is about to go away, so a field holding a
-    # pointer into it has to be re-owned here or the destination image outlives its
-    # own bytes - which is what a dangling body did at object-write time
+    # a pointer: COPIED, never assigned. the source body lives in the arena this
+    # rehoming exists to escape, so assigning the pointer would leave the destination
+    # image outliving its own bytes - which is what it did, as a segfault at
+    # object-write time rather than anywhere near here (#2828)
     img.attributes = nil;
     img.attributes_len = 0;
     if (src.attributes != nil && src.attributes_len > 0) {

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -1115,6 +1115,16 @@ pub rec ModuleEmitter {
 #                 pairs - so the collapse happens once, at link time, for an image
 #                 read from a file and an image handed straight over from codegen
 #                 alike. nil for an arch whose relocations already stand alone
+# build_attributes: OPTIONAL capability - derive the build-attribute BODY describing
+#                 what an image of this arch holds, from the resolved ABI and the
+#                 emitted bytes (cast back to `BuildAttributesFn`). declared together
+#                 with `merge_attributes` or not at all: an arch that can state its
+#                 claims must be able to combine two inputs' claims, or a link states
+#                 one input's
+# merge_attributes: OPTIONAL capability - fold one input's build-attribute body into
+#                 the accumulated one (cast back to `MergeAttributesFn`). the tag
+#                 semantics and the per-tag merge rule are the arch's; a union is not
+#                 the rule for every tag and no shared layer can know which is
 pub rec RelocSeam {
     apply_reloc:    *u8;
     reloc_traits:   *u8;
@@ -1122,6 +1132,8 @@ pub rec RelocSeam {
     elf_attributes: *u8;
     machine_flags:   *u8;
     normalize_image: *u8;
+    build_attributes: *u8;
+    merge_attributes: *u8;
 }
 
 # the ISA runtime-dispatch interface
@@ -1418,6 +1430,93 @@ pub fun machine_flags(tgt_isa: *IsaVTable, float_arg_bits: u32,
 # f: the normalizer, erased (`of.reloc.NormalizeImageFn`)
 pub fun with_normalize_image(s: *RelocSeam, f: *u8) {
     s.normalize_image = f;
+}
+
+# declare the optional build-attribute derivation and merge, which come as a PAIR
+#
+# Taken together because an arch that can state what one image holds and cannot combine
+# two inputs' statements produces a linked image claiming one input's contents, which
+# is worse than claiming nothing. Without both, an image of this arch carries no
+# attributes section, which is the truth for an arch that defines none.
+# ---
+# s:     the relocatable-object contract to extend
+# build: the derivation, erased (`BuildAttributesFn`)
+# merge: the fold, erased (`MergeAttributesFn`)
+pub fun with_attributes(s: *RelocSeam, build: *u8, merge: *u8) {
+    s.build_attributes = build;
+    s.merge_attributes = merge;
+}
+
+# the concrete signature the erased `RelocSeam.build_attributes` pointer is cast back to
+#
+# An allocator, the two facts an image's claims are derived FROM, and an out-length.
+# Naming no object-format type is what lets it be declared here: the back end builds
+# images without importing a writer, and still states what its output holds.
+# ---
+# arg 0: the allocator the returned body is taken from
+# arg 1: the resolved ABI's float-argument width
+# arg 2: whether the image's bytes contain compressed instructions
+# arg 3: out - the body's length in bytes
+# ret:   the owned attribute body, or the reason it could not be built
+pub def BuildAttributesFn: fun(*A.Allocator, u32, bool, *u32) R.Result[*u8, str];
+
+# the concrete signature the erased `RelocSeam.merge_attributes` pointer is cast back to
+# ---
+# arg 0:       the allocator the returned body is taken from
+# arg 1 / 2:   the accumulated body and its length (nil / 0 when nothing yet)
+# arg 3 / 4:   the input body being folded in and its length (nil / 0 when it has none)
+# arg 5:       out - the merged body's length in bytes
+# ret:         the owned merged body, or the reason the two cannot be combined
+pub def MergeAttributesFn: fun(*A.Allocator, *u8, u32, *u8, u32, *u32) R.Result[*u8, str];
+
+# whether this arch derives a build-attribute body at all
+# ---
+# tgt_isa: the target ISA vtable to ask
+# ret:     true when the arch declares the derivation / merge pair
+pub fun declares_attributes(tgt_isa: *IsaVTable) bool {
+    if (tgt_isa == nil)              { ret false; }
+    if (!emits_relocations(tgt_isa)) { ret false; }
+    ret tgt_isa.reloc.build_attributes != nil && tgt_isa.reloc.merge_attributes != nil;
+}
+
+# the build-attribute body describing what an image of this arch holds
+#
+# Dispatches through the `build_attributes` hook, so the arch DERIVES its claims from
+# the ABI and the bytes and no writer carries a string. An arch that declares no hook
+# has no attributes and gets nil, which the writer emits as no section.
+# ---
+# tgt_isa:        the target ISA vtable supplying the hook
+# alloc:          the allocator the body is taken from
+# float_arg_bits: the resolved ABI's float-argument width
+# has_compressed: whether the image's bytes contain compressed instructions
+# out_len:        out - the body's length in bytes
+# ret:            the owned body (nil when the arch has none), or an error
+pub fun build_attributes(tgt_isa: *IsaVTable, alloc: *A.Allocator, float_arg_bits: u32,
+                         has_compressed: bool, out_len: *u32) R.Result[*u8, str] {
+    @out_len = 0;
+    if (!declares_attributes(tgt_isa)) { ret R.ok[*u8, str](nil); }
+    ret tgt_isa.reloc.build_attributes::BuildAttributesFn(alloc, float_arg_bits,
+                                                         has_compressed, out_len);
+}
+
+# fold one input's build-attribute body into the accumulated one
+#
+# Dispatches through the `merge_attributes` hook. An arch that declares none has no
+# attributes to combine, so the accumulator stays empty rather than adopting an input
+# this compiler cannot interpret.
+# ---
+# tgt_isa:   the target ISA vtable supplying the hook
+# alloc:     the allocator the result is taken from
+# acc / acc_len: the accumulated body so far
+# add / add_len: the input body being folded in
+# out_len:   out - the merged body's length in bytes
+# ret:       the owned merged body, or the reason the two cannot be combined
+pub fun merge_attributes(tgt_isa: *IsaVTable, alloc: *A.Allocator, acc: *u8, acc_len: u32,
+                         add: *u8, add_len: u32, out_len: *u32) R.Result[*u8, str] {
+    @out_len = 0;
+    if (!declares_attributes(tgt_isa)) { ret R.ok[*u8, str](nil); }
+    ret tgt_isa.reloc.merge_attributes::MergeAttributesFn(alloc, acc, acc_len,
+                                                          add, add_len, out_len);
 }
 
 # compose an ISA vtable for a REGISTER MACHINE
@@ -2095,12 +2194,18 @@ test "mach.lang.target.isa.reloc_seam:required_then_optional" {
     if (s.elf_reloc_type == nil) { ret 1; }
     if (s.elf_attributes != nil)  { ret 1; }
     if (s.normalize_image != nil) { ret 1; }
+    if (s.build_attributes != nil) { ret 1; }
+    if (s.merge_attributes != nil) { ret 1; }
 
     var hook: u8;
     with_elf_attributes(?s, ?hook);
     if (s.elf_attributes == nil) { ret 1; }
     with_normalize_image(?s, ?hook);
     if (s.normalize_image == nil) { ret 1; }
+    # the attributes pair is declared together, so neither half can be left behind
+    with_attributes(?s, ?hook, ?hook);
+    if (s.build_attributes == nil) { ret 1; }
+    if (s.merge_attributes == nil) { ret 1; }
 
     # an arch whose relocatable objects are not ELF passes a deliberate nil for the
     # ELF map and still owes the applier

--- a/src/lang/target/isa/riscv64/attributes.mach
+++ b/src/lang/target/isa/riscv64/attributes.mach
@@ -1,0 +1,1027 @@
+# the riscv64 ELF build-attribute body: what an image CLAIMS about itself
+#
+# `.riscv.attributes` carries the claims a consumer decodes an image with - which
+# extensions its instructions come from, what its stack alignment is, whether its
+# loads may be unaligned. The ELF writer owns the CONTAINER those claims sit in (a
+# version byte, a vendor sub-section, a `Tag_File` sub-sub-section), because that
+# container is the same one the ARM EABI defines and nothing in it is arch-specific.
+# This module owns the BODY: the tag/value pairs inside, whose meaning, whose value
+# encoding, and whose merge rule are all RISC-V's.
+#
+# It exists because the arch string was a constant. A constant describes what this
+# compiler's encoder emits, and an image is not what its encoder emits - it is what
+# its encoder emits PLUS every object linked into it. The moment a clang object built
+# for `rv64gc` joined a mach image, the image claimed an instruction set it did not
+# have and omitted one it did, which is exactly the shape of the `e_flags` defect one
+# section over (#2813, #2828). So nothing here states a string: an image's claims are
+# derived from what it holds, and a linked image's are MERGED from its inputs.
+#
+# WHY MERGE RULES ARE NOT ONE RULE. A union is right for the arch string and wrong for
+# everything else. Two objects with different stack alignments cannot be combined at
+# all - the union of 8 and 16 is not a stack alignment, it is a contradiction, and the
+# psABI says refuse. Unaligned access is a permission, so the merged image permits it
+# if any input needed it. A tag this compiler does not model is kept only when every
+# input that states it agrees, because an image may only claim what all of its parts
+# claim. Each of those is a different rule and the test for this module is the
+# DISAGREEMENT cases, since identical inputs exercise the parser and nothing else.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use std.allocator.page;
+
+use A: std.allocator;
+use R: std.types.result;
+
+# the RISC-V build attribute tags this compiler models
+#
+# `Tag_RISCV_arch` is odd and so carries a null-terminated string; the rest are even
+# and carry an unsigned LEB128. That parity rule is the container format's, not a
+# per-tag table, which is what lets an unknown tag be parsed (and so preserved)
+# without knowing what it means.
+pub val TAG_STACK_ALIGN:       u32 = 4;
+pub val TAG_ARCH:              u32 = 5;
+pub val TAG_UNALIGNED_ACCESS:  u32 = 6;
+pub val TAG_PRIV_SPEC:         u32 = 8;
+pub val TAG_PRIV_SPEC_MINOR:   u32 = 10;
+pub val TAG_PRIV_SPEC_REVISION: u32 = 12;
+
+# the stack alignment every RV64 member in this compiler uses, in bytes. stated here
+# because it is a claim about the frame layout the back end emits, and the frame
+# layout is not free to disagree with it
+pub val RISCV64_STACK_ALIGN: u32 = 16;
+
+# the largest extension count, extension name, and unmodelled-tag count a parsed
+# attribute body may hold. an input past any of these is refused rather than
+# truncated: a silently shortened claim is a wrong claim, and these bounds are far
+# past anything a real toolchain emits (llvm's rv64gc profile parses to 7 extensions)
+val MAX_EXTS:    u32 = 64;
+val MAX_NAME:    u32 = 24;
+val MAX_UNKNOWN: u32 = 16;
+val MAX_UNKNOWN_VALUE: u32 = 64;
+
+# one extension of an ISA string: its name and its two-part version
+# ---
+# name:     the extension's letters, lowercase, without its version
+# name_len: number of valid bytes in `name`
+# major:    the version's major part
+# minor:    the version's minor part (the `p` half)
+pub rec Ext {
+    name:     [24]u8;
+    name_len: u32;
+    major:    u32;
+    minor:    u32;
+}
+
+# a parsed ISA string: its base width and its extensions in canonical order
+# ---
+# xlen:  the register width the string names (32 or 64)
+# exts:  the extensions, the base integer extension first
+# count: number of valid entries in `exts`
+pub rec Arch {
+    xlen:  u32;
+    exts:  [64]Ext;
+    count: u32;
+}
+
+# one attribute this compiler does not model, kept verbatim
+#
+# Preserved rather than dropped because an unmodelled tag is still a true claim about
+# the inputs, and dropping it silently narrows what the image says about itself. Kept
+# only while every input that states it agrees - see `merge_unknown`.
+# ---
+# tag:      the attribute tag number
+# is_str:   whether its value is a string (odd tag) rather than a uleb (even tag)
+# value:    the raw value bytes, as they appeared
+# value_len: number of valid bytes in `value`
+pub rec Unknown {
+    tag:       u32;
+    is_str:    bool;
+    value:     [64]u8;
+    value_len: u32;
+}
+
+# every claim a `.riscv.attributes` body makes, parsed
+#
+# Each modelled tag carries a `has_` flag rather than a sentinel value: "this input
+# said nothing about its stack alignment" and "this input said its stack alignment is
+# zero" are different claims and merge differently, and a sentinel collapses them.
+# ---
+# arch / has_arch:                 the ISA string
+# stack_align / has_stack_align:   stack alignment in bytes
+# unaligned / has_unaligned:       whether unaligned access is permitted
+# priv / has_priv:                 the three privileged-spec tags, in tag order
+# unknown / unknown_count:         attributes this compiler does not model
+pub rec Attrs {
+    arch:            Arch;
+    has_arch:        bool;
+    stack_align:     u32;
+    has_stack_align: bool;
+    unaligned:       u32;
+    has_unaligned:   bool;
+    priv:            [3]u32;
+    has_priv:        [3]bool;
+    unknown:         [16]Unknown;
+    unknown_count:   u32;
+}
+
+# the canonical order of the single-letter standard extensions, from the RISC-V
+# unprivileged spec's "Subset Naming Convention" table. an ISA string that lists them
+# in any other order is legal to READ and wrong to WRITE, so this is the order the
+# serializer emits and has nothing to do with the order an input arrived in
+val SINGLE_ORDER: str = "mafdqlcbkjtpvn";
+
+# clear every claim, so a fresh `Attrs` states nothing rather than stating zeros
+# ---
+# at: the record to reset
+pub fun attrs_blank(at: *Attrs) {
+    at.arch.xlen = 0;
+    at.arch.count = 0;
+    at.has_arch = false;
+    at.stack_align = 0;
+    at.has_stack_align = false;
+    at.unaligned = 0;
+    at.has_unaligned = false;
+    var i: u32 = 0;
+    for (i < 3) { at.priv[i] = 0; at.has_priv[i] = false; i = i + 1; }
+    at.unknown_count = 0;
+}
+
+# whether `c` is an ASCII lowercase letter
+fun is_lower(c: u8) bool { ret c >= 97 && c <= 122; }
+
+# whether `c` is an ASCII digit
+fun is_digit(c: u8) bool { ret c >= 48 && c <= 57; }
+
+# the index of `c` in `SINGLE_ORDER`, or -1 when it is not a single-letter standard
+# extension. drives the serializer's ordering
+fun single_rank(c: u8) i64 {
+    var i: i64 = 0;
+    for (i < 14) {
+        if (SINGLE_ORDER[i::usize]::u8 == c) { ret i; }
+        i = i + 1;
+    }
+    ret -1;
+}
+
+# compare two extension names bytewise, shorter-first on a common prefix
+# ---
+# ret: negative when a sorts before b, 0 when equal, positive otherwise
+fun name_cmp(a: *Ext, b: *Ext) i64 {
+    var i: u32 = 0;
+    for (i < a.name_len && i < b.name_len) {
+        if (a.name[i] != b.name[i]) { ret (a.name[i]::i64) - (b.name[i]::i64); }
+        i = i + 1;
+    }
+    ret (a.name_len::i64) - (b.name_len::i64);
+}
+
+# whether two extensions name the same extension (version ignored)
+fun same_ext(a: *Ext, b: *Ext) bool { ret name_cmp(a, b) == 0; }
+
+# read an unsigned LEB128 out of `buf`, advancing `pos`
+#
+# Refuses an encoding that runs off the end or past 32 bits rather than wrapping: a
+# truncated attribute body is a corrupt claim, and a wrapped one is a wrong claim.
+# ---
+# buf: the bytes to read from
+# len: their length
+# pos: in/out - the offset to read at, advanced past the value
+# out: out - the decoded value
+# ret: true on success
+fun read_uleb(buf: *u8, len: u32, pos: *u32, out: *u32) bool {
+    var v: u64 = 0;
+    var shift: u32 = 0;
+    var p: u32 = @pos;
+    for (p < len) {
+        val b: u8 = buf[p];
+        p = p + 1;
+        if (shift > 28 && (b & 0x7F) > 15) { ret false; }
+        v = v | (((b & 0x7F)::u64) << shift);
+        if ((b & 0x80) == 0) {
+            @pos = p;
+            @out = v::u32;
+            ret true;
+        }
+        shift = shift + 7;
+        if (shift > 35) { ret false; }
+    }
+    ret false;
+}
+
+# the byte length of `value`'s unsigned LEB128 encoding
+fun uleb_size(value: u32) u32 {
+    var v: u32 = value;
+    var n: u32 = 1;
+    for (v > 127) { v = v >> 7; n = n + 1; }
+    ret n;
+}
+
+# write `value` as an unsigned LEB128 at `pos`, returning the bytes written
+fun write_uleb(buf: *u8, pos: u32, value: u32) u32 {
+    var v: u32 = value;
+    var n: u32 = 0;
+    var more: bool = true;
+    for (more) {
+        var b: u8 = (v & 0x7F)::u8;
+        v = v >> 7;
+        if (v != 0) { b = b | 0x80; } or { more = false; }
+        buf[pos + n] = b;
+        n = n + 1;
+    }
+    ret n;
+}
+
+# parse an ISA string into `out`
+#
+# Accepts both spellings a real toolchain produces: `rv64imafdc` with the single
+# letters run together and no versions, and `rv64i2p1_m2p0_a2p1` with explicit
+# versions and separators. An extension with no stated version parses as 0p0, which
+# the merge then treats as "older than anything stated" so a version-carrying input
+# wins - the alternative, treating it as newest, would let an unversioned string
+# silently downgrade a precise one.
+# ---
+# s:   the string bytes
+# len: their length
+# out: the parsed result
+# ret: true when the whole string parsed
+pub fun parse_arch(s: *u8, len: u32, out: *Arch) bool {
+    out.xlen = 0;
+    out.count = 0;
+    if (len < 5) { ret false; }
+    if (s[0] != 114 || s[1] != 118) { ret false; }
+    var p: u32 = 2;
+    var xlen: u32 = 0;
+    for (p < len && is_digit(s[p])) {
+        xlen = xlen * 10 + (s[p] - 48)::u32;
+        p = p + 1;
+    }
+    if (xlen != 32 && xlen != 64) { ret false; }
+    out.xlen = xlen;
+
+    for (p < len) {
+        if (s[p] == 95) { p = p + 1; cnt; }
+        if (!is_lower(s[p])) { ret false; }
+
+        var e: Ext;
+        e.name_len = 0;
+        e.major = 0;
+        e.minor = 0;
+
+        # a multi-letter extension starts with z, s or x and runs to its version, its
+        # separator, or the end; a single-letter one is exactly one character
+        val multi: bool = s[p] == 122 || s[p] == 115 || s[p] == 120;
+        e.name[0] = s[p];
+        e.name_len = 1;
+        p = p + 1;
+        if (multi) {
+            for (p < len && is_lower(s[p])) {
+                # a trailing letter that begins a version ("...p0") is not a name byte,
+                # but only a digit can precede a version's `p`, so a run of letters is
+                # unambiguous here
+                if (e.name_len >= MAX_NAME) { ret false; }
+                e.name[e.name_len] = s[p];
+                e.name_len = e.name_len + 1;
+                p = p + 1;
+            }
+        }
+
+        if (p < len && is_digit(s[p])) {
+            for (p < len && is_digit(s[p])) {
+                e.major = e.major * 10 + (s[p] - 48)::u32;
+                p = p + 1;
+            }
+            if (p < len && s[p] == 112) {
+                p = p + 1;
+                if (p >= len || !is_digit(s[p])) { ret false; }
+                for (p < len && is_digit(s[p])) {
+                    e.minor = e.minor * 10 + (s[p] - 48)::u32;
+                    p = p + 1;
+                }
+            }
+        }
+
+        if (out.count >= MAX_EXTS) { ret false; }
+        # a repeated extension keeps the higher version rather than appearing twice
+        var dup: bool = false;
+        var i: u32 = 0;
+        for (i < out.count) {
+            if (same_ext(?out.exts[i], ?e)) {
+                dup = true;
+                if (e.major > out.exts[i].major
+                    || (e.major == out.exts[i].major && e.minor > out.exts[i].minor)) {
+                    out.exts[i].major = e.major;
+                    out.exts[i].minor = e.minor;
+                }
+                brk;
+            }
+            i = i + 1;
+        }
+        if (!dup) {
+            out.exts[out.count] = e;
+            out.count = out.count + 1;
+        }
+    }
+    ret true;
+}
+
+# merge `b`'s extensions into `a`: the union, each at the higher version
+#
+# Two images' instruction sets combine by union because the merged image contains
+# both sets of instructions - this is the one tag where a union is the right answer.
+# Version maxing is the same argument at finer grain: an image containing a 2p1 `i`
+# and a 2p0 `i` contains 2p1 instructions.
+#
+# Differing xlen is refused. An rv32 object and an rv64 object do not combine into an
+# image of either width, and a merged string that named one of them would be a claim
+# no consumer could act on.
+# ---
+# a:   the accumulator, updated in place
+# b:   the ISA string being folded in
+# ret: ok(true), or the reason the two cannot combine
+pub fun merge_arch(a: *Arch, b: *Arch) R.Result[bool, str] {
+    if (a.xlen == 0) {
+        @a = @b;
+        ret R.ok[bool, str](true);
+    }
+    if (b.xlen == 0) { ret R.ok[bool, str](true); }
+    if (a.xlen != b.xlen) {
+        ret R.err[bool, str](
+            "link: riscv attribute merge: inputs disagree on register width (rv32 with rv64)");
+    }
+    var i: u32 = 0;
+    for (i < b.count) {
+        var found: bool = false;
+        var j: u32 = 0;
+        for (j < a.count) {
+            if (same_ext(?a.exts[j], ?b.exts[i])) {
+                found = true;
+                if (b.exts[i].major > a.exts[j].major
+                    || (b.exts[i].major == a.exts[j].major
+                        && b.exts[i].minor > a.exts[j].minor)) {
+                    a.exts[j].major = b.exts[i].major;
+                    a.exts[j].minor = b.exts[i].minor;
+                }
+                brk;
+            }
+            j = j + 1;
+        }
+        if (!found) {
+            if (a.count >= MAX_EXTS) {
+                ret R.err[bool, str](
+                    "link: riscv attribute merge: more extensions than the merger can hold");
+            }
+            a.exts[a.count] = b.exts[i];
+            a.count = a.count + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# fold one unmodelled attribute into the accumulator
+#
+# Kept when no input has stated it, or when every input that states it states the same
+# bytes. Dropped the moment two inputs disagree: this compiler does not know the tag's
+# merge rule, so it cannot pick between them, and emitting either would put a claim on
+# the image that only half its parts support. Dropping is the only answer that is
+# never wrong.
+fun merge_unknown(at: *Attrs, u: *Unknown) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < at.unknown_count) {
+        if (at.unknown[i].tag == u.tag) {
+            var same: bool = at.unknown[i].value_len == u.value_len;
+            var k: u32 = 0;
+            for (same && k < u.value_len) {
+                if (at.unknown[i].value[k] != u.value[k]) { same = false; }
+                k = k + 1;
+            }
+            if (same) { ret R.ok[bool, str](true); }
+            # drop it by moving the last entry down over it
+            at.unknown[i] = at.unknown[at.unknown_count - 1];
+            at.unknown_count = at.unknown_count - 1;
+            ret R.ok[bool, str](true);
+        }
+        i = i + 1;
+    }
+    if (at.unknown_count >= MAX_UNKNOWN) { ret R.ok[bool, str](true); }
+    at.unknown[at.unknown_count] = @u;
+    at.unknown_count = at.unknown_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# parse one attribute body - a run of `<tag uleb><value>` pairs - into `out`
+#
+# The body is what sits inside the container's `Tag_File` sub-sub-section; the ELF
+# writer owns the container and hands only this over, so nothing here knows what a
+# vendor sub-section is.
+# ---
+# body: the attribute bytes
+# len:  their length
+# out:  the parsed claims
+# ret:  ok(true), or the reason the body could not be read
+pub fun parse_body(body: *u8, len: u32, out: *Attrs) R.Result[bool, str] {
+    attrs_blank(out);
+    if (body == nil || len == 0) { ret R.ok[bool, str](true); }
+    var p: u32 = 0;
+    for (p < len) {
+        var tag: u32 = 0;
+        if (!read_uleb(body, len, ?p, ?tag)) {
+            ret R.err[bool, str]("link: riscv attributes: truncated attribute tag");
+        }
+        # the container's parity rule: an odd tag carries a string, an even tag a uleb
+        val is_str: bool = (tag & 1) == 1;
+        if (is_str) {
+            val start: u32 = p;
+            for (p < len && body[p] != 0) { p = p + 1; }
+            if (p >= len) {
+                ret R.err[bool, str]("link: riscv attributes: unterminated attribute string");
+            }
+            val slen: u32 = p - start;
+            p = p + 1;
+            if (tag == TAG_ARCH) {
+                if (!parse_arch(?body[start], slen, ?out.arch)) {
+                    ret R.err[bool, str](
+                        "link: riscv attributes: Tag_RISCV_arch is not a readable ISA string");
+                }
+                out.has_arch = true;
+            }
+            or {
+                if (slen <= MAX_UNKNOWN_VALUE) {
+                    var u: Unknown;
+                    u.tag = tag;
+                    u.is_str = true;
+                    u.value_len = slen;
+                    var k: u32 = 0;
+                    for (k < slen) { u.value[k] = body[start + k]; k = k + 1; }
+                    val mr: R.Result[bool, str] = merge_unknown(out, ?u);
+                    if (R.is_err[bool, str](mr)) { ret mr; }
+                }
+            }
+            cnt;
+        }
+
+        var v: u32 = 0;
+        if (!read_uleb(body, len, ?p, ?v)) {
+            ret R.err[bool, str]("link: riscv attributes: truncated attribute value");
+        }
+        if (tag == TAG_STACK_ALIGN)           { out.stack_align = v; out.has_stack_align = true; cnt; }
+        if (tag == TAG_UNALIGNED_ACCESS)      { out.unaligned = v;   out.has_unaligned = true;   cnt; }
+        if (tag == TAG_PRIV_SPEC)             { out.priv[0] = v; out.has_priv[0] = true; cnt; }
+        if (tag == TAG_PRIV_SPEC_MINOR)       { out.priv[1] = v; out.has_priv[1] = true; cnt; }
+        if (tag == TAG_PRIV_SPEC_REVISION)    { out.priv[2] = v; out.has_priv[2] = true; cnt; }
+
+        var u2: Unknown;
+        u2.tag = tag;
+        u2.is_str = false;
+        u2.value_len = uleb_size(v);
+        write_uleb(?u2.value[0], 0, v);
+        val mr2: R.Result[bool, str] = merge_unknown(out, ?u2);
+        if (R.is_err[bool, str](mr2)) { ret mr2; }
+    }
+    ret R.ok[bool, str](true);
+}
+
+# fold `b`'s claims into `a`, one merge rule per tag
+#
+# The four rules, and why each is what it is:
+#
+#   arch              UNION at the higher version. the merged image holds both
+#                     instruction sets, so it holds their union
+#   stack_align       must AGREE. the union of two alignments is not an alignment; a
+#                     frame laid out for 8 and read as 16 is a corrupt frame, so two
+#                     inputs that disagree cannot be linked and this refuses rather
+#                     than picking
+#   unaligned_access  the MAXIMUM, which for a 0/1 permission is a logical or. an
+#                     image containing one unaligned access performs unaligned access
+#   priv_spec         must AGREE, and is DROPPED when it does not. unlike stack
+#                     alignment a disagreement here is not fatal - the image simply
+#                     cannot state one privileged spec version - so the honest result
+#                     is to say nothing rather than to refuse or to guess
+#   anything else     kept while every input agrees, dropped otherwise
+# ---
+# a:   the accumulator, updated in place
+# b:   the claims being folded in
+# ret: ok(true), or the reason the two cannot be combined
+pub fun merge_attrs(a: *Attrs, b: *Attrs) R.Result[bool, str] {
+    if (b.has_arch) {
+        val ar: R.Result[bool, str] = merge_arch(?a.arch, ?b.arch);
+        if (R.is_err[bool, str](ar)) { ret ar; }
+        a.has_arch = true;
+    }
+
+    if (b.has_stack_align) {
+        if (a.has_stack_align && a.stack_align != b.stack_align) {
+            ret R.err[bool, str](
+                "link: riscv attribute merge: inputs disagree on Tag_RISCV_stack_align");
+        }
+        a.stack_align = b.stack_align;
+        a.has_stack_align = true;
+    }
+
+    if (b.has_unaligned) {
+        if (!a.has_unaligned || b.unaligned > a.unaligned) { a.unaligned = b.unaligned; }
+        a.has_unaligned = true;
+    }
+
+    var i: u32 = 0;
+    for (i < 3) {
+        if (b.has_priv[i]) {
+            if (a.has_priv[i] && a.priv[i] != b.priv[i]) {
+                # disagreement means the merged image states no privileged spec at all
+                a.has_priv[i] = false;
+                a.priv[i] = 0;
+            }
+            or {
+                a.priv[i] = b.priv[i];
+                a.has_priv[i] = true;
+            }
+        }
+        i = i + 1;
+    }
+
+    var k: u32 = 0;
+    for (k < b.unknown_count) {
+        val ur: R.Result[bool, str] = merge_unknown(a, ?b.unknown[k]);
+        if (R.is_err[bool, str](ur)) { ret ur; }
+        k = k + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the serialized length of `a`'s ISA string, excluding its terminator
+fun arch_string_size(a: *Arch) u32 {
+    var n: u32 = 2 + decimal_size(a.xlen);
+    var i: u32 = 0;
+    for (i < a.count) {
+        if (i > 0) { n = n + 1; }
+        n = n + a.exts[i].name_len;
+        n = n + decimal_size(a.exts[i].major) + 1 + decimal_size(a.exts[i].minor);
+        i = i + 1;
+    }
+    ret n;
+}
+
+# the number of decimal digits `v` prints as
+fun decimal_size(v: u32) u32 {
+    var n: u32 = 1;
+    var x: u32 = v;
+    for (x > 9) { x = x / 10; n = n + 1; }
+    ret n;
+}
+
+# write `v` in decimal at `pos`, returning the bytes written
+fun write_decimal(buf: *u8, pos: u32, v: u32) u32 {
+    val n: u32 = decimal_size(v);
+    var x: u32 = v;
+    var i: u32 = n;
+    for (i > 0) {
+        i = i - 1;
+        buf[pos + i] = (48 + (x % 10))::u8;
+        x = x / 10;
+    }
+    ret n;
+}
+
+# order `a`'s extensions the way the spec's naming convention requires
+#
+# The base integer extension first, then the single-letter standard extensions in the
+# spec's fixed order, then everything multi-letter alphabetically. An input may list
+# them in any order and remain readable; an OUTPUT that does is a string other tools
+# will read back differently from the one meant, so the canonical order is applied on
+# the way out and never assumed on the way in.
+fun sort_exts(a: *Arch) {
+    var i: u32 = 1;
+    for (i < a.count) {
+        var j: u32 = i;
+        for (j > 0 && ext_before(?a.exts[j], ?a.exts[j - 1])) {
+            var tmp: Ext = a.exts[j];
+            a.exts[j] = a.exts[j - 1];
+            a.exts[j - 1] = tmp;
+            j = j - 1;
+        }
+        i = i + 1;
+    }
+}
+
+# whether `x` sorts before `y` in the spec's naming convention
+fun ext_before(x: *Ext, y: *Ext) bool {
+    val xk: u32 = ext_class(x);
+    val yk: u32 = ext_class(y);
+    if (xk != yk) { ret xk < yk; }
+    if (xk == 1) { ret single_rank(x.name[0]) < single_rank(y.name[0]); }
+    ret name_cmp(x, y) < 0;
+}
+
+# the naming convention's three classes: the base integer extension, the single-letter
+# standard extensions, then everything multi-letter
+fun ext_class(e: *Ext) u32 {
+    if (e.name_len == 1 && (e.name[0] == 105 || e.name[0] == 101)) { ret 0; }
+    if (e.name_len == 1) { ret 1; }
+    ret 2;
+}
+
+# serialize `at` into a freshly allocated attribute body
+#
+# Emits the modelled tags in ascending tag order, which is what every producer does
+# and what makes two equal claim-sets serialize to equal bytes. The caller owns the
+# returned buffer.
+# ---
+# alloc: the allocator the body is taken from
+# at:    the claims to serialize
+# out_len: out - the body's length in bytes
+# ret:   the owned body, or an allocation error
+pub fun serialize(alloc: *A.Allocator, at: *Attrs, out_len: *u32) R.Result[*u8, str] {
+    @out_len = 0;
+    sort_exts(?at.arch);
+
+    var n: u32 = 0;
+    if (at.has_stack_align) { n = n + uleb_size(TAG_STACK_ALIGN) + uleb_size(at.stack_align); }
+    if (at.has_arch)        { n = n + uleb_size(TAG_ARCH) + arch_string_size(?at.arch) + 1; }
+    if (at.has_unaligned)   { n = n + uleb_size(TAG_UNALIGNED_ACCESS) + uleb_size(at.unaligned); }
+    var i: u32 = 0;
+    for (i < 3) {
+        if (at.has_priv[i]) { n = n + uleb_size(priv_tag(i)) + uleb_size(at.priv[i]); }
+        i = i + 1;
+    }
+    var k: u32 = 0;
+    for (k < at.unknown_count) {
+        n = n + uleb_size(at.unknown[k].tag) + at.unknown[k].value_len;
+        if (at.unknown[k].is_str) { n = n + 1; }
+        k = k + 1;
+    }
+    if (n == 0) { ret R.ok[*u8, str](nil); }
+
+    val br: R.Result[*u8, str] = A.allocate[u8](alloc, n::usize);
+    if (R.is_err[*u8, str](br)) { ret br; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](br);
+
+    var p: u32 = 0;
+    if (at.has_stack_align) {
+        p = p + write_uleb(buf, p, TAG_STACK_ALIGN);
+        p = p + write_uleb(buf, p, at.stack_align);
+    }
+    if (at.has_arch) {
+        p = p + write_uleb(buf, p, TAG_ARCH);
+        p = p + write_arch_string(buf, p, ?at.arch);
+        buf[p] = 0;
+        p = p + 1;
+    }
+    if (at.has_unaligned) {
+        p = p + write_uleb(buf, p, TAG_UNALIGNED_ACCESS);
+        p = p + write_uleb(buf, p, at.unaligned);
+    }
+    i = 0;
+    for (i < 3) {
+        if (at.has_priv[i]) {
+            p = p + write_uleb(buf, p, priv_tag(i));
+            p = p + write_uleb(buf, p, at.priv[i]);
+        }
+        i = i + 1;
+    }
+    k = 0;
+    for (k < at.unknown_count) {
+        p = p + write_uleb(buf, p, at.unknown[k].tag);
+        var b: u32 = 0;
+        for (b < at.unknown[k].value_len) {
+            buf[p + b] = at.unknown[k].value[b];
+            b = b + 1;
+        }
+        p = p + at.unknown[k].value_len;
+        if (at.unknown[k].is_str) { buf[p] = 0; p = p + 1; }
+        k = k + 1;
+    }
+
+    @out_len = n;
+    ret R.ok[*u8, str](buf);
+}
+
+# the tag number of privileged-spec slot `i`
+fun priv_tag(i: u32) u32 {
+    if (i == 0) { ret TAG_PRIV_SPEC; }
+    if (i == 1) { ret TAG_PRIV_SPEC_MINOR; }
+    ret TAG_PRIV_SPEC_REVISION;
+}
+
+# write `a` as an ISA string at `pos`, returning the bytes written (no terminator)
+fun write_arch_string(buf: *u8, pos: u32, a: *Arch) u32 {
+    var p: u32 = pos;
+    buf[p] = 114; buf[p + 1] = 118;
+    p = p + 2;
+    p = p + write_decimal(buf, p, a.xlen);
+    var i: u32 = 0;
+    for (i < a.count) {
+        if (i > 0) { buf[p] = 95; p = p + 1; }
+        var k: u32 = 0;
+        for (k < a.exts[i].name_len) { buf[p + k] = a.exts[i].name[k]; k = k + 1; }
+        p = p + a.exts[i].name_len;
+        p = p + write_decimal(buf, p, a.exts[i].major);
+        buf[p] = 112;
+        p = p + 1;
+        p = p + write_decimal(buf, p, a.exts[i].minor);
+        i = i + 1;
+    }
+    ret p - pos;
+}
+
+# add one extension to `a` at an explicit version
+fun push_ext(a: *Arch, name: str, major: u32, minor: u32) {
+    if (a.count >= MAX_EXTS) { ret; }
+    var e: Ext;
+    e.name_len = 0;
+    for (name[e.name_len::usize] != 0) {
+        e.name[e.name_len] = name[e.name_len::usize]::u8;
+        e.name_len = e.name_len + 1;
+    }
+    e.major = major;
+    e.minor = minor;
+    a.exts[a.count] = e;
+    a.count = a.count + 1;
+}
+
+# the attribute body describing what THIS compiler's riscv64 output holds
+#
+# Derived from the emitted bytes, never stated. `has_compressed` decides the `c`
+# extension for the same reason it decides the `EF_RISCV_RVC` header bit: it is a fact
+# about the instructions in the image, and an object mach writes contains none while a
+# linked image contains whatever its inputs contained (#2813).
+#
+# `float_arg_bits` does NOT vary the string, and that is a claim rather than an
+# oversight: this encoder emits F and D instructions for every member of the family,
+# including soft-float lp64, which passes float scalars in integer registers while
+# still computing with the float unit. The parameter is taken because the derivation's
+# inputs are the ABI and the bytes, and an arch whose instruction set did vary with the
+# convention would need it.
+# ---
+# alloc:          the allocator the body is taken from
+# float_arg_bits: the resolved ABI's float-argument width (0 / 32 / 64)
+# has_compressed: whether the image's bytes contain compressed instructions
+# out_len:        out - the body's length in bytes
+# ret:            the owned body, or an allocation error
+pub fun riscv64_build_attributes(alloc: *A.Allocator, float_arg_bits: u32,
+                                 has_compressed: bool, out_len: *u32) R.Result[*u8, str] {
+    var at: Attrs;
+    attrs_blank(?at);
+
+    at.arch.xlen = 64;
+    push_ext(?at.arch, "i", 2, 1);
+    push_ext(?at.arch, "m", 2, 0);
+    push_ext(?at.arch, "a", 2, 1);
+    push_ext(?at.arch, "f", 2, 2);
+    push_ext(?at.arch, "d", 2, 2);
+    if (has_compressed) { push_ext(?at.arch, "c", 2, 0); }
+    at.has_arch = true;
+
+    at.stack_align = RISCV64_STACK_ALIGN;
+    at.has_stack_align = true;
+
+    # this back end emits no unaligned access: every load and store it selects is
+    # naturally aligned for its width, so the image honestly claims none
+    at.unaligned = 0;
+    at.has_unaligned = true;
+
+    ret serialize(alloc, ?at, out_len);
+}
+
+# merge two attribute bodies into a freshly allocated one
+#
+# The linker's fold, called once per input. Either side may be empty, which is what an
+# input carrying no `.riscv.attributes` section looks like and is not an error: an
+# object that claims nothing constrains nothing.
+# ---
+# alloc:   the allocator the result is taken from
+# a / a_len: the accumulated body so far
+# b / b_len: the input body being folded in
+# out_len: out - the result's length in bytes
+# ret:     the owned merged body, or the reason the two cannot be combined
+pub fun riscv64_merge_attributes(alloc: *A.Allocator, a: *u8, a_len: u32,
+                                 b: *u8, b_len: u32, out_len: *u32) R.Result[*u8, str] {
+    var acc: Attrs;
+    val pa: R.Result[bool, str] = parse_body(a, a_len, ?acc);
+    if (R.is_err[bool, str](pa)) { ret R.err[*u8, str](R.unwrap_err[bool, str](pa)); }
+
+    var other: Attrs;
+    val pb: R.Result[bool, str] = parse_body(b, b_len, ?other);
+    if (R.is_err[bool, str](pb)) { ret R.err[*u8, str](R.unwrap_err[bool, str](pb)); }
+
+    val mr: R.Result[bool, str] = merge_attrs(?acc, ?other);
+    if (R.is_err[bool, str](mr)) { ret R.err[*u8, str](R.unwrap_err[bool, str](mr)); }
+
+    ret serialize(alloc, ?acc, out_len);
+}
+
+# build a body holding exactly one arch string, for a test that needs an input
+# spelled the way a foreign toolchain spells it rather than the way this one does
+fun t_arch_body(buf: *u8, s: str) u32 {
+    var p: u32 = 0;
+    p = p + write_uleb(buf, p, TAG_ARCH);
+    var i: usize = 0;
+    for (s[i] != 0) { buf[p + i::u32] = s[i]::u8; i = i + 1; }
+    p = p + i::u32;
+    buf[p] = 0;
+    ret p + 1;
+}
+
+# whether writing `a` produces exactly `want`
+fun t_arch_is_direct(a: *Arch, want: str) bool {
+    var out: [128]u8;
+    val n: u32 = write_arch_string(?out[0], 0, a);
+    var i: u32 = 0;
+    for (i < n) {
+        if (want[i::usize] == 0 || want[i::usize]::u8 != out[i]) { ret false; }
+        i = i + 1;
+    }
+    ret want[n::usize] == 0;
+}
+
+# whether the serialized body `buf` carries `want` as its Tag_RISCV_arch string
+fun t_arch_is(buf: *u8, len: u32, want: str) bool {
+    var at: Attrs;
+    if (R.is_err[bool, str](parse_body(buf, len, ?at))) { ret false; }
+    if (!at.has_arch) { ret false; }
+    ret t_arch_is_direct(?at.arch, want);
+}
+
+# the ISA-string reader takes both spellings a real toolchain produces, and normalizes
+# what it read into the naming convention's order rather than the order it arrived in.
+# the run-together spelling with no versions is what a hand-written `-march` produces
+# and the separated spelling with versions is what llvm writes into the section
+test "mach.lang.target.isa.riscv64.attributes.parse_arch:both_spellings_and_ordering" {
+    var a: Arch;
+    if (!parse_arch("rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0"::*u8, 33, ?a)) { ret 1; }
+    if (a.xlen != 64 || a.count != 6) { ret 1; }
+    if (a.exts[0].name[0] != 105 || a.exts[0].major != 2 || a.exts[0].minor != 1) { ret 1; }
+    if (a.exts[5].name[0] != 99 || a.exts[5].major != 2 || a.exts[5].minor != 0) { ret 1; }
+
+    # run together, unversioned, and deliberately out of canonical order. an
+    # unversioned extension reads as 0p0, which is what makes a version-carrying input
+    # win the merge instead of being silently downgraded by one that states nothing
+    var b: Arch;
+    if (!parse_arch("rv64icma"::*u8, 8, ?b)) { ret 1; }
+    if (b.xlen != 64 || b.count != 4) { ret 1; }
+    sort_exts(?b);
+    if (!t_arch_is_direct(?b, "rv64i0p0_m0p0_a0p0_c0p0")) { ret 1; }
+
+    # a multi-letter extension keeps its whole name and its version
+    var z: Arch;
+    if (!parse_arch("rv64i2p1_zicsr2p0_zifencei2p0"::*u8, 29, ?z)) { ret 1; }
+    if (z.count != 3) { ret 1; }
+    sort_exts(?z);
+    if (!t_arch_is_direct(?z, "rv64i2p1_zicsr2p0_zifencei2p0")) { ret 1; }
+
+    # a width this compiler cannot emit, and a string that is not an ISA string
+    var bad: Arch;
+    if (parse_arch("rv128i2p1"::*u8, 9, ?bad))  { ret 1; }
+    if (parse_arch("x86_64"::*u8, 6, ?bad))     { ret 1; }
+    ret 0;
+}
+
+# THE MERGE IS TESTED ON INPUTS THAT DISAGREE. two identical bodies merge to
+# themselves under any rule, including a wrong one, so the cases here are the ways two
+# real objects differ: an extension one has and the other does not, the same extension
+# at two versions, an input that states nothing, and two widths that do not combine
+test "mach.lang.target.isa.riscv64.attributes.merge_attributes:disagreeing_inputs" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # one side has `c` and `zicsr`, the other does not: the union, in canonical order
+    var lhs: [96]u8;
+    var rhs: [96]u8;
+    val ln: u32 = t_arch_body(?lhs[0], "rv64i2p1_m2p0_a2p1_f2p2_d2p2");
+    val rn: u32 = t_arch_body(?rhs[0], "rv64i2p1_c2p0_zicsr2p0");
+    var out_len: u32 = 0;
+    val mr: R.Result[*u8, str] =
+        riscv64_merge_attributes(?alloc, ?lhs[0], ln, ?rhs[0], rn, ?out_len);
+    if (R.is_err[*u8, str](mr)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](mr), out_len,
+                   "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0")) { ret 1; }
+
+    # the SAME extension at two versions takes the higher, in BOTH directions, so the
+    # answer cannot come from whichever side happened to be the accumulator
+    val an: u32 = t_arch_body(?lhs[0], "rv64i2p0_m2p0");
+    val bn: u32 = t_arch_body(?rhs[0], "rv64i2p1_m1p0");
+    var vlen: u32 = 0;
+    val vr: R.Result[*u8, str] =
+        riscv64_merge_attributes(?alloc, ?lhs[0], an, ?rhs[0], bn, ?vlen);
+    if (R.is_err[*u8, str](vr)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](vr), vlen, "rv64i2p1_m2p0")) { ret 1; }
+    var wlen: u32 = 0;
+    val wr: R.Result[*u8, str] =
+        riscv64_merge_attributes(?alloc, ?rhs[0], bn, ?lhs[0], an, ?wlen);
+    if (R.is_err[*u8, str](wr)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](wr), wlen, "rv64i2p1_m2p0")) { ret 1; }
+
+    # an input that claims nothing constrains nothing, which is what an object with no
+    # `.riscv.attributes` section looks like and is not an error
+    var elen: u32 = 0;
+    val er: R.Result[*u8, str] =
+        riscv64_merge_attributes(?alloc, ?lhs[0], an, nil, 0, ?elen);
+    if (R.is_err[*u8, str](er)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](er), elen, "rv64i2p0_m2p0")) { ret 1; }
+
+    # rv32 and rv64 do not combine into an image of either width
+    val x32: u32 = t_arch_body(?lhs[0], "rv32i2p1");
+    val x64: u32 = t_arch_body(?rhs[0], "rv64i2p1");
+    var xo: u32 = 0;
+    if (!R.is_err[*u8, str](
+            riscv64_merge_attributes(?alloc, ?lhs[0], x32, ?rhs[0], x64, ?xo))) { ret 1; }
+    ret 0;
+}
+
+# the tags whose merge rule is NOT a union, each checked against the rule it has
+# rather than against the union it would be easy to write
+test "mach.lang.target.isa.riscv64.attributes.merge_attrs:non_union_tags" {
+    var a: Attrs;
+    var b: Attrs;
+
+    # stack alignment must AGREE. two frames laid out to different alignments cannot be
+    # combined, so this refuses rather than picking one
+    attrs_blank(?a); attrs_blank(?b);
+    a.stack_align = 16; a.has_stack_align = true;
+    b.stack_align = 8;  b.has_stack_align = true;
+    if (!R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+
+    # agreeing is fine, and an input that states nothing does not erase one that does
+    attrs_blank(?a); attrs_blank(?b);
+    a.stack_align = 16; a.has_stack_align = true;
+    if (R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+    if (!a.has_stack_align || a.stack_align != 16) { ret 1; }
+
+    # unaligned access is a PERMISSION: an image holding one unaligned access performs
+    # unaligned access, so the merge is the maximum and not an agreement check. checked
+    # both ways round, so the answer is the rule and not the argument order
+    attrs_blank(?a); attrs_blank(?b);
+    a.unaligned = 0; a.has_unaligned = true;
+    b.unaligned = 1; b.has_unaligned = true;
+    if (R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+    if (!a.has_unaligned || a.unaligned != 1) { ret 1; }
+    attrs_blank(?a); attrs_blank(?b);
+    a.unaligned = 1; a.has_unaligned = true;
+    b.unaligned = 0; b.has_unaligned = true;
+    if (R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+    if (a.unaligned != 1) { ret 1; }
+
+    # a privileged-spec disagreement is not fatal, but the merged image cannot state
+    # one: it says nothing rather than picking a side
+    attrs_blank(?a); attrs_blank(?b);
+    a.priv[0] = 1; a.has_priv[0] = true;
+    b.priv[0] = 2; b.has_priv[0] = true;
+    if (R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+    if (a.has_priv[0]) { ret 1; }
+
+    # an unmodelled tag survives while every input that states it agrees, and is
+    # dropped the moment two disagree - this compiler does not know its rule, so
+    # emitting either value would put a claim on the image half its parts deny
+    attrs_blank(?a); attrs_blank(?b);
+    a.unknown[0].tag = 14; a.unknown[0].is_str = false;
+    a.unknown[0].value[0] = 7; a.unknown[0].value_len = 1;
+    a.unknown_count = 1;
+    b.unknown[0].tag = 14; b.unknown[0].is_str = false;
+    b.unknown[0].value[0] = 7; b.unknown[0].value_len = 1;
+    b.unknown_count = 1;
+    if (R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+    if (a.unknown_count != 1) { ret 1; }
+    b.unknown[0].value[0] = 9;
+    if (R.is_err[bool, str](merge_attrs(?a, ?b))) { ret 1; }
+    if (a.unknown_count != 0) { ret 1; }
+    ret 0;
+}
+
+# what this compiler claims about its OWN output is derived from the bytes, never
+# stated: the same call with and without compressed instructions differs by exactly
+# the `c` extension, which is the fact `EF_RISCV_RVC` reports one section over
+test "mach.lang.target.isa.riscv64.attributes.build_attributes:derived_from_bytes" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var plain_len: u32 = 0;
+    val pr: R.Result[*u8, str] = riscv64_build_attributes(?alloc, 64, false, ?plain_len);
+    if (R.is_err[*u8, str](pr)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](pr), plain_len,
+                   "rv64i2p1_m2p0_a2p1_f2p2_d2p2")) { ret 1; }
+
+    var comp_len: u32 = 0;
+    val cr: R.Result[*u8, str] = riscv64_build_attributes(?alloc, 64, true, ?comp_len);
+    if (R.is_err[*u8, str](cr)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](cr), comp_len,
+                   "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0")) { ret 1; }
+
+    # the soft-float member computes with the float unit even though it passes float
+    # scalars in integer registers, so its instruction set is the same one
+    var soft_len: u32 = 0;
+    val sr: R.Result[*u8, str] = riscv64_build_attributes(?alloc, 0, false, ?soft_len);
+    if (R.is_err[*u8, str](sr)) { ret 1; }
+    if (!t_arch_is(R.unwrap_ok[*u8, str](sr), soft_len,
+                   "rv64i2p1_m2p0_a2p1_f2p2_d2p2")) { ret 1; }
+
+    # the whole body round-trips, not just the string: the stack alignment and the
+    # unaligned-access claim are there beside it
+    var at: Attrs;
+    if (R.is_err[bool, str](parse_body(R.unwrap_ok[*u8, str](pr), plain_len, ?at))) { ret 1; }
+    if (!at.has_stack_align || at.stack_align != RISCV64_STACK_ALIGN) { ret 1; }
+    if (!at.has_unaligned || at.unaligned != 0) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -24,6 +24,7 @@ use R: std.types.result;
 use mach.lang.target.isa;
 use mach.lang.target.isa.riscv64;
 use mach.lang.target.isa.riscv64.encode;
+use mach.lang.target.isa.riscv64.attributes;
 use mach.lang.target.isa.riscv64.reloc;
 use mach.lang.target.isa.riscv64.rules;
 use mach.lang.target.of;
@@ -55,15 +56,6 @@ var riscv64_reloc: isa.RelocSeam;
 # `riscv64_reserved_regs`)
 var riscv64_model: isa.MachineModel;
 
-# the RV64 ISA arch string the ELF build-attributes section carries (`Tag_RISCV_arch`,
-# a normalized NTBS with an explicit version per extension). it names the imafd
-# instructions the backend actually emits - base integer (i), mul / div / rem (m), the
-# RV64A atomics (a), and the scalar single / double float (f / d) - so external tools
-# (llvm-objdump, gdb, readelf) decode the full instruction set with no manual
-# `--mattr`. the soft-float lp64 member passes float scalars in integer registers, but
-# the codegen emits F / D instructions whichever family member is selected, so the arch
-# string declares them
-val RISCV64_ARCH_STRING: str = "rv64i2p1_m2p0_a2p1_f2p2_d2p2";
 
 # process-global storage for the RV64 ELF build-attributes descriptor. written once by
 # `register_riscv64` and returned by the `elf_attributes` hook as a borrowed pointer
@@ -137,7 +129,7 @@ fun riscv64_elf_attributes() *elf.BuildAttributes {
 #
 # THE RVC BIT IS THE BYTES', NOT THE ARCH STRING'S. This encoder emits no compressed
 # instruction (see `INSTR_WIDTH`), so an object mach writes honestly claims none -
-# and `RISCV64_ARCH_STRING` correspondingly omits `c`. A LINKED image is a different
+# and the derived arch string correspondingly omits `c`. A LINKED image is a different
 # question: it carries whatever its inputs carried, and a clang object built for the
 # `rv64gc` profile `int/lib/cc.sh` pins does contain compressed instructions. So the
 # caller passes what is actually in the bytes, and the linker ORs it across inputs
@@ -285,8 +277,6 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_attrs.section  = ".riscv.attributes";
     riscv64_attrs.sht      = elf.SHT_RISCV_ATTRIBUTES;
     riscv64_attrs.vendor   = "riscv";
-    riscv64_attrs.arch_tag = elf.TAG_RISCV_ARCH;
-    riscv64_attrs.arch     = RISCV64_ARCH_STRING;
 
     # the relocatable-object contract: riscv64 names its relocations in an ELF object
     # and resolves them at link time, and both halves are declared here rather than
@@ -300,6 +290,10 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the psABI hi/lo pair collapse, which every riscv64 image needs before anything
     # resolves a relocation in it
     isa.with_normalize_image(?riscv64_reloc, reloc.resolve_riscv_pcrel_pairs::*u8);
+    # the build-attribute body: what an image HOLDS, derived and merged rather than
+    # stated, for the same reason `e_flags` is (#2828)
+    isa.with_attributes(?riscv64_reloc, attributes.riscv64_build_attributes::*u8,
+                        attributes.riscv64_merge_attributes::*u8);
 
     # elf_machine 243 is EM_RISCV
     riscv64_vtable = isa.machine_isa(isa.ARCH_RISCV64, "riscv64", 243, 8,
@@ -404,8 +398,13 @@ test "mach.lang.target.isa.riscv64.register.register_riscv64:build_attributes" {
     if (!str_equals(attr.section, ".riscv.attributes")) { ret 1; }
     if (attr.sht != elf.SHT_RISCV_ATTRIBUTES)           { ret 1; }
     if (!str_equals(attr.vendor, "riscv"))              { ret 1; }
-    if (attr.arch_tag != elf.TAG_RISCV_ARCH)            { ret 1; }
-    if (!str_equals(attr.arch, RISCV64_ARCH_STRING))    { ret 1; }
+
+    # the descriptor names the CONTAINER and nothing inside it. what an image claims
+    # is per-image and comes from the derivation hook, which is declared as a pair
+    # with the merge so a link can never state one input's claims as the image's
+    if (riscv64_vtable.reloc.build_attributes == nil) { ret 1; }
+    if (riscv64_vtable.reloc.merge_attributes == nil) { ret 1; }
+    if (!isa.declares_attributes(?riscv64_vtable))    { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -342,6 +342,13 @@ pub rec ObjectImage {
     # must agree, which is how the header came to claim a soft-float non-compressed
     # ABI while the bytes were neither (#2813)
     machine_flags: u32;
+    # the arch-defined build-attribute BODY this image claims about itself (the
+    # tag/value pairs inside a `.riscv.attributes`-style section, without the
+    # container the format writer owns). owned by the image. nil with a zero length
+    # for an image that claims nothing, which is every arch but riscv64 and every
+    # input that carried no attributes section (#2828)
+    attributes:     *u8;
+    attributes_len: u32;
 }
 
 # one import an archive member declares: a symbol, and the shared library that
@@ -712,6 +719,10 @@ pub rec ImageOptions {
     # `e_flags`), which the linker derives from the resolved ABI and its inputs.
     # 0 for a format or arch that defines none (#2813)
     machine_flags: u32;
+    # the merged build-attribute body for the image being written, folded from every
+    # input by the linker. nil with a zero length when the arch defines none (#2828)
+    attributes:     *u8;
+    attributes_len: u32;
 }
 
 # make executable-image options with no optional resources
@@ -720,6 +731,8 @@ pub fun image_options_default(subsystem: Subsystem) ImageOptions {
     opts.subsystem = subsystem;
     opts.resources = nil;
     opts.machine_flags = 0;
+    opts.attributes = nil;
+    opts.attributes_len = 0;
     ret opts;
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -185,10 +185,6 @@ val ELF_ATTR_VERSION_A: u8 = 'A';
 val ELF_ATTR_TAG_FILE: u32 = 1;
 
 # the RISC-V `Tag_RISCV_arch` build-attribute tag, whose value is the ISA arch string
-# (an NTBS). pub so the riscv64 ISA's `BuildAttributes` descriptor names it; the
-# serializer reads the tag number off the descriptor, never the arch id
-pub val TAG_RISCV_ARCH: u32 = 5;
-
 # the RISC-V ELF `e_flags` bits mach can state. bit 0 says the image contains
 # compressed (C-extension) instructions; bits 2:1 name the float ABI the image's
 # calling convention uses, and a linker refuses to combine two objects that disagree
@@ -722,23 +718,25 @@ fun free_symtab_bytes(alloc: *A.Allocator, b: *SymtabBuild) {
 # ISA-string section the ELF writer stamps into objects and executables
 #
 # Supplied by the ISA through `IsaVTable.elf_attributes` so the writer never branches
-# on the arch id - it reads the section name, type, vendor, tag, and arch string off
-# this descriptor and serializes the standard ELF build-attributes container. The
-# same container backs the ARM EABI's `.ARM.attributes`, so only the values here are
-# arch-specific. An arch that emits no attributes wires a nil hook and the section is
-# simply absent.
+# on the arch id: it reads the section name, type and vendor off this descriptor and
+# serializes the standard ELF build-attributes container around a body the arch
+# supplies separately. The same container backs the ARM EABI's `.ARM.attributes`, so
+# only the values here are arch-specific. An arch that emits no attributes wires a nil
+# hook and the section is simply absent.
+#
+# THE DESCRIPTOR NAMES THE CONTAINER AND NOTHING INSIDE IT. It used to carry the arch
+# string itself, which made every image of an arch claim the same instruction set no
+# matter what was linked into it - the `e_flags` defect one section over, in the
+# section next door (#2813, #2828). What an image holds is per-image and now travels
+# with the image.
 # ---
 # section:  the attributes section name (e.g. ".riscv.attributes")
 # sht:      the ELF section type (e.g. SHT_RISCV_ATTRIBUTES)
 # vendor:   the vendor sub-section name (e.g. "riscv")
-# arch_tag: the build-attribute tag carrying the arch string (e.g. TAG_RISCV_ARCH)
-# arch:     the ISA arch string (e.g. "rv64i2p1_m2p0_a2p1_f2p2_d2p2")
 pub rec BuildAttributes {
     section:  str;
     sht:      u32;
     vendor:   str;
-    arch_tag: u32;
-    arch:     str;
 }
 
 # the concrete signature the erased `isa.IsaVTable.elf_attributes` pointer is cast
@@ -803,14 +801,14 @@ fun write_uleb128(buf: *u8, offset: usize, value: u32) usize {
 # the on-disk byte length of the serialized build-attributes section for `attr`
 #
 # The container is a format-version byte, then one vendor sub-section holding a single
-# `Tag_File` sub-sub-section that carries the lone arch-string attribute. Pairs with
+# `Tag_File` sub-sub-section that carries the arch-supplied attribute body. Pairs with
 # `write_build_attributes`, which serializes exactly this many bytes.
 # ---
-# attr: the build-attributes descriptor to measure
-# ret:  the section's byte length
-fun build_attributes_size(attr: *BuildAttributes) usize {
-    # the lone attribute: <arch_tag uleb><arch NTBS>.
-    val attr_data: usize = uleb128_size(attr.arch_tag) + str_len(attr.arch) + 1;
+# attr:     the build-attributes descriptor naming the container
+# body_len: the length of the arch's attribute body, which goes inside `Tag_File`
+# ret:      the section's byte length
+fun build_attributes_size(attr: *BuildAttributes, body_len: u32) usize {
+    val attr_data: usize = body_len::usize;
     # Tag_File sub-sub-section: <tag uleb><u32 length><attribute>; the length covers
     # the tag, the length field, and the attribute bytes.
     val file_subsec: usize = uleb128_size(ELF_ATTR_TAG_FILE) + 4 + attr_data;
@@ -825,18 +823,27 @@ fun build_attributes_size(attr: *BuildAttributes) usize {
 #
 # Lays out the ELF build-attributes container the RISC-V psABI (and ARM EABI) define:
 # an 'A' format-version byte, a vendor sub-section, and a `Tag_File` sub-sub-section
-# carrying the single arch-string attribute. Writes exactly `build_attributes_size`
+# carrying the arch's attribute body verbatim. Writes exactly `build_attributes_size`
 # bytes.
+#
+# THE BODY IS THE ARCH'S AND IS NOT INTERPRETED HERE. What tags exist, what their
+# values mean, and how two of them combine is RISC-V's business (or ARM's), and the
+# only thing this layer knows is where the body sits inside the container. Before
+# #2828 the body was one attribute built from a constant on the descriptor, which is
+# how an image came to state an instruction set it did not have.
 # ---
-# buf:    the output buffer
-# offset: byte offset to serialize at
-# attr:   the build-attributes descriptor to serialize
-fun write_build_attributes(buf: *u8, offset: usize, attr: *BuildAttributes) {
+# buf:      the output buffer
+# offset:   byte offset to serialize at
+# attr:     the build-attributes descriptor naming the container
+# body:     the arch's attribute body
+# body_len: its length in bytes
+fun write_build_attributes(buf: *u8, offset: usize, attr: *BuildAttributes,
+                           body: *u8, body_len: u32) {
     var p: usize = offset;
     buf[p] = ELF_ATTR_VERSION_A;
     p = p + 1;
 
-    val attr_data:     usize = uleb128_size(attr.arch_tag) + str_len(attr.arch) + 1;
+    val attr_data:     usize = body_len::usize;
     val file_subsec:   usize = uleb128_size(ELF_ATTR_TAG_FILE) + 4 + attr_data;
     val vendor_subsec: usize = 4 + (str_len(attr.vendor) + 1) + file_subsec;
 
@@ -845,14 +852,13 @@ fun write_build_attributes(buf: *u8, offset: usize, attr: *BuildAttributes) {
     p = p + 4;
     p = p + bin.write_str(buf, p, attr.vendor);
 
-    # Tag_File sub-sub-section: <tag uleb><u32 length><attribute>.
+    # Tag_File sub-sub-section: <tag uleb><u32 length><body>.
     p = p + write_uleb128(buf, p, ELF_ATTR_TAG_FILE);
     bin.write_u32_le(buf, p, file_subsec::u32);
     p = p + 4;
 
-    # the lone attribute: <arch_tag uleb><arch NTBS>.
-    p = p + write_uleb128(buf, p, attr.arch_tag);
-    bin.write_str(buf, p, attr.arch);
+    var i: u32 = 0;
+    for (i < body_len) { buf[p + i::usize] = body[i]; i = i + 1; }
 }
 
 # serialize an ObjectImage to a relocatable ELF64 .o file
@@ -888,9 +894,12 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
     # the ELF build-attributes section (the ISA-string `.riscv.attributes` on riscv)
     # is appended after the regular sections, the symtab/strtab/shstrtab, and the rela
     # tables, so it never perturbs their indices. nil for an arch that emits none.
-    val attr: *BuildAttributes = attributes_for(tgt_isa);
+    # the BODY is the image's own claim about itself, not a constant on the
+    # descriptor: an image with nothing to claim gets no section at all (#2828)
+    var attr: *BuildAttributes = attributes_for(tgt_isa);
+    if (img.attributes == nil || img.attributes_len == 0) { attr = nil; }
     var attr_size: usize = 0;
-    if (attr != nil) { attr_size = build_attributes_size(attr); }
+    if (attr != nil) { attr_size = build_attributes_size(attr, img.attributes_len); }
 
     val num_secs:      u32 = img.section_count;
     val num_syms:      u32 = img.symbol_count;
@@ -1154,7 +1163,9 @@ fun emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Resu
     }
 
     # the build-attributes section data, after the rela tables.
-    if (attr != nil) { write_build_attributes(buf, attr_offset, attr); }
+    if (attr != nil) {
+        write_build_attributes(buf, attr_offset, attr, img.attributes, img.attributes_len);
+    }
 
     # section-header table: null, sections, .symtab, .strtab, .shstrtab, relas, then
     # the build-attributes section last (so the indices above stay fixed).
@@ -1476,7 +1487,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     # the ISA describes, framed in its own minimal section-header table after the load
     # segments. nil for an arch that emits none, which leaves the static exe
     # section-header-less exactly as before.
-    val attr: *BuildAttributes = attributes_for(tgt_isa);
+    var attr: *BuildAttributes = attributes_for(tgt_isa);
+    if (image_options.attributes == nil || image_options.attributes_len == 0) { attr = nil; }
 
     val phdr_count: u32 = seg_count + 1;
 
@@ -1541,7 +1553,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     var sht_count:       u32 = 0;
     if (has_sht) {
         if (attr != nil) {
-            attr_sz    = build_attributes_size(attr);
+            attr_sz    = build_attributes_size(attr, image_options.attributes_len);
             attr_off   = total_size;
             total_size = total_size + attr_sz;
         }
@@ -1700,7 +1712,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     # string table, and the section headers, all after the load segments and outside
     # every PT_LOAD.
     if (has_sht) {
-        if (attr != nil) { write_build_attributes(buf, attr_off, attr); }
+        if (attr != nil) {
+            write_build_attributes(buf, attr_off, attr,
+                                   image_options.attributes, image_options.attributes_len);
+        }
 
         var di: u32 = 0;
         for (di < debug_count) {
@@ -4425,6 +4440,87 @@ fun section_has_bytes(ty: u32, machine: u16) bool {
     ret false;
 }
 
+
+# find the build-attributes section and store its BODY on the image
+#
+# Walks the section-header table for a section whose type is the processor-specific
+# attributes type, then unwraps the container this module owns - the version byte, the
+# vendor sub-section, the `Tag_File` sub-sub-section - and copies out what is inside.
+# What is inside is the ARCH's, and nothing here reads it.
+#
+# A malformed container is skipped rather than refused. An object whose attributes
+# this reader cannot follow still links; it simply contributes no claims, which is the
+# same position as an object that carried none. Refusing would turn a cosmetic section
+# into a link failure.
+# ---
+# alloc:      allocator for the copied body
+# buf:        the whole object image
+# buf_size:   its length
+# e_shoff:    section-header table offset
+# e_shentsize / e_shnum: its stride and entry count
+# out:        the image receiving `attributes` / `attributes_len`
+# ret:        ok(true), or an allocation error
+fun read_build_attributes(alloc: *A.Allocator, buf: *u8, buf_size: usize, e_shoff: usize,
+                          e_shentsize: u16, e_shnum: u16,
+                          out: *of.ObjectImage) R.Result[bool, str] {
+    out.attributes = nil;
+    out.attributes_len = 0;
+
+    var si: u32 = 0;
+    for (si < e_shnum::u32) {
+        val so: usize = e_shoff + si::usize * e_shentsize::usize;
+        si = si + 1;
+        if (bin.read_u32_le(buf, so + 4) != SHT_RISCV_ATTRIBUTES) { cnt; }
+
+        val sec_off: usize = bin.read_u64_le(buf, so + 24)::usize;
+        val sec_len: usize = bin.read_u64_le(buf, so + 32)::usize;
+        if (R.is_err[bool, str](bin.require_region(buf_size, sec_off, sec_len,
+            "elf: build-attributes section out of bounds"))) { cnt; }
+        if (sec_len < 2 || buf[sec_off] != ELF_ATTR_VERSION_A) { cnt; }
+
+        # vendor sub-section: <u32 length><vendor NTBS><Tag_File sub-sub-section>
+        var p: usize = sec_off + 1;
+        val end: usize = sec_off + sec_len;
+        if (p + 4 > end) { cnt; }
+        val vend_len: usize = bin.read_u32_le(buf, p)::usize;
+        if (vend_len < 5 || p + vend_len > end) { cnt; }
+        val vend_end: usize = p + vend_len;
+        p = p + 4;
+        # step over the vendor name; only "riscv" is understood, and another vendor's
+        # sub-section is left alone rather than misread as this one
+        val vstart: usize = p;
+        for (p < vend_end && buf[p] != 0) { p = p + 1; }
+        if (p >= vend_end) { cnt; }
+        val vlen: usize = p - vstart;
+        p = p + 1;
+        if (vlen != 5) { cnt; }
+        if (buf[vstart] != 114 || buf[vstart + 1] != 105 || buf[vstart + 2] != 115
+            || buf[vstart + 3] != 99 || buf[vstart + 4] != 118) { cnt; }
+
+        # Tag_File sub-sub-section: <tag uleb><u32 length><body>. the tag is a single
+        # byte for every value the format defines, so it is compared directly
+        if (p >= vend_end || buf[p]::u32 != ELF_ATTR_TAG_FILE) { cnt; }
+        p = p + 1;
+        if (p + 4 > vend_end) { cnt; }
+        val file_len: usize = bin.read_u32_le(buf, p)::usize;
+        # the length covers the tag byte, itself, and the body
+        if (file_len < 5) { cnt; }
+        val body_len: usize = file_len - 5;
+        p = p + 4;
+        if (p + body_len > vend_end || body_len == 0) { cnt; }
+
+        val br: R.Result[*u8, str] = A.allocate[u8](alloc, body_len);
+        if (R.is_err[*u8, str](br)) { ret R.err[bool, str](R.unwrap_err[*u8, str](br)); }
+        val body: *u8 = R.unwrap_ok[*u8, str](br);
+        var k: usize = 0;
+        for (k < body_len) { body[k] = buf[p + k]; k = k + 1; }
+        out.attributes = body;
+        out.attributes_len = body_len::u32;
+        ret R.ok[bool, str](true);
+    }
+    ret R.ok[bool, str](true);
+}
+
 # parse a relocatable ELF64 object into an ObjectImage
 #
 # Reads the section, symbol, and relocation tables of a `.o` produced by
@@ -4470,6 +4566,16 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     val vsht: R.Result[bool, str] = bin.require_region(buf_size, e_shoff,
         e_shnum::usize * e_shentsize::usize, "elf: section header table out of bounds");
     if (R.is_err[bool, str](vsht)) { ret R.err[bool, str](R.unwrap_err[bool, str](vsht)); }
+
+    # the build-attributes section, unwrapped from its container into the body the
+    # arch understands. read here rather than admitted as an ordinary section because
+    # it is not one: nothing relocates into it, it is not laid out, and its bytes are
+    # a structured claim rather than content. without this the linker folded only what
+    # this compiler's own objects claimed, so a foreign object's extensions vanished
+    # from the image that contained its instructions (#2828)
+    val vab: R.Result[bool, str] = read_build_attributes(alloc, buf, buf_size, e_shoff,
+                                                        e_shentsize, e_shnum, out);
+    if (R.is_err[bool, str](vab)) { ret R.err[bool, str](R.unwrap_err[bool, str](vab)); }
 
     # the section-name string table (offset, size); names are read against this
     # window through bin.cstr_at. validated to lie within the input when present.
@@ -5512,18 +5618,26 @@ test "mach.lang.target.of.elf.write_build_attributes:riscv_arch_layout" {
     attr.section  = ".riscv.attributes";
     attr.sht      = SHT_RISCV_ATTRIBUTES;
     attr.vendor   = "riscv";
-    attr.arch_tag = TAG_RISCV_ARCH;
-    attr.arch     = "rv64i2p0";
 
-    # 'A'(1) + [vendor-len(4) + "riscv\0"(6) + Tag_File(1) + file-len(4) + arch-tag(1)
-    # + "rv64i2p0\0"(9)] = 1 + 25 = 26; the inner Tag_File sub-sub-section is 15.
-    val sz: usize = build_attributes_size(?attr);
+    # the body the ARCH supplies, spelled here as the bytes it would produce for a
+    # lone `Tag_RISCV_arch` (5) of "rv64i2p0": this layer frames it and never reads it
+    var body: [10]u8;
+    body[0] = 5;
+    val archs: str = "rv64i2p0";
+    var bi: u32 = 0;
+    for (archs[bi::usize] != 0) { body[1 + bi] = archs[bi::usize]::u8; bi = bi + 1; }
+    body[1 + bi] = 0;
+    val body_len: u32 = bi + 2;
+
+    # 'A'(1) + [vendor-len(4) + "riscv\0"(6) + Tag_File(1) + file-len(4) + body(10)]
+    # = 1 + 25 = 26; the inner Tag_File sub-sub-section is 15.
+    val sz: usize = build_attributes_size(?attr, body_len);
     if (sz != 26) { ret 1; }
 
     val rb: R.Result[*u8, str] = A.zallocate[u8](?alloc, sz);
     if (R.is_err[*u8, str](rb)) { ret 1; }
     val buf: *u8 = R.unwrap_ok[*u8, str](rb);
-    write_build_attributes(buf, 0, ?attr);
+    write_build_attributes(buf, 0, ?attr, ?body[0], body_len);
 
     var bad: bool = false;
     if (buf[0] != ELF_ATTR_VERSION_A)      { bad = true; }
@@ -5533,7 +5647,7 @@ test "mach.lang.target.of.elf.write_build_attributes:riscv_arch_layout" {
     or (!str_equals(R.unwrap_ok[str, str](rv), "riscv")) { bad = true; }
     if (buf[11]::u32 != ELF_ATTR_TAG_FILE) { bad = true; }
     if (bin.read_u32_le(buf, 12) != 15)    { bad = true; }
-    if (buf[16]::u32 != TAG_RISCV_ARCH)    { bad = true; }
+    if (buf[16]::u32 != 5)                 { bad = true; }
     val ra: R.Result[str, str] = bin.cstr_at(buf, sz, 17);
     if (R.is_err[str, str](ra))                             { bad = true; }
     or (!str_equals(R.unwrap_ok[str, str](ra), "rv64i2p0")) { bad = true; }
@@ -5558,8 +5672,6 @@ test "mach.lang.target.of.elf.emit_object:riscv_attributes_section" {
     t_riscv_attrs.section  = ".riscv.attributes";
     t_riscv_attrs.sht      = SHT_RISCV_ATTRIBUTES;
     t_riscv_attrs.vendor   = "riscv";
-    t_riscv_attrs.arch_tag = TAG_RISCV_ARCH;
-    t_riscv_attrs.arch     = "rv64i2p0_m2p0";
 
     var seam: isa.RelocSeam = t_seam(t_riscv_elf_reloc_type::*u8);
     isa.with_elf_attributes(?seam, t_riscv_attributes::*u8);
@@ -5585,6 +5697,17 @@ test "mach.lang.target.of.elf.emit_object:riscv_attributes_section" {
     img.sections = ?secs[0]; img.section_count = 1;
     img.symbols = ?syms[0]; img.symbol_count = 1;
     img.relocations = nil; img.reloc_count = 0;
+
+    # the body travels WITH THE IMAGE: a lone `Tag_RISCV_arch` (5) naming what this
+    # particular image holds, which is the whole point of the field
+    var body: [16]u8;
+    body[0] = 5;
+    val archs: str = "rv64i2p0_m2p0";
+    var bi: u32 = 0;
+    for (archs[bi::usize] != 0) { body[1 + bi] = archs[bi::usize]::u8; bi = bi + 1; }
+    body[1 + bi] = 0;
+    img.attributes = ?body[0];
+    img.attributes_len = bi + 2;
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "elf_attr");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }


### PR DESCRIPTION
Refs #2828. Second of two PRs against that issue; #2847 landed the pairing half. **Do not merge before the 4.17.0 tag** - this is a known gap rather than a regression, and a merge landing while `dev` is being cut into `main` is a race that produces a tag nobody can reproduce.

## What was wrong

`.riscv.attributes` carried an arch string taken from a per-ISA constant. A constant describes what mach's encoder emits, and an image is not what its encoder emits - it is that plus every object linked into it. So a mach image containing a clang object built for `rv64gc` claimed no compressed extension and none of the z-extensions it actually held.

Measured on `int/surface/riscv-pcrel-pair`, whose probe clang builds as `rv64gc`:

| | Tag_RISCV_arch on the linked image | `<unknown>` in `llvm-objdump -d` |
| --- | --- | --- |
| before | `rv64i2p1_m2p0_a2p1_f2p2_d2p2` | 4 |
| after | `rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zicsr2p0_zifencei2p0_zmmul1p0` | 0 |

The four undecodable instructions are compressed float loads. They needed the arch string to say `c`, which is why `int/lib/produce.sh` carried a `--mattr=+c` override; this PR removes it. Keeping it would hide whether the image still describes itself.

## Shape

Nothing states a string. An image's claims are derived from the two facts that decide them - the resolved ABI and the emitted bytes - and a linked image's are merged from its inputs. That is deliberately the same shape as `image_machine_flags` from #2813, one section over.

**The merge rule is the arch's, and it is not one rule.** A union is right for the ISA string and wrong for everything else:

- `Tag_RISCV_arch` - union, each extension at the higher version
- `Tag_RISCV_stack_align` - must agree; the union of 8 and 16 is not an alignment, so the link is refused
- `Tag_RISCV_unaligned_access` - the maximum, since an image holding one unaligned access performs unaligned access
- `Tag_RISCV_priv_spec*` - must agree, and is dropped when it does not: not fatal, but the image cannot state one, so it states none
- anything mach does not model - kept while every input that states it agrees, dropped otherwise, because mach cannot pick between two values whose meaning it does not know

No shared layer can know which tag takes which rule, so the seam hands the arch the whole body and reads none of it. `isa.RelocSeam` gains `build_attributes` and `merge_attributes`, declared as a pair - an arch that can state one image's claims but not combine two inputs' produces a linked image claiming one input's contents, which is worse than claiming nothing.

The ELF layer keeps what is genuinely format-shared: the container, which the ARM EABI defines identically. The reader unwraps it and hands the body over; the writer frames whatever the image supplies. `BuildAttributes` loses its arch-string fields and names only the container.

## The bug this shook out

The body is **copied** in `obj.rehome_remap`, not aliased. I aliased it first, on the reasoning that the source image outlives the rehomed one. It does not - rehoming exists precisely because the source allocator is about to go away - and every riscv64 build segfaulted at object-write time with the body pointing into unmapped memory. That is the third `rehome_remap` field-lifetime trap on this issue's line of work, after `machine_flags` in #2813.

Worth noting the bisect: the crash survived disabling the reader, the linker fold, and replacing the derivation with a two-byte constant body, which ruled out everything except the field itself.

## Tests

Unit tests only, no `int` case; the freeze holds. **The merge is tested on inputs that disagree**, because two identical bodies merge to themselves under any rule including a wrong one:

- an extension one input has and the other lacks
- the same extension at two versions, asserted in **both** argument orders so the answer is the rule and not whichever side was the accumulator
- an input that claims nothing, which is what an object with no attributes section looks like
- rv32 against rv64, which does not combine into an image of either width
- `stack_align` disagreeing (refused), `unaligned_access` disagreeing (max, both orders), `priv_spec` disagreeing (dropped), an unmodelled tag agreeing then disagreeing

I mutation-checked two of them rather than trusting green: disabling version maxing, and turning the `unaligned_access` max into first-wins. Both were caught by the intended test.

Parsing is tested on both spellings a real toolchain produces (`rv64imafdc` run together and unversioned, `rv64i2p1_m2p0...` separated with versions), on multi-letter extensions, on canonical re-ordering, and on two strings that must be rejected.

## Verification

- `mach test .` 1368 passed, 0 failed
- `int` full sweeps green on linux, linux-arm64, linux-riscv64
- self-host fixpoint, each stage into a freshly removed `out/`: `stage3 == stage4` byte-identical
