### PR TITLE
fix(spirv): refuse a function whose parameters exceed the register file instead of truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### A SPIR-V function body truncated its parameters instead of refusing (#2923)
+
+Emitting a function body filled the per-block register file with `for (i < param_count && i < 16)`, so a function reaching that point with more than sixteen parameters had every parameter past the sixteenth silently dropped and read an empty register slot instead. It was unreachable only because `emit_function` refuses first, which made a load-bearing correctness guard look like defensive clamping: any change to that refusal turned it into wrong code with no diagnostic. It now refuses on its own terms.
+
+The bound was also stated in four places rather than one, which is the defect #2748 closed reappearing at the site that fix did not reach. The cross-module call path carried a bare `> 16` rather than the named constant, so the two agreed by construction rather than by checking.
+
+**The constant's own documentation was wrong, and that is what sent the issue at the wrong layer.** It said sixteen came from the emitter assembling signature operands into fixed arrays, so removing the bound read as a buffer resize. The real reason is the argument register bank. `abi/spirv.mach` is an identity convention where the argument at position `i` is classified into register `i`, since SPIR-V passes composites natively and has no frame to spill into, so a parameter position is a physical register id on this target. The shared MIR lowering caps those at `MAX_GP_ARG_REGS`, also sixteen. SPIR-V's own universal limit is 255, and reaching it means decoupling a parameter from the register model rather than widening a buffer.
+
+That shared cap turned out to be unguarded in a way no target owner would expect. `abi_gp_arg_reg` reads a convention's bank into a fixed `[16]isa.Register` and range-checks the index **after** the fill, so a convention publishing a wider bank overruns that array before anything rejects it, from a one-line edit in a target's own file. A test now walks every registered convention against a deliberately oversized scratch and fails if any publishes a wider bank, and it refuses to pass if it checked nothing.
+
 ### Changed
 
 #### The integration suite is retired, and a linking suite replaces the part the codegen corpus cannot reach (#2903)

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -35,12 +35,19 @@ use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
+use treg: mach.lang.target;
 use target: mach.lang.target.resolved;
 use semtype: mach.lang.type;
 
 # upper bound on the GP argument-register file size, sizing the stack buffer
 # `abi_gp_arg_reg` fills from `tgt.abi.gp_arg_regs`. every modeled convention's GP
 # argument file (SysV's six, win64's four) fits
+# the registered (arch, os, abi) triples the shared-array guard walks
+val CONV_COUNT: u32 = 7;
+val CONV_ARCH: [7]str = [7]str{"x86_64", "x86_64", "x86_64", "aarch64", "riscv64", "riscv32", "spirv"};
+val CONV_OS:   [7]str = [7]str{"linux", "windows", "darwin", "linux", "linux", "freestanding", "freestanding"};
+val CONV_ABI:  [7]str = [7]str{"sysv64", "win64", "sysv64", "aapcs64", "lp64d", "ilp32d", "spirv"};
+
 val MAX_GP_ARG_REGS: i32 = 16;
 
 # validate that the active target exposes the ABI and ISA vtable surface
@@ -2454,4 +2461,46 @@ test "mach.lang.be.codegen.mir.abi:vector_by_value_roundtrip" {
     if (!rt_lane_ok(rt_pick(1, src, i32x4{5, 6, 7, 8}), 266, 10, 70000, 40000)) { ret 1; }
     if (!rt_lane_ok(rt_pick(0, i32x4{5, 6, 7, 8}, src), 266, 10, 70000, 40000)) { ret 1; }
     ret 0;
+}
+
+# no registered convention publishes a GP argument bank wider than the array that
+# reads it (#2923)
+#
+# `abi_gp_arg_reg` declares `[MAX_GP_ARG_REGS]isa.Register` and calls the
+# convention's fill BEFORE it range-checks the index, so a convention that
+# published a wider bank would overrun that array and the range check would run
+# afterwards on a stack that had already been written past. The overrun is in code
+# every target shares, and the convention that would cause it is a one-line edit in
+# a target's own file, which is the shape a target owner would not expect to be
+# holding.
+#
+# Asserted here rather than trusted: the scratch is deliberately far wider than the
+# bound, so a convention that overruns the real array is caught by this test
+# instead of by corrupting a frame.
+test "mach.lang.be.codegen.mir.abi.gp_arg_regs:no_convention_exceeds_the_shared_array" {
+    var reg: treg.TargetRegistry = treg.registry_init();
+    if (R.is_err[bool, str](treg.register_all(?reg))) { ret 1; }
+
+    var bad: i32 = 0;
+    var checked: i32 = 0;
+    var i: u32 = 0;
+    for (i < CONV_COUNT) {
+        val tr: R.Result[target.Target, str] =
+            treg.select(?reg, CONV_ARCH[i], CONV_OS[i], CONV_ABI[i]);
+        if (R.is_err[target.Target, str](tr)) { i = i + 1; cnt; }
+        var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+        if (tgt.abi.gp_arg_regs == nil) { i = i + 1; cnt; }
+
+        var scratch: [256]isa.Register;
+        val fill: abi.RegFileFn = tgt.abi.gp_arg_regs::abi.RegFileFn;
+        val n: i32 = fill(?scratch[0]);
+        checked = checked + 1;
+        if (n > MAX_GP_ARG_REGS) { bad = bad + 1; }
+        if (n < 0)               { bad = bad + 1; }
+        i = i + 1;
+    }
+
+    # a run that checked nothing must not read as a pass
+    if (checked == 0) { ret 1; }
+    ret bad;
 }

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -2740,9 +2740,19 @@ fun emit_node(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32, is_en
     # position, valid for the whole function.
     var rg: Regs;
     var i: u32 = 0;
-    for (i < 16) { rg.val_id[i] = 0; rg.imm[i] = 0; rg.is_imm[i] = false; rg.is_bool[i] = false; i = i + 1; }
+    for (i < types.MAX_FN_PARAMS) { rg.val_id[i] = 0; rg.imm[i] = 0; rg.is_imm[i] = false; rg.is_bool[i] = false; i = i + 1; }
+
+    # REFUSED, never truncated. this used to read `i < param_count && i < 16`, which
+    # dropped every parameter past the sixteenth and emitted a function that read an
+    # empty register slot for it. it was unreachable only because `emit_function`
+    # refuses first, so the guard here was load-bearing for correctness while looking
+    # like defensive clamping, and any change to that refusal turned it into wrong
+    # code with no diagnostic (#2923)
+    if (param_count > types.MAX_FN_PARAMS) {
+        ret R.err[bool, str]("spirv.emit: a function reached body emission with more parameters than the register file holds");
+    }
     i = 0;
-    for (i < param_count && i < 16) { rg.val_id[i] = param_ids[i]; i = i + 1; }
+    for (i < param_count) { rg.val_id[i] = param_ids[i]; i = i + 1; }
 
     val blk: *mir.MirBlock = ?mf.blocks[st.nodes[ix].block];
     if (role == cfg.ROLE_REAL) {
@@ -4414,7 +4424,7 @@ fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[bool, str] 
         e.ir = saved_ir; e.cur_mi = saved_mi;
         ret unsupported(e, "unsupported return type in the SPIR-V target");
     }
-    if (irfn.param_count > 16) {
+    if (irfn.param_count > types.MAX_FN_PARAMS) {
         e.ir = saved_ir; e.cur_mi = saved_mi;
         ret unsupported(e, "more than 16 parameters is not supported by the SPIR-V target");
     }

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -118,14 +118,27 @@ pub val MAX_STRUCT_MEMBERS: u32 = 16;
 
 # the largest parameter count a signature may carry in this milestone
 #
-# SPIR-V itself imposes no small bound; sixteen is here because the emitter
-# assembles a signature's operands into fixed arrays. It is stated ONCE and both
-# the refusal in `emit_function` and the operand buffer in `type_fn` are sized from
-# it. They used to be two independent literals - a `> 16` comparison and a
-# `[16]u32` holding a result id and a return type as well - so fifteen and sixteen
-# parameters were accepted by one and rejected by the other, and the rejection was
-# a returned 0 that nobody read and that reached `OpFunction` as the reserved
-# never-valid id (#2748).
+# SPIR-V's own universal limit is 255 parameters. Sixteen is here for a reason that
+# is NOT the operand buffers, and the earlier comment on this constant said it was,
+# which sent #2923 at the wrong layer.
+#
+# THE BOUND IS THE ARGUMENT REGISTER BANK, and it is not this target's to widen
+# alone. `abi/spirv.mach` is an identity convention: the argument at logical
+# position `i` is classified into register `i`, since SPIR-V passes composites
+# natively and has no frame to spill into. So a parameter position IS a physical
+# register id here, and the shared MIR lowering caps those at `MAX_GP_ARG_REGS`,
+# also sixteen, reading a convention's bank into a fixed `[16]isa.Register` before
+# it range-checks the index. A convention publishing a wider bank overruns that
+# array rather than being refused, so widening this without changing the shared
+# contract first is a stack overrun in code every target shares.
+#
+# Removing the bound therefore means decoupling a SPIR-V parameter from the
+# register model, which is a lowering change and not a buffer resize. Until then it
+# is stated ONCE and every site reads it: the refusal in `emit_function`, the
+# refusal in the cross-module call path, the operand buffer in `type_fn`, and the
+# per-block register file's own bound. Those used to be independent literals, which
+# is exactly how fifteen and sixteen came to be accepted by one site and rejected by
+# another (#2748), and how a `> 16` at the call site survived that fix (#2923).
 pub val MAX_FN_PARAMS: u32 = 16;
 
 # a memoized composite constant: its result type id and the borrowed-then-copied


### PR DESCRIPTION
Part of #2923. Does **not** close it: the parameter bound stays at sixteen, and this
explains why that is not a buffer resize.

## The wrong-code path, which is the reason this is a fix and not a cleanup

`emit_node` filled the per-block register file with:

```mach
for (i < param_count && i < 16) { rg.val_id[i] = param_ids[i]; i = i + 1; }
```

A function reaching body emission with more than sixteen parameters had every
parameter past the sixteenth **silently dropped**, and read an empty register slot for
it. It was unreachable only because `emit_function` refuses first. So a guard that
looked like defensive clamping was load-bearing for correctness, and the change #2923
proposes -- deleting that refusal -- would have turned it into a miscompile with no
diagnostic. It now refuses on its own terms.

The bound was also stated in four places, not one. The cross-module call path carried a
bare `> 16` instead of `types.MAX_FN_PARAMS`, so it agreed by construction rather than
by checking. That is the #2748 defect at the site #2748 did not reach.

## Why the bound is sixteen, corrected

The comment on `MAX_FN_PARAMS` claimed sixteen came from the emitter assembling
signature operands into fixed arrays, which is what framed #2923 as a buffer resize. It
is wrong.

`abi/spirv.mach` is an **identity convention**: the argument at logical position `i` is
classified into register `i`, because SPIR-V passes composites natively and has no
frame to spill into. A parameter position therefore **is** a physical register id on
this target, and the shared MIR lowering caps those at `MAX_GP_ARG_REGS`, also sixteen.

SPIR-V's own universal limit is 255. Reaching it means decoupling a SPIR-V parameter
from the register model, which is a lowering change. The constant now says that, so the
next reader is not sent at the buffers.

## A shared-code hazard found on the way

`abi_gp_arg_reg` declares `[16]isa.Register`, calls the convention's fill, and
range-checks the index **afterwards**:

```mach
var regs: [16]isa.Register;
val n: i32 = fill(?regs[0]);
if (index < 0 || index >= n || index >= MAX_GP_ARG_REGS) { ... }
```

A convention publishing a wider bank overruns that array before anything rejects it.
The overrun is in code every target shares and the cause would be a one-line edit in a
target's own file. Had I raised `ARG_REG_COUNT` to 255 as the issue implies, that is a
239-entry stack overrun.

`mach.lang.be.codegen.mir.abi.gp_arg_regs:no_convention_exceeds_the_shared_array` now
walks every registered convention against a deliberately oversized scratch and fails if
any publishes a bank wider than the array that reads it.

## Verification

- 1474 unit tests pass, 0 fail.
- The guard test is not vacuous: it refuses to pass if it checked nothing, and
  inverting its comparison fails with **exit 7**, so all seven registered conventions
  are actually reached and measured.

## What is left on #2923

Raising the bound to SPIR-V's 255 needs a decision about whether the nominal register
bank grows or stops being a concept for this target, plus sizing the emitter's `Regs`
from the function rather than from a literal. That is an ABI design question and is
left open on the issue with the model recorded.
