### PR TITLE
feat(spirv): resolve interface variables across the emission unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### A shader can use an interface variable declared in another module (#2843)
+#2823 let a shader call a function defined in a shared module, but the shader could not use an **interface variable** one declared. A library that owned anything beyond pure math had nowhere to put its descriptor set: a drawn-in body naming its own module's `#[uniform(...)]` found nothing, and the access was refused as computed addressing.
+
+The cause was that `Emit.root` was the module being compiled and every global resolved against it, so `declare_interface`, `iface_slot_of`, `global_var_id` and the block-layout helpers could only ever see the root's. Globals now flatten into one unit-wide table exactly as functions did, `GlobalEnt` carrying the `(member, index)` pair, and every per-global array is indexed by a table index. A global's type ids are read against **its own module's** type table, which is what the `(member, index)` pair exists to make possible - reading them against the root's would resolve each id to whatever type sits at the same index there, which is a wrong type silently rather than a failure. An extern shadow is never entered in the table for the same reason: it is minted against the consumer's type table, so its type id means nothing outside the module that made it.
+
+A drawn-in module contributes globals by **reachability, not membership**, the rule the function table already stated. A shared module may declare a whole descriptor set, and a shader importing it for one helper does not inherit the rest. The root is exempt: its interface list is the module's pipeline contract, declared whole. Existing single-module shaders emit byte-identical modules.
+
+The driver half closes the module set over cross-module **global** references, not only function ones. A shader that reads a shared module's uniform and calls nothing in it must still draw that module in, and before this it could not resolve the variable at all.
+
 ### Fixed
 
 #### riscv64 images claimed an instruction set they did not have (#2828)
@@ -17,6 +28,11 @@ Nothing states a string now. An image's claims are derived from the two facts th
 The merge rule is the arch's, because a union is right for the ISA string and wrong for everything else. Stack alignment must agree or the inputs cannot be linked. Unaligned access is a permission, so the image permits it if any input needed it. A privileged-spec disagreement leaves the image unable to state one, so it states none. A tag mach does not model survives only while every input that states it agrees. No shared layer can know which tag takes which rule, so the seam hands the arch the whole attribute body and reads none of it; the ELF layer keeps only the container, which the ARM EABI defines identically.
 
 `obj.rehome_remap` copies the body rather than aliasing it. Rehoming exists precisely because the source allocator is going away, so a field holding a pointer into it needs a copy and not an assignment - the note on that function now separates the two failure modes, since a missed scalar reverts to zero on the parallel path while a missed pointer segfaults somewhere else entirely.
+
+#### Two modules could claim one descriptor set and binding with no diagnostic (#2843)
+Within one module a repeated `(set, binding)` is a typo its author can see. Across modules it is neither: two shared libraries can each declare `#[uniform(0, 0)]` without either author seeing the other, and the shader importing both is where the conflict first exists. `spirv-val` does not catch it, because two variables at one pair are well-formed SPIR-V and the conflict is with the pipeline layout, which is not in the module.
+
+The pair is now checked over the set one entry point reaches, across the descriptor roles rather than within one, since a `#[uniform(0, 0)]` and a `#[storage(0, 0)]` are two descriptor types claiming one slot. The Location overlap check widened the same way, and both diagnostics name the declaring **module** when it is not the one being compiled - a message naming two `camera`s tells the one person who can act on it nothing.
 
 ## [4.17.0] - 2026-08-08
 

--- a/src/lang/be/codegen/unit.mach
+++ b/src/lang/be/codegen/unit.mach
@@ -130,6 +130,26 @@ pub fun defined_index(m: *ir.Module, name: intern.StrId) u32 {
     ret UNIT_NONE;
 }
 
+# the index of a named global DEFINED in one module, or UNIT_NONE
+#
+# The global counterpart of `defined_index` (#2843). An extern shadow is not a
+# definition here for the same reason it is not one there: the point of asking is
+# to find the module that owns the declaration, and every consumer of a shared
+# variable carries a shadow of it.
+# ---
+# m:    the module
+# name: the interned global symbol
+# ret:  the index in `m.globals`, or UNIT_NONE
+pub fun defined_global_index(m: *ir.Module, name: intern.StrId) u32 {
+    var i: u32 = 0;
+    for (i < m.global_len) {
+        val g: *ir.Global = ?m.globals[i];
+        if (g.name == name && !g.is_extern) { ret i; }
+        i = i + 1;
+    }
+    ret UNIT_NONE;
+}
+
 # the index of the MIR function carrying a named function's body in one member
 # ---
 # u:    the unit

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1801,6 +1801,20 @@ pub fun code_sources(p: *project.Project, mid: session.ModuleId, a: *A.Allocator
                 if (def != n && !mark[def]) { mark[def] = true; changed = true; }
                 fi = fi + 1;
             }
+            # a GLOBAL referenced across a module boundary closes the set exactly as a
+            # function does (#2843): the reference reaches lowering as an extern
+            # declaration by the same mechanism, so a shader reading a shared module's
+            # `#[uniform(...)]` must draw that module in even when it calls nothing in
+            # it. leaving it out is not a missing optimization but a build that cannot
+            # resolve the variable at all.
+            var gi: u32 = 0;
+            for (gi < im.global_len) {
+                val g: *ir.Global = ?im.globals[gi];
+                if (!g.is_extern || g.is_import) { gi = gi + 1; cnt; }
+                val gdef: u32 = global_definer_of(p, g.name);
+                if (gdef != n && !mark[gdef]) { mark[gdef] = true; changed = true; }
+                gi = gi + 1;
+            }
             i = i + 1;
         }
     }
@@ -1898,6 +1912,26 @@ fun definer_of(p: *project.Project, name: intern.StrId) u32 {
     for (i < p.module_len) {
         val im: *ir.Module = p.modules[i].ir_module;
         if (im != nil && unit.defined_index(im, name) != unit.UNIT_NONE) { ret i; }
+        i = i + 1;
+    }
+    ret p.module_len;
+}
+
+# the module index that DEFINES a global symbol, or `p.module_len` for none
+#
+# The global half of `definer_of` (#2843), and separate rather than one walk taking
+# a namespace flag because the two namespaces are separate: a global and a function
+# may share neither storage nor a lookup, and a single "defined here" that consulted
+# both would answer for a name in the other namespace by accident.
+# ---
+# p:    the project
+# name: the global's linkage name
+# ret:  the defining module index, or p.module_len
+fun global_definer_of(p: *project.Project, name: intern.StrId) u32 {
+    var i: u32 = 0;
+    for (i < p.module_len) {
+        val im: *ir.Module = p.modules[i].ir_module;
+        if (im != nil && unit.defined_global_index(im, name) != unit.UNIT_NONE) { ret i; }
         i = i + 1;
     }
     ret p.module_len;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -15189,6 +15189,470 @@ test "mach.lang.driver:spirv_refuses_a_foreign_ext_call_by_name" {
     ret bad;
 }
 
+# --- interface variables across the emission unit (#2843) --------------------
+#
+# The same in-process reading as the #2823 tests above, over the other namespace a
+# drawn-in body can name. What these have to see is again beyond a validator: a
+# module that declares a descriptor it never uses, or one that omits a drawn-in
+# module's input from an entry point's interface list, is well-formed SPIR-V.
+#
+# IDENTIFYING A VARIABLE BY ITS DECORATION is the counterpart of naming a function
+# by its arity. An interface variable carries no name in the emitted module either,
+# but it carries the thing the author actually wrote - a location, or a descriptor
+# pair - and that survives renumbering.
+
+# the id decorated with `decor` carrying `value`, or 0
+# ---
+# w, n:  the instruction words
+# decor: the SPIR-V decoration
+# value: the decoration's single operand
+# ret:   the decorated id, or 0 when nothing carries it
+fun ut_spv_decorated_id(w: *u32, n: u32, decor: u32, value: u32) u32 {
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret 0; }
+        if ((w[i] & 0xFFFF) == spirv.OP_DECORATE && len >= 4
+            && w[i + 2] == decor && w[i + 3] == value) { ret w[i + 1]; }
+        i = i + len;
+    }
+    ret 0;
+}
+
+# how many ids carry `decor` at all
+fun ut_spv_decor_count(w: *u32, n: u32, decor: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        if ((w[i] & 0xFFFF) == spirv.OP_DECORATE && len >= 3 && w[i + 2] == decor) { c = c + 1; }
+        i = i + len;
+    }
+    ret c;
+}
+
+# the id of the variable decorated with both `DescriptorSet set` and `Binding bind`
+#
+# Both halves are required rather than either, because a descriptor is the PAIR: a
+# variable matching only one of them is a different binding that happens to share a
+# number, and accepting it would let a test about `(0, 1)` pass on `(0, 0)`.
+#
+# THE SEARCH IS OVER EVERY VARIABLE IN THE SET, not the first one found in it. Two
+# variables in one descriptor set differing only in binding is the normal shape -
+# it is exactly what two shared modules that do NOT collide look like - so keying
+# on the first `DescriptorSet` match and then testing its binding answers "no such
+# descriptor" for every one but the first.
+# ---
+# w, n: the instruction words
+# set:  the descriptor set
+# bind: the binding
+# ret:  the variable id, or 0
+fun ut_spv_descriptor_var(w: *u32, n: u32, set: u32, bind: u32) u32 {
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret 0; }
+        if ((w[i] & 0xFFFF) == spirv.OP_DECORATE && len >= 4
+            && w[i + 2] == spirv.DECOR_DESCRIPTOR_SET && w[i + 3] == set) {
+            val cand: u32 = w[i + 1];
+            var j: u32 = 0;
+            for (j < n) {
+                val jl: u32 = w[j] >> 16;
+                if (jl == 0) { j = n; cnt; }
+                if ((w[j] & 0xFFFF) == spirv.OP_DECORATE && jl >= 4 && w[j + 1] == cand
+                    && w[j + 2] == spirv.DECOR_BINDING && w[j + 3] == bind) { ret cand; }
+                j = j + jl;
+            }
+        }
+        i = i + len;
+    }
+    ret 0;
+}
+
+# whether entry point `k`'s interface list names `id`
+#
+# The interface operands follow the name, which is a NUL-padded literal string of
+# whatever length, so the list cannot be found at a fixed offset: the walk steps
+# over the words of the name until one of them ends in a zero byte, and what
+# follows to the end of the instruction is the list.
+# ---
+# w, n: the instruction words
+# k:    which entry point, in emission order
+# id:   the variable id
+# ret:  true when the list carries it
+fun ut_spv_entry_iface_has(w: *u32, n: u32, k: u32, id: u32) bool {
+    var i: u32 = 0;
+    var seen: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret false; }
+        if ((w[i] & 0xFFFF) == spirv.OP_ENTRY_POINT) {
+            if (seen == k) {
+                var j: u32 = i + 3;
+                var ended: bool = false;
+                for (j < i + len && !ended) {
+                    if ((w[j] & 0xFF000000) == 0 || (w[j] & 0x00FF0000) == 0
+                        || (w[j] & 0x0000FF00) == 0 || (w[j] & 0x000000FF) == 0) { ended = true; }
+                    j = j + 1;
+                }
+                for (j < i + len) {
+                    if (w[j] == id) { ret true; }
+                    j = j + 1;
+                }
+                ret false;
+            }
+            seen = seen + 1;
+        }
+        i = i + len;
+    }
+    ret false;
+}
+
+# the shared module of the interface fixture: a descriptor and a location pair it
+# owns, one helper that reaches them, and a second that reaches neither
+#
+# `unused_cam` and `unused_in` are the whole point of the omission test: they are
+# declared by a module the shader draws from, and nothing the shader reaches names
+# them. A shader that declared them anyway would validate perfectly.
+fun ut_spv_iface_lib_src() str {
+    ret "rec Used   { a: f32; b: f32; c: f32; d: f32; }\nrec Unused { a: f32; b: f32; c: f32; d: f32; }\n\n#[uniform(0, 0)] pub var used_cam:   Used;\n#[uniform(0, 3)] pub var unused_cam: Unused;\n#[input(6)]      pub var lib_in:     f32;\n#[input(7)]      pub var unused_in:  f32;\n\n#[noinline]\npub fun touch_used(v: f32) f32 { ret v * used_cam.a + lib_in; }\n\n#[noinline]\npub fun touch_nothing(v: f32) f32 { ret v * 2.0; }\n\n#[noinline]\npub fun never_called(v: f32) f32 { ret v * unused_cam.a + unused_in; }\n";
+}
+
+# the shader: one stage reaching the shared module's variables, one reaching none
+fun ut_spv_iface_root_src() str {
+    ret "use l: spvcase.ilib;\n\n#[input(0)]  var in_x:  f32;\n#[output(0)] var out_a: f32;\n#[output(1)] var out_b: f32;\n\n#[stage(\"vertex\")]\nfun vert_main() { out_a = l.touch_used(in_x); }\n\n#[stage(\"fragment\")]\nfun frag_main() { out_b = l.touch_nothing(in_x); }\n\nfun main() i32 { ret 0; }\n";
+}
+
+# load and lower the interface fixture
+fun ut_spv_iface_fixture(s: *session.Session, alloc: *A.Allocator) R.Result[project.Project, outcome.Fail] {
+    var names: [2]str;
+    var texts: [2]str;
+    names[0] = "main.mach"; texts[0] = ut_spv_iface_root_src();
+    names[1] = "ilib.mach"; texts[1] = ut_spv_iface_lib_src();
+    var dn: [1]str;
+    var dt: [1]str;
+    ret ut_spv_lower(s, alloc, ?names[0], ?texts[0], 2, "", ?dn[0], ?dt[0], 0);
+}
+
+# a shader emits an interface variable declared in a module it draws a body from,
+# with the descriptor the shared module's author wrote (#2843)
+#
+# Before this, every global resolved against the root, so a drawn-in body naming
+# one found nothing and the access was refused as computed addressing - a shared
+# module could own functions but not the descriptor set they read, which is the
+# first thing a shader library needs beyond pure math.
+#
+# The assertions are about the DECORATIONS rather than about the variable count,
+# because the decoration is what a pipeline binds against and it is what the author
+# wrote. `(0, 0)` present says the descriptor crossed the boundary intact; the
+# Location assertions say the same for the other two roles.
+test "mach.lang.driver:spirv_emits_an_interface_global_from_another_module" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_iface_fixture(?s, ?alloc);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    # the shared module's `#[uniform(0, 0)]`, carried across with both halves of its
+    # descriptor. this is the case the issue is named for.
+    val cam: u32 = ut_spv_descriptor_var(w, n, 0, 0);
+    if (cam == 0) { bad = 1; }
+    # its `#[input(6)]`, reached through the same drawn-in body.
+    if (ut_spv_decorated_id(w, n, spirv.DECOR_LOCATION, 6) == 0) { bad = 1; }
+    # and the root's own variables still land where they always did, so widening the
+    # table did not renumber or drop what already worked.
+    if (ut_spv_decorated_id(w, n, spirv.DECOR_LOCATION, 0) == 0) { bad = 1; }
+    if (ut_spv_decorated_id(w, n, spirv.DECOR_LOCATION, 1) == 0) { bad = 1; }
+    # every call still names a body this module defines.
+    if (!ut_spv_calls_all_resolve(w, n)) { bad = 1; }
+    # and the shader publishes nothing, so the variable it drew in is its own
+    # private copy rather than a second definition of the library's symbol.
+    if (ut_spv_export_count(w, n) != 0)  { bad = 1; }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a drawn-in module's interface variables arrive by REACHABILITY, not by membership
+# (#2843)
+#
+# The rule the function table already stated, applied to globals, and the reason it
+# has to hold: a shared module may declare a whole descriptor set, and a shader
+# importing it for one helper must not inherit the rest. Two unrelated libraries
+# would otherwise collide on a binding neither the shader nor either author used.
+#
+# `unused_cam` at `(0, 3)` and `unused_in` at location 7 are declared by a module
+# this shader DOES draw from, and are named only by `never_called`. Their absence
+# is the assertion. The control underneath it matters as much: the library's own
+# module still declares both, so this is the shader narrowing what it carries
+# rather than the compiler losing a declaration.
+test "mach.lang.driver:spirv_omits_an_unreached_interface_global" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_iface_fixture(?s, ?alloc);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    # what nothing reaches is absent.
+    if (ut_spv_descriptor_var(w, n, 0, 3) != 0)                      { bad = 1; }
+    if (ut_spv_decorated_id(w, n, spirv.DECOR_LOCATION, 7) != 0)     { bad = 1; }
+    # exactly one descriptor came across, so the omission is not the whole set going
+    # missing.
+    if (ut_spv_decor_count(w, n, spirv.DECOR_DESCRIPTOR_SET) != 1)   { bad = 1; }
+    obj.dnit(?img);
+
+    # THE CONTROL: the library compiled on its own still declares both descriptors.
+    # Without it this test would pass against a compiler that dropped every drawn-in
+    # global, which is the bug it is meant to guard the fix against.
+    var lib: of.ObjectImage;
+    var lerr: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.ilib", ?lib, ?lerr)) { bad = 1; }
+    or {
+        var ln: u32 = 0;
+        val lw: *u32 = ut_spv_words(?lib, ?ln);
+        if (lw == nil)                                                { bad = 1; }
+        or {
+            if (ut_spv_descriptor_var(lw, ln, 0, 0) == 0)             { bad = 1; }
+            if (ut_spv_descriptor_var(lw, ln, 0, 3) == 0)             { bad = 1; }
+            if (ut_spv_decorated_id(lw, ln, spirv.DECOR_LOCATION, 7) == 0) { bad = 1; }
+            # NEITHER MODULE PUBLISHES THE VARIABLE. A consumer linking the library
+            # and a shader that draws from it must meet one definition of each
+            # symbol, and a variable declared in both would be two. The library
+            # exports its three functions and nothing else, so the count is what
+            # says the four interface variables stayed private; the shader exports
+            # nothing at all, being a shader module.
+            if (ut_spv_export_count(lw, ln) != 3)                     { bad = 1; }
+        }
+        obj.dnit(?lib);
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# an entry point names a drawn-in module's interface variable exactly when it can
+# reach it, and not otherwise (#2843)
+#
+# The interface list is per entry point while the declarations are per module, so
+# "declared" and "listed" are different questions and only the second is about
+# reachability. `vert_main` reaches the shared module's variables through
+# `touch_used`; `frag_main` calls `touch_nothing`, which reaches none of them.
+#
+# BOTH DIRECTIONS ARE ASSERTED deliberately. Presence alone would pass against an
+# emitter that listed every declared variable in every entry point - which is a
+# module `spirv-val` accepts and a driver would bind, and which silently makes the
+# reachability walk decorative.
+test "mach.lang.driver:spirv_entry_lists_a_drawn_in_global_only_when_reached" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_iface_fixture(?s, ?alloc);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    val cam: u32 = ut_spv_descriptor_var(w, n, 0, 0);
+    val lin: u32 = ut_spv_decorated_id(w, n, spirv.DECOR_LOCATION, 6);
+    val ob:  u32 = ut_spv_decorated_id(w, n, spirv.DECOR_LOCATION, 1);
+    if (cam == 0 || lin == 0 || ob == 0) {
+        obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+
+    # the fixture's stages are emitted in source order, so entry 0 is `vert_main`.
+    # asserted rather than assumed: `out_b` at location 1 is written only by
+    # `frag_main`, so whichever entry lists it is the fragment one.
+    var vx: u32 = 0;
+    if (ut_spv_entry_iface_has(w, n, 0, ob)) { vx = 1; }
+    val fx: u32 = 1 - vx;
+
+    # the vertex stage reaches both, through `touch_used`.
+    if (!ut_spv_entry_iface_has(w, n, vx, cam)) { bad = 1; }
+    if (!ut_spv_entry_iface_has(w, n, vx, lin)) { bad = 1; }
+    # the fragment stage reaches neither, and must not list them.
+    if (ut_spv_entry_iface_has(w, n, fx, cam))  { bad = 1; }
+    if (ut_spv_entry_iface_has(w, n, fx, lin))  { bad = 1; }
+    # and it does list its own output, so an empty list is not what makes the two
+    # assertions above pass.
+    if (!ut_spv_entry_iface_has(w, n, fx, ob))  { bad = 1; }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# two modules claiming one descriptor are refused, and the diagnostic names the
+# MODULES (#2843)
+#
+# Within one module a repeated `(set, binding)` is a typo its author can see. Across
+# modules it is not: two shared libraries can each declare `#[uniform(0, 0)]`
+# without either author seeing the other, and the shader importing both is where
+# the conflict first exists. So the message has to carry the module paths - naming
+# two variables tells the one person who can act on it nothing.
+#
+# `spirv-val` does not catch this. Two variables at one `(set, binding)` are
+# well-formed SPIR-V; the conflict is with the pipeline layout, which is not in the
+# module. This check is therefore here or nowhere.
+#
+# THE COUNTERFACTUAL IS PART OF THE TEST. The same two modules with `libb` moved to
+# binding 1 must BUILD, because a refusal test whose fixture would be refused for
+# any reason - a parse error, a missing symbol, an unrelated rule - asserts nothing
+# about the rule it names.
+#
+# THE MESSAGE IS ASSERTED, NOT MERELY THE REFUSAL, for the same reason. Before this
+# change these very modules were refused too, as computed addressing, because a
+# drawn-in global resolved to nothing. An `is_err` assertion would have passed
+# against the unfixed compiler and gone on passing forever while proving nothing:
+# whenever the fixed and the broken behaviour are both spelled "an error", only the
+# text tells them apart.
+test "mach.lang.driver:spirv_refuses_a_descriptor_collision_across_modules" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str;
+    var texts: [3]str;
+    names[0] = "main.mach";
+    texts[0] = "use a: spvcase.liba;\nuse b: spvcase.libb;\n\n#[input(0)]  var in_x:  f32;\n#[output(0)] var out_a: f32;\n\n#[stage(\"vertex\")]\nfun vert_main() { out_a = a.from_a(in_x) + b.from_b(in_x); }\n\nfun main() i32 { ret 0; }\n";
+    names[1] = "liba.mach";
+    texts[1] = "rec CamA { x: f32; y: f32; z: f32; w: f32; }\n#[uniform(0, 0)] pub var cam_a: CamA;\n\n#[noinline]\npub fun from_a(v: f32) f32 { ret v * cam_a.x; }\n";
+    names[2] = "libb.mach";
+    texts[2] = "rec CamB { p: f32; q: f32; r: f32; s: f32; }\n#[uniform(0, 0)] pub var cam_b: CamB;\n\n#[noinline]\npub fun from_b(v: f32) f32 { ret v * cam_b.p; }\n";
+    var dn: [1]str;
+    var dt: [1]str;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 3, "", ?dn[0], ?dt[0], 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+
+    # each library alone is clean: one descriptor, no one to collide with. without
+    # this the test would pass against a compiler that refused the fixture outright.
+    var la: of.ObjectImage;
+    var lae: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.liba", ?la, ?lae)) { bad = 1; }
+    or { obj.dnit(?la); }
+
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        bad = 1;
+        obj.dnit(?img);
+    }
+    or {
+        if (err == nil) { bad = 1; }
+        or {
+            # the rule it broke, stated as the pair rather than as one number.
+            if (!ut_str_contains(err, "set = 0, binding = 0")) { bad = 1; }
+            # and BOTH declaring modules, which is the whole point of the message.
+            if (!ut_str_contains(err, "spvcase.liba"))         { bad = 1; }
+            if (!ut_str_contains(err, "spvcase.libb"))         { bad = 1; }
+        }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# the counterfactual for the collision above: the same shape at two DIFFERENT
+# bindings builds, and carries both descriptors (#2843)
+#
+# Separated into its own test rather than tacked onto the refusal so that a failure
+# says which half broke. A check that refuses too much and a check that refuses the
+# right thing are indistinguishable from the refusal alone.
+test "mach.lang.driver:spirv_accepts_two_modules_at_distinct_bindings" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str;
+    var texts: [3]str;
+    names[0] = "main.mach";
+    texts[0] = "use a: spvcase.liba;\nuse b: spvcase.libb;\n\n#[input(0)]  var in_x:  f32;\n#[output(0)] var out_a: f32;\n\n#[stage(\"vertex\")]\nfun vert_main() { out_a = a.from_a(in_x) + b.from_b(in_x); }\n\nfun main() i32 { ret 0; }\n";
+    names[1] = "liba.mach";
+    texts[1] = "rec CamA { x: f32; y: f32; z: f32; w: f32; }\n#[uniform(0, 0)] pub var cam_a: CamA;\n\n#[noinline]\npub fun from_a(v: f32) f32 { ret v * cam_a.x; }\n";
+    names[2] = "libb.mach";
+    # the ONLY difference from the refused fixture: binding 1 rather than binding 0.
+    texts[2] = "rec CamB { p: f32; q: f32; r: f32; s: f32; }\n#[uniform(0, 1)] pub var cam_b: CamB;\n\n#[noinline]\npub fun from_b(v: f32) f32 { ret v * cam_b.p; }\n";
+    var dn: [1]str;
+    var dt: [1]str;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 3, "", ?dn[0], ?dt[0], 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    # both libraries' descriptors are present, and they are DIFFERENT variables.
+    val va: u32 = ut_spv_descriptor_var(w, n, 0, 0);
+    val vb: u32 = ut_spv_descriptor_var(w, n, 0, 1);
+    if (va == 0 || vb == 0 || va == vb) { bad = 1; }
+    if (ut_spv_decor_count(w, n, spirv.DECOR_DESCRIPTOR_SET) != 2) { bad = 1; }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
 # capture of one phase's reported roll-up, for the load-count regression (#2850)
 # ---
 # counts:  per-phase count as reported to `phase_end`

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -118,17 +118,22 @@ use semtype: mach.lang.type;
 # has_entry: whether any function in the ROOT declares a pipeline stage, which
 #           decides whether this is a shader module (entry points, no Linkage) or a
 #           library module (Linkage exports, no entry point)
+# gls:      the unit's globals, flattened into one table exactly as `fns` flattens
+#           its functions - the root's in IR order first, then the globals a drawn-in
+#           body reaches. every per-global array below is indexed by a table index,
+#           NOT by a root IR global index
+# gl_len:   how many entries that table has
 # gtype_ids: the SPIR-V VALUE type each interface variable was declared with, and
 #           gstorage its storage class. An access chain's result is a pointer to a
 #           member of that exact type, and a laid-out block's array members are not
 #           interned, so the declared id has to be remembered rather than rebuilt.
-# gvar_ids: SPIR-V OpVariable id per IR global index, allocated before any body is
+# gvar_ids: SPIR-V OpVariable id per global-table index, allocated before any body is
 #           emitted so a load or store can name a variable declared later (0 for a
 #           global carrying no interface role)
 # iface_ids: the Input / Output variable ids, in declaration order; an entry point
 #           lists the subset of these it can reach
 # iface_len: how many of `iface_ids` are live
-# gslot:    per IR global index, one more than its slot in `iface_ids`, or 0 when
+# gslot:    per global-table index, one more than its slot in `iface_ids`, or 0 when
 #           the global is not entry-point interface
 # iface_use: a (unit function) x (interface slot) matrix, 1 where that function can
 #           reach that variable, transitively through its calls. an entry point
@@ -146,6 +151,8 @@ rec Emit {
     fns:       *FnEnt;
     fn_len:    u32;
     has_entry: bool;
+    gls:       *GlobalEnt;
+    gl_len:    u32;
     gvar_ids:  *u32;
     gtype_ids: *u32;
     gstorage:  *u32;
@@ -253,6 +260,32 @@ rec FnEnt {
     emit:   bool;
 }
 
+# one module-scope global the emission unit offers, wherever it came from
+#
+# The same flattening `FnEnt` performs, applied to the other namespace a body can
+# name (#2843). It is deliberately the same shape rather than a variant of it: the
+# pair (`mi`, `ir_ix`) is again the only place the module boundary stays visible,
+# and again it is visible exactly where it has to be, reading a global's type
+# against the type table that gave its type id meaning.
+#
+# WHY A GLOBAL NEEDS THIS AND A LOCAL DOES NOT. An interface variable is a
+# module-scope `OpVariable` with decorations, and nothing in the emitted module
+# records which mach module the source declaration sat in. So a shared module can
+# own a descriptor set - the pattern a shader library reaches for the moment it
+# owns anything beyond pure functions - and the only thing that ever stopped it was
+# the emitter resolving every global against the root.
+# ---
+# mi:    the unit member this global is declared in
+# ir_ix: its index in that member's IR globals
+# name:  its interned link name, cached so a reference resolves without a nested
+#        walk. module-path mangled and so globally unique, which is what lets a
+#        single linear scan answer for the whole unit
+rec GlobalEnt {
+    mi:    u32;
+    ir_ix: u32;
+    name:  intern.StrId;
+}
+
 # emit a complete SPIR-V module for one lowered emission unit
 #
 # Builds the module preamble (Shader + Linkage capabilities, the logical GLSL450
@@ -295,7 +328,7 @@ pub fun emit_module(tgt: *resolved.Target, u: *unit.Unit,
     var e: Emit;
     e.alloc = mirmod.alloc; e.interner = mirmod.interner;
     e.tgt = tgt; e.u = u; e.root = irmod; e.ir = irmod; e.cur_mi = u.root;
-    e.b = ?b; e.tt = ?tt; e.fns = nil; e.fn_len = 0;
+    e.b = ?b; e.tt = ?tt; e.fns = nil; e.fn_len = 0; e.gls = nil; e.gl_len = 0;
     e.gvar_ids = nil; e.gtype_ids = nil; e.gstorage = nil; e.iface_ids = nil; e.iface_len = 0;
     e.gslot = nil; e.iface_use = nil;
     var xi: u32 = 0;
@@ -329,6 +362,17 @@ pub fun emit_module(tgt: *resolved.Target, u: *unit.Unit,
         types.types_dnit(?tt);
         spirv.builder_dnit(?b);
         ret rr;
+    }
+
+    # the global table is built after the emitted closure is known, because a
+    # drawn-in member contributes the globals that closure REACHES and nothing else
+    # (#2843). The root's own are in it either way.
+    val gtr: R.Result[bool, str] = build_gl_table(?e);
+    if (R.is_err[bool, str](gtr)) {
+        emit_dnit(?e);
+        types.types_dnit(?tt);
+        spirv.builder_dnit(?b);
+        ret gtr;
     }
 
     # interface variables are declared before any body, both because a SPIR-V global
@@ -414,26 +458,30 @@ fun emit_dnit(e: *Emit) {
     if (e.fns != nil && e.fn_len > 0) { A.deallocate[FnEnt](e.alloc, e.fns, e.fn_len::usize); }
     e.fns    = nil;
     e.fn_len = 0;
-    if (e.gvar_ids != nil && e.root.global_len > 0) {
-        A.deallocate[u32](e.alloc, e.gvar_ids, e.root.global_len::usize);
+    if (e.gvar_ids != nil && e.gl_len > 0) {
+        A.deallocate[u32](e.alloc, e.gvar_ids, e.gl_len::usize);
     }
     e.gvar_ids = nil;
-    if (e.iface_ids != nil && e.root.global_len > 0) {
-        A.deallocate[u32](e.alloc, e.iface_ids, e.root.global_len::usize);
+    if (e.iface_ids != nil && e.gl_len > 0) {
+        A.deallocate[u32](e.alloc, e.iface_ids, e.gl_len::usize);
     }
     e.iface_ids = nil;
-    if (e.gslot != nil && e.root.global_len > 0) {
-        A.deallocate[u32](e.alloc, e.gslot, e.root.global_len::usize);
+    if (e.gslot != nil && e.gl_len > 0) {
+        A.deallocate[u32](e.alloc, e.gslot, e.gl_len::usize);
     }
     e.gslot = nil;
-    if (e.gtype_ids != nil && e.root.global_len > 0) {
-        A.deallocate[u32](e.alloc, e.gtype_ids, e.root.global_len::usize);
+    if (e.gtype_ids != nil && e.gl_len > 0) {
+        A.deallocate[u32](e.alloc, e.gtype_ids, e.gl_len::usize);
     }
     e.gtype_ids = nil;
-    if (e.gstorage != nil && e.root.global_len > 0) {
-        A.deallocate[u32](e.alloc, e.gstorage, e.root.global_len::usize);
+    if (e.gstorage != nil && e.gl_len > 0) {
+        A.deallocate[u32](e.alloc, e.gstorage, e.gl_len::usize);
     }
     e.gstorage = nil;
+    # the table itself last: every free above is sized by its length.
+    if (e.gls != nil && e.gl_len > 0) { A.deallocate[GlobalEnt](e.alloc, e.gls, e.gl_len::usize); }
+    e.gls    = nil;
+    e.gl_len = 0;
 }
 
 # flatten every defined function in the unit into one table
@@ -669,6 +717,183 @@ fun fn_mir(e: *Emit, ix: u32) *mir.MirFunction {
     ret ?e.u.mods[e.fns[ix].mi].mir.functions[e.fns[ix].mir_ix];
 }
 
+# flatten the unit's reachable globals into one table (#2843)
+#
+# THE ROOT'S GLOBALS COME FIRST, all of them, in IR order. That is what keeps a
+# module drawing nothing in emitting exactly the bytes it emitted before: the table
+# is then the root's global list with the same indices it always had, and every id
+# minted off it is unchanged.
+#
+# A NON-ROOT MEMBER CONTRIBUTES BY REACHABILITY, NOT BY MEMBERSHIP, which is the
+# same rule the function table already states and is not a convenience here. A
+# shared module may declare a whole descriptor set; a shader importing it for one
+# helper must not inherit the rest, both because the module would grow without
+# bound and because two unrelated libraries could then collide on a binding that
+# neither the shader nor either author ever used. So a member's global is entered
+# only when an EMITTED function names it.
+#
+# The root is exempt from that filter deliberately. Its interface list is the
+# module's pipeline contract, declared whole whether or not a stage happens to read
+# every part of it, and narrowing it here would change what existing shaders emit.
+#
+# ONLY DECLARATIONS ARE ENTERED, never an extern shadow, for the reason the function
+# table states and one more that is specific to globals. A consumer's shadow of
+# someone else's variable is minted by `ensure_extern_global` against the
+# CONSUMER's type table, so its type id means nothing outside that module: reading
+# it as the variable's type would resolve to whatever type sits at the same index
+# there, which is a wrong type silently rather than a failure. The definition is
+# found once, in the module that made it, and every reference resolves to that.
+# ---
+# e:   the emission state
+# ret: true on success, or an allocation error
+fun build_gl_table(e: *Emit) R.Result[bool, str] {
+    var n: u32 = 0;
+    var i0: u32 = 0;
+    for (i0 < e.root.global_len) {
+        if (gl_eligible(?e.root.globals[i0])) { n = n + 1; }
+        i0 = i0 + 1;
+    }
+    var mi: u32 = 0;
+    for (mi < e.u.len) {
+        if (mi == e.u.root) { mi = mi + 1; cnt; }
+        val m: *ir.Module = e.u.mods[mi].ir;
+        var i: u32 = 0;
+        for (i < m.global_len) {
+            if (gl_eligible(?m.globals[i]) && global_is_reached(e, m.globals[i].name)) { n = n + 1; }
+            i = i + 1;
+        }
+        mi = mi + 1;
+    }
+    if (n == 0) { ret R.ok[bool, str](true); }
+
+    val rt: R.Result[*GlobalEnt, str] = A.allocate[GlobalEnt](e.alloc, n::usize);
+    if (R.is_err[*GlobalEnt, str](rt)) { ret R.err[bool, str](R.unwrap_err[*GlobalEnt, str](rt)); }
+    e.gls    = R.unwrap_ok[*GlobalEnt, str](rt);
+    e.gl_len = n;
+
+    var k: u32 = 0;
+    var i2: u32 = 0;
+    for (i2 < e.root.global_len) {
+        if (!gl_eligible(?e.root.globals[i2])) { i2 = i2 + 1; cnt; }
+        e.gls[k].mi    = e.u.root;
+        e.gls[k].ir_ix = i2;
+        e.gls[k].name  = e.root.globals[i2].name;
+        k = k + 1;
+        i2 = i2 + 1;
+    }
+    mi = 0;
+    for (mi < e.u.len) {
+        if (mi == e.u.root) { mi = mi + 1; cnt; }
+        val m: *ir.Module = e.u.mods[mi].ir;
+        var i: u32 = 0;
+        for (i < m.global_len) {
+            if (!gl_eligible(?m.globals[i]) || !global_is_reached(e, m.globals[i].name)) { i = i + 1; cnt; }
+            e.gls[k].mi    = mi;
+            e.gls[k].ir_ix = i;
+            e.gls[k].name  = m.globals[i].name;
+            k = k + 1;
+            i = i + 1;
+        }
+        mi = mi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# whether any EMITTED function names this global
+#
+# A reference reaches the back end as a symbol operand carrying the global's
+# mangled name, which is the same key `address_origin` resolves against, so asking
+# the question here and answering it there cannot drift.
+#
+# The scan is over the emitted closure rather than the whole unit for the reason
+# `build_gl_table` states: a function the module dropped brings nothing with it.
+# ---
+# e:    the emission state
+# name: the global's interned link name
+# ret:  true when some emitted body carries a symbol operand naming it
+fun global_is_reached(e: *Emit, name: intern.StrId) bool {
+    var fx: u32 = 0;
+    for (fx < e.fn_len) {
+        if (!e.fns[fx].emit) { fx = fx + 1; cnt; }
+        val mf: *mir.MirFunction = fn_mir(e, fx);
+        if (mf == nil) { fx = fx + 1; cnt; }
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                val mi: *mir.MirInstr = ?blk.instrs[ii];
+                var oi: u32 = 0;
+                for (oi < mi.operand_count) {
+                    if (mi.operands[oi].kind == mir.MIR_OP_SYM
+                        && mi.operands[oi].sym == name) { ret true; }
+                    oi = oi + 1;
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fx = fx + 1;
+    }
+    ret false;
+}
+
+# whether an IR global is a DECLARATION this unit can resolve against
+# ---
+# g:   the IR global
+# ret: false for an extern shadow of a definition that lives elsewhere
+fun gl_eligible(g: *ir.Global) bool {
+    ret !g.is_extern && !g.is_import;
+}
+
+# the IR record behind a global-table entry
+fun gl_ir(e: *Emit, ix: u32) *ir.Global {
+    ret ?e.u.mods[e.gls[ix].mi].ir.globals[e.gls[ix].ir_ix];
+}
+
+# the type table a global-table entry's type ids belong to
+#
+# The whole reason `GlobalEnt` carries `mi`. A global declared in a drawn-in member
+# types against THAT member's table, and reading it against the root's would resolve
+# the id to whatever type happens to sit at the same index there - a wrong type
+# silently, not a failure.
+fun gl_types(e: *Emit, ix: u32) *type.IrTypeTable {
+    ret ?e.u.mods[e.gls[ix].mi].ir.types;
+}
+
+# the global-table index for an interned link name, or GL_NONE
+fun gl_lookup(e: *Emit, name: intern.StrId) u32 {
+    var i: u32 = 0;
+    for (i < e.gl_len) {
+        if (e.gls[i].name == name) { ret i; }
+        i = i + 1;
+    }
+    ret GL_NONE;
+}
+
+# a global named for a diagnostic, qualified by its module when it is not the root's
+#
+# A collision between two modules' declarations is the case this exists for: a
+# message naming two `camera`s helps nobody, and the module path is the only thing
+# that distinguishes them. The root's own globals stay unqualified so an existing
+# single-module diagnostic reads exactly as it did.
+#
+# IR keeps a global's MANGLED name and no source spelling, so the module path is
+# what is available and the variable itself is named by the decorator the author
+# wrote at each call site rather than by its symbol.
+# ---
+# e:  the emission state
+# ix: the global-table index
+# ret: the module path, or "" for a root global
+fun gl_mod_prefix(e: *Emit, ix: u32) str {
+    if (ix >= e.gl_len || e.gls[ix].mi == e.u.root) { ret ""; }
+    val mo: O.Option[str] = intern.lookup(e.interner, e.u.mods[e.gls[ix].mi].ir.name);
+    if (O.is_none[str](mo)) { ret ""; }
+    val q: R.Result[str, str] = format.sprint(e.alloc, ", declared in `{}`", O.unwrap[str](mo));
+    if (R.is_err[str, str](q)) { ret ""; }
+    ret R.unwrap_ok[str, str](q);
+}
+
 # declare one global OpVariable per interface-roled global, with its decorations
 #
 # A shader stage does not receive its inputs or hand back its outputs through a
@@ -684,7 +909,7 @@ fun fn_mir(e: *Emit, ix: u32) *mir.MirFunction {
 # e:   the emission state
 # ret: true on success, or a precise error string
 fun declare_interface(e: *Emit) R.Result[bool, str] {
-    val n: u32 = e.root.global_len;
+    val n: u32 = e.gl_len;
     if (n == 0) { ret R.ok[bool, str](true); }
 
     val rg: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
@@ -709,7 +934,8 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
 
     i = 0;
     for (i < n) {
-        val g: *ir.Global = ?e.root.globals[i];
+        val g: *ir.Global = gl_ir(e, i);
+        val gt: *type.IrTypeTable = gl_types(e, i);
         if (g.iface == ir.IFACE_NONE) { i = i + 1; cnt; }
 
         # a built-in declared at a type other than the one SPIR-V specifies for it is
@@ -721,7 +947,7 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
         # attribute it to, and attributing it to `<unknown function>` would point a
         # reader away from the declaration that is the whole subject.
         if (g.iface == ir.IFACE_BUILTIN) {
-            val br: str = builtin_type_refusal(?e.root.types, e.alloc, g.iface_a, g.ty);
+            val br: str = builtin_type_refusal(gt, e.alloc, g.iface_a, g.ty);
             if (br != nil) { ret R.err[bool, str](br); }
         }
 
@@ -741,7 +967,7 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
         # otherwise be emitted as an Input-class opaque variable, which no Vulkan
         # environment accepts, and a `#[sampler]` of an ordinary type as a
         # UniformConstant block, which is a different descriptor entirely (#2794).
-        val handle: bool = is_image_type(e, g.ty);
+        val handle: bool = is_image_type(e, gt, g.ty);
         if (handle && g.iface != ir.IFACE_SAMPLER) {
             ret R.err[bool, str]("spirv.emit: an image handle carries an interface role other than `#[sampler(set, binding)]`; a handle is bound as a descriptor and reaches no other storage class");
         }
@@ -755,11 +981,11 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
             # rejects a bare scalar or vector in either class outright, so the mach
             # type has to be a record and the block layout is emitted with it. The two
             # differ in their LAYOUT rules, which `block_type` takes as its posture.
-            val ur: R.Result[u32, str] = block_type(e, g.ty, g.iface == ir.IFACE_STORAGE);
+            val ur: R.Result[u32, str] = block_type(e, gt, g.ty, g.iface == ir.IFACE_STORAGE);
             if (R.is_err[u32, str](ur)) { ret R.err[bool, str](R.unwrap_err[u32, str](ur)); }
             value_ty = R.unwrap_ok[u32, str](ur);
         }
-        or { value_ty = global_spv_type(e, g.ty); }
+        or { value_ty = global_spv_type(e, gt, g.ty); }
         if (value_ty == 0) {
             ret unsupported(e, "unsupported shader interface variable type in the SPIR-V target");
         }
@@ -808,8 +1034,8 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
 # e:   the emission state
 # id:  the IR type of the uniform global
 # ret: the OpTypeStruct id, or a precise error string
-fun block_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun block_type(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform global has no IR type"); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
     if (t.kind != type.IRT_STRUCT) {
@@ -820,7 +1046,7 @@ fun block_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, 
         ret R.err[u32, str]("a `#[uniform(...)]` / `#[storage(...)]` block must have between 1 and 16 fields");
     }
 
-    val sr: R.Result[u32, str] = laid_out_struct(e, id, relaxed_stride);
+    val sr: R.Result[u32, str] = laid_out_struct(e, gt, id, relaxed_stride);
     if (R.is_err[u32, str](sr)) { ret sr; }
     val struct_id: u32 = R.unwrap_ok[u32, str](sr);
 
@@ -838,8 +1064,8 @@ fun block_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, 
 # e:   the emission state
 # id:  the IR struct type
 # ret: the OpTypeStruct id, or a precise error string
-fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun laid_out_struct(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform block member has no IR type"); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
     val n: u32 = t.data.struct_.field_count;
@@ -850,7 +1076,7 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[
     var members: [16]u32;
     var i: u32 = 0;
     for (i < n) {
-        val mr: R.Result[u32, str] = laid_out_type(e, t.data.struct_.fields[i], relaxed_stride);
+        val mr: R.Result[u32, str] = laid_out_type(e, gt, t.data.struct_.fields[i], relaxed_stride);
         if (R.is_err[u32, str](mr)) { ret mr; }
         members[i] = R.unwrap_ok[u32, str](mr);
         i = i + 1;
@@ -859,7 +1085,7 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[
     # the offsets about to be decorated are mach's own, so they are checked against
     # the layout Vulkan requires BEFORE they are emitted, and a block whose members
     # disagree is refused rather than given a plausible wrong offset (#2746).
-    val lr: R.Result[bool, str] = check_block_layout(e, id, relaxed_stride);
+    val lr: R.Result[bool, str] = check_block_layout(e, gt, id, relaxed_stride);
     if (R.is_err[bool, str](lr)) { ret R.err[u32, str](R.unwrap_err[bool, str](lr)); }
     val struct_id: u32 = types.type_struct(e.tt, ?members[0], n, true);
     if (struct_id == 0) { ret R.err[u32, str]("spirv.emit: could not build a uniform block type"); }
@@ -868,7 +1094,7 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[
     for (i < n) {
         var mops: [4]u32;
         mops[0] = struct_id; mops[1] = i; mops[2] = spirv.DECOR_OFFSET;
-        mops[3] = type.byte_offset(?e.root.types, id, i, e.tgt);
+        mops[3] = type.byte_offset(gt, id, i, e.tgt);
         spirv.inst(e.b, ?e.b.decorations, spirv.OP_MEMBER_DECORATE, ?mops[0], 4);
         i = i + 1;
     }
@@ -900,18 +1126,18 @@ fun laid_out_struct(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[
 # e:   the emission state
 # id:  the member's IR type
 # ret: the member type id, or a precise error string
-fun laid_out_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun laid_out_type(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId, relaxed_stride: bool) R.Result[u32, str] {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret R.err[u32, str]("spirv.emit: uniform block member has no IR type"); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
 
-    if (t.kind == type.IRT_STRUCT) { ret laid_out_struct(e, id, relaxed_stride); }
+    if (t.kind == type.IRT_STRUCT) { ret laid_out_struct(e, gt, id, relaxed_stride); }
 
     if (t.kind == type.IRT_ARRAY) {
-        val er: R.Result[u32, str] = laid_out_type(e, t.data.array_.element, relaxed_stride);
+        val er: R.Result[u32, str] = laid_out_type(e, gt, t.data.array_.element, relaxed_stride);
         if (R.is_err[u32, str](er)) { ret er; }
         val elem_ty: u32 = R.unwrap_ok[u32, str](er);
-        val stride: u32 = type.byte_size(?e.root.types, t.data.array_.element, e.tgt);
+        val stride: u32 = type.byte_size(gt, t.data.array_.element, e.tgt);
         # the emitted stride is mach's own element size, and the rule is that a
         # stride must be a multiple of the array's base alignment and no smaller
         # than what one element occupies. The two block classes differ only in that
@@ -919,7 +1145,7 @@ fun laid_out_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u3
         # buffer does not (std430), which is why `[8]f32` is legal in one and not
         # the other. A disagreement is refused rather than repacked - repacking
         # would move the elements out from under a host writing by `$offset_of`.
-        val want: u32 = required_stride(e, t.data.array_.element, relaxed_stride);
+        val want: u32 = required_stride(e, gt, t.data.array_.element, relaxed_stride);
         if (want == 0) {
             ret R.err[u32, str]("unsupported uniform block member type in the SPIR-V target");
         }
@@ -940,7 +1166,7 @@ fun laid_out_type(e: *Emit, id: type.IrTypeId, relaxed_stride: bool) R.Result[u3
         ret R.ok[u32, str](arr_id);
     }
 
-    val mt: u32 = global_spv_type(e, id);
+    val mt: u32 = global_spv_type(e, gt, id);
     if (mt == 0) {
         ret R.err[u32, str]("unsupported uniform block member type in the SPIR-V target");
     }
@@ -997,8 +1223,8 @@ fun storage_hint(std430: bool) str {
 # id:     the member's IR type
 # std430: the storage-buffer posture, which drops the 16-byte roundings
 # ret:    the base alignment in bytes, or 0 for a type with no block layout
-fun std_base_align(e: *Emit, id: type.IrTypeId, std430: bool) u32 {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun std_base_align(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId, std430: bool) u32 {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret 0; }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
 
@@ -1006,7 +1232,7 @@ fun std_base_align(e: *Emit, id: type.IrTypeId, std430: bool) u32 {
         var a: u32 = 1;
         var i: u32 = 0;
         for (i < t.data.struct_.field_count) {
-            val ma: u32 = std_base_align(e, t.data.struct_.fields[i], std430);
+            val ma: u32 = std_base_align(e, gt, t.data.struct_.fields[i], std430);
             if (ma == 0) { ret 0; }
             if (ma > a) { a = ma; }
             i = i + 1;
@@ -1015,18 +1241,18 @@ fun std_base_align(e: *Emit, id: type.IrTypeId, std430: bool) u32 {
         ret a;
     }
     if (t.kind == type.IRT_ARRAY) {
-        val ea: u32 = std_base_align(e, t.data.array_.element, std430);
+        val ea: u32 = std_base_align(e, gt, t.data.array_.element, std430);
         if (ea == 0) { ret 0; }
         if (!std430) { ret round_up_to(ea, 16); }
         ret ea;
     }
     if (t.kind == type.IRT_VECTOR) {
-        val lane: u32 = type.byte_size(?e.root.types, t.data.vector_.element, e.tgt);
+        val lane: u32 = type.byte_size(gt, t.data.vector_.element, e.tgt);
         if (t.data.vector_.lanes == 2) { ret 2 * lane; }
         ret 4 * lane;
     }
     if (t.kind == type.IRT_INT || t.kind == type.IRT_FLOAT) {
-        ret type.byte_size(?e.root.types, id, e.tgt);
+        ret type.byte_size(gt, id, e.tgt);
     }
     ret 0;
 }
@@ -1043,31 +1269,31 @@ fun std_base_align(e: *Emit, id: type.IrTypeId, std430: bool) u32 {
 # id:     the member's IR type
 # std430: the storage-buffer posture
 # ret:    the extent in bytes, or 0 for a type with no block layout
-fun std_extent(e: *Emit, id: type.IrTypeId, std430: bool) u32 {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun std_extent(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId, std430: bool) u32 {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret 0; }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
 
     if (t.kind == type.IRT_STRUCT) {
-        val a: u32 = std_base_align(e, id, std430);
+        val a: u32 = std_base_align(e, gt, id, std430);
         if (a == 0) { ret 0; }
         var end: u32 = 0;
         var i: u32 = 0;
         for (i < t.data.struct_.field_count) {
-            val me: u32 = std_extent(e, t.data.struct_.fields[i], std430);
+            val me: u32 = std_extent(e, gt, t.data.struct_.fields[i], std430);
             if (me == 0) { ret 0; }
-            val moff: u32 = type.byte_offset(?e.root.types, id, i, e.tgt);
+            val moff: u32 = type.byte_offset(gt, id, i, e.tgt);
             if (moff + me > end) { end = moff + me; }
             i = i + 1;
         }
         ret round_up_to(end, a);
     }
     if (t.kind == type.IRT_ARRAY) {
-        val s: u32 = required_stride(e, t.data.array_.element, std430);
+        val s: u32 = required_stride(e, gt, t.data.array_.element, std430);
         if (s == 0) { ret 0; }
         ret s * t.data.array_.count;
     }
-    ret type.byte_size(?e.root.types, id, e.tgt);
+    ret type.byte_size(gt, id, e.tgt);
 }
 
 # the array stride SPIR-V's explicit layout rules require for an element type
@@ -1079,11 +1305,11 @@ fun std_extent(e: *Emit, id: type.IrTypeId, std430: bool) u32 {
 # elem:   the element's IR type
 # std430: the storage-buffer posture
 # ret:    the required stride in bytes, or 0 for a type with no block layout
-fun required_stride(e: *Emit, elem: type.IrTypeId, std430: bool) u32 {
-    var a: u32 = std_base_align(e, elem, std430);
+fun required_stride(e: *Emit, gt: *type.IrTypeTable, elem: type.IrTypeId, std430: bool) u32 {
+    var a: u32 = std_base_align(e, gt, elem, std430);
     if (a == 0) { ret 0; }
     if (!std430) { a = round_up_to(a, 16); }
-    val ext: u32 = std_extent(e, elem, std430);
+    val ext: u32 = std_extent(e, gt, elem, std430);
     if (ext == 0) { ret 0; }
     ret round_up_to(ext, a);
 }
@@ -1102,8 +1328,8 @@ fun required_stride(e: *Emit, elem: type.IrTypeId, std430: bool) u32 {
 # id:     the IR struct type
 # std430: the storage-buffer posture
 # ret:    true when the offsets conform, or a diagnostic naming the member and rule
-fun check_block_layout(e: *Emit, id: type.IrTypeId, std430: bool) R.Result[bool, str] {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun check_block_layout(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId, std430: bool) R.Result[bool, str] {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret R.ok[bool, str](true); }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
 
@@ -1111,11 +1337,11 @@ fun check_block_layout(e: *Emit, id: type.IrTypeId, std430: bool) R.Result[bool,
     var i: u32 = 0;
     for (i < t.data.struct_.field_count) {
         val fty: type.IrTypeId = t.data.struct_.fields[i];
-        val a: u32 = std_base_align(e, fty, std430);
+        val a: u32 = std_base_align(e, gt, fty, std430);
         # a member with no block layout at all is refused by `laid_out_type`, which
         # names the type; there is nothing to add here.
         if (a == 0) { i = i + 1; cnt; }
-        val off: u32 = type.byte_offset(?e.root.types, id, i, e.tgt);
+        val off: u32 = type.byte_offset(gt, id, i, e.tgt);
 
         if ((off % a) != 0 || off < prev_end) {
             var want: u32 = round_up_to(prev_end, a);
@@ -1124,10 +1350,10 @@ fun check_block_layout(e: *Emit, id: type.IrTypeId, std430: bool) R.Result[bool,
             # told which: a misaligned member is the member's own base alignment, and
             # an overlapping one is the member before it occupying more of the block
             # than mach's layout gives it.
-            ret R.err[bool, str](layout_refusal(e, std430, i, fty, off, want, a,
+            ret R.err[bool, str](layout_refusal(e, gt, std430, i, fty, off, want, a,
                                                 off < prev_end, prev_end));
         }
-        val ext: u32 = std_extent(e, fty, std430);
+        val ext: u32 = std_extent(e, gt, fty, std430);
         if (ext == 0) { i = i + 1; cnt; }
         prev_end = off + ext;
         i = i + 1;
@@ -1147,7 +1373,7 @@ fun check_block_layout(e: *Emit, id: type.IrTypeId, std430: bool) R.Result[bool,
 # overlaps: whether the member starts inside the one before it
 # prev_end: where the member before it ends under those rules
 # ret:      the composed diagnostic
-fun layout_refusal(e: *Emit, std430: bool, ix: u32, fty: type.IrTypeId, off: u32,
+fun layout_refusal(e: *Emit, gt: *type.IrTypeTable, std430: bool, ix: u32, fty: type.IrTypeId, off: u32,
                    want: u32, align: u32, overlaps: bool, prev_end: u32) str {
     var why: str = nil;
     if (overlaps) {
@@ -1168,7 +1394,7 @@ fun layout_refusal(e: *Emit, std430: bool, ix: u32, fty: type.IrTypeId, off: u32
 
     val r: R.Result[str, str] = format.sprint(e.alloc,
         "member {} of this `{}` block, a {}, is placed at offset {} by mach's layout and the SPIR-V block layout rules require offset {}: {}. the offsets are the host's contract, so this is refused rather than repacked - repacking would move the members out from under a host writing by `$offset_of`. pad the block explicitly so the member lands where the rules put it, or promote a nested record's members into the block{}",
-        ix, block_role(std430), ir_type_spelling(?e.root.types, e.alloc, fty), off, want,
+        ix, block_role(std430), ir_type_spelling(gt, e.alloc, fty), off, want,
         why, storage_hint(std430));
     if (R.is_err[str, str](r)) {
         ret "a member of this block is placed at an offset the SPIR-V block layout rules do not allow";
@@ -1277,12 +1503,9 @@ fun uses_iface(e: *Emit, fn_ix: u32, slot: u32) bool {
 # ret:  slot + 1, or 0 when the name is not entry-point interface
 fun iface_slot_of(e: *Emit, name: intern.StrId) u32 {
     if (e.gslot == nil) { ret 0; }
-    var i: u32 = 0;
-    for (i < e.root.global_len) {
-        if (e.root.globals[i].name == name) { ret e.gslot[i]; }
-        i = i + 1;
-    }
-    ret 0;
+    val gx: u32 = gl_lookup(e, name);
+    if (gx == GL_NONE) { ret 0; }
+    ret e.gslot[gx];
 }
 
 # refuse a cycle in the module's static call graph
@@ -1433,12 +1656,22 @@ fun cycle_refusal(e: *Emit, path: *u32, depth: u32, closes: u32) str {
 # A Location is written by the author and emitted verbatim, but mach knows each
 # variable's type and so knows how many locations it consumes; two that overlap
 # within one stage are refused here rather than left to a validator message naming
-# an `OpEntryPoint` operand index.
+# an `OpEntryPoint` operand index. A descriptor `(set, binding)` pair claimed twice
+# is refused on the same footing.
+#
+# WHY THE COLLISION RULES MATTER MORE ONCE GLOBALS CROSS MODULES (#2843). Within
+# one module two variables at the same location, or the same `(set, binding)`, are
+# a typo an author can see. Across modules they are neither: two shared libraries
+# can each declare `#[uniform(0, 0)]` without either author ever seeing the other,
+# and the shader that imports both is where the conflict first exists. So the
+# checks run over the DRAWN-IN set rather than the root's globals, and each
+# diagnostic names the declaring MODULE - a message naming two `camera`s tells the
+# one person who can act on it nothing about where either lives.
 # ---
 # e:   the emission state
 # ret: true on success, or a diagnostic naming the variables that collide
 fun check_stage_interfaces(e: *Emit) R.Result[bool, str] {
-    val n: u32 = e.root.global_len;
+    val n: u32 = e.gl_len;
     if (e.iface_len == 0 || n == 0) { ret R.ok[bool, str](true); }
 
     val rf: R.Result[*u8, str] = A.allocate[u8](e.alloc, n::usize);
@@ -1458,7 +1691,8 @@ fun check_stage_interfaces(e: *Emit) R.Result[bool, str] {
         i = 0;
         for (i < n) {
             if (e.gslot[i] == 0 || !uses_iface(e, fx, e.gslot[i] - 1)) { i = i + 1; cnt; }
-            if (e.gstorage[i] == spirv.STORAGE_INPUT && needs_flat(?e.root.types, e.root.globals[i].ty)) {
+            val gi: *ir.Global = gl_ir(e, i);
+            if (e.gstorage[i] == spirv.STORAGE_INPUT && needs_flat(gl_types(e, i), gi.ty)) {
                 if (fn.stage == ir.STAGE_FRAGMENT) { flat[i] = flat[i] | 1; }
                 or (fn.stage == ir.STAGE_VERTEX)   { flat[i] = flat[i] | 2; }
                 if (flat[i] == 3) {
@@ -1468,9 +1702,15 @@ fun check_stage_interfaces(e: *Emit) R.Result[bool, str] {
             }
             # a Location collision is only a collision within one direction: an input
             # at location 0 and an output at location 0 are two different spaces.
-            if (e.root.globals[i].iface == ir.IFACE_INPUT
-                || e.root.globals[i].iface == ir.IFACE_OUTPUT) {
+            if (gi.iface == ir.IFACE_INPUT || gi.iface == ir.IFACE_OUTPUT) {
                 msg = location_overlap(e, fx, i);
+                if (msg != nil) { i = n; cnt; }
+            }
+            # a descriptor pair is a claim on the pipeline layout, and two variables
+            # claiming one is a binding the host can satisfy for only one of them.
+            if (gi.iface == ir.IFACE_UNIFORM || gi.iface == ir.IFACE_STORAGE
+                || gi.iface == ir.IFACE_SAMPLER) {
+                msg = descriptor_overlap(e, fx, i);
                 if (msg != nil) { i = n; cnt; }
             }
             i = i + 1;
@@ -1494,13 +1734,13 @@ fun check_stage_interfaces(e: *Emit) R.Result[bool, str] {
 # and that cannot be decorated to satisfy both
 # ---
 # e:  the emission state
-# gi: the IR global index
+# gi: the global-table index
 # ret: the composed diagnostic
 fun flat_conflict(e: *Emit, gi: u32) str {
-    val g: *ir.Global = ?e.root.globals[gi];
+    val g: *ir.Global = gl_ir(e, gi);
     val r: R.Result[str, str] = format.sprint(e.alloc,
-        "this `#[input({})]` variable, {}, is read by a vertex stage and by a fragment stage, and no SPIR-V module serves both: a fragment stage's integer or 64-bit input MUST carry a Flat decoration because such a value cannot be interpolated, and a vertex stage's input must NOT carry one. declare two variables. the two are different things anyway - a vertex stage's input is a vertex attribute, and a fragment stage's is the interpolated output of the stage before it",
-        g.iface_a, ir_type_spelling(?e.root.types, e.alloc, g.ty));
+        "this `#[input({})]` variable, {}{}, is read by a vertex stage and by a fragment stage, and no SPIR-V module serves both: a fragment stage's integer or 64-bit input MUST carry a Flat decoration because such a value cannot be interpolated, and a vertex stage's input must NOT carry one. declare two variables. the two are different things anyway - a vertex stage's input is a vertex attribute, and a fragment stage's is the interpolated output of the stage before it",
+        g.iface_a, ir_type_spelling(gl_types(e, gi), e.alloc, g.ty), gl_mod_prefix(e, gi));
     if (R.is_err[str, str](r)) {
         ret "an integer or 64-bit `#[input(...)]` cannot be read by a vertex stage and a fragment stage at once: the fragment stage requires a Flat decoration and the vertex stage forbids one";
     }
@@ -1516,30 +1756,33 @@ fun flat_conflict(e: *Emit, gi: u32) str {
 # ---
 # e:  the emission state
 # fx: the entry point's unit function-table index
-# gi: the global being placed
+# gi: the global-table index of the variable being placed
 # ret: nil when the span is free, or the composed diagnostic
 fun location_overlap(e: *Emit, fx: u32, gi: u32) str {
-    val g: *ir.Global = ?e.root.globals[gi];
+    val g: *ir.Global = gl_ir(e, gi);
     val lo: u32 = g.iface_a;
-    val span: u32 = location_span(e, g.ty);
+    val span: u32 = location_span(e, gl_types(e, gi), g.ty);
     var j: u32 = 0;
     for (j < gi) {
-        val o: *ir.Global = ?e.root.globals[j];
+        val o: *ir.Global = gl_ir(e, j);
         if (o.iface != g.iface) { j = j + 1; cnt; }
         if (e.gslot[j] == 0 || !uses_iface(e, fx, e.gslot[j] - 1)) { j = j + 1; cnt; }
         val olo: u32 = o.iface_a;
-        val ospan: u32 = location_span(e, o.ty);
+        val ospan: u32 = location_span(e, gl_types(e, j), o.ty);
         if (lo < olo + ospan && olo < lo + span) {
             var what: str = "input";
             if (g.iface == ir.IFACE_OUTPUT) { what = "output"; }
             # named by the decorator the author wrote rather than by the variable's
             # symbol: IR keeps a global's mangled linkage name and no source
-            # spelling, and a mangled name in a diagnostic points nowhere.
+            # spelling, and a mangled name in a diagnostic points nowhere. the
+            # declaring MODULE is appended when it is not this one, which is the
+            # only thing that separates two drawn-in variables (#2843).
             val fr: R.Result[str, str] = format.sprint(e.alloc,
-                "two `#[{}(...)]` variables overlap in the stage `{}`: `#[{}({})]`, {}, occupies {} location(s) and so runs through location {}, and `#[{}({})]`, {}, starts inside it. a type wider than one location consumes the ones that follow it, so the numbers an author writes have to leave room for the type",
+                "two `#[{}(...)]` variables overlap in the stage `{}`: `#[{}({})]`, {}{}, occupies {} location(s) and so runs through location {}, and `#[{}({})]`, {}{}, starts inside it. a type wider than one location consumes the ones that follow it, so the numbers an author writes have to leave room for the type",
                 what, ir_fn_spelling(e, fx), what, olo,
-                ir_type_spelling(?e.root.types, e.alloc, o.ty), ospan, olo + ospan - 1,
-                what, lo, ir_type_spelling(?e.root.types, e.alloc, g.ty));
+                ir_type_spelling(gl_types(e, j), e.alloc, o.ty), gl_mod_prefix(e, j),
+                ospan, olo + ospan - 1,
+                what, lo, ir_type_spelling(gl_types(e, gi), e.alloc, g.ty), gl_mod_prefix(e, gi));
             if (R.is_err[str, str](fr)) {
                 ret "two shader interface variables occupy the same location: a type wider than one location consumes the ones that follow it";
             }
@@ -1548,6 +1791,60 @@ fun location_overlap(e: *Emit, fx: u32, gi: u32) str {
         j = j + 1;
     }
     ret nil;
+}
+
+# the diagnostic for a descriptor `(set, binding)` an earlier variable already
+# claims, or nil
+#
+# The same shape as `location_overlap` and for the same reason, over the other
+# namespace a shader binds: a descriptor pair names a slot in the pipeline layout,
+# and a host binds one resource to it. Two variables claiming one pair is not a
+# module a consumer can satisfy - whichever it binds, the other reads the wrong
+# resource - so it is refused rather than emitted for a validator to accept.
+#
+# `spirv-val` does NOT catch this. A module with two variables at the same
+# `(set, binding)` is well-formed SPIR-V; the conflict is with the pipeline layout,
+# which lives outside the module entirely. So this is one of the checks that has to
+# be here or nowhere.
+#
+# UNLIKE a Location, the pair is compared across the interface roles rather than
+# within one: a `#[uniform(0, 0)]` and a `#[storage(0, 0)]` are two descriptor types
+# claiming one slot, which is the same conflict, not two spaces.
+# ---
+# e:  the emission state
+# fx: the entry point's unit function-table index
+# gi: the global-table index of the variable being placed
+# ret: nil when the pair is free, or the composed diagnostic
+fun descriptor_overlap(e: *Emit, fx: u32, gi: u32) str {
+    val g: *ir.Global = gl_ir(e, gi);
+    var j: u32 = 0;
+    for (j < gi) {
+        val o: *ir.Global = gl_ir(e, j);
+        if (o.iface != ir.IFACE_UNIFORM && o.iface != ir.IFACE_STORAGE
+            && o.iface != ir.IFACE_SAMPLER) { j = j + 1; cnt; }
+        if (e.gslot[j] == 0 || !uses_iface(e, fx, e.gslot[j] - 1)) { j = j + 1; cnt; }
+        if (o.iface_a != g.iface_a || o.iface_b != g.iface_b) { j = j + 1; cnt; }
+        val fr: R.Result[str, str] = format.sprint(e.alloc,
+            "two descriptor-bound variables claim the same `(set = {}, binding = {})` in the stage `{}`: `{}`, {}{}, and `{}`, {}{}. a host binds one resource to a descriptor slot, so a pipeline layout can satisfy only one of them and the other would read whatever the first was bound to. give them different bindings",
+            g.iface_a, g.iface_b, ir_fn_spelling(e, fx),
+            descriptor_role(o.iface), ir_type_spelling(gl_types(e, j), e.alloc, o.ty), gl_mod_prefix(e, j),
+            descriptor_role(g.iface), ir_type_spelling(gl_types(e, gi), e.alloc, g.ty), gl_mod_prefix(e, gi));
+        if (R.is_err[str, str](fr)) {
+            ret "two descriptor-bound variables claim the same descriptor set and binding: a pipeline layout can satisfy only one of them";
+        }
+        ret R.unwrap_ok[str, str](fr);
+    }
+    ret nil;
+}
+
+# the decorator an author wrote for one descriptor-bound interface role
+# ---
+# iface: the IR interface role
+# ret:   the decorator's spelling
+fun descriptor_role(iface: u8) str {
+    if (iface == ir.IFACE_STORAGE) { ret "#[storage(...)]"; }
+    if (iface == ir.IFACE_SAMPLER) { ret "#[sampler(...)]"; }
+    ret "#[uniform(...)]";
 }
 
 # how many interface locations a type consumes
@@ -1561,26 +1858,26 @@ fun location_overlap(e: *Emit, fx: u32, gi: u32) str {
 # e:  the emission state
 # id: the interface variable's IR type
 # ret: the number of locations, at least 1
-fun location_span(e: *Emit, id: type.IrTypeId) u32 {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun location_span(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId) u32 {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret 1; }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
     if (t.kind == type.IRT_STRUCT) {
         var total: u32 = 0;
         var i: u32 = 0;
         for (i < t.data.struct_.field_count) {
-            total = total + location_span(e, t.data.struct_.fields[i]);
+            total = total + location_span(e, gt, t.data.struct_.fields[i]);
             i = i + 1;
         }
         if (total == 0) { ret 1; }
         ret total;
     }
     if (t.kind == type.IRT_ARRAY) {
-        val es: u32 = location_span(e, t.data.array_.element);
+        val es: u32 = location_span(e, gt, t.data.array_.element);
         if (t.data.array_.count == 0) { ret 1; }
         ret es * t.data.array_.count;
     }
-    val bytes: u32 = type.byte_size(?e.root.types, id, e.tgt);
+    val bytes: u32 = type.byte_size(gt, id, e.tgt);
     if (bytes <= 16) { ret 1; }
     ret (bytes + 15) / 16;
 }
@@ -1853,12 +2150,9 @@ fun builtin_storage(which: u32) u32 {
 # ret:  the OpVariable id, or 0
 fun global_var_id(e: *Emit, name: intern.StrId) u32 {
     if (e.gvar_ids == nil) { ret 0; }
-    var i: u32 = 0;
-    for (i < e.root.global_len) {
-        if (e.root.globals[i].name == name) { ret e.gvar_ids[i]; }
-        i = i + 1;
-    }
-    ret 0;
+    val gx: u32 = gl_lookup(e, name);
+    if (gx == GL_NONE) { ret 0; }
+    ret e.gvar_ids[gx];
 }
 
 # emit the module preamble: capabilities and the memory model
@@ -2080,11 +2374,8 @@ val ADDR_ALLOCA:  u8 = 2;  # a function-local allocation
 fun address_origin(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand, out_ix: *u32) u8 {
     @out_ix = 0;
     if (op.kind == mir.MIR_OP_SYM) {
-        var i: u32 = 0;
-        for (i < e.root.global_len) {
-            if (e.root.globals[i].name == op.sym) { @out_ix = i; ret ADDR_GLOBAL; }
-            i = i + 1;
-        }
+        val gx: u32 = gl_lookup(e, op.sym);
+        if (gx != GL_NONE) { @out_ix = gx; ret ADDR_GLOBAL; }
         ret ADDR_UNKNOWN;
     }
     # a MEM operand's register base rides in `vreg`; a physical-register base leaves
@@ -2961,8 +3252,8 @@ fun ir_value_spv_type(e: *Emit, id: type.IrTypeId) u32 {
 # e:  the emission state
 # id: the IR type id, in the root's table
 # ret: the SPIR-V type id, or 0
-fun global_spv_type(e: *Emit, id: type.IrTypeId) u32 {
-    ret spv_type_of(e, ?e.root.types, id);
+fun global_spv_type(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId) u32 {
+    ret spv_type_of(e, gt, id);
 }
 
 # the SPIR-V type an IR image handle names, declaring it on first use (#2794)
@@ -3058,6 +3349,9 @@ fun ir_return_spv_type(e: *Emit, irfn: *ir.Function, out_void: *bool) u32 {
 # reports absence with it and this table stores that answer verbatim.
 val FN_NONE: u32 = unit.UNIT_NONE;
 
+# no global in the emission unit carries the requested name
+val GL_NONE: u32 = unit.UNIT_NONE;
+
 # the diagnostic for a value type the emitter cannot map, naming the mach type
 #
 # A LANE COUNT IS NO LONGER ONE OF THESE (#2749). A vector of more lanes than a
@@ -3129,16 +3423,16 @@ fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand
     if (origin != ADDR_GLOBAL) {
         ret "addressed memory is not yet supported by the SPIR-V target: this access reached the back end as a computed address with no object behind it that the emitter can name, and logical addressing has no general pointer to follow";
     }
-    val g: *ir.Global = ?e.root.globals[gix];
+    val g: *ir.Global = gl_ir(e, gix);
     if (g.iface == ir.IFACE_NONE) {
         ret "a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role (`#[input]`, `#[output]`, `#[builtin]`, or `#[uniform]`)";
     }
-    if (is_aggregate_type(e, g.ty)) {
+    if (is_aggregate_type(e, gl_types(e, gix), g.ty)) {
         ret "copying a whole record or array to or from a shader interface variable is not supported by the SPIR-V target: an aggregate assignment lowers to a byte copy, which addresses the object rather than loading or storing a value of it. reading and writing its MEMBERS individually is supported, and is what a shader wants anyway - a whole-block copy would move the descriptor's contents rather than the values in it";
     }
     val r: R.Result[str, str] = format.sprint(e.alloc,
         "this shader interface variable carries a role and is not an aggregate, so it is reachable - but the access reached the back end as COMPUTED ADDRESSING rather than as a direct reference to the variable, which is the one shape the SPIR-V target can name. that is a lowering that ran where it should not have, not a limit of the declaration: the variable is {}",
-        ir_type_spelling(?e.root.types, e.alloc, g.ty));
+        ir_type_spelling(gl_types(e, gix), e.alloc, g.ty));
     if (R.is_err[str, str](r)) {
         ret "this shader interface variable is reachable only as a whole-variable read or write in the SPIR-V target";
     }
@@ -3150,8 +3444,8 @@ fun addressed_memory_refusal(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand
 # e:   the emission state
 # id:  the IR type id
 # ret: true for an IRT_IMAGE
-fun is_image_type(e: *Emit, id: type.IrTypeId) bool {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun is_image_type(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId) bool {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret false; }
     ret O.unwrap[*type.IrType](opt).kind == type.IRT_IMAGE;
 }
@@ -3161,8 +3455,8 @@ fun is_image_type(e: *Emit, id: type.IrTypeId) bool {
 # e:   the emission state
 # id:  the IR type id
 # ret: true for an array or a struct
-fun is_aggregate_type(e: *Emit, id: type.IrTypeId) bool {
-    val opt: O.Option[*type.IrType] = type.get(?e.root.types, id);
+fun is_aggregate_type(e: *Emit, gt: *type.IrTypeTable, id: type.IrTypeId) bool {
+    val opt: O.Option[*type.IrType] = type.get(gt, id);
     if (O.is_none[*type.IrType](opt)) { ret false; }
     val k: type.IrTypeKind = O.unwrap[*type.IrType](opt).kind;
     ret k == type.IRT_ARRAY || k == type.IRT_STRUCT;
@@ -3243,14 +3537,11 @@ fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Reg
 # ret: the value type id, or 0
 fun interface_value_type(e: *Emit, op: *mir.MirOperand) u32 {
     if (op.kind != mir.MIR_OP_SYM) { ret 0; }
-    var i: u32 = 0;
-    for (i < e.root.global_len) {
-        if (e.root.globals[i].name == op.sym && e.root.globals[i].iface != ir.IFACE_NONE) {
-            ret global_spv_type(e, e.root.globals[i].ty);
-        }
-        i = i + 1;
-    }
-    ret 0;
+    val gx: u32 = gl_lookup(e, op.sym);
+    if (gx == GL_NONE) { ret 0; }
+    val g: *ir.Global = gl_ir(e, gx);
+    if (g.iface == ir.IFACE_NONE) { ret 0; }
+    ret global_spv_type(e, gl_types(e, gx), g.ty);
 }
 
 # emit an OpAccessChain for a structural GEP into a shader interface variable
@@ -3301,7 +3592,7 @@ fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Reg
         if (address_origin(e, mf, ?mi.operands[1], ?gix) != ADDR_GLOBAL) {
             ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
         }
-        val g: *ir.Global = ?e.root.globals[gix];
+        val g: *ir.Global = gl_ir(e, gix);
         if (g.iface == ir.IFACE_NONE || e.gvar_ids[gix] == 0) {
             ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
         }


### PR DESCRIPTION
Closes #2843.

`#2823` let a shader call a function defined in a shared module. It could not use an **interface variable** one declared, so a shader library had nowhere to put a descriptor set it owned. A drawn-in body naming its own module's `#[uniform(...)]` found nothing and the access was refused as computed addressing.

## What changed

**Globals flatten into one unit-wide table**, exactly as `#2823` did for functions. `GlobalEnt` carries the `(member, index)` pair and every per-global array is indexed by a table index rather than a root IR global index.

A global's type ids are read against **its own module's** type table. That is what the pair exists for: an `IrTypeId` indexes one module's table, so reading a drawn-in global's type against the root's would resolve it to whatever type sits at the same index there. A wrong type silently, not a failure.

An **extern shadow is never entered** in the table. `ensure_extern_global` mints it against the *consumer's* type table, so its type id means nothing outside the module that made it. The definition is found once, in the module that owns it.

**Reachability, not membership**, for a drawn-in member. A shared module may declare a whole descriptor set and a shader importing it for one helper does not inherit the rest, both because the module would grow without bound and because two unrelated libraries could otherwise collide on a binding neither the shader nor either author used. The root is exempt: its interface list is the pipeline contract, declared whole, which is also what keeps existing shaders byte-identical.

**The driver closes over cross-module global references**, not only function ones. A shader that reads a shared module's uniform and calls nothing in it must still draw that module in.

## The three decisions the issue left open

1. **Collisions** are checked over the drawn-in set, per entry point. Descriptor `(set, binding)` had **no check at all** before, so that one is new. It compares *across* the descriptor roles rather than within one, since a `#[uniform(0, 0)]` and a `#[storage(0, 0)]` are two descriptor types claiming one slot. Both these and Location overlaps now name the declaring **module**.
2. **Whose interface list** falls out of `iface_use` as predicted; only its second axis widened.
3. **Whether a shared module's own `.spv` still declares it** — yes, and the shader emits a private copy. Verified rather than assumed: globals were never given a linkage export, so `main.spv` exports nothing and `lib.spv` exports only its three functions. A consumer linking the pair meets one definition.

## Verification

`spirv-val` cannot see most of what is asserted here: a module that declares a descriptor it never uses, or lists every declared variable in every entry point, is well-formed SPIR-V. So the assertions are in-process over the emitted module.

- **1374 unit tests pass**, including five new ones.
- **All five fail against the unfixed compiler** and pass with it. Run by reverting `emit.mach`, `passes.mach` and `unit.mach` to `dev` while keeping the tests: 5 failed / 1365 passed. A fixture that cannot fail is not a fixture.
- The refusal test asserts the **message**, not `is_err`. These same modules were already refused before this change, as computed addressing, so an `is_err` assertion would have passed against the unfixed compiler and proved nothing.
- **Byte-identical output** for an existing single-module shader carrying all five interface roles, compared against a compiler built from `dev` itself. (The first comparison I ran used the compiler on `PATH`, which turned out to be 4.16.0 — that diff was the stale install, not this change.)
- Hand-checked with `spirv-dis` / `spirv-val` on the rebased base: a cross-module `#[uniform]`, `#[input]`, `#[output]` and `#[builtin]` all emit with their decorations intact; the vertex stage lists the drawn-in variables and the fragment stage, which reaches none of them, does not; an unreached shared uniform and input are absent from the shader while the library's own module still declares both; the collision is refused naming both modules, and the same fixture at binding 1 builds and validates.

No `int/` cases added, per the freeze.
