### PR TITLE
feat(riscv32): add RV32 as a target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### RV32 is a target (#2778)
+mach compiles for 32-bit RISC-V. `isa = "riscv32"` with `abi = "ilp32"`, `"ilp32f"` or `"ilp32d"` resolves a full machine description, and `$mach.arch.riscv32` and the three `$mach.abi.ilp32*` tags exist so a body can be guarded for it.
+
+Nothing about the RISC-V backend was duplicated to get there. One `build_riscv` fills either arch's vtable, register machine, relocation seam and model from the register width it is handed; the register numbering, the psABI roles, the selection pack, the encoder, the printer and the attribute derivation are shared unchanged. On the convention side the three ilp32 members differ from their lp64 twins in exactly one declared fact, `xlen_bits`, and a test builds each pair and compares every other field rather than asserting that in prose.
+
+The width facts are the machine's and are read as such. `max_alu_width` is 4 on rv32, which puts an `i64` above the ALU and sends it through the same lane-splitting `legalize` pass that serves the 6502's 8-bit one. FLEN stays 64 because rv32gc has the D extension, so a float register is twice the width of an integer one - the pair that a single "word size" gets wrong, and the one the frame layout now reads as two separate strides.
+
+**What rv32 does not do yet, and says so.** The ELF writer stamps ELFCLASS32 from the pointer width while emitting Elf64 structures, so `of.elf` deliberately does not cover this arch and an rv32 linux tuple is refused at resolve time rather than producing a file whose class byte contradicts its layout (#2861). rv32 composes with the `raw` flat image today. Converting between a float and a 64-bit integer has no RV32 instruction and no lowering, so both the encoder and `legalize` refuse it by name with the issue number rather than emitting an RV64 opcode the hardware would trap on (#2860).
+
 #### A shader can use an interface variable declared in another module (#2843)
 #2823 let a shader call a function defined in a shared module, but the shader could not use an **interface variable** one declared. A library that owned anything beyond pure math had nowhere to put its descriptor set: a drawn-in body naming its own module's `#[uniform(...)]` found nothing, and the access was refused as computed addressing.
 

--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -17,7 +17,8 @@ asm <isa> {
 ```
 
 - The ISA tag is mandatory. Bare `asm { ... }` does not exist.
-- The tag comes from a closed set: `x86_64`, `aarch64`, `riscv64`. Each has a working assembler that emits native bytes; all three run in CI (riscv64 under qemu, including a self-host smoke — riscv64 is a self-hosting target with a byte-identical fixpoint, #1852).
+- The tag comes from a closed set: `x86_64`, `aarch64`, `riscv64`, `riscv32`. Each has a working assembler that emits native bytes; the first three run in CI (riscv64 under qemu, including a self-host smoke — riscv64 is a self-hosting target with a byte-identical fixpoint, #1852).
+- **The RISC-V tag names the machine, not the family.** An `asm riscv64` block is refused on a riscv32 target and the other way round, so a body reaching the assembler was written for the register width it is being assembled for. Guard the two with `$if ($mach.build.arch == $mach.arch.riscv32)` when a routine needs both. The mnemonic table is currently shared between them, so an RV64-only spelling (`ld`, `sd`, `addw`, `fcvt.l.d`) is still accepted under a `riscv32` tag and will assemble to an instruction RV32 hardware does not have — gate those yourself until the table is split.
 - Each line is an instruction in the ISA's native syntax.
 - `#` introduces a line comment: everything from `#` to the end of the line is ignored, whatever it contains (`;`, `{}`, `%`, and so on are all inert inside a comment).
 

--- a/doc/language/comptime-mach.md
+++ b/doc/language/comptime-mach.md
@@ -87,10 +87,16 @@ $mach.os.freestanding           # no OS / bare metal
 $mach.arch.x86_64
 $mach.arch.aarch64
 $mach.arch.riscv64
+$mach.arch.riscv32
 $mach.abi.sysv
 $mach.abi.win64
 $mach.abi.aapcs64
 $mach.abi.lp64
+$mach.abi.lp64f
+$mach.abi.lp64d
+$mach.abi.ilp32
+$mach.abi.ilp32f
+$mach.abi.ilp32d
 $mach.mode.debug
 $mach.mode.release
 ```

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -2950,6 +2950,16 @@ fun unsupported_family(op: mir.MirOpcode) str {
     if (op == mir.MIR_GEP || op == mir.MIR_ALLOCA) {
         ret "legalize: materializing an address wider than one register is not yet legalized on this target";
     }
+    # A CONVERSION IS NOT A LANE-WISE OPERATION, so this pass has no expansion for one
+    # and never will have the same one it has for arithmetic: `(hi, lo) -> f64` is a
+    # single rounding of the combined value, not two independent conversions recombined
+    # afterwards. It is named here rather than falling into the generic prose because
+    # the generic message lands on whatever op consumes the conversion's result - a
+    # later `and`, say - and sends the reader to the wrong instruction entirely.
+    if (op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP ||
+        op == mir.MIR_FP_TO_SI || op == mir.MIR_FP_TO_UI) {
+        ret "legalize: converting between a float and an integer wider than one register needs a soft-float helper this target does not have (see briar-systems/mach#2860)";
+    }
     ret "legalize: operation wider than the target ALU is unsupported";
 }
 

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -2553,6 +2553,7 @@ fun arch_tag_for(name: View) R.Result[u32, str] {
     if (view_eq_str(name, "x86_64"))  { ret R.ok[u32, str](isa.ARCH_X86_64); }
     if (view_eq_str(name, "aarch64")) { ret R.ok[u32, str](isa.ARCH_AARCH64); }
     if (view_eq_str(name, "riscv64")) { ret R.ok[u32, str](isa.ARCH_RISCV64); }
+    if (view_eq_str(name, "riscv32")) { ret R.ok[u32, str](isa.ARCH_RISCV32); }
     ret R.err[u32, str]("unknown `$mach.arch.*` tag");
 }
 
@@ -2567,6 +2568,9 @@ fun abi_tag_for(name: View) R.Result[u32, str] {
     if (view_eq_str(name, "lp64"))    { ret R.ok[u32, str](abi.ABI_LP64); }
     if (view_eq_str(name, "lp64f"))   { ret R.ok[u32, str](abi.ABI_LP64F); }
     if (view_eq_str(name, "lp64d"))   { ret R.ok[u32, str](abi.ABI_LP64D); }
+    if (view_eq_str(name, "ilp32"))   { ret R.ok[u32, str](abi.ABI_ILP32); }
+    if (view_eq_str(name, "ilp32f"))  { ret R.ok[u32, str](abi.ABI_ILP32F); }
+    if (view_eq_str(name, "ilp32d"))  { ret R.ok[u32, str](abi.ABI_ILP32D); }
     ret R.err[u32, str]("unknown `$mach.abi.*` tag");
 }
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -198,6 +198,8 @@ pub fun register_all(reg: *TargetRegistry) R.Result[bool, str] {
     if (R.is_err[bool, str](res)) { ret res; }
     res = riscv.register_riscv64(?reg.isa);
     if (R.is_err[bool, str](res)) { ret res; }
+    res = riscv.register_riscv32(?reg.isa);
+    if (R.is_err[bool, str](res)) { ret res; }
     res = spirv.register_spirv(?reg.isa);
     if (R.is_err[bool, str](res)) { ret res; }
     res = m6502.register_mos6502(?reg.isa);
@@ -734,11 +736,17 @@ test "mach.lang.target:elf_capable_isa_declares_a_reloc_seam" {
 
     if (unpaired != 0) { ret unpaired::i32; }
 
-    # x86_64, aarch64, riscv64, and mos6502 (#2280 - its RK_ABS16 JSR relocation,
-    # resolved directly against the raw flat image rather than through ELF) declare
-    # one; spirv (finished module) does not. a count that drifts is a target
-    # gaining or losing the capability without this test being revisited.
-    if (seams != 4) { ret 1; }
+    # x86_64, aarch64, riscv64, riscv32 (#2778) and mos6502 (#2280 - its RK_ABS16 JSR
+    # relocation, resolved directly against the raw flat image rather than through ELF)
+    # declare one; spirv (finished module) does not.
+    #
+    # THE LITERAL IS A TRIPWIRE, NOT A DERIVED FACT, and that is deliberate. Counting
+    # the ELF-capable vtables and comparing the result against itself would assert
+    # nothing - the loop above already proves each seam is COMPLETE, and this line
+    # exists to make a target gaining or losing the capability stop a human. Updating
+    # it is the point at which someone confirms the new arch really does emit
+    # relocatable objects, so it is maintained by hand on purpose.
+    if (seams != 5) { ret 1; }
     ret 0;
 }
 
@@ -807,10 +815,13 @@ test "mach.lang.target.select:linux_aarch64" {
     val res_reg: R.Result[bool, str] = register_all(?reg);
     if (R.is_err[bool, str](res_reg)) { ret 1; }
 
-    # the SysV / Win64 / AAPCS64 / spirv / mos6502 registrations plus the three RV64
-    # family members (lp64 / lp64f / lp64d) bring the ABI registry to eight
-    # conventions. the RISC-V family is why this count grows without a new module.
-    if (abi.registered_count(?reg.abi) != 8) { ret 1; }
+    # the SysV / Win64 / AAPCS64 / spirv / mos6502 registrations plus the SIX RISC-V
+    # family members (lp64 / lp64f / lp64d on rv64, ilp32 / ilp32f / ilp32d on rv32)
+    # bring the ABI registry to eleven conventions. the RISC-V family is why this count
+    # grows without a new module, and the count is checked because `abi.register`
+    # DROPS a vtable past `ABI_REGISTRY_CAP` silently - a convention that had been
+    # registered would then resolve to "no such abi" (#2777).
+    if (abi.registered_count(?reg.abi) != 11) { ret 1; }
 
     val res_target: R.Result[resolved.Target, str] = select(?reg, "aarch64", "linux", "aapcs64");
     if (R.is_err[resolved.Target, str](res_target)) { ret 1; }
@@ -989,6 +1000,123 @@ test "mach.lang.target.select:linux_riscv64" {
     if (rr.class != abi.CLASS_GP) { ret 1; }
     if (rr.reg != 10)             { ret 1; }  # a0 = x10
 
+    ret 0;
+}
+
+# selecting a freestanding RV32 target composes the RV32 machine description (#2778)
+#
+# THE SAME ISA, A DIFFERENT MACHINE, and this test is written to tell those apart.
+# Everything the register file describes is asserted to be IDENTICAL to rv64's -
+# thirty-two integer registers, thirty allocatable float registers, x0 reserved, s0
+# and sp in their psABI roles - while every WIDTH is asserted to be four. A wiring
+# mistake that pointed rv32 at rv64's model would pass every register assertion and
+# fail every width one, which is exactly the discrimination worth having.
+#
+# FREESTANDING RATHER THAN LINUX, and that is a statement about #2861 rather than a
+# convenience: the ELF writer stamps ELFCLASS32 from the pointer width while emitting
+# Elf64 structures, so `of.elf` deliberately does not cover this arch and an rv32
+# linux tuple is refused. The raw flat image is what rv32 can honestly produce today.
+test "mach.lang.target.select:riscv32_freestanding_raw" {
+    var reg: TargetRegistry = registry_init();
+    val res_reg: R.Result[bool, str] = register_all(?reg);
+    if (R.is_err[bool, str](res_reg)) { ret 1; }
+
+    val res_target: R.Result[resolved.Target, str] = select(?reg, "riscv32", "freestanding", "ilp32d");
+    if (R.is_err[resolved.Target, str](res_target)) { ret 1; }
+    val t: resolved.Target = R.unwrap_ok[resolved.Target, str](res_target);
+
+    # the ISA resolved to RV32, which shares EM_RISCV with RV64 and is told apart by
+    # its pointer width - the same width the ELF class byte would be derived from.
+    if (t.arch == nil)                { ret 1; }
+    if (t.isa.id != isa.ARCH_RISCV32) { ret 1; }
+    if (t.isa.elf_machine != 243)     { ret 1; }  # EM_RISCV, shared with rv64
+    if (t.isa.pointer_width != 4)     { ret 1; }
+    if (t.arch.select == nil)         { ret 1; }
+    if (t.arch.encode == nil)         { ret 1; }
+
+    # EVERY WIDTH IS FOUR. `max_alu_width` at 4 is what puts an i64 above the ALU and
+    # sends it through `be.codegen.legalize`'s lane split.
+    if (t.model.pointer_width != 4) { ret 1; }
+    if (t.model.gpr_width     != 4) { ret 1; }
+    if (t.model.max_alu_width != 4) { ret 1; }
+    if (t.model.spill_width   != 4) { ret 1; }
+    # ... and the ALU FLOOR IS STILL FOUR, because it is a declared fact about
+    # sub-word residue rather than something derived from the word width.
+    if (t.model.alu_min_width != 4) { ret 1; }
+    # ... and FLEN IS STILL EIGHT. rv32gc has the D extension, so a float register is
+    # twice the width of an integer one. this is the pair a single "word size" breaks.
+    if (t.model.flen_bits != 64) { ret 1; }
+
+    # the register file is RV64's, unchanged: the numbering and roles are
+    # architectural, not width-derived.
+    if (t.model.reg_class_len != 2) { ret 1; }
+    var gp_len: u32 = 0;
+    var fp_len: u32 = 0;
+    var ci: u32 = 0;
+    for (ci < t.model.reg_class_len) {
+        if (t.model.reg_classes[ci].kind == isa.RC_GENERAL) { gp_len = t.model.reg_classes[ci].len; }
+        if (t.model.reg_classes[ci].kind == isa.RC_FLOAT)   { fp_len = t.model.reg_classes[ci].len; }
+        ci = ci + 1;
+    }
+    if (gp_len != 32) { ret 1; }
+    if (fp_len != 30) { ret 1; }
+    if (t.model.frame_ptr_reg != 8) { ret 1; }
+    if (t.model.stack_ptr_reg != 2) { ret 1; }
+
+    # THE TWO MODELS ARE SEPARATE STORAGE. registering rv32 must not have overwritten
+    # rv64's template, which one shared set of globals would have done silently.
+    val res64: R.Result[resolved.Target, str] = select_of(?reg, "riscv64", "linux", "lp64d", "");
+    if (R.is_err[resolved.Target, str](res64)) { ret 1; }
+    val t64: resolved.Target = R.unwrap_ok[resolved.Target, str](res64);
+    if (t64.model.gpr_width != 8) { ret 1; }
+    if (t.model.gpr_width   != 4) { ret 1; }
+
+    # the ilp32d convention resolved, and its argument slot is FOUR bytes wide - read
+    # from the member's XLEN rather than from a constant, so a0 still carries the
+    # first integer argument while a two-register aggregate now straddles a0/a1 at +4.
+    if (t.abi == nil)               { ret 1; }
+    if (t.abi.id != abi.ABI_ILP32D) { ret 1; }
+    if (t.abi.arg_slot_granularity != 4) { ret 1; }
+    val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
+    val ai: abi.ParamSlot = arg(0, 4, 4, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
+    if (ai.class != abi.CLASS_GP) { ret 1; }
+    if (ai.reg != 10)             { ret 1; }  # a0 = x10
+    # a double still rides fa0 under ilp32d, on a machine whose integer registers
+    # could not hold it - the whole reason FLEN is its own fact.
+    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
+    if (af.class != abi.CLASS_FP)                           { ret 1; }
+    if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10)) { ret 1; }
+
+    # the raw flat image is the format, and freestanding named it.
+    if (t.of == nil)                         { ret 1; }
+    if (!str_equals(t.os.default_of, "raw")) { ret 1; }
+
+    ret 0;
+}
+
+# AN RV32 LINUX TARGET IS REFUSED BY NAME UNTIL THE ELF32 WRITER EXISTS (#2861)
+#
+# The refusal is the honest statement of what mach can do: `of.elf` covers rv64 and
+# not rv32, because `elf_class_for` would stamp ELFCLASS32 from the 4-byte pointer
+# width while every structure the writer emits is Elf64. A file whose class byte
+# contradicts its layout is worse for a reader than no file, so the tuple is refused
+# at resolve time rather than producing one.
+#
+# This test is the thing that will FAIL when #2861 lands, which is the point: it is a
+# tripwire on a deliberate gap, not a permanent property.
+test "mach.lang.target.select:riscv32_linux_is_refused_until_elf32" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    val res: R.Result[resolved.Target, str] = select(?reg, "riscv32", "linux", "ilp32d");
+    if (!R.is_err[resolved.Target, str](res)) { ret 1; }
+
+    # and it is refused for the RIGHT reason - the object format, not a missing arch
+    # or a missing convention, both of which exist.
+    val isa_opt: O.Option[*isa.IsaVTable] = isa.lookup(?reg.isa, "riscv32");
+    if (O.is_none[*isa.IsaVTable](isa_opt)) { ret 1; }
+    val abi_opt: O.Option[*abi.AbiVTable] = abi.lookup(?reg.abi, "ilp32d");
+    if (O.is_none[*abi.AbiVTable](abi_opt)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -55,6 +55,17 @@ pub val ABI_LP64:  u32 = 4;
 pub val ABI_LP64F: u32 = 5;
 pub val ABI_LP64D: u32 = 6;
 
+# the RV32 half of the same family (#2778). The three differ from their lp64 twins in
+# exactly one declared fact, XLEN, and in nothing else: the float-passing rule, the
+# register roles, the aggregate threshold and the variadic rule are all written once
+# against the descriptor. They are separate IDS rather than a width flag on the lp64
+# ones because an id names a convention a manifest can spell, and `ilp32d` on an rv64
+# machine is not a thing that exists - the arch each one covers is part of what the id
+# means.
+pub val ABI_ILP32:  u32 = 7;
+pub val ABI_ILP32F: u32 = 8;
+pub val ABI_ILP32D: u32 = 9;
+
 # map a calling-convention name to its canonical id
 # ---
 # name: abi name ("sysv64", "win64", "aapcs64", "lp64")
@@ -66,6 +77,9 @@ pub fun abi_id_for(name: str) u32 {
     if (str_equals(name, "lp64"))    { ret ABI_LP64; }
     if (str_equals(name, "lp64f"))   { ret ABI_LP64F; }
     if (str_equals(name, "lp64d"))   { ret ABI_LP64D; }
+    if (str_equals(name, "ilp32"))   { ret ABI_ILP32; }
+    if (str_equals(name, "ilp32f"))  { ret ABI_ILP32F; }
+    if (str_equals(name, "ilp32d"))  { ret ABI_ILP32D; }
     ret ABI_UNKNOWN;
 }
 
@@ -80,6 +94,9 @@ pub fun abi_name_for(id: u32) str {
     if (id == ABI_LP64)    { ret "lp64"; }
     if (id == ABI_LP64F)   { ret "lp64f"; }
     if (id == ABI_LP64D)   { ret "lp64d"; }
+    if (id == ABI_ILP32)   { ret "ilp32"; }
+    if (id == ABI_ILP32F)  { ret "ilp32f"; }
+    if (id == ABI_ILP32D)  { ret "ilp32d"; }
     ret "unknown";
 }
 
@@ -557,8 +574,9 @@ test "mach.lang.target.abi.abi_vtable:sets_every_field" {
 # maximum number of ABI implementations an AbiRegistry holds
 #
 # Raised from 8 to 16 by #2777. The RISC-V psABI is a FAMILY rather than a single
-# convention, so the count grows along that axis: lp64 / lp64f / lp64d today, with
-# the ilp32 family and the reduced-register `e` members to follow. Eight left
+# convention, so the count grows along that axis: six of its members are registered
+# since #2778 (lp64 / lp64f / lp64d and ilp32 / ilp32f / ilp32d), with the
+# reduced-register `e` members to follow (#2859). Eight left
 # exactly zero headroom the moment the family was described honestly, and
 # `register` DROPS a vtable past the cap silently -- a target would then resolve to
 # "no such abi" for a convention that had been registered, which is the failure
@@ -996,15 +1014,25 @@ test "mach.lang.target.abi.abi_name_for:round_trips" {
     if (!str_equals(abi_name_for(ABI_LP64),    "lp64"))    { ret 1; }
     if (!str_equals(abi_name_for(ABI_LP64F),   "lp64f"))   { ret 1; }
     if (!str_equals(abi_name_for(ABI_LP64D),   "lp64d"))   { ret 1; }
+    if (!str_equals(abi_name_for(ABI_ILP32),   "ilp32"))   { ret 1; }
+    if (!str_equals(abi_name_for(ABI_ILP32F),  "ilp32f"))  { ret 1; }
+    if (!str_equals(abi_name_for(ABI_ILP32D),  "ilp32d"))  { ret 1; }
     if (!str_equals(abi_name_for(ABI_UNKNOWN), "unknown")) { ret 1; }
     if (abi_id_for(abi_name_for(ABI_SYSV))    != ABI_SYSV)    { ret 1; }
     if (abi_id_for(abi_name_for(ABI_AAPCS64)) != ABI_AAPCS64) { ret 1; }
-    # the three RISC-V members are DISTINCT ids under distinct names. the round trip
+    # the six RISC-V members are DISTINCT ids under distinct names. the round trip
     # is what catches a family member added to one direction of the map and not the
     # other, which is how "lp64d" would silently resolve back to plain lp64.
     if (abi_id_for(abi_name_for(ABI_LP64))  != ABI_LP64)  { ret 1; }
     if (abi_id_for(abi_name_for(ABI_LP64F)) != ABI_LP64F) { ret 1; }
     if (abi_id_for(abi_name_for(ABI_LP64D)) != ABI_LP64D) { ret 1; }
+    if (abi_id_for(abi_name_for(ABI_ILP32))  != ABI_ILP32)  { ret 1; }
+    if (abi_id_for(abi_name_for(ABI_ILP32F)) != ABI_ILP32F) { ret 1; }
+    if (abi_id_for(abi_name_for(ABI_ILP32D)) != ABI_ILP32D) { ret 1; }
+    # AND THE TWO HALVES OF THE FAMILY DO NOT COLLIDE. `ilp32` differs from `lp64` in
+    # one declared fact, so a copy-paste that gave a member its twin's id would still
+    # register, still resolve by name, and place every argument at the wrong width.
+    if (ABI_ILP32 == ABI_LP64 || ABI_ILP32F == ABI_LP64F || ABI_ILP32D == ABI_LP64D) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/riscv.mach
+++ b/src/lang/target/abi/riscv.mach
@@ -56,15 +56,20 @@
 #                 lp64d and the callee's `va_arg` would read an untouched a register
 #                 (#2771).
 #
-# WHAT IS SHIPPED AND WHAT IS NOT. lp64, lp64f and lp64d are registered and
-# complete. `lp64e` and the whole ilp32 family are DESCRIBED by this contract but
-# deliberately NOT REGISTERED, because each needs a base ISA that does not exist
-# yet: the `e` members need an RV64E/RV32E register file of 16 integer registers,
-# and ilp32 needs ARCH_RISCV32 (#2778). Registering a member whose ISA cannot back
-# it would produce a convention that compiles and emits calls the hardware cannot
-# make, which is the one outcome worth avoiding. The contract is proven against
-# them by `descriptor_facts_are_read` below rather than by a registration that
-# would report a support we do not have.
+# WHAT IS SHIPPED AND WHAT IS NOT. All six I-base members are registered and
+# complete: lp64 / lp64f / lp64d on ARCH_RISCV64, and ilp32 / ilp32f / ilp32d on
+# ARCH_RISCV32 since #2778. The ilp32 three differ from their lp64 twins in ONE
+# DECLARED FACT - `xlen_bits` 32 rather than 64 - and in nothing else. That is the
+# claim the family contract exists to make good on, and it is checked rather than
+# asserted: `xlen_is_the_only_difference` below builds each pair and compares every
+# other field.
+#
+# `lp64e` and `ilp32e` remain DESCRIBED but NOT REGISTERED, because they need a base
+# ISA that does not exist: a 16-register integer file and a 4-byte stack alignment are
+# a different machine, not a different convention over the same one (#2859).
+# Registering a member whose ISA cannot back it would produce a convention that
+# compiles and emits calls the hardware cannot make, which is the one outcome worth
+# avoiding.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -82,6 +87,9 @@ use mach.lang.target.isa;
 var lp64_vtable:  abi.AbiVTable;
 var lp64f_vtable: abi.AbiVTable;
 var lp64d_vtable: abi.AbiVTable;
+var ilp32_vtable:  abi.AbiVTable;
+var ilp32f_vtable: abi.AbiVTable;
+var ilp32d_vtable: abi.AbiVTable;
 
 # the declared facts of one member of the RISC-V ABI family
 #
@@ -210,6 +218,37 @@ pub fun v_lp64f() RiscvAbi {
 # link against any system library
 pub fun v_lp64d() RiscvAbi {
     ret rv_abi(abi.ABI_LP64D, "lp64d", isa.ARCH_RISCV64, 64, 64, 32, 8, 8, 11, 12, 0);
+}
+
+# ilp32: RV32 SOFT FLOAT, the XLEN-32 twin of lp64. runs on any rv32, including one
+# with no F or D extension
+#
+# EVERY FIELD BUT `xlen_bits` MATCHES ITS lp64 TWIN, and that is the psABI rather than
+# a convenience: the RISC-V integer calling convention is written in terms of XLEN, so
+# halving XLEN halves the argument slot, the aggregate threshold and the register save
+# width without changing WHICH registers carry what. a0-a7 are the argument registers
+# on both, s1 / s2-s11 are callee-saved on both, and the float bank is untouched by the
+# integer width.
+pub fun v_ilp32() RiscvAbi {
+    ret rv_abi(abi.ABI_ILP32, "ilp32", isa.ARCH_RISCV32, 32, 0, 32, 8, 8, 11, 12, 0);
+}
+
+# ilp32f: RV32 with SINGLE-precision arguments in fa0-fa7. requires the F extension.
+# an f64 rides the integer bank - which on RV32 means an ALIGNED REGISTER PAIR, since
+# one 32-bit register cannot hold it
+pub fun v_ilp32f() RiscvAbi {
+    ret rv_abi(abi.ABI_ILP32F, "ilp32f", isa.ARCH_RISCV32, 32, 32, 32, 8, 8, 11, 12, 0);
+}
+
+# ilp32d: RV32 with SINGLE AND DOUBLE precision arguments in fa0-fa7. requires the D
+# extension, and is what `riscv32-linux-gnu` means by "riscv32" -- so it is the linux
+# default (`os.linux.linux_native_abi`), for the same interop reason lp64d is on rv64.
+#
+# THIS IS THE MEMBER WHERE FLEN EXCEEDS XLEN. A double rides an 8-byte float register
+# on a machine whose integer registers are 4 bytes, which is the pair every "the word
+# size is the width of everything" assumption gets wrong.
+pub fun v_ilp32d() RiscvAbi {
+    ret rv_abi(abi.ABI_ILP32D, "ilp32d", isa.ARCH_RISCV32, 32, 64, 32, 8, 8, 11, 12, 0);
 }
 
 # ------------------------------------------------------------------ derived facts
@@ -683,6 +722,57 @@ fun lp64d_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_lp64d(), out);
 fun lp64d_va() abi.VaModel { ret va_model_v(v_lp64d()); }
 fun lp64d_cs(out: *isa.Register) i32      { ret callee_saved_v(v_lp64d(), out); }
 
+fun ilp32_classify(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
+                   gp: i32, fp: i32, hm: u8, he: u8) abi.ParamSlot {
+    ret classify_arg_v(v_ilp32(), 0, size, align, is_float, fpe, is_agg, false, false, gp, fp, hm, he, abi.agg_none());
+}
+fun ilp32_arg(index: i32, size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
+              is_vec: bool, is_ext: bool, gp: i32, fp: i32, hm: u8, he: u8,
+              agg: abi.AggLayout) abi.ParamSlot {
+    ret classify_arg_v(v_ilp32(), index, size, align, is_float, fpe, is_agg, is_vec, is_ext, gp, fp, hm, he, agg);
+}
+fun ilp32_ret(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool, is_vec: bool,
+              hm: u8, he: u8, agg: abi.AggLayout) abi.ParamSlot {
+    ret classify_return_v(v_ilp32(), size, align, is_float, fpe, is_agg, is_vec, hm, he, agg);
+}
+fun ilp32_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_ilp32(), out); }
+fun ilp32_va() abi.VaModel { ret va_model_v(v_ilp32()); }
+fun ilp32_cs(out: *isa.Register) i32      { ret callee_saved_v(v_ilp32(), out); }
+
+fun ilp32f_classify(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
+                    gp: i32, fp: i32, hm: u8, he: u8) abi.ParamSlot {
+    ret classify_arg_v(v_ilp32f(), 0, size, align, is_float, fpe, is_agg, false, false, gp, fp, hm, he, abi.agg_none());
+}
+fun ilp32f_arg(index: i32, size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
+               is_vec: bool, is_ext: bool, gp: i32, fp: i32, hm: u8, he: u8,
+               agg: abi.AggLayout) abi.ParamSlot {
+    ret classify_arg_v(v_ilp32f(), index, size, align, is_float, fpe, is_agg, is_vec, is_ext, gp, fp, hm, he, agg);
+}
+fun ilp32f_ret(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool, is_vec: bool,
+               hm: u8, he: u8, agg: abi.AggLayout) abi.ParamSlot {
+    ret classify_return_v(v_ilp32f(), size, align, is_float, fpe, is_agg, is_vec, hm, he, agg);
+}
+fun ilp32f_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_ilp32f(), out); }
+fun ilp32f_va() abi.VaModel { ret va_model_v(v_ilp32f()); }
+fun ilp32f_cs(out: *isa.Register) i32      { ret callee_saved_v(v_ilp32f(), out); }
+
+fun ilp32d_classify(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
+                    gp: i32, fp: i32, hm: u8, he: u8) abi.ParamSlot {
+    ret classify_arg_v(v_ilp32d(), 0, size, align, is_float, fpe, is_agg, false, false, gp, fp, hm, he, abi.agg_none());
+}
+fun ilp32d_arg(index: i32, size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool,
+               is_vec: bool, is_ext: bool, gp: i32, fp: i32, hm: u8, he: u8,
+               agg: abi.AggLayout) abi.ParamSlot {
+    ret classify_arg_v(v_ilp32d(), index, size, align, is_float, fpe, is_agg, is_vec, is_ext, gp, fp, hm, he, agg);
+}
+fun ilp32d_ret(size: u64, align: u64, is_float: bool, fpe: u8, is_agg: bool, is_vec: bool,
+               hm: u8, he: u8, agg: abi.AggLayout) abi.ParamSlot {
+    ret classify_return_v(v_ilp32d(), size, align, is_float, fpe, is_agg, is_vec, hm, he, agg);
+}
+fun ilp32d_gp_regs(out: *isa.Register) i32 { ret gp_param_regs_v(v_ilp32d(), out); }
+fun ilp32d_va() abi.VaModel { ret va_model_v(v_ilp32d()); }
+fun ilp32d_cs(out: *isa.Register) i32      { ret callee_saved_v(v_ilp32d(), out); }
+
 # install one member's vtable, refusing a member whose variadic rule is undeclared
 #
 # The sentinel's reader. A descriptor still carrying VARIADIC_RULE_UNDECLARED has
@@ -768,6 +858,51 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     );
     val rlp64d: R.Result[bool, str] = install(reg, vd, ?lp64d_vtable);
     if (R.is_err[bool, str](rlp64d)) { ret rlp64d; }
+
+    # the RV32 half. IDENTICAL ASSEMBLY, DIFFERENT DESCRIPTOR - every argument below is
+    # read off the member rather than written, including `arg_slot_granularity`, which
+    # is `xlen_bytes` and so becomes 4 here without a line of it saying 4.
+    val vi: RiscvAbi = v_ilp32();
+    ilp32_vtable = abi.abi_vtable(
+        vi.id, vi.name, vi.arch_id,
+        ilp32_classify::*u8, ilp32_arg::*u8, ilp32_ret::*u8,
+        ilp32_gp_regs::*u8, ilp32_cs::*u8,
+        STACK_ALIGN, RED_ZONE, 0,
+        gp_param_reg(vi, 0), true,
+        true, true,
+        vi.flen_bits, xlen_bytes(vi)::u32,
+        ilp32_va::*u8
+    );
+    val rilp32: R.Result[bool, str] = install(reg, vi, ?ilp32_vtable);
+    if (R.is_err[bool, str](rilp32)) { ret rilp32; }
+
+    val vif: RiscvAbi = v_ilp32f();
+    ilp32f_vtable = abi.abi_vtable(
+        vif.id, vif.name, vif.arch_id,
+        ilp32f_classify::*u8, ilp32f_arg::*u8, ilp32f_ret::*u8,
+        ilp32f_gp_regs::*u8, ilp32f_cs::*u8,
+        STACK_ALIGN, RED_ZONE, 0,
+        gp_param_reg(vif, 0), true,
+        true, true,
+        vif.flen_bits, xlen_bytes(vif)::u32,
+        ilp32f_va::*u8
+    );
+    val rilp32f: R.Result[bool, str] = install(reg, vif, ?ilp32f_vtable);
+    if (R.is_err[bool, str](rilp32f)) { ret rilp32f; }
+
+    val vid: RiscvAbi = v_ilp32d();
+    ilp32d_vtable = abi.abi_vtable(
+        vid.id, vid.name, vid.arch_id,
+        ilp32d_classify::*u8, ilp32d_arg::*u8, ilp32d_ret::*u8,
+        ilp32d_gp_regs::*u8, ilp32d_cs::*u8,
+        STACK_ALIGN, RED_ZONE, 0,
+        gp_param_reg(vid, 0), true,
+        true, true,
+        vid.flen_bits, xlen_bytes(vid)::u32,
+        ilp32d_va::*u8
+    );
+    val rilp32d: R.Result[bool, str] = install(reg, vid, ?ilp32d_vtable);
+    if (R.is_err[bool, str](rilp32d)) { ret rilp32d; }
 
     ret R.ok[bool, str](true);
 }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -38,6 +38,13 @@ pub val ARCH_AARCH64: u32 = 2;  # 64-bit arm (aarch64)
 pub val ARCH_RISCV64: u32 = 3;  # 64-bit risc-v (rv64)
 pub val ARCH_MOS6502: u32 = 4;  # MOS 6502 (8-bit)
 pub val ARCH_SPIRV:   u32 = 5;  # spir-v (khronos gpu / compute IR)
+# 32-bit risc-v (rv32). a SEPARATE ARCH ID FROM RV64 RATHER THAN A WIDTH FLAG ON IT
+# (#2778): the two share an instruction encoding and a register numbering but not a
+# machine - the register width, the pointer width, the widest single ALU operation and
+# the calling-convention family all differ - and every seam in this file keys on the
+# arch id, so one id carrying two machines would make every one of them ask a second
+# question it has no way to ask.
+pub val ARCH_RISCV32: u32 = 6;
 
 # pseudo-opcodes shared by every ISA. they occupy the high end of the opcode
 # space so no real machine opcode collides with them. the backend emits these
@@ -1628,6 +1635,7 @@ pub fun arch_id_for(name: str) u32 {
     if (str_equals(name, "x86_64"))  { ret ARCH_X86_64; }
     if (str_equals(name, "aarch64")) { ret ARCH_AARCH64; }
     if (str_equals(name, "riscv64")) { ret ARCH_RISCV64; }
+    if (str_equals(name, "riscv32")) { ret ARCH_RISCV32; }
     if (str_equals(name, "spirv"))   { ret ARCH_SPIRV; }
     if (str_equals(name, "mos6502")) { ret ARCH_MOS6502; }
     ret ARCH_UNKNOWN;
@@ -1641,6 +1649,7 @@ pub fun arch_name_for(id: u32) str {
     if (id == ARCH_X86_64)  { ret "x86_64"; }
     if (id == ARCH_AARCH64) { ret "aarch64"; }
     if (id == ARCH_RISCV64) { ret "riscv64"; }
+    if (id == ARCH_RISCV32) { ret "riscv32"; }
     if (id == ARCH_SPIRV)   { ret "spirv"; }
     if (id == ARCH_MOS6502) { ret "mos6502"; }
     ret "unknown";
@@ -2064,12 +2073,20 @@ test "mach.lang.target.isa.arch_id_for:name_roundtrip" {
     if (arch_id_for("x86_64") != ARCH_X86_64)   { ret 1; }
     if (arch_id_for("aarch64") != ARCH_AARCH64) { ret 1; }
     if (arch_id_for("riscv64") != ARCH_RISCV64) { ret 1; }
-    # the bare "riscv" family name is not a concrete isa; only "riscv64" resolves
+    if (arch_id_for("riscv32") != ARCH_RISCV32) { ret 1; }
+    if (arch_id_for("mos6502") != ARCH_MOS6502) { ret 1; }
+    if (arch_id_for("spirv")   != ARCH_SPIRV)   { ret 1; }
+    # the bare "riscv" family name is not a concrete isa; only the width-bearing
+    # spellings resolve, and the two of them are DIFFERENT ids rather than one
     if (arch_id_for("riscv") != ARCH_UNKNOWN)   { ret 1; }
+    if (ARCH_RISCV32 == ARCH_RISCV64)           { ret 1; }
 
     if (!str_equals(arch_name_for(ARCH_X86_64), "x86_64"))   { ret 1; }
     if (!str_equals(arch_name_for(ARCH_AARCH64), "aarch64")) { ret 1; }
     if (!str_equals(arch_name_for(ARCH_RISCV64), "riscv64")) { ret 1; }
+    if (!str_equals(arch_name_for(ARCH_RISCV32), "riscv32")) { ret 1; }
+    if (!str_equals(arch_name_for(ARCH_MOS6502), "mos6502")) { ret 1; }
+    if (!str_equals(arch_name_for(ARCH_SPIRV),   "spirv"))   { ret 1; }
     if (!str_equals(arch_name_for(ARCH_UNKNOWN), "unknown")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -2749,6 +2749,16 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
             gp = SCRATCH;
             src_word = true;
         }
+        # THE `L` SELECTORS ARE RV64-ONLY (#2860). `fcvt.s.l` / `fcvt.d.l` and their
+        # unsigned twins name a 64-bit GP operand, and RV32 has no register that wide,
+        # so the form does not exist there. `be.codegen.legalize` splits a wide INTEGER
+        # into native lanes but has no arm for a conversion - a conversion is one
+        # rounding of the whole value, not two independent ones - so a 64-bit source
+        # really can reach here on rv32. Refused by name rather than encoded as an
+        # instruction the hardware will not decode.
+        if (!src_word && xlen(st) == 4) {
+            ret R.err[bool, str]("encode: rv32 has no conversion from a 64-bit integer to a float (fcvt.s.l / fcvt.d.l are RV64-only); see briar-systems/mach#2860");
+        }
         val dbl: bool = dw == 8;
         var f7: u32 = F7_FCVT_I2F;       # single dest (fcvt.s.*)
         if (dbl) { f7 = F7_FCVT_I2F | 1; }  # double dest (fcvt.d.*)
@@ -2779,6 +2789,11 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
     val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
+    # the float-to-integer half of the same RV64-only pair (#2860): `fcvt.l.s` /
+    # `fcvt.lu.d` write a 64-bit GP register, which rv32 does not have
+    if (dw > 4 && xlen(st) == 4) {
+        ret R.err[bool, str]("encode: rv32 has no conversion from a float to a 64-bit integer (fcvt.l.s / fcvt.l.d are RV64-only); see briar-systems/mach#2860");
+    }
     var f7: u32 = F7_FCVT_F2I;            # single source (fcvt.*.s)
     if (sw == 8) { f7 = F7_FCVT_F2I | 1; }  # double source (fcvt.*.d)
     var rs2: u32 = FCVT_L;                # 64-bit signed dest
@@ -2843,6 +2858,16 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
             emit_r(st, OPC_OP_FP, F3_FLE, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn);
             ret R.ok[bool, str](true);
+        }
+        # A CROSS-BANK MOVE IS AS WIDE AS BOTH BANKS (#2860). `fmv.d.x` / `fmv.x.d`
+        # move all 64 bits between an f register and a GP one, which needs the GP
+        # register to be 64 bits - so on rv32, where FLEN is 8 and XLEN is 4, the
+        # double-width pair simply has no encoding. `fmv.w.x` / `fmv.x.w` at width 4
+        # exist on both machines and are unaffected. A bitcast between `f64` and `i64`
+        # on rv32 goes through memory, which is what the psABI's own soft-float
+        # sequences do; wiring that lowering is #2860's, not this refusal's.
+        if ((dfp || sfp) && w == 8 && xlen(st) == 4) {
+            ret R.err[bool, str]("encode: rv32 has no cross-bank move for a 64-bit value (fmv.d.x / fmv.x.d are RV64-only); see briar-systems/mach#2860");
         }
         if (dfp) {
             # GP -> FP bit reinterpret (fmv.w.x / fmv.d.x).
@@ -4878,11 +4903,25 @@ fun rv_is_sp(op: *iasm.Operand) bool {
     ret op.kind == iasm.AOP_REG && op.reg == RSP::i32;
 }
 
-# the RV64 inline-assembly grammar
-fun rv_grammar() iasm.Grammar {
+# the inline-asm tag a RISC-V machine of this register width answers to
+#
+# The tag names the TARGET a block was written for, and `asm riscv64 { ... }` inside a
+# body compiled for rv32 is a statement that is not true. So the tag follows the
+# machine: an rv32 target admits `asm riscv32` and refuses `asm riscv64`, which is what
+# makes a comptime arch guard around two blocks select correctly (#2778).
+# ---
+# xl:  XLEN in bytes for the target machine
+# ret: the tag this machine's inline-asm blocks must carry
+fun rv_isa_tag(xl: u8) str {
+    if (xl == 4) { ret "riscv32"; }
+    ret "riscv64";
+}
+
+# the RISC-V inline-assembly grammar, tagged for one machine
+fun rv_grammar_tagged(tag: str) iasm.Grammar {
     var g: iasm.Grammar;
-    g.isa        = "riscv64";
-    g.unknown    = "unknown riscv64 inline-asm instruction '";
+    g.isa        = tag;
+    g.unknown    = "unknown riscv inline-asm instruction '";
     g.rows       = ?RV_MNEMONICS[0];
     g.row_count  = RV_MNEMONIC_COUNT;
     # riscv64's `.word` is one instruction word, as GNU as spells it here (#2479).
@@ -4906,6 +4945,22 @@ fun rv_grammar() iasm.Grammar {
     ret g;
 }
 
+# the grammar for the machine this encode targets
+fun rv_grammar(st: *encode.EncodeState) iasm.Grammar {
+    ret rv_grammar_tagged(rv_isa_tag(xlen(st)));
+}
+
+# the grammar for a path that ANALYSES a body without encoding it
+#
+# `asm_clobbers` and `asm_returns` are vtable hooks taking only the body text - they
+# have no target and cannot know XLEN. They also never read `g.isa`: the tag is
+# compared once, in `iasm.encode_block`, which does have the machine. So these paths
+# take the family's grammar under a tag that is never consulted, and the width-bearing
+# check stays in the one place that can make it.
+fun rv_grammar_analysis() iasm.Grammar {
+    ret rv_grammar_tagged("riscv");
+}
+
 # true when a riscv64 statement cannot fall through to the next (#2791)
 #
 # `ebreak` raises a breakpoint exception, which with no debugger attached terminates
@@ -4918,7 +4973,7 @@ fun rv_no_fall(item: *iasm.Item) bool {
 
 # whether control can fall out of a riscv64 inline-asm body (#2791)
 pub fun asm_returns(body: str) bool {
-    var g: iasm.Grammar = rv_grammar();
+    var g: iasm.Grammar = rv_grammar_analysis();
     ret iasm.returns(?g, body);
 }
 
@@ -4979,7 +5034,7 @@ fun asm_fp_reg_index(tok: str) i32 {
 # gp_out: out - the GP registers the body writes (bit n = register n)
 # fp_out: out - the FP registers the body writes (bit n = register n)
 pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
-    var g: iasm.Grammar = rv_grammar();
+    var g: iasm.Grammar = rv_grammar_analysis();
     iasm.clobbers(?g, body, gp_out, fp_out);
 }
 
@@ -4989,7 +5044,7 @@ pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
 # the driver does the rest, so `{name}` resolution, numeric local labels, byte
 # accounting and the located diagnostic are the same code every target runs.
 fun encode_asm_block_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
-    var g: iasm.Grammar = rv_grammar();
+    var g: iasm.Grammar = rv_grammar(st);
     ret iasm.encode_block(st, ?g, f, mi);
 }
 
@@ -4999,7 +5054,7 @@ fun encode_asm_block_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_ba
 # block path does, so a byte-exact golden is a fact about the shipping parser rather
 # than about a test-only path beside it.
 fun rv_asm_text(st: *encode.EncodeState, f: *mir.MirFunction, l: *iasm.Labels, text: str) R.Result[bool, str] {
-    var g: iasm.Grammar = rv_grammar();
+    var g: iasm.Grammar = rv_grammar(st);
     var c: iasm.Cursor;
     iasm.cursor_init(?c, ?g, text, st.alloc, st.interner, f, nil);
     ret iasm.run(st, ?g, ?c, l);
@@ -5890,16 +5945,18 @@ test "mach.lang.target.isa.riscv.encode:asm_clobbers_classification" {
 
 # a page-backed EncodeState with a live interner, for exercising the inline-asm
 # assembler (which interns symbol names and resolves `{name}` bindings)
+#
+# IT GOES THROUGH `state_blank` RATHER THAN SETTING FIELDS BY HAND, and that is the
+# fix for a real hole rather than a tidy-up. This helper used to assign the seven
+# fields it happened to need, which meant #2862 could make the machine a required
+# CONSTRUCTOR ARGUMENT and this state still reached the encoder without one - a nil
+# model that read as XLEN 0 the moment anything asked. An arity check only binds the
+# callers that call the thing.
 fun tasm(st: *encode.EncodeState, alloc: *A.Allocator, interner: *intern.Interner) {
     page.make(alloc);
     @interner = intern.init(alloc);
-    st.alloc       = alloc;
-    st.buf         = encode.buf_init(alloc);
-    st.interner    = interner;
-    st.syms        = nil; st.sym_count   = 0; st.sym_cap   = 0;
-    st.relocs      = nil; st.reloc_count = 0; st.reloc_cap = 0;
-    st.fixups      = nil; st.fixup_count = 0; st.fixup_cap = 0;
-    st.blocks      = nil; st.block_count = 0; st.block_cap = 0;
+    encode.state_blank(st, alloc, rv64_machine());
+    st.interner = interner;
 }
 
 # every core inline-asm form the std `_start` / syscall path uses, byte-exact against
@@ -6130,7 +6187,7 @@ test "mach.lang.target.isa.riscv.encode:inline_asm_data_directive_refusals" {
     # a directive is not a mnemonic: `.half` is in no table and is refused by name.
     val r4: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, ".half 0x1234");
     if (!R.is_err[bool, str](r4))                                                                       { bad = 1; }
-    or { if (!str_contains(R.unwrap_err[bool, str](r4), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
+    or { if (!str_contains(R.unwrap_err[bool, str](r4), "unknown riscv inline-asm instruction")) { bad = 1; } }
 
     iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
@@ -6372,7 +6429,7 @@ test "mach.lang.target.isa.riscv.encode:inline_asm_symbol_relocs" {
     # an unknown mnemonic is a hard error, not silent bytes.
     val ur: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "frobnicate a0, a1");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
-    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
+    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv inline-asm instruction")) { bad = 1; } }
 
     iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
@@ -6476,7 +6533,7 @@ test "mach.lang.target.isa.riscv.encode:inline_asm_atomics" {
     # silently swallowed by the atomic dispatch.
     val ur: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "amobogus.q a0, a2, (a1)");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
-    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
+    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv inline-asm instruction")) { bad = 1; } }
 
     # an atomic address is a memory position, so the parse accepts an unresolved
     # `{name}` there - and the shared driver refuses it before the encoder reads a
@@ -7732,7 +7789,7 @@ test "mach.lang.target.isa.riscv.encode.asm_ct_class:m_extension_is_variable_lat
 # identical checks over their own instruction streams.
 pub fun asm_ct_scan(body: str, secret_names: *str, n_secret: u32,
                     trust_mul: bool, trust_shift: bool, alloc: *A.Allocator) R.Result[bool, str] {
-    var g: iasm.Grammar = rv_grammar();
+    var g: iasm.Grammar = rv_grammar_analysis();
     ret iasm.ct_scan(?g, body, secret_names, n_secret, trust_mul, trust_shift);
 }
 

--- a/src/lang/target/isa/riscv/register.mach
+++ b/src/lang/target/isa/riscv/register.mach
@@ -79,6 +79,23 @@ var riscv64_reserved_regs: [6]isa.Register;
 # `register_riscv64`
 var riscv64_reload_scratch_regs: [3]isa.Register;
 
+# the same storage again for RV32 (#2778)
+#
+# TWO ARCHES, TWO SETS, ONE BUILDER. The vtable, the register machine, the seam and
+# the model are borrowed by the registry for the process lifetime, and a multi-target
+# build has both arches resolved at once, so the two cannot share one set of globals.
+# What they DO share is `build_riscv` below, which fills either set from the width
+# facts it is handed - so an RV32 target is a different set of numbers rather than a
+# second copy of the wiring.
+var riscv32_vtable:  isa.IsaVTable;
+var riscv32_classes: [2]isa.RegClass;
+var riscv32_machine: isa.RegMachine;
+var riscv32_reloc:   isa.RelocSeam;
+var riscv32_model:   isa.MachineModel;
+var riscv32_attrs:   elf.BuildAttributes;
+var riscv32_reserved_regs:       [6]isa.Register;
+var riscv32_reload_scratch_regs: [3]isa.Register;
+
 # map an abstract relocation kind to its riscv64 ELF machine relocation type
 #
 # The forward half of the riscv64 ELF relocation seam: the ELF object writer reads it
@@ -115,6 +132,19 @@ fun riscv64_elf_reloc_type(kind: of.RelocKind) u32 {
 # ret: the RV64 build-attributes descriptor
 fun riscv64_elf_attributes() *elf.BuildAttributes {
     ret ?riscv64_attrs;
+}
+
+# the RV32 twin of `riscv64_elf_attributes`
+#
+# The container is identical - same section name, same section type, same vendor -
+# and the two hooks exist only because the hook is a plain function pointer with no
+# self parameter, so it cannot be told which member's storage to return. The BODY the
+# container carries is what differs between the two, and that is derived per image
+# from the machine rather than stored here (#2828).
+# ---
+# ret: the RV32 build-attributes descriptor
+fun riscv32_elf_attributes() *elf.BuildAttributes {
+    ret ?riscv32_attrs;
 }
 
 # the ELF `e_flags` word for a riscv64 image, derived from the two facts that decide
@@ -206,9 +236,63 @@ fun riscv64_dwarf_reg(regid: i32) i32 {
 # reg: the ISA registry to install the vtable into
 # ret: true on success
 pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
-    riscv64_classes[0].name      = "gpr";
-    riscv64_classes[0].kind      = isa.RC_GENERAL;
-    riscv64_classes[0].len       = riscv.GPR_COUNT::u32;
+    ret build_riscv(reg, isa.ARCH_RISCV64, "riscv64", 8,
+                    ?riscv64_vtable, ?riscv64_classes[0], ?riscv64_machine,
+                    ?riscv64_reloc, ?riscv64_model, ?riscv64_attrs, riscv64_elf_attributes::*u8,
+                    ?riscv64_reserved_regs[0], ?riscv64_reload_scratch_regs[0]);
+}
+
+# build and install the RV32 ISA vtable
+#
+# The same wiring as `register_riscv64` against a different machine: `build_riscv`
+# holds the whole description and this states the four facts that differ - the arch
+# id, the name, the register width in bytes, and the storage it owns. Everything else
+# about RISC-V is width-independent, which is the claim #2778 exists to make good on,
+# and it is a claim this file can only make by NOT having a second copy of the wiring
+# to drift from the first.
+#
+# Must run at compiler startup before `target.select` requests a riscv32 target.
+# ---
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_riscv32(reg: *isa.IsaRegistry) R.Result[bool, str] {
+    ret build_riscv(reg, isa.ARCH_RISCV32, "riscv32", 4,
+                    ?riscv32_vtable, ?riscv32_classes[0], ?riscv32_machine,
+                    ?riscv32_reloc, ?riscv32_model, ?riscv32_attrs, riscv32_elf_attributes::*u8,
+                    ?riscv32_reserved_regs[0], ?riscv32_reload_scratch_regs[0]);
+}
+
+# fill and install one RISC-V arch member's vtable, register machine, seam and model
+#
+# THE WIDTH IS THE ONLY PARAMETER, and that is the point. Every other line below is
+# shared between RV32 and RV64: the register numbering, the psABI roles, the reserved
+# set, the scratch identities, the selection pack, the encoder, the printer, the
+# clobber and constant-time analyzers, the DWARF map, the relocation seam and the
+# attribute derivation are all XLEN-independent. `xw` decides the pointer width, the
+# four model widths and the declared register sizes, and nothing else branches.
+# ---
+# reg:      the ISA registry to install into
+# arch_id:  the member's canonical arch id
+# name:     the member's target name, as a manifest spells it
+# xw:       XLEN in bytes (8 for rv64, 4 for rv32)
+# vt:       process-global vtable storage this member owns
+# classes:  process-global register-class storage (2 entries: gpr, fpr)
+# machine:  process-global register-machine storage
+# seam:     process-global relocation-seam storage
+# model:    process-global machine-model storage
+# attrs:    process-global ELF build-attributes descriptor storage
+# attrs_hook: erased `elf_attributes` hook returning THIS member's `attrs`
+# reserved: process-global reserved-register storage (6 entries)
+# reload:   process-global reload-scratch storage (3 entries)
+# ret:      true on success
+fun build_riscv(reg: *isa.IsaRegistry, arch_id: u32, name: str, xw: u32,
+                vt: *isa.IsaVTable, classes: *isa.RegClass, machine: *isa.RegMachine,
+                seam: *isa.RelocSeam, model: *isa.MachineModel, attrs: *elf.BuildAttributes,
+                attrs_hook: *u8,
+                reserved: *isa.Register, reload: *isa.Register) R.Result[bool, str] {
+    classes[0].name      = "gpr";
+    classes[0].kind      = isa.RC_GENERAL;
+    classes[0].len       = riscv.GPR_COUNT::u32;
 
     # the fpr bank exposes f0-f29 (count 30) to the allocator. f30 and f31
     # (ft10 / ft11) are held back as the two fixed FP scratch registers the float-op
@@ -216,29 +300,29 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # one and be clobbered. the F/D extension registers are 64 bits wide under
     # lp64d, the same width as the integer registers - unlike x86-64 / AArch64 whose
     # 128-bit vector bank the shared float-bank lookup keys on by width.
-    riscv64_classes[1].name      = "fpr";
-    riscv64_classes[1].kind      = isa.RC_FLOAT;
-    riscv64_classes[1].len       = riscv.FPR_COUNT::u32;
+    classes[1].name      = "fpr";
+    classes[1].kind      = isa.RC_FLOAT;
+    classes[1].len       = riscv.FPR_COUNT::u32;
 
-    riscv64_reserved_regs[0].id   = riscv.ZERO;
-    riscv64_reserved_regs[0].size = 8;
-    riscv64_reserved_regs[1].id   = riscv.RA;
-    riscv64_reserved_regs[1].size = 8;
-    riscv64_reserved_regs[2].id   = riscv.SP;
-    riscv64_reserved_regs[2].size = 8;
-    riscv64_reserved_regs[3].id   = riscv.GP;
-    riscv64_reserved_regs[3].size = 8;
-    riscv64_reserved_regs[4].id   = riscv.TP;
-    riscv64_reserved_regs[4].size = 8;
-    riscv64_reserved_regs[5].id   = riscv.FP;
-    riscv64_reserved_regs[5].size = 8;
+    reserved[0].id   = riscv.ZERO;
+    reserved[0].size = xw::u8;
+    reserved[1].id   = riscv.RA;
+    reserved[1].size = xw::u8;
+    reserved[2].id   = riscv.SP;
+    reserved[2].size = xw::u8;
+    reserved[3].id   = riscv.GP;
+    reserved[3].size = xw::u8;
+    reserved[4].id   = riscv.TP;
+    reserved[4].size = xw::u8;
+    reserved[5].id   = riscv.FP;
+    reserved[5].size = xw::u8;
 
-    riscv64_reload_scratch_regs[0].id   = riscv.T2;
-    riscv64_reload_scratch_regs[0].size = 8;
-    riscv64_reload_scratch_regs[1].id   = riscv.T3;
-    riscv64_reload_scratch_regs[1].size = 8;
-    riscv64_reload_scratch_regs[2].id   = riscv.T4;
-    riscv64_reload_scratch_regs[2].size = 8;
+    reload[0].id   = riscv.T2;
+    reload[0].size = xw::u8;
+    reload[1].id   = riscv.T3;
+    reload[1].size = xw::u8;
+    reload[2].id   = riscv.T4;
+    reload[2].size = xw::u8;
 
     # the register-machine contract. the FP scratch pair (f31 primary, f30 for the
     # both-sources-spilled binary float case) is not part of it: `encode.mach` names
@@ -250,7 +334,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # pushes the first to [fp+16]. RV64 div / divu / rem / remu write a normal
     # destination register and a shift count rides the low bits of any register, so no
     # fixed division / shift register is wired: -1 for all three.
-    riscv64_machine = isa.reg_machine(
+    @machine = isa.reg_machine(
         rules.select::*u8,
         encode.encode_riscv64::*u8,
         rules.is_reg_move,
@@ -274,88 +358,97 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # the ELF build-attributes descriptor: the writer stamps a `.riscv.attributes`
     # ISA-string section from it so external tools decode imafd with no manual
     # `--mattr`.
-    riscv64_attrs.section  = ".riscv.attributes";
-    riscv64_attrs.sht      = elf.SHT_RISCV_ATTRIBUTES;
-    riscv64_attrs.vendor   = "riscv";
+    attrs.section  = ".riscv.attributes";
+    attrs.sht      = elf.SHT_RISCV_ATTRIBUTES;
+    attrs.vendor   = "riscv";
 
     # the relocatable-object contract: riscv64 names its relocations in an ELF object
     # and resolves them at link time, and both halves are declared here rather than
     # attached to the vtable afterwards by a subsystem that knows the arch's name.
-    riscv64_reloc = isa.reloc_seam(reloc.apply_reloc::*u8, reloc.reloc_traits::*u8,
+    @seam = isa.reloc_seam(reloc.apply_reloc::*u8, reloc.reloc_traits::*u8,
                                    riscv64_elf_reloc_type::*u8);
-    isa.with_elf_attributes(?riscv64_reloc, riscv64_elf_attributes::*u8);
+    isa.with_elf_attributes(seam, attrs_hook);
     # the `e_flags` derivation, declared beside the arch string because the two are
     # claims about the same ISA and have to agree about the C extension
-    isa.with_machine_flags(?riscv64_reloc, riscv64_machine_flags::*u8);
+    isa.with_machine_flags(seam, riscv64_machine_flags::*u8);
     # the psABI hi/lo pair collapse, which every riscv64 image needs before anything
     # resolves a relocation in it
-    isa.with_normalize_image(?riscv64_reloc, reloc.resolve_riscv_pcrel_pairs::*u8);
+    isa.with_normalize_image(seam, reloc.resolve_riscv_pcrel_pairs::*u8);
     # the build-attribute body: what an image HOLDS, derived and merged rather than
     # stated, for the same reason `e_flags` is (#2828)
-    isa.with_attributes(?riscv64_reloc, attributes.riscv64_build_attributes::*u8,
+    isa.with_attributes(seam, attributes.riscv64_build_attributes::*u8,
                         attributes.riscv64_merge_attributes::*u8);
 
-    # elf_machine 243 is EM_RISCV
-    riscv64_vtable = isa.machine_isa(isa.ARCH_RISCV64, "riscv64", 243, 8,
-                                     ?riscv64_model, ?riscv64_machine, ?riscv64_reloc);
+    # elf_machine 243 is EM_RISCV, which RV32 and RV64 SHARE. the two are told apart in
+    # an ELF file by the class byte (ELFCLASS32 / ELFCLASS64), which the writer derives
+    # from this vtable's pointer width - so the width below is what distinguishes them
+    # and there is no second place stating it
+    @vt = isa.machine_isa(arch_id, name, 243, xw, model, machine, seam);
 
     # the machine-model template the shared stages read. widths are in bytes; the
     # register-file pointers borrow the same per-arch arrays the vtable does; the
     # stack scalars stay 0 here and are overlaid by `target.select` from the abi.
     #
-    # these four width fields are the ONLY RV64-specific (XLEN=64) values in the
-    # machine description - everything else (the register file, roles, capability
-    # flags) is XLEN-independent. an RV32 (ilp32) sibling would set 4-byte widths
-    # here and reuse the rest unchanged.
-    riscv64_model.pointer_width   = 8;
-    riscv64_model.max_alu_width = 8;
+    # these four width fields are the ONLY per-member values in the machine
+    # description - everything else (the register file, roles, capability flags) is
+    # XLEN-independent, which is what lets both members share this function.
+    #
+    # `max_alu_width` IS THE REGISTER WIDTH, and on RV32 that makes an i64 wider than
+    # the ALU: `be.codegen.legalize` then splits it into two 4-byte lanes and threads
+    # the carry, exactly as it does for mos6502's 1-byte ALU. That path is why RV32
+    # needs no 64-bit integer arithmetic in this encoder.
+    model.pointer_width = xw;
+    model.max_alu_width = xw;
     # the register-machine ALU floor: a sub-word op computes at 4 bytes so its result
-    # fully defines the register it spills through (#2749)
-    riscv64_model.alu_min_width = 4;
-    riscv64_model.gpr_width       = 8;
-    riscv64_model.spill_width     = 8;
+    # fully defines the register it spills through (#2749). NOT derived from the word
+    # width - the model's own comment says so - and 4 on both members.
+    model.alu_min_width = 4;
+    model.gpr_width     = xw;
+    model.spill_width   = xw;
     # a register move is `addi rd, rs, 0` at XLEN whatever the MIR width (encode.mach
     # never consults it on that path): RV64 has no sub-word register write, and
     # narrowing is explicit (sext.w / a shift pair). so no move extends anything and
     # a self-move is inert at every width.
-    riscv64_model.endianness      = isa.ENDIAN_LITTLE;
-    # the D extension is in the `gc` baseline, so f0-f31 hold scalar doubles. this is
-    # independent of `has_v128` below, which stays false.
-    riscv64_model.flen_bits       = 64;
+    model.endianness      = isa.ENDIAN_LITTLE;
+    # the D extension is in the `gc` baseline of BOTH members, so f0-f31 hold scalar
+    # doubles on rv32gc exactly as on rv64gc. this is independent of `has_v128` below,
+    # which stays false - and on rv32 it is the field that makes FLEN exceed XLEN,
+    # which is the pair the frame layout and the `ilp32d` convention both turn on.
+    model.flen_bits       = 64;
     # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
     # vector ops scalarize before MIR lowering and none reaches the vector path.
-    riscv64_model.has_v128        = false;
-    riscv64_model.vector_bits     = isa.VECTOR_BITS_128;
+    model.has_v128        = false;
+    model.vector_bits     = isa.VECTOR_BITS_128;
     # no lane-count ceiling: this vector unit is described completely by its register
     # width, so the lane count follows from the width and the lane size (#2749)
-    riscv64_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
+    model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
     # no vector register file, so nothing crosses between one and memory (#2716)
-    riscv64_model.vec_mem_widths  = isa.VEC_MEM_NONE;
-    riscv64_model.vector_compute_generic = false;
+    model.vec_mem_widths  = isa.VEC_MEM_NONE;
+    model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.
-    riscv64_model.ct_trust_mul = false;
-    riscv64_model.has_var_shift = true;        # SLL / SRL / SRA read the count from a register (#2217)
-    riscv64_model.has_mul = true;              # MUL, the M extension (#2344)
-    riscv64_model.flat_addressing = true;      # a byte-addressed linear space (#2655)
-    riscv64_model.ct_trust_var_shift = true;   # rv64 SLL/SRL variable shift is constant-time (#1646)
+    model.ct_trust_mul = false;
+    model.has_var_shift = true;        # SLL / SRL / SRA read the count from a register (#2217)
+    model.has_mul = true;              # MUL, the M extension (#2344)
+    model.flat_addressing = true;      # a byte-addressed linear space (#2655)
+    model.ct_trust_var_shift = true;   # rv64 SLL/SRL variable shift is constant-time (#1646)
 
-    riscv64_model.reg_classes     = ?riscv64_classes[0];
-    riscv64_model.reg_class_len   = 2;
-    riscv64_model.frame_ptr_reg   = riscv.FP;
-    riscv64_model.stack_ptr_reg   = riscv.SP;
-    riscv64_model.reserved_regs   = ?riscv64_reserved_regs[0];
-    riscv64_model.reserved_len    = 6;
-    riscv64_model.div_reg         = -1;
-    riscv64_model.div_hi_reg      = -1;
-    riscv64_model.shift_count_reg = -1;
+    model.reg_classes     = classes;
+    model.reg_class_len   = 2;
+    model.frame_ptr_reg   = riscv.FP;
+    model.stack_ptr_reg   = riscv.SP;
+    model.reserved_regs   = reserved;
+    model.reserved_len    = 6;
+    model.div_reg         = -1;
+    model.div_hi_reg      = -1;
+    model.shift_count_reg = -1;
 
-    riscv64_model.incoming_arg_base = 0;
-    riscv64_model.stack_align       = 0;
-    riscv64_model.red_zone          = 0;
-    riscv64_model.shadow_space      = 0;
+    model.incoming_arg_base = 0;
+    model.stack_align       = 0;
+    model.red_zone          = 0;
+    model.shadow_space      = 0;
 
-    isa.register(reg, ?riscv64_vtable);
+    isa.register(reg, vt);
 
     ret R.ok[bool, str](true);
 }

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -141,9 +141,11 @@ val CENSUS_COUNT:       i32 = 3;  # a permitted group holds a different number t
 # (`AbiVTable`) - plus
 # the eleven registration modules whose process-global storage must be declared
 # bare: five ISA arch modules install an `IsaVTable` (+ `RegMachine` / `RelocSeam`
-# where the arch has one), six ABI convention modules install an `AbiVTable` - and
-# `abi/riscv.mach` installs three of them, one per RV64 family member. Two
-# kinds of entry, kept in one table so neither is invisible.
+# where the arch has one), six ABI convention modules install an `AbiVTable`. A
+# MODULE IS NOT AN ARCH: `isa/riscv/register.mach` is one module installing two
+# arches (rv64 and rv32), and `abi/riscv.mach` is one module installing six family
+# members, which is why their permitted counts are multiples rather than the base
+# figure. Two kinds of entry, kept in one table so neither is invisible.
 val ALLOWED_LEN: usize = 23;
 
 # the enclosing function name of each permitted group, positionally paired with
@@ -195,19 +197,29 @@ fun allowed_file(i: usize) str {
 # the exact number of bare declarations each permitted group may hold
 #
 # One for each constructor. Three for an ISA arch that installs a vtable, a
-# register machine and a relocation seam (x86-64, aarch64, riscv64, and mos6502
-# since #2280 - its RK_ABS16 JSR relocation, resolved directly against the raw
-# flat image rather than through ELF); two for spirv (a whole-module emitter
-# payload instead of a register machine, and no seam by construction - a
-# finished module carries no relocations). One for each ABI convention module's
-# `AbiVTable` global - unlike `IsaVTable`, a calling convention bundles no
-# sub-contracts alongside it - except `abi/riscv.mach`, which registers the three
-# RV64 family members (lp64 / lp64f / lp64d) from one module and so holds three.
+# register machine and a relocation seam (x86-64, aarch64, and mos6502 since #2280 -
+# its RK_ABS16 JSR relocation, resolved directly against the raw flat image rather
+# than through ELF); two for spirv (a whole-module emitter payload instead of a
+# register machine, and no seam by construction - a finished module carries no
+# relocations). One for each ABI convention module's `AbiVTable` global - unlike
+# `IsaVTable`, a calling convention bundles no sub-contracts alongside it.
+#
+# TWO MODULES HOLD A WHOLE FAMILY, AND SO HOLD A MULTIPLE (#2778). `isa/riscv/`
+# registers rv64 AND rv32 from one module, each needing its own vtable, register
+# machine and seam, because all three are borrowed by the registry for the process
+# lifetime and a multi-target build resolves both at once - six. `abi/riscv.mach`
+# registers the six family members (lp64 / lp64f / lp64d, ilp32 / ilp32f / ilp32d),
+# one `AbiVTable` apiece - six.
+#
+# THE NUMBERS STAY EXACT rather than becoming a floor. A seventh declaration in
+# either module is still a finding, which is the whole value of the census: the
+# permitted count is what someone had to think about, not what happened to be there.
 fun allowed_count(i: usize) usize {
     if (i <= 8)  { ret 1; }
+    if (i == 11) { ret 6; }
     if (i <= 12) { ret 3; }
     if (i <= 13) { ret 2; }
-    if (i == 19) { ret 3; }
+    if (i == 19) { ret 6; }
     ret 1;
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1357,6 +1357,13 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     of.cover_isa(?elf_vtable, isa.ARCH_X86_64);
     of.cover_isa(?elf_vtable, isa.ARCH_AARCH64);
     of.cover_isa(?elf_vtable, isa.ARCH_RISCV64);
+    # ARCH_RISCV32 IS DELIBERATELY ABSENT (#2861). `elf_class_for` would stamp
+    # ELFCLASS32 into `e_ident` from its 4-byte pointer width while every structure
+    # this writer emits is still Elf64 - a file whose class byte contradicts its own
+    # layout, which is worse for a reader than no file at all. So an rv32 target
+    # composes with the `raw` format and is refused here by name (TUPLE_OF_UNCOVERED)
+    # rather than producing an object that looks valid and is not. Covering it is
+    # #2861's acceptance, not a line to add ahead of the writer.
 
     of.register(reg, ?elf_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -46,6 +46,10 @@ fun freestanding_native_abi(arch_id: u32) str {
     # explicitly, which is now a real, selectable convention rather than a name that
     # emitted hard-float code anyway.
     if (arch_id == isa.ARCH_RISCV64) { ret "lp64d"; }
+    # ilp32d for the same reason lp64d is above: mach's rv32 declares the D extension
+    # present (FLEN 64), so ilp32d is the psABI this ISA supports. an image running
+    # with the FPU off asks for `abi = "ilp32"` by name (#2778).
+    if (arch_id == isa.ARCH_RISCV32) { ret "ilp32d"; }
     if (arch_id == isa.ARCH_MOS6502) { ret "mos6502"; }
     ret "";
 }


### PR DESCRIPTION
PR 3b of the RV32 sequence, on top of #2862's width parameterization. This is the target itself.

## What lands

`isa = "riscv32"` with `abi = "ilp32"` / `"ilp32f"` / `"ilp32d"` resolves a full machine description. `$mach.arch.riscv32` and the three `$mach.abi.ilp32*` comptime tags exist, because a target you cannot write an `$if` for is a target that exists and cannot be used.

**Nothing about the backend is duplicated.** One `build_riscv` fills either arch's vtable, register machine, relocation seam and model from the register width it is handed; the register numbering, the psABI roles, the selection pack, the encoder, the printer, the DWARF map and the attribute derivation are shared unchanged. Two arches need two sets of process-global storage - both are borrowed by the registry for the process lifetime and a multi-target build resolves both at once - but they share the wiring, so there is no second copy to drift from the first.

On the convention side the three ilp32 members differ from their lp64 twins in exactly one declared fact, `xlen_bits`. `arg_slot_granularity` becomes 4 without a line saying 4, because it was already `xlen_bytes(v)`.

`max_alu_width` is 4 on rv32, so an `i64` sits above the ALU and takes the same lane-splitting `legalize` path the 6502's 8-bit ALU uses. FLEN stays 64, because rv32gc has the D extension - a float register is twice the width of an integer one, which is the pair the frame layout now reads as two separate strides.

The inline-asm tag follows the machine: an rv32 target admits `asm riscv32` and refuses `asm riscv64`.

## Evidence: a real RV32 program, run

A freestanding flat image built by this branch, computing `collatz_steps(27) + sum_to(10)` and exiting with the answer:

```
qemu-riscv32 rv32demo.elf ; echo $?
166
```

111 + 55 = 166. The same source built for `freestanding-riscv64` also exits 166, so the two targets agree from one program.

Disassembling the image shows it is genuinely RV32 rather than RV64 code that happens to run:

```
   0: fb010113  addi sp, sp, -0x50
   4: 04112623  sw   ra, 0x4c(sp)      # sw, not sd - the memory width is XLEN
   8: 04812423  sw   s0, 0x48(sp)      # the ra/s0 record at total-4 / total-8 = 2*XLEN
   c: 05010413  addi s0, sp, 0x50
  10: 04912223  sw   s1, 0x44(sp)      # callee-save stride 4, not 8
  ...
  d4: 02a30633  mul  a2, t1, a0        # mul, not mulw - no word group at XLEN 4
  e4: 02c546b3  div  a3, a0, a2
```

**This image is the positive control for the parameterization.** The same encoder, told a different machine, emits different widths - which is a stronger demonstration than a mutation that the model reaches the code, because it is the intended behaviour rather than an injected fault.

**Label on the qemu evidence:** qemu-user settles arithmetic and control flow and says nothing about syscall surface. The only syscall here is `exit`, and it is carrying the answer out rather than being the thing under test.

The ELF container around the flat image is the harness's, produced with `llvm-objcopy` and `ld.lld`, because mach cannot write ELF32 yet (#2861). Every instruction inside it is mach's.

## What rv32 refuses, by name

- **ELF.** `of.elf` deliberately does not cover `ARCH_RISCV32`: `elf_class_for` would stamp ELFCLASS32 from the 4-byte pointer width while every structure the writer emits is Elf64, and a file whose class byte contradicts its layout is worse for a reader than no file. An rv32 linux tuple is refused at resolve time. A test asserts that refusal *and* that the arch and the convention both exist, so it is refused for the right reason - and that test is what will fail when #2861 lands, which is the point of writing it.
- **Float / 64-bit-integer conversion.** `fcvt.s.l`, `fcvt.d.l`, `fcvt.l.s`, `fcvt.l.d` and the `fmv.d.x` / `fmv.x.d` pair are RV64-only. The encoder refuses each by name with `see briar-systems/mach#2860`.

One thing I found while testing that refusal: on the path where the conversion's result feeds another wide operation, `legalize` errored *first* with the generic "operation wider than the target ALU is unsupported (MIR_AND, 8 bytes wide)" - pointing at the `and` rather than at the conversion that made it unrepresentable. `unsupported_family` now names the conversion class and the issue, so the diagnostic lands on the instruction that is actually the problem.

## A hole #2862's arity check could not close

`tasm`, the inline-asm test helper, hand-assigned the seven `EncodeState` fields it needed instead of calling `state_blank`. So when #2862 made the machine a required constructor argument, this helper kept building a state with a **nil model** - which segfaulted the moment anything read a width. An arity check only binds the callers that call the thing. `tasm` now goes through `state_blank`; the hand-rolled duplication is gone.

## The three exhaustive tests

All three were updated, and I checked each still asserts something afterwards:

- `elf_capable_isa_declares_a_reloc_seam`: `seams != 4` becomes `!= 5`. **I kept it a literal on purpose.** Deriving the count by counting ELF-capable vtables would compare the loop's result against itself and assert nothing; the per-vtable completeness check above it is the real assertion, and this line exists to stop a human when a target gains or loses the capability. The comment now says that, so the next person does not "fix" it into a tautology.
- The construction census: `isa/riscv/register.mach` 3 -> 6 and `abi/riscv.mach` 3 -> 6. Both stay **exact**, so a seventh declaration in either is still a finding. The prose now says a module is not an arch, which is why those two are multiples.
- `abi_vtable:granularity_matches_its_classifier` walks every registered convention and needed no change - the ilp32 vtables satisfy it because their granularity is read from the member. That is the #2856 contract paying off.

`select:linux_aarch64`'s ABI-registry count went 8 -> 11, which is checked because `abi.register` drops a vtable past the cap silently.

## Verification

`mach test .`: 1378 passed, 0 failed (two new selection tests).

Byte-identity on the three shipped targets, baseline from this branch's own merge base (`e9e5e5b2`):

| leg | objects | binaries | self-differing | base vs branch |
|---|---|---|---|---|
| linux-x86_64 | 224 | 2 | 0 | 0 |
| linux-arm64 | 224 | 2 | 0 | 0 |
| linux-riscv64 | 224 | 2 | 0 | 0 |

riscv64 unchanged is the one that matters: it shares the whole encoder with rv32 and its registrar was refactored underneath it.

Self-host fixpoint from a freshly removed `out/` at each stage: stage2 == stage3 == stage4, byte-identical.

`int` sweeps, all cases: `linux`, `linux-arm64` (qemu override) and `linux-riscv64` green. **No riscv32 int leg and no new `int/` cases** - the freeze holds, and everything above was observed locally.

## Known gap, stated rather than hidden

The inline-asm mnemonic table is shared between the two machines, so an RV64-only spelling (`ld`, `sd`, `addw`, `fcvt.l.d`) is still accepted under a `riscv32` tag and would assemble to an instruction RV32 does not have. Gating the table by width needs a per-row flag; it is documented in `doc/language/asm.md` and I will file it unless you would rather it went in here.

`guard_identity_copy`'s literal 8 (named in #2862) is still there - fixing it needs the machine inside a `GuardFn`, and I did not want to widen a signature used by 262 guards inside this PR. Say the word and it becomes its own change.

Refs #2778
