### PR TITLE
fix(spirv): take a gep index width from the addressing model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Resolve reaches the position through a mechanism that was already there: `bind_c
 
 Two limits are filed rather than left implicit: `$length_of` still does not fold in a gate (#2875), and no declaration-scope gate can see a type at all, which is shared with type queries and comparisons (#2876).
 
+### Fixed
+
+#### A shader indexing with a `u32` no longer requires `shaderInt64` (#2878)
+A SPIR-V module whose arithmetic was entirely 32-bit declared `OpCapability Int64`, because every array index was widened to the target's pointer width before it reached the emitter. That is right for a byte-addressed machine, where an index is scaled by the element size and added to a base address and so must fill a machine word. SPIR-V addresses logically: an `OpAccessChain` index selects a member, nothing scales it, and the widening bought nothing.
+
+It cost a device requirement. `shaderInt64` is an optional feature, so a shader that performed no 64-bit arithmetic was refused outright by `vkCreateShaderModule` on hardware without it, and was invalid usage on hardware with it unless the application had enabled the feature. Downstream this was worked around by requesting the feature unconditionally and refusing to start without it, which narrowed the hardware the application ran on.
+
+The index width is now taken from `MachineModel.flat_addressing`, the same axis that already gates float address materialization and aggregate member walks (#2655), so the transformation is gated rather than the target. A genuinely 64-bit index still declares `Int64`, since that is what the program asked for. Every machine target's output is byte-identical.
+
 
 ### Added
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -15159,6 +15159,85 @@ fun ut_spv_export_count(w: *u32, n: u32) u32 {
     ret c;
 }
 
+# whether the module declares one capability
+# ---
+# w, n: the instruction words
+# cap:  the capability
+# ret:  true when an OpCapability names it
+fun ut_spv_has_cap(w: *u32, n: u32, cap: u32) bool {
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret false; }
+        if ((w[i] & 0xFFFF) == spirv.OP_CAPABILITY && len >= 2 && w[i + 1] == cap) { ret true; }
+        i = i + len;
+    }
+    ret false;
+}
+
+# lower and emit a single-module shader, and report whether it declares Int64
+# ---
+# s, alloc:  session and allocator
+# src:       the module text
+# out_has:   receives whether OpCapability Int64 is declared
+# ret:       true when the module lowered and emitted
+fun ut_spv_declares_int64(s: *session.Session, alloc: *A.Allocator, src: str, out_has: *bool) bool {
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach"; texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_lower(s, alloc, ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret false; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, s, "spvcase.main", ?img, ?err)) { project.dnit_project(?p); ret false; }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); ret false; }
+
+    @out_has = ut_spv_has_cap(w, n, spirv.CAP_INT64);
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    ret true;
+}
+
+# a shader indexing an array with a u32 does not acquire Int64 (#2878)
+#
+# `widen_index` normalized every gep index to the target's POINTER width, which is
+# how a byte-addressed machine gets a full-width index register to scale. SPIR-V
+# addresses logically: an OpAccessChain index selects a member and nothing scales
+# it, so the widening bought nothing and cost a `shaderInt64` device requirement on
+# a module whose arithmetic is entirely 32-bit. A device without the feature refuses
+# the module outright, so this narrowed the hardware a shader ran on.
+#
+# BOTH ARMS ARE THE TEST. Asserting only the u32 arm would pass just as well if the
+# emitter had stopped declaring Int64 at all, which would take a genuinely 64-bit
+# shader from a wrong capability list to an invalid module. The u64 arm holds the
+# declaration in place where the program actually asked for it.
+test "mach.lang.driver:spirv_u32_index_does_not_declare_int64" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val narrow: str = "rec Palette { columns: [64]f32x4; }\n#[storage(0, 0)] var palette: Palette;\n\n#[input(0)]            var in_ix:    u32;\n#[builtin(\"position\")] var position: f32x4;\n\n#[stage(\"vertex\")]\nfun vs() { position = palette.columns[in_ix * 2]; }\n\nfun main() i32 { ret 0; }\n";
+    val wide:   str = "rec Palette { columns: [64]f32x4; }\n#[storage(0, 0)] var palette: Palette;\n\n#[input(0)]            var in_ix:    u32;\n#[builtin(\"position\")] var position: f32x4;\n\n#[stage(\"vertex\")]\nfun vs() { val w: u64 = in_ix::u64 * 2::u64; position = palette.columns[w]; }\n\nfun main() i32 { ret 0; }\n";
+
+    var bad: i32 = 0;
+    var has_narrow: bool = false;
+    var has_wide:   bool = false;
+    if (!ut_spv_declares_int64(?s, ?alloc, narrow, ?has_narrow)) { session.dnit(?s); ret 1; }
+    if (!ut_spv_declares_int64(?s, ?alloc, wide,   ?has_wide))   { session.dnit(?s); ret 1; }
+
+    if (has_narrow) { bad = 1; }
+    if (!has_wide)  { bad = 1; }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 # the cross-module fixture's root module: two stages reaching one helper chain
 #
 # `#[noinline]` throughout, because the subject is what the EMITTER put in the

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3831,26 +3831,49 @@ fun ir_type_of_expr(ctx: *context.LowerContext, eid: id.ExprId) R.Result[ir_type
     ret context.lower_type(ctx, context.expr_type_of(ctx, eid));
 }
 
-# the IR integer type used for gep indices and alloca element counts (pointer-width)
+# the bit width an index carries: a machine word on a flat target, an ordinal on a
+# logical one
+#
+# On a flat target an index is scaled by the element size and added to a base
+# address, so it is address arithmetic and must be a full machine word. On a logical
+# one (`MachineModel.flat_addressing` false) nothing is scaled: an index selects a
+# MEMBER, and SPIR-V's OpAccessChain takes it at whatever integer width it is given.
+# Pointer width is meaningless there, and taking it anyway is what made a shader
+# written entirely in u32 declare OpCapability Int64 (#2878) - a hardware requirement
+# for arithmetic the module never performs.
+#
+# 32 rather than the narrowest width that fits, because the SPIR-V capability ladder
+# runs the other way too: an 8- or 16-bit index would declare Int8 or Int16. 32 is
+# the one width a Vulkan environment always has, and it is the conventional width for
+# an access chain index.
 # ---
 # ctx: per-module lowering context
-# ret: the pointer-width IR int type, or an error
-fun index_type(ctx: *context.LowerContext) R.Result[ir_type.IrTypeId, str] {
-    ret ir_type.intern_int(?ctx.m.types, ctx.tgt.isa.pointer_width * 8);
+# ret: the index width in bits
+fun index_bits(ctx: *context.LowerContext) u32 {
+    if (!ctx.tgt.model.flat_addressing) { ret 32; }
+    ret ctx.tgt.isa.pointer_width * 8;
 }
 
-# widen a runtime gep index to the pointer-width machine-word index type
+# the IR integer type used for gep indices and alloca element counts
+# ---
+# ctx: per-module lowering context
+# ret: the index-width IR int type, or an error
+fun index_type(ctx: *context.LowerContext) R.Result[ir_type.IrTypeId, str] {
+    ret ir_type.intern_int(?ctx.m.types, index_bits(ctx));
+}
+
+# widen a runtime gep index to the index-width type
 #
-# A narrower index (e.g. a u8 enum/kind) is extended per its signedness; a pointer-width
-# (or wider) index is left as-is. Without this the back end scales the index's full
-# register while its high bits are undefined, producing a wild address.
+# A narrower index (e.g. a u8 enum/kind) is extended per its signedness; one already
+# at or above the index width is left as-is. Without this a flat target's back end
+# scales the index's full register while its high bits are undefined, producing a
+# wild address.
 #
-# This is the intentional, target-derived index-normalization point: the width is
-# the active target's pointer width (index_type), and the sign/zero extension is
-# chosen here from the semantic signedness. it deliberately stays in the middle-end,
-# not the back end - the IR is signless and OP_GEP carries no per-index signedness,
-# so the back end could not pick sext vs zext; relocating it would regress signed
-# sub-word indices (#1598).
+# This is the intentional, target-derived index-normalization point: the width comes
+# from `index_bits` and the sign/zero extension is chosen here from the semantic
+# signedness. it deliberately stays in the middle-end, not the back end - the IR is
+# signless and OP_GEP carries no per-index signedness, so the back end could not pick
+# sext vs zext; relocating it would regress signed sub-word indices (#1598).
 # ---
 # ctx:    per-module lowering context
 # v:      the index value
@@ -3860,7 +3883,7 @@ fun widen_index(ctx: *context.LowerContext, v: value.Value, sem_ty: type.TypeId)
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
     val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
-    if (scalar_bits(ctx, sem_ty) >= ctx.tgt.isa.pointer_width * 8) { ret R.ok[value.Value, str](v); }
+    if (scalar_bits(ctx, sem_ty) >= index_bits(ctx)) { ret R.ok[value.Value, str](v); }
     if (is_signed_type(ctx, sem_ty))    { ret builder.emit_sext(?ctx.builder, v, xty); }
     ret builder.emit_zext(?ctx.builder, v, xty);
 }


### PR DESCRIPTION
`widen_index` in `src/lang/me/lower/expr.mach` normalized every gep index to `pointer_width * 8`. Its own doc gave the reason: the back end scales the index's full register, so a sub-word index must be widened first or its undefined high bits corrupt the scaled offset.

That reason is true for a byte-addressed machine and false for SPIR-V. Under logical addressing an `OpAccessChain` index selects a member and nothing is scaled, so the widening bought nothing and emitted an `OpUConvert` to `%ulong` in front of every runtime index, which pulled in `OpCapability Int64`.

The width now comes from `MachineModel.flat_addressing`, the axis that already gates float address materialization and aggregate member walks (#2655). `isa.mach:592` states the rule this follows: gate the transformation, not the target.

32 bits rather than the narrowest width that fits, because the capability ladder runs the other way too and an 8- or 16-bit index would declare `Int8` or `Int16`. A genuinely 64-bit index is left alone and still declares `Int64`, which is what the program asked for.

## Verification

Against a baseline compiler built from `dev`, not the 4.16.0 on PATH.

- The issue's repro: `OpCapability Int64`, `%ulong`, and all four `OpUConvert` gone. `spirv-val --target-env vulkan1.3` passes.
- **Counterfactual run.** Reverting `expr.mach` while keeping the test fails it. Restored, 1393 pass.
- **Byte-identical on every machine target**, 224 objects each for `linux-x86_64`, `linux-arm64` and `linux-riscv64`, one fixed source tree compiled by both compilers.
- The existing `int/surface/spirv-storage` fixture was carrying the bug: it declared `Int64` before and does not now. Its opcode histogram moves by exactly the four `OpUConvert` and the `ulong` temps each fed, plus the type, its pointer type and the capability. `OpIAdd`, `OpFAdd`, `OpAccessChain` and `OpCompositeExtract` counts are unchanged, so no arithmetic moved. The result validates.

## On the test

`spirv_u32_index_does_not_declare_int64` asserts **both** directions. The u32 arm alone would pass equally well if the emitter had stopped declaring `Int64` at all, which would take a genuinely 64-bit shader from a wrong capability list to an invalid module. The u64 arm holds the declaration in place. I confirmed by hand that the u64 arm passes for the stated reason and not incidentally: that module really does carry a 64-bit index into its access chain, and validates.

No integration case, per the freeze. Checked by hand with `spirv-dis` and `spirv-val`.

Found and not fixed here: a no-op `OpBitcast %ulong %ulong_2` casting a constant to its own type. It predates this change and is filed separately.

Closes #2878.
