### PR TITLE
fix(codegen): substitute scalarized lane reads across the whole function

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -19087,3 +19087,147 @@ test "mach.lang.driver:a_spirv_backend_refusal_is_located" {
     session.dnit(?s);
     ret bad;
 }
+
+# true when instruction `iid` is reachable from `f`'s block lists
+#
+# The instruction POOL retains everything a pass ever created, including what it
+# detached, so a pool lookup answers yes for a dropped value. Only the block lists
+# say what still reaches the back end.
+fun ut_instr_in_blocks(f: *ir.Function, iid: ir.InstructionId) bool {
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val b: *ir.Block = ?f.blocks[bi];
+        var k: u32 = 0;
+        for (k < b.phi_count) {
+            if (b.phis[k] == iid) { ret true; }
+            k = k + 1;
+        }
+        k = 0;
+        for (k < b.instr_count) {
+            if (b.instructions[k] == iid) { ret true; }
+            k = k + 1;
+        }
+        if (b.terminator == iid) { ret true; }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# how many of instruction `iid`'s operands name an instruction outside `f`'s blocks
+fun ut_dangling_ops(f: *ir.Function, iid: ir.InstructionId) u32 {
+    val opt_ins: O.Option[*instruction.Instruction] = ir.instruction_get(f, iid);
+    if (O.is_none[*instruction.Instruction](opt_ins)) { ret 0; }
+    val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_ins);
+    var hits: u32 = 0;
+    var oi: u32 = 0;
+    for (oi < ins.operand_count) {
+        val v: *value.Value = ?ins.operands[oi];
+        if (v.kind == value.VAL_INSTR) {
+            if (!ut_instr_in_blocks(f, v.data.instr)) { hits = hits + 1; }
+        }
+        oi = oi + 1;
+    }
+    ret hits;
+}
+
+# audit every live instruction's operands across `p`'s lowered modules
+#
+# `@phis` is how many phis survive - the fixture's own positive control, since an
+# audit over a function with no merge proves nothing - and `@dangling` is how many
+# VAL_INSTR operands name an instruction no block list holds. A dangling operand is
+# a silent wrong answer rather than a crash: MIR phi destruction emits a merge copy
+# only for an incoming it can resolve, so the merge register is left unwritten on
+# that edge and read undefined (#2917).
+fun ut_operand_audit(p: *project.Project, phis: *u32, dangling: *u32) {
+    @phis     = 0;
+    @dangling = 0;
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var fi: u32 = 0;
+            for (fi < m.function_len) {
+                val f: *ir.Function = ?m.functions[fi];
+                var bi: u32 = 0;
+                for (bi < f.block_count) {
+                    val b: *ir.Block = ?f.blocks[bi];
+                    @phis = @phis + b.phi_count;
+                    var k: u32 = 0;
+                    for (k < b.phi_count) {
+                        @dangling = @dangling + ut_dangling_ops(f, b.phis[k]);
+                        k = k + 1;
+                    }
+                    k = 0;
+                    for (k < b.instr_count) {
+                        @dangling = @dangling + ut_dangling_ops(f, b.instructions[k]);
+                        k = k + 1;
+                    }
+                    @dangling = @dangling + ut_dangling_ops(f, b.terminator);
+                    bi = bi + 1;
+                }
+                fi = fi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+}
+
+# the fixture from #2917: a vector local whose lane feeds a conditional scalar merge
+#
+# `mx` is a[0] on the fall-through edge and a[1] on the taken one, so the merge phi
+# sits in a block the lowerer emits BEFORE the block that computes the lanes. On a
+# target with no vector unit the placement stage rewrites each lane read into a gep
+# and a load, and the phi's fall-through incoming has to follow that rewrite even
+# though its own block was walked first.
+fun ut_lane_merge_src() str {
+    ret "#[noinline]\nfun sink(h: u64, v: f32) u64 { ret h + 1; }\n\npub fun probe(seed: u64) f32 {\n    val z: f32 = seed::f32;\n    var a: f32x4 = f32x4{1.5, -2.25, 3.75, -0.5};\n    a[0] = a[0] + z;\n    var h: u64 = 0;\n    h = sink(h, a[0]);\n    var mx: f32 = a[0];\n    if (a[1] > mx) { mx = a[1]; }\n    ret mx;\n}\n\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+}
+
+# 0 when the fixture lowers for `target_name` with at least one surviving phi and no
+# operand naming a dropped instruction; 1 on any other outcome
+fun ut_lane_merge_operands_ok(target_name: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, ut_lane_merge_src(), target_name);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad:      i32 = 0;
+    var phis:     u32 = 0;
+    var dangling: u32 = 0;
+    ut_operand_audit(?p, ?phis, ?dangling);
+    # the positive control: the merge the audit is about is actually there.
+    if (phis == 0)     { bad = 1; }
+    if (dangling != 0) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a lane read feeding a conditional merge keeps the phi pointing at the value that
+# replaced it (#2917)
+#
+# The placement stage rewrites a lane read into a gep and a load, and its
+# substitution has to be a WHOLE-FUNCTION step: the merge phi of an `if` sits at a
+# lower block index than the block computing the condition's lanes, so rewriting a
+# block's phis while later blocks were still unwalked left the fall-through incoming
+# naming the dropped lane read. MIR phi destruction then emitted no copy on that
+# edge and the merge register was read undefined - on riscv64 at -O2 the fixture
+# returned 0x00000000 where every other leg returned 0x3fc00000.
+#
+# All three machine targets are checked, not only the one that was wrong: rv64 has
+# no vector unit so the placement stage rewrites there, and the two capable targets
+# are the standing controls that the whole-function substitution did not disturb a
+# leg that was already right.
+test "mach.lang.me.pass.scalarize:lane_merge_phi_keeps_its_incoming" {
+    var bad: i32 = 0;
+    if (ut_lane_merge_operands_ok("linux-riscv64") != 0) { bad = 1; }
+    if (ut_lane_merge_operands_ok("linux") != 0)         { bad = 1; }
+    if (ut_lane_merge_operands_ok("linux-arm64") != 0)   { bad = 1; }
+    ret bad;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -19179,8 +19179,46 @@ fun ut_operand_audit(p: *project.Project, phis: *u32, dangling: *u32) {
 # target with no vector unit the placement stage rewrites each lane read into a gep
 # and a load, and the phi's fall-through incoming has to follow that rewrite even
 # though its own block was walked first.
+#
+# Lowered at opt 2, and both the call and the vector local are load-bearing. At opt
+# 0 the merge's fall-through incoming is a load out of `mx`'s own slot rather than
+# the lane read. At opt 2 inlining `sink` SPLITS the entry block, and the halves
+# after the split are appended past the end of the block array - which is what puts
+# the block computing the lanes at a HIGHER index than the merge that reads them.
+# Without the call every lane read precedes the merge in block order and the forward
+# reference the substitution has to survive never forms.
 fun ut_lane_merge_src() str {
-    ret "#[noinline]\nfun sink(h: u64, v: f32) u64 { ret h + 1; }\n\npub fun probe(seed: u64) f32 {\n    val z: f32 = seed::f32;\n    var a: f32x4 = f32x4{1.5, -2.25, 3.75, -0.5};\n    a[0] = a[0] + z;\n    var h: u64 = 0;\n    h = sink(h, a[0]);\n    var mx: f32 = a[0];\n    if (a[1] > mx) { mx = a[1]; }\n    ret mx;\n}\n\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+    ret "fun sink(h: u64, v: f32) u64 { ret h + 1; }\n\npub fun probe(seed: u64) f32 {\n    val z: f32 = seed::f32;\n    var a: f32x4 = f32x4{1.5, -2.25, 3.75, -0.5};\n    a[0] = a[0] + z;\n    var h: u64 = 0;\n    h = sink(h, a[0]);\n    var mx: f32 = a[0];\n    if (a[1] > mx) { mx = a[1]; }\n    ret mx;\n}\n\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+}
+
+# the three machine targets over a single opt-2 profile, so an empty profile
+# selector resolves to it and the fixture lowers the way a release build does
+fun ut_manifest_o2() str {
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[target.linux-riscv64]\nisa = \"riscv64\"\nos = \"linux\"\nabi = \"lp64d\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# scaffold one-file `src` under the opt-2 manifest, select `target_name`, and run
+# resolve + sema + lower so each module's `ir_module` carries its post-pipeline IR.
+# the session is the caller's to tear down
+fun ut_o2_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name: str) R.Result[project.Project, outcome.Fail] {
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_manifest_o2(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[str, str](root_r))); }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { fs.remove_all(alloc, root); ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[bool, str](rr))); }
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, target_name);
+    fs.remove_all(alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[bool, outcome.Fail](se)); }
+    val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+    if (R.is_err[bool, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[bool, outcome.Fail](le)); }
+    ret R.ok[project.Project, outcome.Fail](p);
 }
 
 # 0 when the fixture lowers for `target_name` with at least one surviving phi and no
@@ -19192,7 +19230,7 @@ fun ut_lane_merge_operands_ok(target_name: str) i32 {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, ut_lane_merge_src(), target_name);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_o2_lower(?s, ?alloc, ut_lane_merge_src(), target_name);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -733,7 +733,8 @@ fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[bool, str] {
     }
 
     # fill pass: rewrite each block's body, expanding operators and copying loads /
-    # stores; rewrite phi value operands and the terminator in place.
+    # stores. BODIES ONLY - the phi value operands and the terminator are left to the
+    # whole-function substitution below.
     var bi: u32 = 0;
     for (bi < fn.block_count) {
         val blk: *ir.Block = ?fn.blocks[bi];
@@ -741,6 +742,17 @@ fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[bool, str] {
         if (R.is_err[bool, str](rf)) { slots_free(c, slots); ret rf; }
         bi = bi + 1;
     }
+
+    # WHOLE-FUNCTION operand substitution, for the same reason the gap-operator stage
+    # needs one (#2749, #2917). A lane read's replacement load is not mapped until its
+    # own block is filled, and a use is not confined to a block already walked: the
+    # merge phi of an `if` that assigns a lane sits at a LOWER block index than the
+    # block computing the lane, and a loop header's phi names a value the latch
+    # defines. Rewriting a block's phis while later blocks are still unfilled left
+    # those operands naming an instruction this pass had dropped, and MIR phi
+    # destruction then emitted no copy at all on that edge - a silent wrong answer on
+    # rv64, where the merge register was read undefined.
+    rewrite_uses(c, fn);
 
     slots_free(c, slots);
     ret R.ok[bool, str](true);
@@ -755,8 +767,6 @@ fun slots_free(c: *Ctx, slots: *id.InstructionId) {
 
 # rebuild one block's body, expanding vector operators into per-lane scalar sequences
 fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId, slot_len: u32, i8_ty: ir_type.IrTypeId) R.Result[bool, str] {
-    val fn: *ir.Function = c.fn;
-
     # snapshot the old body ids: the fill re-appends into a cleared body, and emits
     # fresh instructions between them, so the original order is preserved.
     val old_len: u32 = blk.instr_count;
@@ -789,17 +799,6 @@ fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId
     }
 
     body_free(c, old, old_len);
-
-    # phis carry value operands from predecessors; retype vector incomings to pointers.
-    var p: u32 = 0;
-    for (p < blk.phi_count) {
-        rewrite_ops(c, ?fn.instrs[blk.phis[p]::u32]);
-        p = p + 1;
-    }
-    # the terminator (a vector `ret`) consumes a vector value by address.
-    if (blk.terminator != id.INSTR_NIL) {
-        rewrite_ops(c, ?fn.instrs[blk.terminator::u32]);
-    }
     ret R.ok[bool, str](true);
 }
 


### PR DESCRIPTION
Closes #2917

## Root cause

The vector **placement** stage (`scalarize.run`, `src/lang/me/pass/scalarize.mach`) rewrote each block's phi value operands and terminator *inside* `fill_block`, immediately after filling that block's body, against a replacement map that is only complete once every block has been filled.

A lane read (`OP_VEC_EXTRACT`) is not in the pre-pass map: it produces a scalar, and its replacement gep + load is recorded in `c.pval` only when `expand_lane_read_scalarized` runs, during its own block's fill. So any use of a lane read sitting in a **lower-indexed** block kept naming the instruction the pass had just dropped.

That is exactly the issue's shape. At `-O2`, inlining `sink` splits the entry block and the halves are appended past the end of the block array, so `probe` ends up with the merge phi in `bb3` and the block computing the lanes in `bb5`. `bb3` is filled first, `%36`'s replacement does not exist yet, and the phi keeps `[bb2 %36]` with `%36` in no block list.

MIR phi destruction (`lower_block_phis`) emits a copy only for an incoming it can resolve, and silently emits none otherwise, so the fall-through edge got no copy at all and the merge register was read undefined.

### How it was identified

`--emit-ir` on the issue's repro for riscv64 at `-O2`: `%50 = phi f32 [bb1 %104, bb2 %36]` with **no `%36` anywhere in `probe`**. The same build for x86-64 had a live `%71` there. The only pipeline stage that differs between those two legs on this input is `scalarize.run`'s placement work (`has_v128` is false on rv64), and reading it showed the per-block rewrite in `fill_block`.

The identical defect class was already fixed for the gap-operator stage in #2749, which grew `rewrite_uses` for precisely this reason. The placement stage was never given one.

## The fix

Delete the per-block phi/terminator rewrite from `fill_block` and run the existing whole-function `rewrite_uses` once, after every block has been filled. Re-resolving an already-rewritten operand is a no-op, since a replacement instruction's id is `>= c.n` and `resolve` only maps ids below it.

## Executed evidence (qemu-riscv64 11.0.3 — compute evidence, not ABI evidence)

The issue's repro, extended so **both edges** run in one program and their correct values differ from each other and from the stale register content. `a[0] = a[0] - z`, `seed = argc - 1` (0, not taken, `mx = 1.5`) and `seed = argc + 4` (5, taken, `mx = -2.25`). Compared by bit pattern.

| leg | not_taken | taken |
|---|---|---|
| baseline riscv64 `-O2` | **`7fc00000`** | `c0100000` |
| fixed riscv64 `-O2` | `3fc00000` | `c0100000` |
| fixed riscv64 `-O0` | `3fc00000` | `c0100000` |
| fixed x86_64 `-O2` | `3fc00000` | `c0100000` |
| fixed aarch64 `-O2` (qemu) | `3fc00000` | `c0100000` |

The baseline's `7fc00000` is the canonical NaN the issue predicted for an unwritten NaN-boxed FP register. The taken edge is the paired positive control: it was already correct and stays correct.

The corpus case itself, `vec/vec_scalar_mix`, FNV checksum printed from the same source on every leg:

| leg | checksum |
|---|---|
| baseline riscv64 `-O2` | **`2563b1be899df3f7`** |
| fixed riscv64 `-O2` | `4fb315b5427f63e7` |
| fixed riscv64 `-O0` | `4fb315b5427f63e7` |
| fixed x86_64 `-O2` (baseline and fixed) | `4fb315b5427f63e7` |
| fixed aarch64 `-O2` (qemu) | `4fb315b5427f63e7` |

## Object diff, per architecture

Corpus of 89 `test/cases` modules built at `opt = 2` for the three linux targets, baseline built from the merge base `8c0dea20` and kept outside the build tree.

Determinism control, run first: two clean builds with the same compiler, 273 objects, **0 differing**.

| target | objects | differing |
|---|---|---|
| linux-x86_64 | 91 | 0 |
| linux-arm64 | 91 | 0 |
| linux-riscv64 | 91 | **1** |

The single differing object is `obj/corpus/cases/vec/vec_scalar_mix.o` — the case the issue reports, and nothing else.

A full six-target self-build of the compiler (1352 objects) is byte-identical baseline to fixed, which is expected: the compiler's own sources have no vector local feeding a conditional merge.

## Test

One unit test appended to `src/lang/driver/tests.mach`, no `int/` case:

`mach.lang.me.pass.scalarize:lane_merge_phi_keeps_its_incoming`

It lowers the issue's fixture at `opt = 2` for riscv64, x86-64 and aarch64 and audits every live instruction's operands for one naming an instruction no block list holds. The surviving phi count is the paired positive control, and the two capable targets are the controls that the whole-function substitution did not disturb a leg that was already right.

Counterfactual, both halves run:

- fix reverted, test present: `FAIL mach.lang.me.pass.scalarize:lane_merge_phi_keeps_its_incoming (exit 1)`, suite `1455 passed, 1 failed, 1456 total`
- fix restored: `ok ... 15ms`, suite `1456 passed, 0 failed, 1456 total`

Compiler under test: `out/linux-x86_64/debug/bin/mach`, built from this branch, mtime 2026-08-08 19:42.

## Found, not fixed

Two things this change does not address, both filed rather than patched here:

1. #2930 — the IR verifier does not check that an operand names a live instruction. `--verify-ir` ran clean over the broken module. This is the second time the class has shipped (#2749 was the first), and both were found by running a program rather than by any check in the compiler.
2. #2931 — `lower_block_phis` treats "this predecessor has no resolvable incoming" as *emit nothing*, while every other malformed input in the same function is an error. That is what turns the IR defect into silent wrong code.
