### PR TITLE
fix(fe): fold `$length_of` in a comptime gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### `$length_of` folds in a comptime gate, and a gate folds the same way in both passes (#2875)
+`$if ($length_of([4]f32) != 4)` was refused, in a function body and at module scope alike, with `` `$offset_of` has no value in a comptime condition `` against an operand that is plainly a fixed array. `$size_of` and `$align_of` had folded in a gate since #2857, so the one layout intrinsic that counts elements was the odd member of the set.
+
+Lowering walks a `$if` chain by evaluating every gate again, so a layout gate is measured twice: once by sema, choosing which arms are type-checked, and once at lowering, choosing which arms become code. Lowering's layout resolver answered `$size_of` and `$align_of` and returned "not mine" for `$length_of`, and the evaluator renders that as `$offset_of`'s refusal. It now answers the count from the operand's `element_count` over the sema type, which is where an element count belongs: how many elements a type holds is a property of the spelling and is the same on every target, unlike a size, which is measured through the IR against the target's layout.
+
+That exposed the second half. Lowering reads the operand's type out of the slot sema stamps on it, and the ordinary sema fold, the path a plain layout gate takes, folded the gate without typing it first, unlike the two folds beside it. So the operand carried no type at lowering, where `$length_of` read no count and `$size_of` silently measured **zero**: `$if ($size_of([4]f32) == 16)` type-checked its true arm in sema and then lowered its false one, with no diagnostic from either pass. A gate sema folds is now a gate sema typed, so the two passes read the same measurement and select the same arm.
+
 #### `--pie` and dynamic linking on a loaderless OS are refused by name (#2898)
 `mach build --pie` on a freestanding ELF target failed with `elf: PIE program headers exceed the one-page header reservation (too many load segments)`. That was wrong in both clauses. There were four load segments, not too many, and the reservation was not a page: freestanding declares `page_size = 1` because bare metal has no paging, so the check refused whatever the image contained. On riscv32 a third answer arrived first, the ELF32 dynamic-image message. None of the three named the reason.
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2185,6 +2185,63 @@ test "mach.lang.driver:layout_intrinsic_in_a_comptime_gate" {
     ret bad;
 }
 
+# A GATE SEMA FOLDS AND A GATE LOWERING FOLDS SELECT THE SAME ARM (#2875)
+#
+# Lowering re-evaluates every `$if` gate when it walks the chain, so a layout gate is
+# measured twice: once by sema, choosing which arms are type-checked, and once here,
+# choosing which arms become code. The two read the operand's type from different
+# places - sema resolves the type spelling, lowering reads the type sema stamped onto
+# the operand - so they agree only if sema typed the gate it folded.
+#
+# THE SEMA-ONLY HALF OF THIS IS NOT AN ASSERTION ABOUT ARM SELECTION. `ut_arm` stops
+# at sema, where a `$error` in the selected arm fires, and a chain whose lowering
+# picks the OTHER arm passes every one of those cases. So the selection lowering made is
+# asserted over the LOWERED IR instead, through the `#[oblivious]` requirement: a
+# secret compute in an arm is reported when that arm becomes code and is absent when
+# it does not, which is exactly one bit of "was this arm lowered", read after sema.
+#
+# EVERY CASE IS ASSERTED IN BOTH DIRECTIONS, the same rule `ut_arm` enforces: a gate
+# that stops folding, or one that measures nothing and reads zero, satisfies one
+# direction of each pair.
+test "mach.lang.driver:length_of_in_a_comptime_gate" {
+    var bad: i32 = 0;
+
+    # ELEMENTS ARE NOT BYTES in a gate either: `[3]i64` gates true on 3 and false on
+    # 24, so a count that measured storage fails the pair.
+    if (ut_arm("fun main() i32 { $if ($length_of([3]i64) == 3) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("fun main() i32 { $if ($length_of([3]i64) == 24) { $error(\"BYTES\"); } $or { $error(\"ELEMENTS\"); } ret 0; }\n", "ELEMENTS", "BYTES") != 0) { bad = 1; }
+
+    # a vector's lane count and a value binding's length, the two other spellings the
+    # operand slot accepts
+    if (ut_arm("fun main() i32 { $if ($length_of(u8x16) == 16) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("val A: [7]u16 = [7]u16{1, 2, 3, 4, 5, 6, 7};\nfun main() i32 { $if ($length_of(A) == 7) { $error(\"Y\"); } $or { $error(\"N\"); } ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # AT MODULE SCOPE, where a chain that declares nothing is decided in sema (#2876)
+    if (ut_arm("$if ($length_of([3]i64) == 3) { $error(\"Y\"); } $or { $error(\"N\"); }\nfun main() i32 { ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+    if (ut_arm("$if ($length_of([3]i64) == 4) { $error(\"N\"); } $or { $error(\"Y\"); }\nfun main() i32 { ret 0; }\n", "Y", "N") != 0) { bad = 1; }
+
+    # a module-scope gate that selects NO arm still reaches lowering, which folds it
+    # again: that second fold must answer rather than refuse an operand that plainly
+    # carries a count.
+    if (ut_lower_ok("$if ($length_of([3]i64) != 3) { $error(\"BAD\"); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n") != 0) { bad = 1; }
+
+    # THE ARM LOWERING SELECTED, read out of the IR. the secret compute is reported
+    # only when its arm becomes code, so the true gate must be rejected and the false
+    # gate must lower clean.
+    if (ut_lower_rejects("fun f(a: ^u32, b: ^u32) ^u32 { $if ($length_of([3]i64) == 3) { ret a + b; } ret a; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n",
+        "not declared `#[oblivious]`") != 0) { bad = 1; }
+    if (ut_lower_ok("fun f(a: ^u32, b: ^u32) ^u32 { $if ($length_of([3]i64) == 4) { ret a + b; } ret a; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n") != 0) { bad = 1; }
+
+    # the same pair for `$size_of`, whose gate folds in sema but measured an untyped
+    # operand as zero at lowering: `== 24` is the true gate and `== 0` the false one,
+    # so a fold that reads nothing fails both.
+    if (ut_lower_rejects("fun f(a: ^u32, b: ^u32) ^u32 { $if ($size_of([3]i64) == 24) { ret a + b; } ret a; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n",
+        "not declared `#[oblivious]`") != 0) { bad = 1; }
+    if (ut_lower_ok("fun f(a: ^u32, b: ^u32) ^u32 { $if ($size_of([3]i64) == 0) { ret a + b; } ret a; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # positions the fold does NOT cover keep reporting the real cause, and a genuinely
 # non-comptime operand keeps the original wording - so neither correction absorbs the
 # other (#2316, #2442)
@@ -2521,9 +2578,9 @@ test "mach.lang.driver:comptime_reflection_recursion" {
 # cannot be written - so a program could index an embed and pass it around and never
 # learn its length.
 #
-# EVERY ANSWER IS DRIVEN OUT AS A NUMBER, not as "it compiled". A layout intrinsic is
-# not foldable in a `$if` gate, so the count is spliced into an array length and read
-# back through `$type_name`, which is: `$length_of([3]i64)` yielding 3 makes
+# EVERY ANSWER IS DRIVEN OUT AS A NUMBER, not as "it compiled". The count is spliced
+# into an array length and read back through `$type_name`, which is:
+# `$length_of([3]i64)` yielding 3 makes
 # `[$length_of([3]i64)]u8` spell "[3]u8". A wrong count spells a different type.
 #
 # NO LENGTH HERE IS 4, and none of the array cases is `u8`. A suite built on length-4
@@ -2567,9 +2624,10 @@ test "mach.lang.driver:comptime_length_of" {
                     "`$length_of` has no answer for `u64`") != 0) { bad = 1; }
     if (ut_vec_diag("val A: [4]u8 = [4]u8{1, 2, 3, 4};\nfun main() i32 { var n: u64 = $length_of(A, A); ret 0; }\n",
                     "$length_of: expected 1 argument(s)") != 0) { bad = 1; }
-    # a DECLARATION-SCOPE gate still cannot measure, exactly as for its siblings
-    # (#2857). `$length_of` additionally does not fold in a function-body gate, which
-    # its siblings now do - see #2875.
+    # a gate one of whose arms DECLARES something is decided during name resolution,
+    # before any type is laid out, so it cannot measure - exactly as for its siblings
+    # (#2857, #2876). a gate that declares nothing folds, and is covered by
+    # `length_of_in_a_comptime_gate`.
     if (ut_vec_diag("val A: [4]u8 = [4]u8{1, 2, 3, 4};\n$if ($length_of(A) == 4) {\n    fun helper() i32 { ret 1; }\n}\nfun main() i32 { ret 0; }\n",
                     "only comptime-evaluable after type checking") != 0) { bad = 1; }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -2642,6 +2642,24 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
     var i: u32 = 0;
     for (i < len) {
         val br: *decl.ComptimeBranch = ?sc.a.comptime_branches[start + i];
+
+        # A GATE SEMA FOLDS IS A GATE SEMA TYPED, the same rule
+        # `prune_type_comparison_chain` and `infer_bodies_deferred_chain` follow.
+        # Lowering re-evaluates this gate at monomorphization and its layout and
+        # type-query resolvers answer out of the operand types stamped here, so a
+        # gate folded untyped measures a type lowering cannot see and the two passes
+        # select different arms (#2875).
+        if (br.cond != id.EXPR_NIL) {
+            val saved_gate: bool = sc.in_comptime_gate;
+            sc.in_comptime_gate = true;
+            val gate_ty: type.TypeId = infer.infer_expr(sc, br.cond);
+            sc.in_comptime_gate = saved_gate;
+            # a gate that did not type decides nothing, and its error is already
+            # filed. walking the arms anyway would fire a `$error` guard that
+            # contradicts it (#2464)
+            if (gate_ty == type.TYPE_ERROR) { ret R.ok[bool, str](true); }
+        }
+
         val res_active: R.Result[bool, str] = comptime_branch_active(sc, br);
         if (R.is_err[bool, str](res_active)) { ret res_active; }
         if (R.unwrap_ok[bool, str](res_active)) {

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -680,8 +680,8 @@ pub fun resolve_type_query(data: ptr, tid: u32, which: u8) R.Result[O.Option[com
     ret infer.answer_type_query(lc.s, tid, which);
 }
 
-# the layout resolver lowering installs so a `$size_of` / `$align_of` gate folds
-# here as well as in sema (#2857)
+# the layout resolver lowering installs so a `$size_of` / `$align_of` / `$length_of`
+# gate folds here as well as in sema (#2857, #2875)
 #
 # LOWERING NEEDS ITS OWN because a `$if` chain does not always fold in sema: a chain
 # gated on a comptime value parameter, or one inside a generic body, has its arm
@@ -696,15 +696,13 @@ pub fun resolve_type_query(data: ptr, tid: u32, which: u8) R.Result[O.Option[com
 # expression: sema's `type_extent` and this both resolve through the one session
 # layout entry (see the note at `lower_type`), so the three cannot disagree.
 #
+# `$length_of` counts elements rather than measuring storage, so it is answered from
+# the SEMA type's `element_count` and never reaches the IR: an element count is a
+# property of the type spelling and is the same on every target, which is exactly
+# what makes reading it here equal to sema's answer.
+#
 # `$offset_of` answers none: it takes a field as its second argument, which this
 # signature does not carry, and sema does not fold it in a gate either.
-#
-# `$length_of` answers none too, for a different and narrower reason: its operand is
-# often written inline (`$length_of([4]f32)`), and an inline type-ref inside a GATE
-# carries no recorded expression type here, so the count cannot be read back. Rather
-# than report a false "expects a fixed array" against an operand that plainly is one,
-# a `$length_of` gate is not deferred to this point at all - see
-# `gate_has_layout_intrinsic` in resolve, and #2875.
 # ---
 # data: the erased *LowerContext
 # eid:  the intrinsic call expression, as a raw id
@@ -716,7 +714,8 @@ pub fun resolve_layout_intrinsic(data: ptr, eid: u32) R.Result[O.Option[comptime
     val src: str = module_source(lc);
     val is_size:  bool = comptime.is_size_of_call(lc.a, src, e);
     val is_align: bool = comptime.is_align_of_call(lc.a, src, e);
-    if (!is_size && !is_align) {
+    val is_len:   bool = comptime.is_length_of_call(lc.a, src, e);
+    if (!is_size && !is_align && !is_len) {
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
 
@@ -727,6 +726,17 @@ pub fun resolve_layout_intrinsic(data: ptr, eid: u32) R.Result[O.Option[comptime
     # secret-stripped for the reason every other shape decision here is (#2297):
     # `^T` occupies exactly `T`'s storage.
     val op_ty: type.TypeId = type.strip_secret(?lc.s.types, expr_type_of(lc, arg));
+
+    if (is_len) {
+        # the count is read after substitution, so `$length_of(T)` inside a
+        # monomorphized body counts the instance's type argument.
+        val n_opt: O.Option[u32] = type.element_count(?lc.s.types, substitute_type(lc, op_ty));
+        if (O.is_none[u32](n_opt)) {
+            ret R.err[O.Option[comptime.CTValue], str]("`$length_of` expects a fixed array or a vector");
+        }
+        ret R.ok[O.Option[comptime.CTValue], str](
+            O.some[comptime.CTValue](comptime.ct_uint(O.unwrap[u32](n_opt)::u64)));
+    }
 
     val res_ir: R.Result[ir_type.IrTypeId, str] = lower_type(lc, op_ty);
     if (R.is_err[ir_type.IrTypeId, str](res_ir)) {


### PR DESCRIPTION
Closes #2875

## Root cause

Lowering walks a `$if` chain by evaluating every gate again, so a layout gate is measured twice: once by sema, choosing which arms are type-checked, and once at lowering, choosing which arms become code. Two things kept `$length_of` out of the second measurement.

`context.resolve_layout_intrinsic` answered `$size_of` and `$align_of` and returned "not mine" for `$length_of`, and the evaluator renders that as `$offset_of`'s refusal, so `$if ($length_of([4]f32) != 4)` was refused with "a field's offset is decided at lowering" against an operand that is plainly a fixed array. That happened in a function body and at module scope alike.

Behind it, lowering reads the operand's type out of the slot sema stamps on it, and the ordinary sema fold, the path a plain layout gate takes, folded the gate without typing it first, unlike `prune_type_comparison_chain` and `infer_bodies_deferred_chain` beside it. With no type on the operand, lowering read no count for `$length_of` and measured **zero** for `$size_of`: `$if ($size_of([4]f32) == 16)` type-checked its true arm in sema and lowered its false one, with no diagnostic from either pass.

## Fix

- `src/lang/me/lower/context.mach`: the layout resolver answers `$length_of` from `type.element_count` over the substituted sema type. An element count is a property of the type spelling and is the same on every target, so it is read from the sema type rather than through the IR the way a size is.
- `src/lang/fe/sema.mach`: the ordinary `$if` fold types its gate before folding it, the rule the two folds beside it already follow. A gate that does not type ends the chain, per #2464.

The `$length_of` exclusion the issue asks to remove from `gate_has_layout_intrinsic` does not exist on current dev: `is_layout_intrinsic_call` already covers it, so resolve already defers such a chain. Only the note in `context.resolve_layout_intrinsic` was there, and it is gone.

## Verification

`mach build .` clean. `mach test .` **1422 passed, 0 failed** (1421 before, one new test).

New unit test `mach.lang.driver:length_of_in_a_comptime_gate` in `src/lang/driver/tests.mach`. The sema half asserts both arms through `ut_arm`, in a body and at module scope. Because `ut_arm` stops at sema and so proves nothing about the arm lowering picked, the selection lowering made is asserted over the lowered IR through the `#[oblivious]` requirement: a secret compute in an arm is reported when that arm becomes code and absent when it does not. Both directions are asserted for `$length_of` and for `$size_of`.

Counterfactual, test kept and source reverted:

- both changes reverted: `1421 passed, 1 failed` (the new test)
- only the sema change reverted: `1421 passed, 1 failed`
- only the lowering change reverted: `1421 passed, 1 failed`
- both restored: `1422 passed, 0 failed`

Hand-verified with the freshly built compiler (`out/linux-x86_64/debug/bin/mach`, 4.17.0). A fixture gating on `$length_of` over an inline array, a `def`, a vector and a value binding, at module scope and in a body, builds with exit 0, and its three selected arms each add to the exit code: the program returns 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6L67517WpZTPQDhtMsuJ2
