### PR TITLE
fix(sema): evaluate a comptime float at its declared width

### DIFF
--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -43,6 +43,7 @@ use mach.lang.fe.lexer;
 use mach.lang.fe.parser;
 use mach.lang.fe.resolve;
 use mach.lang.fe.token;
+use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.query;
 use mach.lang.readout;
@@ -1394,9 +1395,23 @@ fun register_val_for_load(p: *project.Project, mid: session.ModuleId, d: *decl.D
     # evaluation errors "identifier is not a comptime constant in scope" if the
     # name was never registered. do not promote this skip to a hard
     # definition-site error.
-    val r_val: R.Result[comptime.CTValue, str] = comptime.eval(?m.ctx, m.a, source, d.data.bind.init, ?p.s.interner);
+    #
+    # A FLOAT initializer folds at the width the annotation spells, so an `f32`
+    # constant is the f32 the program computes rather than an f64 that agrees
+    # with it only sometimes (#2918).
+    val fw: float.FloatWidth = comptime.declared_float_width(m.a, source, d.data.bind.ty);
+    val r_val: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(?m.ctx, m.a, source, d.data.bind.init, ?p.s.interner, fw);
     if (R.is_err[comptime.CTValue, str](r_val)) { ret R.ok[bool, str](true); }
     val v: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](r_val);
+
+    # a float whose declared width the annotation did not spell (a float type
+    # reached through an alias) is a float this pass cannot fold correctly: no
+    # type exists yet to read the alias through. skipped by the same rule as a
+    # non-foldable initializer above, and bound at lowering, where the type is
+    # known - never bound here at f64, which would export a constant that
+    # disagrees with the one the program computes.
+    if (comptime.float_width_unread(v)) { ret R.ok[bool, str](true); }
 
     val rr: R.Result[bool, str] = comptime.bind(?m.ctx, name_id, v);
     if (R.is_err[bool, str](rr)) { ret rr; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -48,6 +48,7 @@ use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
 use generics: mach.lang.fe.sema.generics;
 use mach.lang.fe.token;
+use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.layout;
 use mach.lang.manifest;
@@ -19081,6 +19082,169 @@ test "mach.lang.driver:a_spirv_backend_refusal_is_located" {
         if (!ut_str_contains(err, "main.mach:")) { bad = 1; }
         # the unlocated form the fix deleted, which carried none of the above
         if (ut_str_contains(err, "no source location on this instruction")) { bad = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# the bits of module `m`'s global whose linkage name contains `needle`, when its
+# initialiser is a folded float constant; -1 when there is no such global or it
+# did not fold to one
+#
+# BITS, not a float value: a near miss and an exact answer are different u64s
+# that an epsilon comparison would call equal, and -0.0 has to stay
+# distinguishable from +0.0.
+# ---
+# s:      the session owning the interner
+# m:      the lowered module
+# needle: substring of the global's linkage name
+# is_f32: true to read the value as its IEEE single pattern, false for double
+# ret:    the bit pattern, or -1
+fun ut_global_float_bits(s: *session.Session, m: *ir.Module, needle: str, is_f32: bool) i64 {
+    val gi: i64 = ut_global_ix(s, m, needle);
+    if (gi < 0) { ret 0 - 1; }
+    val g: *ir.Global = ?m.globals[gi::u32];
+    if (g.init.kind != value.VAL_CONST_FLOAT) { ret 0 - 1; }
+    if (is_f32) { ret float.f64_to_f32_bits(float.f64_bits(g.init.data.float_lit))::i64; }
+    ret float.f64_bits(g.init.data.float_lit)::i64;
+}
+
+# a comptime float constant is evaluated at its DECLARED width, rounding after
+# every step of the chain (#2918)
+#
+# THE PROPERTY IS COMPTIME == RUN TIME for one expression. The evaluator carried
+# every float in an f64 and never narrowed it, so an `f32` chain folded at double
+# precision and the emitted constant disagreed with the identical computation at
+# run time - the exact thing the codegen corpus case `comptime/ct_runtime_agree`
+# exists to hold.
+#
+# `C` IS THE ONE THAT MATTERS. It is a multi-step chain of untyped literals at a
+# declared `f32`, so it separates the three candidate rules that a single
+# operation cannot: rounding nothing gives 0x3eaaaaab, rounding once at the end
+# gives that same 0x3eaaaaab, and rounding after every step - what the running
+# program does - gives 0x3eaaaab0. A fix that narrowed only at the binding would
+# still pass on `A` and `B` alone.
+#
+# Every f32 assertion is paired with the run-time value of the identical
+# expression, and with an f64 chain that must NOT move: the narrowing has to
+# reach f32 without reaching the type the language says is already f64.
+test "mach.lang.driver:a_comptime_float_folds_at_its_declared_width" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "val A: f32 = 16777217.0;\nval B: f32 = A - 16777216.0;\nval C: f32 = 1.0 / 3.0 * 7.0 - 2.0;\nval H: f32 = 1.0 / 3.0 * 0.1;\nval N: f32 = 0.0 - (1.0 / 3.0);\nval D: f64 = 1.0 / 3.0 * 7.0 - 2.0;\nval E: f64 = 16777217.0 - 16777216.0;\nfun main() i32 { ret 0; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    # the run-time answers: the same expressions at the same declared types,
+    # computed through the path the emitted program runs
+    var ra: f32 = 16777217.0;
+    var rb: f32 = ra - 16777216.0;
+    var rc: f32 = 1.0 / 3.0 * 7.0 - 2.0;
+    var rh: f32 = 1.0 / 3.0 * 0.1;
+    var rn: f32 = 0.0 - (1.0 / 3.0);
+    var rd: f64 = 1.0 / 3.0 * 7.0 - 2.0;
+    var re: f64 = 16777217.0 - 16777216.0;
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        # a literal not representable in f32 IS its f32 rounding
+        if (ut_global_float_bits(?s, m, "uniontest.main.A", true) != 0x4B800000)      { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.A", true) != (ra:~u32)::i64)  { bad = 1; }
+
+        # so the difference is exactly zero, not the 1.0f (0x3F800000) the f64
+        # subtraction produced
+        if (ut_global_float_bits(?s, m, "uniontest.main.B", true) != 0x00000000)      { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.B", true) != (rb:~u32)::i64)  { bad = 1; }
+
+        # THE MULTI-STEP DISCRIMINATOR: round at each step, not once at the end
+        if (ut_global_float_bits(?s, m, "uniontest.main.C", true) != 0x3EAAAAB0)      { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.C", true) != (rc:~u32)::i64)  { bad = 1; }
+
+        # an inexact literal beside an f32 operand is the f32 literal
+        if (ut_global_float_bits(?s, m, "uniontest.main.H", true) != 0x3D088889)      { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.H", true) != (rh:~u32)::i64)  { bad = 1; }
+
+        # negation keeps the width and stays a pure sign flip
+        if (ut_global_float_bits(?s, m, "uniontest.main.N", true) != 0xBEAAAAAB)      { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.N", true) != (rn:~u32)::i64)  { bad = 1; }
+
+        # POSITIVE CONTROLS: an f64 chain must not move. the digits that cancel
+        # at f32 do not cancel at f64, and the f64 chain keeps every bit it had
+        if (ut_global_float_bits(?s, m, "uniontest.main.D", false) != 0x3FD5555555555550) { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.D", false) != (rd:~u64)::i64)     { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.E", false) != 0x3FF0000000000000) { bad = 1; }
+        if (ut_global_float_bits(?s, m, "uniontest.main.E", false) != (re:~u64)::i64)     { bad = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a comptime GATE on a float constant reads it at the constant's width (#2918)
+#
+# The value path and the gate path are two different readers of the same folded
+# constant, and a fix that reached only the first would leave `$if` selecting
+# arms by a precision the program does not have. Both an equality and an
+# ordering are held, because they are separate comparisons in the evaluator.
+#
+# EVERY ARM IS PAIRED WITH ITS f64 TWIN, which must select the OTHER way for the
+# equality gate (16777217.0 - 16777216.0 is 1.0 at f64 and 0.0 at f32) and the
+# SAME way for the ordering gate (0.1 is equal to itself at either width, once
+# both sides are read at one width).
+test "mach.lang.driver:a_comptime_gate_on_a_float_reads_it_at_its_width" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "val K: f32 = 16777217.0;\n$if (K - 16777216.0 == 0.0) { val G: i64 = 1; }\n$or { val G: i64 = 0; }\nval K64: f64 = 16777217.0;\n$if (K64 - 16777216.0 == 0.0) { val G64: i64 = 1; }\n$or { val G64: i64 = 0; }\nval P: f32 = 0.1;\n$if (P > 0.1) { val GT: i64 = 1; }\n$or { val GT: i64 = 0; }\nval P64: f64 = 0.1;\n$if (P64 > 0.1) { val GT64: i64 = 1; }\n$or { val GT64: i64 = 0; }\nfun main() i32 { ret 0; }\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        # at f32 the difference cancels, so the gate takes the first arm
+        val gg: i64 = ut_global_ix(?s, m, "uniontest.main.G");
+        if (gg < 0) { bad = 1; }
+        or { if ((?m.globals[gg::u32]).init.data.int_lit != 1) { bad = 1; } }
+
+        # POSITIVE CONTROL: the f64 twin does not cancel, and must not move
+        val gg64: i64 = ut_global_ix(?s, m, "uniontest.main.G64");
+        if (gg64 < 0) { bad = 1; }
+        or { if ((?m.globals[gg64::u32]).init.data.int_lit != 0) { bad = 1; } }
+
+        # an f32 constant against an untyped literal orders at f32, where the two
+        # are one value; against the f64 `0.1` the f32 read as a double was greater
+        val gt: i64 = ut_global_ix(?s, m, "uniontest.main.GT");
+        if (gt < 0) { bad = 1; }
+        or { if ((?m.globals[gt::u32]).init.data.int_lit != 0) { bad = 1; } }
+
+        # POSITIVE CONTROL: the f64 twin was already equal and stays equal
+        val gt64: i64 = ut_global_ix(?s, m, "uniontest.main.GT64");
+        if (gt64 < 0) { bad = 1; }
+        or { if ((?m.globals[gt64::u32]).init.data.int_lit != 0) { bad = 1; } }
     }
 
     project.dnit_project(?p);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -47,6 +47,7 @@ use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
+use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.token;
 use mach.lang.float;
 use mach.lang.intern;
@@ -138,10 +139,18 @@ pub val COMPTIME_BARE_IDENT_MSG: str =
 #               travels with the bits - comparison and arithmetic interpret the
 #               payload as the mathematical value it names, so comptime agrees
 #               with runtime value semantics. ignored for the non-int kinds.
+# float_width:  for CT_KIND_FLOAT, the IEEE width `data.f` is carried AT. the
+#               payload is always an f64, but an `f32` value is one the f32
+#               round trip leaves unchanged, so the next operation on it rounds
+#               where the running program rounds instead of accumulating double
+#               precision the declared type never had (#2918). FLOAT_W_NONE is an
+#               untyped literal, which stays at f64 until something declares
+#               otherwise. ignored for the non-float kinds.
 # data:         kind-specific payload
 pub rec CTValue {
     kind:         CTKind;
     int_unsigned: bool;
+    float_width:  float.FloatWidth;
     data: uni {
         i: i64;
         f: f64;
@@ -241,6 +250,13 @@ pub def IdentBindingFn: fun(ptr, id.ExprId) bool;
 # what the expression denotes
 pub val COMPTIME_IDENT_RUNTIME_MSG: str =
     "identifier names a runtime binding, so it has no comptime value";
+
+# surfaced when the two operands of a float operation carry different declared
+# widths. mach has no implicit widening, so this is a type error the typed
+# passes report against the source; the evaluator refuses rather than picking a
+# width, because folding at either one names a value the program never computes
+pub val FLOAT_WIDTH_MISMATCH_MSG: str =
+    "float operands have different declared widths; mach has no implicit widening";
 
 # the questions a comptime type query answers about one already-resolved type
 # (#2128). `eval` holds no type universe, so the typed layer installs the answer
@@ -814,7 +830,16 @@ fun consts_push(a: *A.Allocator, arr: **NamedConst, len: *u32, cap: *u32, nc: Na
     ret R.ok[bool, str](true);
 }
 
-# evaluates a comptime expression in the given context
+# evaluates a comptime expression in a context that declares no float width
+#
+# Every non-float expression, and every float expression whose value is not
+# being stored into a declared float type - a `$if` condition, a `$assert`, an
+# array length. A float literal in such a position is untyped and stays at f64,
+# which is the type a Mach float literal takes when nothing narrows it.
+#
+# An INITIALIZER for a declared float type must go through
+# `eval_at_float_width` instead, or the chain folds at f64 and disagrees with
+# the same chain at run time (#2918).
 # ---
 # c:        the comptime context (target params + user constants)
 # a:        the ast that owns `e`
@@ -829,6 +854,35 @@ pub fun eval(
     e:        id.ExprId,
     interner: *intern.Interner
 ) R.Result[CTValue, str] {
+    ret eval_at_float_width(c, a, source, e, interner, float.FLOAT_W_NONE);
+}
+
+# evaluates a comptime expression whose float type the context declares
+#
+# `fw` is the width the expression's own declared type fixes, and it reaches
+# every untyped float literal in the tree. That is what makes an `f32` chain
+# round at f32 after EVERY operation, which is what the running program does:
+# rounding once at the end is a different value (#2918), and rounding a literal
+# that a wider binding was going to hold would be wrong in the other direction.
+#
+# Pass `FLOAT_W_NONE` when the context declares no float type; `eval` is that
+# call spelled out.
+# ---
+# c:        the comptime context (target params + user constants)
+# a:        the ast that owns `e`
+# source:   source text covering `e` (for span lookup)
+# e:        expression id to evaluate
+# interner: shared string interner; used to compare identifier text via StrId
+# fw:       the float width the declared type fixes for this expression
+# ret:      a CTValue, or an error message describing why evaluation failed
+pub fun eval_at_float_width(
+    c:        *ComptimeCtx,
+    a:        *ast.Ast,
+    source:   str,
+    e:        id.ExprId,
+    interner: *intern.Interner,
+    fw:       float.FloatWidth
+) R.Result[CTValue, str] {
     if (e == id.EXPR_NIL) { ret R.err[CTValue, str]("missing expression"); }
 
     val n_opt: O.Option[*expr.Expr] = ast.get_expr(a, e);
@@ -837,13 +891,20 @@ pub fun eval(
     val k: expr.ExprKind = node.kind;
 
     if (k == expr.EXPR_KIND_LIT_INT)   { ret eval_lit_int(source, node.span); }
-    if (k == expr.EXPR_KIND_LIT_FLOAT) { ret eval_lit_float(source, node.span); }
+    # the literal's decimal text is decoded exactly, then taken at the declared
+    # width: `16777217.0` in an f32 context IS 16777216.0f, and every later
+    # operation must see that value and not the f64 the digits spell.
+    if (k == expr.EXPR_KIND_LIT_FLOAT) {
+        val r_lit: R.Result[CTValue, str] = eval_lit_float(source, node.span);
+        if (R.is_err[CTValue, str](r_lit)) { ret r_lit; }
+        ret float_value(R.unwrap_ok[CTValue, str](r_lit).data.f, fw);
+    }
     if (k == expr.EXPR_KIND_LIT_CHAR)  { ret eval_lit_char(source, node.span); }
     if (k == expr.EXPR_KIND_LIT_STR)   { ret eval_lit_str(source, node.span, interner); }
     if (k == expr.EXPR_KIND_LIT_NIL)   { ret R.err[CTValue, str]("nil is not comptime-evaluable"); }
 
-    if (k == expr.EXPR_KIND_BINARY) { ret eval_binary(c, a, source, ?node.data.binary, interner); }
-    if (k == expr.EXPR_KIND_UNARY)  { ret eval_unary(c, a, source, ?node.data.unary, interner); }
+    if (k == expr.EXPR_KIND_BINARY) { ret eval_binary(c, a, source, ?node.data.binary, interner, fw); }
+    if (k == expr.EXPR_KIND_UNARY)  { ret eval_unary(c, a, source, ?node.data.unary, interner, fw); }
 
     if (k == expr.EXPR_KIND_IDENT) {
         val r_id: R.Result[CTValue, str] = eval_ident(c, source, e, node.span, interner);
@@ -854,7 +915,7 @@ pub fun eval(
         # yields its constant; a record element (a struct literal) is not a comptime
         # scalar and surfaces the struct-literal rejection, exactly as intended.
         if (v_id.kind == CT_KIND_CONST_ELEM) {
-            ret eval(c, a, source, v_id.data.celem.elem::id.ExprId, interner);
+            ret eval_at_float_width(c, a, source, v_id.data.celem.elem::id.ExprId, interner, fw);
         }
         ret r_id;
     }
@@ -877,7 +938,7 @@ pub fun eval(
         # field-descriptor path since a constant-element object is a plain identifier
         # (not a CT_KIND_FIELD), so the two never collide.
         val cel: O.Option[R.Result[CTValue, str]] =
-            eval_const_elem_member(c, a, source, node.data.member.object, node.data.member.name, interner);
+            eval_const_elem_member(c, a, source, node.data.member.object, node.data.member.name, interner, fw);
         if (O.is_some[R.Result[CTValue, str]](cel)) { ret O.unwrap[R.Result[CTValue, str]](cel); }
         # a `.name` / `.type` / `.offset` projection off a comptime field
         # descriptor (#1473): fires only when the object evaluates to a
@@ -1247,10 +1308,10 @@ pub fun eval_lit_float(source: str, span: token.Span) R.Result[CTValue, str] {
 
     val bits: u64 = decimal_to_f64(?mant, dexp + exp, trunc);
 
-    var v: CTValue;
-    v.kind   = CT_KIND_FLOAT;
-    v.data.f = float.bits_f64(bits);
-    ret R.ok[CTValue, str](v);
+    # the literal alone declares no width: the exact f64 decoding is what the
+    # parser stores in the ast, and `eval_at_float_width` is what takes it at the
+    # width its context declares.
+    ret R.ok[CTValue, str](ct_float(float.bits_f64(bits), float.FLOAT_W_NONE));
 }
 
 # parse a character literal `'X'`, including escape sequences
@@ -1395,13 +1456,16 @@ fun hex_digit(c: u8) i64 {
     ret 0 - 1;
 }
 
-# binary-operator dispatch
+# binary-operator dispatch. `fw` is the declared float width of the RESULT, which
+# both operands share: a float operator has one width, and an operand written as
+# an untyped literal takes it
 fun eval_binary(
     c:        *ComptimeCtx,
     a:        *ast.Ast,
     source:   str,
     bin:      *expr.ExprBinary,
-    interner: *intern.Interner
+    interner: *intern.Interner,
+    fw:       float.FloatWidth
 ) R.Result[CTValue, str] {
     if (bin.op == expr.BIN_ASSIGN) { ret R.err[CTValue, str]("assignment is not comptime-evaluable"); }
 
@@ -1421,9 +1485,19 @@ fun eval_binary(
         ret eval_type_comparison(c, a, source, bin, interner);
     }
 
-    val lhs_r: R.Result[CTValue, str] = eval(c, a, source, bin.lhs, interner);
+    # a comparison yields a bool, so the enclosing declared width says nothing
+    # about its operands: their shared float width comes from the operands
+    # themselves, and `apply_compare` / `apply_equality` reconcile it.
+    var operand_fw: float.FloatWidth = fw;
+    if (bin.op == expr.BIN_EQ || bin.op == expr.BIN_NEQ
+     || bin.op == expr.BIN_LT || bin.op == expr.BIN_LEQ
+     || bin.op == expr.BIN_GT || bin.op == expr.BIN_GEQ) {
+        operand_fw = float.FLOAT_W_NONE;
+    }
+
+    val lhs_r: R.Result[CTValue, str] = eval_at_float_width(c, a, source, bin.lhs, interner, operand_fw);
     if (R.is_err[CTValue, str](lhs_r)) { ret lhs_r; }
-    val rhs_r: R.Result[CTValue, str] = eval(c, a, source, bin.rhs, interner);
+    val rhs_r: R.Result[CTValue, str] = eval_at_float_width(c, a, source, bin.rhs, interner, operand_fw);
     if (R.is_err[CTValue, str](rhs_r)) { ret rhs_r; }
 
     val lhs: CTValue = R.unwrap_ok[CTValue, str](lhs_r);
@@ -1439,27 +1513,30 @@ fun eval_binary(
     ret apply_arith(bin.op, lhs, rhs);
 }
 
-# unary-operator dispatch
+# unary-operator dispatch. `fw` is the declared float width of the result, which
+# a `-` operand shares
 fun eval_unary(
     c:        *ComptimeCtx,
     a:        *ast.Ast,
     source:   str,
     un:       *expr.ExprUnary,
-    interner: *intern.Interner
+    interner: *intern.Interner,
+    fw:       float.FloatWidth
 ) R.Result[CTValue, str] {
     if (un.op == expr.UN_ADDR || un.op == expr.UN_DEREF) {
         ret R.err[CTValue, str]("address-of and dereference are not comptime-evaluable");
     }
 
-    val r: R.Result[CTValue, str] = eval(c, a, source, un.operand, interner);
+    val r: R.Result[CTValue, str] = eval_at_float_width(c, a, source, un.operand, interner, fw);
     if (R.is_err[CTValue, str](r)) { ret r; }
     val v: CTValue = R.unwrap_ok[CTValue, str](r);
 
     if (un.op == expr.UN_NEG) {
         if (v.kind == CT_KIND_INT)   { ret ct_negate(v); }
-        # float negation is a sign-bit flip, exact for every operand. `0.0 - x`
+        # float negation is a sign-bit flip, exact for every operand, so it
+        # neither changes nor needs to re-round the operand's width. `0.0 - x`
         # would return `+0.0` for either zero and make `-0.0` unspellable (#2274).
-        if (v.kind == CT_KIND_FLOAT) { ret float_value(float.f64_neg(v.data.f)); }
+        if (v.kind == CT_KIND_FLOAT) { ret float_value(float.f64_neg(v.data.f), v.float_width); }
         ret R.err[CTValue, str]("unary - requires a numeric operand");
     }
     if (un.op == expr.UN_NOT) {
@@ -1738,6 +1815,58 @@ pub fun fields_type_arg(a: *ast.Ast, eid: id.ExprId) id.ExprId {
 pub rec ArrayLitInfo {
     elems_start: u32;
     elems_len:   u32;
+}
+
+# reads the float width a type ANNOTATION spells, for the passes that run before
+# any type exists
+#
+# The load-time module walk and name resolution both fold module-level `val`
+# initializers, and both need the declared width to fold a float one correctly
+# (#2918) - but neither has a type universe to ask. It does not need one for the
+# primitive spellings: `f32` and `f64` are recognised in type position ahead of
+# scope, so no declaration can make either name anything else, and reading the
+# spelling is exact rather than a guess.
+#
+# `^f32` is an f32 under a secret wrapper, and the wrapper changes where the
+# value may flow, not what it rounds to.
+#
+# FLOAT_W_NONE means the annotation does not spell a float width HERE. For a
+# non-float declaration that is simply true. For a float type reached through an
+# alias it means the width is unreadable this early, which the caller must treat
+# as "cannot fold this float yet" rather than as f64 - see
+# `register_val_for_load`.
+# ---
+# a:      the ast owning `t`
+# source: source text covering `t`
+# t:      the annotation's TypeId
+# ret:    the width the spelling fixes, or FLOAT_W_NONE
+pub fun declared_float_width(a: *ast.Ast, source: str, t: id.TypeId) float.FloatWidth {
+    if (t == id.TYPE_NIL) { ret float.FLOAT_W_NONE; }
+    val opt: O.Option[*atype.Type] = ast.get_type(a, t);
+    if (O.is_none[*atype.Type](opt)) { ret float.FLOAT_W_NONE; }
+    val ty: *atype.Type = O.unwrap[*atype.Type](opt);
+
+    if (ty.kind == atype.TYPE_KIND_SECRET) {
+        ret declared_float_width(a, source, ty.data.secret.inner);
+    }
+    if (ty.kind != atype.TYPE_KIND_NAMED)   { ret float.FLOAT_W_NONE; }
+    if (ty.data.named.args_len != 0)        { ret float.FLOAT_W_NONE; }
+
+    val text: View = span_text(source, ty.data.named.name);
+    if (view_eq_str(text, "f32")) { ret float.FLOAT_W_32; }
+    if (view_eq_str(text, "f64")) { ret float.FLOAT_W_64; }
+    ret float.FLOAT_W_NONE;
+}
+
+# whether a folded value is a float whose declared width the folding pass could
+# not read: the value is a float, but nothing narrowed it, so it is still the
+# f64 the digits spell rather than a value of its declared type
+#
+# The pre-type passes bind only what they can bind correctly, so a value that
+# answers true here is left for a pass that has the type. Binding it anyway
+# would publish a constant that disagrees with the one the program computes.
+pub fun float_width_unread(v: CTValue) bool {
+    ret v.kind == CT_KIND_FLOAT && v.float_width == float.FLOAT_W_NONE;
 }
 
 # extracts the element slice of a binding declaration's array-literal initializer
@@ -2058,9 +2187,15 @@ fun apply_equality(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue,
     if (lhs.kind != rhs.kind) {
         ret R.err[CTValue, str]("equality requires operands of the same kind");
     }
+    if (lhs.kind == CT_KIND_FLOAT && !float.widths_agree(lhs.float_width, rhs.float_width)) {
+        ret R.err[CTValue, str](FLOAT_WIDTH_MISMATCH_MSG);
+    }
     var eq: bool = false;
     if (lhs.kind == CT_KIND_INT)   { eq = ct_int_eq(lhs, rhs); }
-    or (lhs.kind == CT_KIND_FLOAT) { eq = lhs.data.f == rhs.data.f; }
+    or (lhs.kind == CT_KIND_FLOAT) {
+        val w: float.FloatWidth = float.unify_width(lhs.float_width, rhs.float_width);
+        eq = float.round_at(lhs.data.f, w) == float.round_at(rhs.data.f, w);
+    }
     or (lhs.kind == CT_KIND_BOOL)  { eq = lhs.data.b == rhs.data.b; }
     or (lhs.kind == CT_KIND_STR)   { eq = lhs.data.s == rhs.data.s; }
     or (lhs.kind == CT_KIND_TYPE)  { eq = lhs.data.t == rhs.data.t; }
@@ -2082,10 +2217,19 @@ fun apply_compare(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue, 
         ret bool_value(!ct_int_lt(lhs, rhs));
     }
     if (lhs.kind == CT_KIND_FLOAT) {
-        if (op == expr.BIN_LT)  { ret bool_value(lhs.data.f <  rhs.data.f); }
-        if (op == expr.BIN_LEQ) { ret bool_value(lhs.data.f <= rhs.data.f); }
-        if (op == expr.BIN_GT)  { ret bool_value(lhs.data.f >  rhs.data.f); }
-        ret bool_value(lhs.data.f >= rhs.data.f);
+        # an f32 constant against an untyped literal is an f32 comparison: the
+        # literal is the f32 the running program would have compared against, so
+        # both sides round to the shared width before they are ordered.
+        if (!float.widths_agree(lhs.float_width, rhs.float_width)) {
+            ret R.err[CTValue, str](FLOAT_WIDTH_MISMATCH_MSG);
+        }
+        val w: float.FloatWidth = float.unify_width(lhs.float_width, rhs.float_width);
+        val l: f64 = float.round_at(lhs.data.f, w);
+        val r: f64 = float.round_at(rhs.data.f, w);
+        if (op == expr.BIN_LT)  { ret bool_value(l <  r); }
+        if (op == expr.BIN_LEQ) { ret bool_value(l <= r); }
+        if (op == expr.BIN_GT)  { ret bool_value(l >  r); }
+        ret bool_value(l >= r);
     }
     ret R.err[CTValue, str]("ordered comparison requires numeric operands");
 }
@@ -2093,10 +2237,12 @@ fun apply_compare(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue, 
 # the truncated (C `fmod`) floating-point remainder: rem = a - trunc(a / b) * b,
 # taking the sign of the dividend `a`. `::i64` truncates the quotient toward zero,
 # matching the back end's FP_TO_SI lowering, so the comptime fold and the runtime
-# sequence agree bit for bit. the caller guards `b == 0`
-fun float_trunc_rem(a: f64, b: f64) f64 {
-    val q: i64 = (a / b)::i64;
-    ret a - q::f64 * b;
+# sequence agree bit for bit. every intermediate rounds at `w` because that is
+# what the emitted divide / convert / multiply / subtract sequence does at that
+# width. the caller guards `b == 0`
+fun float_trunc_rem(a: f64, b: f64, w: float.FloatWidth) f64 {
+    val q: i64 = float.round_at(a / b, w)::i64;
+    ret float.round_at(a - float.round_at(float.round_at(q::f64, w) * b, w), w);
 }
 
 fun apply_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue, str] {
@@ -2104,21 +2250,41 @@ fun apply_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue, st
         ret R.err[CTValue, str]("arithmetic requires operands of the same kind");
     }
     if (lhs.kind == CT_KIND_INT)   { ret apply_int_arith(op, lhs, rhs); }
-    if (lhs.kind == CT_KIND_FLOAT) {
-        if (op == expr.BIN_ADD) { ret float_value(lhs.data.f + rhs.data.f); }
-        if (op == expr.BIN_SUB) { ret float_value(lhs.data.f - rhs.data.f); }
-        if (op == expr.BIN_MUL) { ret float_value(lhs.data.f * rhs.data.f); }
-        if (op == expr.BIN_DIV) {
-            if (rhs.data.f == 0.0) { ret R.err[CTValue, str]("float division by zero"); }
-            ret float_value(lhs.data.f / rhs.data.f);
-        }
-        if (op == expr.BIN_MOD) {
-            if (rhs.data.f == 0.0) { ret R.err[CTValue, str]("float modulo by zero"); }
-            ret float_value(float_trunc_rem(lhs.data.f, rhs.data.f));
-        }
-        ret R.err[CTValue, str]("unsupported float operator");
-    }
+    if (lhs.kind == CT_KIND_FLOAT) { ret apply_float_arith(op, lhs, rhs); }
     ret R.err[CTValue, str]("arithmetic requires numeric operands");
+}
+
+# float arithmetic at the operands' shared declared width (#2918)
+#
+# BOTH OPERANDS ARE ROUNDED TO THE SHARED WIDTH BEFORE THE OPERATION, and the
+# result is rounded again. That is the whole of the fix: an f32 chain rounds
+# after every step, exactly as the emitted code does, so a folded constant and
+# the identical run-time computation cannot disagree. Rounding only the final
+# result would give a different value for any chain longer than one operation,
+# and rounding neither is what produced an f32 constant carrying f64 precision.
+#
+# An untyped literal beside a typed operand takes the typed operand's width
+# here, which is where `A * 0.1` at f32 stops multiplying by the f64 `0.1`.
+fun apply_float_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue, str] {
+    if (!float.widths_agree(lhs.float_width, rhs.float_width)) {
+        ret R.err[CTValue, str](FLOAT_WIDTH_MISMATCH_MSG);
+    }
+    val w: float.FloatWidth = float.unify_width(lhs.float_width, rhs.float_width);
+    val l: f64 = float.round_at(lhs.data.f, w);
+    val r: f64 = float.round_at(rhs.data.f, w);
+
+    if (op == expr.BIN_ADD) { ret float_value(l + r, w); }
+    if (op == expr.BIN_SUB) { ret float_value(l - r, w); }
+    if (op == expr.BIN_MUL) { ret float_value(l * r, w); }
+    if (op == expr.BIN_DIV) {
+        if (r == 0.0) { ret R.err[CTValue, str]("float division by zero"); }
+        ret float_value(l / r, w);
+    }
+    if (op == expr.BIN_MOD) {
+        if (r == 0.0) { ret R.err[CTValue, str]("float modulo by zero"); }
+        ret float_value(float_trunc_rem(l, r, w), w);
+    }
+    ret R.err[CTValue, str]("unsupported float operator");
 }
 
 # integer arithmetic with value-correct signedness. bitwise ops produce a pure
@@ -2340,7 +2506,8 @@ fun eval_const_elem_member(
     source:      str,
     object_eid:  id.ExprId,
     member_span: token.Span,
-    interner:    *intern.Interner
+    interner:    *intern.Interner,
+    fw:          float.FloatWidth
 ) O.Option[R.Result[CTValue, str]] {
     val obj_opt: O.Option[*expr.Expr] = ast.get_expr(a, object_eid);
     if (O.is_none[*expr.Expr](obj_opt))                                       { ret O.none[R.Result[CTValue, str]](); }
@@ -2371,7 +2538,7 @@ fun eval_const_elem_member(
         val fname_r: R.Result[intern.StrId, str] = intern.intern_span(interner, source, fi.name);
         if (R.is_err[intern.StrId, str](fname_r)) { ret O.some[R.Result[CTValue, str]](R.err[CTValue, str](R.unwrap_err[intern.StrId, str](fname_r))); }
         if (R.unwrap_ok[intern.StrId, str](fname_r) == mname) {
-            ret O.some[R.Result[CTValue, str]](eval(c, a, source, fi.value, interner));
+            ret O.some[R.Result[CTValue, str]](eval_at_float_width(c, a, source, fi.value, interner, fw));
         }
         i = i + 1;
     }
@@ -2827,11 +2994,24 @@ fun ct_negate(v: CTValue) R.Result[CTValue, str] {
     ret make_int_value(0 - v.data.i, false);
 }
 
-fun float_value(f: f64) R.Result[CTValue, str] {
+# a CT_KIND_FLOAT value at width `w`, its payload rounded to that width so the
+# stored f64 is exactly a value of the declared type
+fun float_value(f: f64, w: float.FloatWidth) R.Result[CTValue, str] {
+    ret R.ok[CTValue, str](ct_float(f, w));
+}
+
+# a CT_KIND_FLOAT value at width `w`, for a typed pass materializing a float
+# constant it already knows the type of (an explicit cast, a resolver answer)
+# ---
+# f:   the value
+# w:   the width the value's declared type fixes
+# ret: the rounded CT_KIND_FLOAT value
+pub fun ct_float(f: f64, w: float.FloatWidth) CTValue {
     var v: CTValue;
-    v.kind   = CT_KIND_FLOAT;
-    v.data.f = f;
-    ret R.ok[CTValue, str](v);
+    v.kind        = CT_KIND_FLOAT;
+    v.float_width = w;
+    v.data.f      = float.round_at(f, w);
+    ret v;
 }
 
 fun bool_value(b: bool) R.Result[CTValue, str] {
@@ -3020,27 +3200,27 @@ test "mach.lang.fe.comptime.apply_arith:int_min_idiv_traps" {
 
 # float % folds to the truncated (fmod) remainder (#1378)
 test "mach.lang.fe.comptime.apply_arith:float_mod_truncated" {
-    val a: CTValue = R.unwrap_ok[CTValue, str](float_value(5.5));
-    val b: CTValue = R.unwrap_ok[CTValue, str](float_value(3.0));
+    val a: CTValue = R.unwrap_ok[CTValue, str](float_value(5.5, float.FLOAT_W_NONE));
+    val b: CTValue = R.unwrap_ok[CTValue, str](float_value(3.0, float.FLOAT_W_NONE));
     val r: R.Result[CTValue, str] = apply_arith(expr.BIN_MOD, a, b);
     if (R.is_err[CTValue, str](r))                  { ret 1; }
     if (R.unwrap_ok[CTValue, str](r).data.f != 2.5) { ret 1; }
 
     # the result takes the dividend's sign (C fmod): -5.5 % 3.0 = -2.5.
-    val na: CTValue = R.unwrap_ok[CTValue, str](float_value(0.0 - 5.5));
+    val na: CTValue = R.unwrap_ok[CTValue, str](float_value(0.0 - 5.5, float.FLOAT_W_NONE));
     val rn: R.Result[CTValue, str] = apply_arith(expr.BIN_MOD, na, b);
     if (R.is_err[CTValue, str](rn))                          { ret 1; }
     if (R.unwrap_ok[CTValue, str](rn).data.f != (0.0 - 2.5)) { ret 1; }
 
     # lhs < rhs passes the dividend through unchanged.
-    val s:   CTValue = R.unwrap_ok[CTValue, str](float_value(0.45));
-    val one: CTValue = R.unwrap_ok[CTValue, str](float_value(1.0));
+    val s:   CTValue = R.unwrap_ok[CTValue, str](float_value(0.45, float.FLOAT_W_NONE));
+    val one: CTValue = R.unwrap_ok[CTValue, str](float_value(1.0, float.FLOAT_W_NONE));
     val rs: R.Result[CTValue, str] = apply_arith(expr.BIN_MOD, s, one);
     if (R.is_err[CTValue, str](rs))                   { ret 1; }
     if (R.unwrap_ok[CTValue, str](rs).data.f != 0.45) { ret 1; }
 
     # modulo by zero is an error, not a silent fold.
-    val z: CTValue = R.unwrap_ok[CTValue, str](float_value(0.0));
+    val z: CTValue = R.unwrap_ok[CTValue, str](float_value(0.0, float.FLOAT_W_NONE));
     if (!R.is_err[CTValue, str](apply_arith(expr.BIN_MOD, a, z))) { ret 1; }
     ret 0;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -44,6 +44,7 @@ use mach.lang.fe.ast.stmt;
 use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.comptime;
 use mach.lang.fe.token;
+use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.session;
 use src: mach.lang.source;
@@ -1037,7 +1038,8 @@ fun collect_one_decl(rc: *ResolveContext, decl_id: id.DeclId, scope: ScopeId, at
         val r: R.Result[bool, str] = declare_decl(rc, SYM_VAL, sym_flags, d.data.bind.name, decl_id, scope);
         if (R.is_err[bool, str](r)) { ret r; }
         if (d.data.bind.init != id.EXPR_NIL) {
-            val rcr: R.Result[bool, str] = try_register_comptime_const(rc, d.data.bind.name, d.data.bind.init);
+            val rcr: R.Result[bool, str] =
+                try_register_comptime_const(rc, d.data.bind.name, d.data.bind.ty, d.data.bind.init);
             if (R.is_err[bool, str](rcr)) { ret rcr; }
         }
         ret R.ok[bool, str](true);
@@ -1140,9 +1142,11 @@ fun symbol_flags_from(decl_flags: u8, at_module_scope: bool) u8 {
 # ---
 # rc:        resolver state for the module being resolved
 # name_span: span of the val's name
+# ty:        the val's type annotation, which fixes a float initializer's width
 # init_expr: the initializer expression
 # ret:       ok(true); only a bind allocation failure is reported as an error
-fun try_register_comptime_const(rc: *ResolveContext, name_span: token.Span, init_expr: id.ExprId) R.Result[bool, str] {
+fun try_register_comptime_const(rc: *ResolveContext, name_span: token.Span, ty: id.TypeId,
+                                init_expr: id.ExprId) R.Result[bool, str] {
     if (name_span.len == 0) { ret R.ok[bool, str](true); }
     val r_id: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, name_span);
     if (R.is_err[intern.StrId, str](r_id)) { ret R.ok[bool, str](true); }
@@ -1150,9 +1154,15 @@ fun try_register_comptime_const(rc: *ResolveContext, name_span: token.Span, init
 
     if (O.is_some[*comptime.NamedConst](comptime.lookup(rc.ctx, name_id))) { ret R.ok[bool, str](true); }
 
-    val r_val: R.Result[comptime.CTValue, str] = comptime.eval(rc.ctx, rc.a, rc.source, init_expr, ?rc.s.interner);
+    # a float initializer folds at the width the annotation spells, and a float
+    # whose width the annotation did not spell is left to lowering, exactly as
+    # the load-time walk leaves it (#2918).
+    val fw: float.FloatWidth = comptime.declared_float_width(rc.a, rc.source, ty);
+    val r_val: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(rc.ctx, rc.a, rc.source, init_expr, ?rc.s.interner, fw);
     if (R.is_err[comptime.CTValue, str](r_val)) { ret R.ok[bool, str](true); }
     val v: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](r_val);
+    if (comptime.float_width_unread(v)) { ret R.ok[bool, str](true); }
 
     ret comptime.bind(rc.ctx, name_id, v);
 }

--- a/src/lang/float.mach
+++ b/src/lang/float.mach
@@ -10,6 +10,24 @@ use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 
+# the IEEE-754 width a float value is carried AT, as distinct from the f64 a
+# comptime evaluator happens to hold it in
+#
+# A float constant chain must round at its declared width after every operation,
+# because that is what the running program does: `f32 a = x - y` rounds the
+# difference to f32 before the next operation sees it. Carrying the width beside
+# the value is what lets a fold reproduce that, so this def is a leaf shared by
+# the comptime evaluator (which tags every float CTValue with one) and the typed
+# passes (which read one off a checked type).
+pub def FloatWidth: u8;
+
+# no width is fixed: an untyped float literal in a context that declares no
+# float type. Such a value is carried at f64, the default a float literal takes
+# when nothing narrows it, and never rounded.
+pub val FLOAT_W_NONE: FloatWidth = 0;
+pub val FLOAT_W_32:   FloatWidth = 32;
+pub val FLOAT_W_64:   FloatWidth = 64;
+
 # reinterpret an f64 as its raw 64-bit IEEE-754 pattern
 # ---
 # f:   the value
@@ -114,4 +132,70 @@ pub fun f64_to_f32_bits(d: u64) u32 {
         }
     }
     ret (sign << 31) | (em << 23) | frac;
+}
+
+# convert an IEEE-754 single bit pattern to the IEEE-754 double pattern
+#
+# Exact in every case: every f32 is an f64, so nothing rounds. The inverse
+# direction of `f64_to_f32_bits`, and integer-only for the same reason.
+# ---
+# s:   the 32-bit single bit pattern
+# ret: the 64-bit double bit pattern
+pub fun f32_bits_to_f64_bits(s: u32) u64 {
+    val sign: u64 = ((s >> 31) & 0x1)::u64;
+    val exp:  u32 = (s >> 23) & 0xFF;
+    val mant: u32 = s & 0x7FFFFF;
+
+    # NaN / infinity: the exponent stays all-ones and the payload keeps its
+    # position at the top of the wider significand.
+    if (exp == 0xFF) { ret (sign << 63) | 0x7FF0000000000000 | (mant::u64 << 29); }
+
+    if (exp == 0) {
+        # zero, or a single subnormal: `mant * 2^-149`, which is a NORMAL double.
+        # renormalise by finding the significand's top set bit at position `p`,
+        # giving an unbiased exponent of `p - 149`.
+        if (mant == 0) { ret sign << 63; }
+        var p: u32 = 22;
+        for ((mant & (1::u32 << p)) == 0) { p = p - 1; }
+        val e64: u64 = (p + 874)::u64;
+        val m64: u64 = (mant::u64 << (52 - p)::u64) & 0xFFFFFFFFFFFFF;
+        ret (sign << 63) | (e64 << 52) | m64;
+    }
+
+    # normal: rebias from single (127) to double (1023) and left-align the
+    # 23-bit significand in the 52-bit field.
+    ret (sign << 63) | ((exp + 896)::u64 << 52) | (mant::u64 << 29);
+}
+
+# round an f64 to the nearest value representable at `w`, returned as an f64
+#
+# The one place a comptime float is narrowed. `FLOAT_W_NONE` and `FLOAT_W_64`
+# are already exact at f64 and pass through untouched; `FLOAT_W_32` makes the
+# round trip through the single pattern, so the result is bit-for-bit what the
+# hardware produces for the same operation at f32.
+# ---
+# f:   the value
+# w:   the width to round at
+# ret: `f` rounded to `w`
+pub fun round_at(f: f64, w: FloatWidth) f64 {
+    if (w != FLOAT_W_32) { ret f; }
+    ret bits_f64(f32_bits_to_f64_bits(f64_to_f32_bits(f64_bits(f))));
+}
+
+# whether two float operand widths name one width
+#
+# A float operation in Mach has ONE width: there is no implicit widening, so a
+# typed operand fixes the width and an untyped literal adopts it. Operands of
+# two different declared widths are a type error the typed passes report, and a
+# fold that guessed one of them would produce a value the program can never
+# compute, so the evaluator declines instead.
+pub fun widths_agree(a: FloatWidth, b: FloatWidth) bool {
+    ret a == b || a == FLOAT_W_NONE || b == FLOAT_W_NONE;
+}
+
+# the width two agreeing operands share: the declared one, or none when neither
+# operand is typed. `widths_agree` is the caller's precondition
+pub fun unify_width(a: FloatWidth, b: FloatWidth) FloatWidth {
+    if (a == FLOAT_W_NONE) { ret b; }
+    ret a;
 }

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -570,7 +570,9 @@ fun place_scalar(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId
         }
     }
 
-    val res_ctval: R.Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
+    val res_ctval: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner,
+                                     lower.expr_float_width(ctx, eid));
     if (R.is_err[comptime.CTValue, str](res_ctval)) {
         # comptime.eval models no cast width / sign, so a constant cast leaf lands
         # here rather than folding above. route it through the same cast path the

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -40,6 +40,7 @@ use mach.lang.session;
 use mach.lang.source;
 use isa: mach.lang.target.isa;
 use target:  mach.lang.target.resolved;
+use mach.lang.float;
 use mach.lang.type;
 
 
@@ -1628,6 +1629,34 @@ pub fun expr_type_of(lc: *LowerContext, eid: id.ExprId) type.TypeId {
     if (eid == id.EXPR_NIL)          { ret type.TYPE_NIL; }
     if (eid::usize >= lc.a.expr_len) { ret type.TYPE_NIL; }
     ret lc.sema_result.expr_type[eid];
+}
+
+# the float width sema fixed for an expression, for handing to the comptime
+# evaluator so a folded float constant rounds at its declared type (#2918)
+#
+# Lowering is the pass that HAS the answer: the alias, the generic substitution
+# and the coercion are all resolved by the time it runs, so it reads the checked
+# type rather than a spelling. FLOAT_W_NONE for a non-float expression.
+# ---
+# lc:  the context
+# eid: AST ExprId
+# ret: the expression's float width, or FLOAT_W_NONE
+pub fun expr_float_width(lc: *LowerContext, eid: id.ExprId) float.FloatWidth {
+    ret float_width_of_type(lc, expr_type_of(lc, eid));
+}
+
+# the float width of a semantic type, under the active generic substitution and
+# through the secret `^` wrapper: a `^f32` rounds at f32 like any other f32
+# ---
+# lc:  the context
+# tid: the semantic type
+# ret: the type's float width, or FLOAT_W_NONE
+pub fun float_width_of_type(lc: *LowerContext, tid: type.TypeId) float.FloatWidth {
+    if (tid == type.TYPE_NIL) { ret float.FLOAT_W_NONE; }
+    val ct: type.TypeId = type.strip_secret(?lc.s.types, substitute_type(lc, tid));
+    val opt_t: O.Option[*type.Type] = type.get(?lc.s.types, ct);
+    if (O.is_none[*type.Type](opt_t)) { ret float.FLOAT_W_NONE; }
+    ret type.float_width_of(O.unwrap[*type.Type](opt_t).kind);
 }
 
 # whether expression `eid` carries the secret `^` qualifier, per sema's flow typing

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1733,13 +1733,17 @@ fun param_symbol(ctx: *context.LowerContext, fun_did: id.DeclId, index: u32) res
 # attempt to fold a global initialiser to a comptime constant
 #
 # Returns none when the initialiser is not comptime-evaluable (its runtime logic
-# belongs in the module init function instead).
+# belongs in the module init function instead). A float initialiser folds at the
+# width sema checked it at, so an `f32` global holds the f32 the same expression
+# computes at run time (#2918).
 # ---
 # ctx: the context
 # eid: the initialiser expression
 # ret: some(CTValue) when foldable, none otherwise
 fun try_comptime(ctx: *context.LowerContext, eid: id.ExprId) O.Option[comptime.CTValue] {
-    val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner);
+    val res_eval: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner,
+                                     context.expr_float_width(ctx, eid));
     if (R.is_ok[comptime.CTValue, str](res_eval)) {
         ret O.some[comptime.CTValue](R.unwrap_ok[comptime.CTValue, str](res_eval));
     }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -48,6 +48,7 @@ use mach.lang.me.lower.mangle;
 use mach.lang.session;
 use mach.lang.source;
 use isa: mach.lang.target.isa;
+use mach.lang.float;
 use mach.lang.type;
 
 # lower an expression to its rvalue: the loaded value it denotes
@@ -1713,7 +1714,8 @@ fun fold_const_scalar(ctx: *context.LowerContext, eid: id.ExprId) O.Option[R.Res
 
     if (e.kind != expr.EXPR_KIND_CAST) {
         val res_eval: R.Result[comptime.CTValue, str] =
-            comptime.eval(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner);
+            comptime.eval_at_float_width(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner,
+                                         context.expr_float_width(ctx, eid));
         if (R.is_err[comptime.CTValue, str](res_eval)) { ret O.none[R.Result[comptime.CTValue, str]](); }
         ret O.some[R.Result[comptime.CTValue, str]](R.ok[comptime.CTValue, str](R.unwrap_ok[comptime.CTValue, str](res_eval)));
     }
@@ -1759,14 +1761,19 @@ fun convert_const_scalar(
     # so the comptime payload already carries those bits unchanged.
     if (reinterpret) { ret R.ok[comptime.CTValue, str](v); }
 
-    if (from_float && to_float) { ret float_ct(v.data.f); }
+    # a float target is the one place a cast changes a float's width, so the
+    # result is taken AT the target width: `X::f32` is the f32, not an f64 that
+    # a later emission step happens to narrow (#2918).
+    val to_fw: float.FloatWidth = context.float_width_of_type(ctx, to_ty);
+
+    if (from_float && to_float) { ret float_ct(v.data.f, to_fw); }
     if (from_float && !to_float) {
         # float -> int truncates toward zero into the target representation.
         ret int_ct(rerepresent_int(v.data.f::i64, to_bits, to_signed));
     }
     if (!from_float && to_float) {
-        # int -> float yields the integer's real value as an f64.
-        ret float_ct(v.data.i::f64);
+        # int -> float yields the integer's real value, rounded to the target.
+        ret float_ct(v.data.i::f64, to_fw);
     }
 
     ret int_ct(rerepresent_int(v.data.i, to_bits, to_signed));
@@ -1801,15 +1808,13 @@ fun int_ct(i: i64) R.Result[comptime.CTValue, str] {
     ret R.ok[comptime.CTValue, str](v);
 }
 
-# wrap a float in a CT_KIND_FLOAT comptime value
+# wrap a float in a CT_KIND_FLOAT comptime value at width `w`
 # ---
 # f:   the float payload
+# w:   the width the value's type fixes
 # ret: the wrapped comptime value
-fun float_ct(f: f64) R.Result[comptime.CTValue, str] {
-    var v: comptime.CTValue;
-    v.kind   = comptime.CT_KIND_FLOAT;
-    v.data.f = f;
-    ret R.ok[comptime.CTValue, str](v);
+fun float_ct(f: f64, w: float.FloatWidth) R.Result[comptime.CTValue, str] {
+    ret R.ok[comptime.CTValue, str](comptime.ct_float(f, w));
 }
 
 # lower a call: the callee rvalue, then each argument rvalue, then an OP_CALL
@@ -2202,7 +2207,9 @@ fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
 # eid: the argument expression
 # ret: some(folded value) for a compile-time constant, none otherwise
 fun fold_comptime_arg(ctx: *context.LowerContext, eid: id.ExprId) O.Option[comptime.CTValue] {
-    val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner);
+    val res_eval: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner,
+                                     context.expr_float_width(ctx, eid));
     if (R.is_ok[comptime.CTValue, str](res_eval)) {
         ret O.some[comptime.CTValue](R.unwrap_ok[comptime.CTValue, str](res_eval));
     }
@@ -3452,7 +3459,9 @@ fun lower_strip(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value,
 # eid: the comptime-path expression
 # ret: the materialized constant Value, or an error
 fun lower_comptime_path(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.Value, str] {
-    val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner);
+    val res_eval: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(ctx.ctx, ctx.a, context.module_source(ctx), eid, ?ctx.s.interner,
+                                     context.expr_float_width(ctx, eid));
     if (R.is_err[comptime.CTValue, str](res_eval)) { ret R.err[value.Value, str](R.unwrap_err[comptime.CTValue, str](res_eval)); }
     ret const_value_of(ctx, eid, R.unwrap_ok[comptime.CTValue, str](res_eval));
 }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -29,6 +29,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.fe.ast.id;
+use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.module;
 
@@ -278,6 +279,21 @@ pub fun prim_name(kind: TypeKind) str {
     or (kind == TYPE_F64) { ret "f64"; }
     or (kind == TYPE_PTR) { ret "ptr"; }
     ret nil;
+}
+
+# the IEEE width a primitive float TypeKind is carried at
+#
+# What a typed pass hands the comptime evaluator so a folded float constant
+# rounds where the running program rounds (#2918). FLOAT_W_NONE for every
+# non-float kind, which says the same thing there as it does everywhere else:
+# this type fixes no float width.
+# ---
+# kind: the TypeKind to read
+# ret:  the float width, or FLOAT_W_NONE for a non-float kind
+pub fun float_width_of(kind: TypeKind) float.FloatWidth {
+    if (kind == TYPE_F32) { ret float.FLOAT_W_32; }
+    if (kind == TYPE_F64) { ret float.FLOAT_W_64; }
+    ret float.FLOAT_W_NONE;
 }
 
 # how reading a spelling as the vector form `<element>x<lanes>` came out


### PR DESCRIPTION
Closes #2918

## Root cause

`CTValue` carried a float in a bare `f64` with no width, so a float constant was
computed at double precision whatever its declared type. `val B: f32 = A -
16777216.0` folded to `3f800000` where the running program computes `00000000`.
Narrowing existed only at the very end, when the constant was emitted at its IR
type, which is why `A` read back correct and `B` did not.

## The fix

`CTValue` now carries the IEEE width its payload is at, beside the signedness the
integer side already carried, and `eval` takes the width the expression's
declared type fixes.

* An untyped float literal adopts the context width, so `val C: f32 = 1.0 / 3.0 *
  7.0 - 2.0` is an f32 chain from the first literal rather than an f64 chain
  narrowed at the end.
* Every float operation reconciles its operands' widths, rounds BOTH operands to
  the shared width, and rounds the result. That is the whole of the fix: the
  chain rounds after every step the way the emitted code does. Narrowing only at
  the binding is a different, still wrong value.
* Comparisons reconcile the same way, so `$if` on a float constant and a
  constant keyed comparison are decided at the constant's width.
* Two operands of different declared widths are refused rather than folded at a
  guessed width. Mach has no implicit widening, so that shape is a type error the
  typed passes report.

Where each pass gets the width:

* Lowering reads the checked type off the expression, through the generic
  substitution and the `^` wrapper. It is the pass that has the answer.
* An explicit `::f32` cast now takes its result AT the target width.
* The load-time walk and name resolution read the annotation's spelling. That is
  exact rather than a guess for `f32` and `f64`, because a primitive wins over
  scope in type position, so no declaration can make either name anything else.
  A float whose width they cannot read (a float type reached through an alias) is
  not bound at all, by the same rule those passes already apply to a non-foldable
  initializer, and it binds at lowering where the type exists.

## Verification

Repro, comptime against run time for the identical expression:

| binding | before | after | run time |
|---|---|---|---|
| `A: f32 = 16777217.0` | `4b800000` | `4b800000` | `4b800000` |
| `B: f32 = A - 16777216.0` | `3f800000` | `00000000` | `00000000` |
| `C: f32 = 1.0/3.0*7.0 - 2.0` | `3eaaaaab` | `3eaaaab0` | `3eaaaab0` |
| `H: f32 = 1.0/3.0*0.1` | `3d088889` | `3d088889` | `3d088889` |
| `N: f32 = -(1.0/3.0)` | `beaaaaab` | `beaaaaab` | `beaaaaab` |
| `D: f64 = 1.0/3.0*7.0 - 2.0` | `3fd5555555555550` | `3fd5555555555550` | `3fd5555555555550` |
| `E: f64 = 16777217.0 - 16777216.0` | `3ff0000000000000` | `3ff0000000000000` | `3ff0000000000000` |

`C` is the one that matters: it is a multi-step chain, and rounding once at the
end gives `3eaaaaab`, the same answer as rounding nothing. Only rounding at each
step gives the `3eaaaab0` the program computes.

Two tests in `src/lang/driver/tests.mach`, asserting bit patterns against both a
literal pattern and the run-time value of the identical expression, each paired
with an f64 control that must not move. Reverting the narrowing fails exactly
those two and nothing else: 1455 passed / 2 failed. Restored: 1457 passed / 0
failed, and the self-built compiler gives the same 1457 / 0.

Object output: identical across all six declared targets, 1352 objects, zero
differing files, against a merge-base baseline kept outside the build tree. The
determinism control (the same compiler over the same source twice) is also
byte-identical. Self-host fixpoint holds: stage3 and stage4 are byte-identical
binaries and byte-identical output trees.

## Behaviour change worth a look

A module level float `val` whose type is reached through an alias (`def F: f32;
val X: F = 0.5;`) is no longer comptime-usable BEFORE lowering. Its emitted value
is correct, and it folds normally inside its own module's lowering, but a
decl-level `$if` gate on it now reports "identifier is not a comptime constant in
scope" instead of folding at f64. That trades a silently wrong value for a
diagnostic, which is the right direction, but the message describes it badly.
Worth a follow-up issue.
