### PR TITLE
fix(codegen): a spirv value is typed by what defines it, not by a MIR width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ A textured shader emits a **byte-identical module** across the migration: the sa
 
 ### Fixed
 
+#### A SPIR-V value is typed by what defines it, not by a MIR width (#2919, #2920)
+Two modules the compiler wrote while reporting success, and that only the external validator refused. A `for` loop whose counter is 8 or 16 bits allocated the counter as a 64-bit variable while its increment and its bound stayed narrow, so the comparison mixed bit widths. A `:~` between two 16-byte vector types declared an `OpTypeInt 128`, which SPIR-V has no form for, beside an `OpBitcast` that was itself typed as the vector it read rather than as the one it produces.
+
+Both reconstruct a type from a **MIR byte width** at a point where the value's real type lives somewhere else. A phi merge materializes its constant at the machine word because a sub-word write to a machine register leaves the upper bits unspecified, which is a statement about a register file SPIR-V does not have. The emitter already knew a copy is not the source of type truth and skipped register copies, but not immediate ones. A conversion reconstructed its source type unconditionally, and interning a type declares it, so a 16-byte source width put a scalar integer in the module the instruction never read. And `compute_vec_lane` describes an instruction by its first vector operand, which is right for every instruction whose two sides share a shape and wrong for the one whose operand shape is exactly what it discards.
+
+**The emission point now refuses rather than writing an invalid module.** `type_int` and `type_float` return 0 for a width SPIR-V has no type at, on the same terms `type_vector` already returns 0 for a component count no Shader module may declare, and the arithmetic and comparison forms refuse an operand whose own type is not the one its position declares. A width guard alone could not have seen the loop counter, where every individual type was legal and only the pairing was wrong.
+
+Every machine target's output is unchanged byte for byte: 675 objects across linux-x86_64, linux-arm64 and linux-riscv64, plus a vector-reinterpret fixture built for all three, which is the shape the shared lane descriptor touches and which mach's own source does not contain.
+
 #### An aggregate is passed and returned by value on the SPIR-V target (#2914, #2915)
 `fun sum(p: Pair) u32` was refused for `spirv` with an addressed-memory diagnostic, and `fun make() Pair` failed earlier still with a bare `spirv.emit: unreadable move source` that named no opcode, no function and no position. A shader API where a record cannot cross a call in either direction is not a finished one.
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -388,11 +388,23 @@ pub fun vec_lane_for_type(ctx: *LowerCtx, ty: ir_type.IrTypeId) u32 {
 # the element kind/width its unsigned-mask result does not - falling back to a
 # vector result (a load or literal has no vector operand). VEC_LANE_NONE when
 # nothing vector-typed flows through, which is every non-vector instruction.
+#
+# A BIT REINTERPRET IS DESCRIBED BY ITS RESULT (#2920). Every other instruction's
+# operand and result share a lane shape, which is why the operand answers for both.
+# A `:~` is the one whose operand's shape is exactly what it discards: the two sides
+# share a byte width and nothing else, so a consumer reading the operand's shape as
+# the result's saw `f32x4 :~ u32x4` produce another `f32x4`, and every lane read off
+# that was then a type error. A register machine copies the whole 16-byte register
+# either way, so only a target that realizes a vector as a TYPE can see it.
 # ---
 # ctx:  the lowering context
 # inst: the IR instruction being lowered
 # ret:  the packed vec_lane descriptor to stamp on its MIR instructions
 pub fun compute_vec_lane(ctx: *LowerCtx, inst: *instruction.Instruction) u32 {
+    if (inst.kind == instruction.OP_BITCAST) {
+        val r: u32 = vec_lane_for_type(ctx, inst.ty);
+        if (mir.vec_lane_is_vector(r)) { ret r; }
+    }
     var i: u32 = 0;
     for (i < inst.operand_count) {
         val d: u32 = vec_lane_for_type(ctx, inst.operands[i].ty);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -19087,3 +19087,223 @@ test "mach.lang.driver:a_spirv_backend_refusal_is_located" {
     session.dnit(?s);
     ret bad;
 }
+
+# whether an opcode's first two words really are a result type and a result id
+#
+# The membership matters: scanning every instruction long enough to have the pair
+# would read an `OpStore`'s pointer and object as one, which is a different pair of
+# numbers that can collide with a real id.
+# ---
+# op:  the SPIR-V opcode
+# ret: true when word one is a result type and word two a result id
+fun ut_spv_defines_typed_value(op: u32) bool {
+    ret op == spirv.OP_LOAD || op == spirv.OP_CONSTANT || op == spirv.OP_FUNCTION_PARAMETER
+     || op == spirv.OP_I_ADD || op == spirv.OP_I_SUB || op == spirv.OP_I_MUL
+     || op == spirv.OP_BITCAST || op == spirv.OP_COMPOSITE_EXTRACT;
+}
+
+# the type an instruction gave the value `id`, or 0 when nothing in the typed-value
+# set defines it
+# ---
+# w, n: the instruction words
+# id:   the value id
+# ret:  the value's type id, or 0
+fun ut_spv_value_type(w: *u32, n: u32, id: u32) u32 {
+    if (id == 0) { ret 0; }
+    var i: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret 0; }
+        if (len >= 3 && w[i + 2] == id && ut_spv_defines_typed_value(w[i] & 0xFFFF)) {
+            ret w[i + 1];
+        }
+        i = i + len;
+    }
+    ret 0;
+}
+
+# whether an opcode is a two-operand integer arithmetic or comparison instruction
+# ---
+# op:  the SPIR-V opcode
+# ret: true for the forms whose two operands must share one type
+fun ut_spv_is_binary_int(op: u32) bool {
+    ret op == spirv.OP_I_ADD || op == spirv.OP_I_SUB || op == spirv.OP_I_MUL
+     || op == spirv.OP_U_LESS_THAN || op == spirv.OP_S_LESS_THAN
+     || op == spirv.OP_I_EQUAL;
+}
+
+# how many two-operand integer instructions read operands of DIFFERENT types
+#
+# This is the validator's rule stated in-tree: SPIR-V requires both operands of an
+# arithmetic or comparison instruction to have the same component bit width. An
+# operand nothing in the typed-value set defines answers 0 and is skipped, so only
+# pairs both sides of which are visible are counted.
+# ---
+# w, n: the instruction words
+# ret:  the number of mixed-type instructions
+fun ut_spv_mixed_operand_types(w: *u32, n: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        if (len == 5 && ut_spv_is_binary_int(w[i] & 0xFFFF)) {
+            val ta: u32 = ut_spv_value_type(w, n, w[i + 3]);
+            val tb: u32 = ut_spv_value_type(w, n, w[i + 4]);
+            if (ta != 0 && tb != 0 && ta != tb) { c = c + 1; }
+        }
+        i = i + len;
+    }
+    ret c;
+}
+
+# how many OpTypeInt declarations the module makes at `bits` width
+# ---
+# w, n: the instruction words
+# bits: the width to count
+# ret:  the number of declarations
+fun ut_spv_int_type_count(w: *u32, n: u32, bits: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        if ((w[i] & 0xFFFF) == spirv.OP_TYPE_INT && len >= 3 && w[i + 2] == bits) { c = c + 1; }
+        i = i + len;
+    }
+    ret c;
+}
+
+# how many OpBitcast results carry their OPERAND's type rather than the one the
+# reinterpret produces
+#
+# A `:~` that came out typed as its source is a no-op cast the validator accepts,
+# and every later read of the result is then a type error somewhere else in the
+# module, which is why this is asserted at the bitcast rather than at the use.
+# ---
+# w, n: the instruction words
+# ret:  the number of bitcasts that kept their source type
+fun ut_spv_bitcasts_keeping_source_type(w: *u32, n: u32) u32 {
+    var i: u32 = 0;
+    var c: u32 = 0;
+    for (i < n) {
+        val len: u32 = w[i] >> 16;
+        if (len == 0) { ret c; }
+        if ((w[i] & 0xFFFF) == spirv.OP_BITCAST && len == 4) {
+            val st: u32 = ut_spv_value_type(w, n, w[i + 3]);
+            if (st != 0 && st == w[i + 1]) { c = c + 1; }
+        }
+        i = i + len;
+    }
+    ret c;
+}
+
+# an 8- or 16-bit loop counter is stored at its declared width, so nothing compares
+# or adds across widths (#2919)
+#
+# A phi merge materializes its constant at the machine word, because a sub-word
+# write to a machine register leaves the upper bits unspecified. That is a statement
+# about a register file, and the SPIR-V emitter was reading it as the value's TYPE:
+# the counter became a 64-bit Function variable while the increment and the loop
+# bound stayed at the declared width, and `OpULessThan` mixed a 64-bit load with an
+# 8-bit constant. mach reported success and wrote the module, and only `spirv-val`
+# refused it.
+#
+# THE MIXED-OPERAND COUNT IS THE ASSERTION and the comparison counts are its
+# positive control: four loops really are in the module, two unsigned and two
+# signed, so a zero is agreement rather than a fixture that emitted nothing. The
+# absence of any 64-bit integer type is the sharper half - it is the width that was
+# wrong, and no other value in the fixture is 64 bits - while the 8- and 16-bit
+# declarations keep that honest by showing the module does type these values.
+test "mach.lang.driver:a_narrow_spirv_loop_counter_keeps_its_declared_width" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach";
+    texts[0] = "pub fun c8() u8 { var i: u8 = 0; for (i < 32) { i = i + 1; } ret i; }\n\npub fun s8() i8 { var i: i8 = 0; for (i < 32) { i = i + 1; } ret i; }\n\npub fun c16() u16 { var i: u16 = 0; for (i < 32) { i = i + 1; } ret i; }\n\npub fun s16() i16 { var i: i16 = 0; for (i < 32) { i = i + 1; } ret i; }\n";
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    if (ut_spv_count(w, n, spirv.OP_U_LESS_THAN) != 2) { bad = 1; }
+    if (ut_spv_count(w, n, spirv.OP_S_LESS_THAN) != 2) { bad = 1; }
+    if (ut_spv_int_type_count(w, n, 8) != 1)  { bad = 1; }
+    if (ut_spv_int_type_count(w, n, 16) != 1) { bad = 1; }
+    or {
+        if (ut_spv_mixed_operand_types(w, n) != 0) { bad = 1; }
+        if (ut_spv_int_type_count(w, n, 64) != 0)  { bad = 1; }
+    }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a bit reinterpret between two vector types declares no scalar integer and takes
+# the type it produces (#2920)
+#
+# `f32x4 :~ u32x4` is 16 bytes wide on both sides. Reading that width as a scalar
+# integer declared an `OpTypeInt 128`, which SPIR-V has no form for, and describing
+# the instruction by its OPERAND'S lane shape typed the result as another `f32x4`,
+# so the lane read that followed pulled a `u32` out of a float vector. Both were
+# written into a module mach reported success for.
+#
+# THE SCALAR BITCAST IS THE POSITIVE CONTROL: it is the shape that always worked, it
+# keeps the bitcast count from being satisfied by an emitter that stopped emitting
+# one, and it holds the retype assertion to something a same-type cast could not
+# pass either.
+test "mach.lang.driver:a_spirv_vector_reinterpret_declares_no_scalar_integer" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach";
+    texts[0] = "pub fun lane(a: f32x4) u32 { val u: u32x4 = a:~u32x4; ret u[0]; }\n\npub fun flat(x: f32) u32 { ret x:~u32; }\n";
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    if (ut_spv_count(w, n, spirv.OP_BITCAST) != 2) { bad = 1; }
+    or {
+        if (ut_spv_int_type_count(w, n, 128) != 0)      { bad = 1; }
+        if (ut_spv_bitcasts_keeping_source_type(w, n) != 0) { bad = 1; }
+    }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -3277,15 +3277,25 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
     ret R.ok[bool, str](true);
 }
 
-# whether an instruction is a register-to-register copy, whose destination type is
-# the source's rather than the move's width
+# whether an instruction is a copy, whose destination type is the copied value's
+# rather than the move's width
+#
+# AN IMMEDIATE SOURCE IS ONE TOO (#2919). A move's width is a register-machine
+# MATERIALIZATION convention, never the value's type: a phi merge's constant rides
+# the machine word because a sub-word register write leaves the upper bits
+# unspecified, which is a statement about a register file SPIR-V does not have.
+# Reading a type off it allocated an `i8` loop counter as a 64-bit variable while
+# every operation on it stayed 8 bits wide, so the module compared and added across
+# widths. The destination is typed by the value copied into it on the other edge
+# instead, and only falls back to the move's width when nothing else defines it.
 # ---
 # mi:  the instruction
-# ret: true for a move or declassify from a virtual or physical register
+# ret: true for a move or declassify from a register or an immediate
 fun is_reg_copy(mi: *mir.MirInstr) bool {
     if (mi.opcode != mir.MIR_MOV && mi.opcode != mir.MIR_DECLASSIFY) { ret false; }
     if (mi.operand_count != 2) { ret false; }
-    ret mi.operands[1].kind == mir.MIR_OP_VREG || mi.operands[1].kind == mir.MIR_OP_PREG;
+    ret mi.operands[1].kind == mir.MIR_OP_VREG || mi.operands[1].kind == mir.MIR_OP_PREG
+     || mi.operands[1].kind == mir.MIR_OP_IMM;
 }
 
 # carry types across register copies to a fixed point
@@ -4607,6 +4617,41 @@ fun read_operand(e: *Emit, vm: *VMaps, preg_val: *Regs, op: *mir.MirOperand, wan
     ret 0;
 }
 
+# whether an operand is read at a type of its own, so a consumer's declared type
+# does not describe it
+#
+# A boolean vreg is NOT one: it has no numeric representation, so what it is read
+# as is whatever the consumer declares (#2749).
+# ---
+# vm:  the per-vreg value maps
+# op:  the operand
+# ret: true when the operand carries its own type
+fun operand_carries_type(vm: *VMaps, op: *mir.MirOperand) bool {
+    if (op.kind != mir.MIR_OP_VREG) { ret false; }
+    if (op.vreg >= vm.n || vm.type_id[op.vreg] == 0) { ret false; }
+    ret !vm.is_bool[op.vreg];
+}
+
+# refuse when a value operand's own type is not the one its position declares
+#
+# SPIR-V requires the operands and the result of an arithmetic, bitwise or
+# comparison instruction to share ONE type, and a vreg operand is loaded at the type
+# its variable was declared with rather than at the declared one - so the two
+# disagreeing is a module the validator rejects and this emitter would otherwise
+# write while reporting success (#2919). The check is here rather than in
+# `read_operand` because it is these positions, not every position, that SPIR-V
+# holds to one type: an access chain's index, for one, may legally be any integer
+# width.
+# ---
+# vm:   the per-vreg value maps
+# op:   the operand
+# want_ty: the type the position declares
+# ret:  true when the operand may be read at `want_ty`
+fun operand_matches_type(vm: *VMaps, op: *mir.MirOperand, want_ty: u32) bool {
+    if (!operand_carries_type(vm, op)) { ret true; }
+    ret vm.type_id[op.vreg] == want_ty;
+}
+
 # materialize a SPIR-V boolean as the 0/1 value of `want_ty`
 #
 # `OpSelect` rather than a conversion opcode: a boolean has no numeric representation
@@ -4692,6 +4737,10 @@ fun emit_binary(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_cod
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: binary result vreg out of range"); }
     val ty: u32 = vm.type_id[dst];
+    if (!operand_matches_type(vm, ?mi.operands[1], ty)
+     || !operand_matches_type(vm, ?mi.operands[2], ty)) {
+        ret emit_fail(e, "spirv.emit: binary instruction mixes operand types");
+    }
     val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], ty);
     val b: u32 = read_operand(e, vm, preg_val, ?mi.operands[2], ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in binary instruction"); }
@@ -4742,7 +4791,11 @@ fun emit_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_co
     }
     var cbits: u32 = mi.width::u32 * 8;
     if (cbits == 0) { cbits = e.tgt.model.gpr_width * 8; }
-    ret emit_compare_typed(e, vm, preg_val, mi, op_code, types.type_int(e.tt, cbits));
+    val cmp_ty: u32 = types.type_int(e.tt, cbits);
+    if (cmp_ty == 0) {
+        ret unsupported(e, "unsupported comparison width in the SPIR-V target");
+    }
+    ret emit_compare_typed(e, vm, preg_val, mi, op_code, cmp_ty);
 }
 
 # emit a lane-wise vector comparison as mach's unsigned MASK vector
@@ -5013,6 +5066,10 @@ fun emit_compare_typed(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
     }
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: comparison result vreg out of range"); }
+    if (!operand_matches_type(vm, ?mi.operands[1], operand_ty)
+     || !operand_matches_type(vm, ?mi.operands[2], operand_ty)) {
+        ret emit_fail(e, "spirv.emit: comparison mixes operand types");
+    }
     val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], operand_ty);
     val b: u32 = read_operand(e, vm, preg_val, ?mi.operands[2], operand_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in comparison"); }
@@ -5031,6 +5088,13 @@ fun emit_compare_typed(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
 # fixes the class. That only matters for a source that carries no type of its own -
 # an immediate or a nominal register - since a vreg source is loaded at its own
 # declared type.
+#
+# SO IT IS RECONSTRUCTED ONLY WHEN IT IS NEEDED (#2920). Interning a type DECLARES
+# it, so reconstructing one the source never reads still put it in the module: a
+# `:~` between two 16-byte vectors has a 16-byte source width, and reading that as
+# a scalar integer declared an `OpTypeInt 128` beside an otherwise correct
+# `OpBitcast`. SPIR-V has no 128-bit integer, so the module was invalid on a type
+# nothing referenced.
 # ---
 # e:      the emission state
 # vm:     the per-vreg value maps
@@ -5046,14 +5110,15 @@ fun emit_convert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
     }
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: conversion result vreg out of range"); }
-    var sbits: u32 = mi.src_width::u32 * 8;
-    if (sbits == 0) { sbits = e.tgt.model.gpr_width * 8; }
-    var src_ty: u32 = types.type_int(e.tt, sbits);
-    if (src_is_float) {
-        if (sbits != 32 && sbits != 64) {
-            ret unsupported(e, "unsupported float conversion width in the SPIR-V target");
+    var src_ty: u32 = 0;
+    if (!operand_carries_type(vm, ?mi.operands[1])) {
+        var sbits: u32 = mi.src_width::u32 * 8;
+        if (sbits == 0) { sbits = e.tgt.model.gpr_width * 8; }
+        if (src_is_float) { src_ty = types.type_float(e.tt, sbits); }
+        or { src_ty = types.type_int(e.tt, sbits); }
+        if (src_ty == 0) {
+            ret unsupported(e, "unsupported conversion source width in the SPIR-V target");
         }
-        src_ty = types.type_float(e.tt, sbits);
     }
     val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], src_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in conversion"); }

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -317,11 +317,18 @@ fun scalar_put(tt: *TypeTable, tag: u8, a: u32, b: u32, id: u32) {
 }
 
 # the id of the sign-less integer type of `bits` width, emitting it on first use
+#
+# Returns 0 for a width SPIR-V has no integer type at, on the same terms as
+# `type_vector` for a component count no Shader module may declare: the caller names
+# the offending shape in a diagnostic. Without it a width derived from a MIR byte
+# size declared whatever it was handed, and a 16-byte vector's width put an
+# `OpTypeInt 128` in an otherwise valid module (#2920).
 # ---
 # tt:   the table
 # bits: the integer width in bits (8, 16, 32, 64)
-# ret:  the OpTypeInt id
+# ret:  the OpTypeInt id, or 0 when `bits` is not a SPIR-V integer width
 pub fun type_int(tt: *TypeTable, bits: u32) u32 {
+    if (bits != 8 && bits != 16 && bits != 32 && bits != 64) { ret 0; }
     val hit: u32 = scalar_find(tt, TAG_INT, bits, 0);
     if (hit != 0) { ret hit; }
     if (bits == 8)  { tt.b.caps_needed = tt.b.caps_needed | spirv.NEED_INT8; }
@@ -336,11 +343,15 @@ pub fun type_int(tt: *TypeTable, bits: u32) u32 {
 }
 
 # the id of the floating-point type of `bits` width, emitting it on first use
+#
+# Returns 0 for a width SPIR-V has no float type at, on the same terms as
+# `type_int`.
 # ---
 # tt:   the table
-# bits: the float width in bits (32, 64)
-# ret:  the OpTypeFloat id
+# bits: the float width in bits (16, 32, 64)
+# ret:  the OpTypeFloat id, or 0 when `bits` is not a SPIR-V float width
 pub fun type_float(tt: *TypeTable, bits: u32) u32 {
+    if (bits != 16 && bits != 32 && bits != 64) { ret 0; }
     val hit: u32 = scalar_find(tt, TAG_FLOAT, bits, 0);
     if (hit != 0) { ret hit; }
     if (bits == 16) { tt.b.caps_needed = tt.b.caps_needed | spirv.NEED_FLOAT16; }
@@ -792,6 +803,9 @@ pub fun type_is_float(tt: *TypeTable, id: u32) bool {
 # hi:      the high 32 bits (ignored for a type 32 bits or narrower)
 # ret:     the OpConstant id
 pub fun const_scalar(tt: *TypeTable, type_id: u32, lo: u32, hi: u32) u32 {
+    # a refused type never becomes a constant of it: the callers already read 0 as
+    # "no such type", and minting one here would put the refusal back in the module.
+    if (type_id == 0) { ret 0; }
     val wide: bool = type_bits(tt, type_id) > 32;
     var high: u32 = 0;
     if (wide) { high = hi; }


### PR DESCRIPTION
Closes #2919
Closes #2920

Both issues are the same shape: a SPIR-V type reconstructed from a MIR byte width
at a point where the value's real type lives somewhere else. They are not one
lever, and neither fix would have exposed the other, but they belong together
because the rule they violate is one rule, and it is now stated once in the
emitter.

## #2919, a narrow loop counter

`imm_merge_width` materializes a phi merge's constant at the machine word, because
a sub-word write to a machine register leaves the upper bits unspecified. That is a
statement about a register file, not about the value. The SPIR-V emitter already
knew a copy is not the source of type truth and skipped register copies when typing
a vreg, but it did not skip immediate ones, so the entry edge of a `for` loop typed
the counter at the machine word. An `i8` counter became a 64-bit Function variable
while its increment and its bound stayed 8 bits wide:

```
%63 = OpVariable %_ptr_Function_ulong Function
%75 = OpLoad %ulong %63
%77 = OpULessThan %bool %75 %uchar_32
```

`u32` was unaffected only because `imm_merge_width` special-cases width 4.

An immediate source is now a copy too, so the destination is typed by the value
copied into it on the back edge, and falls back to the move's width only when
nothing else defines it.

## #2920, a vector reinterpret

Two defects, both in the one instruction.

`emit_convert` reconstructed its source type unconditionally, and interning a type
DECLARES it. A `:~` between two 16-byte vectors has a 16-byte source width, so
reading that as a scalar integer put `OpTypeInt 128` in the module even though the
vreg source never read it. The reconstruction now happens only for an operand that
carries no type of its own.

The reinterpret was also stamped with its OPERAND'S lane shape. `compute_vec_lane`
takes the first vector-typed operand, which is right for every instruction whose
two sides share a shape, and a `:~` is exactly the one whose operand shape is what
it discards. So `f32x4 :~ u32x4` emitted `OpBitcast %v4float`, and the lane read
that followed pulled a `u32` out of a float vector. `spirv-val` never got that far,
because the 128-bit type stopped it first. A reinterpret is now described by its
result.

## The in-tree check

`type_vector` already returns 0 for a component count no Shader module may declare,
and its callers name the offending type in a diagnostic. `type_int` and
`type_float` did not, so a width derived from a MIR byte size declared whatever it
was handed. They do now, which would have turned #2920 into a compiler refusal
rather than a `.spv` only CI looks at.

A width guard cannot see #2919, where every individual type was legal and only the
pairing was wrong. So the arithmetic and comparison forms, which SPIR-V holds to
one shared type, now refuse an operand whose own type is not the one its position
declares. That fires on the `OpIAdd` as well as the `OpULessThan` in the #2919
repro. It is deliberately not in `read_operand`: an access chain's index may
legally be any integer width, and only these positions carry the one-type rule.

## Evidence

spirv-val, SPIRV-Tools v2026.3, universal env (the fixture is a library module, so
Vulkan's rejection of `OpCapability Linkage` does not apply).

| | before | after |
|---|---|---|
| repro `.spv` | `error: Invalid number of bits (128) used for OpTypeInt` | clean, exit 0 |
| `OpULessThan` operands | `%ulong` load vs `%uchar` constant | both `%uchar` |
| `OpBitcast` result | `%v4float` from `%v4float` | `%v4uint` from `%v4float` |
| `OpCapability Int64` | declared | gone, nothing is 64 bits |

Unit tests: 1457 passed, 0 failed (1455 before, two added).

Counterfactual: with the three source files reverted to `dev` and the tests kept,
1455 passed / 2 failed, and `spirv-val` rejected the repro again. Restored, 1457
passed / 0 failed and `spirv-val` exits 0.

Machine target output, mach's own source built as the corpus at the merge base,
baseline kept outside the build tree:

| leg | objects | differences |
|---|---|---|
| determinism control (baseline compiler, twice) | 675 | 0 |
| linux-x86_64 + linux-arm64 + linux-riscv64 | 675 | 0 |
| vector-reinterpret fixture, three targets | 3 | 0 |

The last leg matters because `compute_vec_lane` is shared code and mach's own
source has no vector `:~` in it. The fixture is five reinterprets across four
vector shapes plus a scalar one, and its objects are byte-identical on all three.

int suite, linux leg, `--deps pin`: 40 spirv case runs pass, 0 fail.
