### PR TITLE
fix(spirv): convert a comparison result at a call and return boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### A comparison result crosses a call and a return boundary on the SPIR-V target (#2910)
+`mix(h, x == x)` compiled for `spirv` handed the `OpIEqual`'s `%bool` straight to an `OpFunctionCall` whose callee declares `%uchar`, and `ret x == x` from a `u8` function returned one out of a `%uchar` function. `spirv-val` rejected both. Neither is float specific: an integer comparison did it too.
+
+A SPIR-V comparison yields an `OpTypeBool`, which is abstract and has no storage layout, so it cannot be an argument or a return value where a byte is declared. Every other target computes a comparison into a 0/1 byte in a register, where the value widens by zero extension and nothing has to be reconciled. The emitter already converted at every position that knows the type it is converting to: a store to a variable, a store through a pointer and a store into a record member all emitted the `OpSelect` that turns the boolean into the declared type's 0 and 1.
+
+The two positions that did not are the two that go through the ABI pre-coloring's nominal register file, and they share one cause. That file is written by moves emitted at the machine word, which cannot type the value, so it already carries an immediate unmaterialized and mints the constant at the use site with the width the declaration asks for. A boolean now rides the same way: the register slot records that it holds one, and the use site - the `OpFunctionCall` that knows the callee's parameter types, or the `OpReturnValue` that knows the function's result type - widens it, or leaves it alone where the declaration is itself a boolean. Comparisons are still typed as booleans, so `OpBranchConditional` keeps receiving the real `%bool` the specification requires there.
+
 #### `$length_of` folds in a comptime gate, and a gate folds the same way in both passes (#2875)
 `$if ($length_of([4]f32) != 4)` was refused, in a function body and at module scope alike, with `` `$offset_of` has no value in a comptime condition `` against an operand that is plainly a fixed array. `$size_of` and `$align_of` had folded in a gate since #2857, so the one layout intrinsic that counts elements was the odd member of the set.
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -17289,6 +17289,170 @@ test "mach.lang.driver:spirv_refuses_an_escaping_readonly_storage_address" {
     ret bad;
 }
 
+# the module's OpTypeBool id, or 0 when it declares none
+fun ut_spv_bool_type(w: *u32, n: u32) u32 {
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret 0; }
+        if ((w[i] & 0xFFFF) == spirv.OP_TYPE_BOOL) { ret w[i + 1]; }
+        i = i + len;
+    }
+    ret 0;
+}
+
+# whether `id` names a value whose type is the boolean one
+#
+# An id that appears in a RESULT-TYPE position holding the bool type id is a boolean
+# value, and that position is word one of every instruction that has one. A type id
+# and a value id are never the same id, so nothing but a result type can match: the
+# condition operand of `OpBranchConditional` and the pointer of `OpStore` are value
+# ids, and `OpTypePointer` names the bool type a word later.
+fun ut_spv_is_bool_value(w: *u32, n: u32, bool_ty: u32, id: u32) bool {
+    if (bool_ty == 0 || id == 0) { ret false; }
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret false; }
+        if (len >= 3 && w[i + 1] == bool_ty && w[i + 2] == id) { ret true; }
+        i = i + len;
+    }
+    ret false;
+}
+
+# how many OpFunctionCall arguments are boolean values
+#
+# `OpFunctionCall <result-type> <id> <callee> <args...>`, so the arguments start at
+# word four. None of the fixture's callees declares a boolean parameter, so any hit
+# is a boolean handed where a number is declared.
+fun ut_spv_bool_call_args(w: *u32, n: u32, bool_ty: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        if ((w[i] & 0xFFFF) == spirv.OP_FUNCTION_CALL) {
+            var k: u32 = 4;
+            for (k < len) {
+                if (ut_spv_is_bool_value(w, n, bool_ty, w[i + k])) { c = c + 1; }
+                k = k + 1;
+            }
+        }
+        i = i + len;
+    }
+    ret c;
+}
+
+# how many OpReturnValue instructions return a boolean out of a non-boolean function
+#
+# The enclosing function's declared result type is word one of its OpFunction, so a
+# function that really does return a boolean is not counted and the check stays about
+# the mismatch rather than about booleans.
+fun ut_spv_bool_returns(w: *u32, n: u32, bool_ty: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    var fn_ret: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        val op: u32 = w[i] & 0xFFFF;
+        if (op == spirv.OP_FUNCTION) { fn_ret = w[i + 1]; }
+        if (op == spirv.OP_RETURN_VALUE && fn_ret != bool_ty
+            && ut_spv_is_bool_value(w, n, bool_ty, w[i + 1])) { c = c + 1; }
+        i = i + len;
+    }
+    ret c;
+}
+
+# how many OpBranchConditional conditions are boolean values
+#
+# The counterpart assertion: SPIR-V requires a real `OpTypeBool` here, so this is what
+# would break if a comparison were retyped as a number to settle the boundary.
+fun ut_spv_bool_conditions(w: *u32, n: u32, bool_ty: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        if ((w[i] & 0xFFFF) == spirv.OP_BRANCH_CONDITIONAL
+            && ut_spv_is_bool_value(w, n, bool_ty, w[i + 1])) { c = c + 1; }
+        i = i + len;
+    }
+    ret c;
+}
+
+# the fixture for the boundary a comparison result has to cross (#2910)
+#
+# Three positions, one comparison each, distinguished by nothing but where the result
+# goes: into a call argument the callee declares as a byte, out of a function whose
+# result is a byte, and into a conditional branch. The first two are the defect, the
+# third is what must not change.
+fun ut_spv_cmp_boundary_src() str {
+    ret "fun mix(h: u64, b: u8) u64 { ret h * 31 + b::u64; }\n\npub fun crosses(seed: u32) u64 {\n    val x: u32 = 7 + seed;\n    ret mix(1, x == x);\n}\n\npub fun returns_cmp(seed: u32) u8 {\n    val x: u32 = 7 + seed;\n    ret x == x;\n}\n\npub fun branches(seed: u32) u64 {\n    val x: u32 = 7 + seed;\n    if (x == x) { ret 1; }\n    ret 0;\n}\n";
+}
+
+# a comparison result converts to the declared type where it crosses a call or return
+# boundary, and stays a boolean where a branch consumes it (#2910)
+#
+# A SPIR-V comparison yields an `OpTypeBool`, which has no storage layout and so
+# cannot be an argument or a return value where a byte is declared. Both of those
+# positions go through the ABI pre-coloring's nominal register file, which is emitted
+# at the machine word and therefore cannot type the value; the conversion belongs at
+# the use site, which is the first point that knows what the declaration asks for.
+#
+# THE BRANCH ASSERTION IS THE HALF THAT PINS THE FIX. Retyping comparisons as numbers
+# would satisfy the first two counts and produce a module `spirv-val` rejects at the
+# branch instead, so the test insists the same fixture still hands a real boolean to
+# `OpBranchConditional`. The `OpIEqual` and `OpSelect` counts keep the zeroes honest:
+# three comparisons really are in the module, and exactly the two boundary crossings
+# widen.
+test "mach.lang.driver:spirv_converts_a_comparison_at_a_call_boundary" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach"; texts[0] = ut_spv_cmp_boundary_src();
+    var dn: [1]str;
+    var dt: [1]str;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", ?dn[0], ?dt[0], 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    val bt: u32 = ut_spv_bool_type(w, n);
+    # the fixture is not degenerate: the module declares a boolean and compares three
+    # times, so a zero below is a conversion rather than a missing comparison.
+    if (bt == 0) { bad = 1; }
+    if (ut_spv_count(w, n, spirv.OP_I_EQUAL) != 3) { bad = 1; }
+    or {
+        if (ut_spv_bool_call_args(w, n, bt) != 0) { bad = 1; }
+        if (ut_spv_bool_returns(w, n, bt) != 0)   { bad = 1; }
+        # and the branch still gets the boolean SPIR-V requires there.
+        if (ut_spv_bool_conditions(w, n, bt) != 1) { bad = 1; }
+        # exactly the two crossings widen, so nothing converted the branch's.
+        if (ut_spv_count(w, n, spirv.OP_SELECT) != 2) { bad = 1; }
+    }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
 # a manifest carrying the two riscv members side by side, both writing ELF, so one
 # fixture can be compiled at either pointer width. freestanding is the only os that
 # runs riscv32 today, and `of = "elf"` overrides its "raw" default

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -17397,8 +17397,8 @@ fun ut_spv_cmp_boundary_src() str {
 # A SPIR-V comparison yields an `OpTypeBool`, which has no storage layout and so
 # cannot be an argument or a return value where a byte is declared. Both of those
 # positions go through the ABI pre-coloring's nominal register file, which is emitted
-# at the machine word and therefore cannot type the value; the conversion belongs at
-# the use site, which is the first point that knows what the declaration asks for.
+# at the machine word and therefore cannot type the value, so the conversion belongs
+# at the use site, the first point that knows what the declaration asks for.
 #
 # THE BRANCH ASSERTION IS THE HALF THAT PINS THE FIX. Retyping comparisons as numbers
 # would satisfy the first two counts and produce a module `spirv-val` rejects at the

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -226,14 +226,23 @@ rec VMaps {
 # carrying `imm` rather than an id, and the constant is minted at the use site with
 # the width the declaration asks for. A parameter's slot holds its
 # OpFunctionParameter id from the start.
+#
+# A COMPARISON'S RESULT RIDES HERE THE SAME WAY, for the same reason (#2910). It is
+# an `OpTypeBool`, which has no numeric representation and cannot be an argument or a
+# return value where a byte is declared, and the move that pre-colors it carries the
+# machine word rather than the declared type. `is_bool` marks the slot so the use
+# site widens it to whatever the declaration asks for, or leaves it alone where the
+# declaration is itself a boolean.
 # ---
-# val_id: the SSA id held in each register index (0 when empty or pending)
-# imm:    the pending immediate value per register index
-# is_imm: whether the slot holds a pending immediate rather than an id
+# val_id:  the SSA id held in each register index (0 when empty or pending)
+# imm:     the pending immediate value per register index
+# is_imm:  whether the slot holds a pending immediate rather than an id
+# is_bool: whether the slot's id is a boolean awaiting the consumer's type
 rec Regs {
-    val_id: [16]u32;
-    imm:    [16]i64;
-    is_imm: [16]bool;
+    val_id:  [16]u32;
+    imm:     [16]i64;
+    is_imm:  [16]bool;
+    is_bool: [16]bool;
 }
 
 # one defined function the emission unit offers, wherever it came from
@@ -2713,7 +2722,7 @@ fun emit_node(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32, is_en
     # position, valid for the whole function.
     var rg: Regs;
     var i: u32 = 0;
-    for (i < 16) { rg.val_id[i] = 0; rg.imm[i] = 0; rg.is_imm[i] = false; i = i + 1; }
+    for (i < 16) { rg.val_id[i] = 0; rg.imm[i] = 0; rg.is_imm[i] = false; rg.is_bool[i] = false; i = i + 1; }
     i = 0;
     for (i < param_count && i < 16) { rg.val_id[i] = param_ids[i]; i = i + 1; }
 
@@ -3086,7 +3095,7 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
                 }
                 if (t != 0 && v < n && out.type_id[v] == 0) {
                     out.type_id[v] = t;
-                    out.is_bool[v] = false;
+                    out.is_bool[v] = types.type_is_bool(e.tt, t);
                 }
             }
             ei = ei + 1;
@@ -3236,7 +3245,7 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
                 val lt: u32 = interface_value_type(e, ?mi.operands[1]);
                 if (lv < out.n && out.type_id[lv] == 0 && lt != 0) {
                     out.type_id[lv] = lt;
-                    out.is_bool[lv] = false;
+                    out.is_bool[lv] = types.type_is_bool(e.tt, lt);
                     ii = ii + 1;
                     cnt;
                 }
@@ -4190,8 +4199,9 @@ fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] 
     spirv.inst(e.b, ?e.b.functions, spirv.OP_FUNCTION_CALL, ?ops[0], total);
     # the return register, which the result move reads next.
     if (!returns_void) {
-        preg_val.val_id[0] = result;
-        preg_val.is_imm[0] = false;
+        preg_val.val_id[0]  = result;
+        preg_val.is_imm[0]  = false;
+        preg_val.is_bool[0] = types.type_is_bool(e.tt, ret_ty);
     }
     ret R.ok[bool, str](true);
 }
@@ -4332,8 +4342,9 @@ fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[bool, st
 
     # the return register, which the result move reads next - the same handoff a
     # real OpFunctionCall makes.
-    preg_val.val_id[0] = result;
-    preg_val.is_imm[0] = false;
+    preg_val.val_id[0]  = result;
+    preg_val.is_imm[0]  = false;
+    preg_val.is_bool[0] = types.type_is_bool(e.tt, ret_ty);
     ret R.ok[bool, str](true);
 }
 
@@ -4925,21 +4936,32 @@ fun emit_mov(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[
         # parameter or the function's return type declares, not the move's, which the
         # ABI pre-coloring always emits at the machine word in the integer class.
         if (src.kind == mir.MIR_OP_IMM) {
-            preg_val.val_id[dst.preg] = 0;
-            preg_val.imm[dst.preg]    = src.imm;
-            preg_val.is_imm[dst.preg] = true;
+            preg_val.val_id[dst.preg]  = 0;
+            preg_val.imm[dst.preg]     = src.imm;
+            preg_val.is_imm[dst.preg]  = true;
+            preg_val.is_bool[dst.preg] = false;
             ret R.ok[bool, str](true);
         }
+        # a boolean waits here untyped for the same reason an immediate does, and is
+        # read out with `want_ty` 0 so nothing widens it before the use site knows
+        # what the declaration asks for.
+        val boolean: bool = operand_is_bool(vm, preg_val, src);
         val val_id: u32 = read_operand(e, vm, preg_val, src, 0);
         if (e.b.err) { ret R.err[bool, str]("spirv.emit: unreadable move source"); }
-        preg_val.val_id[dst.preg] = val_id;
-        preg_val.is_imm[dst.preg] = false;
+        preg_val.val_id[dst.preg]  = val_id;
+        preg_val.is_imm[dst.preg]  = false;
+        preg_val.is_bool[dst.preg] = boolean;
         ret R.ok[bool, str](true);
     }
     ret unsupported(e, "memory-destination move is not yet supported by the SPIR-V target");
 }
 
-# the SSA value in a nominal register, minting a pending immediate at `want_ty`
+# the SSA value in a nominal register, resolved against the type the consumer declares
+#
+# Both deferrals the register file carries are settled here, because this is the first
+# point that knows `want_ty`: a pending immediate is minted at it, and a boolean is
+# widened to it. A boolean position leaves the boolean alone, which is what a callee
+# declaring an actual `OpTypeBool` parameter needs.
 # ---
 # e:       the emission state
 # rg:      the register file
@@ -4947,8 +4969,23 @@ fun emit_mov(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[
 # want_ty: the SPIR-V type the consumer declares for this position
 # ret:     the SSA value id, or 0 when the register holds nothing
 fun reg_value(e: *Emit, rg: *Regs, k: u32, want_ty: u32) u32 {
-    if (!rg.is_imm[k]) { ret rg.val_id[k]; }
-    ret immediate(e, want_ty, rg.imm[k]);
+    if (rg.is_imm[k]) { ret immediate(e, want_ty, rg.imm[k]); }
+    if (rg.is_bool[k] && rg.val_id[k] != 0 && want_ty != 0 && !types.type_is_bool(e.tt, want_ty)) {
+        ret widen_bool(e, rg.val_id[k], want_ty);
+    }
+    ret rg.val_id[k];
+}
+
+# whether an operand's value is a SPIR-V boolean rather than a number
+# ---
+# vm: the per-vreg value maps
+# rg: the register file
+# op: the operand
+# ret: true for a comparison result, wherever it is currently held
+fun operand_is_bool(vm: *VMaps, rg: *Regs, op: *mir.MirOperand) bool {
+    if (op.kind == mir.MIR_OP_VREG) { ret op.vreg < vm.n && vm.is_bool[op.vreg]; }
+    if (op.kind == mir.MIR_OP_PREG) { ret op.preg < 16 && rg.is_bool[op.preg]; }
+    ret false;
 }
 
 # the `#[builtin]` type table, at every built-in and in both directions


### PR DESCRIPTION
A SPIR-V comparison yields an `OpTypeBool`, which is abstract and has no storage layout, so it cannot be a call argument or a return value where a byte is declared. On a byte-addressed machine the same comparison is a 0/1 in a register that widens by zero extension, which is why this worked everywhere else.

## Root cause

The emitter already converted at every position that knows the type it is converting to. `read_operand` takes the consumer's declared type and emits the `OpSelect` widening when a boolean vreg lands somewhere numeric, so a store to a variable, a store through a pointer and a store into a record member were all already correct.

The two positions that were not are the two that go through the ABI pre-coloring's nominal register file, and they share one cause. `emit_mov` into a physical register read its source with `want_ty` 0, because the move is emitted at the machine word and does not know the callee's declaration. The immediate case was already handled by deferring: the slot records the immediate and the constant is minted at the use site with the declared width. A boolean had no such deferral, so the raw `%bool` id sat in the register and `reg_value` handed it on unchanged to `OpFunctionCall` and to `OpReturnValue`.

## The fix

`Regs` gains `is_bool`, the second deferral the register file carries, for the same reason it carries the first. `reg_value` is now the single point that resolves both against `want_ty`: an immediate is minted at it, a boolean is widened to it, and a boolean declaration leaves the boolean alone. That last clause is what keeps a callee declaring an actual `OpTypeBool` parameter working, and comparisons are still typed as booleans, so `OpBranchConditional` keeps receiving the real `%bool` the specification requires.

Two `is_bool[v] = false` assignments in the vreg type map became `types.type_is_bool(e.tt, t)`, so the flag cannot disagree with the type beside it. Both sit where the type comes from a callee's declared return or from a variable, the only places a genuinely boolean SPIR-V type could arrive that way.

## Adjacent positions

All five were checked by compiling one fixture and reading the module.

| position | before |
| --- | --- |
| call argument | **broken**, `OpFunctionCall` given `%bool` where `%uchar` is declared |
| return value | **broken**, `OpReturnValue %bool` out of a `%uchar` function |
| store to a variable | already correct, `OpSelect` present |
| store into a record member | already correct, `OpSelect` present |
| store through a pointer | already correct, `OpSelect` present |
| conditional branch | correct and unchanged, still a real `%bool` |

The two broken ones share the one cause and are both fixed here. Nothing was found that is a separate defect, so nothing was filed.

## Verification

`spirv-val`, target environment `spv1.6` (the Vulkan environments reject the module at `OpCapability Linkage` before reaching any of this, so the universal environment is the one that answers the question).

The issue's repro, before:

```
error: line 65: OpFunctionCall Argument <id> '45[%45]'s type does not match Function <id> '4[%uchar]'s parameter type.
  %46 = OpFunctionCall %ulong %1 %ulong_1 %45
```

After: exit 0, no diagnostics. The six-position fixture above also validates clean, where before it failed at the first call argument.

**Counterfactual.** With `emit.mach` reverted and `tests.mach` kept, the new unit test fails (0 passed, 1 failed) and `spirv-val` rejects the repro with the error above. Restored: the test passes and `spirv-val` exits 0.

**Test.** One unit test in `src/lang/driver/tests.mach`, reading the emitted module in process. It counts boolean values reaching a call argument and reaching an `OpReturnValue` out of a non-boolean function, both of which must be 0. Its positive controls are that the fixture really contains three `OpIEqual`, that exactly two `OpSelect` appear (the two crossings and not the branch), and that the `OpBranchConditional` condition is still a boolean value. That last one is what pins the fix: retyping comparisons as numbers would satisfy the two zeroes and break the branch instead.

Full suite: **1442 passed, 0 failed**. `mach build .` exit 0.

**Machine target output.** The merge base's own source tree compiled for `linux-x86_64` by a baseline compiler built from the merge base, and by this branch's compiler, both outside the build tree: **177 objects each, 0 differing**.

Closes #2910
