### PR TITLE
feat(sema): measure a layout intrinsic inside a comptime gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### A layout intrinsic can be measured inside a comptime `$if` (#2857)
+`$size_of` and `$align_of` are constants, but they could not appear in a `$if` condition, so the thing most worth asserting about a layout - a **relationship** between two of them - could only be a runtime test. Two records a renderer writes into one slot at a fixed offset must be the same size; if they diverge, one shader reads its colour out of the middle of a matrix, with no diagnostic at any layer. A test catches that only if someone runs the suite. A `$error` catches it in the build that introduced it.
+
+`$if ($size_of(A) != $size_of(B)) { $error("..."); }` now compiles inside a function body, as does a comparison against a literal and an intrinsic folded into a larger expression.
+
+The measurement is not new and deliberately is not duplicated: the comptime evaluator gained a resolver seam, and sema answers it through the same `fold_layout_intrinsic` a type position already used, so a size measured in an array length and the same size measured in a `$if` cannot disagree. Lowering installs its own resolver beside the type-query one it already had, because a chain gated on a comptime parameter or inside a generic body has its arm selected at monomorphization and never reaches sema's.
+
+Resolve reaches the position through a mechanism that was already there: `bind_comptime_if` defers a chain it cannot fold yet, binding every arm and leaving arm selection to a later pass, which is what a type comparison has always done. A layout gate joins that list rather than introducing a second rule.
+
+### Changed
+
+#### A refused layout intrinsic now says which position refused it, and why (#2857)
+`a layout intrinsic has no value in this position: it measures a type, which only a type position resolves` was true of every position and is now true of one. A **declaration-scope** `$if` still cannot measure, because it selects which declarations exist and that is decided before any type is laid out, so it says that instead and points at the position that does work. `$offset_of` is named apart, since it is unavailable for a different reason - a field offset is decided at lowering - and a message about type checking would be a stale explanation the moment the resolver exists.
+
+Two limits are filed rather than left implicit: `$length_of` still does not fold in a gate (#2875), and no declaration-scope gate can see a type at all, which is shared with type queries and comparisons (#2876).
+
+
+### Added
+
 #### RV32 is a target (#2778)
 mach compiles for 32-bit RISC-V. `isa = "riscv32"` with `abi = "ilp32"`, `"ilp32f"` or `"ilp32d"` resolves a full machine description, and `$mach.arch.riscv32` and the three `$mach.abi.ilp32*` tags exist so a body can be guarded for it.
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2032,15 +2032,73 @@ test "mach.lang.driver:layout_intrinsic_cycles" {
     ret bad;
 }
 
+# a layout intrinsic MEASURES inside a `$if` gate in a function body (#2857)
+#
+# Before this, every layout intrinsic in a comptime condition was refused, so the
+# thing most worth asserting about a layout - a RELATIONSHIP between two of them -
+# could only be a runtime test. `MeshUniforms` and `SkinnedUniforms` in
+# briar-systems/boom must be the same size because the renderer writes both into one
+# slot at a fixed offset; if they diverge, one shader reads its colour out of the
+# middle of a matrix with no diagnostic at any layer. A test catches that only if
+# someone runs the suite; a `$error` catches it in the build that introduced it.
+#
+# EVERY CASE IS ASSERTED IN BOTH DIRECTIONS through `ut_arm`, which requires the
+# expected marker to fire AND the other one to be absent. That is not politeness: a
+# gate that fails to fold selects no arm and type-checks every arm, so BOTH markers
+# fire - and a one-sided "the expected marker is present" assertion passes against a
+# gate that stopped folding entirely. This whole test would otherwise pass on the
+# unfixed compiler.
+#
+# The sizes are chosen so no single constant satisfies the set, and the alignment
+# case is checked against a value the size is not, so a fold that returned an
+# alignment where a size was asked for fails here.
+#
+# NOT ASSERTED HERE: `$offset_of`'s own refusal. It is refused by name and for its
+# own reason - a field offset is decided at lowering - but that message surfaces
+# AFTER sema, and `ut_vec_diag` stops at sema, so a harness that cannot see it would
+# assert nothing. Recorded rather than quietly omitted; verified by hand.
+test "mach.lang.driver:layout_intrinsic_in_a_comptime_gate" {
+    var bad: i32 = 0;
+
+    # THE MOTIVATING CASE: two records that must agree, and two that must not.
+    if (ut_arm("rec A { x: u64; y: u64; }\nrec B { p: u64; q: u64; }\nfun main() i32 { $if ($size_of(A) == $size_of(B)) { $error(\"SAME\"); } $or { $error(\"DIFF\"); } ret 0; }\n", "SAME", "DIFF") != 0) { bad = 1; }
+    if (ut_arm("rec A { x: u64; y: u64; }\nrec C { z: u64; w: u64; v: u64; }\nfun main() i32 { $if ($size_of(A) == $size_of(C)) { $error(\"SAME\"); } $or { $error(\"DIFF\"); } ret 0; }\n", "DIFF", "SAME") != 0) { bad = 1; }
+
+    # against a LITERAL, the wire-format shape. 24 and not 16, so a fold that
+    # measured the wrong operand of the pair above cannot also satisfy this.
+    if (ut_arm("rec C { z: u64; w: u64; v: u64; }\nfun main() i32 { $if ($size_of(C) == 24) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec C { z: u64; w: u64; v: u64; }\nfun main() i32 { $if ($size_of(C) > 16) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # `$align_of` answers the ALIGNMENT, not the size: `C` is 24 bytes aligned to 8,
+    # so a fold that confused the two fails one of this pair.
+    if (ut_arm("rec C { z: u64; w: u64; v: u64; }\nfun main() i32 { $if ($align_of(C) == 8) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("rec C { z: u64; w: u64; v: u64; }\nfun main() i32 { $if ($align_of(C) == 24) { $error(\"N\"); } $or { $error(\"Y\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # FOLDS INSIDE A LARGER EXPRESSION rather than only as a whole gate: the sum is
+    # 40, which neither operand equals, so a fold that read one side and ignored the
+    # other cannot pass.
+    if (ut_arm("rec A { x: u64; y: u64; }\nrec C { z: u64; w: u64; v: u64; }\nfun main() i32 { $if ($size_of(A) + $size_of(C) == 40) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # a SELF-REFERENTIAL measurement is a cycle, named as one, rather than the
+    # position being refused.
+    if (ut_vec_diag("rec SelfRef { buf: [$size_of(SelfRef)]u8; }\nfun main() i32 { ret 0; }\n",
+                    "layout cycle: measuring `SelfRef`") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # positions the fold does NOT cover keep reporting the real cause, and a genuinely
 # non-comptime operand keeps the original wording - so neither correction absorbs the
 # other (#2316, #2442)
 test "mach.lang.driver:layout_intrinsic_remaining_positions" {
     var bad: i32 = 0;
 
-    # a `$if` condition is not a type position and has no layout to force
+    # a DECLARATION-SCOPE `$if` still has no layout to force: it selects which
+    # declarations exist, which is decided before any type is laid out. since #2857 a
+    # gate inside a function body DOES measure, so the message names the position
+    # rather than claiming the intrinsic has no value anywhere.
     if (ut_vec_diag("rec Pair { a: u64; b: u64; }\n$if ($size_of(Pair) == 16) {\n    fun helper() i32 { ret 1; }\n}\nfun main() i32 { ret 0; }\n",
-                    "a layout intrinsic has no value in this position") != 0) { bad = 1; }
+                    "only comptime-evaluable after type checking") != 0) { bad = 1; }
 
     # a real call in array-length position is still reported as a call
     if (ut_vec_diag("fun sz() u64 { ret 16; }\nfun main() i32 { var a: [sz()]u8; ret a[0]::i32; }\n",
@@ -2411,9 +2469,11 @@ test "mach.lang.driver:comptime_length_of" {
                     "`$length_of` has no answer for `u64`") != 0) { bad = 1; }
     if (ut_vec_diag("val A: [4]u8 = [4]u8{1, 2, 3, 4};\nfun main() i32 { var n: u64 = $length_of(A, A); ret 0; }\n",
                     "$length_of: expected 1 argument(s)") != 0) { bad = 1; }
-    # a `$if` gate is not a type position, exactly as for its siblings
+    # a DECLARATION-SCOPE gate still cannot measure, exactly as for its siblings
+    # (#2857). `$length_of` additionally does not fold in a function-body gate, which
+    # its siblings now do - see #2875.
     if (ut_vec_diag("val A: [4]u8 = [4]u8{1, 2, 3, 4};\n$if ($length_of(A) == 4) {\n    fun helper() i32 { ret 1; }\n}\nfun main() i32 { ret 0; }\n",
-                    "a layout intrinsic has no value in this position") != 0) { bad = 1; }
+                    "only comptime-evaluable after type checking") != 0) { bad = 1; }
 
     # A VALUE BINDING IN THE OPERAND SLOT denotes its type, which is the motivating
     # gap: the length exists and is otherwise unnameable. asserted for both counts on

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -258,6 +258,18 @@ pub val TYPE_QUERY_IS_SECRET:  u8 = 4;
 # the name, or none when this context cannot answer (no resolver installed)
 pub def TypeQueryFn: fun(ptr, u32, u8) R.Result[O.Option[CTValue], str];
 
+# the layout-intrinsic resolver `eval` calls to measure `$size_of` / `$align_of` /
+# `$length_of` in a comptime VALUE position (#2857)
+#
+# Takes the call expression rather than a type id, because the measurement needs the
+# intrinsic's own argument resolved against the installing pass's type universe and
+# needs to know WHICH intrinsic was written. The pass that owns layout answers; the
+# evaluator neither measures nor decides what is measurable.
+#
+# ok(none) means "not something this resolver answers", which falls through to the
+# position's own refusal. An err carries a precise message the caller reports.
+pub def LayoutFoldFn: fun(ptr, u32) R.Result[O.Option[CTValue], str];
+
 # surfaced when a type predicate is used where no type query resolver is installed
 pub val COMPTIME_TYPE_QUERY_NO_RESOLVER_MSG: str =
     "a comptime type predicate is only evaluable after type checking";
@@ -384,6 +396,8 @@ pub rec ComptimeCtx {
     field_data:     ptr;
     query_fn:       *u8;
     query_data:     ptr;
+    layout_fn:      *u8;
+    layout_data:    ptr;
     ident_fn:       *u8;
     ident_data:     ptr;
 }
@@ -460,6 +474,8 @@ pub fun init(
     c.field_data     = nil;
     c.query_fn       = nil;
     c.query_data     = nil;
+    c.layout_fn      = nil;
+    c.layout_data    = nil;
     c.ident_fn       = nil;
     c.ident_data     = nil;
     ret c;
@@ -514,6 +530,22 @@ pub fun set_field_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 pub fun set_type_query_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
     c.query_fn   = fn;
     c.query_data = data;
+}
+
+# install the layout resolver `eval` calls to measure a layout intrinsic in a
+# comptime value position (#2857)
+#
+# Only a pass that has the type universe AND can force a type's layout may install
+# one - in practice sema. Resolve leaves it nil, and a layout intrinsic in a
+# declaration-gating `$if` is refused there with a message saying so, which is the
+# same line the type queries already draw.
+# ---
+# c:    the comptime context
+# fn:   erased LayoutFoldFn, or nil to clear
+# data: opaque context handed back to `fn`
+pub fun set_layout_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
+    c.layout_fn   = fn;
+    c.layout_data = data;
 }
 
 # install (or clear) the identifier-binding resolver `eval` consults before it
@@ -841,17 +873,16 @@ pub fun eval(
     # generic call rejection describes it wrongly and sends the reader hunting for a
     # non-constant operand that is not there (#2316). TYPE positions do not arrive
     # here at all - they fold the intrinsic against forced layout material before
-    # asking the evaluator (#2442) - so what reaches this arm is a position with no
-    # layout to force: a `$if` / `$or` condition, or a `$assert` once it evaluates.
+    # asking the evaluator (#2442) - so what reaches this arm is a `$if` / `$or`
+    # condition or a `$assert`, which since #2857 is measured through the installed
+    # layout resolver rather than refused outright.
     if (k == expr.EXPR_KIND_CALL) {
         # a type predicate answers about the SHAPE of its operand type rather than
         # its storage, so it folds here in the comptime channel - which is where the
         # `$if` gate that consumes it is decided (#2128).
         val q: O.Option[R.Result[CTValue, str]] = eval_type_query(c, a, source, e, interner);
         if (O.is_some[R.Result[CTValue, str]](q)) { ret O.unwrap[R.Result[CTValue, str]](q); }
-        if (is_layout_intrinsic_call(a, source, e)) {
-            ret R.err[CTValue, str]("a layout intrinsic has no value in this position: it measures a type, which only a type position resolves");
-        }
+        if (is_layout_intrinsic_call(a, source, e)) { ret eval_layout_intrinsic(c, a, source, e); }
         ret R.err[CTValue, str]("function calls are not comptime-evaluable");
     }
     if (k == expr.EXPR_KIND_INDEX)      { ret R.err[CTValue, str]("index expressions are not comptime-evaluable"); }
@@ -862,6 +893,53 @@ pub fun eval(
     if (k == expr.EXPR_KIND_ERROR)      { ret R.err[CTValue, str]("expression has a parse error"); }
 
     ret R.err[CTValue, str]("expression is not comptime-evaluable");
+}
+
+# measure a layout intrinsic in a comptime value position, or say why not (#2857)
+#
+# A size is a constant, and the thing worth asserting about a layout is usually a
+# RELATIONSHIP between two of them - `$size_of(A) == $size_of(B)` for two records a
+# renderer writes into one slot, `$size_of(Header) == 64` for a wire format. That is
+# exactly what a `$if` expresses, so refusing the position turned a compile-time
+# invariant into a runtime test that only fires if someone runs the suite.
+#
+# THE MEASUREMENT IS NOT HERE, and deliberately. Measuring needs the type universe
+# and needs to FORCE the operand's layout material, both of which belong to the pass
+# that owns them; this module would otherwise hold a second layout policy that could
+# disagree with sema's. So the resolver answers and this function only routes.
+#
+# WITH NO RESOLVER INSTALLED the answer is a refusal that says WHEN the intrinsic
+# becomes available rather than claiming it has no value anywhere. That case is a
+# declaration-gating `$if` during resolve, where no type has been checked yet - the
+# same line the type queries already draw, and stated the same way, because a reader
+# who hits one and then the other should not think they are different rules.
+# ---
+# c:      the comptime context
+# a:      the AST
+# source: the module's source text
+# e:      the intrinsic call expression
+# ret:    the measured constant, or a precise refusal
+fun eval_layout_intrinsic(c: *ComptimeCtx, a: *ast.Ast, source: str, e: id.ExprId) R.Result[CTValue, str] {
+    if (c.layout_fn == nil) {
+        # `$offset_of` is named apart because it is unavailable for a DIFFERENT
+        # reason - sema's field-descriptor contract leaves offsets to lowering - so a
+        # message about type checking would be a stale explanation the moment the
+        # resolver exists.
+        if (is_comptime_call(a, source, e, "offset_of")) {
+            ret R.err[CTValue, str]("`$offset_of` has no value in a comptime condition: a field's offset is decided at lowering, later than any comptime branch");
+        }
+        ret R.err[CTValue, str]("a layout intrinsic is only comptime-evaluable after type checking: this position selects a DECLARATION, which is decided before any type is laid out. a `$if` inside a function body is checked later and can measure a type");
+    }
+    val fn: LayoutFoldFn = c.layout_fn::LayoutFoldFn;
+    val r: R.Result[O.Option[CTValue], str] = fn(c.layout_data, e::u32);
+    if (R.is_err[O.Option[CTValue], str](r)) {
+        ret R.err[CTValue, str](R.unwrap_err[O.Option[CTValue], str](r));
+    }
+    val ans: O.Option[CTValue] = R.unwrap_ok[O.Option[CTValue], str](r);
+    if (O.is_none[CTValue](ans)) {
+        ret R.err[CTValue, str]("`$offset_of` has no value in a comptime condition: a field's offset is decided at lowering, later than any comptime branch");
+    }
+    ret R.ok[CTValue, str](O.unwrap[CTValue](ans));
 }
 
 # returns a length-counted view into source covering `span`. the returned view

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1938,6 +1938,7 @@ fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, 
 fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32, at_decl_scope: bool) R.Result[bool, str] {
     if (!at_decl_scope && (comptime_if_gated_on_param(rc, branches_start, branches_len)
                         || comptime_if_has_type_comparison(rc, branches_start, branches_len)
+                        || comptime_if_has_layout_intrinsic(rc, branches_start, branches_len)
                         || comptime_if_gated_on_field_descriptor(rc, branches_start, branches_len)
                         || comptime_if_gated_on_each_loopvar(rc, branches_start, branches_len))) {
         var ai: u32 = 0;
@@ -2055,6 +2056,65 @@ fun comptime_if_gated_on_param(rc: *ResolveContext, branches_start: u32, branche
 # branches_start: first branch index
 # branches_len:   number of branches
 # ret:            true when an arm gate contains a type comparison
+# reports whether any arm gate of a `$if` chain measures a type (#2857)
+#
+# A layout intrinsic needs the type LAID OUT, which happens after resolve, so a
+# chain gated on one defers exactly as a type-comparison chain does: bind every
+# arm, and let sema select once the layout resolver exists. Without this the gate
+# folds against no resolver here and the whole chain is refused, which is what made
+# `$if ($size_of(A) != $size_of(B))` unusable.
+#
+# SEPARATE FROM `comptime_if_has_type_comparison` rather than folded into it,
+# although both defer for the same underlying reason. That predicate has a second
+# job: sema reads its twin to route a chain into `prune_type_comparison_chain`,
+# which checks only the live arm and leaves the dead ones untyped. A layout gate
+# wants the ordinary path, so widening the type-comparison predicate would change
+# which machinery runs, not just when it runs.
+# ---
+# rc:             resolver state for the module being resolved
+# branches_start: first branch index
+# branches_len:   number of branches
+# ret:            true when an arm gate measures a type
+fun comptime_if_has_layout_intrinsic(rc: *ResolveContext, branches_start: u32, branches_len: u32) bool {
+    var bi: u32 = 0;
+    for (bi < branches_len) {
+        val br: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + bi];
+        if (br.cond != id.EXPR_NIL && gate_has_layout_intrinsic(rc, br.cond)) {
+            ret true;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# walks `eid` reporting whether any leaf is a layout intrinsic call
+#
+# The same walk shape as `gate_has_type_comparison`, and it must stay that shape: a
+# gate is an expression, so the intrinsic can sit under a comparison, an arithmetic
+# operator or a negation - `$size_of(A) + $size_of(B) > LIMIT` is the case that
+# makes a top-level-only test wrong.
+# ---
+# rc:  resolver state for the module being resolved
+# eid: the gate expression
+# ret: true when a layout intrinsic appears anywhere in it
+fun gate_has_layout_intrinsic(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        ret gate_has_layout_intrinsic(rc, e.data.binary.lhs)
+         || gate_has_layout_intrinsic(rc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret gate_has_layout_intrinsic(rc, e.data.unary.operand);
+    }
+    if (e.kind == expr.EXPR_KIND_CALL) {
+        ret comptime.is_layout_intrinsic_call(rc.a, rc.source, eid);
+    }
+    ret false;
+}
+
 fun comptime_if_has_type_comparison(rc: *ResolveContext, branches_start: u32, branches_len: u32) bool {
     var bi: u32 = 0;
     for (bi < branches_len) {

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -191,11 +191,13 @@ pub fun sema(
     comptime.set_field_resolver(ctx, context.resolve_field_member::*u8, scp::ptr);
     comptime.set_type_resolver(ctx, context.resolve_type_comparison_operand::*u8, scp::ptr);
     comptime.set_type_query_resolver(ctx, infer.resolve_type_query::*u8, scp::ptr);
+    comptime.set_layout_resolver(ctx, infer.resolve_layout_intrinsic::*u8, scp::ptr);
     val res_bodies: R.Result[bool, str] = infer_all_bodies(?sc);
     if (R.is_err[bool, str](res_bodies)) {
         comptime.set_field_resolver(ctx, nil, nil);
         comptime.set_type_resolver(ctx, nil, nil);
         comptime.set_type_query_resolver(ctx, nil, nil);
+        comptime.set_layout_resolver(ctx, nil, nil);
         dnit_context(?sc);
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_bodies));
     }
@@ -209,6 +211,7 @@ pub fun sema(
     comptime.set_field_resolver(ctx, nil, nil);
     comptime.set_type_resolver(ctx, nil, nil);
     comptime.set_type_query_resolver(ctx, nil, nil);
+    comptime.set_layout_resolver(ctx, nil, nil);
     context.inst_worklist_dnit(?sc);
     if (R.is_err[bool, str](res_reval)) {
         dnit_context(?sc);
@@ -660,11 +663,14 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     val saved_td:  ptr                  = octx.type_data;
     val saved_qfn: *u8                  = octx.query_fn;
     val saved_qd:  ptr                  = octx.query_data;
+    val saved_lfn: *u8                  = octx.layout_fn;
+    val saved_ld:  ptr                  = octx.layout_data;
     val saved_ifn: *u8                  = octx.ident_fn;
     val saved_id:  ptr                  = octx.ident_data;
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, tscp::ptr);
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, tscp::ptr);
     comptime.set_type_query_resolver(octx, infer.resolve_type_query::*u8, tscp::ptr);
+    comptime.set_layout_resolver(octx, infer.resolve_layout_intrinsic::*u8, tscp::ptr);
     comptime.set_ident_resolver(octx, context.comptime_ident_is_runtime::*u8, tscp::ptr);
     tsc.inst_site     = site;
     tsc.inst_site_set = true;
@@ -673,6 +679,7 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     comptime.set_field_resolver(octx, saved_ffn, saved_fd);
     comptime.set_type_resolver(octx, saved_tfn, saved_td);
     comptime.set_type_query_resolver(octx, saved_qfn, saved_qd);
+    comptime.set_layout_resolver(octx, saved_lfn, saved_ld);
     comptime.set_ident_resolver(octx, saved_ifn, saved_id);
 
     free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -515,6 +515,56 @@ fun fold_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, span: token.
     ret O.some[O.Option[comptime.CTValue]](O.some[comptime.CTValue](comptime.ct_uint(n::u64)));
 }
 
+# the comptime channel's door onto `fold_layout_intrinsic` (#2857)
+#
+# ONE MEASUREMENT POLICY, TWO POSITIONS. A type position folds the intrinsic before
+# the evaluator ever sees it; a comptime CONDITION reaches the evaluator, which calls
+# back here. Both go through `fold_layout_intrinsic`, so a size measured in an array
+# length and the same size measured in a `$if` cannot disagree - which they would the
+# moment this grew its own copy of "force the layout, then ask `type_extent`".
+#
+# The failure path reports through sema's sink rather than handing a string back,
+# because the rich diagnostics live there: a layout cycle names the type it could not
+# break, and an unmeasurable operand names the type. Returning a bare string would
+# flatten both. What travels back is only whether an answer exists.
+# ---
+# data: the erased SemaContext
+# eid:  the intrinsic call expression, as a raw id
+# ret:  ok(some(v)) measured; ok(none) not answerable here (`$offset_of`); err when
+#       a diagnostic was already reported against it
+pub fun resolve_layout_intrinsic(data: ptr, eid: u32) R.Result[O.Option[comptime.CTValue], str] {
+    val sc: *context.SemaContext = data::*context.SemaContext;
+    if (sc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val e: id.ExprId = eid::id.ExprId;
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, e);
+    if (O.is_none[*expr.Expr](e_opt)) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+    val span: token.Span = O.unwrap[*expr.Expr](e_opt).span;
+
+    val lay: O.Option[O.Option[comptime.CTValue]] = fold_layout_intrinsic(sc, e, span);
+    # `$offset_of` is not folded here - sema's field-descriptor contract leaves an
+    # offset to lowering - so it falls back to the evaluator's own refusal, which
+    # names that reason rather than this one.
+    if (O.is_none[O.Option[comptime.CTValue]](lay)) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+    val inner: O.Option[comptime.CTValue] = O.unwrap[O.Option[comptime.CTValue]](lay);
+    if (O.is_none[comptime.CTValue](inner)) {
+        ret R.err[O.Option[comptime.CTValue], str](LAYOUT_REPORTED_MSG);
+    }
+    ret R.ok[O.Option[comptime.CTValue], str](
+        O.some[comptime.CTValue](O.unwrap[comptime.CTValue](inner)));
+}
+
+# what a caller prints when the real diagnostic is already on the sink
+#
+# `fold_layout_intrinsic` reports the precise cause itself, so this exists only to
+# keep the evaluator's contract total. It says what happened rather than restating a
+# cause it does not have, because a second guess at the reason beside an accurate one
+# is worse than a pointer to it.
+pub val LAYOUT_REPORTED_MSG: str = "this layout intrinsic could not be measured; see the diagnostic reported against it";
+
 # the by-value nesting depth the forcing walk follows before leaving the rest to the
 # measurement. cycle protection is the ACTIVE marker, not this; the bound only stops
 # a pathological nest from running the stack out ahead of `SEMA_LAYOUT_MAX_DEPTH`,

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -543,6 +543,7 @@ fun comptime_resolvers_install(octx: *comptime.ComptimeCtx, lc: *context.LowerCo
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, lc::ptr);
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, lc::ptr);
     comptime.set_type_query_resolver(octx, context.resolve_type_query::*u8, lc::ptr);
+    comptime.set_layout_resolver(octx, context.resolve_layout_intrinsic::*u8, lc::ptr);
     comptime.set_ident_resolver(octx, context.comptime_ident_is_runtime::*u8, lc::ptr);
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -384,6 +384,10 @@ pub fun init_context(
     comptime.set_field_resolver(ctx, resolve_field_member::*u8, lc::ptr);
     # install the type-query resolver so a `$is_record` / `$type_name` gate folds here.
     comptime.set_type_query_resolver(ctx, resolve_type_query::*u8, lc::ptr);
+    # and the layout resolver, so a `$size_of` / `$align_of` gate folds here too
+    # (#2857) - a chain whose arm is selected at monomorphization never reaches
+    # sema's resolver.
+    comptime.set_layout_resolver(ctx, resolve_layout_intrinsic::*u8, lc::ptr);
     # install the identifier-binding resolver so a gate folded here reads the
     # declaration each leaf resolves to rather than its spelling (#2764).
     comptime.set_ident_resolver(ctx, comptime_ident_is_runtime::*u8, lc::ptr);
@@ -470,6 +474,7 @@ pub fun dnit_context(lc: *LowerContext) {
         comptime.set_type_resolver(lc.ctx, nil, nil);
         comptime.set_field_resolver(lc.ctx, nil, nil);
         comptime.set_type_query_resolver(lc.ctx, nil, nil);
+        comptime.set_layout_resolver(lc.ctx, nil, nil);
         comptime.set_ident_resolver(lc.ctx, nil, nil);
     }
     map.dnit[intern.StrId, LocalBinding](?lc.local_names);
@@ -673,6 +678,65 @@ pub fun resolve_type_query(data: ptr, tid: u32, which: u8) R.Result[O.Option[com
     val lc: *LowerContext = data::*LowerContext;
     if (lc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
     ret infer.answer_type_query(lc.s, tid, which);
+}
+
+# the layout resolver lowering installs so a `$size_of` / `$align_of` gate folds
+# here as well as in sema (#2857)
+#
+# LOWERING NEEDS ITS OWN because a `$if` chain does not always fold in sema: a chain
+# gated on a comptime value parameter, or one inside a generic body, has its arm
+# selected here at monomorphization instead - which is why lowering already installs
+# a type-query resolver beside this one. A layout gate reaching that point with no
+# resolver was refused outright, so the sema-side fix alone left the generic case
+# broken.
+#
+# The measurement is `ir_type.byte_size` / `byte_align` over the IR type, the same
+# authority `lower_comptime_intrinsic` reads for a VALUE position two files over.
+# That is what keeps a size folded in a gate equal to the same size folded in an
+# expression: sema's `type_extent` and this both resolve through the one session
+# layout entry (see the note at `lower_type`), so the three cannot disagree.
+#
+# `$offset_of` answers none: it takes a field as its second argument, which this
+# signature does not carry, and sema does not fold it in a gate either.
+#
+# `$length_of` answers none too, for a different and narrower reason: its operand is
+# often written inline (`$length_of([4]f32)`), and an inline type-ref inside a GATE
+# carries no recorded expression type here, so the count cannot be read back. Rather
+# than report a false "expects a fixed array" against an operand that plainly is one,
+# a `$length_of` gate is not deferred to this point at all - see
+# `gate_has_layout_intrinsic` in resolve, and #2875.
+# ---
+# data: the erased *LowerContext
+# eid:  the intrinsic call expression, as a raw id
+# ret:  ok(some(v)) measured; ok(none) not answerable here; err on a real failure
+pub fun resolve_layout_intrinsic(data: ptr, eid: u32) R.Result[O.Option[comptime.CTValue], str] {
+    val lc: *LowerContext = data::*LowerContext;
+    if (lc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val e: id.ExprId = eid::id.ExprId;
+    val src: str = module_source(lc);
+    val is_size:  bool = comptime.is_size_of_call(lc.a, src, e);
+    val is_align: bool = comptime.is_align_of_call(lc.a, src, e);
+    if (!is_size && !is_align) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+
+    val arg: id.ExprId = comptime.layout_intrinsic_type_arg(lc.a, e);
+    if (arg == id.EXPR_NIL) {
+        ret R.err[O.Option[comptime.CTValue], str]("a layout intrinsic takes one type argument");
+    }
+    # secret-stripped for the reason every other shape decision here is (#2297):
+    # `^T` occupies exactly `T`'s storage.
+    val op_ty: type.TypeId = type.strip_secret(?lc.s.types, expr_type_of(lc, arg));
+
+    val res_ir: R.Result[ir_type.IrTypeId, str] = lower_type(lc, op_ty);
+    if (R.is_err[ir_type.IrTypeId, str](res_ir)) {
+        ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[ir_type.IrTypeId, str](res_ir));
+    }
+    val op_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_ir);
+
+    var n: u32 = ir_type.byte_size(?lc.m.types, op_ir, lc.tgt);
+    if (is_align) { n = ir_type.byte_align(?lc.m.types, op_ir, lc.tgt); }
+    ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_uint(n::u64)));
 }
 
 # the field-descriptor member resolver lowering installs on every ComptimeCtx it


### PR DESCRIPTION
Closes #2857.

`$size_of` and `$align_of` are constants, but a `$if` condition refused them. The thing most worth asserting about a layout is usually a **relationship** between two of them, and that is exactly what a `$if` expresses — so the assertion could only be a runtime test that fires if someone runs the suite, rather than a `$error` in the build that introduced the mistake.

The motivating case, from `boom`: two uniform records the renderer writes into one slot at a fixed offset must be the same size. If they diverge, one shader reads its colour out of the middle of a matrix, with no diagnostic at any layer.

## What changed

**A resolver seam, not a second measurement.** The comptime evaluator gained `set_layout_resolver`, the same shape as the type-query hook beside it. Sema answers it through the same `fold_layout_intrinsic` a type position already used, so a size measured in an array length and the same size measured in a `$if` cannot disagree — which they would the moment this grew its own copy of "force the layout, then ask `type_extent`".

**Lowering installs one too.** A chain gated on a comptime parameter, or inside a generic body, has its arm selected at monomorphization and never reaches sema's resolver — which is why lowering already installs a type-query resolver. Without the layout one, the sema-side fix alone left the generic case broken.

**Resolve reaches the position through a mechanism that already existed.** `bind_comptime_if` binds every arm and defers arm selection when a gate cannot fold yet — what a type-comparison gate has always done. A layout gate joins that list. It is a **separate predicate** rather than folded into `comptime_if_has_type_comparison`, because sema reads that one's twin to route a chain into `prune_type_comparison_chain`; widening it would change which machinery runs, not just when.

## Diagnostics

`a layout intrinsic has no value in this position` was true of every position and is now true of one. A declaration-scope `$if` still cannot measure — it selects which declarations exist, decided before any type is laid out — so it says that and points at the position that works. `$offset_of` is named apart, since it is unavailable for a different reason (a field offset is decided at lowering) and a message about type checking would be stale the moment the resolver exists.

## Verification

- **1392 tests pass.** The new test **fails against the unfixed compiler** — verified by reverting the six source files to `dev` while keeping the tests.
- **Every case is asserted in both directions** via `ut_arm`, which requires the expected marker to fire *and* the other to be absent. This is load-bearing: a gate that fails to fold selects no arm and type-checks **every** arm, so both markers fire, and a one-sided "expected marker present" assertion passes against a gate that stopped folding entirely. I hit exactly this while developing — my first hand-checks used conditions that were *false*, and a silent build is indistinguishable between "folded false" and "failed to fold". Every positive case now uses a condition that must fire.
- Sizes are chosen so no single constant satisfies the set, and the alignment case is checked against a value the size is not, so a fold returning an alignment where a size was asked for fails.
- Two updated tests assert the **new wording** for declaration-scope refusals. Behaviour there is unchanged; only the message improved.

## Deliberately not closed

- **#2875** — `$length_of` still does not fold in a gate. Its operand is usually inline (`$length_of([4]f32)`), and an inline type-ref in a gate carries no recorded expression type by the time lowering re-folds the chain. Rather than report *"expects a fixed array or a vector"* against an operand that plainly is one, it keeps its previous honest refusal. A false statement about correct code is worse than the refusal it would replace.
- **#2876** — no declaration-scope gate can see a type at all. That is shared with type queries and comparisons, is a genuine resolve-ordering question rather than an oversight, and is much larger than this issue.

No `int/` cases added, per the freeze.
