### PR TITLE
fix(elf): emit no header segment on a target with no loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### A freestanding target can select `of = "elf"` and link, on every architecture (#2895)
+`os = "freestanding"` declares `page_size = 1`, and that is deliberate: bare metal has no paging, so segments carry no alignment obligation and 1 packs them tightly in a flat image. The ELF writer read that length as the size of the one-page reservation the ELF header and the program-header table have to fit inside, so the test was `64 + n*56 <= 1` and every freestanding ELF image was refused no matter how few segments it had. The objects were written correctly; only the link step failed, on x86_64, aarch64, riscv64 and riscv32 alike.
+
+Behind the refusal sat a second fault that the refusal was hiding. `header_segment_vaddr` frames the header block one page **below** segment 0, which at a base address of 0 and a page of 1 is `0 - 1` - an underflow to the top of the address space. Relaxing the check alone would have traded a loud link error for a leading `PT_LOAD` mapping the header block at `0xFFFFFFFFFFFFFFFF`: an image that links and is malformed, which is worse.
+
+Both come from applying a loader construct to a target with no loader. The leading `PT_LOAD` covering the header block exists so a **program loader** can read the program headers back out of the mapped image - `PT_PHDR`, PIE self-relocation, dynamic linking. A bare-metal image has none: the reset vector enters at the entry point and nothing parses a header at run time. So a loaderless image now emits no header segment at all, and the header block stays file metadata that is never mapped. That is also the only shape available at base address 0, where there is nothing below segment 0 to map it in.
+
+The gate is a fact the OS states about itself - `os.OsVTable.mapped_by_loader`, carried to the writer through `of.ImageOptions` - and deliberately not `page_size == 1` read as a sentinel. A page size is a length in bytes and whether an image is loader-mapped is a property of the platform; spelling one as the other is the same unit confusion that produced the bug. Every linux, darwin and windows image is unchanged, byte for byte, as is `os = "freestanding"` with `of = "raw"`.
+
 #### An RV64-only mnemonic in an `asm riscv32` body is refused rather than assembled (#2864)
 `ld`, `sd`, `addw` and the rest of the `*W` group do not exist at XLEN 32, and an `asm riscv32` body naming one assembled it anyway. The image carried an instruction the hardware does not implement, so the mistake surfaced as an illegal-instruction trap at run time instead of a diagnostic at build time - a wrong answer through a green build, which is the failure mode this target class exists to catch.
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -657,6 +657,9 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (R.is_err[*u8, str](at_r)) { ret R.err[bool, str](R.unwrap_err[*u8, str](at_r)); }
     opts.attributes = R.unwrap_ok[*u8, str](at_r);
     opts.attributes_len = attr_len;
+    # the writers decide what the image header needs to be from the OS's own fact,
+    # never from the page size (#2895).
+    opts.mapped_by_loader = tgt.os.mapped_by_loader;
     var local_atoms: AtomPlan;
     init_atom_plan(?local_atoms);
     var pre_atoms: *AtomPlan = nil;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -73,6 +73,7 @@ use bemit: mach.lang.build.emit;
 use bplan: mach.lang.build.plan;
 use dcfg: mach.lang.driver.config;
 use mach.lang.driver;
+use oslinux: mach.lang.target.os.linux;
 use mos_enc: mach.lang.target.isa.mos6502.encode;
 use mach.lang.target.isa.mos6502;
 use rv32: mach.lang.target.isa.riscv.refcore;
@@ -16828,6 +16829,284 @@ test "mach.lang.be.codegen.dwarf.produce:address_reloc_matches_pointer_width" {
     if (ut_dwarf_addr_reloc_width("rv64", ".debug_info") != 8) { bad = true; }
     if (ut_dwarf_addr_reloc_width("rv32", ".debug_line") != 4) { bad = true; }
     if (ut_dwarf_addr_reloc_width("rv32", ".debug_info") != 4) { bad = true; }
+
+    if (bad) { ret 1; }
+    ret 0;
+}
+
+# a manifest carrying every freestanding ELF member side by side plus a linux member,
+# so one fixture links on both sides of the loader-mapped question (#2895). `of =
+# "elf"` overrides freestanding's "raw" default
+# ---
+# ret: the manifest text
+fun ut_fs_elf_manifest() str {
+    ret "[project]\nid = \"fself\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.fsx]\nisa = \"x86_64\"\nos = \"freestanding\"\nabi = \"sysv64\"\nof = \"elf\"\n\n[target.fsa]\nisa = \"aarch64\"\nos = \"freestanding\"\nabi = \"aapcs64\"\nof = \"elf\"\n\n[target.fsr]\nisa = \"riscv64\"\nos = \"freestanding\"\nabi = \"lp64d\"\nof = \"elf\"\n\n[target.fsr32]\nisa = \"riscv32\"\nos = \"freestanding\"\nabi = \"ilp32d\"\nof = \"elf\"\n\n[target.lx]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.fself]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/fself\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# the fixture: an entry symbol reaching a read-only table and mutable globals, so the
+# link produces text, rodata, data and bss rather than one segment
+# ---
+# ret: the module source
+fun ut_fs_elf_src() str {
+    ret "val table: [4]u32 = [4]u32{11, 22, 33, 44};\nvar counter: u32 = 0;\nvar scratch: [16]u32;\n#[symbol(\"_start\")]\npub fun start() {\n    var i: u32 = 0;\n    for (i < 4) {\n        counter = counter + table[i];\n        scratch[i] = counter;\n        i = i + 1;\n    }\n}\n";
+}
+
+# one PT_LOAD of a linked image, in the fields the header-segment assertions read
+rec UtLoadSeg {
+    off:    u64;
+    vaddr:  u64;
+    filesz: u64;
+}
+
+# little-endian scalar reads over a linked image's bytes
+fun ut_le16(b: *u8, off: usize) u64 {
+    ret b[off]::u64 | (b[off + 1]::u64 << 8);
+}
+
+fun ut_le32(b: *u8, off: usize) u64 {
+    ret b[off]::u64 | (b[off + 1]::u64 << 8) | (b[off + 2]::u64 << 16) | (b[off + 3]::u64 << 24);
+}
+
+fun ut_le64(b: *u8, off: usize) u64 {
+    ret ut_le32(b, off) | (ut_le32(b, off + 4) << 32);
+}
+
+# collect every PT_LOAD out of a linked ELF image, at either class
+#
+# Reads the class byte and takes every field offset from it, so an ELF32 image is read
+# as ELF32 rather than through 64-bit offsets that would land in the wrong bytes.
+# ---
+# img:       the linked image bytes
+# segs:      out - the PT_LOADs, in program-header order
+# cap:       capacity of segs
+# entry_out: out - the image entry address
+# ret:       number of PT_LOADs written to segs
+fun ut_elf_loads(img: *Vector[u8], segs: *UtLoadSeg, cap: u32, entry_out: *u64) u32 {
+    if (img.len < 64) { ret 0; }
+    val b: *u8 = img.data;
+    val elf32: bool = b[4] == 1;
+
+    var phoff:     u64 = 0;
+    var phentsize: u64 = 0;
+    var phnum:     u64 = 0;
+    if (elf32) {
+        @entry_out = ut_le32(b, 24);
+        phoff      = ut_le32(b, 28);
+        phentsize  = ut_le16(b, 42);
+        phnum      = ut_le16(b, 44);
+    }
+    or {
+        @entry_out = ut_le64(b, 24);
+        phoff      = ut_le64(b, 32);
+        phentsize  = ut_le16(b, 54);
+        phnum      = ut_le16(b, 56);
+    }
+
+    var n: u32 = 0;
+    var i: u64 = 0;
+    for (i < phnum && n < cap) {
+        val p: usize = (phoff + i * phentsize)::usize;
+        if (p + phentsize::usize > img.len) { ret n; }
+        if (ut_le32(b, p) == 1) {
+            if (elf32) {
+                segs[n].off    = ut_le32(b, p + 4);
+                segs[n].vaddr  = ut_le32(b, p + 8);
+                segs[n].filesz = ut_le32(b, p + 16);
+            }
+            or {
+                segs[n].off    = ut_le64(b, p + 8);
+                segs[n].vaddr  = ut_le64(b, p + 16);
+                segs[n].filesz = ut_le64(b, p + 32);
+            }
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# link a built project's codegen images into an executable and hand back its bytes
+#
+# The link is the shipping one - `linker.link_images`, the same call `mach build` makes
+# - so the writer under test is reached through the code that reaches it in a real
+# build, image options and all.
+# ---
+# p:    the built project, after codegen
+# root: the scaffold root the image is written into
+# out:  out - the image bytes, owned by the caller
+# ret:  true when the link succeeded and the image was read back
+fun ut_link_exe_image(p: *project.Project, root: str, out: *Vector[u8]) bool {
+    val alloc: *A.Allocator = p.alloc;
+    if (p.emit_len == 0) { ret false; }
+
+    val ir: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, p.emit_len::usize);
+    if (R.is_err[*of.ObjectImage, str](ir)) { ret false; }
+    val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](ir);
+    var missing: bool = false;
+    var i: u32 = 0;
+    for (i < p.emit_len) {
+        val m: *project.ModuleEntry = ?p.modules[(p.topo[i])::u32];
+        if (m.object_image == nil) { missing = true; }
+        or                         { images[i] = @m.object_image; }
+        i = i + 1;
+    }
+
+    var linked: bool = false;
+    val path: str = ut_cc3(alloc, root, "/", "image.elf");
+    if (!missing) {
+        val lr: R.Result[bool, str] = linker.link_images(p.s, ?p.target, images, p.emit_len,
+            nil::*of.DynLib, 0, path::*u8, "fself"::*u8, linker.LINK_EXE, false,
+            of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        linked = R.is_ok[bool, str](lr);
+    }
+    A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+    if (!linked) { ret false; }
+
+    val br: R.Result[Vector[u8], str] = fs.read_bytes(alloc, path);
+    if (R.is_err[Vector[u8], str](br)) { ret false; }
+    @out = R.unwrap_ok[Vector[u8], str](br);
+    ret true;
+}
+
+# build the fixture for `target_name` and link it into an ELF image
+# ---
+# alloc:       allocator owning the returned bytes
+# target_name: the manifest target to build for
+# out:         out - the image bytes
+# ret:         true when the build and the link both succeeded
+fun ut_fs_elf_image(alloc: *A.Allocator, target_name: str, out: *Vector[u8]) bool {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = ut_fs_elf_src();
+    val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_fs_elf_manifest(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret false; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var ok: bool = false;
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_ok[bool, str](rr)) {
+        val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, target_name);
+        if (R.is_ok[project.Project, outcome.Fail](pr)) {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            if (ut_run_codegen_ok(?p) == 0) { ok = ut_link_exe_image(?p, root, out); }
+            project.dnit_project(?p);
+        }
+    }
+    fs.remove_all(alloc, root);
+    session.dnit(?s);
+    ret ok;
+}
+
+# the ceiling a bare-metal segment address must stay under. the fixture links at base
+# address 0 and is a few hundred bytes, so anything at or above a megabyte is an address
+# no segment was placed at deliberately - in particular the 0xFFFFFFFFFFFFFFFF a header
+# segment framed a page below zero carries
+val UT_FS_VADDR_CEIL: u64 = 0x100000;
+
+# every PT_LOAD of a bare-metal image maps real content at a real address
+# ---
+# alloc:       allocator for the image bytes
+# target_name: the freestanding manifest target to check
+# ret:         true when the image links and every segment holds
+fun ut_fs_elf_unmapped_header(alloc: *A.Allocator, target_name: str) bool {
+    var img: Vector[u8];
+    if (!ut_fs_elf_image(alloc, target_name, ?img)) { ret false; }
+
+    var segs: [16]UtLoadSeg;
+    var entry: u64 = 0;
+    val n: u32 = ut_elf_loads(?img, ?segs[0], 16, ?entry);
+
+    var ok: bool = n > 0;
+    var covers_entry: bool = false;
+    var i: u32 = 0;
+    for (i < n) {
+        # a segment at file offset 0 covers the header block, which is the thing an
+        # image with no loader must not map.
+        if (segs[i].off == 0)                            { ok = false; }
+        if (segs[i].vaddr >= UT_FS_VADDR_CEIL)           { ok = false; }
+        if (segs[i].off + segs[i].filesz > img.len::u64) { ok = false; }
+        if (entry >= segs[i].vaddr && entry < segs[i].vaddr + segs[i].filesz) { covers_entry = true; }
+        i = i + 1;
+    }
+    if (!covers_entry) { ok = false; }
+
+    vector.dnit[u8](?img);
+    ret ok;
+}
+
+# a loader-mapped image still maps its header block, one page below its first content
+# segment - the counterfactual arm, so a fix that dropped the header segment everywhere
+# could not read as a pass
+# ---
+# alloc: allocator for the image bytes
+# ret:   true when the linux image carries exactly one header segment, correctly placed
+fun ut_linux_elf_maps_header(alloc: *A.Allocator) bool {
+    var img: Vector[u8];
+    if (!ut_fs_elf_image(alloc, "lx", ?img)) { ret false; }
+
+    var segs: [16]UtLoadSeg;
+    var entry: u64 = 0;
+    val n: u32 = ut_elf_loads(?img, ?segs[0], 16, ?entry);
+
+    var headers: u32 = 0;
+    var content: u32 = 0;
+    var ok: bool = n > 1;
+    var i: u32 = 0;
+    for (i < n) {
+        if (segs[i].off == 0) {
+            headers = headers + 1;
+            if (segs[i].vaddr != oslinux.LINUX_BASE_ADDR - oslinux.LINUX_PAGE_SIZE) { ok = false; }
+        }
+        or {
+            content = content + 1;
+            if (segs[i].vaddr < oslinux.LINUX_BASE_ADDR) { ok = false; }
+        }
+        i = i + 1;
+    }
+    if (headers != 1 || content == 0) { ok = false; }
+
+    vector.dnit[u8](?img);
+    ret ok;
+}
+
+# a freestanding target selecting `of = "elf"` links, on every architecture, and the
+# image it produces is well formed (#2895)
+#
+# WHAT WAS BROKEN. `os = "freestanding"` declares `page_size = 1` deliberately - bare
+# metal has no paging, so segments need no alignment - and the ELF writer read that
+# length as the size of the one-page reservation the header block must fit inside, so
+# `64 + n*56 <= 1` refused every image on every architecture. Behind that refusal sat a
+# second fault: `header_segment_vaddr` frames the header block a page BELOW segment 0,
+# which at base address 0 is `0 - 1`, an underflow to the top of the address space. A
+# fix that only relaxed the check would have traded a loud link error for a silently
+# malformed image, so these assertions check the addresses rather than that a file
+# appeared.
+#
+# WHY THERE IS NO HEADER SEGMENT TO PLACE. The leading PT_LOAD covering the ELF header
+# and the program-header table exists so a LOADER can read the program headers out of
+# memory. Bare metal has no loader: the reset vector enters at the entry point and
+# nothing parses a header at run time. So the header block stays file metadata, which is
+# also the only shape available at base address 0, where there is nothing below segment
+# 0 to map it in.
+#
+# THE LINUX ARM IS NOT DECORATION. It is what stops this passing for the wrong reason:
+# an image that dropped the header segment everywhere would satisfy every bare-metal
+# assertion here, and only the linux arm notices.
+test "mach.lang.driver:freestanding_elf_links_with_no_header_segment" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    var bad: bool = false;
+    if (!ut_fs_elf_unmapped_header(?alloc, "fsx"))   { bad = true; }
+    if (!ut_fs_elf_unmapped_header(?alloc, "fsa"))   { bad = true; }
+    if (!ut_fs_elf_unmapped_header(?alloc, "fsr"))   { bad = true; }
+    if (!ut_fs_elf_unmapped_header(?alloc, "fsr32")) { bad = true; }
+    if (!ut_linux_elf_maps_header(?alloc))           { bad = true; }
 
     if (bad) { ret 1; }
     ret 0;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -723,6 +723,16 @@ pub rec ImageOptions {
     # input by the linker. nil with a zero length when the arch defines none (#2828)
     attributes:     *u8;
     attributes_len: u32;
+    # the OS's `mapped_by_loader` fact, carried to the writer by the linker: true
+    # when a program loader maps this image and reads its headers back out of
+    # memory, false on bare metal where nothing does (#2895). A writer that maps
+    # its header block into the image for the loader's benefit emits it only when
+    # this is true; see `os.OsVTable.mapped_by_loader` for the contract.
+    #
+    # `image_options_default` states true, which is what every image got before the
+    # fact existed, so a caller that constructs options without stating it keeps the
+    # loader-mapped shape rather than silently dropping a segment.
+    mapped_by_loader: bool;
 }
 
 # make executable-image options with no optional resources
@@ -733,6 +743,7 @@ pub fun image_options_default(subsystem: Subsystem) ImageOptions {
     opts.machine_flags = 0;
     opts.attributes = nil;
     opts.attributes_len = 0;
+    opts.mapped_by_loader = true;
     ret opts;
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1763,12 +1763,17 @@ fun copy_segment_bytes(buf: *u8, segs: *of.LoadSegment, seg_offsets: *usize, seg
 # write a static ET_EXEC executable, installed in the ELF `of.OfVTable` as its
 # `of.ExecFn`
 #
-# Emits the ELF header, a program-header table, then the loadable segments. The
-# first PT_LOAD always covers the ELF header and the program headers so the loader
-# maps them; each provided segment becomes a page-aligned PT_LOAD at its `vaddr`.
-# The linker computes vaddrs (from the OS base address) and the entry address
-# before calling this. Each segment's file offset is page-aligned so
-# `offset % page == vaddr % page` holds for the loader.
+# Emits the ELF header, a program-header table, then the loadable segments. On a
+# loader-mapped image (`image_options.mapped_by_loader`) the first PT_LOAD covers the
+# ELF header and the program headers so the loader maps them; each provided segment
+# becomes a page-aligned PT_LOAD at its `vaddr`. The linker computes vaddrs (from the
+# OS base address) and the entry address before calling this. Each segment's file
+# offset is page-aligned so `offset % page == vaddr % page` holds for the loader.
+#
+# A bare-metal image has no loader: nothing reads the program headers at run time, so
+# no header segment is emitted and the header block is file metadata that is never
+# mapped. That is also the only shape available at base address 0, where there is no
+# room below segment 0 for one (#2895).
 #
 # `funcs`/`func_count` are accepted for `of.ExecFn` conformance; the static writer
 # emits no unwind table and does not consume them.
@@ -1785,7 +1790,8 @@ fun copy_segment_bytes(buf: *u8, segs: *of.LoadSegment, seg_offsets: *usize, seg
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (ELF does not sign)
-# image_options: accepted for of.ExecFn conformance; ELF has no image options
+# image_options: read for `mapped_by_loader` (whether to map the header block) and
+#             the machine-flags word and build-attribute body
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, image_base: u64, entry: u64,
@@ -1812,13 +1818,22 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     var attr: *BuildAttributes = attributes_for(tgt_isa);
     if (image_options.attributes == nil || image_options.attributes_len == 0) { attr = nil; }
 
-    val phdr_count: u32 = seg_count + 1;
+    # the leading PT_LOAD covering the header block exists for a LOADER: it is what
+    # lets one read the program headers back out of the mapped image. an image no
+    # loader maps gets no such segment, so the header block stays file metadata
+    # (#2895).
+    val map_headers: bool = image_options.mapped_by_loader;
+
+    var phdr_count: u32 = seg_count;
+    if (map_headers) { phdr_count = seg_count + 1; }
 
     # the same one-page header reservation the PIE and dynamic writers refuse to
     # overrun. the static writer needs it for the same reason and did not have it,
     # because until the header block moved below segment 0 it had no reserved page to
-    # overrun - it simply sat on top of segment 0's address instead.
-    if (!header_fits_reserved_page(?lay, phdr_count, page_size)) {
+    # overrun - it simply sat on top of segment 0's address instead. an unmapped
+    # header block overruns nothing: there is no reservation, and the congruence the
+    # reservation preserves is what a loader needs to map segment 0 at its vaddr.
+    if (map_headers && !header_fits_reserved_page(?lay, phdr_count, page_size)) {
         ret R.err[bool, str]("elf: static program headers exceed the one-page header reservation (too many load segments)");
     }
 
@@ -1990,12 +2005,15 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 
     var phdr_pos: usize = phdr_offset;
 
-    # leading PT_LOAD covering the ELF header and the program headers.
-    var hdr_vaddr: u64 = entry & ~(page_size - 1);
-    if (seg_count > 0) { hdr_vaddr = header_segment_vaddr(segs[0].vaddr, page_size); }
-    val hdr_filesz: usize = phdr_offset + phdr_table_size;
-    phdr_pos = write_phdr_at(buf, phdr_pos, ?lay, PT_LOAD, PF_R, 0, hdr_vaddr, hdr_vaddr,
-                             hdr_filesz::u64, hdr_filesz::u64, page_size);
+    # leading PT_LOAD covering the ELF header and the program headers, for a loader
+    # to find them at. omitted entirely when nothing maps the image.
+    if (map_headers) {
+        var hdr_vaddr: u64 = entry & ~(page_size - 1);
+        if (seg_count > 0) { hdr_vaddr = header_segment_vaddr(segs[0].vaddr, page_size); }
+        val hdr_filesz: usize = phdr_offset + phdr_table_size;
+        phdr_pos = write_phdr_at(buf, phdr_pos, ?lay, PT_LOAD, PF_R, 0, hdr_vaddr, hdr_vaddr,
+                                 hdr_filesz::u64, hdr_filesz::u64, page_size);
+    }
 
     li = 0;
     for (li < seg_count) {
@@ -2137,6 +2155,12 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # pushing the first segment's file offset a page past `hdr_vaddr + page` so segment 0 no
 # longer maps at its vaddr - an image the kernel refuses to exec. The writer refuses at
 # link time instead.
+#
+# PRECONDITION, same as `header_segment_vaddr`'s: the image is loader-mapped. Without
+# a loader there is no reserved page and no congruence to preserve (at a no-paging
+# page size of 1 every value is congruent), so the question this asks does not arise
+# and a caller must not ask it - `page_size` is a length in bytes, and comparing a
+# header block against a page size of 1 refuses every image ever built (#2895).
 # ---
 # lay:        the class layout sizing the header and the program headers
 # phdr_count: the number of program headers the writer will emit
@@ -2164,6 +2188,13 @@ fun header_fits_reserved_page(lay: *ElfLayout, phdr_count: u32, page_size: u64) 
 # The degenerate no-segment case stays with each caller: a writer's default for an
 # image with nothing to load is not this policy, and folding it in here would invent
 # an answer (a PIE image's `entry` of 0 would underflow a page below zero).
+#
+# PRECONDITION: the image is loader-mapped (`os.OsVTable.mapped_by_loader`), which is
+# what makes a header segment meaningful at all and what puts segment 0 at least one
+# page above zero. A caller that asks this on a bare-metal image at base address 0
+# gets `0 - page`, an underflow to the top of the address space, which is a segment
+# mapped at a wild address rather than a diagnosable failure - so the callers gate on
+# the fact instead of clamping the answer here (#2895).
 # ---
 # first_seg_vaddr: virtual address of the lowest load segment
 # page_size:       the segment-alignment page
@@ -7289,8 +7320,7 @@ test "mach.lang.target.of.elf.emit_exec:load_segments_do_not_overlap" {
     var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
     val tpath: str = fs.temp_path(?tf);
 
-    var opts: of.ImageOptions;
-    opts.subsystem = 0;
+    val opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
     val em: R.Result[bool, str] = emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x400000, 0x400000,
                                             nil::*of.ExecFunction, 0, nil::*of.Section, 0,
                                             nil::*of.Section, 0, nil::*of.SymtabEntry, 0,

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -209,6 +209,28 @@ pub def NaturalStackArgsFn: fun(u32) bool;
 #                 reserved memory (Windows); false when the OS auto-grows the
 #                 stack on any in-range fault (Linux, Darwin) and a bare
 #                 `sub rsp, N` suffices
+# mapped_by_loader: true when a PROGRAM LOADER maps this OS's images at run time by
+#                 reading their headers out of the mapped image (#2895) - the kernel
+#                 ELF loader, dyld, the PE loader. false on bare metal, where the
+#                 reset vector enters at the entry point and nothing parses a header
+#                 at run time.
+#
+#                 THE CONTRACT A FORMAT SIGNS BY READING THIS: the header block is
+#                 image metadata that only a loader needs mapped. ELF's writers put
+#                 the ELF header and the program-header table in a leading PT_LOAD so
+#                 the loader can find the program headers in memory (PT_PHDR, PIE
+#                 self-relocation, dynamic linking), which costs a reserved page below
+#                 the first load segment and the `p_offset == p_vaddr (mod page)`
+#                 congruence that page preserves. With no loader there is no reader,
+#                 no reservation, and nothing to preserve - the header block stays
+#                 file metadata that is never mapped, which is also the only shape
+#                 that works at base address 0, where nothing fits below segment 0.
+#
+#                 Gate the transformation, not the target: this is deliberately NOT
+#                 `page_size == 1` read as a sentinel. A page size is a length in
+#                 bytes; whether an image is loader-mapped is a fact about the OS,
+#                 and spelling one as the other is how the header reservation came to
+#                 read a no-paging page size as a one-byte reservation.
 # pie_exec:       per-architecture position-independence policy, or nil when the OS
 #                 never requires PIE; the linker uses a PIE layout + base-relocation
 #                 collection when it returns true for the target architecture
@@ -246,6 +268,7 @@ pub rec OsVTable {
     base_addr:           u64;
     page_size:           u64;
     stack_probe:         bool;
+    mapped_by_loader:    bool;
     pie_exec:            PieExecFn;
     platform_lib:        str;
     page_size_for:       PageSizeFn;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -141,6 +141,9 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     # Darwin commits the thread stack up front and auto-grows the main thread; no
     # per-page probe needed.
     darwin_vtable.stack_probe    = false;
+    # the kernel Mach-O loader and dyld map the image from its load commands and
+    # read them back out of memory.
+    darwin_vtable.mapped_by_loader = true;
     # arm64 Darwin requires PIE main executables; x86_64 does not.
     darwin_vtable.pie_exec       = darwin_pie_exec;
     # a dyld-loaded Darwin executable implicitly links libSystem (the platform

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -95,6 +95,10 @@ pub fun register_freestanding(reg: *os.OsRegistry) R.Result[bool, str] {
     freestanding_vtable.page_size      = FREESTANDING_PAGE_SIZE;
     # no OS to grow the stack and no guard-page commit, so no per-page probe.
     freestanding_vtable.stack_probe    = false;
+    # nothing maps this image: the reset vector enters at the entry point and no
+    # loader parses a header at run time, so the header block is file metadata and
+    # never gets a segment of its own (#2895).
+    freestanding_vtable.mapped_by_loader = false;
     # the standard per-arch psABI; bare metal mandates no convention of its own.
     freestanding_vtable.native_abi     = freestanding_native_abi;
     # no platform variadic divergence: the selected convention's ordinary

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -120,6 +120,9 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     linux_vtable.page_size_for  = linux_page_size;
     # Linux auto-grows the stack on any in-range fault; no per-page probe needed.
     linux_vtable.stack_probe    = false;
+    # the kernel ELF loader maps the image from its program headers and reads them
+    # back out of memory (PT_PHDR, PIE self-relocation, ld.so).
+    linux_vtable.mapped_by_loader = true;
     # the System V psABI per arch; `mach init` scaffolds it as the target block's abi.
     linux_vtable.native_abi     = linux_native_abi;
     # no platform variadic divergence: the selected convention's ordinary

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -102,6 +102,9 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     # Windows grows the committed stack one guard page at a time, so a frame larger
     # than a page must probe each page in order (see encode.emit_stack_probe).
     windows_vtable.stack_probe    = true;
+    # the PE loader maps the image from its headers and reads them back out of
+    # memory (the import directory, base relocations).
+    windows_vtable.mapped_by_loader = true;
     # Windows PE executables are position-independent (ASLR): the link collects base
     # relocations and the COFF writer emits a `.reloc` section + DYNAMIC_BASE.
     windows_vtable.pie_exec       = windows_pie_exec;


### PR DESCRIPTION
A freestanding target selecting `of = "elf"` could compile but never link, on any architecture, and the obvious one-line fix would have replaced the link error with a malformed image. Both halves are fixed together.

## The two faults

`os = "freestanding"` declares `page_size = 1` deliberately - bare metal has no paging, so segments carry no alignment obligation and 1 packs them tightly in a flat image. `header_fits_reserved_page` read that length as the size of the reservation the ELF header plus the program-header table must fit inside, so the comparison was `64 + n*56 <= 1` and every freestanding ELF image was refused regardless of how few segments it had.

Behind the refusal, `header_segment_vaddr` computes `(first_seg_vaddr & ~(page - 1)) - page`, which at base address 0 and page 1 is `0 - 1`. Unreachable only because the check refused first. Confirmed by building a relax-the-check-only compiler: the image links and carries a leading `PT_LOAD` at `0xffffffffffffffff`.

```
LOAD 0x0000000000000000 0xffffffffffffffff 0xffffffffffffffff
     0x0000000000000158 0x0000000000000158  R      0x1
```

## The fix

The leading `PT_LOAD` covering the header block exists so a **program loader** can read the program headers back out of the mapped image - `PT_PHDR`, PIE self-relocation, dynamic linking. A bare-metal image has no loader: the reset vector enters at the entry point and nothing parses a header at run time. So a loaderless image emits no header segment at all - `phdr_count` is `seg_count`, the reservation check is not asked, `header_segment_vaddr` is not called, and the header block stays file metadata that is never mapped. That is also the only shape available at base address 0, where there is nothing below segment 0 to map it in.

The gate is `os.OsVTable.mapped_by_loader`, a fact the OS states about itself, carried to the writer through `of.ImageOptions` (the linker fills it beside `machine_flags` and the build attributes). Deliberately not `page_size == 1` read as a sentinel: a page size is a length in bytes and whether an image is loader-mapped is a property of the platform, and spelling one as the other is the unit confusion that caused the bug. `of.image_options_default` states `true`, so a caller that constructs options without stating it keeps the loader-mapped shape rather than silently dropping a segment.

## Verification

`mach build .` then `mach test .`: **1410 passed, 0 failed**.

The new test links the same fixture through the shipping linker for `fsx`/`fsa`/`fsr`/`fsr32` (freestanding x86_64, aarch64, riscv64, riscv32, all `of = "elf"`) and for a linux member, then reads the program headers back out of each image at its own ELF class. It asserts that no bare-metal segment is at file offset 0 (the header block being mapped), that no segment address reached the underflow, that every segment lies inside the file, and that the entry is covered by a segment. The linux arm asserts the opposite - exactly one segment at file offset 0, one page below the first content segment - so a fix that dropped the header segment everywhere cannot read as a pass.

**Counterfactuals, all three run:**

| variant | result |
|---|---|
| unfixed (`map_headers = true`) | test fails; `dev`-built baseline refuses all four arches with the reported error |
| check relaxed only (header segment still emitted) | test fails; image carries `PT_LOAD` at `0xffffffffffffffff` |
| header segment dropped everywhere (`map_headers = false`) | test fails on the linux arm |

**Linked images, by hand.** Four freestanding images linked and inspected with `readelf -a` and `llvm-readobj --all`, both exiting 0 with no warnings on all four. Each carries exactly four `PT_LOAD`s at 0x0, and low addresses for data/rodata/bss - no header segment, nothing at a wild address, every offset inside the file.

**Byte identity.** The compiler's own source tree compiled by a `dev`-built baseline and by this branch for `linux-x86_64`, `linux-arm64` and `linux-riscv64`: 675 files, `diff -r` clean - every object and every linked image identical. `os = "freestanding"` with `of = "raw"` on x86_64 and riscv64: identical, as are the freestanding objects on all four architectures. The only difference anywhere is that four ELF images now exist.

Closes #2895.
