### PR TITLE
chore: release 4.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.18.1] - 2026-08-09
+
 ### Fixed
 
 #### A SPIR-V function body truncated its parameters instead of refusing (#2923)

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.18.0"
+version = "4.18.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Patch release. 53 commits since v4.18.0, every one a fix, a docs correction, or test infrastructure. No language or API change.

**Fixes**
- #2923 a SPIR-V function body truncated its parameters instead of refusing, plus a guard on the shared `[16]isa.Register` array a widened bank would have overrun
- #2952 a COFF long section name was space-padded, so llvm refused every x86_64-windows object carrying a constant pool
- #2937 a float constant typed through an alias now says why it does not fold
- #2935 a folded cast records the signedness of the type it casts to
- #2930 / #2931 the IR verifier catches a dangling operand and a phi edge with no incoming

**Infrastructure**
- #2903 the integration suite is retired and the unified codegen corpus at `test/` replaces it, with `test/link/` for what it cannot reach
- #2948 the registry assigns corpus legs and host capability is a check rather than a second selector

**Docs**
- #2959 an executable extension is literal, so a cross-platform binary cannot use `targets = ["*"]`

Verified on this branch: `mach 4.18.1`, 1474 unit tests pass, 0 fail.