### PR TITLE
test(riscv32): execute emitted code on a reference RV32IM core

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -74,6 +74,7 @@ use dcfg: mach.lang.driver.config;
 use mach.lang.driver;
 use mos_enc: mach.lang.target.isa.mos6502.encode;
 use mach.lang.target.isa.mos6502;
+use rv32: mach.lang.target.isa.riscv.refcore;
 
 # concatenate three strings into a fresh nul-terminated buffer owned by
 # `alloc`. a path-join helper for the union-build tests below
@@ -7787,7 +7788,7 @@ test "mach.lang.driver:secret_mul_codegen_rejected" {
 # a manifest with the non-mainstream spirv + mos6502 targets, for the constant-time
 # edge-consumer tests (a `:^` on a direct-emit / narrow-ALU backend, #1646)
 fun ut_ct_edge_manifest() str {
-    ret "[project]\nid = \"ct\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.spv]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\n\n[target.mos]\nisa = \"mos6502\"\nos = \"freestanding\"\nabi = \"mos6502\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.ct]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/ct\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    ret "[project]\nid = \"ct\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.spv]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\n\n[target.mos]\nisa = \"mos6502\"\nos = \"freestanding\"\nabi = \"mos6502\"\n\n[target.rv32]\nisa = \"riscv32\"\nos = \"freestanding\"\nabi = \"ilp32d\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.ct]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/ct\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # build `src` for `target_name` under the ct-edge manifest and return the project; the
@@ -11873,8 +11874,11 @@ fun ut_shift_value(i: u32) u64 {
 # the number of values swept per function
 val UT_SHIFT_VALUES: u32 = 16;
 
-# collect the `.text` bytes and the function offsets of a built mos6502 image
-# (test helper)
+# collect the `.text` bytes and the function offsets of a built image (test helper)
+#
+# TARGET-AGNOSTIC, and named for that since #2778 gave it a second caller: it walks the
+# object image's sections and symbols and reads nothing architecture-specific, so the
+# mos6502 sweeps and the riscv32 ones share it rather than each growing a copy.
 #
 # The emitted symbols are read back in offset order, which is declaration order, so
 # `offs[k]` is the k-th function of the probe source. A build that produced no `.text`
@@ -11886,7 +11890,7 @@ val UT_SHIFT_VALUES: u32 = 16;
 # offs:  receives the per-function offsets, ascending
 # nfns:  the number of functions expected
 # ret:   true when `.text` and `nfns` function offsets were found
-fun ut_mos_text(p: *project.Project, text: **u8, len: *u32, offs: *u32, nfns: u32) bool {
+fun ut_image_text(p: *project.Project, text: **u8, len: *u32, offs: *u32, nfns: u32) bool {
     var mi: u32 = 0;
     for (mi < p.module_len) {
         val m: *project.ModuleEntry = ?p.modules[mi];
@@ -11957,7 +11961,7 @@ fun ut_mos_shift_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: 
     var text: *u8 = nil;
     var tlen: u32 = 0;
     var offs: [65]u32;
-    if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], bits + 1)) { project.dnit_project(?p); ret 1; }
+    if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], bits + 1)) { project.dnit_project(?p); ret 1; }
     # the loaded image must not reach the argument block it would otherwise overwrite.
     if (UT_MOS_CODE + tlen >= UT_MOS_ARGS) { project.dnit_project(?p); ret 1; }
     ut_mos_load(text, tlen, mem);
@@ -12228,7 +12232,7 @@ test "mach.lang.driver:wide_divide_executes_on_a_6502_core_mos6502" {
     var text: *u8 = nil;
     var tlen: u32 = 0;
     var offs: [8]u32;
-    if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_DIVMOD_OPS)) { project.dnit_project(?p); session.dnit(?s); ret 3; }
+    if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_DIVMOD_OPS)) { project.dnit_project(?p); session.dnit(?s); ret 3; }
     if (UT_MOS_CODE + tlen >= UT_MOS_ARGS)                          { project.dnit_project(?p); session.dnit(?s); ret 3; }
     ut_mos_load(text, tlen, mem);
 
@@ -12297,7 +12301,7 @@ test "mach.lang.driver:u64_computation_executes_on_a_6502_core_mos6502" {
     var text: *u8 = nil;
     var tlen: u32 = 0;
     var offs: [16]u32;
-    if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_U64_OPS)) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_U64_OPS)) { project.dnit_project(?p); session.dnit(?s); ret 1; }
     if (UT_MOS_CODE + tlen >= UT_MOS_ARGS)                        { project.dnit_project(?p); session.dnit(?s); ret 1; }
     ut_mos_load(text, tlen, mem);
 
@@ -12339,7 +12343,7 @@ test "mach.lang.driver:u64_computation_executes_on_a_6502_core_mos6502" {
             var stext: *u8 = nil;
             var stlen: u32 = 0;
             var soffs: [4]u32;
-            if (!ut_mos_text(?pf, ?stext, ?stlen, ?soffs[0], UT_MOS_SEXT_OPS)) { bad = 1; }
+            if (!ut_image_text(?pf, ?stext, ?stlen, ?soffs[0], UT_MOS_SEXT_OPS)) { bad = 1; }
             or (UT_MOS_CODE + stlen >= UT_MOS_ARGS)                           { bad = 1; }
             or {
                 ut_mos_load(stext, stlen, mem);
@@ -12485,7 +12489,7 @@ fun ut_mos_mul_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: st
             var text: *u8 = nil;
             var tlen: u32 = 0;
             var offs: [1]u32;
-            if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], 1))    { bad = 1; }
+            if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], 1))    { bad = 1; }
             or (UT_MOS_CODE + tlen >= UT_MOS_ARGS)              { bad = 1; }
             or {
                 ut_mos_load(text, tlen, mem);
@@ -12515,6 +12519,298 @@ fun ut_mos_mul_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: st
     A.deallocate[u8](alloc, mem, UT_MOS_MEM);
     A.deallocate[u8](alloc, srcbuf, 8192);
     ret bad;
+}
+
+# ------------------------------------------------- the riscv32 execution harness
+
+# the reference core's flat image: code, then a stack well clear of it
+#
+# 256 KiB rather than the 6502's 64: `be.codegen.legalize` expansions are large at a
+# 32-bit lane width (a wide divide is thousands of bytes), and the sweeps below want
+# headroom to grow without the constant becoming the thing under test.
+val UT_RV32_MEM:   usize = 262144;
+# where `.text` loads. non-zero so a null dereference in emitted code lands outside the
+# image and is reported rather than reading an instruction.
+val UT_RV32_CODE:  u32   = 0x1000;
+# the initial stack pointer: 16-byte aligned per the psABI, high enough that a frame
+# cannot reach the code, and inside the image so a runaway push is caught.
+val UT_RV32_STACK: u32   = 0x3FFF0;
+
+# load a built riscv32 image's `.text` into the reference core's memory once
+# ---
+# text: the image's `.text`
+# len:  its length
+# mem:  the reference core's memory image
+fun ut_rv32_load(text: *u8, len: u32, mem: *u8) {
+    var i: usize = 0;
+    for (i < UT_RV32_MEM) { mem[i] = 0; i = i + 1; }
+    i = 0;
+    for (i < len::usize) { mem[UT_RV32_CODE::usize + i] = text[i]; i = i + 1; }
+}
+
+# run one function of a loaded riscv32 image on the reference core
+#
+# THE HARNESS PLACES ARGUMENTS BY THE psABI AS WRITTEN HERE, NOT AS THE COMPILER
+# CLASSIFIED THEM (#2870), and that is what makes these sweeps check the calling
+# convention rather than assume it. Arguments are a list of 32-bit WORDS: an `i64` is
+# two of them, low word first, and they fill a0..a7 (x10..x17) in order before
+# overflowing to the outgoing stack area at the initial `sp`. No alignment is imposed
+# on a pair, because RISC-V imposes none.
+#
+# A PROBE MUST THEREFORE BE ENTERED DIRECTLY rather than through a compiled wrapper. If
+# the harness called a compiled function that in turn called the one under test, caller
+# and callee would both use the compiler's own convention and would agree even when
+# that convention is wrong - which is precisely how #2870 survived: the emitted caller
+# wrote `a1` twice and the emitted callee read the same wrong layout back. Entering at
+# the function under test makes this harness the independent party.
+# ---
+# mem:   the memory image, already loaded by `ut_rv32_load`
+# off:   the function's offset within `.text`
+# args:  the argument words, low word of a wide value first
+# nargs: how many argument words
+# lo:    receives a0 (the result, or its low word)
+# hi:    receives a1 (a wide result's high word)
+# steps: receives the instruction count the run retired
+# ret:   true when the run returned inside the modeled instruction set
+fun ut_rv32_run(mem: *u8, off: u32, args: *u32, nargs: u32,
+                lo: *u32, hi: *u32, steps: *u32) bool {
+    var core: rv32.Core;
+    var i: usize = 0;
+    for (i < 32) { core.x[i] = 0; i = i + 1; }
+
+    # x1 is `ra`: the sentinel the core treats as "returned to the caller".
+    # x2 is `sp`.
+    core.x[1] = rv32.RETURN_SENTINEL;
+    core.x[2] = UT_RV32_STACK;
+    core.pc   = UT_RV32_CODE + off;
+
+    # a0..a7 are x10..x17 (the manual's numbering, not the compiler's tables)
+    var k: u32 = 0;
+    for (k < nargs && k < 8) {
+        core.x[(10 + k)::usize] = args[k];
+        k = k + 1;
+    }
+    # anything past the bank goes to the outgoing stack area at [sp + 0] upward
+    for (k < nargs) {
+        val at: u32 = UT_RV32_STACK + (k - 8) * 4;
+        var b: u32 = 0;
+        for (b < 4) {
+            mem[(at + b)::usize] = ((args[k] >> (b * 8)) & 0xFF)::u8;
+            b = b + 1;
+        }
+        k = k + 1;
+    }
+
+    if (!rv32.exec_reference(mem, UT_RV32_MEM, ?core)) { ret false; }
+    @lo    = core.x[10];
+    @hi    = core.x[11];
+    @steps = core.steps;
+    ret true;
+}
+
+# run a probe taking two `i64`s and returning one, on 64-bit values
+# ---
+# ret: true when the run completed; `out` receives the 64-bit result
+fun ut_rv32_run2(mem: *u8, off: u32, a: u64, b: u64, out: *u64, steps: *u32) bool {
+    var args: [4]u32;
+    args[0] = (a & 0xFFFFFFFF)::u32;
+    args[1] = (a >> 32)::u32;
+    args[2] = (b & 0xFFFFFFFF)::u32;
+    args[3] = (b >> 32)::u32;
+    var lo: u32 = 0;
+    var hi: u32 = 0;
+    if (!ut_rv32_run(mem, off, ?args[0], 4, ?lo, ?hi, steps)) { ret false; }
+    @out = lo::u64 | (hi::u64 << 32);
+    ret true;
+}
+
+# the probe module every riscv32 execution sweep builds
+#
+# One module for every sweep so a single build serves them all. The functions come
+# first and `main` last, because `ut_image_text` returns symbol offsets in ascending
+# order and the sweeps index them positionally.
+#
+# NO FLOATS AND NO GLOBALS. The core models RV32I and M only and refuses a float by
+# name, and the harness loads `.text` alone, so a global would be an address into a
+# section that was never loaded. Both restrictions are the harness being honest about
+# its coverage rather than accidents to work around.
+fun ut_rv32_probe_src(buf: *u8) usize {
+    var w: usize = 0;
+    w = ut_app(buf, w, "fun mul64(a: i64, b: i64) i64 { ret a * b; }\n");
+    w = ut_app(buf, w, "fun xor64(a: i64, b: i64) i64 { ret a ^ b; }\n");
+    w = ut_app(buf, w, "fun add64(a: i64, b: i64) i64 { ret a + b; }\n");
+    w = ut_app(buf, w, "fun eq64(a: i64, b: i64) i64 { if (a == b) { ret 1; } ret 0; }\n");
+    w = ut_app(buf, w, "fun ltu64(a: u64, b: u64) i64 { if (a < b) { ret 1; } ret 0; }\n");
+    w = ut_app(buf, w, "fun lts64(a: i64, b: i64) i64 { if (a < b) { ret 1; } ret 0; }\n");
+    w = ut_app(buf, w, "fun shl64(a: u64, n: u64) u64 { ret a << n; }\n");
+    w = ut_app(buf, w, "fun shru64(a: u64, n: u64) u64 { ret a >> n; }\n");
+    w = ut_app(buf, w, "fun shrs64(a: i64, n: i64) i64 { ret a >> n; }\n");
+    w = ut_app(buf, w, "fun divu64(a: u64, b: u64) u64 { ret a / b; }\n");
+    w = ut_app(buf, w, "fun remu64(a: u64, b: u64) u64 { ret a % b; }\n");
+    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
+    buf[w] = 0;
+    ret w;
+}
+
+# the probe functions, in the order `ut_rv32_probe_src` declares them
+val UT_RV32_MUL:   u32 = 0;
+val UT_RV32_XOR:   u32 = 1;
+val UT_RV32_ADD:   u32 = 2;
+val UT_RV32_EQ:    u32 = 3;
+val UT_RV32_LTU:   u32 = 4;
+val UT_RV32_LTS:   u32 = 5;
+val UT_RV32_SHL:   u32 = 6;
+val UT_RV32_SHRU:  u32 = 7;
+val UT_RV32_SHRS:  u32 = 8;
+val UT_RV32_DIVU:  u32 = 9;
+val UT_RV32_REMU:  u32 = 10;
+val UT_RV32_FNS:   u32 = 11;
+
+# riscv32 (#2778): wide integer work BUILDS AND RUNS, executed on a reference RV32IM
+# core with the answers checked against independently computed references
+#
+# WHY THIS TEST EXISTS. riscv32 shipped passing the entire suite with four separate
+# defects in it, and every one of them was a wrong ANSWER rather than a failed build:
+# two `i64` arguments overlapped so the first one's high half was destroyed (#2870), a
+# wide equality compare answered false for equal values (#2868), a constant shift by a
+# whole lane returned garbage (#2869), and the wide multiply had never been executed at
+# all (#2871). The suite proved codegen emitted something. Nothing proved what the
+# bytes computed. mos6502 was the only target with an execution harness and it was the
+# only target where this class of defect got caught.
+#
+# EVERY CASE BELOW FAILS AGAINST AT LEAST ONE OF THOSE FOUR when its fix is reverted,
+# which was checked one revert at a time rather than assumed - a harness that has never
+# failed is a harness whose green means nothing, which is the state this target
+# shipped in.
+#
+# The reference answers are computed here in host arithmetic, not by a second path
+# through the compiler, and the core decodes from the ISA manual rather than from the
+# encoder's tables (see `isa.riscv.refcore`). Both are the same principle: an oracle
+# that shares the machinery under test agrees with it by construction.
+test "mach.lang.driver:wide_integer_executes_on_an_rv32_core_riscv32" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val bufr: R.Result[*u8, str] = A.allocate[u8](?alloc, 8192);
+    if (R.is_err[*u8, str](bufr)) { ret 1; }
+    val srcbuf: *u8 = R.unwrap_ok[*u8, str](bufr);
+    ut_rv32_probe_src(srcbuf);
+
+    val memr: R.Result[*u8, str] = A.zallocate[u8](?alloc, UT_RV32_MEM);
+    if (R.is_err[*u8, str](memr)) { A.deallocate[u8](?alloc, srcbuf, 8192); ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](memr);
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, srcbuf::str, "rv32");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
+        or {
+            var text: *u8 = nil;
+            var tlen: u32 = 0;
+            var offs: [16]u32;
+            if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], UT_RV32_FNS)) { bad = 1; }
+            or (UT_RV32_CODE + tlen >= UT_RV32_STACK)                    { bad = 1; }
+            or {
+                ut_rv32_load(text, tlen, mem);
+                if (ut_rv32_sweep(mem, ?offs[0]) != 0) { bad = 1; }
+            }
+        }
+        project.dnit_project(?p);
+    }
+
+    A.deallocate[u8](?alloc, mem, UT_RV32_MEM);
+    A.deallocate[u8](?alloc, srcbuf, 8192);
+    ret bad;
+}
+
+# drive every probe over the value sweep and check each against a host-computed answer
+#
+# Split out of the test body so the build-and-teardown scaffolding does not bury the
+# assertions. `ut_shift_value` supplies the patterns a lane-crossing operation can
+# confuse - zero, all-ones, alternating, one bit per lane, a spread - which is the same
+# set the mos6502 sweeps use and for the same reason.
+# ---
+# mem:  the loaded image
+# offs: the probe function offsets, indexed by the UT_RV32_* constants
+# ret:  0 when every case answered correctly
+fun ut_rv32_sweep(mem: *u8, offs: *u32) i32 {
+    var bad: i32 = 0;
+    var steps: u32 = 0;
+    var vi: u32 = 0;
+    for (vi < UT_SHIFT_VALUES) {
+        val a: u64 = ut_shift_value(vi);
+        val b: u64 = ut_shift_value((vi + 5) % UT_SHIFT_VALUES);
+        var got: u64 = 0;
+
+        # the widening multiply (#2871): schoolbook over lane pairs, `mul` + `mulhu`
+        if (!ut_rv32_run2(mem, offs[UT_RV32_MUL], a, b, ?got, ?steps)) { bad = 1; }
+        or (got != ut_mul_ref(64, a, b))                               { bad = 1; }
+
+        # both halves of BOTH arguments must survive the call (#2870). a xor is the
+        # sharpest probe for the overlap: it reads every bit of both operands, so a
+        # second argument landing on the first one's high half changes the answer.
+        if (!ut_rv32_run2(mem, offs[UT_RV32_XOR], a, b, ?got, ?steps)) { bad = 1; }
+        or (got != (a ^ b))                                           { bad = 1; }
+
+        # the carry chain across the lane boundary
+        if (!ut_rv32_run2(mem, offs[UT_RV32_ADD], a, b, ?got, ?steps)) { bad = 1; }
+        or (got != a + b)                                             { bad = 1; }
+
+        # wide comparisons (#2868). equality against an EQUAL value is the case that
+        # was wrong, so the sweep compares each value with itself as well as with its
+        # partner - a sweep of unequal pairs would have passed against the defect.
+        if (!ut_rv32_run2(mem, offs[UT_RV32_EQ], a, a, ?got, ?steps))  { bad = 1; }
+        or (got != 1)                                                  { bad = 1; }
+        if (!ut_rv32_run2(mem, offs[UT_RV32_EQ], a, b, ?got, ?steps))  { bad = 1; }
+        or (got != ut_rv32_bool(a == b))                               { bad = 1; }
+
+        if (!ut_rv32_run2(mem, offs[UT_RV32_LTU], a, b, ?got, ?steps)) { bad = 1; }
+        or (got != ut_rv32_bool(a < b))                                { bad = 1; }
+        if (!ut_rv32_run2(mem, offs[UT_RV32_LTS], a, b, ?got, ?steps)) { bad = 1; }
+        or (got != ut_rv32_bool(a::i64 < b::i64))                      { bad = 1; }
+
+        # division and remainder, skipping the zero divisor the language does not define
+        if (b != 0) {
+            if (!ut_rv32_run2(mem, offs[UT_RV32_DIVU], a, b, ?got, ?steps)) { bad = 1; }
+            or (got != a / b)                                              { bad = 1; }
+            if (!ut_rv32_run2(mem, offs[UT_RV32_REMU], a, b, ?got, ?steps)) { bad = 1; }
+            or (got != a % b)                                              { bad = 1; }
+        }
+        vi = vi + 1;
+    }
+
+    # shifts at every count, which is where #2869 lived: a count of 32 is a WHOLE LANE
+    # and no residual bits, the one shape where no lane's value comes from a shift at
+    # all, and the one the old expansion got wrong. sweeping only a few counts would
+    # have missed it, so this walks all 64.
+    var n: u64 = 0;
+    for (n < 64) {
+        var vj: u32 = 0;
+        for (vj < 4) {
+            val v: u64 = ut_shift_value(vj);
+            var got: u64 = 0;
+            if (!ut_rv32_run2(mem, offs[UT_RV32_SHL], v, n, ?got, ?steps))  { bad = 1; }
+            or (got != (v << n))                                            { bad = 1; }
+            if (!ut_rv32_run2(mem, offs[UT_RV32_SHRU], v, n, ?got, ?steps)) { bad = 1; }
+            or (got != (v >> n))                                            { bad = 1; }
+            if (!ut_rv32_run2(mem, offs[UT_RV32_SHRS], v, n, ?got, ?steps)) { bad = 1; }
+            or (got != (v::i64 >> n::i64)::u64)                             { bad = 1; }
+            vj = vj + 1;
+        }
+        n = n + 1;
+    }
+    ret bad;
+}
+
+# the probe functions return 1 / 0 rather than a bool, so the reference does too
+fun ut_rv32_bool(b: bool) u64 {
+    if (b) { ret 1; }
+    ret 0;
 }
 
 # mos6502 (#2344): a wide multiply BUILDS AND RUNS, executed on a reference 6502 core
@@ -12563,7 +12859,7 @@ test "mach.lang.driver:mul_executes_on_a_6502_core_mos6502" {
                 var text: *u8 = nil;
                 var tlen: u32 = 0;
                 var offs: [1]u32;
-                if (!ut_mos_text(?pf, ?text, ?tlen, ?offs[0], 1)) { bad = 1; }
+                if (!ut_image_text(?pf, ?text, ?tlen, ?offs[0], 1)) { bad = 1; }
                 or {
                     ut_mos_load(text, tlen, mem);
                     var vi: u32 = 0;
@@ -12762,7 +13058,7 @@ fun ut_mos_cmp_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, uty: s
             var text: *u8 = nil;
             var tlen: u32 = 0;
             var offs: [8]u32;
-            if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_CMP_OPS)) { bad = 1; }
+            if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], UT_MOS_CMP_OPS)) { bad = 1; }
             or (UT_MOS_CODE + tlen >= UT_MOS_ARGS)                        { bad = 1; }
             or {
                 ut_mos_load(text, tlen, mem);
@@ -12890,7 +13186,7 @@ fun ut_mos_cast_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: s
             var text: *u8 = nil;
             var tlen: u32 = 0;
             var offs: [1]u32;
-            if (!ut_mos_text(?p, ?text, ?tlen, ?offs[0], 1))    { bad = 1; }
+            if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], 1))    { bad = 1; }
             or (UT_MOS_CODE + tlen >= UT_MOS_ARGS)              { bad = 1; }
             or {
                 ut_mos_load(text, tlen, mem);

--- a/src/lang/target/isa/riscv/refcore.mach
+++ b/src/lang/target/isa/riscv/refcore.mach
@@ -1,0 +1,537 @@
+# a reference RV32IM core: execute emitted bytes and say what they compute
+#
+# The riscv32 counterpart of the reference 6502 core in `isa.mos6502.encode`, and it
+# exists for the reason that one does. rv32 shipped passing the whole suite while four
+# separate defects sat in it - an argument convention that destroyed a register, a wide
+# compare that answered false for equal values, a whole-lane shift that returned
+# garbage, and a wide multiply nothing had ever run - because every test the target had
+# asserted that codegen EMITTED something, and none of them asserted what the emitted
+# bytes COMPUTE. mos6502 was the only target with an execution harness and it was the
+# only target where that class of defect was caught. This closes that gap.
+#
+# ===========================================================================
+# THIS CORE DECODES INDEPENDENTLY OF THE ENCODER. THAT IS THE WHOLE POINT.
+# ===========================================================================
+#
+# Nothing here imports `isa.riscv`, `isa.riscv.inst` or `isa.riscv.encode`. Every field
+# position, every opcode number and every funct3 / funct7 value below is written out as
+# the number the RISC-V unprivileged ISA manual gives, next to the mnemonic the manual
+# gives it. That is deliberate DUPLICATION of the encoder's knowledge, and deduplicating
+# it would silently destroy this file's only reason to exist.
+#
+# The argument is short. A harness that decoded `add` by asking the encoder which bits
+# mean `add` would agree with the encoder BY CONSTRUCTION: if the encoder emitted the
+# wrong funct7, the core would read it back with the same wrong funct7, execute the
+# instruction the encoder meant, and report a pass. It would verify that the compiler
+# is self-consistent, which nothing has ever doubted, while LOOKING like execution
+# coverage - which makes it worse than no harness at all, because a green run would
+# retire the suspicion that motivated it.
+#
+# So the rule is: where a number is needed, write the manual's number. Where a field is
+# needed, shift and mask it here. If you are reading this because the duplication
+# offends you, that instinct is correct in general and wrong here, and the cost of
+# acting on it is that this file stops testing anything.
+#
+# The one thing legitimately shared with the compiler is the ABI's register numbering,
+# and even that is not imported: `a0` is x10 because the manual says so.
+#
+# ===========================================================================
+#
+# SCOPE IS RV32I PLUS M, and that is a closed set from the manual rather than "whatever
+# the corpus showed". Implementing only the instructions one program happened to select
+# would make the harness fail on the next program and look like a codegen bug.
+#
+# NOT COVERED, AND REFUSED BY NAME RATHER THAN IGNORED: the F and D extensions, fences,
+# and CSR access. rv32 codegen does select float instructions, so a probe program that
+# uses a float reaches an `fld` here and gets a refusal naming the opcode - a harness
+# that skipped what it did not model would report a pass for a program it never ran.
+# Float coverage is a later change and wants the whole of IEEE 754 done properly.
+#
+# TERMINATION is a return to a sentinel address seeded into `ra` before entry: the
+# emitted `ret` is `jalr x0, 0(ra)`, so a jump whose target is the sentinel is the
+# function returning to its caller. Any access outside the image, any instruction
+# outside the set above, and any run that exceeds the step cap is a failure rather than
+# a truncated answer - the same discipline the 6502 core holds to, and for the same
+# reason: a harness that degrades quietly reports green for the runs it gave up on.
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+
+# the address seeded into `ra`; a jump here is the entry function returning
+#
+# Word-aligned and far outside any image this harness loads, so it cannot collide with
+# a real instruction address. `jalr` clears the low bit of its target, so the sentinel
+# must be even or the comparison would never match.
+pub val RETURN_SENTINEL: u32 = 0xFFFFFFF0;
+
+# the runaway backstop
+#
+# A cap on executed instructions, not a workload ceiling. Generous enough for the
+# expansions `be.codegen.legalize` produces on a 32-bit machine (a wide divide is
+# hundreds of instructions per call and a probe may loop over it), and finite so a
+# sequence that never returns is reported instead of hanging the test binary.
+pub val MAX_STEPS: u32 = 2000000;
+
+# the reference core's architectural state
+#
+# `x[0]` is present so register numbering needs no adjustment, and is forced to zero on
+# every write, which is the manual's rule rather than a convenience.
+# ---
+# x:     the 32 integer registers, x[0] hardwired to zero
+# pc:    the program counter
+# steps: instructions retired, for the runaway backstop and for cost assertions
+pub rec Core {
+    x:     [32]u32;
+    pc:    u32;
+    steps: u32;
+}
+
+# sign-extend the low `bits` of `v`
+fun sext(v: u32, bits: u32) u32 {
+    val sh: u32 = 32 - bits;
+    ret ((v << sh)::i32 >> sh::i32)::u32;
+}
+
+# write a register, honoring x0 (manual: writes to x0 are discarded)
+fun wr(core: *Core, rd: u32, v: u32) {
+    if (rd != 0) { core.x[rd] = v; }
+}
+
+# read `n` bytes little-endian from the image, or report an out-of-bounds access
+#
+# RISC-V is little-endian in every configuration this compiler targets, so the byte
+# order is written out here rather than taken from the machine model - the model is the
+# compiler's own description and this file does not read the compiler's descriptions.
+fun rd_mem(mem: *u8, size: usize, addr: u32, n: u32, out: *u32) bool {
+    if (addr::usize + n::usize > size) { ret false; }
+    var v: u32 = 0;
+    var i: u32 = 0;
+    for (i < n) {
+        v = v | (mem[(addr + i)::usize]::u32 << (i * 8));
+        i = i + 1;
+    }
+    @out = v;
+    ret true;
+}
+
+# write `n` bytes little-endian into the image, or report an out-of-bounds access
+fun wr_mem(mem: *u8, size: usize, addr: u32, n: u32, v: u32) bool {
+    if (addr::usize + n::usize > size) { ret false; }
+    var i: u32 = 0;
+    for (i < n) {
+        mem[(addr + i)::usize] = ((v >> (i * 8)) & 0xFF)::u8;
+        i = i + 1;
+    }
+    ret true;
+}
+
+# execute from `core.pc` until the entry function returns to `RETURN_SENTINEL`
+#
+# Field extraction below is the manual's instruction formats, spelled out:
+#
+#   opcode = bits  6:0     rd     = bits 11:7    funct3 = bits 14:12
+#   rs1    = bits 19:15    rs2    = bits 24:20   funct7 = bits 31:25
+#
+#   I-immediate = sext(bits 31:20, 12)
+#   S-immediate = sext(bits 31:25 : bits 11:7, 12)
+#   B-immediate = sext(bit 31 : bit 7 : bits 30:25 : bits 11:8 : 0, 13)
+#   U-immediate = bits 31:12 << 12
+#   J-immediate = sext(bit 31 : bits 19:12 : bit 20 : bits 30:21 : 0, 21)
+#
+# The B and J forms have their bits scrambled relative to source order; that scrambling
+# is the manual's, it exists so the immediate's bits land under the same wires as the
+# other formats, and getting it wrong is one of the two most likely ways for this file
+# to be quietly incorrect. The other is the division edge cases, which are handled at
+# their opcodes below.
+# ---
+# mem:  the flat memory image, little-endian, address 0 at `mem[0]`
+# size: the image size in bytes
+# core: the core state; `pc` is the entry point, `x[1]` must hold RETURN_SENTINEL
+# ret:  true when the run returned through the sentinel inside the modeled set
+pub fun exec_reference(mem: *u8, size: usize, core: *Core) bool {
+    core.steps = 0;
+    for (core.steps < MAX_STEPS) {
+        core.steps = core.steps + 1;
+        core.x[0] = 0;
+
+        var w: u32 = 0;
+        if (!rd_mem(mem, size, core.pc, 4, ?w)) { ret false; }
+
+        val opcode: u32 = w & 0x7F;
+        val rd:     u32 = (w >> 7)  & 0x1F;
+        val funct3: u32 = (w >> 12) & 0x07;
+        val rs1:    u32 = (w >> 15) & 0x1F;
+        val rs2:    u32 = (w >> 20) & 0x1F;
+        val funct7: u32 = (w >> 25) & 0x7F;
+        val a:      u32 = core.x[rs1];
+        val b:      u32 = core.x[rs2];
+        val next:   u32 = core.pc + 4;
+
+        # LUI (opcode 0110111): the upper immediate, low 12 bits zero
+        if (opcode == 0x37) {
+            wr(core, rd, w & 0xFFFFF000);
+            core.pc = next;
+        }
+        # AUIPC (opcode 0010111): the upper immediate added to THIS instruction's pc
+        or (opcode == 0x17) {
+            wr(core, rd, core.pc + (w & 0xFFFFF000));
+            core.pc = next;
+        }
+        # JAL (opcode 1101111)
+        or (opcode == 0x6F) {
+            val imm: u32 = sext(((w >> 31) & 1) << 20
+                              | ((w >> 12) & 0xFF) << 12
+                              | ((w >> 20) & 1) << 11
+                              | ((w >> 21) & 0x3FF) << 1, 21);
+            val tgt: u32 = core.pc + imm;
+            wr(core, rd, next);
+            if (tgt == RETURN_SENTINEL) { ret true; }
+            core.pc = tgt;
+        }
+        # JALR (opcode 1100111, funct3 000): the target's low bit is cleared
+        or (opcode == 0x67) {
+            if (funct3 != 0) { ret false; }
+            val imm: u32 = sext(w >> 20, 12);
+            val tgt: u32 = (a + imm) & 0xFFFFFFFE;
+            wr(core, rd, next);
+            if (tgt == RETURN_SENTINEL) { ret true; }
+            core.pc = tgt;
+        }
+        # BRANCH (opcode 1100011)
+        or (opcode == 0x63) {
+            val imm: u32 = sext(((w >> 31) & 1) << 12
+                              | ((w >> 7)  & 1) << 11
+                              | ((w >> 25) & 0x3F) << 5
+                              | ((w >> 8)  & 0x0F) << 1, 13);
+            var take: bool = false;
+            if (funct3 == 0)      { take = a == b; }                      # BEQ
+            or (funct3 == 1)      { take = a != b; }                      # BNE
+            or (funct3 == 4)      { take = a::i32 <  b::i32; }            # BLT
+            or (funct3 == 5)      { take = a::i32 >= b::i32; }            # BGE
+            or (funct3 == 6)      { take = a < b; }                       # BLTU
+            or (funct3 == 7)      { take = a >= b; }                      # BGEU
+            or { ret false; }
+            if (take) { core.pc = core.pc + imm; }
+            or        { core.pc = next; }
+        }
+        # LOAD (opcode 0000011)
+        or (opcode == 0x03) {
+            val addr: u32 = a + sext(w >> 20, 12);
+            var v: u32 = 0;
+            if (funct3 == 0)      { if (!rd_mem(mem, size, addr, 1, ?v)) { ret false; } v = sext(v, 8);  }  # LB
+            or (funct3 == 1)      { if (!rd_mem(mem, size, addr, 2, ?v)) { ret false; } v = sext(v, 16); }  # LH
+            or (funct3 == 2)      { if (!rd_mem(mem, size, addr, 4, ?v)) { ret false; } }                   # LW
+            or (funct3 == 4)      { if (!rd_mem(mem, size, addr, 1, ?v)) { ret false; } }                   # LBU
+            or (funct3 == 5)      { if (!rd_mem(mem, size, addr, 2, ?v)) { ret false; } }                   # LHU
+            or { ret false; }
+            wr(core, rd, v);
+            core.pc = next;
+        }
+        # STORE (opcode 0100011)
+        or (opcode == 0x23) {
+            val imm:  u32 = sext(((w >> 25) & 0x7F) << 5 | ((w >> 7) & 0x1F), 12);
+            val addr: u32 = a + imm;
+            if (funct3 == 0)      { if (!wr_mem(mem, size, addr, 1, b)) { ret false; } }  # SB
+            or (funct3 == 1)      { if (!wr_mem(mem, size, addr, 2, b)) { ret false; } }  # SH
+            or (funct3 == 2)      { if (!wr_mem(mem, size, addr, 4, b)) { ret false; } }  # SW
+            or { ret false; }
+            core.pc = next;
+        }
+        # OP-IMM (opcode 0010011)
+        or (opcode == 0x13) {
+            val imm:   u32 = sext(w >> 20, 12);
+            # a shift-immediate's count is the low 5 bits of the immediate field on
+            # RV32, and the bits above it select arithmetic vs logical
+            val shamt: u32 = (w >> 20) & 0x1F;
+            if (funct3 == 0)      { wr(core, rd, a + imm); }                                   # ADDI
+            or (funct3 == 2)      { var t: u32 = 0; if (a::i32 < imm::i32) { t = 1; } wr(core, rd, t); }  # SLTI
+            or (funct3 == 3)      { var t: u32 = 0; if (a < imm)           { t = 1; } wr(core, rd, t); }  # SLTIU
+            or (funct3 == 4)      { wr(core, rd, a ^ imm); }                                   # XORI
+            or (funct3 == 6)      { wr(core, rd, a | imm); }                                   # ORI
+            or (funct3 == 7)      { wr(core, rd, a & imm); }                                   # ANDI
+            or (funct3 == 1)      {
+                if (funct7 != 0x00) { ret false; }
+                wr(core, rd, a << shamt);                                                      # SLLI
+            }
+            or (funct3 == 5)      {
+                if (funct7 == 0x00)      { wr(core, rd, a >> shamt); }                         # SRLI
+                or (funct7 == 0x20)      { wr(core, rd, (a::i32 >> shamt::i32)::u32); }        # SRAI
+                or { ret false; }
+            }
+            or { ret false; }
+            core.pc = next;
+        }
+        # OP (opcode 0110011): the base register-register set at funct7 0000000 /
+        # 0100000, and the M extension at funct7 0000001
+        or (opcode == 0x33) {
+            # a register shift's count is the low 5 bits of rs2 on RV32
+            val shamt: u32 = b & 0x1F;
+            if (funct7 == 0x00) {
+                if (funct3 == 0)      { wr(core, rd, a + b); }                                     # ADD
+                or (funct3 == 1)      { wr(core, rd, a << shamt); }                                # SLL
+                or (funct3 == 2)      { var t: u32 = 0; if (a::i32 < b::i32) { t = 1; } wr(core, rd, t); }  # SLT
+                or (funct3 == 3)      { var t: u32 = 0; if (a < b)           { t = 1; } wr(core, rd, t); }  # SLTU
+                or (funct3 == 4)      { wr(core, rd, a ^ b); }                                     # XOR
+                or (funct3 == 5)      { wr(core, rd, a >> shamt); }                                # SRL
+                or (funct3 == 6)      { wr(core, rd, a | b); }                                     # OR
+                or (funct3 == 7)      { wr(core, rd, a & b); }                                     # AND
+                or { ret false; }
+            }
+            or (funct7 == 0x20) {
+                if (funct3 == 0)      { wr(core, rd, a - b); }                                     # SUB
+                or (funct3 == 5)      { wr(core, rd, (a::i32 >> shamt::i32)::u32); }               # SRA
+                or { ret false; }
+            }
+            or (funct7 == 0x01) {
+                if (!exec_muldiv(core, rd, funct3, a, b)) { ret false; }
+            }
+            or { ret false; }
+            core.pc = next;
+        }
+        or { ret false; }
+    }
+    ret false;
+}
+
+# the M extension's eight instructions, at opcode 0110011 funct7 0000001
+#
+# THE EDGE CASES ARE THE MANUAL'S AND THEY ARE NOT THE HOST'S. RISC-V defines division
+# by zero and signed overflow rather than leaving them undefined, and the definitions
+# are unusual enough that a core written from intuition gets them wrong: a division by
+# zero yields ALL ONES as the quotient and the dividend unchanged as the remainder, and
+# the single overflow case (the most negative integer divided by -1) yields that same
+# most negative integer as the quotient and zero as the remainder. Neither traps.
+#
+# They are also exactly the cases a compiler's own expansion is most likely to get
+# wrong, so a core that took the host's behaviour here would agree with a wrong
+# expansion for the same reason importing the encoder's tables would.
+# ---
+# core:   the core state
+# rd:     the destination register
+# funct3: 0 MUL, 1 MULH, 2 MULHSU, 3 MULHU, 4 DIV, 5 DIVU, 6 REM, 7 REMU
+# a, b:   the two source register values
+# ret:    true when `funct3` names a modeled instruction
+fun exec_muldiv(core: *Core, rd: u32, funct3: u32, a: u32, b: u32) bool {
+    # the most negative 32-bit integer, the sole signed-overflow dividend
+    val int_min: u32 = 0x80000000;
+
+    if (funct3 == 0) {                                                        # MUL
+        wr(core, rd, (a::u64 * b::u64)::u32);
+        ret true;
+    }
+    if (funct3 == 1) {                                                        # MULH
+        val p: i64 = a::i32::i64 * b::i32::i64;
+        wr(core, rd, (p::u64 >> 32)::u32);
+        ret true;
+    }
+    if (funct3 == 2) {                                                        # MULHSU
+        val p: i64 = a::i32::i64 * b::u64::i64;
+        wr(core, rd, (p::u64 >> 32)::u32);
+        ret true;
+    }
+    if (funct3 == 3) {                                                        # MULHU
+        wr(core, rd, ((a::u64 * b::u64) >> 32)::u32);
+        ret true;
+    }
+    if (funct3 == 4) {                                                        # DIV
+        if (b == 0)                            { wr(core, rd, 0xFFFFFFFF); ret true; }
+        if (a == int_min && b == 0xFFFFFFFF)   { wr(core, rd, int_min);    ret true; }
+        wr(core, rd, (a::i32 / b::i32)::u32);
+        ret true;
+    }
+    if (funct3 == 5) {                                                        # DIVU
+        if (b == 0) { wr(core, rd, 0xFFFFFFFF); ret true; }
+        wr(core, rd, a / b);
+        ret true;
+    }
+    if (funct3 == 6) {                                                        # REM
+        if (b == 0)                            { wr(core, rd, a); ret true; }
+        if (a == int_min && b == 0xFFFFFFFF)   { wr(core, rd, 0); ret true; }
+        wr(core, rd, (a::i32 % b::i32)::u32);
+        ret true;
+    }
+    if (funct3 == 7) {                                                        # REMU
+        if (b == 0) { wr(core, rd, a); ret true; }
+        wr(core, rd, a % b);
+        ret true;
+    }
+    ret false;
+}
+
+# the core's decode agrees with the manual's field layout on hand-written words
+#
+# EVERY WORD HERE IS ASSEMBLED BY HAND from the manual's format tables, not by the
+# encoder. That is the same independence the file header argues for, applied to the
+# file's own test: a fixture built by calling the encoder would pass against a core
+# that shared the encoder's mistakes, which is the exact failure this core exists to
+# rule out. Hand-assembly is tedious and it is the only version of this test that
+# means anything.
+test "mach.lang.target.isa.riscv.refcore:decodes_the_manual_field_layout" {
+    var mem: [256]u8;
+    var i: usize = 0;
+    for (i < 256) { mem[i] = 0; i = i + 1; }
+
+    # addi x10, x0, 5      -> imm=5 rs1=0 f3=0 rd=10 op=0010011
+    val addi: u32 = (5 << 20) | (0 << 15) | (0 << 12) | (10 << 7) | 0x13;
+    # addi x11, x0, -3     -> the immediate is sign-extended from 12 bits
+    val addin: u32 = ((0xFFD & 0xFFF) << 20) | (0 << 15) | (0 << 12) | (11 << 7) | 0x13;
+    # sub  x12, x10, x11   -> f7=0100000 rs2=11 rs1=10 f3=0 rd=12 op=0110011
+    val sub: u32 = (0x20 << 25) | (11 << 20) | (10 << 15) | (0 << 12) | (12 << 7) | 0x33;
+    # jalr x0, 0(x1)       -> the `ret` the core terminates on
+    val jr: u32 = (0 << 20) | (1 << 15) | (0 << 12) | (0 << 7) | 0x67;
+
+    var w: [4]u32;
+    w[0] = addi; w[1] = addin; w[2] = sub; w[3] = jr;
+    var k: usize = 0;
+    for (k < 4) {
+        var byt: usize = 0;
+        for (byt < 4) {
+            mem[k * 4 + byt] = ((w[k] >> (byt::u32 * 8)) & 0xFF)::u8;
+            byt = byt + 1;
+        }
+        k = k + 1;
+    }
+
+    var core: Core;
+    var z: usize = 0;
+    for (z < 32) { core.x[z] = 0; z = z + 1; }
+    core.pc   = 0;
+    core.x[1] = RETURN_SENTINEL;
+    if (!exec_reference(?mem[0], 256, ?core)) { ret 1; }
+
+    # 5 - (-3) == 8, which needs the immediate sign-extended and SUB distinguished from
+    # ADD by funct7 alone
+    if (core.x[10] != 5)          { ret 1; }
+    if (core.x[11] != 0xFFFFFFFD) { ret 1; }
+    if (core.x[12] != 8)          { ret 1; }
+    # four instructions retired, so the terminator is counted and nothing ran on
+    if (core.steps != 4)          { ret 1; }
+    ret 0;
+}
+
+# the branch and jump immediates are the manual's SCRAMBLED bit order
+#
+# Pinned separately because it is the likeliest place for this core to be quietly wrong:
+# B and J pack their immediate bits out of source order, and a core that read them as
+# contiguous fields would still run straight-line code perfectly and would take every
+# branch to the wrong place. A test that only ran arithmetic would never notice.
+test "mach.lang.target.isa.riscv.refcore:branch_and_jump_immediates_are_scrambled" {
+    var mem: [256]u8;
+    var i: usize = 0;
+    for (i < 256) { mem[i] = 0; i = i + 1; }
+
+    # at 0: beq x0, x0, +8   -> imm 8 is bit3, which B packs into bits 11:8 of the word
+    val beq: u32 = (0 << 25) | (0 << 20) | (0 << 15) | (0 << 12) | (4 << 8) | 0x63;
+    # at 4: addi x5, x0, 99  -> SKIPPED if the branch decoded correctly
+    val skipped: u32 = (99 << 20) | (0 << 15) | (0 << 12) | (5 << 7) | 0x13;
+    # at 8: jal x0, +8       -> imm 8 is bit3, which J packs into bits 30:21
+    val jal: u32 = ((8 >> 1) << 21) | (0 << 7) | 0x6F;
+    # at 12: addi x5, x0, 77 -> SKIPPED if the jump decoded correctly
+    val skipped2: u32 = (77 << 20) | (0 << 15) | (0 << 12) | (5 << 7) | 0x13;
+    # at 16: jalr x0, 0(x1)
+    val jr: u32 = (1 << 15) | 0x67;
+
+    var w: [5]u32;
+    w[0] = beq; w[1] = skipped; w[2] = jal; w[3] = skipped2; w[4] = jr;
+    var k: usize = 0;
+    for (k < 5) {
+        var byt: usize = 0;
+        for (byt < 4) {
+            mem[k * 4 + byt] = ((w[k] >> (byt::u32 * 8)) & 0xFF)::u8;
+            byt = byt + 1;
+        }
+        k = k + 1;
+    }
+
+    var core: Core;
+    var z: usize = 0;
+    for (z < 32) { core.x[z] = 0; z = z + 1; }
+    core.pc   = 0;
+    core.x[1] = RETURN_SENTINEL;
+    if (!exec_reference(?mem[0], 256, ?core)) { ret 1; }
+
+    # neither skipped instruction ran: x5 is untouched
+    if (core.x[5] != 0) { ret 1; }
+    # branch, jump, return: three instructions
+    if (core.steps != 3) { ret 1; }
+    ret 0;
+}
+
+# the M extension's division edge cases are the manual's, not the host's
+#
+# Division by zero and the single signed-overflow case are DEFINED on RISC-V and defined
+# unusually. A core that inherited the host's behaviour would trap or disagree, and it
+# would disagree in exactly the direction that makes a wrong compiler expansion look
+# right.
+test "mach.lang.target.isa.riscv.refcore:division_edges_follow_the_manual" {
+    var core: Core;
+    var z: usize = 0;
+    for (z < 32) { core.x[z] = 0; z = z + 1; }
+
+    # divide by zero: quotient all ones, remainder the dividend, neither traps
+    if (!exec_muldiv(?core, 5, 4, 17, 0)) { ret 1; }
+    if (core.x[5] != 0xFFFFFFFF) { ret 1; }
+    if (!exec_muldiv(?core, 5, 5, 17, 0)) { ret 1; }
+    if (core.x[5] != 0xFFFFFFFF) { ret 1; }
+    if (!exec_muldiv(?core, 5, 6, 17, 0)) { ret 1; }
+    if (core.x[5] != 17) { ret 1; }
+    if (!exec_muldiv(?core, 5, 7, 17, 0)) { ret 1; }
+    if (core.x[5] != 17) { ret 1; }
+
+    # signed overflow: INT_MIN / -1 is INT_MIN, and its remainder is 0
+    if (!exec_muldiv(?core, 5, 4, 0x80000000, 0xFFFFFFFF)) { ret 1; }
+    if (core.x[5] != 0x80000000) { ret 1; }
+    if (!exec_muldiv(?core, 5, 6, 0x80000000, 0xFFFFFFFF)) { ret 1; }
+    if (core.x[5] != 0) { ret 1; }
+
+    # the high-half multiplies differ by signedness on the same bits, which is the
+    # distinction PR #2871's schoolbook expansion depends on
+    if (!exec_muldiv(?core, 5, 3, 0xFFFFFFFF, 0xFFFFFFFF)) { ret 1; }
+    if (core.x[5] != 0xFFFFFFFE) { ret 1; }   # MULHU: (2^32-1)^2 >> 32
+    if (!exec_muldiv(?core, 5, 1, 0xFFFFFFFF, 0xFFFFFFFF)) { ret 1; }
+    if (core.x[5] != 0)          { ret 1; }   # MULH:  (-1 * -1) >> 32
+    ret 0;
+}
+
+# an instruction outside the modeled set is REFUSED, not skipped
+#
+# The property that makes every other assertion in this harness mean something. A core
+# that ignored what it did not model would run a program with a float in it, execute
+# the integer half, and report the answer as if the whole thing had run - a pass for a
+# program that never really ran. `fld` is the concrete case: rv32 codegen does select
+# float instructions, and this harness does not model them.
+test "mach.lang.target.isa.riscv.refcore:an_unmodeled_instruction_is_refused" {
+    var mem: [64]u8;
+    var i: usize = 0;
+    for (i < 64) { mem[i] = 0; i = i + 1; }
+
+    # fld f0, 0(x2) -> opcode 0000111, the D-extension load. not modeled.
+    val fld: u32 = (0 << 20) | (2 << 15) | (3 << 12) | (0 << 7) | 0x07;
+    var byt: usize = 0;
+    for (byt < 4) { mem[byt] = ((fld >> (byt::u32 * 8)) & 0xFF)::u8; byt = byt + 1; }
+
+    var core: Core;
+    var z: usize = 0;
+    for (z < 32) { core.x[z] = 0; z = z + 1; }
+    core.pc   = 0;
+    core.x[1] = RETURN_SENTINEL;
+    if (exec_reference(?mem[0], 64, ?core)) { ret 1; }
+
+    # and a load past the end of the image is refused too, rather than reading zeros
+    var mem2: [64]u8;
+    i = 0;
+    for (i < 64) { mem2[i] = 0; i = i + 1; }
+    # lw x5, 0(x6) with x6 pointing past the image
+    val lw: u32 = (0 << 20) | (6 << 15) | (2 << 12) | (5 << 7) | 0x03;
+    byt = 0;
+    for (byt < 4) { mem2[byt] = ((lw >> (byt::u32 * 8)) & 0xFF)::u8; byt = byt + 1; }
+    var c2: Core;
+    z = 0;
+    for (z < 32) { c2.x[z] = 0; z = z + 1; }
+    c2.pc   = 0;
+    c2.x[1] = RETURN_SENTINEL;
+    c2.x[6] = 0x1000;
+    if (exec_reference(?mem2[0], 64, ?c2)) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
The rv32 equivalent of the 6502 core harness. In-process, driven by `mach test .`, no qemu, no `int/` case.

## Why

rv32 shipped passing the whole suite with four defects in it, and every one was a wrong **answer** rather than a failed build: #2870 (two `i64` arguments overlapped, destroying the first one's high half), #2868 (a wide equality compare answered false for equal values), #2869 (a constant shift by a whole lane returned garbage), #2871 (the wide multiply had never been executed). Every test the target had asserted that codegen *emitted* something. None asserted what the bytes *compute*.

## The core decodes independently of the encoder

`src/lang/target/isa/riscv/refcore.mach` imports nothing from `isa.riscv`, `isa.riscv.inst` or `isa.riscv.encode`. Every field position, opcode number and funct3/funct7 value is written out as the number the RISC-V manual gives, next to the mnemonic the manual gives it.

That duplication is the file's entire reason to exist, and the header says so at length, because the next reader's instinct will be to remove it. A core that asked the encoder which bits mean `add` would agree with the encoder *by construction*: emit the wrong funct7, read back the same wrong funct7, execute the instruction the encoder meant, report a pass. It would verify the compiler is self-consistent — which nothing has ever doubted — while looking like execution coverage, which is worse than no harness, because a green run would retire the suspicion that motivated it.

**This is proven, not asserted.** See mutation C′ in the table below: dropping the `srai` funct7 bit in the encoder — so `>>` on a signed value emits a *logical* shift — is caught by this harness. A core sharing the encoder's constants would have decoded the wrong bits as `sra` and agreed.

Two more independence choices:

- **The harness places arguments by the psABI as written in the harness**, not as the compiler classified them, and enters the function under test *directly*. A compiled wrapper would not work: under #2870 the emitted caller and callee agreed on the same wrong layout, so only an independent caller can see it.
- **Reference answers are host arithmetic**, not a second pass through the compiler.

## Scope

RV32I plus M — a closed set from the manual, not "whatever the corpus showed", since implementing only the observed subset would make the harness fail on the next program and look like a codegen bug. I histogrammed a broad rv32 corpus to confirm what codegen selects before choosing.

**Anything outside it is refused by name, not skipped** — F/D, fences, CSRs. rv32 codegen *does* select float instructions, so a probe containing one gets a refusal rather than a pass for a program that never really ran. Float coverage is a later change and wants IEEE 754 done properly. Out-of-bounds accesses, unmodeled opcodes and step-cap overruns are all failures rather than truncated answers.

The division edge cases are the manual's and are deliberately not the host's: divide-by-zero yields all-ones quotient and the dividend as remainder, `INT_MIN / -1` yields `INT_MIN` and 0, neither traps. A core that took the host's behaviour would agree with a wrong expansion for the same reason importing the encoder's tables would.

## Proving the harness can fail

Every control run one at a time, with the tree otherwise clean.

| # | reverted / mutated | rv32 harness | also caught by |
|---|---|---|---|
| A | **#2870's fix** — the ilp32 wide-scalar argument arm | **FAILS** | the abi unit tests |
| B | **#2871's fix** — `accum_into`'s liveness propagation | *passes* — see below | 6502 core + legalize unit tests |
| B′ | the multiply's high half via `MIR_MUL` instead of `MIR_MUL_HI_U` (a fast wrong multiply) | **FAILS** | one legalize unit test |
| C′ | the encoder drops `srai`'s funct7 bit — `sra` emitted as `srl` | **FAILS** | one encoder unit test |
| D | a wide equality joins its lanes with `OR` instead of `AND` | **FAILS** | 6502 core + one legalize unit test |

**B is an honest negative and I am reporting it rather than papering over it.** PR #2871's liveness defect is invisible at two lanes: the carry chain only makes *higher* lanes live, and on rv32 an `i64` has one lane above lane 0, so the buggy and correct counts coincide. It needs three or more lanes, which means mos6502 remains the only target that can observe it. That is a real limit of what a 32-bit lane width can exercise, not a gap in the harness — and it is exactly why B′ exists: a multiply defect that *is* observable at two lanes, to show the multiply path is genuinely checked.

#2868 and #2869 have no separate fix to revert — they were closed by #2870's — so control A is what demonstrates the harness sees the compare and shift failures, and D and C′ show those two paths are checked on their own terms rather than only as downstream symptoms.

## What the harness checks

One probe module, eleven functions, entered directly. Over the `ut_shift_value` pattern set (zero, all-ones, alternating, one bit per lane, a spread): 64-bit multiply, xor, add, unsigned/signed less-than, unsigned divide and remainder, and equality **compared against an equal value as well as an unequal one** — a sweep of unequal pairs alone would have passed against #2868. Shifts walk **all 64 counts** in all three directions, because a count of 32 is the whole-lane case #2869 lived in and sampling a few counts would have missed it.

`ut_mos_text` is renamed `ut_image_text`: it reads nothing architecture-specific and now has two callers.

## Verification

`mach test .`: **1391 passed, 0 failed** (1386 before, plus five: four core self-tests and the executed sweep). The executed test runs in 47 ms.

The core's four self-tests are hand-assembled from the manual's format tables rather than by calling the encoder — same independence argument applied to the core's own test. They pin the field layout, the **scrambled B and J immediate bit order** (the likeliest place for this file to be quietly wrong: a core reading them as contiguous fields would run straight-line code perfectly and branch to the wrong address), the division edges, and that an unmodeled instruction and an out-of-bounds access are both refused.

**Byte-identity**, baseline from this branch's own merge base (`30872d8f`):

| leg | objects | binaries | self-differing | base vs branch |
|---|---|---|---|---|
| linux-x86_64 | 224 | 2 | 0 | 0 |
| linux-arm64 | 224 | 2 | 0 | 0 |
| linux-riscv64 | 224 | 2 | 0 | 0 |

Zero is expected and checkable here rather than hopeful: this change is test-only and adds no code any compilation path reaches. The positive control that the harness is doing something is the mutation table — five deliberate defects, four of which it catches.

`int` sweeps: green on `linux` and `linux-arm64` (qemu). `linux-riscv64` has the same 2 `surface/riscv-pcrel-pair` failures as on the baseline — the sandbox has no riscv64 libc headers. **No `int/` cases touched.**

## Open

Float coverage. rv32 selects `fld`, `fmul.d`, `fcvt.*` and friends, and the core refuses them by name, so no float path on rv32 is executed by anything today. That is the same gap this PR just closed for integers, one extension over, and it is now visible rather than silent. Worth filing before PR 5 rather than after.

Refs #2778
