### PR TITLE
fix(riscv32): wire the RV32 register machine to its own storage

### DIFF
--- a/src/lang/target/isa/riscv/register.mach
+++ b/src/lang/target/isa/riscv/register.mach
@@ -338,22 +338,22 @@ fun build_riscv(reg: *isa.IsaRegistry, arch_id: u32, name: str, xw: u32,
         rules.select::*u8,
         encode.encode_riscv64::*u8,
         rules.is_reg_move,
-        ?riscv64_reserved_regs[0], 6,
-        ?riscv64_reload_scratch_regs[0], 3,
+        reserved, 6,
+        reload, 3,
         riscv.SCRATCH_REG, riscv.SCRATCH_REG2,
         riscv.FP, riscv.SP, 0,
         -1, -1, -1
     );
     # the printer is the encoder's own sink (#2193), so the `.s` renders the
     # instruction stream that was emitted rather than a second MIR-level walk.
-    isa.with_asm_printer(?riscv64_machine, encode.encode_riscv64_asm::*u8);
-    isa.with_asm_clobbers(?riscv64_machine, encode.asm_clobbers);
-    isa.with_asm_returns(?riscv64_machine, encode.asm_returns);
+    isa.with_asm_printer(machine, encode.encode_riscv64_asm::*u8);
+    isa.with_asm_clobbers(machine, encode.asm_clobbers);
+    isa.with_asm_returns(machine, encode.asm_returns);
 
-    isa.with_asm_ct_scan(?riscv64_machine, encode.asm_ct_scan);
+    isa.with_asm_ct_scan(machine, encode.asm_ct_scan);
     # the per-ISA DWARF register map (#1693). riscv64 has no CodeView numbering (no
     # Windows target), so `with_codeview_regs` is not called.
-    isa.with_dwarf_regs(?riscv64_machine, riscv64_dwarf_reg);
+    isa.with_dwarf_regs(machine, riscv64_dwarf_reg);
 
     # the ELF build-attributes descriptor: the writer stamps a `.riscv.attributes`
     # ISA-string section from it so external tools decode imafd with no manual
@@ -498,6 +498,59 @@ test "mach.lang.target.isa.riscv.register.register_riscv64:build_attributes" {
     if (riscv64_vtable.reloc.build_attributes == nil) { ret 1; }
     if (riscv64_vtable.reloc.merge_attributes == nil) { ret 1; }
     if (!isa.declares_attributes(?riscv64_vtable))    { ret 1; }
+    ret 0;
+}
+
+# ONE BUILDER MUST WIRE ITS TWO MEMBERS ALIKE
+#
+# `build_riscv` fills either arch's storage from the width it is handed, so the two
+# members can differ in their WIDTHS and in nothing else. A setter inside it that
+# names a module global instead of its parameter still compiles, still passes every
+# rv64 test - because rv64 is the member whose globals those are - and silently leaves
+# the other member's machine half-built. That is exactly what happened between #2778
+# and this fix: five capability setters and the two register files named
+# `riscv64_*` inside the shared builder, so the rv32 register machine had no assembly
+# printer, no inline-asm clobber analyser, no `asm_returns`, no constant-time scanner
+# and no DWARF register map, and pointed at rv64's reserved-register array.
+#
+# THE ASYMMETRY IS THE ASSERTION. Checking rv32's hooks against a hand-written list
+# would restate the builder; checking them against RV64'S proves the builder wired
+# both members from the same lines, which is the property that was broken. A capability
+# added to one member and not the other now fails here rather than at a user's build.
+test "mach.lang.target.isa.riscv.register.build_riscv:both_members_are_wired_alike" {
+    var reg: isa.IsaRegistry = isa.registry_init();
+    if (R.is_err[bool, str](register_riscv64(?reg))) { ret 1; }
+    if (R.is_err[bool, str](register_riscv32(?reg))) { ret 1; }
+
+    val m64: *isa.RegMachine = riscv64_vtable.machine;
+    val m32: *isa.RegMachine = riscv32_vtable.machine;
+    if (m64 == nil || m32 == nil) { ret 1; }
+    # the two machines are DISTINCT objects, or the rest of this test is vacuous
+    if (m64 == m32) { ret 1; }
+
+    # every capability either both members have or neither does
+    if ((m64.emit_asm == nil)     != (m32.emit_asm == nil))     { ret 1; }
+    if ((m64.asm_clobbers == nil) != (m32.asm_clobbers == nil)) { ret 1; }
+    if ((m64.asm_returns == nil)  != (m32.asm_returns == nil))  { ret 1; }
+    if ((m64.asm_ct_scan == nil)  != (m32.asm_ct_scan == nil))  { ret 1; }
+    if ((m64.dwarf_reg == nil)    != (m32.dwarf_reg == nil))    { ret 1; }
+    if ((m64.cv_reg == nil)       != (m32.cv_reg == nil))       { ret 1; }
+    if ((m64.select == nil)       != (m32.select == nil))       { ret 1; }
+    if ((m64.encode == nil)       != (m32.encode == nil))       { ret 1; }
+    # and rv32 really does have them, so "alike" cannot be satisfied by both being nil
+    if (m32.emit_asm == nil || m32.asm_clobbers == nil || m32.dwarf_reg == nil) { ret 1; }
+
+    # each member's register files are ITS OWN storage, not a borrow of the other's -
+    # the reserved list carries a declared width, so a shared array would report one
+    # member's registers as the other's size
+    if (m64.reserved_regs == m32.reserved_regs)             { ret 1; }
+    if (m64.reload_scratch_regs == m32.reload_scratch_regs) { ret 1; }
+    if (m64.reserved_reg_count != m32.reserved_reg_count)   { ret 1; }
+    if (m32.reserved_regs[0].size != 4) { ret 1; }
+    if (m64.reserved_regs[0].size != 8) { ret 1; }
+    # the same register ids, because the numbering is architectural
+    if (m32.reserved_regs[0].id != m64.reserved_regs[0].id) { ret 1; }
+    if (m32.scratch_reg != m64.scratch_reg)                 { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
A defect I shipped in #2863, found while measuring for PR 4. Fixing it before that work rather than carrying it.

## What was wrong

`build_riscv` fills either arch's storage from the width it is handed. Seven lines inside it named the **rv64 module globals** instead of their parameters:

```
isa.with_asm_printer(?riscv64_machine, ...);   # x5, the capability setters
isa.with_dwarf_regs(?riscv64_machine, ...);
...
@machine = isa.reg_machine(..., ?riscv64_reserved_regs[0], 6,
                                ?riscv64_reload_scratch_regs[0], 3, ...);
```

That compiles, and **every rv64 test passes**, because rv64 is the member whose globals those are. The rv32 register machine got:

- no assembly printer - `--emit-asm` on an rv32 target was refused with "the target architecture registered no assembly printer", which is how I found it
- no inline-asm clobber analyser, no `asm_returns`, no constant-time scanner
- no DWARF register map
- a `reserved_regs` pointer into **rv64's** array, whose declared register size is 8 rather than 4

## Why the existing tests did not catch it

`elf_capable_isa_declares_a_reloc_seam` checks the relocation seam, which was wired correctly. Nothing checked the register machine's optional capabilities, and they are optional by design - a target legitimately may not have a CodeView map. So "rv32 has a printer" is not a property any generic test could assert.

## The test

The assertion is that **the two members are wired alike**, not that rv32 matches a hand-written list:

```
if ((m64.emit_asm == nil)     != (m32.emit_asm == nil))     { ret 1; }
if ((m64.asm_clobbers == nil) != (m32.asm_clobbers == nil)) { ret 1; }
...
if (m64.reserved_regs == m32.reserved_regs)             { ret 1; }
if (m32.reserved_regs[0].size != 4) { ret 1; }
if (m64.reserved_regs[0].size != 8) { ret 1; }
```

Restating the builder's list would prove nothing. It is the **asymmetry between two members built from the same lines** that was broken, and this is the shape that catches it - including a future capability added to one member and not the other. It also asserts the two machines are distinct objects, so the comparison cannot be vacuously true, and that rv32's hooks are really non-nil, so "alike" cannot be satisfied by both being nil.

I confirmed it fails against the defect rather than assuming: re-introducing the `with_asm_printer` leak fails it, and separately re-introducing the `reserved_regs` leak fails it. Both were checked one at a time.

## Verification

`mach test .`: 1379 passed, 0 failed.

Byte-identity, baseline from this branch's own merge base (`6f66feb7`):

| leg | objects | binaries | self-differing | base vs branch |
|---|---|---|---|---|
| linux-x86_64 | 224 | 2 | 0 | 0 |
| linux-arm64 | 224 | 2 | 0 | 0 |
| linux-riscv64 | 224 | 2 | 0 | 0 |

Zero is the right answer here and it is not a vacuous one: rv64 was always getting the correct wiring by accident, so a fix that changed rv64 output would mean I had broken something. The behaviour that changes is on rv32, which no shipped leg builds.

`--emit-asm` now produces `main.s` for an rv32 target, which it could not before.

`int` sweeps green on `linux`, `linux-arm64` (qemu) and `linux-riscv64`. No `int/` cases touched.

## The general lesson

This is the same shape as the `tasm` finding in #2863, one level up. There, a constructor-level guarantee missed a caller that hand-assigned fields instead of calling the constructor. Here, a parameterized builder missed seven lines that named globals instead of parameters. **Both are cases where the compiler cannot see that a name is the wrong name**, because the wrong name is a valid one of the right type. The defence is the same in both: when you introduce a parameter that replaces a global, grep the function body for the global's name before believing it is done.

Refs #2778
