### PR TITLE
fix(lower): a cast that converts nothing emits nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### A cast that converts nothing emits nothing (#2881)
+`lower_cast` chooses a conversion from the source and target pair and fell through to a bitcast whenever the two shared a width, so a cast whose operand already had the destination type emitted a reinterpretation of a type as itself. In SPIR-V that surfaced as `OpBitcast %ulong %ulong_2`, an instruction with no effect, which is how it was found.
+
+It was never only cosmetic. An identity bitcast is an opaque SSA definition, so the value behind it stops being a constant: `~(0::usize) / 0xFF` in `std.memory.raw_fill` - the byte-splat every `raw_fill` performs - lowered to a runtime `div` on every target, because `0::usize` on a literal already typed `usize` put a bitcast between the constant and the fold. Seventy such divisions disappear from the compiler's own image.
+
+The fold is keyed on the two IR types being EQUAL rather than on their widths matching, which is the distinction that makes it safe: a same-width cast that genuinely reinterprets - an integer and a float, where the bitcast is what carries the general/float register-bank crossing to the backend - has two different IR types and still emits. It sits in the lowerer's conversion selection rather than in `builder.emit_bitcast`, because choosing no instruction is a selection decision and the builder's callers, including the IR verifier's own width test, are entitled to emit exactly what they ask for.
+
+Secrecy is unaffected. `OP_BITCAST` is classified a secret move, so an identity bitcast was a link in the taint chain the `#[oblivious]`-required check reads, but sema forbids `::` and `:~` from adding or dropping `^`, so a cast and its operand always agree on secrecy and the operand's own definition is already stamped. A secret compute reached through an identity cast is still required to declare `#[oblivious]`.
+
 #### An RV64-only mnemonic in an `asm riscv32` body is refused rather than assembled (#2864)
 `ld`, `sd`, `addw` and the rest of the `*W` group do not exist at XLEN 32, and an `asm riscv32` body naming one assembled it anyway. The image carried an instruction the hardware does not implement, so the mistake surfaced as an illegal-instruction trap at run time instead of a diagnostic at build time - a wrong answer through a green build, which is the failure mode this target class exists to catch.
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1189,6 +1189,102 @@ test "mach.lang.me.pass.scalarize:vector_bitcast_survives_on_capable_target" {
     ret bad;
 }
 
+# count the OP_BITCAST instructions across `p`'s lowered modules
+fun ut_count_bitcasts(p: *project.Project) u32 {
+    var n: u32 = 0;
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var fi: u32 = 0;
+            for (fi < m.function_len) {
+                val fn: *ir.Function = ?m.functions[fi];
+                var bi: u32 = 0;
+                for (bi < fn.block_count) {
+                    val blk: *ir.Block = ?fn.blocks[bi];
+                    var ix: u32 = 0;
+                    for (ix < blk.instr_count) {
+                        if ((?fn.instrs[blk.instructions[ix]]).kind == instruction.OP_BITCAST) { n = n + 1; }
+                        ix = ix + 1;
+                    }
+                    bi = bi + 1;
+                }
+                fi = fi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+    ret n;
+}
+
+# a cast whose operand already has the destination IR type emits no instruction (#2881)
+#
+# `lower_cast` picks its conversion from the source / target pair and fell through to a
+# bitcast whenever the two shared a width, so `2::u64` on a value already `u64` emitted
+# `bitcast i64 2: i64` - visible in SPIR-V as `OpBitcast %ulong %ulong_2`, which
+# reinterprets a type as itself. In the IR an identity bitcast is worse than cosmetic:
+# it is an opaque SSA definition, so the constant behind it stops being a constant and
+# `~(0::usize) / 0xFF` in `std.memory.raw_fill` lowered to a runtime `div`.
+#
+# The two arms differ only in whether the cast crosses a representation: the fold is
+# keyed on the IR types being EQUAL, not on the widths matching, so the int/float
+# crossing - the case where the bitcast carries the register bank and removing it would
+# be a miscompile - must survive. A test that only counted the identity arm would be
+# satisfied by a fold that erased every same-width bitcast.
+test "mach.lang.me.lower.expr:identity_cast_emits_no_bitcast" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var bad: i32 = 0;
+
+    # identity (`u64::u64`), signedness flip (`i64::u64`, one IR type), and a same-width
+    # float identity: three casts, no reinterpretation between them
+    val ident: str = "pub fun f(a: u64, b: i64, c: f64) u64 { ret a::u64 + b::u64 + (c::f64)::u64; }\nfun main() i32 { ret 0; }\n";
+    val ir: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, ident, "linux");
+    if (R.is_err[project.Project, outcome.Fail](ir)) { bad = 1; }
+    or {
+        var pi: project.Project = R.unwrap_ok[project.Project, outcome.Fail](ir);
+        if (ut_count_bitcasts(?pi) != 0) { bad = 1; }
+        project.dnit_project(?pi);
+    }
+
+    # the nearest program that must NOT fold: `:~` between an integer and a float of the
+    # same width crosses the general and float register banks, and the bitcast is what
+    # carries that crossing to the backend
+    val cross: str = "pub fun g(a: u64) u64 { ret (a:~f64):~u64; }\nfun main() i32 { ret 0; }\n";
+    val cr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, cross, "linux");
+    if (R.is_err[project.Project, outcome.Fail](cr)) { bad = 1; }
+    or {
+        var pc: project.Project = R.unwrap_ok[project.Project, outcome.Fail](cr);
+        if (ut_count_bitcasts(?pc) != 2) { bad = 1; }
+        project.dnit_project(?pc);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# folding an identity cast does not launder a secret (#2881, #2136)
+#
+# `OP_BITCAST` is classified a secret MOVE, so an identity bitcast in front of a secret
+# was a link in the taint chain the `#[oblivious]`-required check reads. Removing it is
+# safe only because sema forbids `::` from adding or dropping `^` (`check_secrecy_cast`),
+# so the cast and its operand always agree on secrecy and the operand's own instruction
+# is already stamped. This pins that: a secret compute reached through an identity cast
+# is still required to declare `#[oblivious]`, and the transparent sibling still is not.
+test "mach.lang.me.lower.expr:identity_cast_keeps_secret_taint" {
+    var bad: i32 = 0;
+    if (ut_lower_rejects("fun f(a: ^u64, b: ^u64) ^u64 { ret a::^u64 * b::^u64; }\nfun main() i32 { ret 0; }\n",
+        "#[oblivious]") != 0) { bad = 1; }
+    # the same cast with no compute after it stays annotation-free, so the arm above is
+    # asserting the taint survived rather than that any secret at all is refused
+    if (ut_lower_ok("fun f(a: ^u64) ^u64 { ret a::^u64; }\nfun main() i32 { ret 0; }\n") != 0) { bad = 1; }
+    ret bad;
+}
+
 # true when `p`'s lowered modules hold a vector `==` compare whose two operands
 # read back as vectors with the given lane kind and element width. a compare
 # records its OPERAND shape, not its unsigned-mask result shape - the substrate a

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3273,10 +3273,10 @@ fun lower_unary(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Res
 # target type pair (trunc/ext for integers, fp trunc/ext for floats, int<->float
 # CVT). When source and target share a width, the operand's bit pattern already
 # represents the target type (a same-type identity, a signedness flip like
-# i64::u64, or a pointer retype), so it emits a same-size bitcast. A `:~`
-# bit-reinterpret (sema-validated equal size) always emits a same-size bitcast
-# that reinterprets the operand's raw bits as the target type, regardless of int /
-# float category.
+# i64::u64, or a pointer retype), so it goes through `emit_retype`, which emits a
+# same-size bitcast or nothing at all. A `:~` bit-reinterpret (sema-validated equal
+# size) always retypes the operand's raw bits to the target type, regardless of int
+# / float category.
 # ---
 # ctx: per-module lowering context
 # eid: the cast expression
@@ -3306,7 +3306,7 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
     if (from_float && to_float) {
         if (to_bits < from_bits) { ret builder.emit_fp_trunc(?ctx.builder, v, dst); }
         if (to_bits > from_bits) { ret builder.emit_fp_ext(?ctx.builder, v, dst); }
-        ret builder.emit_bitcast(?ctx.builder, v, dst);
+        ret emit_retype(ctx, v, dst);
     }
     if (from_float && !to_float) {
         if (to_signed) { ret builder.emit_fp_to_si(?ctx.builder, v, dst); }
@@ -3322,6 +3322,36 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
         if (from_signed) { ret builder.emit_sext(?ctx.builder, v, dst); }
         ret builder.emit_zext(?ctx.builder, v, dst);
     }
+    ret emit_retype(ctx, v, dst);
+}
+
+# emit the same-size retype a conversion selector settled on, or nothing when the
+# operand already has the destination type (#2881)
+#
+# The three points where `::` and `:~` conclude "the operand's bits already are the
+# destination's representation" - a same-width float pair, a same-width int/pointer
+# pair, and a `:~` within one representation class. When the operand's IR type IS
+# `dst` the reinterpretation is empty: the IR carries no signedness, so `i64::u64`
+# and `2::u64` both land here with nothing left to describe, and the emitted
+# instruction is a pure identity (`OpBitcast %ulong %ulong_2` in SPIR-V, a coalesced
+# register copy on the machine targets). Handing the operand back drops it.
+#
+# This belongs to conversion SELECTION, not emission, which is why it is not folded
+# inside `builder.emit_bitcast`: the builder's contract is to emit what it is asked
+# for, and the verifier's own width test constructs an identity bitcast on purpose
+# to prove the equal-width case stays clean.
+#
+# Secrecy is unaffected. Sema forbids `::` and `:~` from adding or dropping `^`
+# (`check_secrecy_cast`), so a cast and its operand always agree on taint, and the
+# operand's own `lower_rvalue` has already stamped it; the caller's `stamp_secret`
+# then re-marks that same defining instruction rather than a bitcast in front of it.
+# ---
+# ctx: per-module lowering context
+# v:   the already-lowered operand
+# dst: the destination IR type, the same size as the operand's
+# ret: `v` unchanged when it is already typed `dst`, else a bitcast, or an error
+fun emit_retype(ctx: *context.LowerContext, v: value.Value, dst: ir_type.IrTypeId) R.Result[value.Value, str] {
+    if (v.ty == dst) { ret R.ok[value.Value, str](v); }
     ret builder.emit_bitcast(?ctx.builder, v, dst);
 }
 
@@ -3359,7 +3389,7 @@ fun lower_reinterpret(ctx: *context.LowerContext, v: value.Value, from_ty: type.
 
     val src_agg: bool = is_aggregate_ir(ctx, src);
     val dst_agg: bool = is_aggregate_ir(ctx, dst);
-    if (src_agg == dst_agg) { ret builder.emit_bitcast(?ctx.builder, v, dst); }
+    if (src_agg == dst_agg) { ret emit_retype(ctx, v, dst); }
 
     if (src_agg) {
         # `v` is the aggregate's storage address; read the destination out of it.


### PR DESCRIPTION
`lower_cast` picks a conversion from the source / target type pair and fell through to `emit_bitcast` whenever the two shared a width, so a cast whose operand already had the destination type emitted a reinterpretation of a type as itself. The issue found it in SPIR-V as `%30 = OpBitcast %ulong %ulong_2`.

## Where the fix sits, and why not the builder

In the lowerer, in a new `emit_retype` that the three same-size sites in `expr.mach` call (`lower_cast`'s float and integer fallthroughs, and `lower_reinterpret`'s within-one-class path). Not in `builder.emit_bitcast`.

Choosing to emit *no* instruction is a conversion-**selection** decision, and selection is what `lower_cast` does. `builder.emit_bitcast` is an emitter whose contract is to produce what it is asked for, and it has callers that mean it: `verify.mach`'s `bitcast_must_keep_width` test constructs an identity bitcast on purpose, as the "nearest correct program" arm proving the width rule stays clean at equal widths. A folding builder makes that arm vacuous. `transform/sroa.mach` also has its own local `emit_bitcast`, so the builder is not the single choke point in any case.

The fold keys on the two **IR types being equal**, not on the widths matching. That is the load-bearing distinction: an int/float `:~` at the same width has two different IR types and still emits, so the bitcast that carries the general/float register-bank crossing to the backend is untouched. A fold keyed on width would have erased it and been a miscompile.

## It was not only cosmetic

An identity bitcast is an opaque SSA definition, so the value behind it stops being a constant. `std.memory.raw_fill` computes its byte splat as `(~(0::usize) / 0xFF) * value`, and `0::usize` on a literal already typed `usize` put a bitcast between the constant and the fold, so the divide stayed at run time. On x86-64 at `-O0`:

```
-  mov r12, 0          |  +  movabs rbx, 72340172838076673
-  xor r12, -1         |
-  mov rax, r12        |
-  mov r12, 255        |
-  xor edx, edx        |
-  div r12             |
```

70 such divisions disappear from the compiler's own image (`div` 878 -> 808 on x86-64, `udiv` 881 -> 811 on arm64, `divu` 681 -> 611 on riscv64).

## Secrecy

`OP_BITCAST` is classified a secret MOVE (`op_is_secret_move`), so an identity bitcast was a link in the taint chain the `#[oblivious]`-required check reads. Removing it cannot lose taint, because sema's `check_secrecy_cast` forbids `::` and `:~` from adding or dropping `^`: the cast expression and its operand always agree on secrecy, and the operand was already stamped by its own `lower_rvalue`, so `stamp_secret` re-marks that same defining instruction instead of a bitcast in front of it. Declassification is `OP_DECLASSIFY` via `lower_strip` and never reaches this path. A test pins it: a secret compute reached through an identity cast is still refused without `#[oblivious]`, and the transparent sibling is still accepted.

## Verification

`mach build .` then `mach test .`: **1411 passed, 0 failed** (1409 + 2 new).

**Counterfactual.** With `emit_retype`'s fold disabled and everything else in place, `mach.lang.me.lower.expr:identity_cast_emits_no_bitcast` fails; restoring it passes. The int/float arm of that test passes either way, which is the point of pairing them.

**SPIR-V.** The issue's repro, `spirv-val --target-env vulkan1.3` clean before and after. Opcode histogram diff over the disassembly, base -> fix:

```
-1 OpBitcast   -1 OpVariable   -1 OpStore   -1 OpLoad
```

Nothing else changed. The extra three are the emitter's per-SSA-definition `Function` variable for the bitcast result; `%ulong_2` is now the `OpIMul` operand directly. 66 -> 62 instructions.

**Machine targets: they MOVE.** Objects were compared over a fixed source tree (this repo) for `linux-x86_64`, `linux-arm64` and `linux-riscv64`, both profiles, against a baseline compiler built from `dev` and kept outside the build tree.

| profile | target | objects | dev vs dev (control) | dev vs fix |
|---|---|---|---|---|
| debug | linux-x86_64 | 224 | 0 differ | 127 differ |
| debug | linux-arm64 | 224 | 0 differ | 131 differ |
| debug | linux-riscv64 | 224 | 0 differ | 131 differ |
| release | linux-x86_64 | 224 | 0 differ | 130 differ |
| release | linux-arm64 | 224 | 0 differ | 133 differ |
| release | linux-riscv64 | 224 | 0 differ | 133 differ |

The control is byte-identical, so the movement is real and not build nondeterminism. Whole-tree instruction counts:

| profile | target | dev | fix | delta |
|---|---|---|---|---|
| debug | linux-x86_64 | 1416263 | 1414025 | -2238 |
| debug | linux-arm64 | 1460769 | 1457611 | -3158 |
| debug | linux-riscv64 | 1532378 | 1530287 | -2091 |
| release | linux-x86_64 | 2023333 | 2026468 | **+3135** |

At `-O0` the change is dominated by removed register copies (`mov` -1984 on x86-64, -2040 on arm64) plus the folded divisions above. At `-O2` the tree **grows**, which is why "fewer instructions" is not the argument: `call` goes 60543 -> 61019 while `ret` is unchanged at 34863, so no function was added or removed and more callee bodies were expanded inline. `pass/inline.mach` admits a callee that is "small (under the instruction threshold)"; removing bitcasts lowers callee instruction counts and pushes more of them under it. A second-order heuristic shift, not a codegen change.

Instruction-level, on a case covering every shape that reaches the fallthrough:

- x86-64: `ident`, `flip` (`i64::u64`) and `fident` are byte-identical - the allocator already coalesced those copies. Only the constant case changes: `mov rax, 2; imul rdi, rax` becomes `imul rdi, 2`.
- arm64 and riscv64: identical instruction *sequences*, different register assignment (`x1`/`a1` -> `x16`/`t0`), because the folded operand shifts virtual-register numbering. Same count, same operations.
- `i2f` / `f2i` keep their bitcasts in the IR on all three.

The register-allocator hazard does not apply: the bank a bitcast might cross is decided by operand register class, which comes from the IR types, and a folded bitcast has *identical* IR types on both sides, so it was a same-bank copy by construction. `be/codegen/mir.mach` states the same rule.

**Behavioural.**

- Self-host fixed point: `mach-fix` builds stage2, stage2 builds stage3, **stage2 and stage3 objects are byte-identical**, and both pass 1409/1409. A compiler whose every object was produced through the folded IR reproduces itself exactly.
- `int/run.sh --target linux`: all cases passed.
- `int/run.sh --target linux-arm64 --runmode qemu`: all cases passed.
- `int/run.sh --target linux-riscv64 --runmode qemu`: 6 failures, the **same 6** on the `dev` baseline (`c-variadic`, `narrow-stack-args`, `riscv-pcrel-pair`), all pre-existing and environmental - this host has no riscv64 cross libc headers.

No integration cases were added.

## The size check the issue asks for

Already present, and the issue's premise is out of date: `verify.mach`'s `check_convert_width` has held `dw == sw` for `OP_BITCAST` since #2373, with `bitcast_must_keep_width` covering it. It bails when `type.bit_width` returns 0, which is every pointer and aggregate, so a bitcast between two differently sized **aggregates** is still unchecked. Closing that needs `type.byte_size`, which needs a `*target.Target` the verifier is not given, so it is a signature change through `verify_module_ext` and its callers rather than a cheap addition. Filed as #2899 rather than bolted on here. It turned up no existing violations - nothing in tree constructs one.

Closes #2881.
