### PR TITLE
fix(codegen): keep an aggregate copy whole on a logical-addressing target

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -493,6 +493,22 @@ pub val MIR_FNEG: MirOpcode = 0x111B;
 # on partial zeroing, interleaved stores, or a change of chunk widths.
 pub val MIR_MEMZERO: MirOpcode = 0x111C;
 
+# copy an entire object between two memory operands; operands [dst_mem, src_mem,
+# size_imm] (#2911).
+#
+# The sibling of MIR_MEMZERO and it exists for the same reason. An aggregate store
+# is a storage-to-storage copy, and expanding it into a run of word-sized
+# load/store pairs is a BYTE-SPACE transformation: a chunk is sized for the machine
+# rather than for the object, so it spans member boundaries and addresses INTO the
+# storage rather than naming the object. A logical-addressing target has no pointer
+# for that at all - it reaches an object as one whole value at one type - so the
+# copy is kept whole here and expanded only where a byte space exists. A flat
+# target never sees one: `lower_store_aggregate` still emits the chunk run there.
+#
+# The size rides as an operand for the same reason MIR_MEMZERO's does: the
+# instruction's width field is a byte width and an aggregate outgrows it.
+pub val MIR_MEMCPY: MirOpcode = 0x111D;
+
 # a bit reinterpret (`:~`) BETWEEN TWO VALUES is a plain MIR_BITCAST. a same-bank
 # reinterpret (GP<->GP or XMM<->XMM) is a register copy; a `:~` between a float and
 # an equal-size integer crosses the GP and XMM banks. both select to a plain MOV:
@@ -1243,6 +1259,8 @@ pub fun opcode_name(op: MirOpcode) str {
     if (op == MIR_FDIV)         { ret "MIR_FDIV"; }
     if (op == MIR_FCMP)         { ret "MIR_FCMP"; }
     if (op == MIR_FNEG)         { ret "MIR_FNEG"; }
+    if (op == MIR_MEMZERO)      { ret "MIR_MEMZERO"; }
+    if (op == MIR_MEMCPY)       { ret "MIR_MEMCPY"; }
     ret "<unknown MIR opcode>";
 }
 
@@ -1846,7 +1864,7 @@ test "mach.lang.be.codegen.mir.instr_like:carries_every_field" {
 # is deliberately sparse (the selected forms start at 0x1000), so a dense walk
 # would spend most of its time on values that are not opcodes at all.
 test "mach.lang.be.codegen.mir.opcode_name:total_and_distinct" {
-    var ops: [85]MirOpcode;
+    var ops: [87]MirOpcode;
     ops[0]  = MIR_ADD;         ops[1]  = MIR_SUB;         ops[2]  = MIR_MUL;
     ops[3]  = MIR_DIV_S;       ops[4]  = MIR_DIV_U;       ops[5]  = MIR_REM_S;
     ops[6]  = MIR_REM_U;       ops[7]  = MIR_NEG;         ops[8]  = MIR_AND;
@@ -1876,9 +1894,10 @@ test "mach.lang.be.codegen.mir.opcode_name:total_and_distinct" {
     ops[78] = MIR_FSUB;        ops[79] = MIR_FMUL;        ops[80] = MIR_FDIV;
     ops[81] = MIR_FCMP;        ops[82] = MIR_FNEG;
     ops[83] = MIR_VEC_BUILD;   ops[84] = MIR_MUL_HI_U;
+    ops[85] = MIR_MEMZERO;     ops[86] = MIR_MEMCPY;
 
     var i: usize = 0;
-    for (i < 85) {
+    for (i < 87) {
         val n: str = opcode_name(ops[i]);
         # total: no declared opcode reaches the fallback
         if (str_equals(n, "<unknown MIR opcode>")) { ret 1; }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2506,6 +2506,25 @@ fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
 # ret:  true on success, or a lowering / allocation error
 fun lower_store_aggregate(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) R.Result[bool, str] {
     val size: u32 = ir_type.byte_size(ctx.types, inst.operands[0].ty, ctx.tgt);
+
+    # a logical-addressing target keeps the whole-object form (#2911), for the same
+    # reason MIR_MEMZERO does: the chunk run below is sized for the machine word, so
+    # a chunk spans member boundaries and every access it makes is an address INTO
+    # the storage rather than a name for the object. There is no structural access
+    # that expresses either, and the intent cannot be recovered from the run
+    # afterwards.
+    if (!ctx.tgt.model.flat_addressing) {
+        val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+        if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](r)); }
+        val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+        ops[0] = agg_pointer_mem(ctx, inst.operands[1], 0);
+        ops[1] = agg_pointer_mem(ctx, inst.operands[0], 0);
+        ops[2] = mir.op_imm(size::i64);
+        var mi: mir.MirInstr = mir.instr(mir.MIR_MEMCPY, ops, 3,
+                                         ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
+        ret lctx.push_instr(ctx, mb, mi);
+    }
+
     var off: i64 = 0;
     for (off::u32 < size) {
         val chunk: u8 = lctx.copy_chunk_width(ctx.tgt, (size - off::u32)::u64);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -17688,3 +17688,330 @@ test "mach.lang.driver:freestanding_elf_links_with_no_header_segment" {
     if (bad) { ret 1; }
     ret 0;
 }
+
+# the id capacity of the SPIR-V evaluator below
+#
+# The fixture it runs on binds around a hundred ids, so this is slack rather than a
+# limit; an id past it fails the evaluation rather than aliasing another.
+val UT_SPV_EV_IDS: u32 = 256;
+
+# the evaluator answers with this when the module is outside what it models
+#
+# It is a value no fixture computes, and every arm that cannot proceed returns it,
+# so an assertion against an expected number cannot be satisfied by an evaluation
+# that quietly gave up.
+val UT_SPV_EV_BAD: u64 = 0xFFFFFFFFFFFFFFFF;
+
+# the evaluator's per-id state: scalars, four-element arrays, and access chains
+rec UtSpvEval {
+    is_arr_ty: [256]bool;
+    sc:        [256]u64;
+    sc_ok:     [256]bool;
+    arr:       [1024]u64;
+    arr_ok:    [256]bool;
+    ch_var:    [256]u32;
+    ch_ix:     [256]u32;
+    ch_ok:     [256]bool;
+}
+
+# run a fixture module's one function body and report the value it stores into the
+# interface variable decorated `Location loc`
+#
+# THIS READS VALUES BACK, which is the only thing that settles whether an
+# initializer took effect. A structural assertion - that a copy instruction is
+# present, that the module validates - is satisfied just as well by a copy that
+# moves the wrong bytes, and a whole-object copy emitted at the wrong type is
+# exactly the shape that passes one and fails the other.
+#
+# ANY INSTRUCTION IN THE BODY IT DOES NOT MODEL FAILS THE EVALUATION. The set below
+# is what the fixture emits and nothing more, so an emitter change that routes the
+# initializer through some other instruction is reported rather than skipped, which
+# is what would let the read-back keep answering from a stale store.
+# ---
+# w, n: the instruction words, header already skipped
+# loc:  the interface location to read
+# ret:  the value stored there, or UT_SPV_EV_BAD
+fun ut_spv_eval_location(w: *u32, n: u32, loc: u32) u64 {
+    var st: UtSpvEval;
+
+    # the array types, so a null constant is recognized as an aggregate zero rather
+    # than a scalar one.
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret UT_SPV_EV_BAD; }
+        if ((w[i] & 0xFFFF) == spirv.OP_TYPE_ARRAY) {
+            if (w[i + 1] >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            st.is_arr_ty[w[i + 1]] = true;
+        }
+        i = i + len;
+    }
+
+    # the constants, which the module declares ahead of every function.
+    i = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret UT_SPV_EV_BAD; }
+        val op: u32 = w[i] & 0xFFFF;
+        if (op == spirv.OP_CONSTANT && len == 4) {
+            if (w[i + 2] >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            st.sc[w[i + 2]] = w[i + 3]::u64;
+            st.sc_ok[w[i + 2]] = true;
+        }
+        if (op == spirv.OP_CONSTANT_NULL) {
+            if (w[i + 2] >= UT_SPV_EV_IDS || w[i + 1] >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            if (st.is_arr_ty[w[i + 1]]) { st.arr_ok[w[i + 2]] = true; }
+            or { st.sc_ok[w[i + 2]] = true; }
+        }
+        i = i + len;
+    }
+
+    # the variable the location names.
+    var target: u32 = 0;
+    i = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret UT_SPV_EV_BAD; }
+        if ((w[i] & 0xFFFF) == spirv.OP_DECORATE && len == 4
+            && w[i + 2] == spirv.DECOR_LOCATION && w[i + 3] == loc) { target = w[i + 1]; }
+        i = i + len;
+    }
+    if (target == 0 || target >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+
+    var in_body: bool = false;
+    i = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret UT_SPV_EV_BAD; }
+        val op: u32 = w[i] & 0xFFFF;
+
+        if (op == spirv.OP_FUNCTION)     { in_body = true;  i = i + len; cnt; }
+        if (op == spirv.OP_FUNCTION_END) { in_body = false; i = i + len; cnt; }
+        if (!in_body) { i = i + len; cnt; }
+        if (op == spirv.OP_LABEL || op == spirv.OP_RETURN || op == spirv.OP_VARIABLE) {
+            i = i + len; cnt;
+        }
+
+        if (op == spirv.OP_ACCESS_CHAIN) {
+            if (len != 5) { ret UT_SPV_EV_BAD; }
+            val res: u32 = w[i + 2];
+            val base: u32 = w[i + 3];
+            val ix: u32 = w[i + 4];
+            if (res >= UT_SPV_EV_IDS || base >= UT_SPV_EV_IDS || ix >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            if (!st.sc_ok[ix] || st.sc[ix] >= 4) { ret UT_SPV_EV_BAD; }
+            st.ch_var[res] = base;
+            st.ch_ix[res] = st.sc[ix]::u32;
+            st.ch_ok[res] = true;
+            i = i + len; cnt;
+        }
+
+        if (op == spirv.OP_LOAD) {
+            if (len != 4) { ret UT_SPV_EV_BAD; }
+            val res: u32 = w[i + 2];
+            val ptr: u32 = w[i + 3];
+            if (res >= UT_SPV_EV_IDS || ptr >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            if (st.ch_ok[ptr]) {
+                st.sc[res] = st.arr[st.ch_var[ptr] * 4 + st.ch_ix[ptr]];
+                st.sc_ok[res] = true;
+            } or (st.arr_ok[ptr]) {
+                var k: u32 = 0;
+                for (k < 4) { st.arr[res * 4 + k] = st.arr[ptr * 4 + k]; k = k + 1; }
+                st.arr_ok[res] = true;
+            } or {
+                if (!st.sc_ok[ptr]) { ret UT_SPV_EV_BAD; }
+                st.sc[res] = st.sc[ptr];
+                st.sc_ok[res] = true;
+            }
+            i = i + len; cnt;
+        }
+
+        if (op == spirv.OP_STORE) {
+            if (len != 3) { ret UT_SPV_EV_BAD; }
+            val ptr: u32 = w[i + 1];
+            val v: u32 = w[i + 2];
+            if (ptr >= UT_SPV_EV_IDS || v >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            if (st.ch_ok[ptr]) {
+                if (!st.sc_ok[v]) { ret UT_SPV_EV_BAD; }
+                st.arr[st.ch_var[ptr] * 4 + st.ch_ix[ptr]] = st.sc[v];
+                st.arr_ok[st.ch_var[ptr]] = true;
+            } or (st.arr_ok[v]) {
+                var k: u32 = 0;
+                for (k < 4) { st.arr[ptr * 4 + k] = st.arr[v * 4 + k]; k = k + 1; }
+                st.arr_ok[ptr] = true;
+            } or {
+                if (!st.sc_ok[v]) { ret UT_SPV_EV_BAD; }
+                st.sc[ptr] = st.sc[v];
+                st.sc_ok[ptr] = true;
+            }
+            i = i + len; cnt;
+        }
+
+        if (op == spirv.OP_I_ADD || op == spirv.OP_I_MUL) {
+            if (len != 5) { ret UT_SPV_EV_BAD; }
+            val res: u32 = w[i + 2];
+            val a: u32 = w[i + 3];
+            val b: u32 = w[i + 4];
+            if (res >= UT_SPV_EV_IDS || a >= UT_SPV_EV_IDS || b >= UT_SPV_EV_IDS) { ret UT_SPV_EV_BAD; }
+            if (!st.sc_ok[a] || !st.sc_ok[b]) { ret UT_SPV_EV_BAD; }
+            if (op == spirv.OP_I_ADD) { st.sc[res] = st.sc[a] + st.sc[b]; }
+            or { st.sc[res] = st.sc[a] * st.sc[b]; }
+            st.sc_ok[res] = true;
+            i = i + len; cnt;
+        }
+
+        ret UT_SPV_EV_BAD;
+    }
+
+    if (!st.sc_ok[target]) { ret UT_SPV_EV_BAD; }
+    ret st.sc[target];
+}
+
+# the shader both assertions below read: two locals holding the same four values,
+# one filled by an array literal initializer and one element by element
+#
+# The weights are positional, so a copy that permutes, truncates or drops elements
+# reads back a different number rather than the same total.
+fun ut_spv_array_init_src() str {
+    ret "#[output(0)] var o_lit: u32;\n#[output(1)] var o_elem: u32;\n\n#[stage(\"vertex\")]\nfun vs() {\n    val lit: [4]u32 = [4]u32{7, 6, 5, 4};\n    var elem: [4]u32;\n    elem[0] = 7; elem[1] = 6; elem[2] = 5; elem[3] = 4;\n    o_lit  = lit[0]  + lit[1]  * 10 + lit[2]  * 100 + lit[3]  * 1000;\n    o_elem = elem[0] + elem[1] * 10 + elem[2] * 100 + elem[3] * 1000;\n}\n\nfun main() i32 { ret 0; }\n";
+}
+
+# an array literal initializer on a function-local array reaches the local, with the
+# elements it was written with (#2911)
+#
+# WHAT WAS BROKEN. The initializer lowers to a temporary filled element by element
+# and then an aggregate store into the declared local, and that store expanded into
+# a run of word-sized load / store pairs walking the two objects by byte offset.
+# Under logical addressing there is no pointer INTO an object, so the run was
+# refused outright for an array and - worse - accepted for a two-word record, whose
+# single 8-byte chunk resolved to the variable itself and produced a load at the
+# wrong type. The copy now reaches the emitter whole, which spells it as one load
+# and one store of the object's own value.
+#
+# THE ELEMENT-WISE ARM IS THE CONTROL, and it is the arm that already worked. Both
+# locals hold the same four values in the same order, so both locations must read
+# back the same number; asserting the literal arm alone would pass just as well if
+# the whole fixture were mis-evaluated, and asserting that a copy instruction is
+# present would pass on a copy that moved the wrong bytes.
+test "mach.lang.driver:an_array_literal_initializer_reaches_a_local_on_spirv" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach"; texts[0] = ut_spv_array_init_src();
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    var bad: i32 = 0;
+    if (w == nil || n == 0) { bad = 1; }
+    or {
+        # 7 + 6*10 + 5*100 + 4*1000, the elements in their declared positions.
+        if (ut_spv_eval_location(w, n, 0) != 4567) { bad = 1; }
+        if (ut_spv_eval_location(w, n, 1) != 4567) { bad = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# count, over a lowered MIR module, the whole-object copies and the byte-chunked
+# loads the flat expansion of one produces
+# ---
+# mm:        the lowered MIR module
+# out_loads: receives the number of MIR_LOAD instructions
+# ret:       the number of MIR_MEMCPY instructions
+fun ut_memcpy_and_loads(mm: *mir.MirModule, out_loads: *u32) u32 {
+    var mc: u32 = 0;
+    var ld: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < mm.function_len) {
+        val mf: *mir.MirFunction = ?mm.functions[fi];
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                if (blk.instrs[ii].opcode == mir.MIR_MEMCPY) { mc = mc + 1; }
+                if (blk.instrs[ii].opcode == mir.MIR_LOAD)   { ld = ld + 1; }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+    @out_loads = ld;
+    ret mc;
+}
+
+# lower `src` for `tname` to MIR and report (memcpy count, load count)
+fun ut_memcpy_shape(alloc: *A.Allocator, src: str, tname: str, out_loads: *u32) i64 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, alloc, src, tname);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var out: i64 = -1;
+    var loads: u32 = 0;
+    var mi: u32 = 0;
+    for (mi < p.module_len) {
+        val me: *project.ModuleEntry = ?p.modules[mi];
+        if (me.ir_module == nil) { mi = mi + 1; cnt; }
+        val mr: R.Result[mir.MirModule, str] = mirlower.lower_ir(?p.target, me.ir_module, alloc, ?s.interner, ?s.sources);
+        if (R.is_err[mir.MirModule, str](mr)) { mi = mi + 1; cnt; }
+        var mm: mir.MirModule = R.unwrap_ok[mir.MirModule, str](mr);
+        var lc: u32 = 0;
+        val c: u32 = ut_memcpy_and_loads(?mm, ?lc);
+        if (out < 0) { out = 0; }
+        out = out + c::i64;
+        loads = loads + lc;
+        mi = mi + 1;
+    }
+    @out_loads = loads;
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret out;
+}
+
+# an aggregate store stays a whole-object copy on a logical-addressing target and
+# still expands into the byte-chunked run on a flat one (#2911)
+#
+# THE MACHINE TARGETS ARE THE HALF THAT MATTERS HERE. The gate exists so the flat
+# expansion is untouched, and a fix applied one level too high - rewriting the
+# initializer for everyone - moves their numbers too. So both sides are asserted:
+# spirv carries the copy whole, while every flat target carries no copy instruction
+# at all and still issues the chunk loads that ARE its copy. Dropping the gate, or
+# gating it the wrong way round, moves one of the two.
+test "mach.lang.driver:an_aggregate_copy_survives_whole_on_logical_addressing" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val src: str = ut_spv_array_init_src();
+    val nsrc: str = "fun rd() u32 {\n    val lit: [4]u32 = [4]u32{7, 6, 5, 4};\n    ret lit[0] + lit[1] * 10 + lit[2] * 100 + lit[3] * 1000;\n}\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret rd()::i32; }\n";
+
+    var bad: i32 = 0;
+
+    var sl: u32 = 0;
+    if (ut_memcpy_shape(?alloc, src, "spirv", ?sl) < 1) { bad = 1; }
+
+    var fl: u32 = 0;
+    if (ut_memcpy_shape(?alloc, nsrc, "linux", ?fl)         != 0) { bad = 1; }
+    if (fl < 2) { bad = 1; }
+    if (ut_memcpy_shape(?alloc, nsrc, "linux-arm64", ?fl)   != 0) { bad = 1; }
+    if (fl < 2) { bad = 1; }
+    if (ut_memcpy_shape(?alloc, nsrc, "linux-riscv64", ?fl) != 0) { bad = 1; }
+    if (fl < 2) { bad = 1; }
+
+    ret bad;
+}

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -3930,6 +3930,59 @@ fun emit_memzero(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) 
     ret R.ok[bool, str](true);
 }
 
+# emit the copy of a whole object as an OpLoad of its value followed by an OpStore
+#
+# `MIR_MEMCPY` survives to this target as a whole-object operation (#2911) rather
+# than being expanded into a run of word-sized load / store pairs, which is what
+# makes this expressible: logical addressing reaches an object as one value at one
+# type, and that is exactly what a load and a store of it are. The value type comes
+# from the DESTINATION, and the source is required to agree - a copy between two
+# different types is a reinterpretation, and there is no pointer to perform one
+# through.
+#
+# The byte count rides along in operand 2 and is deliberately unused here. It sizes
+# the flat expansion and says nothing structural, so consulting it would reintroduce
+# the byte space this form exists to avoid.
+# ---
+# e:   the emission state
+# mf:  the MIR function
+# vm:  the per-vreg value maps
+# mi:  the MIR_MEMCPY instruction ([dst_mem, src_mem, size])
+# ret: true on success, or a precise error string
+fun emit_memcpy(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count < 2) { ret R.err[bool, str]("spirv.emit: memcpy with no source or destination"); }
+
+    var dst_ty: u32 = 0;
+    var dst: u32 = chain_target(vm, ?mi.operands[0], ?dst_ty);
+    if (dst == 0) {
+        dst = interface_target(e, ?mi.operands[0]);
+        dst_ty = interface_value_type(e, ?mi.operands[0]);
+    }
+    if (dst == 0 || dst_ty == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
+
+    var src_ty: u32 = 0;
+    var src: u32 = chain_target(vm, ?mi.operands[1], ?src_ty);
+    if (src == 0) {
+        src = interface_target(e, ?mi.operands[1]);
+        src_ty = interface_value_type(e, ?mi.operands[1]);
+    }
+    if (src == 0 || src_ty == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1])); }
+
+    if (src_ty != dst_ty) {
+        ret unsupported(e, "copying between two objects of different types is not supported by the SPIR-V target: logical addressing carries an object as a value of its own type, so a copy that reinterprets one type as another has no pointer to perform it through");
+    }
+
+    val value: u32 = spirv.alloc_id(e.b);
+    var lops: [3]u32;
+    lops[0] = dst_ty; lops[1] = value; lops[2] = src;
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_LOAD, ?lops[0], 3);
+
+    var sops: [2]u32;
+    sops[0] = dst; sops[1] = value;
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_STORE, ?sops[0], 2);
+    ret R.ok[bool, str](true);
+}
+
 # select the integer or float form of a class-polymorphic opcode
 # ---
 # lane_float: whether the operation's lanes are float
@@ -4090,6 +4143,7 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: 
     # the allocation's variable was declared at the entry, where SPIR-V requires it.
     if (op == mir.MIR_ALLOCA) { ret R.ok[bool, str](true); }
     if (op == mir.MIR_MEMZERO) { ret emit_memzero(e, mf, vm, mi); }
+    if (op == mir.MIR_MEMCPY) { ret emit_memcpy(e, mf, vm, mi); }
 
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");
 }


### PR DESCRIPTION
## Root cause

An aggregate store is a storage-to-storage copy, and `lower_store_aggregate` expanded every one into a run of word-sized `MIR_LOAD` / `MIR_STORE` pairs walking both objects by byte offset. That run is a byte-space transformation, and it fails a logical-addressing target twice over: each access addresses INTO the storage rather than naming the object, and a chunk is sized for the machine word so it spans member boundaries.

The lowering the literal was taking:

```
val pat: [4]u32 = [4]u32{1, 2, 3, 4};
```

lowers to a temporary alloca filled element by element (which SPIR-V expresses fine, as `OpAccessChain` plus `OpStore`), then an aggregate store of that temporary into the declared local. It was that store, not the literal, that became the byte-chunked run. Hence the refusal naming `MIR_LOAD`, and hence the element-wise form working: the element-wise form never produces an aggregate store at all.

## The lowering it gets now

`MIR_MEMCPY`, the sibling of `MIR_MEMZERO` (#2669) and gated the same way on `MachineModel.flat_addressing`. The copy reaches the emitter whole and is spelled as one `OpLoad` of the object's own value plus one `OpStore`:

```
%47 = OpLoad %_arr_uint_uint_4 %13
      OpStore %12 %47
```

A flat target still gets the chunk run, unchanged.

`MIR_MEMZERO` was also missing from `opcode_name`, so a refusal naming it read as `<unknown MIR opcode>`. Both are named now and the totality sweep covers them.

## Adjacent shapes

Probed each against the branch and against its own merge base. Seven shapes shared the one cause and are all fixed here:

| shape | before | after |
| --- | --- | --- |
| array literal on a local (#2911) | refused | ok, `spirv-val` 0 |
| record literal on a local | **built, `spirv-val` rejected** | ok, `spirv-val` 0 |
| nested array literal | refused | ok, `spirv-val` 0 |
| nested record literal | refused | ok, `spirv-val` 0 |
| array of record literals | refused | ok, `spirv-val` 0 |
| local initialized from another whole value | refused | ok, `spirv-val` 0 |
| whole-value assignment to an existing local | refused | ok, `spirv-val` 0 |

The record literal was the worse one: it compiled and delivered a module `spirv-val` rejects, because its single 8-byte chunk happened to resolve to the variable itself and emitted `OpLoad %ulong` from a pointer to the record. A silent miscompile, not a refusal.

Genuinely separate, filed rather than folded in:

- a module-scope array literal is refused by the module-scope-storage rule, which is the declared design and unchanged here
- an aggregate passed BY VALUE to a function (#2914) is a different producer, `context.copy_aggregate` on the outgoing-argument path
- an aggregate RETURNED by value (#2915) fails earlier still, in the sret move

## Evidence

`spirv-val` exit 0 on every fixed shape.

Read-back values, folded out of the delivered module by `spirv-opt -O` so the numbers come from the module's own semantics rather than from a structural claim. Weights are positional, so a permuted or truncated copy reads back a different number:

```
o_lit   = 4567    # literal-initialized [4]u32 {7,6,5,4}
o_elem  = 4567    # the element-wise form, the control
o_rec   = 67      # record literal
o_nest  = 567     # nested record literal
o_mat   = 4567    # nested array literal
o_copy  = 4567    # local initialized from another whole value
```

The literal-initialized array reads back exactly what the element-wise form does, which is the property the issue is about.

## Tests

Two unit tests in `src/lang/driver/tests.mach`, no new integration cases.

`an_array_literal_initializer_reaches_a_local_on_spirv` evaluates the emitted module's function body and asserts the value stored at each interface location. The literal arm and the element-wise control must both read back 4567. The evaluator fails on any instruction it does not model, so a routing change is reported rather than skipped.

`an_aggregate_copy_survives_whole_on_logical_addressing` asserts both sides of the gate: spirv carries at least one `MIR_MEMCPY`, and each of `linux`, `linux-arm64`, `linux-riscv64` carries none while still issuing the chunk loads that ARE its copy.

Counterfactual, reverting only the `lower.mach` gate:

- `an_array_literal_initializer_reaches_a_local_on_spirv` 0 passed, 1 failed
- `an_aggregate_copy_survives_whole_on_logical_addressing` 0 passed, 1 failed

Restored: both pass, suite 1443 passed / 0 failed / 1443 total.

## Machine output

The compiler source compiled with the merge-base binary and with this branch's binary, objects compared byte for byte. Baseline built from the merge base and kept outside the build tree.

```
linux-x86_64:   224 objects, 224 identical, 0 differing
linux-arm64:    224 objects, 224 identical, 0 differing
linux-riscv64:  224 objects, 224 identical, 0 differing
```

672 objects compared, none differ. `mos6502` and `riscv32` also declare `flat_addressing = true`, so they take the same unchanged path by construction.

Closes #2911
