### PR TITLE
fix(ir): hold an aggregate bitcast to one size

### DIFF
--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -37,6 +37,8 @@ use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.target;
+use mach.lang.target.resolved;
 
 # selects which invariant a `Violation` records
 pub def VerifyCheck: u8;
@@ -163,24 +165,54 @@ pub rec VerifyReport {
 # seed capacity for the violations array on its first growth
 val VIOLATION_SEED_CAP: u32 = 8;
 
+# what one verification run is allowed to ask, and of what machine
+#
+# `full` selects the CFG-shape invariants that only hold after dead-code elimination -
+# reachability and dominance. Freshly-lowered IR legitimately carries unreachable
+# blocks (the lowerer parks the cursor on a fresh block after each terminator, which
+# `dce` later removes), so the entry verification runs with `full` clear and checks
+# only the structural invariants, and the post-optimisation verification sets it.
+#
+# `repr` enables the opt-in aggregate-representation / type-resolution / type-agreement
+# checks (VC_AGG_ADDRESS, VC_TYPE_RESOLVE, VC_TYPE_AGREE) that a clean self-host
+# promotes to always-on.
+#
+# `tgt` is the resolved target the layout-dependent checks measure against. A type
+# table alone cannot size an aggregate, so a check that compares aggregate extents
+# needs one and every caller supplies one.
+# ---
+# tgt:  resolved compilation target the layout queries are answered for
+# full: enforce reachability / dominance (post-DCE invariants)
+# repr: enable the aggregate-representation checks
+pub rec VerifyOpts {
+    tgt:  *resolved.Target;
+    full: bool;
+    repr: bool;
+}
+
+# builds the settings for one verification run
+# ---
+# tgt:  resolved compilation target the layout queries are answered for
+# full: enforce reachability / dominance (post-DCE invariants)
+# repr: enable the aggregate-representation checks
+# ret:  the populated options
+pub fun opts(tgt: *resolved.Target, full: bool, repr: bool) VerifyOpts {
+    var o: VerifyOpts;
+    o.tgt  = tgt;
+    o.full = full;
+    o.repr = repr;
+    ret o;
+}
+
 # runs the full check suite on a module, recording one Violation per failure;
 # verification does not short-circuit and returns a clean report (len == 0) for
-# well-formed IR (`err` is reserved for an allocation failure while recording).
-# `full` selects whether the CFG-shape invariants that only
-# hold after dead-code elimination - reachability and dominance - are enforced.
-# freshly-lowered IR legitimately carries unreachable blocks (the lowerer parks
-# the cursor on a fresh block after each terminator, which `dce` later removes),
-# so the entry verification passes `full = false` and checks only the structural
-# invariants; the post-optimisation verification passes `full = true`
+# well-formed IR (`err` is reserved for an allocation failure while recording)
 # ---
 # m:     the module to validate
 # alloc: allocator for the report's violations array
-# full:  enforce reachability / dominance (post-DCE invariants)
-# repr:  enable the opt-in aggregate-representation / type-resolution / type-
-#        agreement checks (VC_AGG_ADDRESS, VC_TYPE_RESOLVE, VC_TYPE_AGREE) that a
-#        clean self-host promotes to always-on
+# o:     which checks run and the target they measure against
 # ret:   a VerifyReport, or an allocation error
-pub fun verify_module_ext(m: *ir.Module, alloc: *A.Allocator, full: bool, repr: bool) R.Result[VerifyReport, str] {
+pub fun verify_module_ext(m: *ir.Module, alloc: *A.Allocator, o: VerifyOpts) R.Result[VerifyReport, str] {
     var r: VerifyReport;
     r.alloc      = alloc;
     r.violations = nil;
@@ -191,7 +223,7 @@ pub fun verify_module_ext(m: *ir.Module, alloc: *A.Allocator, full: bool, repr: 
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val res_fn: R.Result[bool, str] = verify_function(m, ?m.functions[fi], fi, ?r, full, repr);
+        val res_fn: R.Result[bool, str] = verify_function(m, ?m.functions[fi], fi, ?r, o);
         if (R.is_err[bool, str](res_fn)) {
             dnit_report(?r);
             ret R.err[VerifyReport, str](R.unwrap_err[bool, str](res_fn));
@@ -345,10 +377,9 @@ pub fun describe_located(m: *ir.Module, v: *Violation, itn: *intern.Interner,
 # fn:   the function to validate
 # fi:   index of fn into Module.functions (located on each violation)
 # r:    the report to record into
-# full: enforce reachability / dominance (post-DCE invariants)
-# repr: enable the opt-in representation / type checks
+# o:    which checks run and the target they measure against
 # ret:  true on completion, or an allocation error
-fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, full: bool, repr: bool) R.Result[bool, str] {
+fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, o: VerifyOpts) R.Result[bool, str] {
     if ((fn.flags & ir.FN_FLAG_EXTERN) != 0) { ret R.ok[bool, str](true); }
     if (fn.block_count == 0)                 { ret R.ok[bool, str](true); }
 
@@ -368,7 +399,7 @@ fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, 
         if (R.is_err[bool, str](res_uniq)) { ret res_uniq; }
         val res_succ: R.Result[bool, str] = check_successors(fn, blk, fi, r);
         if (R.is_err[bool, str](res_succ)) { ret res_succ; }
-        val res_arity: R.Result[bool, str] = check_arity_and_consts(m, fn, blk, fi, r, repr);
+        val res_arity: R.Result[bool, str] = check_arity_and_consts(m, fn, blk, fi, r, o);
         if (R.is_err[bool, str](res_arity)) { ret res_arity; }
         bi = bi + 1;
     }
@@ -381,7 +412,7 @@ fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, 
     # reachability and dominance only hold once dead-code elimination has
     # removed the unreachable blocks the lowerer parks after terminators; they
     # are checked only in the post-optimisation (full) verification.
-    if (full) {
+    if (o.full) {
         val res_reach: R.Result[bool, str] = check_reachability(fn, fi, r);
         if (R.is_err[bool, str](res_reach)) { ret res_reach; }
         val res_dom: R.Result[bool, str] = check_dominance(fn, fi, r);
@@ -594,23 +625,23 @@ fun check_successors(fn: *ir.Function, blk: *ir.Block, fi: u32, r: *VerifyReport
 # blk:  the block to walk
 # fi:   index of fn into Module.functions
 # r:    the report to record into
-# repr: enable the opt-in representation / type checks
+# o:    which checks run and the target they measure against
 # ret:  true on completion, or an allocation error
-fun check_arity_and_consts(m: *ir.Module, fn: *ir.Function, blk: *ir.Block, fi: u32, r: *VerifyReport, repr: bool) R.Result[bool, str] {
+fun check_arity_and_consts(m: *ir.Module, fn: *ir.Function, blk: *ir.Block, fi: u32, r: *VerifyReport, o: VerifyOpts) R.Result[bool, str] {
     var p: u32 = 0;
     for (p < blk.phi_count) {
-        val rr: R.Result[bool, str] = check_one_instr(m, fn, blk.phis[p], fi, blk.id, r, repr);
+        val rr: R.Result[bool, str] = check_one_instr(m, fn, blk.phis[p], fi, blk.id, r, o);
         if (R.is_err[bool, str](rr)) { ret rr; }
         p = p + 1;
     }
     var ix: u32 = 0;
     for (ix < blk.instr_count) {
-        val rr: R.Result[bool, str] = check_one_instr(m, fn, blk.instructions[ix], fi, blk.id, r, repr);
+        val rr: R.Result[bool, str] = check_one_instr(m, fn, blk.instructions[ix], fi, blk.id, r, o);
         if (R.is_err[bool, str](rr)) { ret rr; }
         ix = ix + 1;
     }
     if (blk.terminator != id.INSTR_NIL) {
-        val rr: R.Result[bool, str] = check_one_instr(m, fn, blk.terminator, fi, blk.id, r, repr);
+        val rr: R.Result[bool, str] = check_one_instr(m, fn, blk.terminator, fi, blk.id, r, o);
         if (R.is_err[bool, str](rr)) { ret rr; }
     }
     ret R.ok[bool, str](true);
@@ -625,9 +656,9 @@ fun check_arity_and_consts(m: *ir.Module, fn: *ir.Function, blk: *ir.Block, fi: 
 # fi:   index of fn into Module.functions
 # bid:  the block holding iid (located on a violation)
 # r:    the report to record into
-# repr: enable the opt-in representation / type checks
+# o:    which checks run and the target they measure against
 # ret:  true on completion, or an allocation error
-fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: u32, bid: id.BlockId, r: *VerifyReport, repr: bool) R.Result[bool, str] {
+fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: u32, bid: id.BlockId, r: *VerifyReport, o: VerifyOpts) R.Result[bool, str] {
     if (iid >= fn.instr_len) { ret R.ok[bool, str](true); }
     val ins: *instruction.Instruction = ?fn.instrs[iid];
 
@@ -645,7 +676,7 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
         }
         # the aggregate-representation invariants are opt-in until a clean
         # self-host promotes them to always-on (see pipeline `verify_ir`).
-        if (repr) {
+        if (o.repr) {
             # VC_TYPE_RESOLVE: a non-sentinel operand type must resolve.
             if (op.ty != type.IRT_NIL) {
                 val ot: O.Option[*type.IrType] = type.get(?m.types, op.ty);
@@ -667,7 +698,7 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
         }
         oi = oi + 1;
     }
-    if (repr) {
+    if (o.repr) {
         val res_aux: R.Result[bool, str] = check_aux_resolve(m, ins, fi, bid, iid, r);
         if (R.is_err[bool, str](res_aux)) { ret res_aux; }
         val res_agree: R.Result[bool, str] = check_type_agree(m, ins, fi, bid, iid, r);
@@ -681,7 +712,7 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
     if (R.is_err[bool, str](res_bc)) { ret res_bc; }
     val res_call: R.Result[bool, str] = check_call_arg_types(m, ins, fi, bid, iid, r);
     if (R.is_err[bool, str](res_call)) { ret res_call; }
-    val res_cw: R.Result[bool, str] = check_convert_width(m, ins, fi, bid, iid, r);
+    val res_cw: R.Result[bool, str] = check_convert_width(m, ins, fi, bid, iid, r, o.tgt);
     if (R.is_err[bool, str](res_cw)) { ret res_cw; }
     ret R.ok[bool, str](true);
 }
@@ -695,13 +726,20 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
 #
 # An unknown width on either side is not a verdict. `type.bit_width` answers 0 for a
 # pointer, a function, an aggregate and void, and the ptr/int BITCAST a `::` cast
-# lowers to is the common shape that lands there - judging it would require the
-# target's pointer width, which the verifier does not carry.
+# lowers to is the common shape that lands there.
+#
+# An aggregate is the one 0-width case that is still settled (#2899). Its extent is a
+# layout answer rather than a type-table one, so it is asked of the target the run
+# carries, and only when BOTH sides are aggregates - a crossing between an aggregate
+# and a value is VC_BITCAST_CLASS's to report, and reading it here would double-report
+# one defect. A zero-sized aggregate is a real extent and judged like any other, so
+# the equal-size test runs before the 0-width bail rather than through it.
 # ---
 # m:   the module (type table)
 # ins: the instruction to check
+# tgt: the resolved target sizing an aggregate operand
 # ret: ok(true) once checked, or an allocation error from `push`
-fun check_convert_width(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport) R.Result[bool, str] {
+fun check_convert_width(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid: id.BlockId, iid: id.InstructionId, r: *VerifyReport, tgt: *resolved.Target) R.Result[bool, str] {
     val k: instruction.InstrKind = ins.kind;
     val narrows: bool = k == instruction.OP_TRUNC || k == instruction.OP_FP_TRUNC;
     val widens:  bool = k == instruction.OP_SEXT  || k == instruction.OP_ZEXT
@@ -711,8 +749,15 @@ fun check_convert_width(m: *ir.Module, ins: *instruction.Instruction, fi: u32, b
     if (ins.operand_count < 1)         { ret R.ok[bool, str](true); }
 
     val src: type.IrTypeId = (?ins.operands[0]).ty;
-    val sw:  u32 = type.bit_width(?m.types, src);
-    val dw:  u32 = type.bit_width(?m.types, ins.ty);
+    if (keeps && type.is_aggregate(?m.types, src) && type.is_aggregate(?m.types, ins.ty)) {
+        if (type.byte_size(?m.types, src, tgt) == type.byte_size(?m.types, ins.ty, tgt)) {
+            ret R.ok[bool, str](true);
+        }
+        ret push(r, fi, bid, iid, VC_CONVERT_WIDTH);
+    }
+
+    val sw: u32 = type.bit_width(?m.types, src);
+    val dw: u32 = type.bit_width(?m.types, ins.ty);
     if (sw == 0 || dw == 0) { ret R.ok[bool, str](true); }
 
     if (narrows && dw < sw) { ret R.ok[bool, str](true); }
@@ -1805,11 +1850,13 @@ fun push(r: *VerifyReport, function: u32, block: id.BlockId, iid: id.Instruction
 # m:     the IR module under test
 # bld:   builder positioned on the test function
 # i64ty: cached i64 IR type for synthesizing operands
+# tgt:   resolved x86_64-linux target the layout-dependent checks measure against
 rec TEnv {
     alloc: A.Allocator;
     m:     ir.Module;
     bld:   builder.Builder;
     i64ty: type.IrTypeId;
+    tgt:   resolved.Target;
 }
 
 # initializes a TEnv in place: page allocator, empty module, one void() function,
@@ -1819,6 +1866,13 @@ rec TEnv {
 # ret: true on success, false on any allocation / interning failure
 fun t_env(env: *TEnv) bool {
     page.make(?env.alloc);
+
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret false; }
+    val tr: R.Result[resolved.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[resolved.Target, str](tr)) { ret false; }
+    env.tgt = R.unwrap_ok[resolved.Target, str](tr);
+
     val mr: R.Result[ir.Module, str] = ir.init(?env.alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](mr)) { ret false; }
     env.m = R.unwrap_ok[ir.Module, str](mr);
@@ -1871,7 +1925,7 @@ fun t_ci(env: *TEnv, n: u64) value.Value {
 # check: the check to count
 # ret:   the number of violations carrying `check`, or -1 on an allocation failure
 fun t_count(env: *TEnv, full: bool, repr: bool, check: VerifyCheck) i64 {
-    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, full, repr);
+    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, opts(?env.tgt, full, repr));
     if (R.is_err[VerifyReport, str](rr)) { ret -1; }
     var rep: VerifyReport = R.unwrap_ok[VerifyReport, str](rr);
     var c: i64 = 0;
@@ -1891,7 +1945,7 @@ fun t_count(env: *TEnv, full: bool, repr: bool, check: VerifyCheck) i64 {
 # repr: enable the aggregate-representation checks
 # ret:  the total number of violations, or -1 on an allocation failure
 fun t_total(env: *TEnv, full: bool, repr: bool) i64 {
-    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, full, repr);
+    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, opts(?env.tgt, full, repr));
     if (R.is_err[VerifyReport, str](rr)) { ret -1; }
     var rep: VerifyReport = R.unwrap_ok[VerifyReport, str](rr);
     val c: i64 = rep.len::i64;
@@ -2276,6 +2330,85 @@ test "mach.lang.me.ir.verify.check_convert_width:bitcast_must_keep_width" {
     ret 0;
 }
 
+# a BITCAST between two AGGREGATES is refused when their extents differ (#2899)
+#
+# `check_bitcast_class` (#2670) asks only that both sides agree on being aggregates,
+# and `type.bit_width` answers 0 for every aggregate, so the width rule #2373 shipped
+# stopped exactly where the project's miscompiles live: a 16-byte struct reinterpreted
+# as an 8-byte one reached codegen with the verifier silent. Nothing in tree builds one
+# today - sema proves equal size for `:~`, `lower_reinterpret` retags within one class,
+# and sroa derives its types from the slot it splits - which is the point: the verifier
+# exists to catch the lowering or transform bug that breaks one of those.
+#
+# The three arms differ only in the extents involved, which is the property under test.
+# A "some violation was recorded" assertion would be satisfied by any malformed operand
+# and these cannot be, and the VC_BITCAST_CLASS count pins the verdict to SIZE rather
+# than to the class crossing the other check owns.
+test "mach.lang.me.ir.verify.check_convert_width:aggregate_bitcast_must_keep_size" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+
+    var fields: [2]type.IrTypeId;
+    fields[0] = env.i64ty;
+    fields[1] = env.i64ty;
+    val big_r: R.Result[type.IrTypeId, str] = type.intern_struct(?env.m.types, ?fields[0], 2, 0, false);
+    if (R.is_err[type.IrTypeId, str](big_r)) { ret 1; }
+    val big: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](big_r);
+    val small_r: R.Result[type.IrTypeId, str] = type.intern_struct(?env.m.types, ?env.i64ty, 1, 0, false);
+    if (R.is_err[type.IrTypeId, str](small_r)) { ret 1; }
+    val small: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](small_r);
+
+    val b0: id.BlockId = t_block(?env);
+    builder.set_block(?env.bld, b0);
+    val slot_r: R.Result[value.Value, str] = builder.emit_alloca(?env.bld, big, t_ci(?env, 1));
+    if (R.is_err[value.Value, str](slot_r)) { ret 1; }
+    val agg: value.Value = value.retype(R.unwrap_ok[value.Value, str](slot_r), big);
+    val bad: R.Result[value.Value, str] = builder.emit_bitcast(?env.bld, agg, small);
+    if (R.is_err[value.Value, str](bad)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_count(?env, false, false, VC_CONVERT_WIDTH) != 1) { ret 1; }
+    # always on: the repr run sees the same one violation, not a second.
+    if (t_count(?env, false, true,  VC_CONVERT_WIDTH) != 1) { ret 1; }
+    # both sides are aggregates, so the class check is content and the size check alone
+    # is what fired.
+    if (t_count(?env, false, false, VC_BITCAST_CLASS) != 0) { ret 1; }
+
+    # the nearest correct program: two aggregates of EQUAL extent, a `{i64, i64}` retagged
+    # as `[2]i64`, which the tree is full of and must stay clean.
+    var ok_env: TEnv;
+    if (!t_env(?ok_env)) { ret 1; }
+    var ofields: [2]type.IrTypeId;
+    ofields[0] = ok_env.i64ty;
+    ofields[1] = ok_env.i64ty;
+    val ost_r: R.Result[type.IrTypeId, str] = type.intern_struct(?ok_env.m.types, ?ofields[0], 2, 0, false);
+    if (R.is_err[type.IrTypeId, str](ost_r)) { ret 1; }
+    val ost: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ost_r);
+    val oar_r: R.Result[type.IrTypeId, str] = type.intern_array(?ok_env.m.types, ok_env.i64ty, 2);
+    if (R.is_err[type.IrTypeId, str](oar_r)) { ret 1; }
+    val oar: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](oar_r);
+
+    val ob0: id.BlockId = t_block(?ok_env);
+    builder.set_block(?ok_env.bld, ob0);
+    val oslot_r: R.Result[value.Value, str] = builder.emit_alloca(?ok_env.bld, ost, t_ci(?ok_env, 1));
+    if (R.is_err[value.Value, str](oslot_r)) { ret 1; }
+    val oagg: value.Value = value.retype(R.unwrap_ok[value.Value, str](oslot_r), ost);
+    val good: R.Result[value.Value, str] = builder.emit_bitcast(?ok_env.bld, oagg, oar);
+    if (R.is_err[value.Value, str](good)) { ret 1; }
+
+    # and a pointer retag, which every target sizes alike and which must not be judged
+    # by a rule the type table cannot state a width for.
+    val pr: R.Result[type.IrTypeId, str] = type.intern_ptr(?ok_env.m.types);
+    if (R.is_err[type.IrTypeId, str](pr)) { ret 1; }
+    val pty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](pr);
+    val pbc: R.Result[value.Value, str] = builder.emit_bitcast(?ok_env.bld, value.const_null(pty), pty);
+    if (R.is_err[value.Value, str](pbc)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?ok_env.bld))) { ret 1; }
+
+    if (t_count(?ok_env, false, false, VC_CONVERT_WIDTH) != 0) { ret 1; }
+    ret 0;
+}
+
 # a TRUNC must narrow and an extension must widen, in that direction and no other
 #
 # Each row is its own opcode because the rule is stated per opcode, and each is paired
@@ -2337,9 +2470,10 @@ fun t_convert(k: instruction.InstrKind, from: u32, to: u32) i64 {
 # a width the type table alone cannot state is not judged
 #
 # A `::` cast between a pointer and an integer lowers to a BITCAST whose pointer side
-# is the TARGET's width, which the verifier does not carry. Guessing it would turn a
-# correct program into a violation, so the pair is skipped - and this is the arm that
-# keeps the rule from being unshippable rather than merely strict.
+# the type table gives no width for. The rule is stated on the widths a type carries,
+# so the pair is skipped - and this is the arm that keeps the rule from being
+# unshippable rather than merely strict. The aggregate exception below is exactly that:
+# a 0-width type whose extent a layout query does answer.
 test "mach.lang.me.ir.verify.check_convert_width:unknown_width_not_judged" {
     var env: TEnv;
     if (!t_env(?env)) { ret 1; }
@@ -2746,7 +2880,7 @@ test "mach.lang.me.ir.verify.describe_located:names_module_function_and_position
     if (R.is_err[bool, str](builder.emit_store(?env.bld, t_ci(?env, 1), t_ci(?env, 0)))) { ret 1; }
     if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))                            { ret 1; }
 
-    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, false, true);
+    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, opts(?env.tgt, false, true));
     if (R.is_err[VerifyReport, str](rr)) { ret 1; }
     var rep: VerifyReport = R.unwrap_ok[VerifyReport, str](rr);
     if (rep.len == 0) { dnit_report(?rep); ret 1; }
@@ -2798,7 +2932,7 @@ test "mach.lang.me.ir.verify.describe_located:spanless_says_so" {
     val b0: id.BlockId = t_block(?env);
     if (b0 != 0) { ret 1; }
 
-    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, false, false);
+    val rr: R.Result[VerifyReport, str] = verify_module_ext(?env.m, ?env.alloc, opts(?env.tgt, false, false));
     if (R.is_err[VerifyReport, str](rr)) { ret 1; }
     var rep: VerifyReport = R.unwrap_ok[VerifyReport, str](rr);
     if (rep.len == 0) { dnit_report(?rep); ret 1; }

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -40,6 +40,8 @@ use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.me.ir.verify;
 use mach.lang.source;
+use mach.lang.target;
+use resolved: mach.lang.target.resolved;
 use semtype: mach.lang.type;
 
 # sentinel marking an unprocessed entry in a u32 work array (idom / rpo index /
@@ -1851,7 +1853,14 @@ test "mach.lang.me.pass.mem2reg.run:phi_dbg_birth" {
 # m:   the module to verify
 # ret: the number of aggregate-representation violations, or -1 on an allocation error
 fun agg_address_violations(m: *ir.Module) i64 {
-    val res_rep: R.Result[verify.VerifyReport, str] = verify.verify_module_ext(m, m.alloc, false, true);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret -1; }
+    val tr: R.Result[resolved.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[resolved.Target, str](tr)) { ret -1; }
+    var tgt: resolved.Target = R.unwrap_ok[resolved.Target, str](tr);
+
+    val res_rep: R.Result[verify.VerifyReport, str] =
+        verify.verify_module_ext(m, m.alloc, verify.opts(?tgt, false, true));
     if (R.is_err[verify.VerifyReport, str](res_rep)) { ret -1; }
     var rep: verify.VerifyReport = R.unwrap_ok[verify.VerifyReport, str](res_rep);
     var n: i64 = 0;

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -85,6 +85,7 @@ pub val OPT_RELEASE: OptLevel = 1;
 pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool, vectorize_enabled: bool, simd_require: bool, float_reassoc: bool, itn: *intern.Interner, srcmap: *source.SourceMap) R.Result[bool, str] {
     var vc: VerifyCtx;
     vc.verify_ir = verify_ir;
+    vc.tgt       = tgt;
     vc.itn       = itn;
     vc.srcmap    = srcmap;
 
@@ -384,11 +385,13 @@ fun require_msg(m: *ir.Module, tgt: *target.Target, itn: *intern.Interner, site:
 # should not mean editing twenty call sites again.
 # ---
 # verify_ir: gate, run the verifier after every pass with representation checks on
+# tgt:       resolved target the verifier's layout-dependent checks measure against
 # itn:       interner resolving the module and function names in a failure message
 # srcmap:    source map resolving the offending instruction's SrcLoc to
 #            path:line:col, or nil when the caller has none
 rec VerifyCtx {
     verify_ir: bool;
+    tgt:       *target.Target;
     itn:       *intern.Interner;
     srcmap:    *source.SourceMap;
 }
@@ -425,7 +428,8 @@ fun verify_stage(m: *ir.Module, full: bool, vc: *VerifyCtx) R.Result[bool, str] 
 # vc:   the localization tables the message is rendered through
 # ret:  ok(true) on a clean module, or an err naming and locating the first violation
 fun run_verify(m: *ir.Module, full: bool, repr: bool, vc: *VerifyCtx) R.Result[bool, str] {
-    val res_report: R.Result[verify.VerifyReport, str] = verify.verify_module_ext(m, m.alloc, full, repr);
+    val res_report: R.Result[verify.VerifyReport, str] =
+        verify.verify_module_ext(m, m.alloc, verify.opts(vc.tgt, full, repr));
     if (R.is_err[verify.VerifyReport, str](res_report)) {
         ret R.err[bool, str](R.unwrap_err[verify.VerifyReport, str](res_report));
     }

--- a/src/lang/me/transform/versioning.mach
+++ b/src/lang/me/transform/versioning.mach
@@ -589,6 +589,21 @@ fun has_live_out(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
 use std.allocator.page;
 use mach.lang.intern;
 use verify: mach.lang.me.ir.verify;
+use mach.lang.target;
+use resolved: mach.lang.target.resolved;
+
+# resolves the host-shaped target the verifier's layout checks are answered against
+# ---
+# o_tgt: receives the resolved target
+# ret:   0 on success
+fun t_target(o_tgt: *resolved.Target) i32 {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[resolved.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[resolved.Target, str](tr)) { ret 1; }
+    @o_tgt = R.unwrap_ok[resolved.Target, str](tr);
+    ret 0;
+}
 
 # intern a `fun(i64, ptr, ptr, ptr) void` signature (n, a, b, c)
 fun mk_sig(m: *ir.Module, i64t: ir_type.IrTypeId, ptrt: ir_type.IrTypeId, o_sig: *ir_type.IrTypeId) i32 {
@@ -789,7 +804,10 @@ test "mach.lang.me.transform.versioning:version_verifier_clean" {
     }
 
     # the surgery is verifier-clean (reachability + dominance enforced)
-    val rvr: R.Result[verify.VerifyReport, str] = verify.verify_module_ext(?m, ?alloc, true, false);
+    var tgt: resolved.Target;
+    if (t_target(?tgt) != 0) { code = 1; }
+    val rvr: R.Result[verify.VerifyReport, str] =
+        verify.verify_module_ext(?m, ?alloc, verify.opts(?tgt, true, false));
     if (R.is_err[verify.VerifyReport, str](rvr)) { code = 1; }
     or {
         var rep: verify.VerifyReport = R.unwrap_ok[verify.VerifyReport, str](rvr);


### PR DESCRIPTION
Closes #2899

## What

`check_convert_width` judged a bitcast on `type.bit_width`, which answers `0` for every aggregate, so the check bailed before reaching a verdict. `check_bitcast_class` (#2670) asks only that the two sides agree on being aggregates, never that they are the same size. A 16-byte struct reinterpreted as an 8-byte one therefore passed the verifier silently and reached codegen.

An aggregate's extent is a layout answer, not a type-table one, so the verifier now carries the resolved target it measures against. The equal-size test runs before the 0-width bail so a zero-sized aggregate is judged like any other. Both sides must be aggregates: a crossing between an aggregate and a value is `VC_BITCAST_CLASS`'s to report, and reading it here would double-report one defect. Pointer-to-pointer is untouched and stays clean.

`full`, `repr`, and the new `tgt` move into a `VerifyOpts` record, so `verify_module_ext` and the four internal hops that forwarded the flags positionally take one value and the next verifier input is a drop-in.

## Evidence

New unit test `mach.lang.me.ir.verify.check_convert_width:aggregate_bitcast_must_keep_size`. Three arms differing only in the extents involved: `{i64, i64}` into `{i64}` records exactly one `VC_CONVERT_WIDTH` with `VC_BITCAST_CLASS` at zero (the verdict is about size, not class), `{i64, i64}` into `[2]i64` stays clean, and a pointer retag stays clean.

Counterfactual, fix removed and restored:

- fix removed: `1421 passed, 1 failed, 1422 total`, failing at the first `VC_CONVERT_WIDTH` assertion
- fix restored: `1422 passed, 0 failed, 1422 total`

End to end, with a temporary lowerer injection that retypes an aggregate `:~` to a differently sized struct, `mach build . --verify-ir` on a program whose correct answer is 42:

- without the fix: build exit 0, program exits 128, a miscompile shipped past the verifier
- with the fix: build exit 1, `error: conversion width: a conversion's result width contradicts its opcode ... (in aggproj.bin.main.main, at ./src/bin/main.mach:13:16)`

No false positives: the same program without the injection builds clean under `--verify-ir` and exits 42.

## Not in this PR

With a target now in hand the verifier could also judge the ptr/int bitcast a `::` cast lowers to, since `lower_cast` selects trunc/ext for unequal widths and only reaches a bitcast at equal ones. That is a separate rule over a much-travelled shape and is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6L67517WpZTPQDhtMsuJ2