### PR TITLE
fix(ci): materialise dependencies on the darwin legs before the corpus runs

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -106,6 +106,16 @@ jobs:
           echo "MACH_CORPUS_MACH=$PWD/mach-${{ matrix.runner }}" >> "$GITHUB_ENV"
           echo "MACH_LINK_MACH=$PWD/mach-${{ matrix.runner }}" >> "$GITHUB_ENV"
 
+      # this leg takes a BINARY from the seed job rather than building here, so it
+      # never runs the `mach dep pull` a from-source build does, and the checkout has
+      # no `dep/`. every other leg gets the pull for free from its own build, which is
+      # why nothing else needs this step and why the gap only shows on the two darwin
+      # rows. the corpus refuses to start without mach-std rather than skipping the
+      # cases that need it, which is how this surfaced as a red leg instead of a
+      # quietly smaller run.
+      - name: materialise dependencies
+        run: ./mach-${{ matrix.runner }} dep pull .
+
       # the registry decides what this leg covers, exactly as on the pr lane: see the
       # comment on the same step in ci.yml.
       - name: codegen corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### The darwin corpus legs could never have run (#2965)
+
+`test-main.yml`'s darwin legs take a cross-built binary from the seed job rather than building in place, so they never run the `mach dep pull` a from-source build does, and their checkout has no `dep/`. Every other leg gets that pull for free from its own build, which is why the gap existed only on the two darwin rows and only became visible when those rows started running the codegen corpus at all.
+
+It surfaced as a red leg rather than a quietly smaller run because the corpus refuses to start when a dependency it needs is absent, instead of skipping the cases that need it. That is the behaviour that made a missing step legible as a missing step.
+
+The 4.18.1 release itself was unaffected: CD builds and publishes on the tag and completed with all five binaries, and this is the release-cadence test workflow that runs on the push to `main` beside it.
+
 ## [4.18.1] - 2026-08-09
 
 ### Fixed


### PR DESCRIPTION
Closes #2965.

The darwin legs in `test-main.yml` take a cross-built binary from the seed job rather than building in place, so they never run the `mach dep pull` a from-source build does, and their checkout has no `dep/`. Every other leg gets that pull for free from its own build, which is why the gap is darwin-only and why it only became visible once those rows started running the codegen corpus at all.

Adds the pull with the seeded binary, after it is named and before the corpus.

**The 4.18.1 release is unaffected.** CD builds and publishes on the tag and completed with all five binaries plus SHA256SUMS. This is `test main`, the release-cadence workflow that runs on the push to `main` beside it.

**Worth keeping:** this surfaced as a red leg because the corpus refuses to start when a dependency is absent rather than skipping the cases that need it. Had it skipped, the two darwin columns would have reported a smaller green run and nobody would have looked at them again. That is the same property as #2957 and the reason a check that cannot fail is worse than no check.

CI cannot prove this one on the pull request, since the darwin legs run at `main` cadence by design. The next push to `main` is the first real exercise, which is exactly the gap #2957 is about.