### PR TITLE
feat(codegen): expand a wide multiply schoolbook where the machine declares a widening one

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -132,7 +132,7 @@ use target: mach.lang.target.resolved;
 # the machine facts the pass reads, lifted off the resolved target once
 #
 # Keeping them in a record rather than threading the whole `target.Target` is what
-# lets the pass be exercised directly by its own tests, and it names the exact five
+# lets the pass be exercised directly by its own tests, and it names the exact six
 # facts legalization depends on.
 # ---
 # lane_width: the native ALU width in bytes (`model.max_alu_width`); one lane
@@ -142,6 +142,9 @@ use target: mach.lang.target.resolved;
 # has_mul:    whether the ISA has a hardware integer multiply at all
 #             (`model.has_mul`); false hands this pass every MIR_MUL, native width
 #             included - unlike every other gate here, this one is not width-driven
+# mul_hi:     the width in bytes at which the ISA yields the HIGH half of an unsigned
+#             lane product (`model.mul_hi_width`), or 0. equal to `lane_width` selects
+#             the schoolbook wide multiply; 0 selects the synthesized lane product
 # stage_lo:   low half of the backend's reserved address-staging register pair
 #             (`RegMachine.scratch_reg`), the fixed base a runtime-pointer access
 #             is decomposed at
@@ -151,6 +154,7 @@ rec Machine {
     ptr_width:  u8;
     var_shift:  bool;
     has_mul:    bool;
+    mul_hi:     u8;
     stage_lo:   i32;
     stage_hi:   i32;
 }
@@ -205,6 +209,7 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
     mach.ptr_width  = tgt.model.pointer_width::u8;
     mach.var_shift  = tgt.model.has_var_shift;
     mach.has_mul    = tgt.model.has_mul;
+    mach.mul_hi     = tgt.model.mul_hi_width::u8;
     mach.stage_lo   = -1;
     mach.stage_hi   = -1;
     # a register machine declares the reserved scratch pair; a whole-module emitter
@@ -582,11 +587,31 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
         i = i + 1;
     }
 
+    # THE COUNT AND THE EMIT MUST AGREE, AND THIS IS WHERE THAT IS CHECKED (#2778).
+    # Every expansion computes its piece count before emitting and this array is sized
+    # from the sum, so the two agreeing is an invariant each expansion honours by hand.
+    # Nothing used to verify it: the block took its length from the PREDICTED total, so
+    # an expansion that emitted fewer pieces than it counted left the tail as zeroed
+    # `MirInstr`s - opcode 0, no operands - silently inside the block, and no test
+    # asserting "block length equals the count" could ever have seen it, because that
+    # length WAS the count. An over-emit is worse and already past the end of the array
+    # by the time it is noticed.
+    #
+    # Taking the length from the cursor and refusing on disagreement turns the quietest
+    # failure this pass has into a named one. It is not defensive: the cost is one
+    # comparison per block, and the alternative is that a miscounted expansion is
+    # discovered as wrong arithmetic on a target nobody runs.
+    if (w != total) {
+        free_pieces(alloc, dst, w);
+        A.deallocate[mir.MirInstr](alloc, dst, total::usize);
+        ret R.err[bool, str]("legalize: an expansion emitted a different number of pieces than it counted (internal compiler error, see briar-systems/mach#2778)");
+    }
+
     if (b.instrs != nil && b.instr_cap > 0) {
         A.deallocate[mir.MirInstr](alloc, b.instrs, b.instr_cap::usize);
     }
     b.instrs      = dst;
-    b.instr_count = total;
+    b.instr_count = w;
     b.instr_cap   = total;
     ret R.ok[bool, str](true);
 }
@@ -1778,13 +1803,243 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
     ret R.ok[bool, str](true);
 }
 
-# the exact piece count of a wide multiply's double-and-add expansion, or a loud
-# error
+# the exact piece count of a double-and-add run of `stages` stages over `nl` lanes
+#
+# Read by the count and walked by `emit_double_and_add`, so the two cannot drift.
+# ---
+# nl:     the lane count of the running values and the accumulator
+# stages: how many multiplier bits the run consumes
+fun double_and_add_pieces(nl: u32, stages: u32) u32 {
+    # per stage: extract the running multiplier's low bit, turn it into a select
+    # mask, accumulate the running multiplicand into the result through the carry
+    # chain, and branchlessly select the accumulated-or-unchanged result.
+    val per_stage: u32 = 2 + addsub_chain_piece_count(nl) + 3 * nl;
+    # every stage but the last also advances both running values by one bit: the
+    # multiplicand left (doubling it), the multiplier right (consuming the bit
+    # just tested) - both a shift-by-one template, one lane classification each.
+    val shl1: u32 = const_shift_pieces(nl, 0, 1, true, false);
+    val shr1: u32 = const_shift_pieces(nl, 0, 1, false, false);
+    ret stages * per_stage + (stages - 1) * (shl1 + shr1);
+}
+
+# whether an accumulator lane still holds the immediate zero it was seeded with
+#
+# Named rather than inlined because the emit and the count must agree on it exactly:
+# a lane this answers true for costs no pieces, and a count that disagreed would size
+# the rebuilt array wrong.
+fun lane_is_seed_zero(op: mir.MirOperand) bool {
+    ret op.kind == mir.MIR_OP_IMM && op.imm == 0;
+}
+
+# the pieces accumulating into lane `p` costs, advancing the liveness `live` tracks
+#
+# THE COUNT AND THE EMIT MUST AGREE ON LIVENESS, NOT JUST ON ARITHMETIC, and getting
+# that wrong is how this expansion first shipped a wrong 6502 multiply. A value landing
+# in a lane still holding its seed zero repoints that ONE lane and emits nothing; a
+# value landing in a live lane runs the carry chain, and that chain writes a fresh vreg
+# into EVERY lane above it, so all of them become live too. Tracking only the lane
+# written directly undercounts the next product into a lane the chain had already
+# quietly made live, and an undercounted expansion overruns the array it was sized for.
+# ---
+# live: per-lane liveness, advanced in place
+# nl:   the accumulator's lane count
+# p:    the lane the value is added into
+fun accum_into(live: *bool, nl: u32, p: u32) u32 {
+    if (!live[p]) { live[p] = true; ret 0; }
+    var k: u32 = p;
+    for (k < nl) { live[k] = true; k = k + 1; }
+    ret accum_lane_pieces(nl, p);
+}
+
+# the pieces one `emit_accumulate_lane` costs, when the lane is already live
+#
+# The lane itself, then one add and one carry test per lane above it, less the carry
+# test the top lane does not need because nothing reads its carry-out. `p == nl - 1`
+# lands on 1, which is the same formula and not a special case.
+fun accum_lane_pieces(nl: u32, p: u32) u32 {
+    ret 2 * (nl - p) - 1;
+}
+
+# add a single native-width value into lane `p` of an accumulator, carrying upward
+#
+# The counterpart of `emit_addsub_chain` for the schoolbook multiply: a partial
+# product is ONE lane (or two), not a whole wide value, so adding it through the
+# full-width chain would spend a lane's work on every lane below and above it. This
+# starts at `p` and stops carrying as soon as the top lane is reached.
+#
+# The accumulator lanes are REPLACED, not mutated: each write lands in a fresh vreg
+# and `acc[k]` is repointed, because this pass emits into a single straight-line block
+# where a value is defined once. A lane this has not reached yet may still be the
+# `mir.op_imm(0)` the caller seeded it with, and that is deliberate - the first
+# accumulation into a lane reads the immediate and needs no zeroing move at all.
+# ---
+# alloc:  backing allocator for piece operand arrays and lane temporaries
+# f:      the MIR function (for appending temporaries)
+# src:    the instruction the sequence replaces (source of loc / inline_site)
+# dst:    the rebuilt instruction array
+# cursor: next write index into `dst`; advanced past the emitted pieces
+# acc:    the `nl` accumulator lane operands, repointed in place
+# nl:     the accumulator's lane count
+# lw:     the native lane width in bytes
+# p:      the lane `v` is added into
+# v:      the value added
+# ret:    ok(true) on success, or an allocation error
+fun emit_accumulate_lane(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
+                         dst: *mir.MirInstr, cursor: *u32, acc: *mir.MirOperand,
+                         nl: u32, lw: u8, p: u32, v: mir.MirOperand) R.Result[bool, str] {
+    # the FIRST value into a lane is the lane, and costs nothing. the accumulator is
+    # seeded with immediate zeros, and `0 + v` is `v` with no carry out, so this
+    # repoints the lane rather than emitting an add the target would have to
+    # materialize the zero for. `mul_schoolbook_pieces` tracks the same seeding.
+    if (lane_is_seed_zero(acc[p])) { acc[p] = v; ret R.ok[bool, str](true); }
+
+    val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](rt)) { ret R.err[bool, str](R.unwrap_err[u32, str](rt)); }
+    val t: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rt));
+    val r1: R.Result[bool, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, t, acc[p], v, lw);
+    if (R.is_err[bool, str](r1)) { ret r1; }
+
+    # the top lane's carry-out is discarded (wrapping arithmetic), so it is never built
+    if (p == nl - 1) { acc[p] = t; ret R.ok[bool, str](true); }
+
+    val rc: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
+    var carry: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rc));
+    val r2: R.Result[bool, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, carry, t, v, lw);
+    if (R.is_err[bool, str](r2)) { ret r2; }
+    acc[p] = t;
+
+    var k: u32 = p + 1;
+    for (k < nl) {
+        val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (R.is_err[u32, str](rn)) { ret R.err[bool, str](R.unwrap_err[u32, str](rn)); }
+        val n: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rn));
+        val r3: R.Result[bool, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, n, acc[k], carry, lw);
+        if (R.is_err[bool, str](r3)) { ret r3; }
+        acc[k] = n;
+        if (k == nl - 1) { ret R.ok[bool, str](true); }
+
+        # carrying a 0/1 into a lane wraps only when the lane was all-ones, which is
+        # exactly `n <u carry` - the same unsigned-compare carry the add chain uses.
+        val rc2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (R.is_err[u32, str](rc2)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc2)); }
+        val c2: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rc2));
+        val r4: R.Result[bool, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, c2, n, carry, lw);
+        if (R.is_err[bool, str](r4)) { ret r4; }
+        carry = c2;
+        k = k + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the pieces one lane product costs
+# ---
+# native:   whether the target declares a widening lane multiply
+# want_hi:  whether the high half is wanted as well as the low
+# lane_bits: bits in one lane
+fun lane_product_pieces(native: bool, want_hi: bool, lane_bits: u32) u32 {
+    if (native) {
+        if (want_hi) { ret 2; }
+        ret 1;
+    }
+    # synthesized: a double-and-add whose multiplier is one lane wide, so it runs
+    # `lane_bits` stages rather than the whole value's - over two lanes when the high
+    # half is wanted and one when it is not.
+    if (want_hi) { ret double_and_add_pieces(2, lane_bits); }
+    ret double_and_add_pieces(1, lane_bits);
+}
+
+# emit the product of two native-width lanes into `lo` and, when wanted, `hi`
+#
+# THE ONE PLACE THE DECLARED FACT IS READ. Everything else in the schoolbook is
+# target-blind; this picks between the ISA's own `MIR_MUL` / `MIR_MUL_HI_U` pair and a
+# double-and-add that synthesizes the same two lanes. That is the contract's whole
+# shape: the EXPANSION is shared and the LEAF is declared, so a target with no
+# multiply at all is a member of the same expansion rather than a separate algorithm.
+# ---
+# alloc:   backing allocator for piece operand arrays and lane temporaries
+# plan:    the function's lane assignment (supplies the declared fact)
+# f:       the MIR function (for appending temporaries)
+# src:     the instruction the sequence replaces
+# dst:     the rebuilt instruction array
+# cursor:  next write index into `dst`; advanced past the emitted pieces
+# a, b:    the two native-width lane operands
+# lo:      destination operand for the low half
+# hi:      destination operand for the high half, ignored when `want_hi` is false
+# want_hi: whether the high half is wanted
+# ret:     ok(true) on success, or an allocation error
+fun emit_lane_product(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, src: *mir.MirInstr,
+                      dst: *mir.MirInstr, cursor: *u32,
+                      a: mir.MirOperand, b: mir.MirOperand,
+                      lo: mir.MirOperand, hi: mir.MirOperand, want_hi: bool) R.Result[bool, str] {
+    val lw: u8 = plan.lane_width;
+    if (plan.mach.mul_hi != 0) {
+        val r1: R.Result[bool, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_MUL, lo, a, b, lw);
+        if (R.is_err[bool, str](r1)) { ret r1; }
+        if (!want_hi) { ret R.ok[bool, str](true); }
+        ret emit_bin(alloc, dst, cursor, src, mir.MIR_MUL_HI_U, hi, a, b, lw);
+    }
+
+    # no native lane product: zero-extend both lanes to the width of the answer and run
+    # the double-and-add for exactly one lane's worth of multiplier bits.
+    var mc:  [MAX_SHIFT_LANES]mir.MirOperand;
+    var mp:  [MAX_SHIFT_LANES]mir.MirOperand;
+    var out: [MAX_SHIFT_LANES]mir.MirOperand;
+    mc[0]  = a;
+    mp[0]  = b;
+    out[0] = lo;
+    var n: u32 = 1;
+    if (want_hi) {
+        mc[1]  = mir.op_imm(0);
+        mp[1]  = mir.op_imm(0);
+        out[1] = hi;
+        n = 2;
+    }
+    ret emit_double_and_add(alloc, plan, f, src, dst, cursor, ?mc[0], ?mp[0], ?out[0], n, lw::u32 * 8);
+}
+
+# the exact piece count of the schoolbook expansion over `nl` lanes
+#
+# Walks the same two loops the emit does rather than closing the form, because the
+# per-position cost is not uniform: a partial product at position `p` carries into
+# `nl - p` lanes, and one at the top position needs no high half at all.
+fun mul_schoolbook_pieces(plan: *LanePlan, nl: u32) u32 {
+    val native:    bool = plan.mach.mul_hi != 0;
+    val lane_bits: u32  = plan.lane_width::u32 * 8;
+    # mirrors the emit's seeding lane by lane, which is why this walks rather than
+    # closing the form: which lanes are still their seed zero depends on the order the
+    # partial products arrive in, and the emit and the count must agree exactly.
+    var live: [MAX_SHIFT_LANES]bool;
+    var total: u32 = 0;
+    var i: u32 = 0;
+    for (i < nl) { live[i] = false; i = i + 1; }
+    i = 0;
+    for (i < nl) {
+        var j: u32 = 0;
+        for (i + j < nl) {
+            val p: u32 = i + j;
+            val want_hi: bool = p + 1 < nl;
+            total = total + lane_product_pieces(native, want_hi, lane_bits);
+            total = total + accum_into(?live[0], nl, p);
+            if (want_hi) { total = total + accum_into(?live[0], nl, p + 1); }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    # the accumulator lives in temporaries and is copied out at the end, so a
+    # destination lane that also feeds the multiply is not clobbered mid-expansion.
+    ret total + nl;
+}
+
+# the exact piece count of a wide multiply's expansion, or a loud error
 #
 # Rejects the shapes the expansion cannot realize before any block is rebuilt: an
 # operand that is neither lane-ready, a lane count past what a scalar can span, and
 # a destination that is not a plain vreg - the same shapes `expand_mul` itself
-# checks, so the two cannot disagree.
+# checks, so the two cannot disagree. Also rejects a machine description this pass
+# does not model, LOUDLY and by name rather than by emitting the wrong sequence: a
+# `mul_hi_width` that is neither 0 nor the ALU width, or one declared on a target that
+# says it has no multiply at all.
 # ---
 # plan: the function's lane assignment
 # mi:   the multiply instruction
@@ -1796,53 +2051,54 @@ fun mul_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.R
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) || !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
         ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
-    val lw:   u8  = plan.lane_width;
-    val bits: u32 = nl * lw::u32 * 8;
-    # per stage: extract the running multiplier's low bit, turn it into a select
-    # mask, accumulate the running multiplicand into the result through the carry
-    # chain, and branchlessly select the accumulated-or-unchanged result.
-    val per_stage: u32 = 2 + addsub_chain_piece_count(nl) + 3 * nl;
-    # every stage but the last also advances both running values by one bit: the
-    # multiplicand left (doubling it), the multiplier right (consuming the bit
-    # just tested) - both a shift-by-one template, one lane classification each.
-    val shl1: u32 = const_shift_pieces(nl, 0, 1, true, false);
-    val shr1: u32 = const_shift_pieces(nl, 0, 1, false, false);
-    ret R.ok[u32, str](bits * per_stage + (bits - 1) * (shl1 + shr1));
+    if (plan.mach.mul_hi != 0 && plan.mach.mul_hi != plan.lane_width) {
+        ret R.err[u32, str]("legalize: this target declares a widening multiply at a width other than its ALU width, which this pass does not model (see briar-systems/mach#2778)");
+    }
+    if (plan.mach.mul_hi != 0 && !plan.mach.has_mul) {
+        ret R.err[u32, str]("legalize: this target declares the high half of a multiply but no multiply (see briar-systems/mach#2778)");
+    }
+    if (nl > 1) { ret R.ok[u32, str](mul_schoolbook_pieces(plan, nl)); }
+    # a single lane is not a schoolbook of anything: there is one partial product and
+    # it is the answer, so this is the leaf expansion run directly.
+    ret R.ok[u32, str](double_and_add_pieces(nl, nl * plan.lane_width::u32 * 8));
 }
 
-# expand a wide multiply into a double-and-add sequence over the operation's own
-# width
+# expand a wide multiply
 #
-# THE ALGORITHM (#2344). Classic shift-and-add, "Russian peasant" multiplication:
-# for every bit of the multiplier, from the low bit up, the running multiplicand
-# joins an accumulator when that bit is set, then the multiplicand doubles (shifts
-# left one) and the multiplier is consumed one bit (shifts right one) so the NEXT
-# bit tested is always the running value's own low bit - no per-stage lane/bit
-# indexing into the original operand is needed, only two per-stage constant
-# shifts-by-one, which is why this reuses the shift template so directly.
+# THE SHAPE IS SHARED, THE LEAF IS DECLARED (#2778). Above one lane this is schoolbook
+# long multiplication: every pair of lanes contributes a two-lane partial product at
+# lane position `i + j`, and the wrapping result reads only the low `nl` lanes, so a
+# pair whose position is already past the top contributes nothing and is never emitted
+# at all. `emit_lane_product` is the only place that asks what the machine can do; a
+# target declaring `mul_hi_width` gets one `mul` / `mulhu` pair per position, and one
+# declaring 0 gets a double-and-add over that position's two lanes instead.
 #
-# BRANCHLESS, NOT CONSTANT-TIME - and that distinction is deliberate, not an
-# oversight. This pass emits straight-line code into ONE block; it cannot build the
-# new control-flow edges a data-dependent branch would need, so the per-stage
-# "add or don't" decision is a mask-and-select exactly like the shift barrel's own
-# per-stage decision (#2217), for the same structural reason. It is NOT for secrecy:
-# `ct_trust_mul = false` on every target this compiler has (mos6502 included), so
-# `mir.lower`'s GATE (#1646) already refuses a secret multiply operand before this
-# pass ever runs - nothing here needs to be data-independent, and the full
-# `bits`-stage cost (linear in width, no early exit) is paid by every multiply,
-# public values included, purely because this pass cannot express "stop early."
+# WHY THIS BEATS THE DOUBLE-AND-ADD IT REPLACED (#2344). The old expansion was one
+# stage per BIT of the whole value, each stage touching every lane - O(nl * lane_bits)
+# stages of O(nl) work. Schoolbook is O(nl^2) positions of one lane product each. With
+# a native lane product that is the difference between 64 stages and four instructions
+# for an `i64` multiply on a 32-bit machine. Without one the leaf is still a
+# double-and-add, but over ONE lane's multiplier bits rather than the whole value's and
+# over two lanes rather than all of them, so a machine with no multiply at all wins
+# too - less dramatically, and for the same structural reason.
 #
-# THE COST IS HONEST RATHER THAN CHEAP, the same call the shift barrel already
-# made: `bits` stages of an add-chain plus two shifts-by-one is asymptotically
-# BETTER than a lane-wise schoolbook of partial products would be (O(width) stages
-# against O(lanes^2) partial products, each itself a smaller multiply), not merely
-# simpler to write.
+# THE OLD DOC'S ARITHMETIC WAS RIGHT AND ITS CONCLUSION WAS WRONG. It argued O(width)
+# stages beat O(lanes^2) partial products "each itself a smaller multiply". That holds
+# only where a lane product IS a smaller multiply. Where the machine has one it is a
+# single instruction, and where it does not the smaller multiply is cheaper than the
+# bigger one by exactly the factor the recursion saves. The unstated assumption was
+# that the leaf costs the same as the whole, and it never did.
 #
-# SHARED, NOT MOS6502-SPECIFIC: nothing here reads a mos6502 fact: only
-# `plan.lane_width`, the shift template, and the carry chain, all already
-# target-blind. It also serves the native-width case (`u8 * u8`) the same way as
-# the wide one - `nl == 1` runs the identical loop with a single-lane accumulator,
-# the same shape `emit_addsub_chain` already handles for a single-lane add.
+# BRANCHLESS FOR THE SAME STRUCTURAL REASON AS BEFORE, and still not for secrecy: this
+# pass emits straight-line code into one block and cannot build the control-flow edges
+# a data-dependent branch needs. `ct_trust_mul = false` on every target this compiler
+# has, so `mir.lower`'s GATE (#1646) already refuses a secret multiply operand before
+# this pass runs.
+#
+# UNSIGNED LANE PRODUCTS, WHATEVER THE VALUE'S SIGNEDNESS, and that is not an
+# approximation. A wrapping product of `nl` lanes is determined by the low `nl` lanes
+# of the schoolbook sum, and every lane is an unsigned digit of its operand's two's-
+# complement image, so the sign lives entirely in the lanes this discards.
 # ---
 # alloc:  backing allocator for piece operand arrays and lane temporaries
 # plan:   the function's lane assignment
@@ -1858,24 +2114,130 @@ fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *m
 
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
-    val lb: u32 = lw::u32 * 8;
-    val bits: u32 = nl * lb;
 
     var dst_ops: [MAX_SHIFT_LANES]mir.MirOperand;
-    var mcand:   [MAX_SHIFT_LANES]mir.MirOperand;  # the running multiplicand, doubles each stage
-    var mplier:  [MAX_SHIFT_LANES]mir.MirOperand;  # the running multiplier, halves each stage
-    var result:  [MAX_SHIFT_LANES]mir.MirOperand;  # the accumulator, zero initially
+    var a_ops:   [MAX_SHIFT_LANES]mir.MirOperand;
+    var b_ops:   [MAX_SHIFT_LANES]mir.MirOperand;
     var i: u32 = 0;
     for (i < nl) {
         dst_ops[i] = lane_operand(plan, ?mi.operands[0], i);
-        mcand[i]   = lane_operand(plan, ?mi.operands[1], i);
-        mplier[i]  = lane_operand(plan, ?mi.operands[2], i);
-        result[i]  = mir.op_imm(0);
+        a_ops[i]   = lane_operand(plan, ?mi.operands[1], i);
+        b_ops[i]   = lane_operand(plan, ?mi.operands[2], i);
+        i = i + 1;
+    }
+
+    if (nl == 1) {
+        ret emit_double_and_add(alloc, plan, f, mi, dst, cursor, ?a_ops[0], ?b_ops[0], ?dst_ops[0],
+                                nl, lw::u32 * 8);
+    }
+
+    # the accumulator starts as immediate zeros, so the first partial product added to
+    # a lane reads the immediate and no zeroing move is emitted for it.
+    var acc: [MAX_SHIFT_LANES]mir.MirOperand;
+    i = 0;
+    for (i < nl) { acc[i] = mir.op_imm(0); i = i + 1; }
+
+    i = 0;
+    for (i < nl) {
+        var j: u32 = 0;
+        for (i + j < nl) {
+            val p: u32 = i + j;
+            val want_hi: bool = p + 1 < nl;
+
+            val rl: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (R.is_err[u32, str](rl)) { ret R.err[bool, str](R.unwrap_err[u32, str](rl)); }
+            val lo: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rl));
+
+            var hi: mir.MirOperand = mir.op_imm(0);
+            if (want_hi) {
+                val rh: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (R.is_err[u32, str](rh)) { ret R.err[bool, str](R.unwrap_err[u32, str](rh)); }
+                hi = mir.op_vreg(R.unwrap_ok[u32, str](rh));
+            }
+
+            val rp: R.Result[bool, str] = emit_lane_product(alloc, plan, f, mi, dst, cursor,
+                                                            a_ops[i], b_ops[j], lo, hi, want_hi);
+            if (R.is_err[bool, str](rp)) { ret rp; }
+
+            val ra: R.Result[bool, str] = emit_accumulate_lane(alloc, f, mi, dst, cursor, ?acc[0], nl, lw, p, lo);
+            if (R.is_err[bool, str](ra)) { ret ra; }
+            if (want_hi) {
+                val rb: R.Result[bool, str] = emit_accumulate_lane(alloc, f, mi, dst, cursor, ?acc[0], nl, lw, p + 1, hi);
+                if (R.is_err[bool, str](rb)) { ret rb; }
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+
+    # copy out last. the destination may be one of the operands (`a = a * b`), so the
+    # expansion must not write a destination lane while a partial product still reads it.
+    i = 0;
+    for (i < nl) {
+        var ops: [2]mir.MirOperand;
+        ops[0] = dst_ops[i];
+        ops[1] = acc[i];
+        val rm: R.Result[bool, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        if (R.is_err[bool, str](rm)) { ret rm; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# run `stages` double-and-add stages, leaving the product in `out`
+#
+# THE ALGORITHM (#2344). Classic shift-and-add, "Russian peasant" multiplication:
+# for every bit of the multiplier, from the low bit up, the running multiplicand
+# joins an accumulator when that bit is set, then the multiplicand doubles (shifts
+# left one) and the multiplier is consumed one bit (shifts right one) so the NEXT
+# bit tested is always the running value's own low bit - no per-stage lane/bit
+# indexing into the original operand is needed, only two per-stage constant
+# shifts-by-one, which is why this reuses the shift template so directly.
+#
+# `stages` IS A PARAMETER RATHER THAN THE VALUE'S WIDTH (#2778), and that is the whole
+# reason this is a function of its own. As the leaf of the schoolbook expansion it
+# multiplies two ONE-LANE values into two lanes, so the multiplier gives out after a
+# lane's worth of bits even though the answer is twice that wide; running the full
+# `nl * lane_bits` stages there would spend half of them on a multiplier already zero.
+#
+# BRANCHLESS, NOT CONSTANT-TIME - and that distinction is deliberate, not an
+# oversight. This pass emits straight-line code into ONE block; it cannot build the
+# new control-flow edges a data-dependent branch would need, so the per-stage
+# "add or don't" decision is a mask-and-select exactly like the shift barrel's own
+# per-stage decision (#2217), for the same structural reason.
+# ---
+# alloc:   backing allocator for piece operand arrays and lane temporaries
+# plan:    the function's lane assignment
+# f:       the MIR function (for appending temporaries)
+# src:     the instruction the sequence replaces
+# dst:     the rebuilt instruction array
+# cursor:  next write index into `dst`; advanced past the emitted pieces
+# a_in:    the `nl` multiplicand lane operands
+# b_in:    the `nl` multiplier lane operands
+# out:     the `nl` destination lane operands, written by the last stage
+# nl:      the lane count of the running values
+# stages:  how many multiplier bits to consume
+# ret:     ok(true) on success, or an allocation error
+fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, src: *mir.MirInstr,
+                        dst: *mir.MirInstr, cursor: *u32,
+                        a_in: *mir.MirOperand, b_in: *mir.MirOperand, out: *mir.MirOperand,
+                        nl: u32, stages: u32) R.Result[bool, str] {
+    val mi: *mir.MirInstr = src;
+    val lw: u8 = plan.lane_width;
+
+    var mcand:  [MAX_SHIFT_LANES]mir.MirOperand;  # the running multiplicand, doubles each stage
+    var mplier: [MAX_SHIFT_LANES]mir.MirOperand;  # the running multiplier, halves each stage
+    var result: [MAX_SHIFT_LANES]mir.MirOperand;  # the accumulator, zero initially
+    var i: u32 = 0;
+    for (i < nl) {
+        mcand[i]  = a_in[i];
+        mplier[i] = b_in[i];
+        result[i] = mir.op_imm(0);
         i = i + 1;
     }
 
     var j: u32 = 0;
-    for (j < bits) {
+    for (j < stages) {
         # the running multiplier's own low bit - always the next bit to test,
         # because the multiplier itself shifts right one lower each stage.
         val rb: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
@@ -1905,11 +2267,11 @@ fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *m
 
         # select: result = result ^ ((result ^ cand) & mask), per lane - the last
         # stage lands in the destination lanes, every earlier one in fresh temps.
-        val is_last: bool = j == bits - 1;
+        val is_last: bool = j == stages - 1;
         var nxt: [MAX_SHIFT_LANES]mir.MirOperand;
         i = 0;
         for (i < nl) {
-            if (is_last) { nxt[i] = dst_ops[i]; }
+            if (is_last) { nxt[i] = out[i]; }
             or {
                 val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (R.is_err[u32, str](rn)) { ret R.err[bool, str](R.unwrap_err[u32, str](rn)); }
@@ -2974,6 +3336,9 @@ fun t_mach(maw: u8, ptr: u8) Machine {
     # a hardware multiply by default: only the multiply-specific tests flip this,
     # so every existing shift / add / memory test keeps its established shape
     m.has_mul    = true;
+    # no widening lane product by default: the schoolbook path is opt-in, so every
+    # existing expansion test keeps the double-and-add shape it was written against
+    m.mul_hi     = 0;
     m.stage_lo   = 6;
     m.stage_hi   = 7;
     ret m;
@@ -3122,8 +3487,12 @@ fun t_divmod_fn(alloc: *A.Allocator, f: *mir.MirFunction, b: *mir.MirBlock,
 # The count agreeing with the emit is the load-bearing assertion, not a detail: this
 # pass sizes the rebuilt instruction array from `expansion_count` BEFORE it expands,
 # so a count that disagreed with the emit would overrun the array or leave it short.
-# Asserting the block length equals the two source moves plus `divmod_piece_count`
-# checks both halves against each other at every width below.
+# The agreement itself is checked in `legalize_block`, which refuses when the emitted
+# cursor and the predicted total differ; what the block length below pins is the
+# `divmod_piece_count` FORMULA, against a width sweep. Those are two different claims
+# and this comment used to conflate them - the length was taken from the predicted
+# total, so it agreed with the count by construction and could not have caught a
+# disagreeing emit (#2778).
 test "mach.lang.be.codegen.legalize:expands_a_wide_divide" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -3221,6 +3590,172 @@ test "mach.lang.be.codegen.legalize:divide_family_costs_agree" {
     if (rs <= ru) { ret 1; }
     # and a signed remainder is exactly one piece cheaper: no sign-word combine.
     if (ds != rs + 1) { ret 1; }
+    ret 0;
+}
+
+# THE PIECE COUNT AND THE EMIT AGREE, at every lane count and under BOTH leaves
+# (#2778)
+#
+# This is the load-bearing assertion for the schoolbook multiply, not a detail, and it
+# is the one that caught the first version of it: the pass sizes the rebuilt array from
+# `expansion_count` BEFORE expanding, so a count that disagrees overruns the array or
+# leaves it short. The disagreement there was about LIVENESS rather than arithmetic -
+# the emit's carry chain writes every lane above the one it starts at, making them all
+# live, and the count only marked the lane written directly, so the next partial
+# product into a lane the chain had already made live was counted at zero. It passed
+# every unit test and produced a wrong multiply on a 6502 core.
+#
+# BOTH LEAVES, because they are counted by different formulas: a declared
+# `mul_hi_width` costs two pieces per position, and no declaration costs a whole
+# double-and-add. A count that agreed with the emit for one and not the other would be
+# invisible to a single-machine sweep.
+test "mach.lang.be.codegen.legalize:multiply_costs_agree_at_every_lane_count" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # from two lanes up. one lane is not a schoolbook of anything and `has_mul` is
+    # true here, so a native-width multiply is never handed to this pass at all.
+    var widths: [3]u8;
+    widths[0] = 2; widths[1] = 4; widths[2] = 8;
+    var native: u32 = 0;
+    for (native < 2) {
+        var mach: Machine = t_mach(1, 2);
+        if (native == 1) { mach.mul_hi = 1; }
+
+        var k: u32 = 0;
+        for (k < 3) {
+            var f: mir.MirFunction;
+            var b: mir.MirBlock;
+            t_divmod_fn(?alloc, ?f, ?b, mir.MIR_MUL, widths[k], 1000, 7);
+            var plan: LanePlan;
+            if (R.is_err[bool, str](plan_lanes(?alloc, ?mach, ?f, ?plan))) { ret 1; }
+            val rc: R.Result[u32, str] = mul_piece_count(?alloc, ?plan, ?b.instrs[2]);
+            if (R.is_err[u32, str](rc)) { ret 1; }
+            val n: u32 = R.unwrap_ok[u32, str](rc);
+            free_plan(?alloc, ?plan);
+            if (R.is_err[bool, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+            # the two source moves are one piece per lane each, so `2 * width` of the
+            # block is the operands and the rest is the multiply.
+            if (b.instr_count != 2 * widths[k]::u32 + n) { ret 1; }
+            k = k + 1;
+        }
+        native = native + 1;
+    }
+    ret 0;
+}
+
+# A DECLARED WIDENING MULTIPLY SELECTS THE NATIVE LEAF, and the shape of the answer is
+# schoolbook rather than a shorter double-and-add (#2778)
+#
+# The rv32 shape exactly: `lane_width` 4, an 8-byte multiply, two lanes. Every count
+# below is derived rather than quoted, because the derivation is the specification:
+#
+#   positions are (i, j) with i + j < 2, so (0,0), (0,1) and (1,0).
+#   (0,0) is the only one whose high half is still inside the value, so it costs a
+#   `mul` and a `mulhu`; the other two cost a `mul` each.  -> 4 lane products
+#   (0,0)'s two halves land in lanes 0 and 1, both still holding their seed zero, so
+#   they repoint and emit nothing.                         -> 0 pieces
+#   (0,1) and (1,0) both land in lane 1, now live and also the top lane, so each is a
+#   single add with no carry-out.                          -> 2 pieces
+#   the accumulator is copied into the destination lanes.  -> 2 pieces
+#                                                          => 8 pieces
+#
+# 8 against the 1272 the double-and-add spends at this width is the entire point of
+# the change, and pinning it as a literal is what makes a regression in either
+# direction a failure rather than a slower build nobody notices.
+test "mach.lang.be.codegen.legalize:a_declared_widening_multiply_selects_the_native_leaf" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    var b: mir.MirBlock;
+    t_divmod_fn(?alloc, ?f, ?b, mir.MIR_MUL, 8, 1000, 7);
+
+    var mach: Machine = t_mach(4, 4);
+    mach.mul_hi = 4;
+    if (R.is_err[bool, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+
+    # two source moves at two lanes each, then the eight pieces derived above
+    if (b.instr_count != 4 + 8) { ret 1; }
+
+    var muls:   u32 = 0;
+    var highs:  u32 = 0;
+    var shifts: u32 = 0;
+    var i: u32 = 4;
+    for (i < b.instr_count) {
+        val op: mir.MirOpcode = b.instrs[i].opcode;
+        if (op == mir.MIR_MUL)      { muls   = muls + 1; }
+        if (op == mir.MIR_MUL_HI_U) { highs  = highs + 1; }
+        if (op == mir.MIR_SHL || op == mir.MIR_SHR_U) { shifts = shifts + 1; }
+        i = i + 1;
+    }
+    # three positions, one of which also wants its high half
+    if (muls != 3)  { ret 1; }
+    if (highs != 1) { ret 1; }
+    # the double-and-add's two shifts-per-stage are gone entirely, which is the
+    # difference between the two expansions and not merely a smaller count of them
+    if (shifts != 0) { ret 1; }
+
+    # and the same instruction on a machine that declares nothing takes the other
+    # leaf: no native product anywhere, and the shifts are back
+    var f2: mir.MirFunction;
+    var b2: mir.MirBlock;
+    t_divmod_fn(?alloc, ?f2, ?b2, mir.MIR_MUL, 8, 1000, 7);
+    var m2: Machine = t_mach(4, 4);
+    if (R.is_err[bool, str](legalize_function(?alloc, ?m2, ?f2))) { ret 1; }
+    var muls2:   u32 = 0;
+    var shifts2: u32 = 0;
+    i = 4;
+    for (i < b2.instr_count) {
+        val op: mir.MirOpcode = b2.instrs[i].opcode;
+        if (op == mir.MIR_MUL || op == mir.MIR_MUL_HI_U) { muls2 = muls2 + 1; }
+        if (op == mir.MIR_SHL || op == mir.MIR_SHR_U)    { shifts2 = shifts2 + 1; }
+        i = i + 1;
+    }
+    if (muls2 != 0)    { ret 1; }
+    if (shifts2 == 0)  { ret 1; }
+    # and it is dramatically longer, which is the claim the change makes
+    if (b2.instr_count <= b.instr_count * 10) { ret 1; }
+    ret 0;
+}
+
+# A MACHINE DESCRIPTION THIS PASS DOES NOT MODEL IS REFUSED BY NAME (#2778)
+#
+# Both refusals are about the DECLARATION rather than the instruction, and that is why
+# they are here rather than left to whatever would go wrong downstream. A
+# `mul_hi_width` that is not the ALU width would have the pass emit a lane product at
+# a width the ISA does not compute at, and a high half declared without a low half
+# would emit a `MIR_MUL` no rule admits. Both are a silent wrong encoding if not
+# caught, which is the failure mode #2860 established the standard for.
+test "mach.lang.be.codegen.legalize:refuses_an_unmodelled_widening_multiply" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # a widening multiply at a width other than the ALU's
+    var f: mir.MirFunction;
+    var b: mir.MirBlock;
+    t_divmod_fn(?alloc, ?f, ?b, mir.MIR_MUL, 4, 1000, 7);
+    var m1: Machine = t_mach(1, 2);
+    m1.mul_hi = 4;
+    if (!R.is_err[bool, str](legalize_function(?alloc, ?m1, ?f))) { ret 1; }
+
+    # a high half declared on a machine that says it has no multiply at all
+    var f2: mir.MirFunction;
+    var b2: mir.MirBlock;
+    t_divmod_fn(?alloc, ?f2, ?b2, mir.MIR_MUL, 4, 1000, 7);
+    var m2: Machine = t_mach(1, 2);
+    m2.mul_hi  = 1;
+    m2.has_mul = false;
+    if (!R.is_err[bool, str](legalize_function(?alloc, ?m2, ?f2))) { ret 1; }
+
+    # and the coherent declaration this pass DOES model is accepted, so the two
+    # refusals above are not passing because a multiply is refused generally
+    var f3: mir.MirFunction;
+    var b3: mir.MirBlock;
+    t_divmod_fn(?alloc, ?f3, ?b3, mir.MIR_MUL, 4, 1000, 7);
+    var m3: Machine = t_mach(1, 2);
+    m3.mul_hi = 1;
+    if (R.is_err[bool, str](legalize_function(?alloc, ?m3, ?f3))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -189,6 +189,28 @@ pub val MIR_VEC_INSERT:  MirOpcode = 0x1006;
 # build form
 pub val MIR_VEC_BUILD:   MirOpcode = 0x1007;
 
+# the HIGH half of an unsigned product; operands [dst, lhs, rhs] (#2778). `width` is
+# the operand width, and the result is the top `width` bytes of the 2*`width`-byte
+# product - `mulhu` on riscv, the companion `MIR_MUL` giving the bottom half.
+#
+# NEVER FORMED BY `lower_ir`. The language has no expression that means "the high
+# half", so no IR opcode lowers to this; `be.codegen.legalize` is its only producer,
+# building a wide multiply out of native-width lane products. That is why it is a
+# high sentinel rather than a member of the generic 0..45 space: it is not part of the
+# alphabet lowering emits.
+#
+# REACHABLE ONLY WHERE `MachineModel.mul_hi_width` IS NON-ZERO, and a pack that does
+# not opt in keeps it default-deny, which is why it is not in `selection_reachable`.
+# The opting-in pack consults `selection_widening_mul` from its coverage test, the same
+# shape `selection_lane` already has for `has_lane_ops`.
+#
+# UNSIGNED ONLY, and that is a property of the caller rather than a gap. A wrapping
+# product of `n` lanes reads only the low `n` lanes of the schoolbook sum, and every
+# lane below the top is an unsigned digit whatever the whole value's signedness is, so
+# the signed high half is never needed. Add `MIR_MUL_HI_S` with the consumer that wants
+# it - a full 2N-wide product - and not before.
+pub val MIR_MUL_HI_U:    MirOpcode = 0x1008;
+
 # selection-output sentinels for the generic opcodes that survive instruction
 # selection because they need a multi-instruction byte sequence the encoder
 # materializes. isel rewrites each surviving generic opcode to a high sentinel
@@ -291,14 +313,15 @@ pub fun fused_cbr_opcode(cmp: MirOpcode) MirOpcode {
 # is enforced statically by each pack's `generic_opcode_coverage` test probing
 # `find_rule`. The test never runs the pipeline, so "a pass removes it first" does
 # not excuse a pack from covering a reachable opcode - a capability-gated opcode
-# therefore cannot live in this list. `fused` and `lane` are the two CAPABILITY-
-# GATED lists: an opcode only reaches selection on a target that opted into
+# therefore cannot live in this list. `fused`, `lane` and `widening_mul` are the
+# CAPABILITY-GATED lists: an opcode only reaches selection on a target that opted into
 # producing it, so only that target's coverage test consults the list and every
 # other pack keeps it default-deny.
 pub val SELECTION_REACHABLE_COUNT:  u32 = 46;
 pub val SELECTION_ELIMINATED_COUNT: u32 = 3;
 pub val SELECTION_FUSED_COUNT:      u32 = 6;
 pub val SELECTION_LANE_COUNT:       u32 = 2;
+pub val SELECTION_WIDENING_MUL_COUNT: u32 = 1;
 
 # fill `out` (SELECTION_REACHABLE_COUNT wide) with the reachable alphabet
 pub fun selection_reachable(out: *u32) {
@@ -365,6 +388,17 @@ pub fun selection_eliminated(out: *u32) {
 pub fun selection_lane(out: *u32) {
     out[0] = MIR_VEC_EXTRACT;
     out[1] = MIR_VEC_INSERT;
+}
+
+# fill `out` (SELECTION_WIDENING_MUL_COUNT wide) with the widening-multiply opcodes
+#
+# Reachable only on a target whose `MachineModel.mul_hi_width` is non-zero (#2778);
+# every other target has `be.codegen.legalize` synthesize the high half from shifts and
+# adds instead, so their packs keep this default-deny. `MIR_MUL` itself is NOT here -
+# it is unconditionally reachable, and a target with a low-half multiply and no high
+# half is exactly the case this list separates.
+pub fun selection_widening_mul(out: *u32) {
+    out[0] = MIR_MUL_HI_U;
 }
 
 # fill `out` (SELECTION_FUSED_COUNT wide) with the fused survivors
@@ -1175,6 +1209,8 @@ pub fun opcode_name(op: MirOpcode) str {
     if (op == MIR_DECLASSIFY)   { ret "MIR_DECLASSIFY"; }
     if (op == MIR_VEC_EXTRACT)  { ret "MIR_VEC_EXTRACT"; }
     if (op == MIR_VEC_INSERT)   { ret "MIR_VEC_INSERT"; }
+    if (op == MIR_VEC_BUILD)    { ret "MIR_VEC_BUILD"; }
+    if (op == MIR_MUL_HI_U)     { ret "MIR_MUL_HI_U"; }
     if (op == MIR_SEL_ADD)      { ret "MIR_SEL_ADD"; }
     if (op == MIR_SEL_SUB)      { ret "MIR_SEL_SUB"; }
     if (op == MIR_SEL_MUL)      { ret "MIR_SEL_MUL"; }
@@ -1810,7 +1846,7 @@ test "mach.lang.be.codegen.mir.instr_like:carries_every_field" {
 # is deliberately sparse (the selected forms start at 0x1000), so a dense walk
 # would spend most of its time on values that are not opcodes at all.
 test "mach.lang.be.codegen.mir.opcode_name:total_and_distinct" {
-    var ops: [83]MirOpcode;
+    var ops: [85]MirOpcode;
     ops[0]  = MIR_ADD;         ops[1]  = MIR_SUB;         ops[2]  = MIR_MUL;
     ops[3]  = MIR_DIV_S;       ops[4]  = MIR_DIV_U;       ops[5]  = MIR_REM_S;
     ops[6]  = MIR_REM_U;       ops[7]  = MIR_NEG;         ops[8]  = MIR_AND;
@@ -1839,9 +1875,10 @@ test "mach.lang.be.codegen.mir.opcode_name:total_and_distinct" {
     ops[75] = MIR_SEL_CBR_LE_S; ops[76] = MIR_SEL_CBR_LE_U; ops[77] = MIR_FADD;
     ops[78] = MIR_FSUB;        ops[79] = MIR_FMUL;        ops[80] = MIR_FDIV;
     ops[81] = MIR_FCMP;        ops[82] = MIR_FNEG;
+    ops[83] = MIR_VEC_BUILD;   ops[84] = MIR_MUL_HI_U;
 
     var i: usize = 0;
-    for (i < 83) {
+    for (i < 85) {
         val n: str = opcode_name(ops[i]);
         # total: no declared opcode reaches the fallback
         if (str_equals(n, "<unknown MIR opcode>")) { ret 1; }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -539,6 +539,40 @@ pub rec MachineModel {
     # rv64 MUL, and SPIR-V's OpIMul), so the gate is dead everywhere but mos6502.
     has_mul: bool;
 
+    # the width, in bytes, at which this ISA yields the HIGH half of an unsigned
+    # product of two same-width values into an ordinary register, or 0 (#2778). the
+    # companion low half is `has_mul`'s own instruction, so a target declaring this
+    # gets the full 2N-byte product of two N-byte lanes in two instructions.
+    #
+    # THE FACT THAT TURNS A WIDE MULTIPLY FROM O(bits) INTO O(lanes^2).
+    # `be.codegen.legalize` splits a value wider than `max_alu_width` into lanes; with
+    # this declared it multiplies them SCHOOLBOOK, one native product per lane pair,
+    # and without it it falls back to a bit-at-a-time double-and-add over the whole
+    # width. On RV32 that is the difference between four instructions and 64 stages for
+    # one `i64 *`, so this is the fact that makes a 32-bit target usable rather than
+    # merely correct.
+    #
+    # 4 ON RV32 AND 8 ON RV64 - `mulhu` at XLEN either way, which is why the riscv
+    # builder writes the register width here rather than a literal. 0 on mos6502, which
+    # has no multiply of any width, and whose lane products the same pass synthesizes.
+    #
+    # A SELECTION CAPABILITY, NOT AN ISA CENSUS, and the two ISAs where they differ are
+    # the reason to say so. x86-64's high half comes only from the one-operand `MUL`
+    # pinning RDX:RAX, a form the rule engine has no way to express outside the call
+    # barrier; aarch64 has `umulh`, a plain three-operand instruction, but no opcode for
+    # it anywhere in its encoder. BOTH DECLARE 0, and both are honest: this states what
+    # `MIR_MUL_HI_U` selection can realize, and on those two the answer is nothing. It
+    # would also be unread description if they did declare it - their ALU covers every
+    # scalar the language has, so `legalize` never runs there and no consumer could
+    # catch the declaration going wrong. Raising either means adding its opcode, its
+    # rule, and a consumer that observes it, in one change.
+    #
+    # THE CONTRACT A TARGET SIGNS BY DECLARING A NON-ZERO WIDTH: its rule pack admits
+    # `MIR_MUL_HI_U` at that width, which every pack's `generic_opcode_coverage` test
+    # checks by consulting `mir.selection_widening_mul` exactly when this is non-zero -
+    # so the declaration and the rule cannot drift apart.
+    mul_hi_width: u32;
+
     # whether the ISA addresses memory as a FLAT space of bytes reached from a base
     # (#2655). true on every machine target: an address there is an integer, any two
     # objects sit in one numbered space, and a pointer may be re-read at whatever type

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -284,6 +284,9 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.ct_trust_mul  = false;
     arm64_model.has_var_shift = true;        # LSLV / LSRV / ASRV read the count from a register (#2217)
     arm64_model.has_mul = true;              # MUL (#2344)
+    # 0 despite UMULH existing: this encoder has no opcode for it, and max_alu_width
+    # already covers every scalar, so a declaration would have no consumer (#2778).
+    arm64_model.mul_hi_width = 0;
     arm64_model.flat_addressing = true;      # a byte-addressed linear space (#2655)
     arm64_model.ct_trust_var_shift = true;   # aarch64 variable shift is constant-time (#1646)
 

--- a/src/lang/target/isa/arm64/rules.mach
+++ b/src/lang/target/isa/arm64/rules.mach
@@ -757,6 +757,20 @@ test "mach.lang.target.isa.arm64.rules:generic_opcode_coverage" {
         if (rules.find_rule(pack, ?f, ?probe) == nil) { ret 1; }
         i = i + 1;
     }
+
+    # the capability-gated widening multiply: this target declares `mul_hi_width = 0`,
+    # so `be.codegen.legalize` synthesizes the high half instead of forming
+    # MIR_MUL_HI_U, and this table must keep it default-deny. the riscv pack asserts
+    # the other side of the same contract in this position (#2778).
+    var wmul: [mir.SELECTION_WIDENING_MUL_COUNT]u32;
+    mir.selection_widening_mul(?wmul[0]);
+    i = 0;
+    for (i < mir.SELECTION_WIDENING_MUL_COUNT) {
+        probe.opcode   = wmul[i];
+        probe.vec_lane = mir.VEC_LANE_NONE;
+        if (rules.find_rule(pack, ?f, ?probe) != nil) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }
 

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -141,6 +141,9 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # no hardware multiply at any width (#2344): be.codegen.legalize owns every
     # MIR_MUL, native-width included, and expands it into a double-and-add sequence.
     mos6502_model.has_mul = false;
+    # and so no high half either, so the same pass synthesizes each lane product it
+    # needs for a wide multiply rather than selecting one (#2778).
+    mos6502_model.mul_hi_width = 0;
     mos6502_model.flat_addressing = true;   # a 16-bit byte address space (#2655)
 
     mos6502_model.reg_classes     = ?mos6502_classes[0];

--- a/src/lang/target/isa/mos6502/rules.mach
+++ b/src/lang/target/isa/mos6502/rules.mach
@@ -241,6 +241,19 @@ test "mach.lang.target.isa.mos6502.rules:generic_opcode_coverage" {
         if (rules.find_rule(pack, ?f, ?probe) == nil) { ret 1; }
         i = i + 1;
     }
+
+    # the capability-gated widening multiply: this target declares `mul_hi_width = 0`,
+    # so `be.codegen.legalize` synthesizes the high half instead of forming
+    # MIR_MUL_HI_U, and this table must keep it default-deny. the riscv pack asserts
+    # the other side of the same contract in this position (#2778).
+    var wmul: [mir.SELECTION_WIDENING_MUL_COUNT]u32;
+    mir.selection_widening_mul(?wmul[0]);
+    i = 0;
+    for (i < mir.SELECTION_WIDENING_MUL_COUNT) {
+        probe.opcode = wmul[i];
+        if (rules.find_rule(pack, ?f, ?probe) != nil) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }
 

--- a/src/lang/target/isa/riscv.mach
+++ b/src/lang/target/isa/riscv.mach
@@ -207,3 +207,9 @@ pub val EBREAK: Opcode = 15;
 # `ld`/`sd` spill forms. the precision (S vs D) rides the operand width, so this one
 # opcode covers both and an RV32 sibling reuses it unchanged
 pub val FMV:    Opcode = 16;
+# the HIGH half of an unsigned product, `mulhu rd, rs1, rs2` (M extension). NO WORD
+# FORM: RV64 has `mulw` but no `mulhuw`, and the instruction is the same encoding at
+# both XLENs, so unlike MUL this one never consults the operand width. selected only
+# from `MIR_MUL_HI_U`, which `be.codegen.legalize` forms when it builds a wide
+# multiply out of native lane products (#2778)
+pub val MULHU:  Opcode = 17;

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -3188,6 +3188,9 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (op == riscv.ADD::u16)    { ret encode_addsub(st, mi, false); }
     if (op == riscv.SUB::u16)    { ret encode_addsub(st, mi, true); }
     if (op == riscv.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV, true); }
+    # `false` for the word form is the whole difference from MUL above: there is no
+    # `mulhuw`, so the operand width must not reach the opcode choice.
+    if (op == riscv.MULHU::u16)  { ret encode_alu3(st, mi, F3_SLTU, F7_MULDIV, false); }
     if (op == riscv.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO, false); }
     if (op == riscv.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO, false); }
     if (op == riscv.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO, false); }

--- a/src/lang/target/isa/riscv/register.mach
+++ b/src/lang/target/isa/riscv/register.mach
@@ -430,6 +430,9 @@ fun build_riscv(reg: *isa.IsaRegistry, arch_id: u32, name: str, xw: u32,
     model.ct_trust_mul = false;
     model.has_var_shift = true;        # SLL / SRL / SRA read the count from a register (#2217)
     model.has_mul = true;              # MUL, the M extension (#2344)
+    # MULHU, the same M extension, at XLEN either way: 4 on RV32 and 8 on RV64. the
+    # register width rather than a literal, because the parameter IS the fact (#2778).
+    model.mul_hi_width = xw;
     model.flat_addressing = true;      # a byte-addressed linear space (#2655)
     model.ct_trust_var_shift = true;   # rv64 SLL/SRL variable shift is constant-time (#1646)
 

--- a/src/lang/target/isa/riscv/rules.mach
+++ b/src/lang/target/isa/riscv/rules.mach
@@ -86,7 +86,7 @@ pub def SelectFn: fun(*A.Allocator, *target.Target, *mir.MirFunction) R.Result[b
 # the number of rules in the pack: every generic opcode that can reach RV64
 # selection plus the six fused compare-and-branch survivors. the coverage test
 # pins it so a rule added to the table and this count cannot drift apart
-pub val RULE_COUNT: usize = 63;
+pub val RULE_COUNT: usize = 64;
 
 # the number of post-selection plain register-copy opcodes: the concrete GP move
 # (`mv`), the concrete float move (`fmv`), and the generic `mir.MIR_MOV` the
@@ -109,6 +109,12 @@ pub val RULES: [RULE_COUNT]rules.Rule = [RULE_COUNT]rules.Rule{
     rules.Rule{ op: mir.MIR_ADD, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.ADD::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_SUB, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.SUB::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_MUL, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.MUL::u32, expand: nil, expansion_length: 0 },
+    # the capability-gated widening multiply: this target declares a non-zero
+    # `mul_hi_width`, so `be.codegen.legalize` hands it MIR_MUL_HI_U when it builds a
+    # wide multiply from lane products and its table must admit it. a pack that does
+    # not opt in keeps it default-deny, which is why it is not in
+    # `mir.selection_reachable` (#2778).
+    rules.Rule{ op: mir.MIR_MUL_HI_U, gate: rules.GATE_SCALAR, guard: nil, kind: rules.RULE_RETAG, to: riscv.MULHU::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_AND, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.AND::u32, expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_OR,  gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.OR::u32,  expand: nil, expansion_length: 0 },
     rules.Rule{ op: mir.MIR_XOR, gate: rules.GATE_ANY, guard: nil, kind: rules.RULE_RETAG, to: riscv.XOR::u32, expand: nil, expansion_length: 0 },
@@ -472,7 +478,7 @@ test "mach.lang.target.isa.riscv.rules:is_reg_move" {
 # length, so an appended rule and the storage size can never drift apart
 test "mach.lang.target.isa.riscv.rules:generic_opcode_coverage" {
     val pack: *rules.RulePack = ?PACK;
-    if (pack.rule_count != 63) { ret 1; }
+    if (pack.rule_count != 64) { ret 1; }
 
     # the shared selection alphabet (a property of mir.lower_ir, one table for
     # every pack's coverage test): reachable opcodes must terminate in a rule.
@@ -516,6 +522,19 @@ test "mach.lang.target.isa.riscv.rules:generic_opcode_coverage" {
         if (rules.find_rule(pack, ?f, ?probe) == nil) { ret 1; }
         i = i + 1;
     }
+    # the capability-gated widening multiply: this target declares a non-zero
+    # `mul_hi_width`, so `be.codegen.legalize` forms MIR_MUL_HI_U here and the table
+    # must admit it. a pack that does not opt in keeps it default-deny, which is what
+    # the other three packs assert in the same position (#2778).
+    var wmul: [mir.SELECTION_WIDENING_MUL_COUNT]u32;
+    mir.selection_widening_mul(?wmul[0]);
+    i = 0;
+    for (i < mir.SELECTION_WIDENING_MUL_COUNT) {
+        probe.opcode = wmul[i];
+        if (rules.find_rule(pack, ?f, ?probe) == nil) { ret 1; }
+        i = i + 1;
+    }
+
     if (pack.fused_cbr_cc_count != 6) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -136,6 +136,9 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     spirv_model.ct_trust_mul           = false;
     spirv_model.has_var_shift          = true;
     spirv_model.has_mul                = true;   # OpIMul (#2344)
+    # OpUMulExtended exists, but SPIR-V has no rule pack and legalize never runs on a
+    # target whose types are as wide as the language's (#2778).
+    spirv_model.mul_hi_width           = 0;
     # the logical addressing model: a pointer names one object at one pointee type,
     # there is no pointer arithmetic and no pointer bitcast (#2655)
     spirv_model.flat_addressing        = false;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -332,6 +332,10 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.ct_trust_mul    = false;
     x64_model.has_var_shift = true;        # SHL/SHR/SAR by CL is a single instruction (#2217)
     x64_model.has_mul = true;              # IMUL (#2344)
+    # 0 despite the silicon: the high half comes only from the one-operand MUL pinning
+    # RDX:RAX, which no rule form expresses, and nothing here could observe the
+    # declaration since max_alu_width already covers every scalar (#2778).
+    x64_model.mul_hi_width = 0;
     x64_model.flat_addressing = true;      # a byte-addressed linear space (#2655)
     x64_model.ct_trust_var_shift = true;   # SHL/SHR by CL is single-instruction constant-time (#1646)
 

--- a/src/lang/target/isa/x64/rules.mach
+++ b/src/lang/target/isa/x64/rules.mach
@@ -616,5 +616,18 @@ test "mach.lang.target.isa.x64.rules:generic_opcode_coverage" {
         i = i + 1;
     }
     if (pack.fused_cbr_cc_count != 6) { ret 1; }
+
+    # the capability-gated widening multiply: this target declares `mul_hi_width = 0`,
+    # so `be.codegen.legalize` synthesizes the high half instead of forming
+    # MIR_MUL_HI_U, and this table must keep it default-deny. the riscv pack asserts
+    # the other side of the same contract in this position (#2778).
+    var wmul: [mir.SELECTION_WIDENING_MUL_COUNT]u32;
+    mir.selection_widening_mul(?wmul[0]);
+    i = 0;
+    for (i < mir.SELECTION_WIDENING_MUL_COUNT) {
+        probe.opcode = wmul[i];
+        if (rules.find_rule(pack, ?f, ?probe) != nil) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }


### PR DESCRIPTION
PR 4 of #2778. A declared machine fact plus a schoolbook expansion selected by it, replacing the double-and-add where a native widening multiply exists — and improving the target where one does not.

## The numbers

One `i64 *` in a function of its own, `--profile release`, same source for every row:

| target | instructions | image bytes |
|---|---|---|
| riscv32 before | 1420 | 5680 |
| **riscv32 after** | **9** | **36** |
| mos6502 before | no printer | 48427 |
| **mos6502 after** | no printer | **35313** |
| riscv64 before | 3 | 12 |
| riscv64 after | 3 | 12 |

riscv32 is **158x fewer instructions**. mos6502 is **26.6% smaller**. riscv64 is unchanged, which is the correct answer — `legalize` never runs on a target whose ALU covers every scalar.

mos6502 registers no assembly printer, so its column is image bytes; the fixture is one multiply and nothing else, so the image is the expansion.

The riscv32 output is the textbook sequence:

```
mul   a4, a0, a1
mulhu a5, a0, a1
mul   a6, a0, a2
add   a0, a5, a6
mul   a2, a3, a1
add   a1, a0, a2
```

## The contract

`MachineModel.mul_hi_width`: the width at which the ISA yields the HIGH half of an unsigned product of two same-width values into an ordinary register, or 0.

**The shape is shared and only the LEAF is declared.** `expand_mul` is schoolbook over lane pairs for every target above one lane; `emit_lane_product` is the single place that asks what the machine can do. A target declaring the fact gets `MIR_MUL` + `MIR_MUL_HI_U` per position. A target declaring 0 gets a double-and-add over that position's two lanes — over **one lane's worth of multiplier bits** rather than the whole value's, which is why mos6502 is a member of the same expansion rather than a separate algorithm, and why it improves at all.

That is what makes this a contract rather than an rv32 special case: mos6502 is the hardest member (no multiply at any width, 8 lanes), and it is served by the same two loops.

**The old doc's arithmetic was right and its conclusion was wrong.** It argued O(width) stages beat O(lanes²) partial products "each itself a smaller multiply". That holds only where a lane product *is* a smaller multiply. Where the machine has one it is a single instruction; where it does not, the smaller multiply is cheaper than the bigger one by exactly the factor the recursion saves. The unstated assumption was that the leaf costs the same as the whole, and it never did.

### x86-64 and aarch64 declare 0, and both are honest

This is a **selection capability, not an ISA census**, and I have said so in the field's doc. x86-64's high half comes only from the one-operand `MUL` pinning RDX:RAX, a form the rule engine cannot express outside the call barrier. aarch64 has `umulh`, a plain three-operand instruction — and no opcode for it anywhere in its encoder. Declaring either would also be unread machine description: their ALU covers every scalar the language has, so `legalize` never runs there and no consumer could catch the declaration going wrong. Raising either means adding its opcode, its rule, and a consumer, in one change. That is the model's own stated rule and I did not want to be the first to break it.

### Gating follows `has_lane_ops`, not a new mechanism

`MIR_MUL_HI_U` is a capability-gated opcode: riscv's pack admits it and consults `mir.selection_widening_mul`; the x64, arm64 and mos6502 packs assert **default-deny** in the same position. Three packs asserting the negative is the half that keeps the declaration and the rule from drifting apart.

`mir.opcode_name` gained arms for `MIR_MUL_HI_U` and for `MIR_VEC_BUILD`, which had none — 0x1007 rendered as `<unknown MIR opcode>` in every refusal that named it, and the exhaustive name census omitted it, which is why the gap was invisible. Both are in the census now.

## A defect this found in how expansions are checked

`legalize_block` sizes the rebuilt array from the predicted piece count, then set `b.instr_count = total` — **the prediction, never the emitted cursor**. So an expansion emitting fewer pieces than it counted left zeroed `MirInstr`s (opcode 0, no operands) silently inside the block, and no test asserting "block length equals the count" could ever have caught it, because that length *was* the count. The existing divide test's comment claims that assertion "checks both halves against each other"; it did not, and I have corrected the comment rather than leaving it.

The block now takes its length from the cursor and refuses on disagreement.

This is not hypothetical. **The first version of this expansion had exactly that bug** — the emit's carry chain writes every lane above the one it starts at, making them all live, and my count only marked the lane written directly, so the next partial product into a lane the chain had already made live was counted at zero. Every unit test passed. `mul_executes_on_a_6502_core_mos6502` failed, because it runs the code on a 6502 core against a reference implementation.

## Verification

`mach test .`: **1382 passed, 0 failed** (1379 before, plus three).

**Correctness by values, not by shorter sequences.**

- `mul_executes_on_a_6502_core_mos6502` sweeps `u8` / `u16` / `u32` / `u64` runtime multiplies on a reference 6502 core against a reference implementation, and pins a fixed cycle count per value pair. That is the synthesized leaf at 1, 2, 4 and 8 lanes, and it is the test that caught the liveness bug.
- A hand-run riscv32 fixture under qemu: 11 products including `0xFFFFFFFF * 0xFFFFFFFF` (carry out of lane 0 into lane 1), `2^32 * 2^32` (every partial product past the top, discarded), both signs, and the identities. **Exit 42 on riscv32 and on riscv64 from the same source.** The baseline compiler also exits 42, so the two expansions agree on every case.
- Mutation control on that fixture: corrupting one expected value by one bit makes it exit 1. The instrument can see a wrong product.

*qemu-user settles arithmetic and control flow. It says nothing about syscall surface, and nothing here depends on that beyond the `exit` used to report the answer.*

**Mutation controls on the new tests**, each checked one at a time:

| mutation | caught by |
|---|---|
| drop the liveness propagation in `accum_into` | `multiply_costs_agree_at_every_lane_count`, `refuses_an_unmodelled_widening_multiply`, and the 6502 core test |
| invert the leaf selection in `emit_lane_product` | `a_declared_widening_multiply_selects_the_native_leaf` and three others |

I checked the first mutation **before** adding the cursor check as well: only the 6502 core test caught it then. That is what established the count/emit gap was real rather than theoretical.

**Byte-identity**, baseline from this branch's own merge base (`f11cec7c`):

| leg | objects | binaries | self-differing | base vs branch |
|---|---|---|---|---|
| linux-x86_64 | 224 | 2 | 0 | 0 |
| linux-arm64 | 224 | 2 | 0 | 0 |
| linux-riscv64 | 224 | 2 | 0 | 0 |

Zero is the right answer and it is not a vacuous one. The positive control is the table at the top: the same instrument — emitted bytes — shows 5680 → 36 on riscv32 and 48427 → 35313 on mos6502. It sees the change where the change fires, and the shipped legs are legs where it does not.

`int` sweeps: green on `linux` and `linux-arm64` (qemu). `linux-riscv64` has 2 failures, `surface/riscv-pcrel-pair` in both profiles, which fail **identically on the baseline compiler** — the sandbox has no riscv64 libc headers. No `int/` cases touched.

## Four pre-existing riscv32 defects found and filed

Building the value-check fixture took four attempts because each shape hit a different pre-existing defect. All four were confirmed against the merge base with this change stashed, and none involve the multiply.

- **#2870** — *two `i64` arguments overlap on ilp32*, destroying the first argument's high half. The caller writes `a1` twice. **This is the root cause of the next two**, and it is the serious one: it makes essentially every wide computation that crosses a call wrong on riscv32.
- **#2868** — a wide equality compare answers false for equal values. Almost certainly #2870; commented and cross-linked.
- **#2869** — a constant `i64` shift by a whole lane returns garbage. Almost certainly #2870; commented and cross-linked.
- **#2867** — an `i64` global feeding a wide ALU op **segfaults the compiler** instead of refusing, in a shape where the same construct refuses cleanly without the add.

The finished fixture routes around all four: every multiply is written inline in `_start` (no two-`i64`-argument call), cases are checked by XOR rather than comparison, and the difference is read back byte by byte through a `*u8` rather than folded with `>> 32`.

**The general finding is worth more than any one of them.** rv32 shipped in #2863 passing 1379 tests, and none of those tests executes wide arithmetic on it. The suite proves the expansions emit *something*; only mos6502 has a test that runs the result. `int` cannot cover it under the freeze and would not anyway — these are local, and I checked them by hand as instructed. What is missing is an rv32 equivalent of the 6502 core test: an execution harness for the target whose entire reason for existing is that its ALU is narrower than its types.

## Open

I did not fix #2870 here. It is an ABI classifier defect, it is larger than this PR, and folding it in would mean this change could not be reviewed as the multiply change it is. It should be next, ahead of any further RV32 work — until it lands, riscv32 cannot be validated end to end for anything wide, including this.

Refs #2778
