### PR TITLE
refactor(isa): rename isa/riscv64 to isa/riscv

### DIFF
--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -46,7 +46,7 @@ use sabi: mach.lang.target.abi.spirv;
 use mach.lang.target.abi.mos6502;
 use mach.lang.target.isa;
 use arm64: mach.lang.target.isa.arm64.register;
-use riscv64: mach.lang.target.isa.riscv64.register;
+use riscv: mach.lang.target.isa.riscv.register;
 use spirv: mach.lang.target.isa.spirv.register;
 use m6502: mach.lang.target.isa.mos6502.register;
 use x64: mach.lang.target.isa.x64.register;
@@ -196,7 +196,7 @@ pub fun register_all(reg: *TargetRegistry) R.Result[bool, str] {
     if (R.is_err[bool, str](res)) { ret res; }
     res = arm64.register_arm64(?reg.isa);
     if (R.is_err[bool, str](res)) { ret res; }
-    res = riscv64.register_riscv64(?reg.isa);
+    res = riscv.register_riscv64(?reg.isa);
     if (R.is_err[bool, str](res)) { ret res; }
     res = spirv.register_spirv(?reg.isa);
     if (R.is_err[bool, str](res)) { ret res; }
@@ -702,7 +702,7 @@ test "mach.lang.target:registry_enumeration_agrees_with_lookup" {
 # leaves the slot clear rather than reading whatever the frame held.
 #
 # to see it fail, pass nil for a required hook in any arch's `isa.reloc_seam` call
-# (say `riscv64/register.mach`) and re-run: this test alone reports the count.
+# (say `riscv/register.mach`) and re-run: this test alone reports the count.
 test "mach.lang.target:elf_capable_isa_declares_a_reloc_seam" {
     var reg: TargetRegistry = registry_init();
     if (R.is_err[bool, str](register_all(?reg))) { ret 1; }

--- a/src/lang/target/isa/mos6502.mach
+++ b/src/lang/target/isa/mos6502.mach
@@ -2,7 +2,7 @@
 #
 # The leaf definitions for the 8-bit MOS 6502 backend - the register ids, the
 # zero-page mapping, and the logical machine opcodes the sibling `mos6502`
-# sub-modules build on. Data only, no logic; it mirrors `isa.riscv64` /
+# sub-modules build on. Data only, no logic; it mirrors `isa.riscv` /
 # `isa.x64`. The register file and `isa.IsaVTable` are built in
 # `mos6502.register`; the selection pack and byte encoder live in `mos6502.rules`
 # / `mos6502.encode`.

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -1,7 +1,7 @@
 # MOS 6502 ISA vtable registration
 #
 # The composition seam for the 6502 backend: it wires the machine description into
-# an `isa.IsaVTable` installed in the ISA registry, mirroring `isa.riscv64.register`.
+# an `isa.IsaVTable` installed in the ISA registry, mirroring `isa.riscv.register`.
 # It lives in its own module so wiring the children (the selection pack and the
 # encoder) into the parent does not close an import cycle.
 #

--- a/src/lang/target/isa/riscv.mach
+++ b/src/lang/target/isa/riscv.mach
@@ -1,9 +1,9 @@
 # RISC-V (RV64) register numbering and ABI register roles
 #
 # Owns the concrete register ids and the psABI register roles for RV64 - the leaf
-# definitions the sibling `riscv64` sub-modules build on. The register files and
-# the `isa.IsaVTable` are constructed and registered by `riscv64.register`; the
-# selection rule pack and byte encoder live in `riscv64.rules` / `riscv64.encode`.
+# definitions the sibling `riscv` sub-modules build on. The register files and
+# the `isa.IsaVTable` are constructed and registered by `riscv.register`; the
+# selection rule pack and byte encoder live in `riscv.rules` / `riscv.encode`.
 # This module is data only and carries no logic; it mirrors the register tables
 # of `mach.lang.target.isa.x64` and `mach.lang.target.isa.arm64`.
 #
@@ -15,7 +15,7 @@
 # Everything in this module is XLEN-independent: the register numbering, the psABI
 # role assignments (sp=x2, ra=x1, fp=x8, t0-t6, ...), and the bank counts are
 # identical for RV32 and RV64. The register WIDTH lives in the `MachineModel`
-# (`riscv64.register`) and the calling convention in the RISC-V ABI family
+# (`riscv.register`) and the calling convention in the RISC-V ABI family
 # (lp64 / lp64f / lp64d); an RV32 (ilp32)
 # sibling would reuse this file unchanged and differ only there. The "riscv64"
 # naming reflects the only target wired today, not a width assumption baked here.
@@ -146,7 +146,7 @@ pub val GPR_COUNT: i32 = 32;
 pub val FPR_COUNT: i32 = 30;
 
 # the RISC-V machine opcode space. each value names a logical instruction form the
-# selector emits and the encoder (`riscv64.encode`) maps to concrete bytes. pseudo
+# selector emits and the encoder (`riscv.encode`) maps to concrete bytes. pseudo
 # opcodes (`isa.ISA_*`) live above this space and never collide
 #
 # The concrete forms occupy a low, dense range distinct from the high MIR selection

--- a/src/lang/target/isa/riscv/attributes.mach
+++ b/src/lang/target/isa/riscv/attributes.mach
@@ -849,7 +849,7 @@ fun t_arch_is(buf: *u8, len: u32, want: str) bool {
 # what it read into the naming convention's order rather than the order it arrived in.
 # the run-together spelling with no versions is what a hand-written `-march` produces
 # and the separated spelling with versions is what llvm writes into the section
-test "mach.lang.target.isa.riscv64.attributes.parse_arch:both_spellings_and_ordering" {
+test "mach.lang.target.isa.riscv.attributes.parse_arch:both_spellings_and_ordering" {
     var a: Arch;
     if (!parse_arch("rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0"::*u8, 33, ?a)) { ret 1; }
     if (a.xlen != 64 || a.count != 6) { ret 1; }
@@ -883,7 +883,7 @@ test "mach.lang.target.isa.riscv64.attributes.parse_arch:both_spellings_and_orde
 # themselves under any rule, including a wrong one, so the cases here are the ways two
 # real objects differ: an extension one has and the other does not, the same extension
 # at two versions, an input that states nothing, and two widths that do not combine
-test "mach.lang.target.isa.riscv64.attributes.merge_attributes:disagreeing_inputs" {
+test "mach.lang.target.isa.riscv.attributes.merge_attributes:disagreeing_inputs" {
     var alloc: A.Allocator;
     page.make(?alloc);
 
@@ -933,7 +933,7 @@ test "mach.lang.target.isa.riscv64.attributes.merge_attributes:disagreeing_input
 
 # the tags whose merge rule is NOT a union, each checked against the rule it has
 # rather than against the union it would be easy to write
-test "mach.lang.target.isa.riscv64.attributes.merge_attrs:non_union_tags" {
+test "mach.lang.target.isa.riscv.attributes.merge_attrs:non_union_tags" {
     var a: Attrs;
     var b: Attrs;
 
@@ -993,7 +993,7 @@ test "mach.lang.target.isa.riscv64.attributes.merge_attrs:non_union_tags" {
 # what this compiler claims about its OWN output is derived from the bytes, never
 # stated: the same call with and without compressed instructions differs by exactly
 # the `c` extension, which is the fact `EF_RISCV_RVC` reports one section over
-test "mach.lang.target.isa.riscv64.attributes.build_attributes:derived_from_bytes" {
+test "mach.lang.target.isa.riscv.attributes.build_attributes:derived_from_bytes" {
     var alloc: A.Allocator;
     page.make(?alloc);
 

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -74,9 +74,9 @@ use mach.lang.ct;
 use mach.lang.intern;
 use mach.lang.target.isa;
 use iasm: mach.lang.target.isa.asm;
-use mach.lang.target.isa.riscv64;
-use printer: mach.lang.target.isa.riscv64.printer;
-use mach.lang.target.isa.riscv64.inst;
+use mach.lang.target.isa.riscv;
+use printer: mach.lang.target.isa.riscv.printer;
+use mach.lang.target.isa.riscv.inst;
 use mach.lang.target.of;
 use mach.lang.target.resolved;
 
@@ -96,7 +96,7 @@ pub def EncodeFn: fun(*A.Allocator, *resolved.Target, *mir.MirModule) R.Result[e
 # RV32 sibling does not have - the only XLEN-specific major opcodes here
 #
 # the `OPC_` prefix keeps the encoding-FIELD group distinct from the instructions
-# themselves (`isa.riscv64.inst`), whose names overlap it: the manual calls both the
+# themselves (`isa.riscv.inst`), whose names overlap it: the manual calls both the
 # `JAL` opcode field value and the `jal` instruction by the same name, and they are
 # not the same thing - one is a seven-bit field, the other a whole instruction
 val OPC_OP:        u32 = 0x33;  # register ALU (add/sub/and/or/xor/sll/srl/sra/slt + M-ext)
@@ -250,12 +250,12 @@ val A5_AMOMAXU: u32 = 0x1C;
 # register; SP / FP are the frame registers. SCRATCH (t0) is the encoder's address /
 # right-operand materialization register and SCRATCH2 (t1) the left-operand / value
 # materialization register - both reserved from value allocation by the vtable
-val RZERO:    u32 = 0;  # riscv64.ZERO (x0)
-val RRA:      u32 = 1;  # riscv64.RA (x1)
-val RSP:      u32 = 2;  # riscv64.SP (x2)
-val RFP:      u32 = 8;  # riscv64.FP (x8 / s0)
-val SCRATCH:  u32 = 5;  # riscv64.SCRATCH_REG (t0)
-val SCRATCH2: u32 = 6;  # riscv64.SCRATCH_REG2 (t1)
+val RZERO:    u32 = 0;  # riscv.ZERO (x0)
+val RRA:      u32 = 1;  # riscv.RA (x1)
+val RSP:      u32 = 2;  # riscv.SP (x2)
+val RFP:      u32 = 8;  # riscv.FP (x8 / s0)
+val SCRATCH:  u32 = 5;  # riscv.SCRATCH_REG (t0)
+val SCRATCH2: u32 = 6;  # riscv.SCRATCH_REG2 (t1)
 
 # the caller-saved GP register mask an inline-asm call clobbers: ra, t0-t2, a0-a7,
 # t3-t6. none is callee-saved, so a body whose only writes are a call adds no frame
@@ -3074,23 +3074,23 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (mi.opcode == mir.MIR_ASM) { ret encode_asm_block_riscv64(st, f, fn_base, mi); }
 
     # concrete RV64 opcodes.
-    if (op == riscv64.ADD::u16)    { ret encode_addsub(st, mi, false); }
-    if (op == riscv64.SUB::u16)    { ret encode_addsub(st, mi, true); }
-    if (op == riscv64.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV, true); }
-    if (op == riscv64.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO, false); }
-    if (op == riscv64.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO, false); }
-    if (op == riscv64.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO, false); }
-    if (op == riscv64.SLL::u16)    { ret encode_shift(st, mi, F3_SLL, false); }
-    if (op == riscv64.SRL::u16)    { ret encode_shift(st, mi, F3_SRL, false); }
-    if (op == riscv64.SRA::u16)    { ret encode_shift(st, mi, F3_SRL, true); }
-    if (op == riscv64.NEG::u16)    { ret encode_neg(st, mi); }
-    if (op == riscv64.NOT::u16)    { ret encode_not(st, mi); }
-    if (op == riscv64.MOV::u16)    { ret encode_mov(st, f, mi); }
-    if (op == riscv64.FMV::u16)    { ret encode_fmov(st, f, mi); }
-    if (op == riscv64.JMP::u16)    { ret encode_branch(st, fn_base, mi); }
-    if (op == riscv64.RET::u16)    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret R.ok[bool, str](true); }
-    if (op == riscv64.NOP::u16)    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
-    if (op == riscv64.EBREAK::u16) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret R.ok[bool, str](true); }
+    if (op == riscv.ADD::u16)    { ret encode_addsub(st, mi, false); }
+    if (op == riscv.SUB::u16)    { ret encode_addsub(st, mi, true); }
+    if (op == riscv.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV, true); }
+    if (op == riscv.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO, false); }
+    if (op == riscv.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO, false); }
+    if (op == riscv.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO, false); }
+    if (op == riscv.SLL::u16)    { ret encode_shift(st, mi, F3_SLL, false); }
+    if (op == riscv.SRL::u16)    { ret encode_shift(st, mi, F3_SRL, false); }
+    if (op == riscv.SRA::u16)    { ret encode_shift(st, mi, F3_SRL, true); }
+    if (op == riscv.NEG::u16)    { ret encode_neg(st, mi); }
+    if (op == riscv.NOT::u16)    { ret encode_not(st, mi); }
+    if (op == riscv.MOV::u16)    { ret encode_mov(st, f, mi); }
+    if (op == riscv.FMV::u16)    { ret encode_fmov(st, f, mi); }
+    if (op == riscv.JMP::u16)    { ret encode_branch(st, fn_base, mi); }
+    if (op == riscv.RET::u16)    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret R.ok[bool, str](true); }
+    if (op == riscv.NOP::u16)    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
+    if (op == riscv.EBREAK::u16) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret R.ok[bool, str](true); }
 
     ret R.err[bool, str]("encode: unhandled opcode in riscv64 encode");
 }
@@ -3407,7 +3407,7 @@ fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[
             # inlined_subroutine producer; only instance transitions append a record.
             val rip: R.Result[bool, str] = encode.push_inline_pc(st, st.buf.len::u32, mi.inline_site);
             if (R.is_err[bool, str](rip)) { ret rip; }
-            if (mi.opcode::u16 == riscv64.RET::u16 && !naked) {
+            if (mi.opcode::u16 == riscv.RET::u16 && !naked) {
                 emit_epilogue(st, f, total);
             }
             val ei: R.Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
@@ -4956,7 +4956,7 @@ fun label_at(st: *encode.EncodeState, name: intern.StrId, off: u32) bool {
 
 # the R/I/S/U-type packers are byte-exact against `llvm-mc -triple=riscv64
 # --show-encoding`. registers a0/a1/a2 = x10/x11/x12
-test "mach.lang.target.isa.riscv64.encode:rtype_itype_stype_utype_packers" {
+test "mach.lang.target.isa.riscv.encode:rtype_itype_stype_utype_packers" {
     var bad: i32 = 0;
     # add a0, a1, a2 = 0x00c58533 ; sub = 0x40c58533 ; addw = 0x00c5853b ; subw = 0x40c5853b
     if (pack_r(OPC_OP, F3_ADD, F7_ZERO, 10, 11, 12)  != 0x00C58533) { bad = 1; }
@@ -4994,7 +4994,7 @@ test "mach.lang.target.isa.riscv64.encode:rtype_itype_stype_utype_packers" {
 }
 
 # the B-type / J-type immediate scatter is byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:btype_jtype_immediate_scatter" {
+test "mach.lang.target.isa.riscv.encode:btype_jtype_immediate_scatter" {
     var bad: i32 = 0;
     # beq a0,a1,0 = 0x00b50063 ; beq a0,a1,16 = 0x00b50863 ; bne a0,a1,16 = 0x00b51863
     if (pack_b(OPC_BRANCH, F3_BEQ, 10, 11, 0)  != 0x00B50063) { bad = 1; }
@@ -5014,7 +5014,7 @@ test "mach.lang.target.isa.riscv64.encode:btype_jtype_immediate_scatter" {
 
 # constant materialization (`li`): the 12-bit, 32-bit (lui+addiw), and RV64 64-bit
 # (recursive shift sequence) forms, byte-exact against llvm-mc / gnu as `li`
-test "mach.lang.target.isa.riscv64.encode:li_constant_materialization" {
+test "mach.lang.target.isa.riscv.encode:li_constant_materialization" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5055,7 +5055,7 @@ test "mach.lang.target.isa.riscv64.encode:li_constant_materialization" {
 
 # width-driven loads / stores and the in-register ALU helpers select the right
 # RV64 form off operand size, byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:width_driven_loads_stores_and_alu" {
+test "mach.lang.target.isa.riscv.encode:width_driven_loads_stores_and_alu" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5099,7 +5099,7 @@ test "mach.lang.target.isa.riscv64.encode:width_driven_loads_stores_and_alu" {
 # turn a u8 / u16 load into the word `lw` (the #1639 bug); reading `src_width` keeps it
 # `lbu` / `lhu`. a store rides its `width`, which a void-result store leaves unclamped, so
 # a u8 / u16 store is `sb` / `sh`. byte-exact against llvm-mc. operands a0/a1 = x10/x11
-test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
+test "mach.lang.target.isa.riscv.encode:mir_subword_load_store_widths" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5162,7 +5162,7 @@ test "mach.lang.target.isa.riscv64.encode:mir_subword_load_store_widths" {
 
 # the MIR ALU / shift / mv / neg / not dispatch emits the expected words, byte-exact
 # against llvm-mc. operands a0/a1/a2 = x10/x11/x12
-test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {
+test "mach.lang.target.isa.riscv.encode:mir_alu_shift_mov_neg_not" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5222,7 +5222,7 @@ test "mach.lang.target.isa.riscv64.encode:mir_alu_shift_mov_neg_not" {
 # immediate. regression for the call-argument `const << var` encode failure. the
 # `li t1, 1` (addi t1, x0, 1) = 0x00100313 precedes each shift; result a0 = x10,
 # count a2 = x12. byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:const_value_variable_shift_materializes" {
+test "mach.lang.target.isa.riscv.encode:const_value_variable_shift_materializes" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5266,7 +5266,7 @@ test "mach.lang.target.isa.riscv64.encode:const_value_variable_shift_materialize
 
 # the integer compares synthesize their 0/1 result from the set-less-than
 # primitives, byte-exact against llvm-mc. operands a0/a1/a2 = x10/x11/x12
-test "mach.lang.target.isa.riscv64.encode:integer_compare_sequences" {
+test "mach.lang.target.isa.riscv.encode:integer_compare_sequences" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5330,7 +5330,7 @@ test "mach.lang.target.isa.riscv64.encode:integer_compare_sequences" {
 # conditional (zero-displacement placeholder) + `j else`, byte-exact against
 # llvm-mc; the LE relations swap into the GE forms, and each branch records a
 # fixup at its own word against its own target block. operands a1/a2 = x11/x12
-test "mach.lang.target.isa.riscv64.encode:fused_cbr_sequences" {
+test "mach.lang.target.isa.riscv.encode:fused_cbr_sequences" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5405,7 +5405,7 @@ test "mach.lang.target.isa.riscv64.encode:fused_cbr_sequences" {
 # elides only the not-taken / unconditional edge, never a taken edge. pins the win
 # byte-count: the elided emission is exactly one 4-byte j shorter and records one
 # fewer fixup, and a branch to any OTHER block still emits its j.
-test "mach.lang.target.isa.riscv64.encode:branch_to_fallthrough_elided" {
+test "mach.lang.target.isa.riscv.encode:branch_to_fallthrough_elided" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5476,7 +5476,7 @@ test "mach.lang.target.isa.riscv64.encode:branch_to_fallthrough_elided" {
 
 # the prologue / epilogue of a leaf frame (no callee-saves, no locals) - the 16-byte
 # ra / s0 record - is byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:leaf_prologue_epilogue" {
+test "mach.lang.target.isa.riscv.encode:leaf_prologue_epilogue" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5507,7 +5507,7 @@ test "mach.lang.target.isa.riscv64.encode:leaf_prologue_epilogue" {
 
 # a frame with callee-saved GP registers saves / restores them below the record,
 # byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:callee_save_gp_frame" {
+test "mach.lang.target.isa.riscv.encode:callee_save_gp_frame" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5538,7 +5538,7 @@ test "mach.lang.target.isa.riscv64.encode:callee_save_gp_frame" {
 
 # the branch fixups scatter the resolved displacement into the B-type / J-type
 # immediate and reject out-of-range displacements, byte-exact against llvm-objdump
-test "mach.lang.target.isa.riscv64.encode:branch_fixups_scatter_and_range" {
+test "mach.lang.target.isa.riscv.encode:branch_fixups_scatter_and_range" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5585,7 +5585,7 @@ test "mach.lang.target.isa.riscv64.encode:branch_fixups_scatter_and_range" {
 
 # the direct / indirect call emits the call bytes and records the direct-call
 # RK_PLT32 marker at the auipc; the indirect call records no reloc
-test "mach.lang.target.isa.riscv64.encode:call_records_plt32_marker" {
+test "mach.lang.target.isa.riscv.encode:call_records_plt32_marker" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5631,7 +5631,7 @@ test "mach.lang.target.isa.riscv64.encode:call_records_plt32_marker" {
 # record the RK_PCREL_HI20 + RK_PCREL_LO12_I / _S markers naming the same symbol at the
 # two instruction-word offsets. the words match the `auipc a0, 0` / `addi a0, a0, 0` /
 # `ld a0, 0(t0)` / `sd a1, 0(t0)` forms a RISC-V assembler emits with zero placeholders
-test "mach.lang.target.isa.riscv64.encode:global_la_sequences" {
+test "mach.lang.target.isa.riscv.encode:global_la_sequences" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5707,7 +5707,7 @@ test "mach.lang.target.isa.riscv64.encode:global_la_sequences" {
 # clobbers the caller-saved file, destination-writing forms their first register, the
 # store / branch / system / fence forms nothing, and a body the assembler could not
 # read conservatively clobbers everything
-test "mach.lang.target.isa.riscv64.encode:asm_clobbers_classification" {
+test "mach.lang.target.isa.riscv.encode:asm_clobbers_classification" {
     var bad: i32 = 0;
     var gp: u32 = 0;
     var fp: u32 = 0;
@@ -5791,7 +5791,7 @@ fun tasm(st: *encode.EncodeState, alloc: *A.Allocator, interner: *intern.Interne
 # every core inline-asm form the std `_start` / syscall path uses, byte-exact against
 # `llvm-mc -triple=riscv64 --show-encoding`. each statement is one 32-bit word.
 # registers a0/a1/a2 = x10/x11/x12, sp = x2, a7 = x17
-test "mach.lang.target.isa.riscv64.encode:inline_asm_core_forms" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_core_forms" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5875,7 +5875,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_core_forms" {
 # buffer's cap would have truncated it to, and that a genuinely malformed operand
 # (unbalanced `off(base)`) still refuses - proving the region-based lookup did not
 # also turn off malformed-operand detection.
-test "mach.lang.target.isa.riscv64.encode:inline_asm_long_symbol_operand" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_long_symbol_operand" {
     var bad: i32 = 0;
 
     var st1: encode.EncodeState;
@@ -5947,7 +5947,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_long_symbol_operand" {
 # The escape matters more here than anywhere: RV64 is fixed-width, so an instruction
 # the mnemonic table does not name had no spelling at all before - `csrr a0, time`
 # among them, which is what #2481 exists to name.
-test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directives" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_data_directives" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -5989,7 +5989,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directives" {
 # and in the compiler-emitted code following it - and RV64 has no unaligned
 # instruction to fall back on. Refusing names the statement; emitting would silently
 # shift the whole instruction stream.
-test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directive_refusals" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_data_directive_refusals" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6034,7 +6034,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_data_directive_refusals" {
 # single `ASM_NOTE_BYTES` push could not, by itself, cover it), then a real
 # instruction after it. It checks the exact equality `check_accounted` enforces, and
 # that the buffered notes render as the directive text, in order.
-test "mach.lang.target.isa.riscv64.encode:emit_asm_renders_data_directives" {
+test "mach.lang.target.isa.riscv.encode:emit_asm_renders_data_directives" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6089,7 +6089,7 @@ test "mach.lang.target.isa.riscv64.encode:emit_asm_renders_data_directives" {
 # The conservative answer is the same for every spelling of the family: `.word` is no
 # more readable than `.byte`, so widening the escape (#2479) cannot narrow a clobber
 # set.
-test "mach.lang.target.isa.riscv64.encode:asm_clobbers_data_directives_are_opaque" {
+test "mach.lang.target.isa.riscv.encode:asm_clobbers_data_directives_are_opaque" {
     var gp: u32 = 0;
     var fp: u32 = 0;
     var bad: i32 = 0;
@@ -6112,7 +6112,7 @@ test "mach.lang.target.isa.riscv64.encode:asm_clobbers_data_directives_are_opaqu
 # privileged spec defines several hundred CSR addresses across three privilege levels
 # and the grammar's mnemonic table necessarily lags it. A declaration is what lets an
 # unmodeled instruction cost its own registers rather than all sixty-four.
-test "mach.lang.target.isa.riscv64.encode:declared_raw_encodings" {
+test "mach.lang.target.isa.riscv.encode:declared_raw_encodings" {
     var gp: u32 = 0;
     var fp: u32 = 0;
     var bad: i32 = 0;
@@ -6169,7 +6169,7 @@ test "mach.lang.target.isa.riscv64.encode:declared_raw_encodings" {
 # preceding definition, a forward jump is patched when its definition is reached. the
 # B-type / J-type displacement insert is the shared `patch_branch_riscv64`, byte-exact
 # against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:inline_asm_local_labels" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_local_labels" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6213,7 +6213,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_local_labels" {
 # the symbol-bearing forms record the riscv relocations: `call` / `tail` the RK_PLT32
 # marker at the auipc, `la` the RK_PCREL_HI20 + RK_PCREL_LO12_I pair. the words match
 # the zero-placeholder forms a riscv assembler emits
-test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_symbol_relocs" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6269,7 +6269,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
 # funct3, the per-operation funct5, and the .aq / .rl / .aqrl ordering bits, all
 # byte-exact against `llvm-mc -triple=riscv64 -mattr=+a --show-encoding`. `pause` is the
 # fence hint. registers a0/a1/a2 = x10/x11/x12; the address is the base-only `(a1)` form
-test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_atomics" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6390,7 +6390,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
 # `mstatus` (0x300) is the CSR under test throughout; its address is independently
 # confirmed by `inline_asm_csr_names` below, and every word here was computed by
 # hand from the I-type format rather than read back from `rv_csr_name`.
-test "mach.lang.target.isa.riscv64.encode:inline_asm_csr_forms" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_csr_forms" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6445,7 +6445,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_csr_forms" {
 # EVERY ADDRESS BELOW CAME FROM `llvm-mc -triple=riscv64 -mattr=+zicsr
 # --show-encoding`, decoding imm[31:20] of the word it produced for `csrr a0,
 # <name>` - not derived on paper, and not read back from `rv_csr_name` itself.
-test "mach.lang.target.isa.riscv64.encode:inline_asm_csr_names" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_csr_names" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6526,7 +6526,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_csr_names" {
 
 # an unknown CSR name, an out-of-range numeric address, and an out-of-range
 # `uimm5` are each refused rather than silently truncated (#2481)
-test "mach.lang.target.isa.riscv64.encode:inline_asm_csr_refusals" {
+test "mach.lang.target.isa.riscv.encode:inline_asm_csr_refusals" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6571,7 +6571,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_csr_refusals" {
 # shared notifier. This locks that in as a live regression surface: were a future CSR
 # form added straight to the byte stream instead of through `emit_i`, this fails
 # rather than only `--emit-asm` failing silently on a real build.
-test "mach.lang.target.isa.riscv64.encode:emit_asm_renders_csr" {
+test "mach.lang.target.isa.riscv.encode:emit_asm_renders_csr" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6619,7 +6619,7 @@ test "mach.lang.target.isa.riscv64.encode:emit_asm_renders_csr" {
 # encoder's own `classify_*` names the instruction back from those same fields. This
 # is the conformance check that keeps the assembler and the printer from drifting -
 # an instruction they disagree about fails here rather than in an object file
-test "mach.lang.target.isa.riscv64.encode:asm_fields_classify_round_trip" {
+test "mach.lang.target.isa.riscv.encode:asm_fields_classify_round_trip" {
     var bad: i32 = 0;
     var i: usize = 0;
     for (i < RV_MNEMONIC_COUNT) {
@@ -6666,7 +6666,7 @@ test "mach.lang.target.isa.riscv64.encode:asm_fields_classify_round_trip" {
 # the parse accounts for every byte of a statement or refuses it: an operand the
 # grammar does not reach cannot be silently dropped, and the diagnostic names the
 # statement rather than the file
-test "mach.lang.target.isa.riscv64.encode:asm_byte_accounting" {
+test "mach.lang.target.isa.riscv.encode:asm_byte_accounting" {
     var bad: i32 = 0;
     var gp: u32 = 0;
     var fp: u32 = 0;
@@ -6693,7 +6693,7 @@ test "mach.lang.target.isa.riscv64.encode:asm_byte_accounting" {
 # between the printer and the parser. `%got_pcrel_hi` parses but has no riscv64
 # relocation kind in this backend, and is refused by name rather than encoded as a
 # plain pc-relative reference
-test "mach.lang.target.isa.riscv64.encode:asm_relocation_modifiers" {
+test "mach.lang.target.isa.riscv.encode:asm_relocation_modifiers" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6741,7 +6741,7 @@ fun fp_op(idx: i32) mir.MirOperand {
 
 # the M-extension divide / remainder family selects the right funct3 and the RV64
 # word group at 32-bit width, byte-exact against llvm-mc. a0/a1/a2 = x10/x11/x12
-test "mach.lang.target.isa.riscv64.encode:divide_family" {
+test "mach.lang.target.isa.riscv.encode:divide_family" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6774,7 +6774,7 @@ test "mach.lang.target.isa.riscv64.encode:divide_family" {
 
 # the integer width / representation conversions select sext.w / the shift pairs /
 # andi off the source and destination widths, byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:integer_conversions" {
+test "mach.lang.target.isa.riscv.encode:integer_conversions" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6833,7 +6833,7 @@ test "mach.lang.target.isa.riscv64.encode:integer_conversions" {
 
 # the RV64D scalar float arithmetic / negate / move / comparison forms are byte-exact
 # against llvm-mc. fa0/fa1/fa2 = f10/f11/f12 (composite float ids)
-test "mach.lang.target.isa.riscv64.encode:float_arith_neg_cmp" {
+test "mach.lang.target.isa.riscv.encode:float_arith_neg_cmp" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6885,7 +6885,7 @@ test "mach.lang.target.isa.riscv64.encode:float_arith_neg_cmp" {
 
 # the float conversions select the fcvt / fmv forms off the source / destination
 # widths and signedness, byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:float_conversions" {
+test "mach.lang.target.isa.riscv.encode:float_conversions" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -6938,7 +6938,7 @@ test "mach.lang.target.isa.riscv64.encode:float_conversions" {
 
 # the fmv float-move / cross-bank reinterpret and the float loads / stores are
 # byte-exact against llvm-mc
-test "mach.lang.target.isa.riscv64.encode:fmov_and_float_memory" {
+test "mach.lang.target.isa.riscv.encode:fmov_and_float_memory" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -7047,7 +7047,7 @@ fun t_accepted(r: R.Result[bool, str], buf: *encode.ByteBuf) bool {
 # principle: both emitters materialize a wide offset into the scratch register with an
 # `li` + `add` BEFORE the access word, so a check placed at the emission point rather
 # than at the top would leave two stranded instructions behind the error.
-test "mach.lang.target.isa.riscv64.encode:access_width_refusals_emit_nothing" {
+test "mach.lang.target.isa.riscv.encode:access_width_refusals_emit_nothing" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -7161,7 +7161,7 @@ test "mach.lang.target.isa.riscv64.encode:access_width_refusals_emit_nothing" {
 # #2727, which makes over-width vectors legal, is what starts sending sizes down
 # these paths. Under the old default a 16-byte move emitted `fsd` and lost half the
 # value.
-test "mach.lang.target.isa.riscv64.encode:float_width_refusals_emit_nothing" {
+test "mach.lang.target.isa.riscv.encode:float_width_refusals_emit_nothing" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -7290,7 +7290,7 @@ fun t_fcmp(cc: u8, funct3: u32, swap: bool, invert: bool) bool {
 # ONLY ones", which the refusal test beside this closes. Asserting the classifier's
 # value rather than an emitted word is what makes the swapped-operand forms
 # visible: `swap` is invisible in a funct3 and decides which register is rs1.
-test "mach.lang.target.isa.riscv64.encode:classifiers_are_total_over_named_forms" {
+test "mach.lang.target.isa.riscv.encode:classifiers_are_total_over_named_forms" {
     var bad: i32 = 0;
     var swap: bool = false;
 
@@ -7348,7 +7348,7 @@ test "mach.lang.target.isa.riscv64.encode:classifiers_are_total_over_named_forms
 # operand-reversed `bgeu`, an unnamed arithmetic opcode a `remu` or an `fadd`, an
 # unnamed condition code a swapped `fle`, and an unrepresentable scale the same
 # shift as scale 1 - so `base + index*3` addressed `base + index`.
-test "mach.lang.target.isa.riscv64.encode:unnamed_forms_are_refused" {
+test "mach.lang.target.isa.riscv.encode:unnamed_forms_are_refused" {
     var bad: i32 = 0;
     var swap: bool = false;
 
@@ -7515,7 +7515,7 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
 #
 # riscv64 `sd` declares `AW_NONE` for the same reason aarch64 `str` does, so this
 # target and that one are what a `writes`-mask memory domain would silently miss.
-test "mach.lang.target.isa.riscv64.encode.asm_ct_scan:a_spill_does_not_launder_a_secret" {
+test "mach.lang.target.isa.riscv.encode.asm_ct_scan:a_spill_does_not_launder_a_secret" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var bad: i32 = 0;
@@ -7536,7 +7536,7 @@ test "mach.lang.target.isa.riscv64.encode.asm_ct_scan:a_spill_does_not_launder_a
     ret bad;
 }
 
-test "mach.lang.target.isa.riscv64.encode.asm_ct_class:every_grammar_row_is_classified" {
+test "mach.lang.target.isa.riscv.encode.asm_ct_class:every_grammar_row_is_classified" {
     var bad: i32 = 0;
     var i: usize = 0;
     for (i < RV_MNEMONIC_COUNT) {
@@ -7553,7 +7553,7 @@ test "mach.lang.target.isa.riscv64.encode.asm_ct_class:every_grammar_row_is_clas
 # two the check reaches only a register-count shift. This grammar admits the whole
 # M-extension, and this test names all thirteen rows so the per-target honesty note
 # cannot drift from what the grammar actually contains (#2230).
-test "mach.lang.target.isa.riscv64.encode.asm_ct_class:m_extension_is_variable_latency" {
+test "mach.lang.target.isa.riscv.encode.asm_ct_class:m_extension_is_variable_latency" {
     var bad: i32 = 0;
 
     # the eight divide / remainder rows: variable-latency on EVERY target, so a
@@ -7637,7 +7637,7 @@ pub fun asm_ct_scan(body: str, secret_names: *str, n_secret: u32,
 # the count assertion is what keeps the two from drifting: a base name added to the
 # decoder without being added here changes the number the probe accepts, and this
 # test fails rather than silently covering less than it claims.
-test "mach.lang.target.isa.riscv64.encode.asm_ct_class:decode_channel_is_classified" {
+test "mach.lang.target.isa.riscv.encode.asm_ct_class:decode_channel_is_classified" {
     var bad: i32 = 0;
 
     # `rv_decode_amo`'s accepted base names, in its own order.
@@ -7727,7 +7727,7 @@ fun asm_note_bytes(st: *encode.EncodeState, bytes: *u8, n: usize, start: usize) 
 # are zero placeholders, so a pool load that recorded no relocation encodes to
 # exactly these bytes and loads from the wrong address.
 # float-constant materialization matches llvm-mc
-test "mach.lang.target.isa.riscv64.encode:float_constant_materialization" {
+test "mach.lang.target.isa.riscv.encode:float_constant_materialization" {
     var bad: i32 = 0;
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -7824,7 +7824,7 @@ test "mach.lang.target.isa.riscv64.encode:float_constant_materialization" {
 
 # an inline-asm body ending in a trap cannot fall through, and everything else can
 # (#2791). see the x86-64 twin for why the unmodeled rows must all report return.
-test "mach.lang.target.isa.riscv64.encode.asm_returns:trap_ends_control" {
+test "mach.lang.target.isa.riscv.encode.asm_returns:trap_ends_control" {
     var bad: i32 = 0;
 
     if (asm_returns("li a7, 94\necall\nebreak")) { bad = 1; }

--- a/src/lang/target/isa/riscv/inst.mach
+++ b/src/lang/target/isa/riscv/inst.mach
@@ -1,10 +1,10 @@
 # the RV64 machine-instruction surface: the concrete forms the encoder emits
 #
-# `riscv64.Opcode` is NOT this. Those values (`riscv64.ADD`, `MOV`, `JMP`, `RET`,
+# `riscv.Opcode` is NOT this. Those values (`riscv.ADD`, `MOV`, `JMP`, `RET`,
 # ...) are INSTRUCTION-SELECTION tags: seventeen logical operations the selector
 # produces and the encoder realizes, deliberately XLEN- and form-independent.
-# `riscv64.MOV` is not an instruction (`mv rd, rs` is `addi rd, rs, 0`) and
-# `riscv64.RET` is not one either (`ret` is `jalr zero, 0(ra)`); a single `ADD` tag
+# `riscv.MOV` is not an instruction (`mv rd, rs` is `addi rd, rs, 0`) and
+# `riscv.RET` is not one either (`ret` is `jalr zero, 0(ra)`); a single `ADD` tag
 # becomes `add`, `addw`, `addi` or `addiw` depending on width and operand shape.
 # So riscv64 had no name for the instructions it actually emits - the closest thing
 # was the (major opcode, funct3, funct7) triple passed to a packer and discarded.
@@ -24,12 +24,12 @@
 # disappears. This list is the table key that increment needs.
 #
 # The list covers RV64I, the M (multiply / divide), A (atomic) and F/D (scalar
-# float) extensions - every form `riscv64.encode` can produce, from the selector and
+# float) extensions - every form `riscv.encode` can produce, from the selector and
 # from the inline-asm assembler alike. No pseudo-instruction appears: `li`, `mv`,
 # `j`, `ret`, `neg`, `not`, `seqz` and friends are spellings of real instructions in
 # this list, and naming the real one is the point of the artifact.
 
-# a concrete RV64 machine instruction. distinct from `riscv64.Opcode`, which names a
+# a concrete RV64 machine instruction. distinct from `riscv.Opcode`, which names a
 # selection tag; the two spaces never mix in one `isa.Inst`
 pub def MachOp: u16;
 

--- a/src/lang/target/isa/riscv/printer.mach
+++ b/src/lang/target/isa/riscv/printer.mach
@@ -11,7 +11,7 @@
 # representation of "what did this MIR become" and nothing for a second one to
 # disagree with (#2212). The structure reaches it from the instruction-format
 # packers - `pack_r` / `pack_i` / ... each receive every field of the word as an
-# argument, and `riscv64.encode` classifies those arguments into a concrete
+# argument, and `riscv.encode` classifies those arguments into a concrete
 # `inst.MachOp` at the packer - so no RV64 decoder exists anywhere.
 #
 # UNLIKE x86-64, notifications are BUFFERED and rendered when the function's layout
@@ -56,7 +56,7 @@ use R: std.types.result;
 use enc: mach.lang.be.codegen.encode;
 use mach.lang.intern;
 use mach.lang.target.isa;
-use mach.lang.target.isa.riscv64.inst;
+use mach.lang.target.isa.riscv.inst;
 
 # render one function's buffered notifications
 #
@@ -742,7 +742,7 @@ pub fun test_sink_text() str {
 # the psABI register mnemonics name each bank's roles, so a rendered operand reads as
 # the assembler spells it and an out-of-range index degrades to a marker rather than
 # an invented name
-test "mach.lang.target.isa.riscv64.printer.names:abi_mnemonics" {
+test "mach.lang.target.isa.riscv.printer.names:abi_mnemonics" {
     if (!str_equals(gp_name(0), "zero"))  { ret 1; }
     if (!str_equals(gp_name(1), "ra"))    { ret 1; }
     if (!str_equals(gp_name(2), "sp"))    { ret 1; }
@@ -771,7 +771,7 @@ test "mach.lang.target.isa.riscv64.printer.names:abi_mnemonics" {
 # `fcvt.w.s a0,fa0,rtz` for the same four bytes. The int-to-float direction is the
 # control: it encodes the mode its form already defaults to and takes no operand, so a
 # printer appending one unconditionally would be wrong in the other direction.
-test "mach.lang.target.isa.riscv64.printer.render_inst:rounding_mode_is_named" {
+test "mach.lang.target.isa.riscv.printer.render_inst:rounding_mode_is_named" {
     var w: writer.Writer;
     w.ctx     = nil;
     w.f_write = test_sink_write;
@@ -810,7 +810,7 @@ test "mach.lang.target.isa.riscv64.printer.render_inst:rounding_mode_is_named" {
 # every concrete instruction the encoder can emit names a real RV64 mnemonic, and an
 # opcode outside the surface names none - a form reaching the encoder unnamed breaks
 # the render rather than printing text no assembler would accept
-test "mach.lang.target.isa.riscv64.printer.mnemonic:opcode_names" {
+test "mach.lang.target.isa.riscv.printer.mnemonic:opcode_names" {
     # the RV64 word forms are distinct instructions, not width variants of a name
     if (!str_equals(mnemonic(inst.ADD), "add"))     { ret 1; }
     if (!str_equals(mnemonic(inst.ADDW), "addw"))   { ret 1; }
@@ -862,7 +862,7 @@ test "mach.lang.target.isa.riscv64.printer.mnemonic:opcode_names" {
 # records the low half's relocation as the high addend plus its own distance back to
 # the auipc, which is a pairing fact and not a symbol offset. A `%pcrel_lo(g+8)` here
 # would double-count the constant, so the zero is load bearing and is asserted.
-test "mach.lang.target.isa.riscv64.printer.render_inst:a_symbol_addend_is_part_of_the_address" {
+test "mach.lang.target.isa.riscv.printer.render_inst:a_symbol_addend_is_part_of_the_address" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);

--- a/src/lang/target/isa/riscv/register.mach
+++ b/src/lang/target/isa/riscv/register.mach
@@ -1,7 +1,7 @@
 # RISC-V (RV64) ISA vtable registration
 #
 # The composition seam for the RV64 backend: it imports the ISA definitions
-# (`riscv64`) and the byte encoder (`riscv64.encode`) and wires a machine
+# (`riscv`) and the byte encoder (`riscv.encode`) and wires a machine
 # description into an `IsaVTable` installed in the registry. It mirrors
 # `isa.x64.register` and `isa.arm64.register`, living in its own module so wiring the
 # children (the encoder, and the future selector) into the parent does not close an
@@ -11,7 +11,7 @@
 # encoder (`encode`), the inline-asm clobber analyzer (`asm_clobbers`), and the
 # assembly printer (`emit_asm`); the relocatable-object contract carries the ELF
 # relocation forward map (`elf_reloc_type`), the link-time relocation applier
-# (`apply_reloc`, from `riscv64.reloc`), and the ELF build-attributes descriptor.
+# (`apply_reloc`, from `riscv.reloc`), and the ELF build-attributes descriptor.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -22,11 +22,11 @@ use std.types.string.str_equals;
 use R: std.types.result;
 
 use mach.lang.target.isa;
-use mach.lang.target.isa.riscv64;
-use mach.lang.target.isa.riscv64.encode;
-use mach.lang.target.isa.riscv64.attributes;
-use mach.lang.target.isa.riscv64.reloc;
-use mach.lang.target.isa.riscv64.rules;
+use mach.lang.target.isa.riscv;
+use mach.lang.target.isa.riscv.encode;
+use mach.lang.target.isa.riscv.attributes;
+use mach.lang.target.isa.riscv.reloc;
+use mach.lang.target.isa.riscv.rules;
 use mach.lang.target.of;
 use mach.lang.target.of.elf;
 
@@ -170,13 +170,13 @@ fun riscv64_dwarf_reg(regid: i32) i32 {
 
     if (cls == isa.REG_CLASS_ID_GP) {
         # x0..x31 -> 0..31, identity
-        if (idx >= riscv64.X0 && idx <= riscv64.X31) { ret idx; }
+        if (idx >= riscv.X0 && idx <= riscv.X31) { ret idx; }
         ret -1;
     }
 
     if (cls == isa.REG_CLASS_ID_XMM) {
         # f0..f31 -> 32..63
-        if (idx >= riscv64.F0 && idx <= riscv64.F31) { ret DWARF_F0 + idx; }
+        if (idx >= riscv.F0 && idx <= riscv.F31) { ret DWARF_F0 + idx; }
         ret -1;
     }
 
@@ -208,7 +208,7 @@ fun riscv64_dwarf_reg(regid: i32) i32 {
 pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_classes[0].name      = "gpr";
     riscv64_classes[0].kind      = isa.RC_GENERAL;
-    riscv64_classes[0].len       = riscv64.GPR_COUNT::u32;
+    riscv64_classes[0].len       = riscv.GPR_COUNT::u32;
 
     # the fpr bank exposes f0-f29 (count 30) to the allocator. f30 and f31
     # (ft10 / ft11) are held back as the two fixed FP scratch registers the float-op
@@ -218,26 +218,26 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # 128-bit vector bank the shared float-bank lookup keys on by width.
     riscv64_classes[1].name      = "fpr";
     riscv64_classes[1].kind      = isa.RC_FLOAT;
-    riscv64_classes[1].len       = riscv64.FPR_COUNT::u32;
+    riscv64_classes[1].len       = riscv.FPR_COUNT::u32;
 
-    riscv64_reserved_regs[0].id   = riscv64.ZERO;
+    riscv64_reserved_regs[0].id   = riscv.ZERO;
     riscv64_reserved_regs[0].size = 8;
-    riscv64_reserved_regs[1].id   = riscv64.RA;
+    riscv64_reserved_regs[1].id   = riscv.RA;
     riscv64_reserved_regs[1].size = 8;
-    riscv64_reserved_regs[2].id   = riscv64.SP;
+    riscv64_reserved_regs[2].id   = riscv.SP;
     riscv64_reserved_regs[2].size = 8;
-    riscv64_reserved_regs[3].id   = riscv64.GP;
+    riscv64_reserved_regs[3].id   = riscv.GP;
     riscv64_reserved_regs[3].size = 8;
-    riscv64_reserved_regs[4].id   = riscv64.TP;
+    riscv64_reserved_regs[4].id   = riscv.TP;
     riscv64_reserved_regs[4].size = 8;
-    riscv64_reserved_regs[5].id   = riscv64.FP;
+    riscv64_reserved_regs[5].id   = riscv.FP;
     riscv64_reserved_regs[5].size = 8;
 
-    riscv64_reload_scratch_regs[0].id   = riscv64.T2;
+    riscv64_reload_scratch_regs[0].id   = riscv.T2;
     riscv64_reload_scratch_regs[0].size = 8;
-    riscv64_reload_scratch_regs[1].id   = riscv64.T3;
+    riscv64_reload_scratch_regs[1].id   = riscv.T3;
     riscv64_reload_scratch_regs[1].size = 8;
-    riscv64_reload_scratch_regs[2].id   = riscv64.T4;
+    riscv64_reload_scratch_regs[2].id   = riscv.T4;
     riscv64_reload_scratch_regs[2].size = 8;
 
     # the register-machine contract. the FP scratch pair (f31 primary, f30 for the
@@ -256,8 +256,8 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
         rules.is_reg_move,
         ?riscv64_reserved_regs[0], 6,
         ?riscv64_reload_scratch_regs[0], 3,
-        riscv64.SCRATCH_REG, riscv64.SCRATCH_REG2,
-        riscv64.FP, riscv64.SP, 0,
+        riscv.SCRATCH_REG, riscv.SCRATCH_REG2,
+        riscv.FP, riscv.SP, 0,
         -1, -1, -1
     );
     # the printer is the encoder's own sink (#2193), so the `.s` renders the
@@ -342,8 +342,8 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 
     riscv64_model.reg_classes     = ?riscv64_classes[0];
     riscv64_model.reg_class_len   = 2;
-    riscv64_model.frame_ptr_reg   = riscv64.FP;
-    riscv64_model.stack_ptr_reg   = riscv64.SP;
+    riscv64_model.frame_ptr_reg   = riscv.FP;
+    riscv64_model.stack_ptr_reg   = riscv.SP;
     riscv64_model.reserved_regs   = ?riscv64_reserved_regs[0];
     riscv64_model.reserved_len    = 6;
     riscv64_model.div_reg         = -1;
@@ -365,7 +365,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 # for the direct call pair, and the R_RISCV_PCREL_* types for the auipc-based load-
 # address idiom - and 0 (R_RISCV_NONE) for a kind it has no width-correct ELF type for
 # (the x86_64 GOT / 32S and the aarch64 page / lo12 kinds are not riscv64's)
-test "mach.lang.target.isa.riscv64.register.riscv64_elf_reloc_type:forward_map" {
+test "mach.lang.target.isa.riscv.register.riscv64_elf_reloc_type:forward_map" {
     if (riscv64_elf_reloc_type(of.RK_ABS64)        != elf.R_RISCV_64)           { ret 1; }
     if (riscv64_elf_reloc_type(of.RK_PC32)         != elf.R_RISCV_32_PCREL)     { ret 1; }
     if (riscv64_elf_reloc_type(of.RK_PLT32)        != elf.R_RISCV_CALL_PLT)     { ret 1; }
@@ -387,7 +387,7 @@ test "mach.lang.target.isa.riscv64.register.riscv64_elf_reloc_type:forward_map" 
 # riscv vendor, the SHT_RISCV_ATTRIBUTES type, Tag_RISCV_arch, and the imafd arch
 # string the backend's M / A / F / D instructions need, so external tools decode the
 # full instruction set with no manual `--mattr`
-test "mach.lang.target.isa.riscv64.register.register_riscv64:build_attributes" {
+test "mach.lang.target.isa.riscv.register.register_riscv64:build_attributes" {
     var reg: isa.IsaRegistry = isa.registry_init();
     if (R.is_err[bool, str](register_riscv64(?reg))) { ret 1; }
 
@@ -412,19 +412,19 @@ test "mach.lang.target.isa.riscv64.register.register_riscv64:build_attributes" {
 # registers x0..x31 map identically (0..31) and the float registers f0..f31 map to
 # 32..63. The frame pointer s0/fp (x8 -> 8), return address ra (x1 -> 1), and stack
 # pointer sp (x2 -> 2) are the load-bearing entries a DWARF frame base names
-test "mach.lang.target.isa.riscv64.register.riscv64_dwarf_reg:psabi_numbers" {
-    if (riscv64_dwarf_reg(riscv64.X0)  != 0)  { ret 1; }
-    if (riscv64_dwarf_reg(riscv64.RA)  != 1)  { ret 1; }
-    if (riscv64_dwarf_reg(riscv64.SP)  != 2)  { ret 1; }
-    if (riscv64_dwarf_reg(riscv64.FP)  != 8)  { ret 1; }
-    if (riscv64_dwarf_reg(riscv64.X31) != 31) { ret 1; }
+test "mach.lang.target.isa.riscv.register.riscv64_dwarf_reg:psabi_numbers" {
+    if (riscv64_dwarf_reg(riscv.X0)  != 0)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv.RA)  != 1)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv.SP)  != 2)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv.FP)  != 8)  { ret 1; }
+    if (riscv64_dwarf_reg(riscv.X31) != 31) { ret 1; }
 
     # the frame pointer s0/fp (x8) is what DW_AT_frame_base names
-    if (riscv64_dwarf_reg(riscv64.FRAME_REG) != 8) { ret 1; }
+    if (riscv64_dwarf_reg(riscv.FRAME_REG) != 8) { ret 1; }
 
     # f0..f31 are composite ids (the float class tag in the high byte) -> 32..63
-    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F0))  != 32) { ret 1; }
-    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F31)) != 63) { ret 1; }
+    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, riscv.F0))  != 32) { ret 1; }
+    if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, riscv.F31)) != 63) { ret 1; }
 
     # an id riscv64 assigns no DWARF number returns -1
     if (riscv64_dwarf_reg(isa.regid_make(isa.REG_CLASS_ID_GP, 32)) != -1) { ret 1; }

--- a/src/lang/target/isa/riscv/reloc.mach
+++ b/src/lang/target/isa/riscv/reloc.mach
@@ -140,7 +140,7 @@ pub fun apply_reloc(kind: of.RelocKind, dst: *u8, patch_off: u32, sec_len: u32,
 
 # riscv64's call relocation patches the complete auipc+jalr pair and preserves an
 # symbol-relative addend
-test "mach.lang.target.isa.riscv64.reloc.reloc_traits:plt32" {
+test "mach.lang.target.isa.riscv.reloc.reloc_traits:plt32" {
     val t: rel.RelocTraits =
         reloc_traits(of.RK_PLT32, of.SK_TEXT, false);
     if (t.field_width != 8 || t.addend_mode != rel.RELOC_ADDEND_SYMBOL
@@ -199,7 +199,7 @@ fun set_lo12_s(word: u32, delta: i64) u32 {
 # words for a displacement of 0x12345678 (hi20 0x12345, lo12 0x678). a lo12 measures
 # from its own patch site: its addend carries the fold back to the paired auipc, so
 # the pair's distance is the producer's fact and never re-derived here (#1628, #2797)
-test "mach.lang.target.isa.riscv64.reloc.apply_reloc:bitpackers" {
+test "mach.lang.target.isa.riscv.reloc.apply_reloc:bitpackers" {
     var dst: [8]u8;
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
@@ -253,7 +253,7 @@ test "mach.lang.target.isa.riscv64.reloc.apply_reloc:bitpackers" {
 # the riscv pc-relative hi20 / call reach is the auipc + lo12 split's signed 32-bit
 # window: a displacement whose +0x800-rounded high part overflows a signed 32-bit
 # value is rejected; the lo12 kinds never overflow once the hi20 carried the high part
-test "mach.lang.target.isa.riscv64.reloc.apply_reloc:overflow_rejection" {
+test "mach.lang.target.isa.riscv.reloc.apply_reloc:overflow_rejection" {
     var dst: [8]u8;
     dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
 
@@ -352,7 +352,7 @@ pub fun resolve_riscv_pcrel_pairs(img: *of.ObjectImage) R.Result[bool, str] {
 # that only contains pairs: a low half naming a typed symbol is this compiler's own
 # pre-#2828 spelling, and a low half carrying its own addend is not a label reference
 # at all. Both are read back unchanged.
-test "mach.lang.target.isa.riscv64.reloc.resolve_riscv_pcrel_pairs:collapse_and_leave_alone" {
+test "mach.lang.target.isa.riscv.reloc.resolve_riscv_pcrel_pairs:collapse_and_leave_alone" {
     var syms: [3]of.Symbol;
     # 0: the label at the auipc - local, untyped, in the section the low half patches
     syms[0].name = 0::intern.StrId; syms[0].section = 1; syms[0].offset = 0x40;

--- a/src/lang/target/isa/riscv/rules.mach
+++ b/src/lang/target/isa/riscv/rules.mach
@@ -67,7 +67,7 @@ use R: std.types.result;
 use mach.lang.be.codegen.mir;
 use mach.lang.be.codegen.rules;
 use mach.lang.target.isa;
-use mach.lang.target.isa.riscv64;
+use mach.lang.target.isa.riscv;
 use target: mach.lang.target.resolved;
 
 # the concrete signature the erased `isa.RegMachine.select` pointer is cast back
@@ -106,25 +106,25 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # address opcode: operand 0 stays a pure def and the encoder packs one
     # `op rd, rs1, rs2` word (folding an immediate right operand into the `addi` /
     # `andi` / shift-immediate form or materializing it through a scratch).
-    rules.Rule{ op: mir.MIR_ADD, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.ADD::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_SUB, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.SUB::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_MUL, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.MUL::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_AND, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.AND::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_OR,  gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.OR::u32,  expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_XOR, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.XOR::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_ADD, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.ADD::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_SUB, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.SUB::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_MUL, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.MUL::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_AND, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.AND::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_OR,  gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.OR::u32,  expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_XOR, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.XOR::u32, expand: nil, expansion_length: 0 },
 
     # the shifts retag to a single RV64 shift opcode (no x86-64 CL constraint):
     # the encoder selects the register variant (sll/srl/sra) or the immediate
     # variant (slli/srli/srai, masking the shift amount) from operand 2's kind,
     # and the RV64 word form (sllw/srlw/sraw) at 32-bit operand width.
-    rules.Rule{ op: mir.MIR_SHL,   gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.SLL::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_SHR_U, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.SRL::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_SHR_S, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.SRA::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_SHL,   gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.SLL::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_SHR_U, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.SRL::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_SHR_S, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.SRA::u32, expand: nil, expansion_length: 0 },
 
     # division / remainder survive selection as a three-address `[dst, dividend,
     # divisor]` instruction (operand 0 a pure def), lifted to a high SELECTION-
     # OUTPUT sentinel so the encoder never confuses the generic opcode with a
-    # concrete RV64 opcode of the same low value (MIR_REM_U = 6 = riscv64.OR).
+    # concrete RV64 opcode of the same low value (MIR_REM_U = 6 = riscv.OR).
     # the encoder materializes the M-extension div / divu / rem / remu (word
     # forms at 32-bit width); RISC-V defines the divide-by-zero and signed-
     # overflow results, so no guard sequence is needed.
@@ -137,8 +137,8 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # instruction expansion): NEG is `sub rd, x0, rs` (the `neg` alias) and NOT
     # is `xori rd, rs, -1` (the `not` alias). the encoder supplies the missing
     # operand from the surviving `[dst, src]`.
-    rules.Rule{ op: mir.MIR_NEG, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.NEG::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_NOT, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.NOT::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_NEG, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.NEG::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_NOT, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.NOT::u32, expand: nil, expansion_length: 0 },
 
     # the register-to-register / ABI pre-coloring move selects to a plain MOV
     # (`mv rd, rs` for a register source, an `li` materialization for an
@@ -149,17 +149,17 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # spill reload / store moves regalloc inserts after selection keep the
     # generic MIR_MOV (the encoder routes a float spill to the FP path by
     # operand class). the float-bank guard precedes its plain-MOV fallback.
-    rules.Rule{ op: mir.MIR_MOV, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv64.FMV::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_MOV, gate: rules.GATE_ANY, guard: nil,                        kind: rules.RULE_RETAG, to: riscv64.MOV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_MOV, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv.FMV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_MOV, gate: rules.GATE_ANY, guard: nil,                        kind: rules.RULE_RETAG, to: riscv.MOV::u32, expand: nil, expansion_length: 0 },
     # a declassify barrier is a register copy: same FP/GP retag as MIR_MOV (#1646).
-    rules.Rule{ op: mir.MIR_DECLASSIFY, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv64.FMV::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_DECLASSIFY, gate: rules.GATE_ANY, guard: nil,                        kind: rules.RULE_RETAG, to: riscv64.MOV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_DECLASSIFY, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv.FMV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_DECLASSIFY, gate: rules.GATE_ANY, guard: nil,                        kind: rules.RULE_RETAG, to: riscv.MOV::u32, expand: nil, expansion_length: 0 },
 
     # control flow. an unconditional branch selects to JMP (`j`); a return to
     # RET; an unreachable terminator to an `ebreak` trap.
-    rules.Rule{ op: mir.MIR_BR,          gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.JMP::u32,    expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_RET,         gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.RET::u32,    expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_UNREACHABLE, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv64.EBREAK::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_BR,          gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.JMP::u32,    expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_RET,         gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.RET::u32,    expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_UNREACHABLE, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.EBREAK::u32, expand: nil, expansion_length: 0 },
 
     # the comparison family survives selection as a single `[dst, lhs, rhs]`
     # instruction lifted to a high SELECTION-OUTPUT sentinel so the encoder
@@ -239,8 +239,8 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # never writing the float destination. a same-bank GP<->GP reinterpret stays
     # MIR_BITCAST, a plain register copy the integer conversion encoder handles.
     # the float-bank guard precedes its plain pass-through fallback.
-    rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv64.FMV::u32, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: guard_identity_copy,        kind: rules.RULE_RETAG, to: riscv64.MOV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: rules.guard_fp_bank_move, kind: rules.RULE_RETAG, to: riscv.FMV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: guard_identity_copy,        kind: rules.RULE_RETAG, to: riscv.MOV::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_BITCAST, gate: rules.GATE_ANY, guard: nil,                        kind: rules.RULE_PASS,  to: 0,               expand: nil, expansion_length: 0 },
 
     # the integer width conversions and the float conversions pass through
@@ -250,7 +250,7 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     # fcvt.*.* / fmv for the float forms) and the allocator reads operand 0 as a
     # clean def.
     rules.Rule{ op: mir.MIR_TRUNC,    gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
-    rules.Rule{ op: mir.MIR_SEXT,     gate: rules.GATE_ANY, guard: guard_identity_copy, kind: rules.RULE_RETAG, to: riscv64.MOV::u32, expand: nil, expansion_length: 0 },
+    rules.Rule{ op: mir.MIR_SEXT,     gate: rules.GATE_ANY, guard: guard_identity_copy, kind: rules.RULE_RETAG, to: riscv.MOV::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_SEXT,     gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_ZEXT,     gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_FP_TRUNC, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_PASS, to: 0, expand: nil, expansion_length: 0 },
@@ -271,8 +271,8 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
 # the concrete float move (`fmv`), and the generic `mir.MIR_MOV` the reload /
 # store moves regalloc splices after selection keep
 pub val COPY_OPCODES: [COPY_OPCODE_COUNT]u32 = [COPY_OPCODE_COUNT]u32{
-    riscv64.MOV::u32,
-    riscv64.FMV::u32,
+    riscv.MOV::u32,
+    riscv.FMV::u32,
     mir.MIR_MOV,
 };
 
@@ -314,7 +314,7 @@ pub fun select(a: *A.Allocator, tgt: *target.Target, f: *mir.MirFunction) R.Resu
 
 # classify a post-selection opcode as an RV64 plain register move
 #
-# A `mir.MIR_MOV` selects to `riscv64.MOV` (GP, `mv`) or `riscv64.FMV` (float),
+# A `mir.MIR_MOV` selects to `riscv.MOV` (GP, `mv`) or `riscv.FMV` (float),
 # and the reload / store moves regalloc splices after selection stay generic
 # `mir.MIR_MOV`; all three are plain full-width copies. The shared copy-hygiene
 # passes further gate on operand shape and equal source/destination width. This
@@ -367,7 +367,7 @@ fun fp_preg(idx: i32) mir.MirOperand {
 # on the operand register class. all-physical-register operands keep the test
 # free of a vreg table; the engine only nil-checks its target and allocator, so
 # a zeroed pair suffices
-test "mach.lang.target.isa.riscv64.rules:opcode_rewrites" {
+test "mach.lang.target.isa.riscv.rules:opcode_rewrites" {
     var bad: i32 = 0;
     var alloc: A.Allocator;
     var tgt:   target.Target;
@@ -427,31 +427,31 @@ test "mach.lang.target.isa.riscv64.rules:opcode_rewrites" {
     val r: R.Result[bool, str] = select(?alloc, ?tgt, ?f);
     if (R.is_err[bool, str](r)) { ret 1; }
 
-    if (instrs[0].opcode  != riscv64.ADD::u32)    { bad = 1; }
-    if (instrs[1].opcode  != riscv64.SLL::u32)    { bad = 1; }
+    if (instrs[0].opcode  != riscv.ADD::u32)    { bad = 1; }
+    if (instrs[1].opcode  != riscv.SLL::u32)    { bad = 1; }
     if (instrs[2].opcode  != mir.MIR_SEL_DIV_S)   { bad = 1; }
-    if (instrs[3].opcode  != riscv64.NEG::u32)    { bad = 1; }
+    if (instrs[3].opcode  != riscv.NEG::u32)    { bad = 1; }
     if (instrs[4].opcode  != mir.MIR_SEL_CMP_EQ)  { bad = 1; }
     if (instrs[5].opcode  != mir.MIR_SEL_CBR)     { bad = 1; }
     if (instrs[6].opcode  != mir.MIR_FADD)        { bad = 1; }  # float arith survives
-    if (instrs[7].opcode  != riscv64.MOV::u32)    { bad = 1; }  # GP move
-    if (instrs[8].opcode  != riscv64.FMV::u32)    { bad = 1; }  # float move
-    if (instrs[9].opcode  != riscv64.FMV::u32)    { bad = 1; }  # cross-bank bitcast
+    if (instrs[7].opcode  != riscv.MOV::u32)    { bad = 1; }  # GP move
+    if (instrs[8].opcode  != riscv.FMV::u32)    { bad = 1; }  # float move
+    if (instrs[9].opcode  != riscv.FMV::u32)    { bad = 1; }  # cross-bank bitcast
     if (instrs[10].opcode != mir.MIR_BITCAST)     { bad = 1; }  # same-bank GP bitcast survives
-    if (instrs[11].opcode != riscv64.JMP::u32)    { bad = 1; }
-    if (instrs[12].opcode != riscv64.RET::u32)    { bad = 1; }
-    if (instrs[13].opcode != riscv64.FMV::u32)    { bad = 1; }  # same-bank float bitcast (#1762)
+    if (instrs[11].opcode != riscv.JMP::u32)    { bad = 1; }
+    if (instrs[12].opcode != riscv.RET::u32)    { bad = 1; }
+    if (instrs[13].opcode != riscv.FMV::u32)    { bad = 1; }  # same-bank float bitcast (#1762)
 
     ret bad;
 }
 
 # the copy-hygiene move classifier admits both concrete move forms (GP and
 # float) and the generic MIR_MOV regalloc splices, and rejects a non-move opcode
-test "mach.lang.target.isa.riscv64.rules:is_reg_move" {
-    if (!is_reg_move(riscv64.MOV::u32)) { ret 1; }
-    if (!is_reg_move(riscv64.FMV::u32)) { ret 1; }
+test "mach.lang.target.isa.riscv.rules:is_reg_move" {
+    if (!is_reg_move(riscv.MOV::u32)) { ret 1; }
+    if (!is_reg_move(riscv.FMV::u32)) { ret 1; }
     if (!is_reg_move(mir.MIR_MOV))      { ret 1; }
-    if (is_reg_move(riscv64.ADD::u32))  { ret 1; }
+    if (is_reg_move(riscv.ADD::u32))  { ret 1; }
     ret 0;
 }
 
@@ -459,7 +459,7 @@ test "mach.lang.target.isa.riscv64.rules:is_reg_move" {
 # three ops eliminated before selection ever runs stay default-deny: the table
 # cannot silently lose an opcode. also pins the table at its exact storage
 # length, so an appended rule and the storage size can never drift apart
-test "mach.lang.target.isa.riscv64.rules:generic_opcode_coverage" {
+test "mach.lang.target.isa.riscv.rules:generic_opcode_coverage" {
     val pack: *rules.RulePack = ?PACK;
     if (pack.rule_count != 63) { ret 1; }
 
@@ -521,7 +521,7 @@ test "mach.lang.target.isa.riscv64.rules:generic_opcode_coverage" {
 # bytes canonicalizes through `sext.w` (an RV64 32-bit value is HELD sign-extended,
 # so it is not a copy), and a narrowing SEXT takes `sext.w` or the shift pair. x64
 # retags every MIR_BITCAST unconditionally; RV64 cannot, and this pins that.
-test "mach.lang.target.isa.riscv64.rules:identity_conversions_select_to_a_move" {
+test "mach.lang.target.isa.riscv.rules:identity_conversions_select_to_a_move" {
     var bad: i32 = 0;
     var alloc: A.Allocator;
     var tgt:   target.Target;
@@ -575,17 +575,17 @@ test "mach.lang.target.isa.riscv64.rules:identity_conversions_select_to_a_move" 
     val r: R.Result[bool, str] = select(?alloc, ?tgt, ?f);
     if (R.is_err[bool, str](r)) { ret 1; }
 
-    if (instrs[0].opcode != riscv64.MOV::u32) { bad = 1; }
+    if (instrs[0].opcode != riscv.MOV::u32) { bad = 1; }
     if (instrs[1].opcode != mir.MIR_BITCAST)  { bad = 1; }
-    if (instrs[2].opcode != riscv64.MOV::u32) { bad = 1; }
+    if (instrs[2].opcode != riscv.MOV::u32) { bad = 1; }
     if (instrs[3].opcode != mir.MIR_SEXT)     { bad = 1; }
     if (instrs[4].opcode != mir.MIR_SEXT)     { bad = 1; }
-    if (instrs[5].opcode != riscv64.FMV::u32) { bad = 1; }
+    if (instrs[5].opcode != riscv.FMV::u32) { bad = 1; }
     if (instrs[6].opcode != mir.MIR_SEXT)     { bad = 1; }
 
     # the retagged forms must now be what the copy machinery calls a move, which is
     # the entire point of the retag - a MIR_BITCAST is not one.
-    if (!is_reg_move(riscv64.MOV::u32))  { bad = 1; }
+    if (!is_reg_move(riscv.MOV::u32))  { bad = 1; }
     if (is_reg_move(mir.MIR_BITCAST))    { bad = 1; }
     if (is_reg_move(mir.MIR_SEXT))       { bad = 1; }
 

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -178,7 +178,7 @@ fun allowed_file(i: usize) str {
     if (i == 8)  { ret "src/lang/be/codegen/mir.mach"; }
     if (i == 9)  { ret "src/lang/target/isa/x64/register.mach"; }
     if (i == 10) { ret "src/lang/target/isa/arm64/register.mach"; }
-    if (i == 11) { ret "src/lang/target/isa/riscv64/register.mach"; }
+    if (i == 11) { ret "src/lang/target/isa/riscv/register.mach"; }
     if (i == 12) { ret "src/lang/target/isa/mos6502/register.mach"; }
     if (i == 13) { ret "src/lang/target/isa/spirv/register.mach"; }
     if (i == 14) { ret "src/lang/target/abi.mach"; }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4935,7 +4935,7 @@ fun t_x64_elf_reloc_type(kind: of.RelocKind) u32 {
 }
 
 # a test-only riscv64 forward reloc map, mirroring the production map in
-# target/isa/riscv64/register.mach, duplicated here for the same import-cycle reason as
+# target/isa/riscv/register.mach, duplicated here for the same import-cycle reason as
 # the x86_64 helper above. used by the riscv round-trip test to emit real R_RISCV_*
 # relocations whose numbers collide with x86_64's
 # ---
@@ -4958,7 +4958,7 @@ fun t_riscv_elf_reloc_type(kind: of.RelocKind) u32 {
 var t_riscv_attrs: BuildAttributes;
 
 # the test `elf_attributes` hook, mirroring how the production descriptor is wired in
-# target/isa/riscv64/register.mach, duplicated here for the same import-cycle reason as
+# target/isa/riscv/register.mach, duplicated here for the same import-cycle reason as
 # t_riscv_elf_reloc_type
 # ---
 # ret: the test build-attributes descriptor


### PR DESCRIPTION
PR 2 of the five-PR RV32 sequence. Purely mechanical: `src/lang/target/isa/riscv64/` becomes `src/lang/target/isa/riscv/`, and `isa/riscv64.mach` becomes `isa/riscv.mach`. No behaviour change.

The tree was already XLEN-independent. The register numbering, the psABI role assignments, the logical opcode list, the printer, and the relocation seam are identical for RV32 and RV64, and the register width lives in the `MachineModel`. The directory name was the only thing claiming otherwise, and PR 3 cannot add an RV32 target under a name that says 64.

## What moved and what did not

Moved: module paths (`mach.lang.target.isa.riscv64.*` -> `mach.lang.target.isa.riscv.*`), the bare module qualifier inside the tree, the `use riscv64:` alias in `target.mach` (now `riscv:`, matching the `arm64:` / `x64:` / `m6502:` spelling beside it), the test-name prefixes, the source path in `isa/tests.mach`'s permitted-declaration table, and the handful of doc references that name the module.

Not moved: arch-name strings (`"riscv64"` is still the target name), the `register_riscv64` / `encode_riscv64` / `patch_branch_riscv64` function names, and prose about the riscv64 target. The target is still riscv64; only the module is width-neutral.

## Verification

`mach test .`: 1376 passed, 0 failed.

Byte-identity, baseline built from this branch's own merge base (`d659540c`). Two stage-1 compilers, one built from the pre-rename tree and one from the post-rename tree, both by the same parent compiler, then each run over the same corpus:

| leg | objects | binaries | self-differing | base vs branch differing |
|---|---|---|---|---|
| linux-x86_64 | 224 | 2 | 0 | 0 |
| linux-arm64 | 224 | 2 | 0 | 0 |
| linux-riscv64 | 224 | 2 | 0 | 0 |

The self-differing column is the same compiler run twice, so the zeros in the last column are a real comparison and not a determinism artifact. The two stage-1 compilers are themselves 520 bytes apart (shorter mangled module names), so the test is not comparing a binary against itself.

Self-host fixpoint from a freshly removed `out/` at each stage: stage2 == stage3 == stage4, byte-identical.

`int` sweeps, all cases: `linux` green, `linux-arm64` green (qemu run-mode override), `linux-riscv64` green. No `int/` cases added or changed - the freeze holds.

Refs #2778
