### PR TITLE
test(2791): enter the kernel the way darwin does

### DIFF
--- a/int/regression/2791-asm-noreturn/case.conf
+++ b/int/regression/2791-asm-noreturn/case.conf
@@ -1,7 +1,9 @@
-# the bodies that cannot return end control with a Linux kernel entry - x86_64
-# `mov eax, 231` + `syscall` (exit_group), aarch64 `svc 0`, riscv64 `ecall` - each
-# followed by a trap. windows has no syscall ABI, so that instruction is not a
-# kernel entry there and the body it is meant to demonstrate does not exist: the
-# case's premise, not merely its expected output, is linux-only. same reason
-# surface/syscall-inline-asm is exempt here.
+# the bodies that cannot return end control with a kernel entry followed by a trap,
+# so the entry is the one part of this case that is not target-independent. linux
+# takes `mov eax, 231` + `syscall` on x86_64 and `svc 0` with the number in x8 on
+# aarch64; darwin takes the BSD-class number `0x2000001` on x86_64 and `svc 0x80`
+# with the number in x16 on aarch64. windows has no syscall ABI at all, so that
+# instruction is not a kernel entry there and the body this case demonstrates does
+# not exist: for windows the premise fails, not merely the expected output. same
+# reason surface/syscall-inline-asm is exempt here.
 exempt: windows

--- a/int/regression/2791-asm-noreturn/src/main.mach
+++ b/int/regression/2791-asm-noreturn/src/main.mach
@@ -107,7 +107,23 @@ fun after_bytes(v: i64) i64 {
 # the non-returning shape itself, reached only at the very end. it exits cleanly so the
 # observable is the stdout above plus the ABSENCE of the line after the call.
 fun die() {
-    $if ($mach.build.arch == $mach.arch.x86_64) {
+    $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov eax, 0x2000001
+            mov edi, 0
+            syscall
+            hlt
+        }
+    }
+    $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x16, 1
+            mov x0, 0
+            svc 0x80
+            brk 0
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov eax, 231
             mov edi, 0


### PR DESCRIPTION
`int main` has been red on both darwin legs since 09:11 today with `producer exit 133`, which is SIGTRAP.

Not a compiler regression. `regression/2791-asm-noreturn`'s non-returning body hardcoded linux syscall numbers (`eax=231`, `x8=94`) and gated only on `$mach.build.arch`. On darwin those numbers name no exit, so the syscall returned and control fell into the `hlt` / `brk 0` deliberately placed after it. The case.conf even said the premise was linux-only, but exempted windows alone.

The gate now asks the os as well as the arch, and darwin gets its own entry: `0x2000001` on x86_64, and `svc 0x80` with the number in x16 on aarch64.

Verified by cross-compiling all four targets with the branch compiler. darwin-x86_64 contains `0x2000001` and no `231`; linux contains `231` and no `0x2000001`. darwin-aarch64 emits `svc #0x80` 13 times where linux-arm64 emits it zero times. The linux binary still runs and its output matches `expect.txt` exactly.

Darwin keeps the coverage rather than being exempted behind a disclaimer.