### PR TITLE
fix(abi): make the argument-slot granularity the convention's, not a literal 8

### DIFF
--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -1151,7 +1151,7 @@ test "mach.lang.be.codegen.frame.run:stamps_the_omission_decision" {
         16, 0, 0,
         -1, false,
         false, false,
-        0,
+        0, 8,
         nil
     );
 

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -607,12 +607,12 @@ fun natural_stack_slot(tgt: *target.Target, variadic: bool) bool {
 fun stack_only_tail_slot(slot: abi.ParamSlot) abi.ParamSlot {
     if (is_stack_slot_class(slot.class)) { ret slot; }
     if (slot.class == abi.CLASS_BYREF) {
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, slot.size);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, slot.size);
     }
     if (slot.class == abi.CLASS_VEC_BYREF) {
-        ret abi.make_slot(abi.CLASS_VEC_STACK_BYREF, -1, -1, 0, slot.size);
+        ret abi.make_slot(abi.CLASS_VEC_STACK_BYREF, -1, 0, slot.size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, slot.size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, slot.size);
 }
 
 # whether a placement occupies an outgoing stack slot the signature walk assigns and
@@ -2228,18 +2228,18 @@ test "mach.lang.be.codegen.mir.abi.natural_stack_slot:fixed_diverges_variadic_do
 # stack and keeps a by-reference one by reference, with its POINTER on the stack
 test "mach.lang.be.codegen.mir.abi.stack_only_tail_slot:moves_placement_not_form" {
     # a scalar in X1 becomes an 8-byte by-value stack slot.
-    val gp: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_GP, 1, -1, 0, 8));
+    val gp: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_GP, 1, 0, 8));
     if (gp.class != abi.CLASS_STACK) { ret 1; }
     if (gp.reg != -1)                { ret 1; }
     if (gp.piece_count != 0)         { ret 1; }
     if (gp.size != 8)                { ret 1; }
     # a float in V0 too: the Apple rule has no register phase for the tail at all, so
     # the FP bank is no more available to it than the GP bank.
-    val fp: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_FP, isa.regid_make(isa.REG_CLASS_ID_XMM, 0), -1, 0, 8));
+    val fp: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_FP, isa.regid_make(isa.REG_CLASS_ID_XMM, 0), 0, 8));
     if (fp.class != abi.CLASS_STACK) { ret 1; }
     # a 16-byte aggregate in an X0:X1 pair becomes ONE by-value stack slot of the
     # aggregate's own size - not two - and carries no register pieces.
-    val pair: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_GP, 0, 1, 0, 16));
+    val pair: abi.ParamSlot = stack_only_tail_slot(abi.make_slot_pair(abi.CLASS_GP, 0, 1, 0, 16, 8));
     if (pair.class != abi.CLASS_STACK) { ret 1; }
     if (pair.piece_count != 0)         { ret 1; }
     if (pair.size != 16)               { ret 1; }
@@ -2249,13 +2249,13 @@ test "mach.lang.be.codegen.mir.abi.stack_only_tail_slot:moves_placement_not_form
     if (hfa.piece_count != 0)         { ret 1; }
     # a >16-byte aggregate stays BY REFERENCE; only its hidden pointer moves, so the
     # slot is the 8-byte pointer rather than the aggregate's bytes.
-    val byref: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_BYREF, 0, -1, 0, 8));
+    val byref: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_BYREF, 0, 0, 8));
     if (byref.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (byref.size != 8)                      { ret 1; }
-    val vbyref: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_VEC_BYREF, 0, -1, 0, 8));
+    val vbyref: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_VEC_BYREF, 0, 0, 8));
     if (vbyref.class != abi.CLASS_VEC_STACK_BYREF) { ret 1; }
     # a placement the classifier already put on the stack is returned untouched.
-    val stk: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_STACK, -1, -1, 24, 16));
+    val stk: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_STACK, -1, 24, 16));
     if (stk.class != abi.CLASS_STACK) { ret 1; }
     if (stk.offset != 24)             { ret 1; }
     ret 0;
@@ -2268,14 +2268,14 @@ fun probe_arg(index: i32, size: u64, align: u64, is_float: bool, fp_eightbytes: 
               is_aggregate: bool, is_vector: bool, is_ext: bool, is_variadic: bool,
               gp_used: i32, fp_used: i32,
               hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
-    ret abi.make_slot(abi.CLASS_GP, index, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_GP, index, 0, size);
 }
 
 # the return-classifier twin of `probe_arg`
 fun probe_ret(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
               is_aggregate: bool, is_vector: bool, hfa_members: u8, hfa_elem: u8,
               agg: abi.AggLayout) abi.ParamSlot {
-    ret abi.make_slot(abi.CLASS_GP, 0, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_GP, 0, 0, size);
 }
 
 # the ABI surface every lowered call reads is exactly the arg/ret classifiers (#2273).
@@ -2296,7 +2296,7 @@ test "mach.lang.be.codegen.mir.abi.require_abi:variadic_facts_are_not_call_preco
         0, 0, 0,
         -1, false,
         false, false,
-        0,
+        0, 8,
         nil
     );
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -776,7 +776,7 @@ test "mach.lang.target.tuple_capability:refuses_abi_needing_absent_float_extensi
         16, 0, 0,
         -1, false,
         false, false,
-        128,
+        128, 8,
         nil
     );
     # the os / of vtables are never dereferenced: the float check precedes every
@@ -1429,5 +1429,40 @@ test "mach.lang.target.select_of:resolves_debug_model" {
     val ct: resolved.Target = R.unwrap_ok[resolved.Target, str](tc);
     if (ct.debug != nil)               { ret 1; }
     if (ct.debug_id != of.DBG_UNKNOWN) { ret 1; }
+    ret 0;
+}
+
+# every registered convention's DECLARED granularity is the one its classifier
+# actually places a pair at
+#
+# `AbiVTable.arg_slot_granularity` and the `word` a classifier hands to
+# `make_slot_pair` are two spellings of one fact, and two spellings that must agree is
+# a shape this codebase has been bitten by. They agree by construction - each
+# convention feeds both from one constant or one descriptor field - and this checks it
+# rather than trusting it, so a convention wired later that sets one and forgets the
+# other fails at `mach test .` instead of at a call boundary.
+#
+# A convention that never builds a GP pair is skipped by the probe rather than
+# asserted about: it declares a granularity for completeness and no path consumes it.
+test "mach.lang.target.abi_vtable:granularity_matches_its_classifier" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    var i: u32 = 0;
+    for (i < reg.abi.count) {
+        val vt: *abi.AbiVTable = reg.abi.entries[i];
+        if (vt.arg_slot_granularity == 0) { ret 1; }
+        if (vt.arg_passing == nil)        { i = i + 1; cnt; }
+
+        # a 16-byte aggregate is the shape these conventions place in a GP pair
+        val fn: abi.ArgPassingFn = vt.arg_passing::abi.ArgPassingFn;
+        var agg: abi.AggLayout;
+        agg.field_count = 0;
+        val slot: abi.ParamSlot = fn(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, agg);
+        if (slot.piece_count == 2 && slot.pieces[1].kind == abi.PIECE_GP) {
+            if (slot.pieces[1].src_off != vt.arg_slot_granularity::i64) { ret 1; }
+        }
+        i = i + 1;
+    }
     ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -409,6 +409,14 @@ pub def VaModelFn: fun() VaModel;
 #                             beside it. 64 on the AMD64 and AAPCS64 conventions, which
 #                             pass both f32 and f64 in vector registers; 0 on the
 #                             conventions with no float register file at all (mos6502).
+# arg_slot_granularity:       the convention's argument-slot granularity in bytes: the
+#                             width of one general-purpose chunk, and therefore the
+#                             offset of the second register's bytes within a
+#                             two-register aggregate. SysV's eightbyte, AAPCS64's 8,
+#                             RISC-V's XLEN, mos6502's word. declared per CONVENTION
+#                             rather than read off the machine, because that is where
+#                             the specifications put it and it is the only spelling
+#                             that lets a convention disagree with its machine
 # va_model:                   erased fn ptr -- return the convention's `VaModel` (VaModelFn)
 pub rec AbiVTable {
     id:                          u32;
@@ -427,6 +435,7 @@ pub rec AbiVTable {
     consumes_agg_layout:         bool;
     fp_callee_saved_full_vector: bool;
     float_arg_bits:              u32;
+    arg_slot_granularity:        u32;
     va_model:                    *u8;
 }
 
@@ -469,7 +478,7 @@ pub fun abi_vtable(id: u32, name: str, arch_id: u32, classify: *u8, arg_passing:
                    stack_align: u32, red_zone: u32, shadow_space: u32,
                    indirect_result_reg: i32, indirect_result_in_argfile: bool,
                    consumes_agg_layout: bool, fp_callee_saved_full_vector: bool,
-                   float_arg_bits: u32,
+                   float_arg_bits: u32, arg_slot_granularity: u32,
                    va_model: *u8) AbiVTable {
     var v: AbiVTable;
     v.id                          = id;
@@ -488,6 +497,7 @@ pub fun abi_vtable(id: u32, name: str, arch_id: u32, classify: *u8, arg_passing:
     v.consumes_agg_layout         = consumes_agg_layout;
     v.fp_callee_saved_full_vector = fp_callee_saved_full_vector;
     v.float_arg_bits              = float_arg_bits;
+    v.arg_slot_granularity        = arg_slot_granularity;
     v.va_model                    = va_model;
     ret v;
 }
@@ -514,7 +524,7 @@ test "mach.lang.target.abi.abi_vtable:sets_every_field" {
         16, 128, 32,
         3, true,
         true, true,
-        64,
+        64, 8,
         abi_id_for::*u8
     );
 
@@ -537,7 +547,7 @@ test "mach.lang.target.abi.abi_vtable:sets_every_field" {
     if (v.va_model != abi_id_for::*u8)          { ret 1; }
 
     # and the bools genuinely echo the parameter rather than being hard-coded true.
-    val v2: AbiVTable = abi_vtable(0, "", 0, nil, nil, nil, nil, nil, 0, 0, 0, 0, false, false, false, 0, nil);
+    val v2: AbiVTable = abi_vtable(0, "", 0, nil, nil, nil, nil, nil, 0, 0, 0, 0, false, false, false, 0, 8, nil);
     if (v2.indirect_result_in_argfile)  { ret 1; }
     if (v2.consumes_agg_layout)         { ret 1; }
     if (v2.fp_callee_saved_full_vector) { ret 1; }
@@ -780,33 +790,47 @@ pub fun covers_isa(vt: *AbiVTable, arch_id: u32) bool {
 }
 
 # build a register ParamPiece, taking the bank from the register id's class tag and
-# reading a full machine-word chunk at `src_off`. an FP eightbyte rides its register
-# as a double-width SSE move; the consumer reads `width` only for the FP / stack
-# banks, so a GP chunk's nominal 8 is harmless
+# reading a `word`-byte chunk at `src_off`
+#
+# `word` is THE CONVENTION'S ARGUMENT-SLOT GRANULARITY, not a constant. A chunk in a
+# general-purpose register is a whole machine word by definition, and which machine
+# word that is belongs to the convention: SysV's eightbyte and AAPCS64's 8, RISC-V's
+# XLEN, mos6502's word. It read a literal 8 until #2778, under a comment excusing it
+# as "nominal" because the consumer reads `width` only for the FP and stack banks -
+# true, and beside the point, since the same 8 was also the SECOND REGISTER'S SOURCE
+# OFFSET in `make_slot_pair`, which is real geometry and is 4 on ilp32.
 # ---
 # reg:     the register id (its class tag selects PIECE_GP vs PIECE_FP)
 # src_off: byte offset of the chunk within the aggregate's storage
+# word:    the convention's argument-slot granularity in bytes
 # ret:     the assembled register ParamPiece
-fun piece_for_reg(reg: i32, src_off: i64) ParamPiece {
+fun piece_for_reg(reg: i32, src_off: i64, word: u32) ParamPiece {
     var kind: PieceKind = PIECE_GP;
     if (isa.regid_class(reg) == isa.REG_CLASS_ID_XMM) { kind = PIECE_FP; }
-    ret make_piece(kind, reg, src_off, 0, 8);
+    ret make_piece(kind, reg, src_off, 0, word::u8);
 }
 
-# build a single-register or stack `ParamSlot`. A register-bearing placement (one
-# register, or a 9-16 byte two-register pair) fills the canonical `pieces` list -- one
-# chunk per register at the fixed 0 / 8 eightbyte offsets, each piece's bank taken from
-# its register id -- so the backend materializes it through the same per-piece path as a
-# mixed or split placement; `reg` carries the scalar / by-reference register for the
-# consumer paths that route by `class`
+# build a SINGLE-register or stack `ParamSlot`
+#
+# A register-bearing placement fills the canonical `pieces` list so the backend
+# materializes it through the same per-piece path as a mixed or split placement;
+# `reg` carries the scalar / by-reference register for the consumer paths that route
+# by `class`. One register means one chunk at offset 0, so no granularity arises and
+# none is asked for.
+#
+# A TWO-REGISTER PLACEMENT IS NOT EXPRESSIBLE HERE - it goes through `make_slot_pair`,
+# which requires the convention's word. That is the point of the split rather than an
+# inconvenience: the second register's source offset is the machine word, this
+# constructor took a `reg2` and placed it at a literal 8, and every caller that wanted
+# a pair silently got SysV's geometry (#2778). Dropping the parameter makes a pair
+# built without stating its word an arity error at build time instead.
 # ---
 # class:  classification
-# reg:    first register id (-1 if none)
-# reg2:   second register id (-1 if none)
+# reg:    register id (-1 if none)
 # offset: stack offset in bytes
 # size:   slot size in bytes
 # ret:    the assembled ParamSlot
-pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64) ParamSlot {
+pub fun make_slot(class: ParamClass, reg: i32, offset: i64, size: u64) ParamSlot {
     var s: ParamSlot;
     s.class       = class;
     s.reg         = reg;
@@ -814,11 +838,54 @@ pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64
     s.size        = size;
     s.piece_count = 0;
     if (reg >= 0) {
-        s.pieces[0]   = piece_for_reg(reg, 0);
+        s.pieces[0]   = piece_for_reg(reg, 0, PIECE_WORD_SINGLE);
+        s.piece_count = 1;
+    }
+    ret s;
+}
+
+# the chunk width a single-register placement records
+#
+# A one-register placement has no second chunk, so no offset is derived from this and
+# it is genuinely nominal - unlike the pair case, where the same number is geometry.
+# It stays 8 because the consumer reads a GP chunk's width nowhere, and narrowing it
+# would change the recorded width of every single-register placement on every target
+# for no observable gain. Stated as a named constant rather than a literal so a reader
+# can tell which of the two it is looking at.
+val PIECE_WORD_SINGLE: u32 = 8;
+
+# build a TWO-REGISTER `ParamSlot`, the 9-16 byte aggregate pair
+#
+# `word` is the convention's argument-slot granularity, and it is the whole reason
+# this is a separate constructor. The second register carries the aggregate's bytes at
+# `[word, 2*word)`: 8 on lp64 and sysv64 and aapcs64, 4 on ilp32. A literal 8 here
+# compiles, links, runs, and passes the wrong half of the struct.
+#
+# Callers take `word` from the same source their vtable's `arg_slot_granularity` comes
+# from, and `abi_vtable_granularity_matches_classifier` checks the two agree for every
+# registered convention rather than trusting them to.
+# ---
+# class:  classification
+# reg:    first register id
+# reg2:   second register id
+# offset: stack offset in bytes
+# size:   slot size in bytes
+# word:   the convention's argument-slot granularity in bytes
+# ret:    the assembled ParamSlot
+pub fun make_slot_pair(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64,
+                       word: u32) ParamSlot {
+    var s: ParamSlot;
+    s.class       = class;
+    s.reg         = reg;
+    s.offset      = offset;
+    s.size        = size;
+    s.piece_count = 0;
+    if (reg >= 0) {
+        s.pieces[0]   = piece_for_reg(reg, 0, word);
         s.piece_count = 1;
     }
     if (reg2 >= 0) {
-        s.pieces[1]   = piece_for_reg(reg2, 8);
+        s.pieces[1]   = piece_for_reg(reg2, word::i64, word);
         s.piece_count = 2;
     }
     ret s;
@@ -912,7 +979,7 @@ test "mach.lang.target.abi.covers_isa:matches_declared_arch" {
         0, 0, 0,
         -1, false,
         false, false,
-        0,
+        0, 8,
         nil
     );
     if (!covers_isa(?vt, isa.ARCH_AARCH64)) { ret 1; }
@@ -938,5 +1005,47 @@ test "mach.lang.target.abi.abi_name_for:round_trips" {
     if (abi_id_for(abi_name_for(ABI_LP64))  != ABI_LP64)  { ret 1; }
     if (abi_id_for(abi_name_for(ABI_LP64F)) != ABI_LP64F) { ret 1; }
     if (abi_id_for(abi_name_for(ABI_LP64D)) != ABI_LP64D) { ret 1; }
+    ret 0;
+}
+
+# THE PAIR GEOMETRY IS READ FROM THE CONVENTION, AND THIS TEST USES A GRANULARITY NO
+# SHIPPED TARGET HAS.
+#
+# That is the point of the test rather than a detail of it. Every convention this tree
+# ships places a two-register aggregate at a granularity of 8 - sysv64, win64, aapcs64
+# and lp64 all agree - so a test written against any of them passes whether the
+# geometry is READ from the convention or left as the literal 8 it used to be. Such a
+# test states one reason and passes for another.
+#
+# So the granularities here are 4 and 2. 4 is ilp32's, which is why this matters at
+# all; 2 is chosen only because nothing has it, so a 2 appearing in the output cannot
+# have come from any constant lying around.
+test "mach.lang.target.abi.make_slot_pair:geometry_is_the_conventions_word" {
+    # granularity 4: the second register's bytes start at 4, not at 8
+    val p4: ParamSlot = make_slot_pair(CLASS_GP, 10, 11, 0, 8, 4);
+    if (p4.piece_count != 2)       { ret 1; }
+    if (p4.pieces[0].src_off != 0) { ret 1; }
+    if (p4.pieces[0].width != 4)   { ret 1; }
+    if (p4.pieces[1].reg != 11)    { ret 1; }
+    if (p4.pieces[1].src_off != 4) { ret 1; }
+    if (p4.pieces[1].width != 4)   { ret 1; }
+
+    # granularity 2: no target has this, so this arm fails the moment the geometry is
+    # re-hardcoded to anything at all
+    val p2: ParamSlot = make_slot_pair(CLASS_GP, 10, 11, 0, 4, 2);
+    if (p2.pieces[1].src_off != 2) { ret 1; }
+    if (p2.pieces[1].width != 2)   { ret 1; }
+
+    # granularity 8 still produces exactly what every shipped convention produced
+    # before, so this is a parameterization and not a behaviour change on a live target
+    val p8: ParamSlot = make_slot_pair(CLASS_GP, 10, 11, 0, 16, 8);
+    if (p8.pieces[0].src_off != 0) { ret 1; }
+    if (p8.pieces[1].src_off != 8) { ret 1; }
+    if (p8.pieces[1].width != 8)   { ret 1; }
+
+    # a single-register placement has no second chunk and so no geometry to get wrong
+    val one: ParamSlot = make_slot(CLASS_GP, 10, 0, 8);
+    if (one.piece_count != 1)       { ret 1; }
+    if (one.pieces[0].src_off != 0) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -143,6 +143,11 @@ pub def VaModelFn:    abi.VaModelFn;
 # ---
 # index: zero-based GP argument-register index
 # ret:   the physical register id, or -1 if out of range
+# AAPCS64's argument-slot granularity: one 8-byte general-purpose chunk, and so the
+# offset of the second register's bytes within a 9-16 byte aggregate pair. fixed by
+# the procedure call standard rather than derived from the register file
+pub val WORD: u32 = 8;
+
 pub fun gp_param_reg(index: i32) i32 {
     if (index < 0)               { ret -1; }
     if (index >= GP_PARAM_COUNT) { ret -1; }
@@ -251,24 +256,24 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         if (fp_used + hfa_members::i32 <= FP_PARAM_COUNT) {
             ret abi.make_slot_hfa(fp_param_reg(fp_used), hfa_members, hfa_elem, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (is_aggregate && size > MAX_REG_RET) {
         # >16 bytes: passed by reference. the pointer rides the next GP register, or
         # the stack (as an 8-byte pointer) once the GP bank is exhausted.
         if (gp_used < GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), 0, 8);
         }
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, 8);
     }
 
     if (is_aggregate) {
         if (size <= 8) {
             if (gp_used < GP_PARAM_COUNT) {
-                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), 0, size);
             }
-            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
         }
         # 9-16 bytes: a consecutive GP register pair, or spill by value if two GP
         # registers do not remain. the psABI rounds NGRN up to the next even number
@@ -277,9 +282,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         # module header), so the pair starts at the next register regardless of a
         # 16-byte alignment, and a later smaller GP argument may back-fill X7.
         if (gp_used + 2 <= GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
+            ret abi.make_slot_pair(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size, WORD);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     # a short vector is a one-member Homogeneous Short-Vector Aggregate: it rides a
@@ -297,25 +302,25 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             if (fp_used < FP_PARAM_COUNT) {
                 ret abi.make_slot_hfa(fp_param_reg(fp_used), 1, VEC_REG_BYTES, size);
             }
-            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
         }
         if (gp_used < GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), 0, 8);
         }
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, 8);
     }
 
     if (is_float) {
         if (fp_used < FP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), 0, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (gp_used < GP_PARAM_COUNT) {
-        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), 0, size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
 }
 
 # assign registers or an sret pointer for a return value (AAPCS64)
@@ -345,7 +350,7 @@ pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
-        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+        ret abi.make_slot(abi.CLASS_GP, -1, 0, 0);
     }
 
     # an HFA/HVA returns in V0..V(members-1); a return always has the full V bank.
@@ -354,14 +359,14 @@ pub fun classify_return(size: u64, align: u64,
     }
 
     if (is_aggregate && size > MAX_REG_RET) {
-        ret abi.make_slot(abi.CLASS_SRET, REG_X8, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_SRET, REG_X8, 0, 8);
     }
 
     if (is_aggregate) {
         if (size <= 8) {
-            ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_GP, REG_X0, 0, size);
         }
-        ret abi.make_slot(abi.CLASS_GP, REG_X0, REG_X1, 0, size);
+        ret abi.make_slot_pair(abi.CLASS_GP, REG_X0, REG_X1, 0, size, WORD);
     }
 
     # a short vector returns in V0 (a one-member short-vector aggregate) as one whole-
@@ -371,14 +376,14 @@ pub fun classify_return(size: u64, align: u64,
         if (size <= VEC_REG_BYTES::u64) {
             ret abi.make_slot_hfa(fp_param_reg(0), 1, VEC_REG_BYTES, size);
         }
-        ret abi.make_slot(abi.CLASS_SRET, REG_X8, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_SRET, REG_X8, 0, 8);
     }
 
     if (is_float) {
-        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(0), -1, 0, size);
+        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(0), 0, size);
     }
 
-    ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_GP, REG_X0, 0, size);
 }
 
 # fill `out` with the general-purpose argument registers, in passing order
@@ -473,7 +478,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         STACK_ALIGN, RED_ZONE, shadow_space,
         indirect_result_reg, false,
         consumes_agg_layout, fp_callee_saved_full_vector,
-        float_arg_bits,
+        float_arg_bits, WORD,
         va_model::*u8
     );
 

--- a/src/lang/target/abi/mos6502.mach
+++ b/src/lang/target/abi/mos6502.mach
@@ -52,9 +52,9 @@ fun is_byte_scalar(size: u64, is_float: bool, is_aggregate: bool) bool {
 fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
              gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     if (is_byte_scalar(size, is_float, is_aggregate) && gp_used < ARG_REG_COUNT) {
-        ret abi.make_slot(abi.CLASS_GP, mos6502.FIRST_VALUE_REG + gp_used, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, mos6502.FIRST_VALUE_REG + gp_used, 0, size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
 }
 
 # assign the register or stack slot for one argument
@@ -67,9 +67,9 @@ fun arg_passing(index: i32, size: u64, align: u64, is_float: bool, fp_eightbytes
                 gp_used: i32, fp_used: i32,
                 hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (is_byte_scalar(size, is_float, is_aggregate) && gp_used < ARG_REG_COUNT) {
-        ret abi.make_slot(abi.CLASS_GP, mos6502.FIRST_VALUE_REG + gp_used, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, mos6502.FIRST_VALUE_REG + gp_used, 0, size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
 }
 
 # assign the register or hidden-pointer slot for a return value
@@ -79,10 +79,10 @@ fun arg_passing(index: i32, size: u64, align: u64, is_float: bool, fp_eightbytes
 fun ret_passing(size: u64, align: u64, is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
                 is_vector: bool, hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (is_byte_scalar(size, is_float, is_aggregate)) {
-        ret abi.make_slot(abi.CLASS_GP, mos6502.FIRST_VALUE_REG, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, mos6502.FIRST_VALUE_REG, 0, size);
     }
     # a wider or aggregate return goes through a caller-provided hidden pointer.
-    ret abi.make_slot(abi.CLASS_SRET, mos6502.PTR_LO, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_SRET, mos6502.PTR_LO, 0, size);
 }
 
 # fill the byte-argument register bank in canonical order and return its count
@@ -117,6 +117,13 @@ fun va_model() abi.VaModel {
 # ---
 # reg: the ABI registry to install the vtable into
 # ret: true on success
+# the 6502's argument-slot granularity: ONE BYTE. the accumulator is 8 bits, so a
+# general-purpose chunk is a byte and a multi-register aggregate steps a byte at a
+# time. this is the same fact PR #2841 found the shared lowerer overriding with 8,
+# reserving an eight-byte outgoing stack slot per argument on a machine with no such
+# word - which is why "the literal happened to be right everywhere" was never true
+pub val WORD: u32 = 1;
+
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # the hidden sret pointer rides the encoder pointer pair; it is not part of the
     # byte-argument file, so the GP argument cursor starts at 0.
@@ -133,7 +140,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         1, 0, 0,
         indirect_result_reg, false,
         false, fp_callee_saved_full_vector,
-        float_arg_bits,
+        float_arg_bits, WORD,
         va_model::*u8
     );
 

--- a/src/lang/target/abi/riscv.mach
+++ b/src/lang/target/abi/riscv.mach
@@ -384,16 +384,16 @@ pub fun classify_arg_v(v: RiscvAbi, index: i32, size: u64, align: u64,
     # pointer in the next integer register, or on the stack once the bank is spent.
     if (is_vector) {
         if (gp_used < v.gp_arg_count) {
-            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(v, gp_used), -1, 0, word);
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(v, gp_used), 0, word);
         }
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, word);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, word);
     }
 
     if (is_aggregate && size > max_reg_ret(v)) {
         if (gp_used < v.gp_arg_count) {
-            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(v, gp_used), -1, 0, word);
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(v, gp_used), 0, word);
         }
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, word);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, word);
     }
 
     # hard-float struct flattening: an aggregate flattening to one or two float
@@ -427,13 +427,13 @@ pub fun classify_arg_v(v: RiscvAbi, index: i32, size: u64, align: u64,
     if (is_aggregate) {
         if (size <= word) {
             if (gp_used < v.gp_arg_count) {
-                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), -1, 0, size);
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), 0, size);
             }
-            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
         }
         # one to two words: a consecutive integer pair when two registers remain.
         if (gp_used + 2 <= v.gp_arg_count) {
-            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), gp_param_reg(v, gp_used + 1), 0, size);
+            ret abi.make_slot_pair(abi.CLASS_GP, gp_param_reg(v, gp_used), gp_param_reg(v, gp_used + 1), 0, size, xlen_bytes(v)::u32);
         }
         # exactly one register remains: the boundary rule places the low word in it
         # and the high word in an outgoing stack slot rather than spilling the whole
@@ -444,27 +444,27 @@ pub fun classify_arg_v(v: RiscvAbi, index: i32, size: u64, align: u64,
             ps[1] = abi.make_piece(abi.PIECE_STACK, -1,                       word::i64, 0, word::u8);
             ret abi.make_slot_pieces(abi.CLASS_GP, ?ps[0], 2, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (is_float) {
         if (float_in_fp_bank(v, size) && fp_used < v.fp_arg_count) {
-            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(v, fp_used), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(v, fp_used), 0, size);
         }
         # the fa bank is unavailable to this float -- because the member is soft
         # float, because the float is wider than the member carries, or because the
         # bank is spent. in every one of those cases the psABI passes the raw bits in
         # an integer argument register, then on the stack.
         if (gp_used < v.gp_arg_count) {
-            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), 0, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (gp_used < v.gp_arg_count) {
-        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(v, gp_used), 0, size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
 }
 
 # assign registers or an sret pointer for a return value, for ANY family member
@@ -490,10 +490,10 @@ pub fun classify_return_v(v: RiscvAbi, size: u64, align: u64,
                           agg: abi.AggLayout) abi.ParamSlot {
     val word: u64 = xlen_bytes(v);
 
-    if (size == 0) { ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0); }
+    if (size == 0) { ret abi.make_slot(abi.CLASS_GP, -1, 0, 0); }
 
-    if (is_vector)                              { ret abi.make_slot(abi.CLASS_SRET, REG_A0, -1, 0, word); }
-    if (is_aggregate && size > max_reg_ret(v))  { ret abi.make_slot(abi.CLASS_SRET, REG_A0, -1, 0, word); }
+    if (is_vector)                              { ret abi.make_slot(abi.CLASS_SRET, REG_A0, 0, word); }
+    if (is_aggregate && size > max_reg_ret(v))  { ret abi.make_slot(abi.CLASS_SRET, REG_A0, 0, word); }
 
     if (is_aggregate && (hfa_members == 1 || hfa_members == 2)) {
         if (float_in_fp_bank(v, hfa_elem::u64)) {
@@ -511,15 +511,15 @@ pub fun classify_return_v(v: RiscvAbi, size: u64, align: u64,
     }
 
     if (is_aggregate) {
-        if (size <= word) { ret abi.make_slot(abi.CLASS_GP, REG_A0, -1, 0, size); }
-        ret abi.make_slot(abi.CLASS_GP, REG_A0, REG_A1, 0, size);
+        if (size <= word) { ret abi.make_slot(abi.CLASS_GP, REG_A0, 0, size); }
+        ret abi.make_slot_pair(abi.CLASS_GP, REG_A0, REG_A1, 0, size, xlen_bytes(v)::u32);
     }
 
     if (is_float && float_in_fp_bank(v, size)) {
-        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(v, 0), -1, 0, size);
+        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(v, 0), 0, size);
     }
 
-    ret abi.make_slot(abi.CLASS_GP, REG_A0, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_GP, REG_A0, 0, size);
 }
 
 # fill `out` with the member's integer argument registers, in passing order
@@ -735,7 +735,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         STACK_ALIGN, RED_ZONE, 0,
         gp_param_reg(vl, 0), true,
         true, true,
-        vl.flen_bits,
+        vl.flen_bits, xlen_bytes(vl)::u32,
         lp64_va::*u8
     );
     val rlp64: R.Result[bool, str] = install(reg, vl, ?lp64_vtable);
@@ -749,7 +749,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         STACK_ALIGN, RED_ZONE, 0,
         gp_param_reg(vf, 0), true,
         true, true,
-        vf.flen_bits,
+        vf.flen_bits, xlen_bytes(vf)::u32,
         lp64f_va::*u8
     );
     val rlp64f: R.Result[bool, str] = install(reg, vf, ?lp64f_vtable);
@@ -763,7 +763,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         STACK_ALIGN, RED_ZONE, 0,
         gp_param_reg(vd, 0), true,
         true, true,
-        vd.flen_bits,
+        vd.flen_bits, xlen_bytes(vd)::u32,
         lp64d_va::*u8
     );
     val rlp64d: R.Result[bool, str] = install(reg, vd, ?lp64d_vtable);
@@ -896,7 +896,7 @@ test "mach.lang.target.abi.riscv.register:refuses_a_member_with_no_variadic_rule
         STACK_ALIGN, RED_ZONE, 0,
         REG_A0, true,
         true, true,
-        0,
+        0, 4,
         nil
     );
     val undecided: RiscvAbi = rv_abi(abi.ABI_UNKNOWN, "ilp32e", isa.ARCH_RISCV64, 32, 0, 16, 6, 0, 2, 0,

--- a/src/lang/target/abi/spirv.mach
+++ b/src/lang/target/abi/spirv.mach
@@ -48,7 +48,7 @@ fun classify_arg(index: i32, size: u64, align: u64, is_float: bool, fp_eightbyte
                  hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     var sz: u64 = size;
     if (sz > 8) { sz = 8; }  # a wider value rides one nominal slot; the emitter caps scope
-    ret abi.make_slot(abi.CLASS_GP, index, -1, 0, sz);
+    ret abi.make_slot(abi.CLASS_GP, index, 0, sz);
 }
 
 # classify the return value: register 0
@@ -59,7 +59,7 @@ fun classify_return(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                     agg: abi.AggLayout) abi.ParamSlot {
     var sz: u64 = size;
     if (sz > 8) { sz = 8; }
-    ret abi.make_slot(abi.CLASS_GP, 0, -1, 0, sz);
+    ret abi.make_slot(abi.CLASS_GP, 0, 0, sz);
 }
 
 # classify a single value for an indirect (untyped) call: position from `gp_used`
@@ -69,7 +69,7 @@ fun classify_value(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                    is_aggregate: bool, gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     var sz: u64 = size;
     if (sz > 8) { sz = 8; }
-    ret abi.make_slot(abi.CLASS_GP, gp_used, -1, 0, sz);
+    ret abi.make_slot(abi.CLASS_GP, gp_used, 0, sz);
 }
 
 # fill the nominal argument register bank (ids 0..ARG_REG_COUNT-1)
@@ -104,6 +104,12 @@ fun callee_saved(out: *isa.Register) i32 {
 # ---
 # reg: the ABI registry to install the vtable into
 # ret: true on success
+# SPIR-V has no machine register file and no stack: values are SSA ids the emitter
+# types from the IR, so nothing is ever chunked and no aggregate pair is ever built.
+# stated as 4, the module's natural word, rather than 0 so the field never reads as
+# "unset" - but no code path consumes it on this convention
+pub val WORD: u32 = 4;
+
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # no machine float register bank exists: the emitter types values from the IR.
     val float_arg_bits: u32 = 0;
@@ -115,7 +121,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         0, 0, 0,
         0, false,
         false, true,
-        float_arg_bits,
+        float_arg_bits, WORD,
         nil
     );
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -100,6 +100,12 @@ pub val MAX_REG_RET: u64 = 16;
 # ---
 # index: zero-based GP argument-register index
 # ret:   the physical register id, or -1 past the six GP argument registers
+# the AMD64 psABI's EIGHTBYTE: the granularity every argument is classified and placed
+# at, and therefore the offset of the second register's bytes within a 9-16 byte
+# aggregate pair. the specification names this quantity and fixes it at 8 independent
+# of anything about the machine, which is why it lives here and not in the model
+pub val EIGHTBYTE: u32 = 8;
+
 pub fun gp_param_reg(index: i32) i32 {
     if (index == 0) { ret REG_RDI; }
     if (index == 1) { ret REG_RSI; }
@@ -193,7 +199,7 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         # form is for a MEMORY-class return, the sret path). the full-size CLASS_STACK
         # slot keeps the caller's by-value copy, the outgoing-region cursor, and the
         # callee's in-place read agreed on its footprint.
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (is_aggregate) {
@@ -202,14 +208,14 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             # one eightbyte: an SSE eightbyte rides an XMM argument register, else a GP.
             if (eb0_sse) {
                 if (fp_used < FP_PARAM_COUNT) {
-                    ret abi.make_slot(abi.CLASS_GP, fp_param_reg(fp_used), -1, 0, size);
+                    ret abi.make_slot(abi.CLASS_GP, fp_param_reg(fp_used), 0, size);
                 }
-                ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+                ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
             }
             if (gp_used < GP_PARAM_COUNT) {
-                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), 0, size);
             }
-            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
         }
 
         # two eightbytes: assign each to its bank's next register; spill the whole
@@ -227,9 +233,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             var r1: i32 = 0;
             if (eb0_sse) { r0 = fp_param_reg(fi); fi = fi + 1; } or { r0 = gp_param_reg(gi); gi = gi + 1; }
             if (eb1_sse) { r1 = fp_param_reg(fi); fi = fi + 1; } or { r1 = gp_param_reg(gi); gi = gi + 1; }
-            ret abi.make_slot(abi.CLASS_GP, r0, r1, 0, size);
+            ret abi.make_slot_pair(abi.CLASS_GP, r0, r1, 0, size, EIGHTBYTE);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     # a vector wider than an XMM register has no register form: it takes the MEMORY
@@ -242,9 +248,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
     # what the document classifies at all.
     if (is_vector && size > VEC_REG_BYTES) {
         if (gp_used < GP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), 0, 8);
         }
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, 8);
     }
 
     # a 128-bit vector is a single SSE-class value: one XMM argument register (not the
@@ -252,22 +258,22 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
     # stack slot when the XMM argument registers are exhausted (#2014).
     if (is_vector) {
         if (fp_used < FP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), 0, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (is_float) {
         if (fp_used < FP_PARAM_COUNT) {
-            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), 0, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (gp_used < GP_PARAM_COUNT) {
-        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), 0, size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
 }
 
 # assign registers or an sret pointer for a return value (SysV)
@@ -297,18 +303,18 @@ pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
-        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+        ret abi.make_slot(abi.CLASS_GP, -1, 0, 0);
     }
 
     if (is_aggregate && size > MAX_REG_RET) {
-        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8);
     }
 
     if (is_aggregate) {
         val eb0_sse: bool = (fp_eightbytes & 1) != 0;
         if (size <= 8) {
-            if (eb0_sse) { ret abi.make_slot(abi.CLASS_GP, REG_XMM0, -1, 0, size); }
-            ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
+            if (eb0_sse) { ret abi.make_slot(abi.CLASS_GP, REG_XMM0, 0, size); }
+            ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size);
         }
 
         # two eightbytes: INTEGER halves fill RAX then RDX, SSE halves XMM0 then XMM1,
@@ -320,26 +326,26 @@ pub fun classify_return(size: u64, align: u64,
         var r1: i32 = 0;
         if (eb0_sse) { r0 = ret_sse_reg(ns); ns = ns + 1; } or { r0 = ret_int_reg(ni); ni = ni + 1; }
         if (eb1_sse) { r1 = ret_sse_reg(ns); ns = ns + 1; } or { r1 = ret_int_reg(ni); ni = ni + 1; }
-        ret abi.make_slot(abi.CLASS_GP, r0, r1, 0, size);
+        ret abi.make_slot_pair(abi.CLASS_GP, r0, r1, 0, size, EIGHTBYTE);
     }
 
     # a vector wider than an XMM register returns through the hidden result pointer,
     # the same memory class an over-size aggregate takes (#2727).
     if (is_vector && size > VEC_REG_BYTES) {
-        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8);
     }
 
     # a 128-bit vector returns in a single SSE register (XMM0), like a scalar float but
     # at its full 16-byte width (#2014).
     if (is_vector) {
-        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, 0, size);
     }
 
     if (is_float) {
-        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, 0, size);
     }
 
-    ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size);
 }
 
 # the SysV integer return register for eightbyte index 0 / 1 (RAX, RDX)
@@ -441,7 +447,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
         STACK_ALIGN, RED_ZONE, shadow_space,
         indirect_result_reg, true,
         consumes_agg_layout, fp_callee_saved_full_vector,
-        float_arg_bits,
+        float_arg_bits, EIGHTBYTE,
         va_model::*u8
     );
 

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -210,9 +210,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         # value by reference too, so there is nothing to deviate from.
         if (size > VEC_REG_BYTES) {
             if (slot < PARAM_SLOT_COUNT) {
-                ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), -1, 0, 8);
+                ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), 0, 8);
             }
-            ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, 8);
         }
         # CONFORMANT MARSHALLING (#2058): a call to a declared `ext` function follows the
         # Microsoft x64 convention, which passes a 128-bit vector BY REFERENCE -- the
@@ -224,9 +224,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         # register, or spills as an 8-byte pointer once the four slots are exhausted.
         if (is_ext) {
             if (slot < PARAM_SLOT_COUNT) {
-                ret abi.make_slot(abi.CLASS_VEC_BYREF, slot_gp_reg(slot), -1, 0, 8);
+                ret abi.make_slot(abi.CLASS_VEC_BYREF, slot_gp_reg(slot), 0, 8);
             }
-            ret abi.make_slot(abi.CLASS_VEC_STACK_BYREF, -1, -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_VEC_STACK_BYREF, -1, 0, 8);
         }
         # DELIBERATE DEVIATION (#2055): an internal (mach->mach) call passes mach's own
         # 128-bit vector types in an XMM argument register (spilling by value to the stack
@@ -235,9 +235,9 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         # convention above; it is mach's own, correct for every mach->mach call, which is
         # every non-ext call. The return side agrees with MS regardless (XMM0).
         if (slot < PARAM_SLOT_COUNT) {
-            ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), 0, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (is_aggregate) {
@@ -245,30 +245,30 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         # size is passed by reference (a pointer to a caller-allocated copy).
         if (is_by_value_size(size)) {
             if (slot < PARAM_SLOT_COUNT) {
-                ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), -1, 0, size);
+                ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), 0, size);
             }
-            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
         }
         if (slot < PARAM_SLOT_COUNT) {
-            ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), 0, 8);
         }
         # no register slot remains: spill the hidden pointer (8 bytes) to the
         # stack. CLASS_STACK_BYREF keeps the by-reference fact explicit -- the slot
         # holds the pointer, not the aggregate's bytes -- so caller and callee agree.
-        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, 8);
     }
 
     if (is_float) {
         if (slot < PARAM_SLOT_COUNT) {
-            ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), -1, 0, size);
+            ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), 0, size);
         }
-        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
     }
 
     if (slot < PARAM_SLOT_COUNT) {
-        ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), -1, 0, size);
+        ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), 0, size);
     }
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
 }
 
 # assign a register or sret pointer for a return value (win64)
@@ -297,37 +297,37 @@ pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
-        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+        ret abi.make_slot(abi.CLASS_GP, -1, 0, 0);
     }
 
     # a vector wider than an XMM register returns through the hidden result pointer,
     # the same memory class an over-size UDT takes (#2727).
     if (is_vector && size > VEC_REG_BYTES) {
-        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8);
     }
 
     # a 128-bit vector returns in XMM0 (#2055). This matches BOTH the deliberate
     # internal-XMM argument convention above AND the Microsoft x64 __m128 return rule,
     # which happens to agree on the return side (only the argument side deviates).
     if (is_vector) {
-        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, 0, size);
     }
 
     if (is_aggregate) {
         # a 1/2/4/8-byte UDT returns in RAX regardless of its field types;
         # everything else goes through an sret pointer.
         if (is_by_value_size(size)) {
-            ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
+            ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size);
         }
         # the hidden result-storage pointer rides RCX in and is returned in RAX.
-        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, -1, 0, 8);
+        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8);
     }
 
     if (is_float) {
-        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, 0, size);
     }
 
-    ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
+    ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size);
 }
 
 # fill the GP argument register bank in passing order
@@ -443,6 +443,11 @@ fun slot_index(gp_used: i32, fp_used: i32) i32 {
 # ---
 # reg: the ABI registry to install the vtable into
 # ret: true on success
+# the x64 Windows convention's argument-slot granularity: 8. every argument occupies
+# one eight-byte home-space slot regardless of its own size, so a general-purpose
+# chunk is that word and a two-register aggregate steps by it
+pub val EIGHTBYTE: u32 = 8;
+
 pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # win64 reserves 32 bytes of shadow space below the stack arguments for the
     # callee to home RCX/RDX/R8/R9; the outgoing stack args start above it.
@@ -466,7 +471,7 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
         STACK_ALIGN, RED_ZONE, shadow_space,
         indirect_result_reg, true,
         consumes_agg_layout, fp_callee_saved_full_vector,
-        float_arg_bits,
+        float_arg_bits, EIGHTBYTE,
         va_model::*u8
     );
 
@@ -716,7 +721,7 @@ test "mach.lang.target.abi.win64.callee_saved:includes_rdi_rsi" {
         0, 0, 0,
         -1, false,
         false, false,
-        0,
+        0, 8,
         nil
     );
 


### PR DESCRIPTION
Refs #2778, and takes the chunk-geometry piece inherited from #2842. First of five PRs on the RV32 track; this one is target-blind and lands before the architecture exists.

## What was wrong

A 9-16 byte aggregate passed in two general-purpose registers puts the second register's bytes at `[word, 2*word)`. `make_slot` placed them at a literal `8` for every convention. That is right for sysv64, win64, aapcs64 and lp64, and wrong for ilp32, where the word is 4.

The failure mode is the reason this is worth doing before RV32 rather than during it: it compiles, links, runs, and passes the wrong half of the struct. Every other blocker on #2778's list is a loud error.

The comment above it excused the constant as "nominal" because the consumer reads `width` only for the FP and stack banks. That was true of the *width* and beside the point, because the same 8 was also the second register's **source offset**, which is real geometry sitting under a sentence explaining why the number did not matter.

## Shape

`AbiVTable` gains `arg_slot_granularity`, positional in `abi_vtable` so a convention that forgets it is an arity error rather than a zero that reads as a width. Each convention declares its own, which is where the specifications put it:

| convention | granularity | source |
| --- | --- | --- |
| sysv64 | 8 | `EIGHTBYTE`, the psABI's own term |
| win64 | 8 | `EIGHTBYTE`, the home-space slot |
| aapcs64 | 8 | `WORD` |
| lp64 / lp64f / lp64d | XLEN | `xlen_bytes(v)` off the member descriptor |
| mos6502 | **1** | `WORD` - the same fact #2841 found the shared lowerer overriding with 8 |
| spirv | 4 | nominal; no register file, no path consumes it |

Declaring it per convention rather than reading `MachineModel.gpr_width` is deliberate. It is what the ABI documents state, and it is the only spelling that lets a convention disagree with its machine.

**`make_slot` loses `reg2` entirely.** A pair goes through `make_slot_pair`, which requires the word. The split is the point rather than a convenience: a pair built without stating its granularity is now *inexpressible* rather than silently inheriting SysV's geometry, and every one of the 97 single-register call sites was an arity error at build time rather than a site someone had to notice by reading.

Worth recording against the survey: it estimated 109 call sites and treated that as the reason this could not ride along in #2841. **Only six of them build a pair** - two each in sysv, aapcs64 and riscv. Everything else passes `reg2 = -1` and has no geometry at all.

The single-register chunk width stays 8 as a named `PIECE_WORD_SINGLE`. Nothing derives an offset from it, so it is nominal there where the pair's is geometry; narrowing it would change recorded widths on every target for no observable gain. It is named so a reader can tell the two eights apart rather than assuming they are one fact.

## Tests, and which one carries the weight

**`make_slot_pair:geometry_is_the_conventions_word`** uses granularities of **4 and 2**. 4 because it is ilp32's; 2 because no target has it, so a 2 in the output cannot have come from a constant lying around. Mutating the geometry back to the literal 8 makes it **fail**. This is the test that proves the change.

**`abi_vtable:granularity_matches_its_classifier`** walks every registered convention and checks the declared granularity is the one its classifier actually places a pair at, so a convention wired later that sets one and forgets the other fails at `mach test .` rather than at a call boundary. Mutating riscv's declared value to disagree with its classifier makes it **fail**.

Stated plainly, because it matters: **the second test passes under the first mutation.** Every shipped convention's granularity is 8, so it cannot distinguish the read from the literal it replaced. It guards conventions added later and nothing about this change, and its comment says that rather than implying more. A test on any shipped target cannot tell these apart, which is exactly why the synthetic granularity exists.

## Verification

`mach test .` 1376 passed, 0 failed. `int` full sweeps green on linux, linux-arm64, linux-riscv64. Self-host fixpoint, each stage into a freshly removed `out/`: `stage3 == stage4` byte-identical.

Byte-identical output against a compiler built from this branch's own merge base, reported as counts of what was compared:

| target | debug | release |
| --- | --- | --- |
| linux-x86_64 | 224 objects (0 differing), 1 binary (0) | 224 (0), 1 (0) |
| linux-arm64 | 224 objects (0 differing), 1 binary (0) | 224 (0), 1 (0) |
| linux-riscv64 | 224 objects (0 differing), 1 binary (0) | 224 (0), 1 (0) |

The first run of that comparison reported 223 of 223 riscv64 objects differing. It was not this change: the branch was based on a `dev` predating #2852 while the baseline came from current `dev`, so the difference was the `.riscv.attributes` body. Caught by running the same compiler against itself first (0 of 223, so the build is deterministic and the difference was real) and then decoding one differing object rather than theorising. The baseline is now built from the merge base.
