### PR TITLE
feat(spirv): decorate an unwritten storage binding NonWritable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### A storage binding nothing writes is emitted `NonWritable`, and can say so (#2879)
+A `#[storage(set, binding)]` buffer that a stage only reads was emitted with no `NonWritable` decoration, so every consumer had to enable `vertexPipelineStoresAndAtomics` to read one from a vertex stage. The read-only case is the common one - a joint palette, an instance buffer, a light list - and it is the case where the decoration is free and its absence costs a hardware requirement.
+
+The emitter now decides it from the module. A storage binding no emitted body stores through is decorated `NonWritable`, over the same emitted closure every other whole-module rule here is stated about, so a store from a drawn-in library body counts exactly as a local one does. The analysis is a **proof rather than a search**: two positions read - a load's address and an access chain's base, whose result is then subject to the same question - and every other appearance of the binding or of a pointer derived from it counts as a write. A missing decoration is therefore possible and a wrong one is not.
+
+`#[storage(set, binding, "readonly")]` states it explicitly, and a store through such a binding is a compile error naming the line that wrote it, on every target rather than only on a SPIR-V build. That is what the qualifier buys over the inference: an accidental write does not produce a wrong module, it produces a correct one that quietly widens the pipeline's requirements, and the qualifier turns it into a diagnostic. The emitter refuses a write it can still see after lowering - an address handed somewhere it cannot follow - so the decoration cannot become a promise the module breaks. The memory qualifier rides after the descriptor pair rather than in a second decorator name, so a further qualifier is one accepted spelling and no new interface role.
+
+Everything else is unchanged: of boom's seven shaders, the six with no storage binding are byte-identical, and `skinned_vert` differs by exactly the one decoration.
+
 #### A layout intrinsic can be measured inside a comptime `$if` (#2857)
 `$size_of` and `$align_of` are constants, but they could not appear in a `$if` condition, so the thing most worth asserting about a layout - a **relationship** between two of them - could only be a runtime test. Two records a renderer writes into one slot at a fixed offset must be the same size; if they diverge, one shader reads its colour out of the middle of a matrix, with no diagnostic at any layer. A test catches that only if someone runs the suite. A `$error` catches it in the build that introduced it.
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -46,6 +46,7 @@ A decorator is written as an attribute:
 #[builtin("name")]   # pipeline built-in variable (global only)
 #[uniform(set, bnd)] # descriptor-bound uniform block, read-only (global only)
 #[storage(set, bnd)] # descriptor-bound storage buffer, read-write (global only)
+#[storage(set, bnd, "readonly")] # the same buffer, with writes refused
 #[sampler(set, bnd)] # descriptor-bound image / sampler handle (global only)
 #[spirv_op(set,name)] # the SPIR-V instruction this function is (fun only)
 ```
@@ -634,6 +635,27 @@ rules, which use the element's natural stride, and that *is* mach's layout, so
 A compute stage's data path is `storage`: Vulkan forbids the `Output` storage class
 in a compute execution model, so a compute shader reads and writes buffers rather
 than varyings.
+
+`storage` takes **memory qualifiers** after the descriptor pair. There is one,
+`"readonly"`, and it says that nothing writes the binding:
+
+```mach
+rec Palette { columns: [512]f32x4; }
+#[storage(0, 3, "readonly")] var palette: Palette;
+```
+
+A store through a `"readonly"` binding is a compile error on every target, naming
+the line that wrote it. That is what the qualifier buys over what the compiler
+works out on its own: a buffer no body in the module stores through is emitted with
+the SPIR-V `NonWritable` decoration whether or not it is marked, and Vulkan reads
+that decoration to decide whether a stage needs `vertexPipelineStoresAndAtomics`.
+So an accidental write does not produce a wrong module, it produces a **correct one
+that quietly costs a hardware feature**. Marking the binding turns that into a
+diagnostic instead.
+
+The inference is one-sided on purpose. Anything the compiler cannot follow, such as
+the binding's address handed to a function, counts as a write, so a missing
+decoration is possible and a wrong one is not.
 
 `sampler` binds an **image or sampler handle** by descriptor set and binding, at
 the same descriptor addressing `uniform` and `storage` use, so a host binds one the

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -16145,3 +16145,162 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     session.dnit(?s);
     ret bad;
 }
+
+# whether `id` carries the operand-less decoration `decor`
+#
+# The length is checked exactly rather than as a minimum: an operand-less
+# decoration is a three-word instruction, and a longer one at the same target is a
+# DIFFERENT decoration whose operand happens to sit where this one's would not.
+# ---
+# w, n:  the instruction words
+# id:    the decorated id
+# decor: the decoration
+# ret:   true when the stream carries it
+fun ut_spv_has_bare_decor(w: *u32, n: u32, id: u32, decor: u32) bool {
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret false; }
+        if ((w[i] & 0xFFFF) == spirv.OP_DECORATE && len == 3
+            && w[i + 1] == id && w[i + 2] == decor) { ret true; }
+        i = i + len;
+    }
+    ret false;
+}
+
+# the read-only / written storage fixture: three storage bindings in one stage
+#
+# `(0, 3)` is only ever read, `(0, 4)` is read AND written, and `(0, 5)` is read and
+# carries the explicit qualifier. All three are reached by the same stage, so what
+# separates them is what the module does through them and nothing else.
+fun ut_spv_nonwritable_src() str {
+    ret "rec P { c: [8]f32x4; }\n\n#[storage(0, 3)] var ro: P;\n#[storage(0, 4)] var rw: P;\n#[storage(0, 5, \"readonly\")] var ro_marked: P;\n\n#[input(0)] var in_x: f32x4;\n#[builtin(\"position\")] var position: f32x4;\n\n#[stage(\"vertex\")]\nfun vert_main() {\n    rw.c[1] = in_x;\n    position = ro.c[2] + rw.c[3] + ro_marked.c[4];\n}\n";
+}
+
+# a storage binding no body stores through is decorated NonWritable, and one that is
+# written is not (#2879)
+#
+# BOTH DIRECTIONS ARE THE TEST. A pass that decorated every storage buffer would
+# satisfy the first assertion and be a miscompile: the decoration tells a driver the
+# module does not write the descriptor, so `(0, 4)` - which stores into it two
+# instructions earlier - must not carry it. The two bindings differ in nothing else.
+#
+# The read is through an ACCESS CHAIN, which is the shape that matters: a member walk
+# off the variable is how a shader actually reads a block, so an analysis that only
+# looked at whole-variable loads and stores would answer about neither binding.
+test "mach.lang.driver:spirv_marks_an_unwritten_storage_binding_nonwritable" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach"; texts[0] = ut_spv_nonwritable_src();
+    var dn: [1]str;
+    var dt: [1]str;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", ?dn[0], ?dt[0], 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    val ro: u32 = ut_spv_descriptor_var(w, n, 0, 3);
+    val rw: u32 = ut_spv_descriptor_var(w, n, 0, 4);
+    val mk: u32 = ut_spv_descriptor_var(w, n, 0, 5);
+    # the fixture is not degenerate: all three descriptors are really in the module.
+    if (ro == 0 || rw == 0 || mk == 0) { bad = 1; }
+    or {
+        if (!ut_spv_has_bare_decor(w, n, ro, spirv.DECOR_NON_WRITABLE)) { bad = 1; }
+        if (ut_spv_has_bare_decor(w, n, rw, spirv.DECOR_NON_WRITABLE))  { bad = 1; }
+        # the explicit qualifier reaches the same decoration the inference does.
+        if (!ut_spv_has_bare_decor(w, n, mk, spirv.DECOR_NON_WRITABLE)) { bad = 1; }
+    }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a store written as an assignment through a `"readonly"` binding is refused where it
+# is written, on every target (#2879)
+#
+# The qualifier's value over the inference is precisely this diagnostic: without it
+# an accidental write silently widens the module's hardware requirement, and the
+# author learns about it from a validation layer. Checked through the plain sema
+# helper rather than a SPIR-V fixture on purpose - which target a module is compiled
+# for is not a property of its source, so the CPU build of the same file refuses it.
+test "mach.lang.driver:storage_readonly_refuses_a_store" {
+    val src: str = "rec P { c: [8]f32x4; }\n\n#[storage(0, 3, \"readonly\")] var ro: P;\n\nfun poke(v: f32x4) { ro.c[1] = v; }\n\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects_with(src, "cannot store through a `#[storage(set, binding, \"readonly\")]` binding")) { ret 1; }
+    # and the same program without the qualifier is accepted, so the refusal is the
+    # qualifier's and not the shape of the write.
+    val ok: str = "rec P { c: [8]f32x4; }\n\n#[storage(0, 3)] var rw: P;\n\nfun poke(v: f32x4) { rw.c[1] = v; }\n\nfun main() i32 { ret 0; }\n";
+    if (ut_sema_rejects_with(ok, "cannot store through")) { ret 1; }
+    ret 0;
+}
+
+# an unknown `storage` memory qualifier is refused rather than ignored (#2879)
+#
+# A misspelling that was quietly dropped would compile to the UNCONSTRAINED binding -
+# the exact requirement the author wrote the qualifier to drop - and the module would
+# be correct, valid, and more expensive to bind than the one they asked for.
+test "mach.lang.driver:storage_refuses_an_unknown_qualifier" {
+    val src: str = "rec P { c: [8]f32x4; }\n\n#[storage(0, 3, \"readonlyy\")] var ro: P;\n\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects_with(src, "unknown `storage` memory qualifier")) { ret 1; }
+    # `uniform` takes no qualifier: it is read-only by its storage class already.
+    val un: str = "rec P { c: [8]f32x4; }\n\n#[uniform(0, 3, \"readonly\")] var u: P;\n\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects_with(un, "takes two arguments")) { ret 1; }
+    ret 0;
+}
+
+# a store the emitter can still see through a `"readonly"` binding is refused there
+# too (#2879)
+#
+# Sema refuses the ASSIGNMENT, which is the spelling an author reaches for. This is
+# the other half: an address handed somewhere the emitter cannot follow is a write it
+# must assume happens, and the qualifier turns that assumption into a refusal rather
+# than a decoration the module would break. Without it the emitter's promise and the
+# front end's guarantee could differ, and the decoration would be the one that lies.
+test "mach.lang.driver:spirv_refuses_an_escaping_readonly_storage_address" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach";
+    texts[0] = "rec P { c: [8]f32x4; }\n\n#[storage(0, 3, \"readonly\")] var ro: P;\n\n#[input(0)] var in_x: f32x4;\n#[builtin(\"position\")] var position: f32x4;\n\n#[noinline]\nfun bump(p: *f32x4, v: f32x4) { @p = v; }\n\n#[stage(\"vertex\")]\nfun vert_main() {\n    bump(?ro.c[1], in_x);\n    position = ro.c[2];\n}\n";
+    var dn: [1]str;
+    var dt: [1]str;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", ?dn[0], ?dt[0], 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) { bad = 1; obj.dnit(?img); }
+    or {
+        if (err == nil) { bad = 1; }
+        or (!ut_str_contains(err, "a store reaches the `#[storage(0, 3, \"readonly\")]` binding")) { bad = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -1538,6 +1538,37 @@ fun validate_stage_value(sc: *context.SemaContext, dec: *decl.Decorator) {
     context.report(sc, arg.span, "unknown pipeline stage; `stage` accepts \"vertex\", \"fragment\", or \"compute\"");
 }
 
+# report unless every `#[storage(set, binding, ...)]` qualifier names one this
+# compiler acts on (#2879)
+#
+# The vocabulary is closed for the reason every other decorator value set is: a
+# qualifier constrains what the emitter will accept through the binding, and a
+# misspelled one that was quietly ignored would compile to the UNCONSTRAINED
+# binding - the exact requirement the author wrote it to drop. It is checked here
+# rather than in the back end because the decorator is legal on every target, so a
+# typo checked only where it is acted on would go unreported on every CPU build.
+# ---
+# sc:  the context
+# dec: the `storage` decorator, already known to carry at least two arguments
+fun validate_storage_quals(sc: *context.SemaContext, dec: *decl.Decorator) {
+    var i: u32 = 2;
+    for (i < dec.args_len) {
+        val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + i]);
+        if (O.is_none[*expr.Expr](opt_arg)) { i = i + 1; cnt; }
+        val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+        if (arg.kind != expr.EXPR_KIND_LIT_STR || arg.span.len < 2::usize) {
+            context.report(sc, arg.span, "a `storage` memory qualifier must be a string literal; `storage` takes the descriptor set and binding followed by qualifiers, as in `#[storage(0, 3, \"readonly\")]`");
+            i = i + 1; cnt;
+        }
+        val off: usize = arg.span.offset + 1::usize;
+        val len: usize = arg.span.len - 2::usize;
+        if (!str_region_equals(sc.source, off, len, "readonly")) {
+            context.report(sc, arg.span, "unknown `storage` memory qualifier; `storage` accepts \"readonly\"");
+        }
+        i = i + 1;
+    }
+}
+
 # report unless a `#[spirv_op(set, name)]` names an instruction the compiler can
 # actually emit
 #
@@ -1894,7 +1925,10 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         ret;
     }
     if (decorator_named(sc, dec, "uniform") || decorator_named(sc, dec, "storage")) {
-        if (dec.args_len != 2) {
+        # `storage` takes MEMORY QUALIFIERS after the descriptor pair (#2879), and
+        # `uniform` takes none, because a uniform block is read-only already.
+        val quals: bool = decorator_named(sc, dec, "storage");
+        if (dec.args_len < 2 || (dec.args_len > 2 && !quals)) {
             context.report(sc, dec.name, "`uniform` / `storage` decorator takes two arguments: the descriptor set and the binding");
         }
         or {
@@ -1907,6 +1941,7 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
                 }
                 ui = ui + 1;
             }
+            if (quals) { validate_storage_quals(sc, dec); }
         }
         validate_iface_target(sc, d, dec);
         ret;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -49,6 +49,7 @@ use mach.lang.layout;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.session;
+use mach.lang.source;
 use mach.lang.type;
 
 # seed the field tables of built-in nominal types
@@ -1903,8 +1904,103 @@ fun infer_assign(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span
     val rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    check_readonly_storage(sc, b.lhs, span);
     check.check_coercible(sc, lt, b.rhs, rt, span);
     ret lt;
+}
+
+# report an assignment whose destination lives in a `#[storage(..., "readonly")]`
+# binding (#2879)
+#
+# The qualifier's whole point is that an accidental write is a DIAGNOSTIC rather
+# than a silently widened hardware requirement, and this is where the write is
+# written. It is refused for every target, not only for a SPIR-V build: which
+# target a module is compiled for is not a property of its source, so a write that
+# the shader build refuses has to be refused by the CPU build of the same file too.
+#
+# A CHAIN WALK, for the reason `operand_is_packed_field` is one: `b = v`,
+# `b.field = v`, `b.arr[i] = v` and `lib.b.field = v` all store into the binding,
+# and a check that looked only at the outermost expression would catch the first
+# spelling and pass the rest. The question is asked at every link, since a
+# qualified reference resolves at an inner MEMBER rather than at the base
+# identifier.
+# ---
+# sc:   sema context
+# eid:  the assignment's destination expression
+# span: the operator span for the diagnostic
+fun check_readonly_storage(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) {
+    if (eid == id.EXPR_NIL) { ret; }
+    if (expr_names_readonly_storage(sc, eid)) {
+        context.report(sc, span, "cannot store through a `#[storage(set, binding, \"readonly\")]` binding: the qualifier declares that no stage writes it, which is what lets the emitter mark it `NonWritable` and a vertex stage read it without `vertexPipelineStoresAndAtomics`. drop the `\"readonly\"` qualifier to write it");
+        ret;
+    }
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret; }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_MEMBER) { check_readonly_storage(sc, e.data.member.object, span); ret; }
+    if (e.kind == expr.EXPR_KIND_INDEX)  { check_readonly_storage(sc, e.data.index.object, span); ret; }
+    if (e.kind == expr.EXPR_KIND_UNARY && e.data.unary.op == expr.UN_DEREF) {
+        check_readonly_storage(sc, e.data.unary.operand, span);
+    }
+}
+
+# whether `eid` names a global binding carrying `#[storage(..., "readonly")]`
+#
+# The decorator is read out of the symbol's ORIGIN AST and matched against that
+# module's source text, so a binding a shader imports from a library is recognized
+# by the same predicate as one declared beside the write (#2843).
+# ---
+# sc:  sema context
+# eid: the expression to test
+# ret: true when it denotes a read-only storage binding
+fun expr_names_readonly_storage(sc: *context.SemaContext, eid: id.ExprId) bool {
+    val so: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
+    if (O.is_none[*resolve.Symbol](so)) { ret false; }
+    val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
+    if (sym.kind != resolve.SYM_VAR && sym.kind != resolve.SYM_VAL
+        && sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    if (sym.decl == id.DECL_NIL) { ret false; }
+
+    val a: *ast.Ast = symbol_ast(sc, sym);
+    if (a == nil) { ret false; }
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (O.is_none[*decl.Decl](d_opt)) { ret false; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
+
+    val src: str = ast_source(sc, a);
+    if (src == nil) { ret false; }
+    var i: u32 = 0;
+    for (i < d.decorators_len) {
+        val dec: *decl.Decorator = ?a.decorators[d.decorators_start + i];
+        if (!str_region_equals(src, dec.name.offset, dec.name.len, "storage")) { i = i + 1; cnt; }
+        var q: u32 = 2;
+        for (q < dec.args_len) {
+            val q_opt: O.Option[*expr.Expr] = ast.get_expr(a, a.expr_ids[dec.args_start + q]);
+            if (O.is_some[*expr.Expr](q_opt)) {
+                val qa: *expr.Expr = O.unwrap[*expr.Expr](q_opt);
+                if (qa.kind == expr.EXPR_KIND_LIT_STR && qa.span.len >= 2::usize
+                    && str_region_equals(src, qa.span.offset + 1::usize, qa.span.len - 2::usize, "readonly")) {
+                    ret true;
+                }
+            }
+            q = q + 1;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the source text an AST was parsed from, or nil when it is not registered
+# ---
+# sc: sema context
+# a:  the AST
+# ret: the module's source text
+fun ast_source(sc: *context.SemaContext, a: *ast.Ast) str {
+    if (a == sc.a) { ret sc.source; }
+    val opt_file: O.Option[*source.SourceFile] = source.get(?sc.s.sources, a.file_id);
+    if (O.is_none[*source.SourceFile](opt_file)) { ret nil; }
+    ret O.unwrap[*source.SourceFile](opt_file).text;
 }
 
 # UNARY: per-operator rules

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -113,6 +113,14 @@ pub val IFACE_STORAGE: u8 = 5;
 # the type it is given, both of which come from the global's own type
 pub val IFACE_SAMPLER: u8 = 6;
 
+# memory qualifiers a role can carry, an or'd set in `Global.iface_flags`. a
+# qualifier constrains what a stage may do THROUGH the binding, which is a
+# different question from which descriptor it is, so the two are separate fields
+# rather than more role constants: a second qualifier is one more bit here and no
+# new role anywhere. READONLY says no store may reach the binding, which the back
+# end both enforces and publishes as `NonWritable` (#2879)
+pub val IFACE_FLAG_READONLY: u32 = 1;
+
 # the built-in variables `#[builtin("...")]` accepts. each names a value the
 # pipeline supplies or consumes rather than one a location carries, and each has a
 # fixed direction the back end derives rather than the author restating: a vertex
@@ -432,6 +440,9 @@ pub rec Function {
 #            / IFACE_STORAGE / IFACE_SAMPLER
 # iface_b:   second role payload: the binding for IFACE_UNIFORM / IFACE_STORAGE /
 #            IFACE_SAMPLER, unused otherwise
+# iface_flags: the memory qualifiers written on the role, an or of IFACE_FLAG_*.
+#            a qualifier is a property of the BINDING rather than of its address,
+#            which is why it rides beside the role instead of in the type
 pub rec Global {
     name:      intern.StrId;
     ty:        type.IrTypeId;
@@ -450,6 +461,7 @@ pub rec Global {
     iface:     u8;
     iface_a:   u32;
     iface_b:   u32;
+    iface_flags: u32;
 }
 
 # the private allocation channel one IR module owns
@@ -1795,6 +1807,7 @@ test "mach.lang.me.ir.dnit:frees_by_capacity_not_count" {
     gl.iface     = IFACE_NONE;
     gl.iface_a   = 0;
     gl.iface_b   = 0;
+    gl.iface_flags = 0;
     m.globals[0] = gl;
     m.global_len = 1;
 

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -455,6 +455,7 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
         gx.iface     = ir.IFACE_NONE;
         gx.iface_a   = 0;
         gx.iface_b   = 0;
+        gx.iface_flags = 0;
         val res_ext: R.Result[u32, str] = append_global(ctx, gx);
         if (R.is_err[u32, str](res_ext)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_ext)); }
         ret R.ok[bool, str](true);
@@ -476,6 +477,7 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
     g.iface     = ir.IFACE_NONE;
     g.iface_a   = 0;
     g.iface_b   = 0;
+    g.iface_flags = 0;
     fill_iface_role(ctx, d, ?g);
 
     val res_idx: R.Result[u32, str] = append_global(ctx, g);
@@ -1334,6 +1336,7 @@ fun fill_iface_role(ctx: *context.LowerContext, d: *decl.Decl, g: *ir.Global) {
         g.iface   = ir.IFACE_STORAGE;
         g.iface_a = decorator_uint(ctx, d, "storage", 0, 0);
         g.iface_b = decorator_uint(ctx, d, "storage", 1, 0);
+        g.iface_flags = decl_storage_flags(ctx, d);
         ret;
     }
     if (decl_has_decorator(ctx, d, "sampler")) {
@@ -1341,6 +1344,35 @@ fun fill_iface_role(ctx: *context.LowerContext, d: *decl.Decl, g: *ir.Global) {
         g.iface_a = decorator_uint(ctx, d, "sampler", 0, 0);
         g.iface_b = decorator_uint(ctx, d, "sampler", 1, 0);
     }
+}
+
+# the memory qualifiers a `#[storage(set, binding, "...")]` decorator names (#2879)
+#
+# The qualifiers are the arguments after the descriptor pair, read to the end of the
+# list rather than at a fixed ordinal, so a second one is a spelling sema accepts and
+# a constant here. Sema has closed the vocabulary, so an unrecognized spelling
+# cannot reach this.
+# ---
+# ctx: the context
+# d:   the global's Decl
+# ret: an or of ir.IFACE_FLAG_*
+fun decl_storage_flags(ctx: *context.LowerContext, d: *decl.Decl) u32 {
+    val src: str = context.module_source(ctx);
+    var flags: u32 = 0;
+    var ord: u32 = 2;
+    for (true) {
+        val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "storage", ord);
+        if (O.is_none[id.ExprId](opt_arg)) { ret flags; }
+        val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.a, O.unwrap[id.ExprId](opt_arg));
+        if (O.is_none[*aexpr.Expr](opt_val)) { ret flags; }
+        val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+        if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret flags; }
+        val off: usize = ve.span.offset + 1::usize;
+        val len: usize = ve.span.len - 2::usize;
+        if (str_region_equals(src, off, len, "readonly")) { flags = flags | ir.IFACE_FLAG_READONLY; }
+        ord = ord + 1;
+    }
+    ret flags;
 }
 
 # the BUILTIN_* selector a `#[builtin("...")]` decorator names

--- a/src/lang/target/isa/spirv.mach
+++ b/src/lang/target/isa/spirv.mach
@@ -259,6 +259,12 @@ pub val DECOR_DESCRIPTOR_SET: u32 = 34;
 pub val DECOR_OFFSET:         u32 = 35;
 pub val DECOR_ARRAY_STRIDE:   u32 = 6;
 
+# NonWritable: the decoration that says nothing writes through a descriptor-bound
+# variable. Vulkan reads it to decide whether a stage needs the store-and-atomic
+# features, so a storage buffer a vertex stage only reads costs
+# `vertexPipelineStoresAndAtomics` without it and nothing with it (#2879)
+pub val DECOR_NON_WRITABLE:   u32 = 24;
+
 # Flat: the decoration that says a varying is not interpolated across a primitive.
 # Vulkan REQUIRES it on any fragment-stage Input whose type is an integer or a
 # 64-bit float, because neither can be interpolated, so an undecorated one is an

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -161,6 +161,11 @@ rec Emit {
     gslot:     *u32;
     iface_use: *u8;
 
+    # per global-table entry, whether a store can reach it (#2879). the absence of
+    # one is what a `NonWritable` decoration states, so this is a PROOF rather than
+    # a search: anything the derivation walk cannot follow reads as written
+    gwrite:    *u8;
+
     # the id each extended instruction set was imported under, indexed by
     # spirvop.SPV_SET_*; 0 means "not imported yet". indexed rather than one field
     # per set so a second set is a row in `spirvop`, not a change here. the import
@@ -330,7 +335,7 @@ pub fun emit_module(tgt: *resolved.Target, u: *unit.Unit,
     e.tgt = tgt; e.u = u; e.root = irmod; e.ir = irmod; e.cur_mi = u.root;
     e.b = ?b; e.tt = ?tt; e.fns = nil; e.fn_len = 0; e.gls = nil; e.gl_len = 0;
     e.gvar_ids = nil; e.gtype_ids = nil; e.gstorage = nil; e.iface_ids = nil; e.iface_len = 0;
-    e.gslot = nil; e.iface_use = nil;
+    e.gslot = nil; e.iface_use = nil; e.gwrite = nil;
     var xi: u32 = 0;
     for (xi < 8) { e.ext_ids[xi] = 0; xi = xi + 1; }
     e.srcmap = mirmod.srcmap; e.cur_fn = nil; e.cur_instr = nil;
@@ -373,6 +378,18 @@ pub fun emit_module(tgt: *resolved.Target, u: *unit.Unit,
         types.types_dnit(?tt);
         spirv.builder_dnit(?b);
         ret gtr;
+    }
+
+    # which descriptors the module stores through is decided before they are
+    # declared, because it is a decoration ON the declaration: `NonWritable` is
+    # emitted with the variable, and the fact it states is about every body in the
+    # closure rather than about the one being emitted (#2879).
+    val wr: R.Result[bool, str] = build_gl_writes(?e);
+    if (R.is_err[bool, str](wr)) {
+        emit_dnit(?e);
+        types.types_dnit(?tt);
+        spirv.builder_dnit(?b);
+        ret wr;
     }
 
     # interface variables are declared before any body, both because a SPIR-V global
@@ -478,6 +495,10 @@ fun emit_dnit(e: *Emit) {
         A.deallocate[u32](e.alloc, e.gstorage, e.gl_len::usize);
     }
     e.gstorage = nil;
+    if (e.gwrite != nil && e.gl_len > 0) {
+        A.deallocate[u8](e.alloc, e.gwrite, e.gl_len::usize);
+    }
+    e.gwrite = nil;
     # the table itself last: every free above is sized by its length.
     if (e.gls != nil && e.gl_len > 0) { A.deallocate[GlobalEnt](e.alloc, e.gls, e.gl_len::usize); }
     e.gls    = nil;
@@ -799,6 +820,193 @@ fun build_gl_table(e: *Emit) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
+# decide, for every global in the table, whether a store can reach it (#2879)
+#
+# A storage buffer nothing writes is `NonWritable`, and Vulkan reads that
+# decoration to decide whether a stage needs `vertexPipelineStoresAndAtomics`. So
+# the question "does the MODULE ever store through this binding" is worth a pass:
+# it is the common case, it is decidable here, and the answer is free where it is
+# yes and costs a hardware feature where it is wrongly no.
+#
+# THE ANSWER IS ONE-SIDED ON PURPOSE. A wrong "written" costs a decoration. A wrong
+# "not written" is a miscompile - a module that promises the driver something it
+# then does. So the rule is not "find the stores", it is "prove there are none",
+# and everything that is not a proven read counts against the proof. Two positions
+# are reads: the ADDRESS of a load, and the base of an access chain, whose own
+# result is then subject to the same question. Every other appearance of the
+# binding or of a pointer derived from it - a store's destination, a memzero, a
+# call argument, a copy into a vreg this pass does not follow - marks it written,
+# whether or not the emitter would go on to accept the instruction.
+#
+# THE SCAN IS OVER THE EMITTED CLOSURE, the same set every other whole-module
+# decision here is stated about: a function the module drops carries no store a
+# driver can execute. A drawn-in library body is in that closure, so a store from
+# another module counts exactly as a local one does (#2843).
+#
+# It doubles as the enforcement of `#[storage(set, binding, "readonly")]`. Sema
+# refuses the store that is WRITTEN as an assignment, which is the spelling an
+# author reaches for. This refuses a store the emitter can still see after
+# lowering, so the decoration can never be a promise the module breaks.
+# ---
+# e:   the emission state
+# ret: true on success, an allocation error, or the readonly refusal
+fun build_gl_writes(e: *Emit) R.Result[bool, str] {
+    if (e.gl_len == 0) { ret R.ok[bool, str](true); }
+    val rw: R.Result[*u8, str] = A.allocate[u8](e.alloc, e.gl_len::usize);
+    if (R.is_err[*u8, str](rw)) { ret R.err[bool, str](R.unwrap_err[*u8, str](rw)); }
+    e.gwrite = R.unwrap_ok[*u8, str](rw);
+    var i: u32 = 0;
+    for (i < e.gl_len) { e.gwrite[i] = 0; i = i + 1; }
+
+    var fx: u32 = 0;
+    for (fx < e.fn_len) {
+        if (!e.fns[fx].emit) { fx = fx + 1; cnt; }
+        val mf: *mir.MirFunction = fn_mir(e, fx);
+        if (mf == nil) { fx = fx + 1; cnt; }
+        val r: R.Result[bool, str] = scan_fn_writes(e, fx, mf);
+        if (R.is_err[bool, str](r)) { ret r; }
+        fx = fx + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# mark every global one function can store through
+#
+# Two walks. The first gives each vreg the global its pointer was derived from, by
+# following access chains from their base, and iterates to a fixed point because a
+# chain's base may be defined by a later instruction in program order, which a loop
+# makes ordinary. The second asks of every operand carrying such a pointer - or
+# naming a global outright - whether its position is one of the two that only read.
+# ---
+# e:   the emission state
+# fx:  the unit function-table index, for the refusal's function name
+# mf:  the MIR function
+# ret: true on success, an allocation error, or the readonly refusal
+fun scan_fn_writes(e: *Emit, fx: u32, mf: *mir.MirFunction) R.Result[bool, str] {
+    val n: u32 = mf.vreg_count;
+    var origin: *u32 = nil;
+    if (n > 0) {
+        val ro: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
+        if (R.is_err[*u32, str](ro)) { ret R.err[bool, str](R.unwrap_err[*u32, str](ro)); }
+        origin = R.unwrap_ok[*u32, str](ro);
+        var v: u32 = 0;
+        for (v < n) { origin[v] = GL_NONE; v = v + 1; }
+    }
+
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                val mi: *mir.MirInstr = ?blk.instrs[ii];
+                ii = ii + 1;
+                if (mi.opcode != mir.MIR_GEP || mi.operand_count < 2) { cnt; }
+                if (mi.operands[0].kind != mir.MIR_OP_VREG) { cnt; }
+                val dst: u32 = mi.operands[0].vreg;
+                if (origin == nil || dst == mir.MIR_VREG_NIL || dst >= n) { cnt; }
+                val g: u32 = operand_origin(e, origin, n, ?mi.operands[1]);
+                if (g == GL_NONE || origin[dst] == g) { cnt; }
+                # a vreg reached from two bases is followed no further: both are
+                # marked written, since a store through it would reach either.
+                if (origin[dst] != GL_NONE) {
+                    val ra: R.Result[bool, str] = mark_written(e, fx, mi, origin[dst]);
+                    if (R.is_err[bool, str](ra)) { A.deallocate[u32](e.alloc, origin, n::usize); ret ra; }
+                    val rb: R.Result[bool, str] = mark_written(e, fx, mi, g);
+                    if (R.is_err[bool, str](rb)) { A.deallocate[u32](e.alloc, origin, n::usize); ret rb; }
+                    cnt;
+                }
+                origin[dst] = g;
+                changed = true;
+            }
+            bi = bi + 1;
+        }
+    }
+
+    var bi2: u32 = 0;
+    for (bi2 < mf.block_count) {
+        val blk: *mir.MirBlock = ?mf.blocks[bi2];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            var oi: u32 = 0;
+            for (oi < mi.operand_count) {
+                val g: u32 = operand_origin(e, origin, n, ?mi.operands[oi]);
+                if (g == GL_NONE) { oi = oi + 1; cnt; }
+                if (mi.opcode == mir.MIR_LOAD && oi == 1) { oi = oi + 1; cnt; }
+                if (mi.opcode == mir.MIR_GEP && oi < 2)   { oi = oi + 1; cnt; }
+                val rm: R.Result[bool, str] = mark_written(e, fx, mi, g);
+                if (R.is_err[bool, str](rm)) {
+                    if (origin != nil) { A.deallocate[u32](e.alloc, origin, n::usize); }
+                    ret rm;
+                }
+                oi = oi + 1;
+            }
+            ii = ii + 1;
+        }
+        bi2 = bi2 + 1;
+    }
+    if (origin != nil) { A.deallocate[u32](e.alloc, origin, n::usize); }
+    ret R.ok[bool, str](true);
+}
+
+# the global an operand's pointer was derived from, or GL_NONE
+#
+# A symbol operand names its global whatever displacement rides on it, and a
+# register operand names whatever the derivation walk recorded for that vreg. The
+# displacement is deliberately not read: it changes which BYTES an access reaches,
+# never which binding, and this pass answers only the second question.
+# ---
+# e:      the emission state
+# origin: the per-vreg derivation map, or nil for a function with no vregs
+# n:      the map's length
+# op:     the operand
+# ret:    the global-table index, or GL_NONE
+fun operand_origin(e: *Emit, origin: *u32, n: u32, op: *mir.MirOperand) u32 {
+    if (op.kind == mir.MIR_OP_SYM) { ret gl_lookup(e, op.sym); }
+    if (op.kind != mir.MIR_OP_VREG && op.kind != mir.MIR_OP_MEM) { ret GL_NONE; }
+    if (origin == nil || op.vreg == mir.MIR_VREG_NIL || op.vreg >= n) { ret GL_NONE; }
+    ret origin[op.vreg];
+}
+
+# record that a store can reach global `gix`, and refuse it when the binding said
+# it would not be written
+# ---
+# e:   the emission state
+# fx:  the unit function-table index the store sits in
+# mi:  the instruction the store arrived as
+# gix: the global-table index
+# ret: true, or the refusal
+fun mark_written(e: *Emit, fx: u32, mi: *mir.MirInstr, gix: u32) R.Result[bool, str] {
+    if (gix >= e.gl_len || e.gwrite == nil) { ret R.ok[bool, str](true); }
+    if (e.gwrite[gix] != 0) { ret R.ok[bool, str](true); }
+    e.gwrite[gix] = 1;
+    val g: *ir.Global = gl_ir(e, gix);
+    if (g.iface != ir.IFACE_STORAGE || (g.iface_flags & ir.IFACE_FLAG_READONLY) == 0) {
+        ret R.ok[bool, str](true);
+    }
+    val r: R.Result[str, str] = format.sprint(e.alloc,
+        "a store reaches the `#[storage({}, {}, \"readonly\")]` binding{}: the qualifier declares that nothing writes it, which is what lets this module mark the descriptor `NonWritable` and a vertex stage read it without `vertexPipelineStoresAndAtomics`. drop the `\"readonly\"` qualifier to write it",
+        g.iface_a, g.iface_b, gl_mod_prefix(e, gix));
+    if (R.is_err[str, str](r)) {
+        ret R.err[bool, str]("spirv.emit: a store reaches a `\"readonly\"` storage binding");
+    }
+    ret R.err[bool, str](mir.instr_refusal(e.alloc, e.srcmap, ir_fn_spelling(e, fx), mi,
+                                           R.unwrap_ok[str, str](r)));
+}
+
+# whether a store can reach the global at table index `ix`
+# ---
+# e:  the emission state
+# ix: the global-table index
+# ret: true unless the module was proved never to store through it
+fun gl_written(e: *Emit, ix: u32) bool {
+    if (e.gwrite == nil || ix >= e.gl_len) { ret true; }
+    ret e.gwrite[ix] != 0;
+}
+
 # whether any EMITTED function names this global
 #
 # A reference reaches the back end as a symbol operand carrying the global's
@@ -1008,6 +1216,13 @@ fun declare_interface(e: *Emit) R.Result[bool, str] {
             || g.iface == ir.IFACE_SAMPLER) {
             decorate(e, var_id, spirv.DECOR_DESCRIPTOR_SET, g.iface_a);
             decorate(e, var_id, spirv.DECOR_BINDING, g.iface_b);
+        }
+        # a storage buffer no body in the module stores through is NonWritable, which
+        # is what lets a vertex or geometry stage read it without
+        # `vertexPipelineStoresAndAtomics` (#2879). A uniform is read-only by its
+        # storage class and needs nothing said, and a sampler is not memory at all.
+        if (g.iface == ir.IFACE_STORAGE && !gl_written(e, i)) {
+            decorate_bare(e, var_id, spirv.DECOR_NON_WRITABLE);
         }
         # EVERY global an entry point statically uses belongs in its interface list,
         # of any storage class. That is a SPIR-V 1.4 change from the 1.3 rule of
@@ -1721,7 +1936,7 @@ fun check_stage_interfaces(e: *Emit) R.Result[bool, str] {
     if (msg == nil) {
         i = 0;
         for (i < n) {
-            if ((flat[i] & 1) != 0) { decorate_flat(e, e.gvar_ids[i]); }
+            if ((flat[i] & 1) != 0) { decorate_bare(e, e.gvar_ids[i], spirv.DECOR_FLAT); }
             i = i + 1;
         }
     }
@@ -1900,13 +2115,14 @@ fun needs_flat(tt: *type.IrTypeTable, id: type.IrTypeId) bool {
     ret bits == 64;
 }
 
-# emit the operand-less OpDecorate Flat
+# emit an OpDecorate that carries no operand, such as Flat or NonWritable
 # ---
 # e:      the emission state
-# target: the variable id being decorated
-fun decorate_flat(e: *Emit, target: u32) {
+# target: the id being decorated
+# decor:  the decoration
+fun decorate_bare(e: *Emit, target: u32, decor: u32) {
     var ops: [2]u32;
-    ops[0] = target; ops[1] = spirv.DECOR_FLAT;
+    ops[0] = target; ops[1] = decor;
     spirv.inst(e.b, ?e.b.decorations, spirv.OP_DECORATE, ?ops[0], 2);
 }
 


### PR DESCRIPTION
A `#[storage(set, binding)]` buffer a stage only reads was emitted with no `NonWritable` decoration, so every consumer had to enable `vertexPipelineStoresAndAtomics` to read one from a vertex stage. Both halves the issue asks for are here: the inference and an explicit spelling.

## The inference

`build_gl_writes` runs after the global table is built and before the interface variables are declared, because `NonWritable` is a decoration ON the declaration and the fact it states is about every body in the emitted closure rather than about the one being emitted. A drawn-in library body is in that closure, so a store from another module counts exactly as a local one does.

It is a **proof rather than a search**, and that is the load-bearing decision. A wrong "written" costs a decoration. A wrong "not written" is a miscompile, since the decoration is a promise to the driver. So two positions read: the ADDRESS of a load, and the base of an access chain, whose own result is then subject to the same question. Every other appearance of the binding or of a pointer derived from it marks it written: a store's destination, a memzero, a call argument, a copy into a vreg the pass does not follow. A vreg that reaches two bases is followed no further and both are marked. The result is that a missing decoration is possible and a wrong one is not.

Per function it is two walks over the MIR: one gives each vreg the global its pointer derives from, to a fixed point since a chain's base can be defined later in program order, and one asks of every operand carrying such a pointer whether its position is a read.

## The explicit spelling

`#[storage(set, binding, "readonly")]`, not `#[storage_ro(set, binding)]`.

The reason is the axis this grows along. A separate directive name forks the **role** set, which is the axis the roles themselves are added on, and it does not compose: the qualifiers a storage buffer may later want are a family (`writeonly`, `coherent`, `volatile`), and a directive per combination is combinatorial. A qualifier list after the descriptor pair grows one member at a time. It also reuses two patterns already in the grammar rather than introducing a third: `uniform` / `storage` / `sampler` all take the same integer descriptor pair, which #2794 kept deliberately identical so a host binds them the same way, and `builtin` / `stage` / `spirv_op` already validate a closed string vocabulary. The role stays one role, `iface_flags` carries the qualifier beside it, and a second qualifier is one more bit and one more accepted spelling.

A store through such a binding is refused **by sema, where it is written, on every target**. Which target a module is compiled for is not a property of its source, so the CPU build of the same file refuses it too. The check walks the assignment's destination chain and resolves the binding against its origin AST, so a binding imported from a shader library is caught by the same predicate as a local one.

The emitter enforces the same thing over what survives lowering, which is what keeps the decoration honest: an address handed somewhere the emitter cannot follow is a write it must assume, and with the qualifier that becomes a refusal naming the source line rather than a decoration the module would break.

```
error: cannot store through a `#[storage(set, binding, "readonly")]` binding: the
qualifier declares that no stage writes it, ...
  --> ./src/rw_vert.mach:13:5
   |
13 |     palette.columns[1] = p;
   |     ^^^^^^^^^^^^^^^^^^^^^^
```

An unknown qualifier is refused rather than ignored: a misspelling that was quietly dropped would compile to the unconstrained binding, which is exactly the requirement the author wrote it to drop.

## Verification

Everything below was run against `out/linux-x86_64/debug/bin/mach` built from this branch, not the `mach` on PATH.

- `mach build .` clean, `mach test .` green: 1396 passed, 0 failed (1392 before, four new tests).
- **Counterfactual, all four tests.** Removing the decoration entirely fails `spirv_marks_an_unwritten_storage_binding_nonwritable`. Decorating every storage binding unconditionally fails it too, so it is not a presence-only assertion. Dropping the sema check fails `storage_readonly_refuses_a_store`, dropping the qualifier validation fails `storage_refuses_an_unknown_qualifier`, and dropping the emitter refusal fails `spirv_refuses_an_escaping_readonly_storage_address`. Every change was reverted after.
- **Both directions.** The fixture has three storage bindings reached by one stage: `(0, 3)` read only, `(0, 4)` read and written, `(0, 5)` read and explicitly marked. The written one must NOT carry the decoration.
- **`spirv-val --target-env vulkan1.3`** accepts every module emitted by hand here, including boom's `skinned_vert`.
- **Byte identity.** boom's seven shaders built with a compiler from `dev` and with this branch: the six with no storage binding are byte-identical, and `skinned_vert.spv` differs by exactly one disassembled line, `OpDecorate %14 NonWritable`. That is the issue's third acceptance criterion, so `skinned_vert` stops requiring `vertexPipelineStoresAndAtomics`.
- No integration test cases were added, per the freeze.

Closes #2879.
