### PR TITLE
fix(codegen): expand float to unsigned on x86-64

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -17688,3 +17688,62 @@ test "mach.lang.driver:freestanding_elf_links_with_no_header_segment" {
     if (bad) { ret 1; }
     ret 0;
 }
+
+# opaque unit multipliers for the float-to-unsigned case: reading a mutable global
+# keeps the conversion source out of reach of constant folding, so the value is
+# produced by the backend's convert rather than by the frontend
+var ut_fp2u_one:  f64 = 1.0;
+var ut_fp2u_onef: f32 = 1.0;
+
+# `::` from a float to an unsigned integer must be value-preserving across the whole
+# destination range (#2909). x86-64 has no unsigned truncating convert, so SSE2's
+# signed CVTTSS/SD2SI was selected directly and returned the integer-indefinite value
+# for every source at or above 2^31 (`::u32`) or 2^63 (`::u64`) - silently, since the
+# indefinite value is a plausible-looking number.
+#
+# THE BOUNDARY ITSELF IS NOT COVERAGE. At exactly 2^31 and exactly 2^63 the
+# indefinite value equals the correct answer, so the 2^63 row below is a positive
+# control and nothing more; the rows that fail without the fix are the ones STRICTLY
+# ABOVE the boundary. The below-boundary rows are the other control: they were
+# correct before the fix and must stay correct, which is what separates a real
+# conversion from one that now merely biases everything.
+#
+# every source is exactly representable in its own float width, so each expected
+# value is the one true answer and not a rounding choice. this runs wherever the
+# suite runs, so it holds the aarch64 and riscv64 selections to the same result
+test "mach.lang.driver:float_to_unsigned_spans_the_whole_destination_range" {
+    val one:  f64 = ut_fp2u_one;
+    val onef: f32 = ut_fp2u_onef;
+    var bad: bool = false;
+
+    # controls: below the signed boundary, correct before the fix and after it.
+    if ((2147483647.0 * one)::u32 != 2147483647)                    { bad = true; }
+    if ((2147483520.0::f32 * onef)::u32 != 2147483520)              { bad = true; }
+    if ((1.0e18 * one)::u64 != 1000000000000000000)                 { bad = true; }
+    if ((1099511627776.0::f32 * onef)::u64 != 1099511627776)        { bad = true; }
+
+    # positive controls at the boundary, where the indefinite value happens to agree.
+    if ((2147483648.0 * one)::u32 != 2147483648)                    { bad = true; }
+    if ((9223372036854775808.0 * one)::u64 != (1::u64 << 63))       { bad = true; }
+    if ((9223372036854775808.0::f32 * onef)::u64 != (1::u64 << 63)) { bad = true; }
+
+    # strictly above the boundary: the whole of what was wrong.
+    if ((3000000000.0 * one)::u32 != 3000000000)                    { bad = true; }
+    if ((4294967295.0 * one)::u32 != 4294967295)                    { bad = true; }
+    if ((3000000000.0::f32 * onef)::u32 != 3000000000)              { bad = true; }
+    if ((4294967040.0::f32 * onef)::u32 != 4294967040)              { bad = true; }
+
+    if ((1.0e19 * one)::u64 != 1000000000::u64 * 10000000000::u64)  { bad = true; }
+    if ((18446744073709549568.0 * one)::u64 != ~(2047::u64))        { bad = true; }
+    if ((9223373136366403584.0::f32 * onef)::u64
+        != (1::u64 << 63) + (1::u64 << 40))                         { bad = true; }
+    if ((18446742974197923840.0::f32 * onef)::u64
+        != ~((1::u64 << 40) - 1))                                   { bad = true; }
+
+    # sub-word unsigned destinations ride the same 64-bit convert.
+    if ((250.0 * one)::u8 != 250)                                   { bad = true; }
+    if ((65535.0 * one)::u16 != 65535)                              { bad = true; }
+
+    if (bad) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3826,11 +3826,21 @@ fun emit_gp_store(dst: isa.Operand, gp: i32, w: u8, buf: *enc.ByteBuf) R.Result[
 # emit one register-register SSE conversion `cvt_op dst_reg, src_reg`
 # at the given integer-side byte width (sizes REX.W for the GP operand of a
 # CVTSI2SS/SD / CVTTSS2SI/SD; a float-to-float CVTSS2SD / CVTSD2SS ignores it)
+#
+# the encoding reads only `size` and `flags`, but `--emit-asm` names each operand
+# from the operand's own size, so the GP side carries `int_w` and only the XMM side
+# carries 16. which side is which follows the opcode: CVTSI2SS/SD reads a GP source,
+# CVTTSS/SD2SI writes a GP destination, and the float-to-float forms have neither
 fun emit_cvt_reg(cvt_op: u16, dst_reg: i32, src_reg: i32, int_w: u8, buf: *enc.ByteBuf) {
+    var dst_sz: u8 = 16;
+    var src_sz: u8 = 16;
+    if (cvt_op == x64.CVTSI2SS || cvt_op == x64.CVTSI2SD) { src_sz = int_w; }
+    if (cvt_op == x64.CVTTSS2SI || cvt_op == x64.CVTTSD2SI) { dst_sz = int_w; }
+
     var cvt: isa.Inst = isa.inst_blank();
     cvt.opcode = cvt_op;
-    cvt.dst    = isa.make_reg(dst_reg, 16);
-    cvt.src1   = isa.make_reg(src_reg, 16);
+    cvt.dst    = isa.make_reg(dst_reg, dst_sz);
+    cvt.src1   = isa.make_reg(src_reg, src_sz);
     cvt.size   = int_w;
     cvt.flags  = width_flags(int_w);
     encode_inst(?cvt, buf);
@@ -3983,6 +3993,73 @@ fun emit_u64_to_fp(dst: isa.Operand, work: i32, dst_w: u8, cvt_op: u16, buf: *en
     ret emit_float_store(dst, work, dst_w, buf);
 }
 
+# truncate the float in `src_reg` to an unsigned 64-bit integer
+# left in SCRATCH_REG. SSE2 carries no unsigned truncating convert, and the signed
+# CVTTSS/SD2SI it does carry returns the integer-indefinite value for every source
+# at or above 2^63, so the range is split at that boundary: below it the signed
+# convert is already exact, at or above it the boundary is subtracted off first and
+# 2^63 added back to the integer result, which is exact because the biased value
+# lands in [0, 2^63). the boundary is a pooled constant read as `[rip + .Lconst.N]`
+# by both the compare and the subtract, FLOAT_SCRATCH0 holds the biased copy so an
+# allocated source register is never written, and SCRATCH_REG2 carries the re-add.
+# a NaN source leaves UCOMIS unordered with CF set and so takes the direct arm,
+# keeping the indefinite value the signed convert gives it. the two forward rel32
+# jumps are intra-instruction, patched here from the measured branch lengths
+fun emit_fp_to_u64(st: *enc.EncodeState, src_reg: i32, src_w: u8, cvt_op: u16) R.Result[bool, str] {
+    val buf: *enc.ByteBuf = ?st.buf;
+    var bound_bits: u64 = 0x43E0000000000000;
+    if (src_w == 4) { bound_bits = 0x5F000000; }
+    val br: R.Result[isa.Operand, str] = float_const_operand(st, bound_bits, FLOAT_SCRATCH1, src_w);
+    if (R.is_err[isa.Operand, str](br)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](br)); }
+    val bound: isa.Operand = R.unwrap_ok[isa.Operand, str](br);
+
+    var ucom: isa.Inst = isa.inst_blank();
+    ucom.opcode = x64.UCOMISD;
+    if (src_w == 4) { ucom.opcode = x64.UCOMISS; }
+    ucom.dst  = isa.make_reg(src_reg, 16);
+    ucom.src1 = bound;
+    ucom.size = src_w;
+    val ue: R.Result[bool, str] = encode_inst_sym(st, ?ucom);
+    if (R.is_err[bool, str](ue)) { ret ue; }
+
+    var jb: isa.Inst = isa.inst_blank();
+    jb.opcode = x64.JB;
+    jb.dst    = isa.make_label(nil);
+    jb.size   = DEFAULT_OPERAND_SIZE;
+    encode_inst(?jb, buf);
+    val jb_patch: usize = buf.len - 4;
+    val after_jb: usize = buf.len;
+
+    # value >= 2^63: convert the biased value and add the bias back.
+    emit_movaps_rr(FLOAT_SCRATCH0, src_reg, buf);
+    var sub: isa.Inst = isa.inst_blank();
+    sub.opcode = x64.SUBSD;
+    if (src_w == 4) { sub.opcode = x64.SUBSS; }
+    sub.dst  = isa.make_reg(FLOAT_SCRATCH0, 16);
+    sub.src1 = bound;
+    sub.size = src_w;
+    val se: R.Result[bool, str] = encode_inst_sym(st, ?sub);
+    if (R.is_err[bool, str](se)) { ret se; }
+    emit_cvt_reg(cvt_op, x64.SCRATCH_REG, FLOAT_SCRATCH0, 8, buf);
+    emit_gp_ri8(x64.MOV, x64.SCRATCH_REG2, (1::u64 << 63)::i64, buf);
+    emit_gp_rr8(x64.ADD, x64.SCRATCH_REG, x64.SCRATCH_REG2, buf);
+
+    var jmp: isa.Inst = isa.inst_blank();
+    jmp.opcode = x64.JMP;
+    jmp.dst    = isa.make_label(nil);
+    jmp.size   = DEFAULT_OPERAND_SIZE;
+    encode_inst(?jmp, buf);
+    val jmp_patch: usize = buf.len - 4;
+    val after_jmp: usize = buf.len;
+
+    # value < 2^63: the signed conversion is exact.
+    patch_rel32(buf, jb_patch, (buf.len - after_jb)::i32);
+    emit_cvt_reg(cvt_op, x64.SCRATCH_REG, src_reg, 8, buf);
+
+    patch_rel32(buf, jmp_patch, (buf.len - after_jmp)::i32);
+    ret R.ok[bool, str](true);
+}
+
 # materialize a fully-resolved float conversion into its SSE byte
 # sequence. `encode_cvt` names both operands as registers and has no memory form, so
 # an operand the allocator spilled is staged through a scratch register (XMM
@@ -4000,10 +4077,11 @@ fun emit_u64_to_fp(dst: isa.Operand, work: i32, dst_w: u8, cvt_op: u16, buf: *en
 # unsigned 64-bit value >= 2^63 takes a range-fixup path (`emit_u64_to_fp`) since the
 # signed CVTSI2SS/SD has no direct unsigned-64 form.
 #
-# FP_TO_SI / FP_TO_UI map to the signed CVTTSS2SI / CVTTSD2SI: a full unsigned
-# 64-bit conversion needs a range-fixup sequence x86-64 lacks a single instruction
-# for; the signed form is correct for every value in signed range, which is what the
-# language's reachable conversions produce, and matches the prior selection.
+# FP_TO_SI uses the signed CVTTSS2SI / CVTTSD2SI at the destination's own width.
+# FP_TO_UI has no SSE2 instruction of its own, so this target owes the expansion: a
+# sub-64-bit unsigned destination converts at 64-bit width and keeps the low bytes
+# (2^32 - 1 is far inside the signed 64-bit range), and a 64-bit unsigned destination
+# takes the two-arm range fixup in `emit_fp_to_u64`.
 #
 # THE FLOAT SIDE'S WIDTH IS REFUSED WHEN IT IS NOT 4 OR 8 (#2733), and which side is
 # the float one depends on the opcode - both for FP_TRUNC / FP_EXT, the destination
@@ -4091,6 +4169,19 @@ fun encode_float_conv(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
     val src_reg: i32 = R.unwrap_ok[i32, str](sr);
     var cvt_op: u16 = x64.CVTTSD2SI;
     if (src_w == 4) { cvt_op = x64.CVTTSS2SI; }
+
+    if (op == mir.MIR_FP_TO_UI) {
+        if (dst_w >= 8) {
+            val fx: R.Result[bool, str] = emit_fp_to_u64(st, src_reg, src_w, cvt_op);
+            if (R.is_err[bool, str](fx)) { ret fx; }
+        } or {
+            # every value a narrower unsigned destination holds is inside the signed
+            # 64-bit range, so the 64-bit convert is exact and the store truncates.
+            emit_cvt_reg(cvt_op, x64.SCRATCH_REG, src_reg, 8, buf);
+        }
+        ret emit_gp_store(dst, x64.SCRATCH_REG, dst_w, buf);
+    }
+
     emit_cvt_reg(cvt_op, x64.SCRATCH_REG, src_reg, dst_w, buf);
     ret emit_gp_store(dst, x64.SCRATCH_REG, dst_w, buf);
 }


### PR DESCRIPTION
Closes #2909

## Root cause

`encode_float_conv` ignored the signedness of the destination. `MIR_FP_TO_SI` and `MIR_FP_TO_UI` both fell through to the same two lines, selecting the signed `CVTTSS2SI` / `CVTTSD2SI` at the destination's own width. SSE2 carries no unsigned truncating convert, so every source at or above `2^31` (`::u32`) or `2^63` (`::u64`) sat outside the signed destination range and the instruction returned the x86 integer-indefinite value, silently.

riscv64 and aarch64 were already correct because `fcvt.wu.d` / `fcvt.lu.d` and `fcvtzu` exist and are selected.

## The expansion

An unsigned destination is a property of the operation, so the target that lacks the instruction owes the expansion. It sits in `encode_float_conv` where the convert is selected, not behind a caller-side guard and not in a generic pass other targets would pay for.

**Sub-64-bit unsigned destination** converts at 64-bit width and the store keeps the low bytes. `2^32 - 1` is far inside the signed 64-bit range, so no fixup exists to get wrong:

```
cvttsd2si r11, xmm2
mov ecx, r11d
```

**64-bit unsigned destination** takes the two-arm range fixup in the new `emit_fp_to_u64`. The boundary is a pooled constant that both the compare and the subtract read, `FLOAT_SCRATCH0` holds the biased copy so an allocated source register is never written, and `SCRATCH_REG2` carries the re-add:

```
movsd xmm1, qword [rip + .Lconst.2]
mulsd xmm1, qword [rbp - 96]
ucomisd xmm1, qword [rip + .Lconst.3]     ; .Lconst.3 = 2^63
jb .below
movaps xmm14, xmm1
subsd xmm14, qword [rip + .Lconst.3]
cvttsd2si r11, xmm14
movabs r10, -9223372036854775808
add r11, r10
jmp .done
.below:
cvttsd2si r11, xmm1
.done:
```

The biased value lands in `[0, 2^63)`, so the second convert is exact and the re-add is exact. A NaN source leaves `UCOMIS` unordered with CF set and so takes the direct arm, keeping the indefinite value the signed convert already gave it.

`SUBSS` / `UCOMISS` and the `0x5F000000` boundary cover the f32 source. All four combinations go through the same code.

## Executed repro

The issue's program, built and run by the branch compiler.

Before (`stage1_base`, built from the merge base `20062ef0`):

```
f64 3e9 ::u32  = 2147483648
f32 3e9 ::u32  = 2147483648
f64 1e19 ::u64 = 9223372036854775808
f64 2^31-1     = 2147483647
f64 1e18 ::u64 = 1000000000000000000
```

After:

```
f64 3e9 ::u32  = 3000000000
f32 3e9 ::u32  = 3000000000
f64 1e19 ::u64 = 10000000000000000000
f64 2^31-1     = 2147483647
f64 1e18 ::u64 = 1000000000000000000
```

Five of five match the issue's expected block. A wider sweep, run at both `-O0` and `-O2` with identical results:

```
f64 2^31   ::u32 = 2147483648
f64 2^32-1 ::u32 = 4294967295
f32 2^31   ::u32 = 2147483648
f32 2^32-256 ::u32 = 4294967040
f64 2^63     ::u64 = 9223372036854775808
f64 2^63+2^11 ::u64 = 9223372036854777856
f64 near 2^64 ::u64 = 18446744073709549568
f32 2^63     ::u64 = 9223372036854775808
f32 1e19     ::u64 = 9999999980506447872
f32 1e18     ::u64 = 999999984306749440
f64 250 ::u8  = 250
f64 65535 ::u16 = 65535
```

## The test and its counterfactual

One unit test in `src/lang/driver/tests.mach`, no new integration cases. It performs the conversions at run time through mutable globals so the frontend cannot fold them, which means the suite binary the compiler under test produced is what is being measured.

Exactly `2^31` and exactly `2^63` are carried as positive controls and are labelled as such in the test, because the indefinite value agrees with the correct answer there. The rows that actually fail without the fix are strictly above the boundary. The below-boundary rows are the other control: correct before the fix, and still correct after, which is what separates a real conversion from one that now merely biases everything.

- with the fix: **1442 passed, 0 failed, 1442 total**
- counterfactual, the same test compiled by the merge-base compiler: **1441 passed, 1 failed** on `mach.lang.driver:float_to_unsigned_spans_the_whole_destination_range`
- restored: **1442 passed, 0 failed**

## Machine output

Determinism control first, since a nondeterministic build is otherwise indistinguishable from the change having done something. The merge-base compiler built the same source twice: **0 of 224 objects differ**.

Then the same (merge-base) source compiled by the merge-base compiler and by the branch compiler, so the only variable is codegen. Baselines were built from the branch's own merge base and kept outside the build tree.

| target | objects | differing |
| --- | --- | --- |
| linux-x86_64 | 224 | 0 |
| linux-arm64 | 224 | 0 |
| linux-riscv64 | 224 | 0 |

Zero on x86_64 is the honest result rather than a null one: the compiler's own source contains no float-to-unsigned conversion, so nothing in it should move. aarch64 and riscv64 are untouched by construction and confirm it.

Where the construct does occur, the change is exactly as narrow as it should be. The repro project compiled by both compilers: **1 of 31 objects differs**, `obj/case/main.o`, the only object holding a conversion, plus the binary linked from it.

## Self-host

stage2 and stage3 are byte-identical (`9cbf5134f1973d52b2fd0d87f640b97f5ad9ec18fcec028f35ffaee4111847d8`). `mach build .` and `mach test .` are green for all three linux targets.

## Also in this change

`emit_cvt_reg` named both operands at size 16, so `--emit-asm` printed the GP operand of every convert as an XMM register: `cvttsd2si xmm11, xmm2` for an instruction whose destination is `r11`. The encoding reads only `size` and `flags`, so this was display only, but it makes this PR's own assembly unreadable and a printed operand is a claim. Each operand now carries its own width and the listing reads `cvttsd2si r11, xmm1`. Confirmed byte-for-byte inert by the object diff above.

## Found, not fixed

The intra-instruction forward jumps in these expansions print as `jb <internal>` under `--emit-asm`, because the label operand is synthesized in the encoder and has no name. It predates this change (`emit_u64_to_fp` has the same two jumps) and is a listing gap rather than a codegen one, so it is left alone here.
