### PR TITLE
fix(codegen): legalize a wide access at a symbol instead of segfaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### An `i64` global compiles on rv32 instead of crashing the compiler (#2867)
+A wide global feeding wide arithmetic on riscv32 killed the compiler with SIGSEGV and no diagnostic, and the same construct without the arithmetic produced a refusal. Both came from one place. Lowering folds a global straight into the access as a symbol operand, so a `MIR_LOAD` or `MIR_STORE` on one carries no memory operand at all, while `legalize` entered its memory path on the opcode alone and then indexed the memory operand it assumed was there. The index was `-1`: one shape read a wild pointer and faulted, the other read one slot past the operand array and refused off whatever it found. The refusal was never a decision.
+
+The pass now decides that a memory access is one by finding the address, not by reading the opcode, and it recognizes the two forms an address takes: a memory operand walked by displacement, and a symbol walked by addend. So a wide global is no longer refused either - it is legalized like any other fixed base, one native access per lane at successive offsets on the same symbol, which is what a 64-bit value on a 32-bit machine has always cost. An access whose address is neither form falls through to the named refusal for its opcode rather than into an expansion that cannot describe it.
+
+mos6502, the other target that legalizes to a narrower ALU, is unaffected: an `i64` there needs a frame slot and the pass refuses the wide `MIR_ALLOCA` before any access is examined.
+
 ### Added
 
 #### A layout intrinsic can be measured inside a comptime `$if` (#2857)

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -734,30 +734,54 @@ fun wide_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
 # against a stack slot (`MOV pv <- [fp + off]` for an incoming parameter): a move
 # with a memory operand IS a load or a store, and decomposing it per lane makes it
 # one. A declassify rides the move path for the same reason it does everywhere else.
+#
+# THE ADDRESS OPERAND IS WHAT MAKES IT A MEMORY ACCESS, not the opcode alone (#2867).
+# An access whose address this pass cannot name is not routed down the memory path at
+# all. It falls through to the generic refusal, which names the load or store, rather
+# than into an expansion that indexes an operand that is not there.
 # ---
 # mi:  the instruction to test
 # ret: true when the instruction reaches memory
 fun instr_is_memory(mi: *mir.MirInstr) bool {
     val op: mir.MirOpcode = mi.opcode;
-    if (op == mir.MIR_LOAD || op == mir.MIR_STORE) { ret true; }
-    if (op != mir.MIR_MOV && op != mir.MIR_DECLASSIFY) { ret false; }
-    ret mem_operand_index(mi) >= 0;
+    if (op != mir.MIR_LOAD && op != mir.MIR_STORE &&
+        op != mir.MIR_MOV  && op != mir.MIR_DECLASSIFY) { ret false; }
+    ret addr_operand_index(mi) >= 0;
 }
 
-# the index of the instruction's single memory operand, or -1 when it has none
+# the index of the instruction's single address operand, or -1 when it has none
 #
-# A load, a store, and a memory-operand move each carry exactly one; the first one
-# found is therefore the one.
+# An access reaches its address either through a MEM operand or - for a global the
+# lowering folded straight into the access - through a SYM operand naming the datum.
+# Both are fixed bases the expansion walks by displacement, the MEM through `imm` and
+# the SYM through `sym_off`. Only a LOAD or a STORE reads a SYM as an address: a move
+# naming a symbol is materializing that address as a value, which `mir.lower` retags
+# to MIR_GEP, and treating it as an access would decompose the pointer itself.
 # ---
 # mi:  the instruction to inspect
 # ret: the operand index, or -1
-fun mem_operand_index(mi: *mir.MirInstr) i32 {
+fun addr_operand_index(mi: *mir.MirInstr) i32 {
+    val sym_is_addr: bool = mi.opcode == mir.MIR_LOAD || mi.opcode == mir.MIR_STORE;
     var k: u32 = 0;
     for (k < mi.operand_count) {
-        if (mi.operands[k].kind == mir.MIR_OP_MEM) { ret k::i32; }
+        val kind: mir.MirOperandKind = mi.operands[k].kind;
+        if (kind == mir.MIR_OP_MEM) { ret k::i32; }
+        if (kind == mir.MIR_OP_SYM && sym_is_addr) { ret k::i32; }
         k = k + 1;
     }
     ret -1;
+}
+
+# the address operand displaced `off` bytes from `base`
+# ---
+# base: the access's address operand
+# off:  the byte displacement to add
+# ret:  the same address, `off` bytes further along
+fun addr_displaced(base: *mir.MirOperand, off: i64) mir.MirOperand {
+    var o: mir.MirOperand = @base;
+    if (o.kind == mir.MIR_OP_SYM) { o.sym_off = base.sym_off + off::i32; ret o; }
+    o.imm = base.imm + off;
+    ret o;
 }
 
 # whether a memory operand's base is a runtime pointer that must be staged
@@ -789,7 +813,7 @@ fun base_needs_staging(plan: *LanePlan, mem: *mir.MirOperand) bool {
 # ret:  the exact piece count, or an error naming the unsupported shape
 fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     if (mi.operand_count != 2) { ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width)); }
-    val mx: i32 = mem_operand_index(mi);
+    val mx: i32 = addr_operand_index(mi);
     val vx: u32 = 1 - mx::u32;
     var n: u32 = wide_lane_count(plan, mi);
     if (!operand_is_lane_ready(plan, ?mi.operands[vx], n)) {
@@ -811,7 +835,8 @@ fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) 
 # Stages a runtime-pointer base into the backend's reserved address pair first (one
 # native move per pointer lane), then emits one access per value lane at successive
 # displacements off that fixed base. A base that is already fixed - a physical
-# register or a frame-slot key - is used directly and only the displacement walks.
+# register, a frame-slot key, or a symbol - is used directly and only the
+# displacement walks.
 # The pieces are always the explicit `MIR_LOAD` / `MIR_STORE` opcodes even when the
 # source was a memory-operand move, so a backend that has decomposed its addressing
 # sees one memory form rather than two.
@@ -827,7 +852,7 @@ fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
     val rc: R.Result[u32, str] = memory_piece_count(alloc, plan, mi);
     if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
 
-    val mx:  u32 = mem_operand_index(mi)::u32;
+    val mx:  u32 = addr_operand_index(mi)::u32;
     val vx:  u32 = 1 - mx;
     val lw:  u8  = plan.lane_width;
     val nl:  u32 = wide_lane_count(plan, mi);
@@ -847,8 +872,7 @@ fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 
     var i: u32 = 0;
     for (i < nl) {
-        var mem: mir.MirOperand = base;
-        mem.imm = base.imm + (i * lw::u32)::i64;
+        val mem: mir.MirOperand = addr_displaced(?base, (i * lw::u32)::i64);
         var ops: [2]mir.MirOperand;
         var opcode: mir.MirOpcode = mir.MIR_LOAD;
         if (is_store) {
@@ -3817,6 +3841,67 @@ test "mach.lang.be.codegen.legalize:expands_wide_access_at_a_fixed_base" {
         if (b.instrs[i].operands[1].imm != i::i64)          { ret 1; }
         i = i + 1;
     }
+    ret 0;
+}
+
+# a wide access to a GLOBAL reaches its address through a SYM operand rather than a
+# MEM one, and decomposes into one native access per lane at successive addends on the
+# same symbol (#2867). the symbol is a fixed base exactly as a physical register is,
+# so nothing is staged
+test "mach.lang.be.codegen.legalize:expands_a_wide_access_at_a_symbol" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 1);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 1);
+    var ld: [2]mir.MirOperand;
+    ld[0] = mir.op_vreg(0); ld[1] = mir.op_sym(7, 0);
+    t_instr(?alloc, ?b, 0, mir.MIR_LOAD, ?ld[0], 2, 4);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(2, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+    if (b.instr_count != 2)     { ret 1; }
+
+    var i: u32 = 0;
+    for (i < 2) {
+        if (b.instrs[i].opcode != mir.MIR_LOAD)                { ret 1; }
+        if (b.instrs[i].width != 2)                            { ret 1; }
+        if (b.instrs[i].operands[0].vreg != 1 + i)             { ret 1; }
+        if (b.instrs[i].operands[1].kind != mir.MIR_OP_SYM)    { ret 1; }
+        if (b.instrs[i].operands[1].sym != 7)                  { ret 1; }
+        if (b.instrs[i].operands[1].sym_off != (i * 2)::i32)   { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a wide load whose address is neither a MEM nor a SYM is REFUSED BY NAME, not walked
+# down the memory path with an address operand that is not there (#2867)
+#
+# The positive control is the test above: the same wide load, the same width, the same
+# destination, differing only in that its address operand is one this pass can name.
+# That one succeeds, so this refusal is the address shape being rejected rather than a
+# malformed function being rejected for some other reason.
+test "mach.lang.be.codegen.legalize:refuses_a_wide_access_with_no_address_operand" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 1);
+    var ld: [2]mir.MirOperand;
+    ld[0] = mir.op_vreg(0); ld[1] = mir.op_vreg(1);
+    t_instr(?alloc, ?b, 0, mir.MIR_LOAD, ?ld[0], 2, 4);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(2, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (!R.is_err[bool, str](r)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -12581,6 +12581,48 @@ fun ut_mos_mul_sweep(s: *session.Session, alloc: *A.Allocator, bits: u32, ty: st
     ret bad;
 }
 
+# a wide GLOBAL feeding wide arithmetic compiles on every target that legalizes to a
+# narrower ALU (#2867)
+#
+# The lowering folds a global straight into the access as a SYM operand, so the access
+# carries no MEM operand at all. `legalize` used to enter its memory path on the opcode
+# alone and index an operand that was not there, which SEGFAULTED THE COMPILER on the
+# riscv32 shape below and, on the shape without the add, produced a refusal off the same
+# out-of-bounds read.
+#
+# NOTHING ABOUT THE DEFECT IS RISCV32-SPECIFIC and the repair is in shared code, but
+# mos6502 - the only other legalizing target - cannot reach the path: an `i64` there
+# needs a frame slot, and the pass refuses the wide MIR_ALLOCA address before any
+# access is examined. That was checked rather than assumed, and is why this test drives
+# one target.
+#
+# A BUILD, NOT A REFUSAL, IS THE ASSERTION: a wide global on a 32-bit machine is
+# ordinary code and the lane machinery already handles a fixed base, so the symbol is
+# walked by addend exactly as a frame slot is walked by displacement. The values the
+# emitted code computes are checked by hand against a reference RV32IM run. This test
+# holds the shape that used to crash.
+test "mach.lang.driver:wide_global_feeds_wide_arithmetic" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val src: str = "var trip: i64 = 3;\nvar sink: i64 = 0;\n#[noinline]\nfun bump(v: i64) i64 { ret v + trip; }\nfun main() i32 { sink = bump(5); ret 0; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, src, "rv32");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
+        project.dnit_project(?p);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 # ------------------------------------------------- the riscv32 execution harness
 
 # the reference core's flat image: code, then a stack well clear of it


### PR DESCRIPTION
## Root cause

`mir.lower` folds a global straight into the access it feeds, so a `MIR_LOAD` or `MIR_STORE` on a global carries a `MIR_OP_SYM` operand and **no `MIR_OP_MEM` operand at all**. `legalize.instr_is_memory` answered `true` for a load or a store on the opcode alone, and `memory_piece_count` then called `mem_operand_index`, which only ever matched a MEM operand and returned `-1`. Both index computations ran on that `-1`: `vx = 1 - (-1)::u32` is `2`, one slot past a two-operand array, and `mi.operands[mx::u32]` is `operands[0xFFFFFFFF]`, a wild pointer. The wide-load-plus-add shape dereferenced the wild pointer and faulted at `base_needs_staging`. The shape without the add read the slot past the array, found something that did not look lane-ready, and refused. That is why the same unsupported-looking construct was named in one shape and fatal in the other: neither answer was a decision, both were the same out-of-bounds read.

## The fix, and why it supports rather than refuses

`legalize` already walks a fixed base by displacement, and a symbol is a fixed base, so a wide global costs exactly what any other wide access costs on a narrow ALU: one native access per lane at successive offsets. Refusing it would have made `var g: i64` unusable on a 32-bit target for no machine reason, and `encode.emit_global_load` / `emit_global_store` already honour `sym_off`.

- A memory access is identified by **finding its address**, not by reading its opcode. `addr_operand_index` recognizes the two forms an address takes: a MEM walked through `imm`, and a SYM walked through `sym_off`. Only a load or a store reads a SYM as an address, because a move naming a symbol is materializing that address as a value and `mir.lower` retags it to `MIR_GEP`.
- `addr_displaced` owns the "same address, `n` bytes along" rule for both forms, so the expansion no longer pokes `imm` directly.
- An access whose address is neither form is no longer routed down the memory path. It falls through to the generic refusal that names its opcode, which is the invariant the guard was supposed to uphold.

## mos6502

Checked rather than assumed. The repair is in shared code but mos6502 cannot reach the path: an `i64` there needs a frame slot and the pass refuses the wide `MIR_ALLOCA` first (`legalize: materializing an address wider than one register is not yet legalized on this target`). No arch gate was removed.

## Verification

Built and run from `out/linux-x86_64/debug/bin/mach`, never the 4.16.0 on PATH.

- `mach build .` then `mach test .`: **1395 passed, 0 failed**.
- **Counterfactual.** With only the two functional lines reverted (SYM not recognized as an address, load/store memory again on the opcode alone) and the tests kept, all three new tests fail with **signal 11**, and the issue's CLI repro still exits 139. Including the refusal test, which crashes rather than refusing, so it is exercising the guard rather than agreeing with it.
- **Positive control for the refusal test.** `expands_a_wide_access_at_a_symbol` builds the same wide load, same width, same destination, differing only in an address operand the pass can name, and asserts the lane accesses land at addends 0 and 2 on the same symbol. It succeeds, so the refusal beside it is the address shape being rejected and not a malformed function.
- **Values, not just "it compiles".** The reference RV32IM core in the unit-test harness loads `.text` alone with relocations unapplied, so it cannot execute a global. Instead the linked freestanding rv32 image was executed on an independent RV32IM interpreter written from the manual, over five value pairs exercising carry across the lane boundary, borrow, the sign boundary and alternating patterns, through a wide global **load**, a wide global **store**, an add and a subtract. All five matched the host-computed reference exactly. Reverting the fix, the same programs do not build at all.

Closes #2867.
