### PR TITLE
fix(spirv): type copy-only merges from their declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### SPIR-V copy-only merge values keep their declared type (#2939, #2969)
+
+Phi destruction replaces an SSA phi with one `MIR_MOV` into its result on every predecessor edge. Those moves are sized for a physical register, not a typed value: an immediate `i32` edge may use four bytes while a vreg edge uses the eight-byte machine word. The SPIR-V emitter skipped copies while finding type authorities, propagated what it found, then fell back to each move's width. A component made entirely of copies had no authority to propagate and could therefore allocate one merge variable as `i64` while the value stored or compared through it remained `i32`. Mach either wrote a module `spirv-val` rejected or caught its own mismatch and refused a valid shader.
+
+Each source-derived MIR vreg now retains the raw, module-local IR type id of its parameter or instruction result. The metadata is inert for machine targets. SPIR-V consults it only for copy destinations still untyped after concrete definitions and typed sources have propagated, so a comparison result remains a SPIR-V boolean while a copy-only phi component takes its declared numeric type. A second propagation types any synthetic temporary introduced while sequentializing a parallel-copy cycle; move width remains only the last fallback for genuinely synthetic values.
+
+The exact loop-carried integer shader from #2969 now builds, and the three corpus cases quarantined by #2939 are restored to SPIR-V structural validation and golden coverage.
+
 ## [4.18.1] - 2026-08-09
 
 ### Fixed

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -621,6 +621,9 @@ fun add_vreg_like(alloc: *A.Allocator, f: *mir.MirFunction, like: u32) R.Result[
     # carry the class / vector / constant-time seed marker from the template - a
     # loop-rotated copy of a secret-source vreg stays a secret source (#1646).
     f.vregs[vid] = mir.vreg(vid, f.vregs[like].class, f.vregs[like].vector, f.vregs[like].secret);
+    # the rotated clone denotes the same source value. keep its inert source type
+    # metadata in step with the class, vector shape and secrecy seed.
+    f.vregs[vid].ty = f.vregs[like].ty;
     f.vreg_count = f.vreg_count + 1;
     ret R.ok[u32, str](vid);
 }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -943,6 +943,12 @@ pub rec MirBlock {
 # class:      index into `tgt.model.reg_classes` selecting the register bank
 # spill_slot: stack-frame slot index when spilled (-1 while unspilled)
 # assigned:   physical register id assigned by regalloc (MIR_VREG_NIL until then)
+# ty:         the source IR type id for a parameter / instruction result, or
+#             VREG_TY_NIL for a synthesized temporary. Stored raw so MIR takes no
+#             dependency on the middle end's type module. Machine targets need only
+#             widths and register classes, but a logical-addressing target declares
+#             typed values and cannot recover a phi's type from its machine-width
+#             edge copies. The id is module-local and inert outside that use.
 # vector:     true when the vreg holds a 128-bit SIMD vector; distinguishes a vector
 #             from a scalar float within the shared FP bank so regalloc 16-byte-aligns
 #             its spill slot (MOVAPS reloads require it) while scalar-float slots stay
@@ -961,9 +967,14 @@ pub rec MirVReg {
     class:      u32;
     spill_slot: i32;
     assigned:   u32;
+    ty:         u32;
     vector:     bool;
     secret:     bool;
 }
+
+# the `MirVReg.ty` sentinel for a vreg synthesized after the source-definition map
+# was built. Mirrors ir_type.IRT_NIL without importing it.
+pub val VREG_TY_NIL: u32 = 0xFFFFFFFF;
 
 # build a fresh MIR virtual register, unspilled and unassigned
 #
@@ -987,6 +998,7 @@ pub fun vreg(id: u32, class: u32, vector: bool, secret: bool) MirVReg {
     v.class      = class;
     v.spill_slot = -1;
     v.assigned   = MIR_VREG_NIL;
+    v.ty         = VREG_TY_NIL;
     v.vector     = vector;
     v.secret     = secret;
     ret v;
@@ -1013,6 +1025,7 @@ test "mach.lang.be.codegen.mir.vreg:sets_every_field" {
     if (v.class != 3)               { ret 1; }
     if (v.spill_slot != -1)         { ret 1; }
     if (v.assigned != MIR_VREG_NIL) { ret 1; }
+    if (v.ty != VREG_TY_NIL)        { ret 1; }
     if (!v.vector)                  { ret 1; }
     if (!v.secret)                  { ret 1; }
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -159,6 +159,10 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
         if (R.is_err[u32, str](res_vreg)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_vreg)); }
         val pv: u32 = R.unwrap_ok[u32, str](res_vreg);
         ctx.param_vregs[i] = pv;
+        # preserve the declaration behind this source-mapped value. a machine
+        # backend never reads it; a logical-addressing backend needs the type itself
+        # when the value later survives only as machine-width phi copies.
+        ctx.f.vregs[pv].ty = fn.params[i].ty::u32;
         # SEED: a secret parameter is a secret SOURCE (#1646); mark its vreg so the #1648
         # validator's re-derive fixpoint has this seed. the vreg is created once and the
         # table persists, so no transform can launder it.
@@ -179,6 +183,7 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
             if (R.is_err[u32, str](res_vreg)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_vreg)); }
             val rv: u32 = R.unwrap_ok[u32, str](res_vreg);
             ctx.instr_vregs[i] = rv;
+            ctx.f.vregs[rv].ty = inst.ty::u32;
             # SEED: mark the result vreg secret ONLY for a secret SOURCE - a load through
             # welded `*^T` storage / a secret global, or a call returning a secret (#1646).
             # a derived value (arithmetic on secrets) is left unmarked; the #1648 validator

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -599,6 +599,11 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
             val tr: R.Result[u32, str] = lctx.new_vreg_vec(ctx, cls, ctx.f.vregs[freed].vector);
             if (R.is_err[u32, str](tr)) { err_msg = R.unwrap_err[u32, str](tr); cnt; }
             val tmp: u32 = R.unwrap_ok[u32, str](tr);
+            # this temp is a second name for the live phi value, so retain the
+            # source declaration metadata just as class and vector shape are
+            # retained. machine backends ignore it; a logical backend can then
+            # type the parallel-copy component without reading a move width.
+            ctx.f.vregs[tmp].ty = ctx.f.vregs[freed].ty;
             # the cycle-break save is a register-to-register copy of a live value;
             # insert_mov_before_terminator carries the full register width (16 for a
             # vector via the temp's preserved flag).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -19230,7 +19230,7 @@ fun ut_spv_value_type(w: *u32, n: u32, id: u32) u32 {
 fun ut_spv_is_binary_int(op: u32) bool {
     ret op == spirv.OP_I_ADD || op == spirv.OP_I_SUB || op == spirv.OP_I_MUL
      || op == spirv.OP_U_LESS_THAN || op == spirv.OP_S_LESS_THAN
-     || op == spirv.OP_I_EQUAL;
+     || op == spirv.OP_I_EQUAL || op == spirv.OP_I_NOT_EQUAL;
 }
 
 # how many two-operand integer instructions read operands of DIFFERENT types
@@ -19348,6 +19348,58 @@ test "mach.lang.driver:a_narrow_spirv_loop_counter_keeps_its_declared_width" {
     if (ut_spv_int_type_count(w, n, 16) != 1) { bad = 1; }
     or {
         if (ut_spv_mixed_operand_types(w, n) != 0) { bad = 1; }
+        if (ut_spv_int_type_count(w, n, 64) != 0)  { bad = 1; }
+    }
+
+    obj.dnit(?img);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a loop-carried scalar whose first path comes from an immediate keeps its declared
+# type (#2969)
+#
+# out-of-SSA lowering gives the state phi one vreg and writes it from each
+# predecessor. the entry path materializes zero at the machine word while the
+# conditional path writes an i32 value. that word width is a register convention,
+# not the phi's type: letting the immediate copy claim the shared vreg makes the
+# later `state != 0::i32` compare a 64-bit load against a 32-bit constant.
+#
+# the staged shader is the reproduction, including the conditional assignment
+# before the loop: without that join the loop counter coverage above already owns
+# the simpler shape. the inequality count is the positive control, so successful
+# codegen cannot satisfy this by dropping the comparison.
+test "mach.lang.driver:a_loop_carried_spirv_scalar_keeps_its_concrete_type" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    var texts: [1]str;
+    names[0] = "main.mach";
+    texts[0] = "#[input(0)] var in_uv: f32x2;\n#[output(0)] var out_colour: f32x4;\n\n#[stage(\"fragment\")]\nfun frag_main() {\n    var state: i32 = 0;\n    if (in_uv[0] < 0.5) { state = 1; }\n    var i: i32 = 0;\n    for (i < 2) {\n        if (state != 0::i32) { state = 0; }\n        i = i + 1;\n    }\n    out_colour = f32x4{state::f32, 0.0, 0.0, 1.0};\n}\n";
+    val pr: R.Result[project.Project, outcome.Fail] =
+        ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    var img: of.ObjectImage;
+    var err: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) {
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    var n: u32 = 0;
+    val w: *u32 = ut_spv_words(?img, ?n);
+    if (w == nil) { obj.dnit(?img); project.dnit_project(?p); session.dnit(?s); ret 1; }
+
+    if (ut_spv_count(w, n, spirv.OP_I_NOT_EQUAL) != 1) { bad = 1; }
+    or {
+        if (ut_spv_mixed_operand_types(w, n) != 0) { bad = 1; }
+        if (ut_spv_int_type_count(w, n, 32) != 1)  { bad = 1; }
         if (ut_spv_int_type_count(w, n, 64) != 0)  { bad = 1; }
     }
 

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -3131,11 +3131,17 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
         pb = pb + 1;
     }
 
-    # a vreg's type comes from the operation that computes it. A register copy is
-    # not one - it moves a value already typed elsewhere - so copies are left for the
-    # propagation below and only revisited if nothing typed them.
+    # a vreg's type comes from the operation that computes it. a register copy is
+    # not one - it moves a value already typed elsewhere - so definite definitions
+    # and declaration metadata settle the copy graph before its machine width is
+    # allowed to serve as the last fallback.
     val r1: R.Result[bool, str] = type_computed_defs(e, mf, out, true);
     if (R.is_err[bool, str](r1)) { ret r1; }
+    propagate_copy_types(mf, out);
+    seed_declared_copy_types(e, mf, out);
+    # a phi parallel-copy cycle introduces a synthetic temp with no source type of
+    # its own. the declared endpoint now anchors the component, and this second
+    # fixed point carries that authority through every such temp before fallback.
     propagate_copy_types(mf, out);
     val r2: R.Result[bool, str] = type_computed_defs(e, mf, out, false);
     if (R.is_err[bool, str](r2)) { ret r2; }
@@ -3358,6 +3364,49 @@ fun propagate_copy_types(mf: *mir.MirFunction, out: *VMaps) {
             }
             bi = bi + 1;
         }
+    }
+}
+
+# seed a copy-only value from the source definition's declared type
+#
+# phi destruction erases the OP_PHI and leaves only predecessor-end MIR_MOVs into
+# its result vreg. those moves are sized for a machine register: the same i32 phi
+# may have an immediate edge at width four and a vreg edge at the machine word.
+# neither width is the value's type. `MirVReg.ty` keeps the IR authority attached to
+# the result, and this pass consults it only after a computing definition or a
+# typed copy source had the first word. Scalar comparison results therefore remain
+# spirv booleans even though their IR result type is i8, while copy-only merge
+# components no longer depend on block order or move widths (#2939, #2969).
+#
+# a synthesized temp has VREG_TY_NIL and is deliberately skipped; the following
+# copy-propagation fixed point types it from the source-mapped component it joins.
+# an IR type this target cannot represent is also left for the existing fallback
+# and refusal paths, so this metadata does not widen the target's supported surface.
+# ---
+# e:   emission state whose current IR module owns the raw type ids
+# mf:  MIR function carrying the per-vreg source type metadata
+# out: per-vreg SPIR-V type maps to seed
+fun seed_declared_copy_types(e: *Emit, mf: *mir.MirFunction, out: *VMaps) {
+    var bi: u32 = 0;
+    for (bi < mf.block_count) {
+        val blk: *mir.MirBlock = ?mf.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (is_reg_copy(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
+                val v: u32 = mi.operands[0].vreg;
+                if (v < out.n && v < mf.vreg_count && out.type_id[v] == 0
+                    && mf.vregs[v].ty != mir.VREG_TY_NIL) {
+                    val t: u32 = ir_value_spv_type(e, mf.vregs[v].ty);
+                    if (t != 0) {
+                        out.type_id[v] = t;
+                        out.is_bool[v] = types.type_is_bool(e.tt, t);
+                    }
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
     }
 }
 

--- a/test/golden/spirv/SKIPS
+++ b/test/golden/spirv/SKIPS
@@ -42,8 +42,5 @@ mem/uni_layout       ab  a uni has no SPIR-V type: passed by value it is "unsupp
 
 # ---- MACH DEFECT ----
 
-cmp/branch_nest    ab  #2939 a u32 merged across a nested if is given a machine-word variable while the value stored into it stays 32 bits, so spirv-val rejects the module mach reported success for: "OpStore Pointer's type does not match Object's type". this case built and validated before 46cd5558, so the entry pins a regression rather than a gap.
-float/cmp_f32      ab  #2939 the same slot typed two ways, reaching an add rather than a store: "spirv.emit: binary instruction mixes operand types (MIR_ADD in checksum)". the u8 counter accumulated under the float-compare branches is the merge.
-float/cmp_f64      ab  #2939 same.
 mem/rec_layout     ab  #2940 fill_mid takes *Mid and the parameter is refused, "unsupported parameter type in the SPIR-V target (in fill_mid)". logical addressing expresses a Function-storage pointer parameter reached by access chain, so this is a missing lowering rather than a target bound.
 call/call_mixed    ab  #2923 "more than 16 parameters is not supported by the SPIR-V target (in mixed)". SPIR-V allows 255 and types.mach says the sixteen is the emitter's own fixed operand buffer. the case exists to exhaust the integer and float banks in one signature, which needs eighteen, so it cannot be shortened without giving up what it tests.

--- a/test/golden/spirv/float/cmp_f32.dis
+++ b/test/golden/spirv/float/cmp_f32.dis
@@ -1,0 +1,1151 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos; 0
+; Bound: 795
+; Schema: 0
+OpCapability Shader
+OpCapability Linkage
+OpCapability Int8
+OpCapability Int64
+OpMemoryModel Logical GLSL450
+OpDecorate %1 LinkageAttributes "corpus.cases.float.cmp_f32.fold32" Export
+OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f32.checksum" Export
+%ulong = OpTypeInt 64 0
+%float = OpTypeFloat 32
+%9 = OpTypeFunction %ulong %ulong %float
+%bool = OpTypeBool
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Function_bool = OpTypePointer Function %bool
+%uint = OpTypeInt 32 0
+%uint_4294967295 = OpConstant %uint 4294967295
+%39 = OpTypeFunction %ulong %ulong
+%uchar = OpTypeInt 8 0
+%uint_12 = OpConstant %uint 12
+%_arr_float_uint_12 = OpTypeArray %float %uint_12
+%_ptr_Function__arr_float_uint_12 = OpTypePointer Function %_arr_float_uint_12
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_uchar = OpTypePointer Function %uchar
+%254 = OpConstantNull %_arr_float_uint_12
+%uint_4286578688 = OpConstant %uint 4286578688
+%uint_0 = OpConstant %uint 0
+%uint_3212836864 = OpConstant %uint 3212836864
+%uint_1 = OpConstant %uint 1
+%uint_2155872256 = OpConstant %uint 2155872256
+%uint_2 = OpConstant %uint 2
+%uint_2147483649 = OpConstant %uint 2147483649
+%uint_3 = OpConstant %uint 3
+%uint_2147483648 = OpConstant %uint 2147483648
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_6 = OpConstant %uint 6
+%uint_1065353216 = OpConstant %uint 1065353216
+%uint_7 = OpConstant %uint 7
+%uint_2139095039 = OpConstant %uint 2139095039
+%uint_8 = OpConstant %uint 8
+%uint_2139095040 = OpConstant %uint 2139095040
+%uint_9 = OpConstant %uint 9
+%uint_2143289344 = OpConstant %uint 2143289344
+%uint_10 = OpConstant %uint 10
+%uint_2139095041 = OpConstant %uint 2139095041
+%uint_11 = OpConstant %uint 11
+%uchar_1 = OpConstant %uchar 1
+%uchar_0 = OpConstant %uchar 0
+%uchar_2 = OpConstant %uchar 2
+%uchar_4 = OpConstant %uchar 4
+%uchar_8 = OpConstant %uchar 8
+%uchar_16 = OpConstant %uchar 16
+%uchar_32 = OpConstant %uchar 32
+%650 = OpTypeFunction %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%653 = OpTypeFunction %ulong %ulong %uchar
+%ulong_0 = OpConstant %ulong 0
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%703 = OpTypeFunction %ulong %ulong %uint
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %float
+%12 = OpLabel
+%19 = OpVariable %_ptr_Function_ulong Function
+%21 = OpVariable %_ptr_Function_float Function
+%23 = OpVariable %_ptr_Function_bool Function
+%24 = OpVariable %_ptr_Function_ulong Function
+%25 = OpVariable %_ptr_Function_ulong Function
+OpStore %19 %10
+OpStore %21 %11
+%26 = OpLoad %float %21
+%27 = OpLoad %float %21
+%28 = OpFUnordNotEqual %bool %26 %27
+OpStore %23 %28
+%29 = OpLoad %bool %23
+OpSelectionMerge %16 None
+OpBranchConditional %29 %13 %14
+%14 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%30 = OpLoad %ulong %19
+%31 = OpLoad %float %21
+%32 = OpFunctionCall %ulong %6 %30 %31
+OpStore %25 %32
+%33 = OpLoad %ulong %25
+OpReturnValue %33
+%13 = OpLabel
+%34 = OpLoad %ulong %19
+%36 = OpFunctionCall %ulong %5 %34 %uint_4294967295
+OpStore %24 %36
+%38 = OpLoad %ulong %24
+OpReturnValue %38
+%16 = OpLabel
+OpUnreachable
+OpFunctionEnd
+%2 = OpFunction %ulong None %39
+%40 = OpFunctionParameter %ulong
+%41 = OpLabel
+%112 = OpVariable %_ptr_Function__arr_float_uint_12 Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_uint Function
+%117 = OpVariable %_ptr_Function_uint Function
+%118 = OpVariable %_ptr_Function_float Function
+%119 = OpVariable %_ptr_Function_uint Function
+%120 = OpVariable %_ptr_Function_float Function
+%121 = OpVariable %_ptr_Function_uint Function
+%122 = OpVariable %_ptr_Function_float Function
+%123 = OpVariable %_ptr_Function_uint Function
+%124 = OpVariable %_ptr_Function_float Function
+%125 = OpVariable %_ptr_Function_uint Function
+%126 = OpVariable %_ptr_Function_float Function
+%127 = OpVariable %_ptr_Function_float Function
+%128 = OpVariable %_ptr_Function_uint Function
+%129 = OpVariable %_ptr_Function_float Function
+%130 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_float Function
+%132 = OpVariable %_ptr_Function_uint Function
+%133 = OpVariable %_ptr_Function_float Function
+%134 = OpVariable %_ptr_Function_uint Function
+%135 = OpVariable %_ptr_Function_float Function
+%136 = OpVariable %_ptr_Function_uint Function
+%137 = OpVariable %_ptr_Function_float Function
+%138 = OpVariable %_ptr_Function_uint Function
+%139 = OpVariable %_ptr_Function_float Function
+%140 = OpVariable %_ptr_Function_bool Function
+%141 = OpVariable %_ptr_Function_bool Function
+%142 = OpVariable %_ptr_Function_float Function
+%143 = OpVariable %_ptr_Function_float Function
+%144 = OpVariable %_ptr_Function_bool Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_bool Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_bool Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_bool Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_bool Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_bool Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_bool Function
+%158 = OpVariable %_ptr_Function_uchar Function
+%159 = OpVariable %_ptr_Function_bool Function
+%160 = OpVariable %_ptr_Function_uchar Function
+%161 = OpVariable %_ptr_Function_bool Function
+%162 = OpVariable %_ptr_Function_uchar Function
+%163 = OpVariable %_ptr_Function_bool Function
+%164 = OpVariable %_ptr_Function_uchar Function
+%165 = OpVariable %_ptr_Function_bool Function
+%166 = OpVariable %_ptr_Function_uchar Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_bool Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_bool Function
+%172 = OpVariable %_ptr_Function_bool Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_bool Function
+%175 = OpVariable %_ptr_Function_bool Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_bool Function
+%178 = OpVariable %_ptr_Function_bool Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_bool Function
+%181 = OpVariable %_ptr_Function_bool Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_uint Function
+%184 = OpVariable %_ptr_Function_uint Function
+%185 = OpVariable %_ptr_Function_float Function
+%186 = OpVariable %_ptr_Function_float Function
+%187 = OpVariable %_ptr_Function_bool Function
+%188 = OpVariable %_ptr_Function_float Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_float Function
+%191 = OpVariable %_ptr_Function_float Function
+%192 = OpVariable %_ptr_Function_bool Function
+%193 = OpVariable %_ptr_Function_float Function
+%194 = OpVariable %_ptr_Function_uint Function
+%195 = OpVariable %_ptr_Function_bool Function
+%196 = OpVariable %_ptr_Function_bool Function
+%197 = OpVariable %_ptr_Function_float Function
+%198 = OpVariable %_ptr_Function_float Function
+%199 = OpVariable %_ptr_Function_bool Function
+%200 = OpVariable %_ptr_Function_uint Function
+%201 = OpVariable %_ptr_Function_uint Function
+%202 = OpVariable %_ptr_Function_float Function
+%203 = OpVariable %_ptr_Function_float Function
+%204 = OpVariable %_ptr_Function_bool Function
+%205 = OpVariable %_ptr_Function_uint Function
+%206 = OpVariable %_ptr_Function_uint Function
+%207 = OpVariable %_ptr_Function_float Function
+%208 = OpVariable %_ptr_Function_float Function
+%209 = OpVariable %_ptr_Function_bool Function
+%210 = OpVariable %_ptr_Function_uint Function
+%211 = OpVariable %_ptr_Function_uint Function
+%212 = OpVariable %_ptr_Function_float Function
+%213 = OpVariable %_ptr_Function_float Function
+%214 = OpVariable %_ptr_Function_bool Function
+%215 = OpVariable %_ptr_Function_uint Function
+%216 = OpVariable %_ptr_Function_uint Function
+%217 = OpVariable %_ptr_Function_uint Function
+%218 = OpVariable %_ptr_Function_uint Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_uint Function
+%223 = OpVariable %_ptr_Function_uint Function
+%224 = OpVariable %_ptr_Function_uchar Function
+%225 = OpVariable %_ptr_Function_uchar Function
+%226 = OpVariable %_ptr_Function_uchar Function
+%227 = OpVariable %_ptr_Function_uchar Function
+%228 = OpVariable %_ptr_Function_uchar Function
+%229 = OpVariable %_ptr_Function_uchar Function
+%230 = OpVariable %_ptr_Function_bool Function
+%231 = OpVariable %_ptr_Function_bool Function
+%232 = OpVariable %_ptr_Function_bool Function
+%233 = OpVariable %_ptr_Function_bool Function
+%234 = OpVariable %_ptr_Function_float Function
+%235 = OpVariable %_ptr_Function_float Function
+%236 = OpVariable %_ptr_Function_float Function
+%237 = OpVariable %_ptr_Function_float Function
+%238 = OpVariable %_ptr_Function_uint Function
+%239 = OpVariable %_ptr_Function_uint Function
+%240 = OpVariable %_ptr_Function_uint Function
+%241 = OpVariable %_ptr_Function_uint Function
+%242 = OpVariable %_ptr_Function_uint Function
+%243 = OpVariable %_ptr_Function_bool Function
+%244 = OpVariable %_ptr_Function_ulong Function
+%245 = OpVariable %_ptr_Function_ulong Function
+%246 = OpVariable %_ptr_Function_ulong Function
+%247 = OpVariable %_ptr_Function_bool Function
+%248 = OpVariable %_ptr_Function_ulong Function
+%249 = OpVariable %_ptr_Function_ulong Function
+%250 = OpVariable %_ptr_Function_ulong Function
+OpStore %113 %40
+%251 = OpFunctionCall %ulong %3
+OpStore %114 %251
+%252 = OpLoad %ulong %113
+%253 = OpUConvert %uint %252
+OpStore %116 %253
+OpStore %112 %254
+%256 = OpLoad %uint %116
+%257 = OpIAdd %uint %uint_4286578688 %256
+OpStore %117 %257
+%258 = OpLoad %uint %117
+%259 = OpBitcast %float %258
+OpStore %118 %259
+%261 = OpAccessChain %_ptr_Function_float %112 %uint_0
+%262 = OpLoad %float %118
+OpStore %261 %262
+%264 = OpLoad %uint %116
+%265 = OpIAdd %uint %uint_3212836864 %264
+OpStore %119 %265
+%266 = OpLoad %uint %119
+%267 = OpBitcast %float %266
+OpStore %120 %267
+%269 = OpAccessChain %_ptr_Function_float %112 %uint_1
+%270 = OpLoad %float %120
+OpStore %269 %270
+%272 = OpLoad %uint %116
+%273 = OpIAdd %uint %uint_2155872256 %272
+OpStore %121 %273
+%274 = OpLoad %uint %121
+%275 = OpBitcast %float %274
+OpStore %122 %275
+%277 = OpAccessChain %_ptr_Function_float %112 %uint_2
+%278 = OpLoad %float %122
+OpStore %277 %278
+%280 = OpLoad %uint %116
+%281 = OpIAdd %uint %uint_2147483649 %280
+OpStore %123 %281
+%282 = OpLoad %uint %123
+%283 = OpBitcast %float %282
+OpStore %124 %283
+%285 = OpAccessChain %_ptr_Function_float %112 %uint_3
+%286 = OpLoad %float %124
+OpStore %285 %286
+%288 = OpLoad %uint %116
+%289 = OpIAdd %uint %uint_2147483648 %288
+OpStore %125 %289
+%290 = OpLoad %uint %125
+%291 = OpBitcast %float %290
+OpStore %126 %291
+%293 = OpAccessChain %_ptr_Function_float %112 %uint_4
+%294 = OpLoad %float %126
+OpStore %293 %294
+%295 = OpLoad %uint %116
+%296 = OpBitcast %float %295
+OpStore %127 %296
+%298 = OpAccessChain %_ptr_Function_float %112 %uint_5
+%299 = OpLoad %float %127
+OpStore %298 %299
+%300 = OpLoad %uint %116
+%301 = OpIAdd %uint %uint_1 %300
+OpStore %128 %301
+%302 = OpLoad %uint %128
+%303 = OpBitcast %float %302
+OpStore %129 %303
+%305 = OpAccessChain %_ptr_Function_float %112 %uint_6
+%306 = OpLoad %float %129
+OpStore %305 %306
+%308 = OpLoad %uint %116
+%309 = OpIAdd %uint %uint_1065353216 %308
+OpStore %130 %309
+%310 = OpLoad %uint %130
+%311 = OpBitcast %float %310
+OpStore %131 %311
+%313 = OpAccessChain %_ptr_Function_float %112 %uint_7
+%314 = OpLoad %float %131
+OpStore %313 %314
+%316 = OpLoad %uint %116
+%317 = OpIAdd %uint %uint_2139095039 %316
+OpStore %132 %317
+%318 = OpLoad %uint %132
+%319 = OpBitcast %float %318
+OpStore %133 %319
+%321 = OpAccessChain %_ptr_Function_float %112 %uint_8
+%322 = OpLoad %float %133
+OpStore %321 %322
+%324 = OpLoad %uint %116
+%325 = OpIAdd %uint %uint_2139095040 %324
+OpStore %134 %325
+%326 = OpLoad %uint %134
+%327 = OpBitcast %float %326
+OpStore %135 %327
+%329 = OpAccessChain %_ptr_Function_float %112 %uint_9
+%330 = OpLoad %float %135
+OpStore %329 %330
+%332 = OpLoad %uint %116
+%333 = OpIAdd %uint %uint_2143289344 %332
+OpStore %136 %333
+%334 = OpLoad %uint %136
+%335 = OpBitcast %float %334
+OpStore %137 %335
+%337 = OpAccessChain %_ptr_Function_float %112 %uint_10
+%338 = OpLoad %float %137
+OpStore %337 %338
+%340 = OpLoad %uint %116
+%341 = OpIAdd %uint %uint_2139095041 %340
+OpStore %138 %341
+%342 = OpLoad %uint %138
+%343 = OpBitcast %float %342
+OpStore %139 %343
+%345 = OpAccessChain %_ptr_Function_float %112 %uint_11
+%346 = OpLoad %float %139
+OpStore %345 %346
+%347 = OpLoad %ulong %114
+OpStore %221 %347
+OpStore %222 %uint_0
+OpBranch %42
+%42 = OpLabel
+%348 = OpLoad %uint %222
+%349 = OpULessThan %bool %348 %uint_12
+OpStore %140 %349
+%350 = OpLoad %bool %140
+OpLoopMerge %44 %107 None
+OpBranchConditional %350 %43 %44
+%44 = OpLabel
+%351 = OpAccessChain %_ptr_Function_float %112 %uint_0
+%352 = OpLoad %float %351
+OpStore %185 %352
+%353 = OpLoad %float %351
+OpStore %186 %353
+%354 = OpLoad %float %185
+OpStore %235 %354
+%355 = OpLoad %float %186
+OpStore %237 %355
+OpStore %238 %uint_1
+OpBranch %74
+%74 = OpLabel
+%356 = OpLoad %uint %238
+%357 = OpULessThan %bool %356 %uint_12
+OpStore %187 %357
+%358 = OpLoad %bool %187
+OpLoopMerge %76 %106 None
+OpBranchConditional %358 %75 %76
+%76 = OpLabel
+OpBranch %89
+%89 = OpLabel
+%359 = OpLoad %float %235
+%360 = OpLoad %float %235
+%361 = OpFUnordNotEqual %bool %359 %360
+OpStore %243 %361
+%362 = OpLoad %bool %243
+OpSelectionMerge %93 None
+OpBranchConditional %362 %90 %91
+%91 = OpLabel
+OpBranch %92
+%92 = OpLabel
+%363 = OpLoad %ulong %221
+%364 = OpLoad %float %235
+%365 = OpFunctionCall %ulong %6 %363 %364
+OpStore %245 %365
+%366 = OpLoad %ulong %245
+OpStore %246 %366
+OpBranch %93
+%90 = OpLabel
+%367 = OpLoad %ulong %221
+%368 = OpFunctionCall %ulong %5 %367 %uint_4294967295
+OpStore %244 %368
+%369 = OpLoad %ulong %244
+OpStore %246 %369
+OpBranch %93
+%93 = OpLabel
+OpBranch %94
+%94 = OpLabel
+%370 = OpLoad %float %237
+%371 = OpLoad %float %237
+%372 = OpFUnordNotEqual %bool %370 %371
+OpStore %247 %372
+%373 = OpLoad %bool %247
+OpSelectionMerge %98 None
+OpBranchConditional %373 %95 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%374 = OpLoad %ulong %246
+%375 = OpLoad %float %237
+%376 = OpFunctionCall %ulong %6 %374 %375
+OpStore %249 %376
+%377 = OpLoad %ulong %249
+OpStore %250 %377
+OpBranch %98
+%95 = OpLabel
+%378 = OpLoad %ulong %246
+%379 = OpFunctionCall %ulong %5 %378 %uint_4294967295
+OpStore %248 %379
+%380 = OpLoad %ulong %248
+OpStore %250 %380
+OpBranch %98
+%98 = OpLabel
+OpStore %240 %uint_0
+OpStore %241 %uint_0
+OpBranch %83
+%83 = OpLabel
+%381 = OpLoad %uint %241
+%382 = OpULessThan %bool %381 %uint_12
+OpStore %195 %382
+%383 = OpLoad %bool %195
+OpLoopMerge %85 %104 None
+OpBranchConditional %383 %84 %85
+%85 = OpLabel
+%384 = OpLoad %ulong %250
+%385 = OpLoad %uint %240
+%386 = OpFunctionCall %ulong %5 %384 %385
+OpStore %219 %386
+%387 = OpLoad %ulong %219
+OpReturnValue %387
+%84 = OpLabel
+%388 = OpLoad %uint %241
+%389 = OpAccessChain %_ptr_Function_float %112 %388
+%390 = OpLoad %uint %240
+OpStore %239 %390
+OpStore %242 %uint_0
+OpBranch %86
+%86 = OpLabel
+%391 = OpLoad %uint %242
+%392 = OpULessThan %bool %391 %uint_12
+OpStore %196 %392
+%393 = OpLoad %bool %196
+OpLoopMerge %88 %103 None
+OpBranchConditional %393 %87 %88
+%88 = OpLabel
+%394 = OpLoad %uint %241
+%395 = OpIAdd %uint %394 %uint_1
+OpStore %218 %395
+%396 = OpLoad %uint %239
+OpStore %240 %396
+%397 = OpLoad %uint %218
+OpStore %241 %397
+OpBranch %104
+%87 = OpLabel
+%398 = OpLoad %float %389
+OpStore %197 %398
+%399 = OpLoad %uint %242
+%400 = OpAccessChain %_ptr_Function_float %112 %399
+%401 = OpLoad %float %400
+OpStore %198 %401
+%402 = OpLoad %float %197
+%403 = OpLoad %float %198
+%404 = OpFOrdLessThan %bool %402 %403
+OpStore %199 %404
+%405 = OpLoad %bool %199
+%408 = OpSelect %uchar %405 %uchar_1 %uchar_0
+%409 = OpUConvert %uint %408
+OpStore %200 %409
+%410 = OpLoad %uint %239
+%411 = OpLoad %uint %200
+%412 = OpIAdd %uint %410 %411
+OpStore %201 %412
+%413 = OpLoad %float %389
+OpStore %202 %413
+%414 = OpLoad %float %400
+OpStore %203 %414
+%415 = OpLoad %float %202
+%416 = OpLoad %float %203
+%417 = OpFOrdLessThanEqual %bool %415 %416
+OpStore %204 %417
+%418 = OpLoad %bool %204
+%419 = OpSelect %uchar %418 %uchar_1 %uchar_0
+%420 = OpUConvert %uint %419
+OpStore %205 %420
+%421 = OpLoad %uint %201
+%422 = OpLoad %uint %205
+%423 = OpIAdd %uint %421 %422
+OpStore %206 %423
+%424 = OpLoad %float %389
+OpStore %207 %424
+%425 = OpLoad %float %400
+OpStore %208 %425
+%426 = OpLoad %float %207
+%427 = OpLoad %float %208
+%428 = OpFOrdEqual %bool %426 %427
+OpStore %209 %428
+%429 = OpLoad %bool %209
+%430 = OpSelect %uchar %429 %uchar_1 %uchar_0
+%431 = OpUConvert %uint %430
+OpStore %210 %431
+%432 = OpLoad %uint %206
+%433 = OpLoad %uint %210
+%434 = OpIAdd %uint %432 %433
+OpStore %211 %434
+%435 = OpLoad %float %389
+OpStore %212 %435
+%436 = OpLoad %float %400
+OpStore %213 %436
+%437 = OpLoad %float %212
+%438 = OpLoad %float %213
+%439 = OpFUnordNotEqual %bool %437 %438
+OpStore %214 %439
+%440 = OpLoad %bool %214
+%441 = OpSelect %uchar %440 %uchar_1 %uchar_0
+%442 = OpUConvert %uint %441
+OpStore %215 %442
+%443 = OpLoad %uint %211
+%444 = OpLoad %uint %215
+%445 = OpIAdd %uint %443 %444
+OpStore %216 %445
+%446 = OpLoad %uint %242
+%447 = OpIAdd %uint %446 %uint_1
+OpStore %217 %447
+%448 = OpLoad %uint %216
+OpStore %239 %448
+%449 = OpLoad %uint %217
+OpStore %242 %449
+OpBranch %103
+%75 = OpLabel
+%450 = OpLoad %uint %238
+%451 = OpAccessChain %_ptr_Function_float %112 %450
+%452 = OpLoad %float %451
+OpStore %188 %452
+%453 = OpLoad %float %188
+%454 = OpLoad %float %235
+%455 = OpFOrdLessThan %bool %453 %454
+OpStore %189 %455
+%456 = OpLoad %bool %189
+OpSelectionMerge %79 None
+OpBranchConditional %456 %77 %78
+%78 = OpLabel
+%457 = OpLoad %float %235
+OpStore %234 %457
+OpBranch %79
+%77 = OpLabel
+%458 = OpLoad %uint %238
+%459 = OpAccessChain %_ptr_Function_float %112 %458
+%460 = OpLoad %float %459
+OpStore %190 %460
+%461 = OpLoad %float %190
+OpStore %234 %461
+OpBranch %79
+%79 = OpLabel
+%462 = OpLoad %uint %238
+%463 = OpAccessChain %_ptr_Function_float %112 %462
+%464 = OpLoad %float %463
+OpStore %191 %464
+%465 = OpLoad %float %237
+%466 = OpLoad %float %191
+%467 = OpFOrdLessThan %bool %465 %466
+OpStore %192 %467
+%468 = OpLoad %bool %192
+OpSelectionMerge %82 None
+OpBranchConditional %468 %80 %81
+%81 = OpLabel
+%469 = OpLoad %float %237
+OpStore %236 %469
+OpBranch %82
+%80 = OpLabel
+%470 = OpLoad %uint %238
+%471 = OpAccessChain %_ptr_Function_float %112 %470
+%472 = OpLoad %float %471
+OpStore %193 %472
+%473 = OpLoad %float %193
+OpStore %236 %473
+OpBranch %82
+%82 = OpLabel
+%474 = OpLoad %uint %238
+%475 = OpIAdd %uint %474 %uint_1
+OpStore %194 %475
+%476 = OpLoad %float %234
+OpStore %235 %476
+%477 = OpLoad %float %236
+OpStore %237 %477
+%478 = OpLoad %uint %194
+OpStore %238 %478
+OpBranch %106
+%43 = OpLabel
+%479 = OpLoad %uint %222
+%480 = OpAccessChain %_ptr_Function_float %112 %479
+%481 = OpLoad %ulong %221
+OpStore %220 %481
+OpStore %223 %uint_0
+OpBranch %45
+%45 = OpLabel
+%482 = OpLoad %uint %223
+%483 = OpULessThan %bool %482 %uint_12
+OpStore %141 %483
+%484 = OpLoad %bool %141
+OpLoopMerge %47 %105 None
+OpBranchConditional %484 %46 %47
+%47 = OpLabel
+%485 = OpLoad %uint %222
+%486 = OpIAdd %uint %485 %uint_1
+OpStore %184 %486
+%487 = OpLoad %ulong %220
+OpStore %221 %487
+%488 = OpLoad %uint %184
+OpStore %222 %488
+OpBranch %107
+%46 = OpLabel
+%489 = OpLoad %float %480
+OpStore %142 %489
+%490 = OpLoad %uint %223
+%491 = OpAccessChain %_ptr_Function_float %112 %490
+%492 = OpLoad %float %491
+OpStore %143 %492
+%493 = OpLoad %float %142
+%494 = OpLoad %float %143
+%495 = OpFOrdEqual %bool %493 %494
+OpStore %144 %495
+%496 = OpLoad %ulong %220
+%497 = OpLoad %bool %144
+%499 = OpSelect %uchar %497 %uchar_1 %uchar_0
+%498 = OpFunctionCall %ulong %4 %496 %499
+OpStore %145 %498
+%500 = OpLoad %float %142
+%501 = OpLoad %float %143
+%502 = OpFUnordNotEqual %bool %500 %501
+OpStore %146 %502
+%503 = OpLoad %ulong %145
+%504 = OpLoad %bool %146
+%506 = OpSelect %uchar %504 %uchar_1 %uchar_0
+%505 = OpFunctionCall %ulong %4 %503 %506
+OpStore %147 %505
+%507 = OpLoad %float %142
+%508 = OpLoad %float %143
+%509 = OpFOrdLessThan %bool %507 %508
+OpStore %148 %509
+%510 = OpLoad %ulong %147
+%511 = OpLoad %bool %148
+%513 = OpSelect %uchar %511 %uchar_1 %uchar_0
+%512 = OpFunctionCall %ulong %4 %510 %513
+OpStore %149 %512
+%514 = OpLoad %float %142
+%515 = OpLoad %float %143
+%516 = OpFOrdLessThanEqual %bool %514 %515
+OpStore %150 %516
+%517 = OpLoad %ulong %149
+%518 = OpLoad %bool %150
+%520 = OpSelect %uchar %518 %uchar_1 %uchar_0
+%519 = OpFunctionCall %ulong %4 %517 %520
+OpStore %151 %519
+%521 = OpLoad %float %143
+%522 = OpLoad %float %142
+%523 = OpFOrdLessThan %bool %521 %522
+OpStore %152 %523
+%524 = OpLoad %ulong %151
+%525 = OpLoad %bool %152
+%527 = OpSelect %uchar %525 %uchar_1 %uchar_0
+%526 = OpFunctionCall %ulong %4 %524 %527
+OpStore %153 %526
+%528 = OpLoad %float %143
+%529 = OpLoad %float %142
+%530 = OpFOrdLessThanEqual %bool %528 %529
+OpStore %154 %530
+%531 = OpLoad %ulong %153
+%532 = OpLoad %bool %154
+%534 = OpSelect %uchar %532 %uchar_1 %uchar_0
+%533 = OpFunctionCall %ulong %4 %531 %534
+OpStore %155 %533
+%535 = OpLoad %bool %148
+OpSelectionMerge %50 None
+OpBranchConditional %535 %48 %49
+%49 = OpLabel
+OpStore %229 %uchar_0
+OpBranch %50
+%48 = OpLabel
+OpStore %229 %uchar_1
+OpBranch %50
+%50 = OpLabel
+%536 = OpLoad %float %142
+%537 = OpLoad %float %143
+%538 = OpFOrdLessThanEqual %bool %536 %537
+OpStore %156 %538
+%539 = OpLoad %bool %156
+OpSelectionMerge %53 None
+OpBranchConditional %539 %51 %52
+%52 = OpLabel
+%540 = OpLoad %uchar %229
+OpStore %228 %540
+OpBranch %53
+%51 = OpLabel
+%541 = OpLoad %uchar %229
+%543 = OpIAdd %uchar %541 %uchar_2
+OpStore %158 %543
+%544 = OpLoad %uchar %158
+OpStore %228 %544
+OpBranch %53
+%53 = OpLabel
+%545 = OpLoad %float %143
+%546 = OpLoad %float %142
+%547 = OpFOrdLessThan %bool %545 %546
+OpStore %159 %547
+%548 = OpLoad %bool %159
+OpSelectionMerge %56 None
+OpBranchConditional %548 %54 %55
+%55 = OpLabel
+%549 = OpLoad %uchar %228
+OpStore %227 %549
+OpBranch %56
+%54 = OpLabel
+%550 = OpLoad %uchar %228
+%552 = OpIAdd %uchar %550 %uchar_4
+OpStore %160 %552
+%553 = OpLoad %uchar %160
+OpStore %227 %553
+OpBranch %56
+%56 = OpLabel
+%554 = OpLoad %float %143
+%555 = OpLoad %float %142
+%556 = OpFOrdLessThanEqual %bool %554 %555
+OpStore %161 %556
+%557 = OpLoad %bool %161
+OpSelectionMerge %59 None
+OpBranchConditional %557 %57 %58
+%58 = OpLabel
+%558 = OpLoad %uchar %227
+OpStore %226 %558
+OpBranch %59
+%57 = OpLabel
+%559 = OpLoad %uchar %227
+%561 = OpIAdd %uchar %559 %uchar_8
+OpStore %162 %561
+%562 = OpLoad %uchar %162
+OpStore %226 %562
+OpBranch %59
+%59 = OpLabel
+%563 = OpLoad %float %142
+%564 = OpLoad %float %143
+%565 = OpFOrdEqual %bool %563 %564
+OpStore %163 %565
+%566 = OpLoad %bool %163
+OpSelectionMerge %62 None
+OpBranchConditional %566 %60 %61
+%61 = OpLabel
+%567 = OpLoad %uchar %226
+OpStore %225 %567
+OpBranch %62
+%60 = OpLabel
+%568 = OpLoad %uchar %226
+%570 = OpIAdd %uchar %568 %uchar_16
+OpStore %164 %570
+%571 = OpLoad %uchar %164
+OpStore %225 %571
+OpBranch %62
+%62 = OpLabel
+%572 = OpLoad %float %142
+%573 = OpLoad %float %143
+%574 = OpFUnordNotEqual %bool %572 %573
+OpStore %165 %574
+%575 = OpLoad %bool %165
+OpSelectionMerge %65 None
+OpBranchConditional %575 %63 %64
+%64 = OpLabel
+%576 = OpLoad %uchar %225
+OpStore %224 %576
+OpBranch %65
+%63 = OpLabel
+%577 = OpLoad %uchar %225
+%579 = OpIAdd %uchar %577 %uchar_32
+OpStore %166 %579
+%580 = OpLoad %uchar %166
+OpStore %224 %580
+OpBranch %65
+%65 = OpLabel
+%581 = OpLoad %ulong %155
+%582 = OpLoad %uchar %224
+%583 = OpFunctionCall %ulong %4 %581 %582
+OpStore %167 %583
+%584 = OpLoad %float %142
+%585 = OpLoad %float %143
+%586 = OpFOrdLessThan %bool %584 %585
+OpStore %168 %586
+%587 = OpLoad %bool %168
+OpSelectionMerge %67 None
+OpBranchConditional %587 %66 %99
+%99 = OpLabel
+%588 = OpLoad %bool %168
+OpStore %230 %588
+OpBranch %67
+%66 = OpLabel
+%589 = OpLoad %float %143
+%590 = OpLoad %float %142
+%591 = OpFOrdLessThan %bool %589 %590
+OpStore %169 %591
+%592 = OpLoad %bool %169
+OpStore %230 %592
+OpBranch %67
+%67 = OpLabel
+%593 = OpLoad %ulong %167
+%594 = OpLoad %bool %230
+%596 = OpSelect %uchar %594 %uchar_1 %uchar_0
+%595 = OpFunctionCall %ulong %4 %593 %596
+OpStore %170 %595
+%597 = OpLoad %float %142
+%598 = OpLoad %float %143
+%599 = OpFOrdLessThan %bool %597 %598
+OpStore %171 %599
+%600 = OpLoad %bool %171
+OpSelectionMerge %69 None
+OpBranchConditional %600 %100 %68
+%68 = OpLabel
+%601 = OpLoad %float %143
+%602 = OpLoad %float %142
+%603 = OpFOrdLessThan %bool %601 %602
+OpStore %172 %603
+%604 = OpLoad %bool %172
+OpStore %231 %604
+OpBranch %69
+%100 = OpLabel
+%605 = OpLoad %bool %171
+OpStore %231 %605
+OpBranch %69
+%69 = OpLabel
+%606 = OpLoad %ulong %170
+%607 = OpLoad %bool %231
+%609 = OpSelect %uchar %607 %uchar_1 %uchar_0
+%608 = OpFunctionCall %ulong %4 %606 %609
+OpStore %173 %608
+%610 = OpLoad %float %142
+%611 = OpLoad %float %143
+%612 = OpFOrdLessThan %bool %610 %611
+OpStore %174 %612
+%613 = OpLoad %bool %174
+%614 = OpSelect %uchar %613 %uchar_1 %uchar_0
+%615 = OpIEqual %bool %614 %uchar_0
+OpStore %175 %615
+%616 = OpLoad %ulong %173
+%617 = OpLoad %bool %175
+%619 = OpSelect %uchar %617 %uchar_1 %uchar_0
+%618 = OpFunctionCall %ulong %4 %616 %619
+OpStore %176 %618
+%620 = OpLoad %float %142
+%621 = OpLoad %float %142
+%622 = OpFOrdEqual %bool %620 %621
+OpStore %177 %622
+%623 = OpLoad %bool %177
+OpSelectionMerge %71 None
+OpBranchConditional %623 %70 %101
+%101 = OpLabel
+%624 = OpLoad %bool %177
+OpStore %232 %624
+OpBranch %71
+%70 = OpLabel
+%625 = OpLoad %float %143
+%626 = OpLoad %float %143
+%627 = OpFOrdEqual %bool %625 %626
+OpStore %178 %627
+%628 = OpLoad %bool %178
+OpStore %232 %628
+OpBranch %71
+%71 = OpLabel
+%629 = OpLoad %ulong %176
+%630 = OpLoad %bool %232
+%632 = OpSelect %uchar %630 %uchar_1 %uchar_0
+%631 = OpFunctionCall %ulong %4 %629 %632
+OpStore %179 %631
+%633 = OpLoad %float %142
+%634 = OpLoad %float %142
+%635 = OpFUnordNotEqual %bool %633 %634
+OpStore %180 %635
+%636 = OpLoad %bool %180
+OpSelectionMerge %73 None
+OpBranchConditional %636 %102 %72
+%72 = OpLabel
+%637 = OpLoad %float %143
+%638 = OpLoad %float %143
+%639 = OpFUnordNotEqual %bool %637 %638
+OpStore %181 %639
+%640 = OpLoad %bool %181
+OpStore %233 %640
+OpBranch %73
+%102 = OpLabel
+%641 = OpLoad %bool %180
+OpStore %233 %641
+OpBranch %73
+%73 = OpLabel
+%642 = OpLoad %ulong %179
+%643 = OpLoad %bool %233
+%645 = OpSelect %uchar %643 %uchar_1 %uchar_0
+%644 = OpFunctionCall %ulong %4 %642 %645
+OpStore %182 %644
+%646 = OpLoad %uint %223
+%647 = OpIAdd %uint %646 %uint_1
+OpStore %183 %647
+%648 = OpLoad %ulong %182
+OpStore %220 %648
+%649 = OpLoad %uint %183
+OpStore %223 %649
+OpBranch %105
+%103 = OpLabel
+OpBranch %86
+%104 = OpLabel
+OpBranch %83
+%105 = OpLabel
+OpBranch %45
+%106 = OpLabel
+OpBranch %74
+%107 = OpLabel
+OpBranch %42
+OpFunctionEnd
+%3 = OpFunction %ulong None %650
+%651 = OpLabel
+OpReturnValue %ulong_14695981039346656037
+OpFunctionEnd
+%4 = OpFunction %ulong None %653
+%654 = OpFunctionParameter %ulong
+%655 = OpFunctionParameter %uchar
+%656 = OpLabel
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_uchar Function
+%665 = OpVariable %_ptr_Function_ulong Function
+%666 = OpVariable %_ptr_Function_bool Function
+%667 = OpVariable %_ptr_Function_ulong Function
+%668 = OpVariable %_ptr_Function_ulong Function
+%669 = OpVariable %_ptr_Function_ulong Function
+%670 = OpVariable %_ptr_Function_ulong Function
+%671 = OpVariable %_ptr_Function_ulong Function
+%672 = OpVariable %_ptr_Function_ulong Function
+%673 = OpVariable %_ptr_Function_ulong Function
+%674 = OpVariable %_ptr_Function_ulong Function
+OpStore %663 %654
+OpStore %664 %655
+%675 = OpLoad %uchar %664
+%676 = OpUConvert %ulong %675
+OpStore %665 %676
+OpBranch %657
+%657 = OpLabel
+%677 = OpLoad %ulong %663
+OpStore %673 %677
+OpStore %674 %ulong_0
+OpBranch %658
+%658 = OpLabel
+%679 = OpLoad %ulong %674
+%681 = OpULessThan %bool %679 %ulong_8
+OpStore %666 %681
+%682 = OpLoad %bool %666
+OpLoopMerge %660 %662 None
+OpBranchConditional %682 %659 %660
+%660 = OpLabel
+OpBranch %661
+%661 = OpLabel
+%683 = OpLoad %ulong %673
+OpReturnValue %683
+%659 = OpLabel
+%684 = OpLoad %ulong %674
+%685 = OpIMul %ulong %684 %ulong_8
+OpStore %667 %685
+%686 = OpLoad %ulong %665
+%687 = OpLoad %ulong %667
+%688 = OpShiftRightLogical %ulong %686 %687
+OpStore %668 %688
+%689 = OpLoad %ulong %668
+%691 = OpBitwiseAnd %ulong %689 %ulong_255
+OpStore %669 %691
+%692 = OpLoad %ulong %673
+%693 = OpLoad %ulong %669
+%694 = OpBitwiseXor %ulong %692 %693
+OpStore %670 %694
+%695 = OpLoad %ulong %670
+%697 = OpIMul %ulong %695 %ulong_1099511628211
+OpStore %671 %697
+%698 = OpLoad %ulong %674
+%700 = OpIAdd %ulong %698 %ulong_1
+OpStore %672 %700
+%701 = OpLoad %ulong %671
+OpStore %673 %701
+%702 = OpLoad %ulong %672
+OpStore %674 %702
+OpBranch %662
+%662 = OpLabel
+OpBranch %658
+OpFunctionEnd
+%5 = OpFunction %ulong None %703
+%704 = OpFunctionParameter %ulong
+%705 = OpFunctionParameter %uint
+%706 = OpLabel
+%713 = OpVariable %_ptr_Function_ulong Function
+%714 = OpVariable %_ptr_Function_uint Function
+%715 = OpVariable %_ptr_Function_ulong Function
+%716 = OpVariable %_ptr_Function_bool Function
+%717 = OpVariable %_ptr_Function_ulong Function
+%718 = OpVariable %_ptr_Function_ulong Function
+%719 = OpVariable %_ptr_Function_ulong Function
+%720 = OpVariable %_ptr_Function_ulong Function
+%721 = OpVariable %_ptr_Function_ulong Function
+%722 = OpVariable %_ptr_Function_ulong Function
+%723 = OpVariable %_ptr_Function_ulong Function
+%724 = OpVariable %_ptr_Function_ulong Function
+OpStore %713 %704
+OpStore %714 %705
+%725 = OpLoad %uint %714
+%726 = OpUConvert %ulong %725
+OpStore %715 %726
+OpBranch %707
+%707 = OpLabel
+%727 = OpLoad %ulong %713
+OpStore %723 %727
+OpStore %724 %ulong_0
+OpBranch %708
+%708 = OpLabel
+%728 = OpLoad %ulong %724
+%729 = OpULessThan %bool %728 %ulong_8
+OpStore %716 %729
+%730 = OpLoad %bool %716
+OpLoopMerge %710 %712 None
+OpBranchConditional %730 %709 %710
+%710 = OpLabel
+OpBranch %711
+%711 = OpLabel
+%731 = OpLoad %ulong %723
+OpReturnValue %731
+%709 = OpLabel
+%732 = OpLoad %ulong %724
+%733 = OpIMul %ulong %732 %ulong_8
+OpStore %717 %733
+%734 = OpLoad %ulong %715
+%735 = OpLoad %ulong %717
+%736 = OpShiftRightLogical %ulong %734 %735
+OpStore %718 %736
+%737 = OpLoad %ulong %718
+%738 = OpBitwiseAnd %ulong %737 %ulong_255
+OpStore %719 %738
+%739 = OpLoad %ulong %723
+%740 = OpLoad %ulong %719
+%741 = OpBitwiseXor %ulong %739 %740
+OpStore %720 %741
+%742 = OpLoad %ulong %720
+%743 = OpIMul %ulong %742 %ulong_1099511628211
+OpStore %721 %743
+%744 = OpLoad %ulong %724
+%745 = OpIAdd %ulong %744 %ulong_1
+OpStore %722 %745
+%746 = OpLoad %ulong %721
+OpStore %723 %746
+%747 = OpLoad %ulong %722
+OpStore %724 %747
+OpBranch %712
+%712 = OpLabel
+OpBranch %708
+OpFunctionEnd
+%6 = OpFunction %ulong None %9
+%748 = OpFunctionParameter %ulong
+%749 = OpFunctionParameter %float
+%750 = OpLabel
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_float Function
+%759 = OpVariable %_ptr_Function_uint Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_bool Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_ulong Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_ulong Function
+OpStore %757 %748
+OpStore %758 %749
+%770 = OpLoad %float %758
+%771 = OpBitcast %uint %770
+OpStore %759 %771
+%772 = OpLoad %uint %759
+%773 = OpUConvert %ulong %772
+OpStore %760 %773
+OpBranch %751
+%751 = OpLabel
+%774 = OpLoad %ulong %757
+OpStore %768 %774
+OpStore %769 %ulong_0
+OpBranch %752
+%752 = OpLabel
+%775 = OpLoad %ulong %769
+%776 = OpULessThan %bool %775 %ulong_8
+OpStore %761 %776
+%777 = OpLoad %bool %761
+OpLoopMerge %754 %756 None
+OpBranchConditional %777 %753 %754
+%754 = OpLabel
+OpBranch %755
+%755 = OpLabel
+%778 = OpLoad %ulong %768
+OpReturnValue %778
+%753 = OpLabel
+%779 = OpLoad %ulong %769
+%780 = OpIMul %ulong %779 %ulong_8
+OpStore %762 %780
+%781 = OpLoad %ulong %760
+%782 = OpLoad %ulong %762
+%783 = OpShiftRightLogical %ulong %781 %782
+OpStore %763 %783
+%784 = OpLoad %ulong %763
+%785 = OpBitwiseAnd %ulong %784 %ulong_255
+OpStore %764 %785
+%786 = OpLoad %ulong %768
+%787 = OpLoad %ulong %764
+%788 = OpBitwiseXor %ulong %786 %787
+OpStore %765 %788
+%789 = OpLoad %ulong %765
+%790 = OpIMul %ulong %789 %ulong_1099511628211
+OpStore %766 %790
+%791 = OpLoad %ulong %769
+%792 = OpIAdd %ulong %791 %ulong_1
+OpStore %767 %792
+%793 = OpLoad %ulong %766
+OpStore %768 %793
+%794 = OpLoad %ulong %767
+OpStore %769 %794
+OpBranch %756
+%756 = OpLabel
+OpBranch %752
+OpFunctionEnd

--- a/test/golden/spirv/float/cmp_f64.dis
+++ b/test/golden/spirv/float/cmp_f64.dis
@@ -1,0 +1,1441 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos; 0
+; Bound: 1004
+; Schema: 0
+OpCapability Shader
+OpCapability Linkage
+OpCapability Int8
+OpCapability Int64
+OpCapability Float64
+OpMemoryModel Logical GLSL450
+OpDecorate %1 LinkageAttributes "corpus.cases.float.cmp_f64.fold64" Export
+OpDecorate %2 LinkageAttributes "corpus.cases.float.cmp_f64.checksum" Export
+%ulong = OpTypeInt 64 0
+%double = OpTypeFloat 64
+%10 = OpTypeFunction %ulong %ulong %double
+%bool = OpTypeBool
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_double = OpTypePointer Function %double
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
+%39 = OpTypeFunction %ulong %ulong
+%uint = OpTypeInt 32 0
+%float = OpTypeFloat 32
+%uchar = OpTypeInt 8 0
+%uint_12 = OpConstant %uint 12
+%_arr_double_uint_12 = OpTypeArray %double %uint_12
+%_ptr_Function__arr_double_uint_12 = OpTypePointer Function %_arr_double_uint_12
+%uint_8 = OpConstant %uint 8
+%_arr_float_uint_8 = OpTypeArray %float %uint_8
+%_ptr_Function__arr_float_uint_8 = OpTypePointer Function %_arr_float_uint_8
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_uchar = OpTypePointer Function %uchar
+%_ptr_Function_float = OpTypePointer Function %float
+%307 = OpConstantNull %_arr_double_uint_12
+%ulong_18442240474082181120 = OpConstant %ulong 18442240474082181120
+%uint_0 = OpConstant %uint 0
+%ulong_13830554455654793216 = OpConstant %ulong 13830554455654793216
+%uint_1 = OpConstant %uint 1
+%ulong_9227875636482146304 = OpConstant %ulong 9227875636482146304
+%uint_2 = OpConstant %uint 2
+%ulong_9223372036854775809 = OpConstant %ulong 9223372036854775809
+%uint_3 = OpConstant %uint 3
+%ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%ulong_1 = OpConstant %ulong 1
+%uint_6 = OpConstant %uint 6
+%ulong_4607182418800017408 = OpConstant %ulong 4607182418800017408
+%uint_7 = OpConstant %uint 7
+%ulong_9218868437227405311 = OpConstant %ulong 9218868437227405311
+%ulong_9218868437227405312 = OpConstant %ulong 9218868437227405312
+%uint_9 = OpConstant %uint 9
+%ulong_9221120237041090560 = OpConstant %ulong 9221120237041090560
+%uint_10 = OpConstant %uint 10
+%ulong_9218868437227405313 = OpConstant %ulong 9218868437227405313
+%uint_11 = OpConstant %uint 11
+%ulong_0 = OpConstant %ulong 0
+%ulong_12 = OpConstant %ulong 12
+%406 = OpConstantNull %_arr_float_uint_8
+%uint_4286578688 = OpConstant %uint 4286578688
+%uint_3212836864 = OpConstant %uint 3212836864
+%uint_2147483648 = OpConstant %uint 2147483648
+%uint_1065353216 = OpConstant %uint 1065353216
+%uint_2139095040 = OpConstant %uint 2139095040
+%uint_2143289344 = OpConstant %uint 2143289344
+%uchar_1 = OpConstant %uchar 1
+%uchar_0 = OpConstant %uchar 0
+%ulong_8 = OpConstant %ulong 8
+%uchar_2 = OpConstant %uchar 2
+%uchar_4 = OpConstant %uchar 4
+%uchar_8 = OpConstant %uchar 8
+%uchar_16 = OpConstant %uchar 16
+%uchar_32 = OpConstant %uchar 32
+%825 = OpTypeFunction %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%828 = OpTypeFunction %ulong %ulong %ulong
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%870 = OpTypeFunction %ulong %ulong %uchar
+%915 = OpTypeFunction %ulong %ulong %uint
+%1 = OpFunction %ulong None %10
+%11 = OpFunctionParameter %ulong
+%12 = OpFunctionParameter %double
+%13 = OpLabel
+%20 = OpVariable %_ptr_Function_ulong Function
+%22 = OpVariable %_ptr_Function_double Function
+%24 = OpVariable %_ptr_Function_bool Function
+%25 = OpVariable %_ptr_Function_ulong Function
+%26 = OpVariable %_ptr_Function_ulong Function
+OpStore %20 %11
+OpStore %22 %12
+%27 = OpLoad %double %22
+%28 = OpLoad %double %22
+%29 = OpFUnordNotEqual %bool %27 %28
+OpStore %24 %29
+%30 = OpLoad %bool %24
+OpSelectionMerge %17 None
+OpBranchConditional %30 %14 %15
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%31 = OpLoad %ulong %20
+%32 = OpLoad %double %22
+%33 = OpFunctionCall %ulong %7 %31 %32
+OpStore %26 %33
+%34 = OpLoad %ulong %26
+OpReturnValue %34
+%14 = OpLabel
+%35 = OpLoad %ulong %20
+%36 = OpFunctionCall %ulong %4 %35 %ulong_18446744073709551615
+OpStore %25 %36
+%38 = OpLoad %ulong %25
+OpReturnValue %38
+%17 = OpLabel
+OpUnreachable
+OpFunctionEnd
+%2 = OpFunction %ulong None %39
+%40 = OpFunctionParameter %ulong
+%41 = OpLabel
+%122 = OpVariable %_ptr_Function__arr_double_uint_12 Function
+%126 = OpVariable %_ptr_Function__arr_float_uint_8 Function
+%127 = OpVariable %_ptr_Function_ulong Function
+%128 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_uint Function
+%131 = OpVariable %_ptr_Function_ulong Function
+%132 = OpVariable %_ptr_Function_double Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_double Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_double Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_double Function
+%139 = OpVariable %_ptr_Function_ulong Function
+%140 = OpVariable %_ptr_Function_double Function
+%141 = OpVariable %_ptr_Function_double Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_double Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_double Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_double Function
+%148 = OpVariable %_ptr_Function_ulong Function
+%149 = OpVariable %_ptr_Function_double Function
+%150 = OpVariable %_ptr_Function_ulong Function
+%151 = OpVariable %_ptr_Function_double Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_double Function
+%154 = OpVariable %_ptr_Function_bool Function
+%155 = OpVariable %_ptr_Function_bool Function
+%156 = OpVariable %_ptr_Function_double Function
+%157 = OpVariable %_ptr_Function_double Function
+%158 = OpVariable %_ptr_Function_bool Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_bool Function
+%161 = OpVariable %_ptr_Function_ulong Function
+%162 = OpVariable %_ptr_Function_bool Function
+%163 = OpVariable %_ptr_Function_ulong Function
+%164 = OpVariable %_ptr_Function_bool Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_bool Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_bool Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_bool Function
+%172 = OpVariable %_ptr_Function_uchar Function
+%173 = OpVariable %_ptr_Function_bool Function
+%174 = OpVariable %_ptr_Function_uchar Function
+%175 = OpVariable %_ptr_Function_bool Function
+%176 = OpVariable %_ptr_Function_uchar Function
+%177 = OpVariable %_ptr_Function_bool Function
+%178 = OpVariable %_ptr_Function_uchar Function
+%179 = OpVariable %_ptr_Function_bool Function
+%180 = OpVariable %_ptr_Function_uchar Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_bool Function
+%183 = OpVariable %_ptr_Function_bool Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_bool Function
+%186 = OpVariable %_ptr_Function_bool Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_bool Function
+%189 = OpVariable %_ptr_Function_bool Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_bool Function
+%192 = OpVariable %_ptr_Function_bool Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_bool Function
+%195 = OpVariable %_ptr_Function_bool Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_uint Function
+%201 = OpVariable %_ptr_Function_float Function
+%202 = OpVariable %_ptr_Function_uint Function
+%203 = OpVariable %_ptr_Function_float Function
+%204 = OpVariable %_ptr_Function_uint Function
+%205 = OpVariable %_ptr_Function_float Function
+%206 = OpVariable %_ptr_Function_float Function
+%207 = OpVariable %_ptr_Function_uint Function
+%208 = OpVariable %_ptr_Function_float Function
+%209 = OpVariable %_ptr_Function_uint Function
+%210 = OpVariable %_ptr_Function_float Function
+%211 = OpVariable %_ptr_Function_uint Function
+%212 = OpVariable %_ptr_Function_float Function
+%213 = OpVariable %_ptr_Function_uint Function
+%214 = OpVariable %_ptr_Function_float Function
+%215 = OpVariable %_ptr_Function_bool Function
+%216 = OpVariable %_ptr_Function_bool Function
+%217 = OpVariable %_ptr_Function_double Function
+%218 = OpVariable %_ptr_Function_float Function
+%219 = OpVariable %_ptr_Function_double Function
+%220 = OpVariable %_ptr_Function_bool Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_bool Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_bool Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_bool Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_bool Function
+%229 = OpVariable %_ptr_Function_ulong Function
+%230 = OpVariable %_ptr_Function_bool Function
+%231 = OpVariable %_ptr_Function_ulong Function
+%232 = OpVariable %_ptr_Function_ulong Function
+%233 = OpVariable %_ptr_Function_ulong Function
+%234 = OpVariable %_ptr_Function_double Function
+%235 = OpVariable %_ptr_Function_double Function
+%236 = OpVariable %_ptr_Function_bool Function
+%237 = OpVariable %_ptr_Function_double Function
+%238 = OpVariable %_ptr_Function_bool Function
+%239 = OpVariable %_ptr_Function_double Function
+%240 = OpVariable %_ptr_Function_double Function
+%241 = OpVariable %_ptr_Function_bool Function
+%242 = OpVariable %_ptr_Function_double Function
+%243 = OpVariable %_ptr_Function_ulong Function
+%244 = OpVariable %_ptr_Function_bool Function
+%245 = OpVariable %_ptr_Function_bool Function
+%246 = OpVariable %_ptr_Function_double Function
+%247 = OpVariable %_ptr_Function_double Function
+%248 = OpVariable %_ptr_Function_bool Function
+%249 = OpVariable %_ptr_Function_uint Function
+%250 = OpVariable %_ptr_Function_uint Function
+%251 = OpVariable %_ptr_Function_double Function
+%252 = OpVariable %_ptr_Function_double Function
+%253 = OpVariable %_ptr_Function_bool Function
+%254 = OpVariable %_ptr_Function_uint Function
+%255 = OpVariable %_ptr_Function_uint Function
+%256 = OpVariable %_ptr_Function_double Function
+%257 = OpVariable %_ptr_Function_double Function
+%258 = OpVariable %_ptr_Function_bool Function
+%259 = OpVariable %_ptr_Function_uint Function
+%260 = OpVariable %_ptr_Function_uint Function
+%261 = OpVariable %_ptr_Function_double Function
+%262 = OpVariable %_ptr_Function_double Function
+%263 = OpVariable %_ptr_Function_bool Function
+%264 = OpVariable %_ptr_Function_uint Function
+%265 = OpVariable %_ptr_Function_uint Function
+%266 = OpVariable %_ptr_Function_ulong Function
+%267 = OpVariable %_ptr_Function_ulong Function
+%268 = OpVariable %_ptr_Function_ulong Function
+%269 = OpVariable %_ptr_Function_ulong Function
+%270 = OpVariable %_ptr_Function_ulong Function
+%271 = OpVariable %_ptr_Function_ulong Function
+%272 = OpVariable %_ptr_Function_ulong Function
+%273 = OpVariable %_ptr_Function_ulong Function
+%274 = OpVariable %_ptr_Function_ulong Function
+%275 = OpVariable %_ptr_Function_uchar Function
+%276 = OpVariable %_ptr_Function_uchar Function
+%277 = OpVariable %_ptr_Function_uchar Function
+%278 = OpVariable %_ptr_Function_uchar Function
+%279 = OpVariable %_ptr_Function_uchar Function
+%280 = OpVariable %_ptr_Function_uchar Function
+%281 = OpVariable %_ptr_Function_bool Function
+%282 = OpVariable %_ptr_Function_bool Function
+%283 = OpVariable %_ptr_Function_bool Function
+%284 = OpVariable %_ptr_Function_bool Function
+%285 = OpVariable %_ptr_Function_ulong Function
+%286 = OpVariable %_ptr_Function_ulong Function
+%287 = OpVariable %_ptr_Function_double Function
+%288 = OpVariable %_ptr_Function_double Function
+%289 = OpVariable %_ptr_Function_double Function
+%290 = OpVariable %_ptr_Function_double Function
+%291 = OpVariable %_ptr_Function_ulong Function
+%292 = OpVariable %_ptr_Function_uint Function
+%293 = OpVariable %_ptr_Function_uint Function
+%294 = OpVariable %_ptr_Function_ulong Function
+%295 = OpVariable %_ptr_Function_ulong Function
+%296 = OpVariable %_ptr_Function_bool Function
+%297 = OpVariable %_ptr_Function_ulong Function
+%298 = OpVariable %_ptr_Function_ulong Function
+%299 = OpVariable %_ptr_Function_ulong Function
+%300 = OpVariable %_ptr_Function_bool Function
+%301 = OpVariable %_ptr_Function_ulong Function
+%302 = OpVariable %_ptr_Function_ulong Function
+%303 = OpVariable %_ptr_Function_ulong Function
+OpStore %127 %40
+%304 = OpFunctionCall %ulong %3
+OpStore %128 %304
+%305 = OpLoad %ulong %127
+%306 = OpUConvert %uint %305
+OpStore %130 %306
+OpStore %122 %307
+%309 = OpLoad %ulong %127
+%310 = OpIAdd %ulong %ulong_18442240474082181120 %309
+OpStore %131 %310
+%311 = OpLoad %ulong %131
+%312 = OpBitcast %double %311
+OpStore %132 %312
+%314 = OpAccessChain %_ptr_Function_double %122 %uint_0
+%315 = OpLoad %double %132
+OpStore %314 %315
+%317 = OpLoad %ulong %127
+%318 = OpIAdd %ulong %ulong_13830554455654793216 %317
+OpStore %133 %318
+%319 = OpLoad %ulong %133
+%320 = OpBitcast %double %319
+OpStore %134 %320
+%322 = OpAccessChain %_ptr_Function_double %122 %uint_1
+%323 = OpLoad %double %134
+OpStore %322 %323
+%325 = OpLoad %ulong %127
+%326 = OpIAdd %ulong %ulong_9227875636482146304 %325
+OpStore %135 %326
+%327 = OpLoad %ulong %135
+%328 = OpBitcast %double %327
+OpStore %136 %328
+%330 = OpAccessChain %_ptr_Function_double %122 %uint_2
+%331 = OpLoad %double %136
+OpStore %330 %331
+%333 = OpLoad %ulong %127
+%334 = OpIAdd %ulong %ulong_9223372036854775809 %333
+OpStore %137 %334
+%335 = OpLoad %ulong %137
+%336 = OpBitcast %double %335
+OpStore %138 %336
+%338 = OpAccessChain %_ptr_Function_double %122 %uint_3
+%339 = OpLoad %double %138
+OpStore %338 %339
+%341 = OpLoad %ulong %127
+%342 = OpIAdd %ulong %ulong_9223372036854775808 %341
+OpStore %139 %342
+%343 = OpLoad %ulong %139
+%344 = OpBitcast %double %343
+OpStore %140 %344
+%346 = OpAccessChain %_ptr_Function_double %122 %uint_4
+%347 = OpLoad %double %140
+OpStore %346 %347
+%348 = OpLoad %ulong %127
+%349 = OpBitcast %double %348
+OpStore %141 %349
+%351 = OpAccessChain %_ptr_Function_double %122 %uint_5
+%352 = OpLoad %double %141
+OpStore %351 %352
+%354 = OpLoad %ulong %127
+%355 = OpIAdd %ulong %ulong_1 %354
+OpStore %142 %355
+%356 = OpLoad %ulong %142
+%357 = OpBitcast %double %356
+OpStore %143 %357
+%359 = OpAccessChain %_ptr_Function_double %122 %uint_6
+%360 = OpLoad %double %143
+OpStore %359 %360
+%362 = OpLoad %ulong %127
+%363 = OpIAdd %ulong %ulong_4607182418800017408 %362
+OpStore %144 %363
+%364 = OpLoad %ulong %144
+%365 = OpBitcast %double %364
+OpStore %145 %365
+%367 = OpAccessChain %_ptr_Function_double %122 %uint_7
+%368 = OpLoad %double %145
+OpStore %367 %368
+%370 = OpLoad %ulong %127
+%371 = OpIAdd %ulong %ulong_9218868437227405311 %370
+OpStore %146 %371
+%372 = OpLoad %ulong %146
+%373 = OpBitcast %double %372
+OpStore %147 %373
+%374 = OpAccessChain %_ptr_Function_double %122 %uint_8
+%375 = OpLoad %double %147
+OpStore %374 %375
+%377 = OpLoad %ulong %127
+%378 = OpIAdd %ulong %ulong_9218868437227405312 %377
+OpStore %148 %378
+%379 = OpLoad %ulong %148
+%380 = OpBitcast %double %379
+OpStore %149 %380
+%382 = OpAccessChain %_ptr_Function_double %122 %uint_9
+%383 = OpLoad %double %149
+OpStore %382 %383
+%385 = OpLoad %ulong %127
+%386 = OpIAdd %ulong %ulong_9221120237041090560 %385
+OpStore %150 %386
+%387 = OpLoad %ulong %150
+%388 = OpBitcast %double %387
+OpStore %151 %388
+%390 = OpAccessChain %_ptr_Function_double %122 %uint_10
+%391 = OpLoad %double %151
+OpStore %390 %391
+%393 = OpLoad %ulong %127
+%394 = OpIAdd %ulong %ulong_9218868437227405313 %393
+OpStore %152 %394
+%395 = OpLoad %ulong %152
+%396 = OpBitcast %double %395
+OpStore %153 %396
+%398 = OpAccessChain %_ptr_Function_double %122 %uint_11
+%399 = OpLoad %double %153
+OpStore %398 %399
+%400 = OpLoad %ulong %128
+OpStore %272 %400
+OpStore %273 %ulong_0
+OpBranch %42
+%42 = OpLabel
+%402 = OpLoad %ulong %273
+%404 = OpULessThan %bool %402 %ulong_12
+OpStore %154 %404
+%405 = OpLoad %bool %154
+OpLoopMerge %44 %115 None
+OpBranchConditional %405 %43 %44
+%44 = OpLabel
+OpStore %126 %406
+%408 = OpLoad %uint %130
+%409 = OpIAdd %uint %uint_4286578688 %408
+OpStore %199 %409
+%410 = OpLoad %uint %199
+%411 = OpBitcast %float %410
+OpStore %201 %411
+%412 = OpAccessChain %_ptr_Function_float %126 %uint_0
+%413 = OpLoad %float %201
+OpStore %412 %413
+%415 = OpLoad %uint %130
+%416 = OpIAdd %uint %uint_3212836864 %415
+OpStore %202 %416
+%417 = OpLoad %uint %202
+%418 = OpBitcast %float %417
+OpStore %203 %418
+%419 = OpAccessChain %_ptr_Function_float %126 %uint_1
+%420 = OpLoad %float %203
+OpStore %419 %420
+%422 = OpLoad %uint %130
+%423 = OpIAdd %uint %uint_2147483648 %422
+OpStore %204 %423
+%424 = OpLoad %uint %204
+%425 = OpBitcast %float %424
+OpStore %205 %425
+%426 = OpAccessChain %_ptr_Function_float %126 %uint_2
+%427 = OpLoad %float %205
+OpStore %426 %427
+%428 = OpLoad %uint %130
+%429 = OpBitcast %float %428
+OpStore %206 %429
+%430 = OpAccessChain %_ptr_Function_float %126 %uint_3
+%431 = OpLoad %float %206
+OpStore %430 %431
+%432 = OpLoad %uint %130
+%433 = OpIAdd %uint %uint_1 %432
+OpStore %207 %433
+%434 = OpLoad %uint %207
+%435 = OpBitcast %float %434
+OpStore %208 %435
+%436 = OpAccessChain %_ptr_Function_float %126 %uint_4
+%437 = OpLoad %float %208
+OpStore %436 %437
+%439 = OpLoad %uint %130
+%440 = OpIAdd %uint %uint_1065353216 %439
+OpStore %209 %440
+%441 = OpLoad %uint %209
+%442 = OpBitcast %float %441
+OpStore %210 %442
+%443 = OpAccessChain %_ptr_Function_float %126 %uint_5
+%444 = OpLoad %float %210
+OpStore %443 %444
+%446 = OpLoad %uint %130
+%447 = OpIAdd %uint %uint_2139095040 %446
+OpStore %211 %447
+%448 = OpLoad %uint %211
+%449 = OpBitcast %float %448
+OpStore %212 %449
+%450 = OpAccessChain %_ptr_Function_float %126 %uint_6
+%451 = OpLoad %float %212
+OpStore %450 %451
+%453 = OpLoad %uint %130
+%454 = OpIAdd %uint %uint_2143289344 %453
+OpStore %213 %454
+%455 = OpLoad %uint %213
+%456 = OpBitcast %float %455
+OpStore %214 %456
+%457 = OpAccessChain %_ptr_Function_float %126 %uint_7
+%458 = OpLoad %float %214
+OpStore %457 %458
+%459 = OpLoad %ulong %272
+OpStore %270 %459
+OpStore %285 %ulong_0
+OpBranch %74
+%74 = OpLabel
+%460 = OpLoad %ulong %285
+%461 = OpULessThan %bool %460 %ulong_12
+OpStore %215 %461
+%462 = OpLoad %bool %215
+OpLoopMerge %76 %114 None
+OpBranchConditional %462 %75 %76
+%76 = OpLabel
+%463 = OpAccessChain %_ptr_Function_double %122 %uint_0
+%464 = OpLoad %double %463
+OpStore %234 %464
+%465 = OpLoad %double %463
+OpStore %235 %465
+%466 = OpLoad %double %234
+OpStore %288 %466
+%467 = OpLoad %double %235
+OpStore %290 %467
+OpStore %291 %ulong_1
+OpBranch %80
+%80 = OpLabel
+%468 = OpLoad %ulong %291
+%469 = OpULessThan %bool %468 %ulong_12
+OpStore %236 %469
+%470 = OpLoad %bool %236
+OpLoopMerge %82 %112 None
+OpBranchConditional %470 %81 %82
+%82 = OpLabel
+OpBranch %95
+%95 = OpLabel
+%471 = OpLoad %double %288
+%472 = OpLoad %double %288
+%473 = OpFUnordNotEqual %bool %471 %472
+OpStore %296 %473
+%474 = OpLoad %bool %296
+OpSelectionMerge %99 None
+OpBranchConditional %474 %96 %97
+%97 = OpLabel
+OpBranch %98
+%98 = OpLabel
+%475 = OpLoad %ulong %270
+%476 = OpLoad %double %288
+%477 = OpFunctionCall %ulong %7 %475 %476
+OpStore %298 %477
+%478 = OpLoad %ulong %298
+OpStore %299 %478
+OpBranch %99
+%96 = OpLabel
+%479 = OpLoad %ulong %270
+%480 = OpFunctionCall %ulong %4 %479 %ulong_18446744073709551615
+OpStore %297 %480
+%481 = OpLoad %ulong %297
+OpStore %299 %481
+OpBranch %99
+%99 = OpLabel
+OpBranch %100
+%100 = OpLabel
+%482 = OpLoad %double %290
+%483 = OpLoad %double %290
+%484 = OpFUnordNotEqual %bool %482 %483
+OpStore %300 %484
+%485 = OpLoad %bool %300
+OpSelectionMerge %104 None
+OpBranchConditional %485 %101 %102
+%102 = OpLabel
+OpBranch %103
+%103 = OpLabel
+%486 = OpLoad %ulong %299
+%487 = OpLoad %double %290
+%488 = OpFunctionCall %ulong %7 %486 %487
+OpStore %302 %488
+%489 = OpLoad %ulong %302
+OpStore %303 %489
+OpBranch %104
+%101 = OpLabel
+%490 = OpLoad %ulong %299
+%491 = OpFunctionCall %ulong %4 %490 %ulong_18446744073709551615
+OpStore %301 %491
+%492 = OpLoad %ulong %301
+OpStore %303 %492
+OpBranch %104
+%104 = OpLabel
+OpStore %293 %uint_0
+OpStore %294 %ulong_0
+OpBranch %89
+%89 = OpLabel
+%493 = OpLoad %ulong %294
+%494 = OpULessThan %bool %493 %ulong_12
+OpStore %244 %494
+%495 = OpLoad %bool %244
+OpLoopMerge %91 %110 None
+OpBranchConditional %495 %90 %91
+%91 = OpLabel
+%496 = OpLoad %ulong %303
+%497 = OpLoad %uint %293
+%498 = OpFunctionCall %ulong %6 %496 %497
+OpStore %268 %498
+%499 = OpLoad %ulong %268
+OpReturnValue %499
+%90 = OpLabel
+%500 = OpLoad %ulong %294
+%501 = OpAccessChain %_ptr_Function_double %122 %500
+%502 = OpLoad %uint %293
+OpStore %292 %502
+OpStore %295 %ulong_0
+OpBranch %92
+%92 = OpLabel
+%503 = OpLoad %ulong %295
+%504 = OpULessThan %bool %503 %ulong_12
+OpStore %245 %504
+%505 = OpLoad %bool %245
+OpLoopMerge %94 %109 None
+OpBranchConditional %505 %93 %94
+%94 = OpLabel
+%506 = OpLoad %ulong %294
+%507 = OpIAdd %ulong %506 %ulong_1
+OpStore %267 %507
+%508 = OpLoad %uint %292
+OpStore %293 %508
+%509 = OpLoad %ulong %267
+OpStore %294 %509
+OpBranch %110
+%93 = OpLabel
+%510 = OpLoad %double %501
+OpStore %246 %510
+%511 = OpLoad %ulong %295
+%512 = OpAccessChain %_ptr_Function_double %122 %511
+%513 = OpLoad %double %512
+OpStore %247 %513
+%514 = OpLoad %double %246
+%515 = OpLoad %double %247
+%516 = OpFOrdLessThan %bool %514 %515
+OpStore %248 %516
+%517 = OpLoad %bool %248
+%520 = OpSelect %uchar %517 %uchar_1 %uchar_0
+%521 = OpUConvert %uint %520
+OpStore %249 %521
+%522 = OpLoad %uint %292
+%523 = OpLoad %uint %249
+%524 = OpIAdd %uint %522 %523
+OpStore %250 %524
+%525 = OpLoad %double %501
+OpStore %251 %525
+%526 = OpLoad %double %512
+OpStore %252 %526
+%527 = OpLoad %double %251
+%528 = OpLoad %double %252
+%529 = OpFOrdLessThanEqual %bool %527 %528
+OpStore %253 %529
+%530 = OpLoad %bool %253
+%531 = OpSelect %uchar %530 %uchar_1 %uchar_0
+%532 = OpUConvert %uint %531
+OpStore %254 %532
+%533 = OpLoad %uint %250
+%534 = OpLoad %uint %254
+%535 = OpIAdd %uint %533 %534
+OpStore %255 %535
+%536 = OpLoad %double %501
+OpStore %256 %536
+%537 = OpLoad %double %512
+OpStore %257 %537
+%538 = OpLoad %double %256
+%539 = OpLoad %double %257
+%540 = OpFOrdEqual %bool %538 %539
+OpStore %258 %540
+%541 = OpLoad %bool %258
+%542 = OpSelect %uchar %541 %uchar_1 %uchar_0
+%543 = OpUConvert %uint %542
+OpStore %259 %543
+%544 = OpLoad %uint %255
+%545 = OpLoad %uint %259
+%546 = OpIAdd %uint %544 %545
+OpStore %260 %546
+%547 = OpLoad %double %501
+OpStore %261 %547
+%548 = OpLoad %double %512
+OpStore %262 %548
+%549 = OpLoad %double %261
+%550 = OpLoad %double %262
+%551 = OpFUnordNotEqual %bool %549 %550
+OpStore %263 %551
+%552 = OpLoad %bool %263
+%553 = OpSelect %uchar %552 %uchar_1 %uchar_0
+%554 = OpUConvert %uint %553
+OpStore %264 %554
+%555 = OpLoad %uint %260
+%556 = OpLoad %uint %264
+%557 = OpIAdd %uint %555 %556
+OpStore %265 %557
+%558 = OpLoad %ulong %295
+%559 = OpIAdd %ulong %558 %ulong_1
+OpStore %266 %559
+%560 = OpLoad %uint %265
+OpStore %292 %560
+%561 = OpLoad %ulong %266
+OpStore %295 %561
+OpBranch %109
+%81 = OpLabel
+%562 = OpLoad %ulong %291
+%563 = OpAccessChain %_ptr_Function_double %122 %562
+%564 = OpLoad %double %563
+OpStore %237 %564
+%565 = OpLoad %double %237
+%566 = OpLoad %double %288
+%567 = OpFOrdLessThan %bool %565 %566
+OpStore %238 %567
+%568 = OpLoad %bool %238
+OpSelectionMerge %85 None
+OpBranchConditional %568 %83 %84
+%84 = OpLabel
+%569 = OpLoad %double %288
+OpStore %287 %569
+OpBranch %85
+%83 = OpLabel
+%570 = OpLoad %ulong %291
+%571 = OpAccessChain %_ptr_Function_double %122 %570
+%572 = OpLoad %double %571
+OpStore %239 %572
+%573 = OpLoad %double %239
+OpStore %287 %573
+OpBranch %85
+%85 = OpLabel
+%574 = OpLoad %ulong %291
+%575 = OpAccessChain %_ptr_Function_double %122 %574
+%576 = OpLoad %double %575
+OpStore %240 %576
+%577 = OpLoad %double %290
+%578 = OpLoad %double %240
+%579 = OpFOrdLessThan %bool %577 %578
+OpStore %241 %579
+%580 = OpLoad %bool %241
+OpSelectionMerge %88 None
+OpBranchConditional %580 %86 %87
+%87 = OpLabel
+%581 = OpLoad %double %290
+OpStore %289 %581
+OpBranch %88
+%86 = OpLabel
+%582 = OpLoad %ulong %291
+%583 = OpAccessChain %_ptr_Function_double %122 %582
+%584 = OpLoad %double %583
+OpStore %242 %584
+%585 = OpLoad %double %242
+OpStore %289 %585
+OpBranch %88
+%88 = OpLabel
+%586 = OpLoad %ulong %291
+%587 = OpIAdd %ulong %586 %ulong_1
+OpStore %243 %587
+%588 = OpLoad %double %287
+OpStore %288 %588
+%589 = OpLoad %double %289
+OpStore %290 %589
+%590 = OpLoad %ulong %243
+OpStore %291 %590
+OpBranch %112
+%75 = OpLabel
+%591 = OpLoad %ulong %285
+%592 = OpAccessChain %_ptr_Function_double %122 %591
+%593 = OpLoad %ulong %270
+OpStore %269 %593
+OpStore %286 %ulong_0
+OpBranch %77
+%77 = OpLabel
+%594 = OpLoad %ulong %286
+%596 = OpULessThan %bool %594 %ulong_8
+OpStore %216 %596
+%597 = OpLoad %bool %216
+OpLoopMerge %79 %111 None
+OpBranchConditional %597 %78 %79
+%79 = OpLabel
+%598 = OpLoad %ulong %285
+%599 = OpIAdd %ulong %598 %ulong_1
+OpStore %233 %599
+%600 = OpLoad %ulong %269
+OpStore %270 %600
+%601 = OpLoad %ulong %233
+OpStore %285 %601
+OpBranch %114
+%78 = OpLabel
+%602 = OpLoad %double %592
+OpStore %217 %602
+%603 = OpLoad %ulong %286
+%604 = OpAccessChain %_ptr_Function_float %126 %603
+%605 = OpLoad %float %604
+OpStore %218 %605
+%606 = OpLoad %float %218
+%607 = OpFConvert %double %606
+OpStore %219 %607
+%608 = OpLoad %double %217
+%609 = OpLoad %double %219
+%610 = OpFOrdEqual %bool %608 %609
+OpStore %220 %610
+%611 = OpLoad %ulong %269
+%612 = OpLoad %bool %220
+%614 = OpSelect %uchar %612 %uchar_1 %uchar_0
+%613 = OpFunctionCall %ulong %5 %611 %614
+OpStore %221 %613
+%615 = OpLoad %double %217
+%616 = OpLoad %double %219
+%617 = OpFUnordNotEqual %bool %615 %616
+OpStore %222 %617
+%618 = OpLoad %ulong %221
+%619 = OpLoad %bool %222
+%621 = OpSelect %uchar %619 %uchar_1 %uchar_0
+%620 = OpFunctionCall %ulong %5 %618 %621
+OpStore %223 %620
+%622 = OpLoad %double %217
+%623 = OpLoad %double %219
+%624 = OpFOrdLessThan %bool %622 %623
+OpStore %224 %624
+%625 = OpLoad %ulong %223
+%626 = OpLoad %bool %224
+%628 = OpSelect %uchar %626 %uchar_1 %uchar_0
+%627 = OpFunctionCall %ulong %5 %625 %628
+OpStore %225 %627
+%629 = OpLoad %double %217
+%630 = OpLoad %double %219
+%631 = OpFOrdLessThanEqual %bool %629 %630
+OpStore %226 %631
+%632 = OpLoad %ulong %225
+%633 = OpLoad %bool %226
+%635 = OpSelect %uchar %633 %uchar_1 %uchar_0
+%634 = OpFunctionCall %ulong %5 %632 %635
+OpStore %227 %634
+%636 = OpLoad %double %219
+%637 = OpLoad %double %217
+%638 = OpFOrdLessThan %bool %636 %637
+OpStore %228 %638
+%639 = OpLoad %ulong %227
+%640 = OpLoad %bool %228
+%642 = OpSelect %uchar %640 %uchar_1 %uchar_0
+%641 = OpFunctionCall %ulong %5 %639 %642
+OpStore %229 %641
+%643 = OpLoad %double %219
+%644 = OpLoad %double %217
+%645 = OpFOrdLessThanEqual %bool %643 %644
+OpStore %230 %645
+%646 = OpLoad %ulong %229
+%647 = OpLoad %bool %230
+%649 = OpSelect %uchar %647 %uchar_1 %uchar_0
+%648 = OpFunctionCall %ulong %5 %646 %649
+OpStore %231 %648
+%650 = OpLoad %ulong %286
+%651 = OpIAdd %ulong %650 %ulong_1
+OpStore %232 %651
+%652 = OpLoad %ulong %231
+OpStore %269 %652
+%653 = OpLoad %ulong %232
+OpStore %286 %653
+OpBranch %111
+%43 = OpLabel
+%654 = OpLoad %ulong %273
+%655 = OpAccessChain %_ptr_Function_double %122 %654
+%656 = OpLoad %ulong %272
+OpStore %271 %656
+OpStore %274 %ulong_0
+OpBranch %45
+%45 = OpLabel
+%657 = OpLoad %ulong %274
+%658 = OpULessThan %bool %657 %ulong_12
+OpStore %155 %658
+%659 = OpLoad %bool %155
+OpLoopMerge %47 %113 None
+OpBranchConditional %659 %46 %47
+%47 = OpLabel
+%660 = OpLoad %ulong %273
+%661 = OpIAdd %ulong %660 %ulong_1
+OpStore %198 %661
+%662 = OpLoad %ulong %271
+OpStore %272 %662
+%663 = OpLoad %ulong %198
+OpStore %273 %663
+OpBranch %115
+%46 = OpLabel
+%664 = OpLoad %double %655
+OpStore %156 %664
+%665 = OpLoad %ulong %274
+%666 = OpAccessChain %_ptr_Function_double %122 %665
+%667 = OpLoad %double %666
+OpStore %157 %667
+%668 = OpLoad %double %156
+%669 = OpLoad %double %157
+%670 = OpFOrdEqual %bool %668 %669
+OpStore %158 %670
+%671 = OpLoad %ulong %271
+%672 = OpLoad %bool %158
+%674 = OpSelect %uchar %672 %uchar_1 %uchar_0
+%673 = OpFunctionCall %ulong %5 %671 %674
+OpStore %159 %673
+%675 = OpLoad %double %156
+%676 = OpLoad %double %157
+%677 = OpFUnordNotEqual %bool %675 %676
+OpStore %160 %677
+%678 = OpLoad %ulong %159
+%679 = OpLoad %bool %160
+%681 = OpSelect %uchar %679 %uchar_1 %uchar_0
+%680 = OpFunctionCall %ulong %5 %678 %681
+OpStore %161 %680
+%682 = OpLoad %double %156
+%683 = OpLoad %double %157
+%684 = OpFOrdLessThan %bool %682 %683
+OpStore %162 %684
+%685 = OpLoad %ulong %161
+%686 = OpLoad %bool %162
+%688 = OpSelect %uchar %686 %uchar_1 %uchar_0
+%687 = OpFunctionCall %ulong %5 %685 %688
+OpStore %163 %687
+%689 = OpLoad %double %156
+%690 = OpLoad %double %157
+%691 = OpFOrdLessThanEqual %bool %689 %690
+OpStore %164 %691
+%692 = OpLoad %ulong %163
+%693 = OpLoad %bool %164
+%695 = OpSelect %uchar %693 %uchar_1 %uchar_0
+%694 = OpFunctionCall %ulong %5 %692 %695
+OpStore %165 %694
+%696 = OpLoad %double %157
+%697 = OpLoad %double %156
+%698 = OpFOrdLessThan %bool %696 %697
+OpStore %166 %698
+%699 = OpLoad %ulong %165
+%700 = OpLoad %bool %166
+%702 = OpSelect %uchar %700 %uchar_1 %uchar_0
+%701 = OpFunctionCall %ulong %5 %699 %702
+OpStore %167 %701
+%703 = OpLoad %double %157
+%704 = OpLoad %double %156
+%705 = OpFOrdLessThanEqual %bool %703 %704
+OpStore %168 %705
+%706 = OpLoad %ulong %167
+%707 = OpLoad %bool %168
+%709 = OpSelect %uchar %707 %uchar_1 %uchar_0
+%708 = OpFunctionCall %ulong %5 %706 %709
+OpStore %169 %708
+%710 = OpLoad %bool %162
+OpSelectionMerge %50 None
+OpBranchConditional %710 %48 %49
+%49 = OpLabel
+OpStore %280 %uchar_0
+OpBranch %50
+%48 = OpLabel
+OpStore %280 %uchar_1
+OpBranch %50
+%50 = OpLabel
+%711 = OpLoad %double %156
+%712 = OpLoad %double %157
+%713 = OpFOrdLessThanEqual %bool %711 %712
+OpStore %170 %713
+%714 = OpLoad %bool %170
+OpSelectionMerge %53 None
+OpBranchConditional %714 %51 %52
+%52 = OpLabel
+%715 = OpLoad %uchar %280
+OpStore %279 %715
+OpBranch %53
+%51 = OpLabel
+%716 = OpLoad %uchar %280
+%718 = OpIAdd %uchar %716 %uchar_2
+OpStore %172 %718
+%719 = OpLoad %uchar %172
+OpStore %279 %719
+OpBranch %53
+%53 = OpLabel
+%720 = OpLoad %double %157
+%721 = OpLoad %double %156
+%722 = OpFOrdLessThan %bool %720 %721
+OpStore %173 %722
+%723 = OpLoad %bool %173
+OpSelectionMerge %56 None
+OpBranchConditional %723 %54 %55
+%55 = OpLabel
+%724 = OpLoad %uchar %279
+OpStore %278 %724
+OpBranch %56
+%54 = OpLabel
+%725 = OpLoad %uchar %279
+%727 = OpIAdd %uchar %725 %uchar_4
+OpStore %174 %727
+%728 = OpLoad %uchar %174
+OpStore %278 %728
+OpBranch %56
+%56 = OpLabel
+%729 = OpLoad %double %157
+%730 = OpLoad %double %156
+%731 = OpFOrdLessThanEqual %bool %729 %730
+OpStore %175 %731
+%732 = OpLoad %bool %175
+OpSelectionMerge %59 None
+OpBranchConditional %732 %57 %58
+%58 = OpLabel
+%733 = OpLoad %uchar %278
+OpStore %277 %733
+OpBranch %59
+%57 = OpLabel
+%734 = OpLoad %uchar %278
+%736 = OpIAdd %uchar %734 %uchar_8
+OpStore %176 %736
+%737 = OpLoad %uchar %176
+OpStore %277 %737
+OpBranch %59
+%59 = OpLabel
+%738 = OpLoad %double %156
+%739 = OpLoad %double %157
+%740 = OpFOrdEqual %bool %738 %739
+OpStore %177 %740
+%741 = OpLoad %bool %177
+OpSelectionMerge %62 None
+OpBranchConditional %741 %60 %61
+%61 = OpLabel
+%742 = OpLoad %uchar %277
+OpStore %276 %742
+OpBranch %62
+%60 = OpLabel
+%743 = OpLoad %uchar %277
+%745 = OpIAdd %uchar %743 %uchar_16
+OpStore %178 %745
+%746 = OpLoad %uchar %178
+OpStore %276 %746
+OpBranch %62
+%62 = OpLabel
+%747 = OpLoad %double %156
+%748 = OpLoad %double %157
+%749 = OpFUnordNotEqual %bool %747 %748
+OpStore %179 %749
+%750 = OpLoad %bool %179
+OpSelectionMerge %65 None
+OpBranchConditional %750 %63 %64
+%64 = OpLabel
+%751 = OpLoad %uchar %276
+OpStore %275 %751
+OpBranch %65
+%63 = OpLabel
+%752 = OpLoad %uchar %276
+%754 = OpIAdd %uchar %752 %uchar_32
+OpStore %180 %754
+%755 = OpLoad %uchar %180
+OpStore %275 %755
+OpBranch %65
+%65 = OpLabel
+%756 = OpLoad %ulong %169
+%757 = OpLoad %uchar %275
+%758 = OpFunctionCall %ulong %5 %756 %757
+OpStore %181 %758
+%759 = OpLoad %double %156
+%760 = OpLoad %double %157
+%761 = OpFOrdLessThan %bool %759 %760
+OpStore %182 %761
+%762 = OpLoad %bool %182
+OpSelectionMerge %67 None
+OpBranchConditional %762 %66 %105
+%105 = OpLabel
+%763 = OpLoad %bool %182
+OpStore %281 %763
+OpBranch %67
+%66 = OpLabel
+%764 = OpLoad %double %157
+%765 = OpLoad %double %156
+%766 = OpFOrdLessThan %bool %764 %765
+OpStore %183 %766
+%767 = OpLoad %bool %183
+OpStore %281 %767
+OpBranch %67
+%67 = OpLabel
+%768 = OpLoad %ulong %181
+%769 = OpLoad %bool %281
+%771 = OpSelect %uchar %769 %uchar_1 %uchar_0
+%770 = OpFunctionCall %ulong %5 %768 %771
+OpStore %184 %770
+%772 = OpLoad %double %156
+%773 = OpLoad %double %157
+%774 = OpFOrdLessThan %bool %772 %773
+OpStore %185 %774
+%775 = OpLoad %bool %185
+OpSelectionMerge %69 None
+OpBranchConditional %775 %106 %68
+%68 = OpLabel
+%776 = OpLoad %double %157
+%777 = OpLoad %double %156
+%778 = OpFOrdLessThan %bool %776 %777
+OpStore %186 %778
+%779 = OpLoad %bool %186
+OpStore %282 %779
+OpBranch %69
+%106 = OpLabel
+%780 = OpLoad %bool %185
+OpStore %282 %780
+OpBranch %69
+%69 = OpLabel
+%781 = OpLoad %ulong %184
+%782 = OpLoad %bool %282
+%784 = OpSelect %uchar %782 %uchar_1 %uchar_0
+%783 = OpFunctionCall %ulong %5 %781 %784
+OpStore %187 %783
+%785 = OpLoad %double %156
+%786 = OpLoad %double %157
+%787 = OpFOrdLessThan %bool %785 %786
+OpStore %188 %787
+%788 = OpLoad %bool %188
+%789 = OpSelect %uchar %788 %uchar_1 %uchar_0
+%790 = OpIEqual %bool %789 %uchar_0
+OpStore %189 %790
+%791 = OpLoad %ulong %187
+%792 = OpLoad %bool %189
+%794 = OpSelect %uchar %792 %uchar_1 %uchar_0
+%793 = OpFunctionCall %ulong %5 %791 %794
+OpStore %190 %793
+%795 = OpLoad %double %156
+%796 = OpLoad %double %156
+%797 = OpFOrdEqual %bool %795 %796
+OpStore %191 %797
+%798 = OpLoad %bool %191
+OpSelectionMerge %71 None
+OpBranchConditional %798 %70 %107
+%107 = OpLabel
+%799 = OpLoad %bool %191
+OpStore %283 %799
+OpBranch %71
+%70 = OpLabel
+%800 = OpLoad %double %157
+%801 = OpLoad %double %157
+%802 = OpFOrdEqual %bool %800 %801
+OpStore %192 %802
+%803 = OpLoad %bool %192
+OpStore %283 %803
+OpBranch %71
+%71 = OpLabel
+%804 = OpLoad %ulong %190
+%805 = OpLoad %bool %283
+%807 = OpSelect %uchar %805 %uchar_1 %uchar_0
+%806 = OpFunctionCall %ulong %5 %804 %807
+OpStore %193 %806
+%808 = OpLoad %double %156
+%809 = OpLoad %double %156
+%810 = OpFUnordNotEqual %bool %808 %809
+OpStore %194 %810
+%811 = OpLoad %bool %194
+OpSelectionMerge %73 None
+OpBranchConditional %811 %108 %72
+%72 = OpLabel
+%812 = OpLoad %double %157
+%813 = OpLoad %double %157
+%814 = OpFUnordNotEqual %bool %812 %813
+OpStore %195 %814
+%815 = OpLoad %bool %195
+OpStore %284 %815
+OpBranch %73
+%108 = OpLabel
+%816 = OpLoad %bool %194
+OpStore %284 %816
+OpBranch %73
+%73 = OpLabel
+%817 = OpLoad %ulong %193
+%818 = OpLoad %bool %284
+%820 = OpSelect %uchar %818 %uchar_1 %uchar_0
+%819 = OpFunctionCall %ulong %5 %817 %820
+OpStore %196 %819
+%821 = OpLoad %ulong %274
+%822 = OpIAdd %ulong %821 %ulong_1
+OpStore %197 %822
+%823 = OpLoad %ulong %196
+OpStore %271 %823
+%824 = OpLoad %ulong %197
+OpStore %274 %824
+OpBranch %113
+%109 = OpLabel
+OpBranch %92
+%110 = OpLabel
+OpBranch %89
+%111 = OpLabel
+OpBranch %77
+%112 = OpLabel
+OpBranch %80
+%113 = OpLabel
+OpBranch %45
+%114 = OpLabel
+OpBranch %74
+%115 = OpLabel
+OpBranch %42
+OpFunctionEnd
+%3 = OpFunction %ulong None %825
+%826 = OpLabel
+OpReturnValue %ulong_14695981039346656037
+OpFunctionEnd
+%4 = OpFunction %ulong None %828
+%829 = OpFunctionParameter %ulong
+%830 = OpFunctionParameter %ulong
+%831 = OpLabel
+%836 = OpVariable %_ptr_Function_ulong Function
+%837 = OpVariable %_ptr_Function_ulong Function
+%838 = OpVariable %_ptr_Function_bool Function
+%839 = OpVariable %_ptr_Function_ulong Function
+%840 = OpVariable %_ptr_Function_ulong Function
+%841 = OpVariable %_ptr_Function_ulong Function
+%842 = OpVariable %_ptr_Function_ulong Function
+%843 = OpVariable %_ptr_Function_ulong Function
+%844 = OpVariable %_ptr_Function_ulong Function
+%845 = OpVariable %_ptr_Function_ulong Function
+%846 = OpVariable %_ptr_Function_ulong Function
+OpStore %836 %829
+OpStore %837 %830
+%847 = OpLoad %ulong %836
+OpStore %845 %847
+OpStore %846 %ulong_0
+OpBranch %832
+%832 = OpLabel
+%848 = OpLoad %ulong %846
+%849 = OpULessThan %bool %848 %ulong_8
+OpStore %838 %849
+%850 = OpLoad %bool %838
+OpLoopMerge %834 %835 None
+OpBranchConditional %850 %833 %834
+%834 = OpLabel
+%851 = OpLoad %ulong %845
+OpReturnValue %851
+%833 = OpLabel
+%852 = OpLoad %ulong %846
+%853 = OpIMul %ulong %852 %ulong_8
+OpStore %839 %853
+%854 = OpLoad %ulong %837
+%855 = OpLoad %ulong %839
+%856 = OpShiftRightLogical %ulong %854 %855
+OpStore %840 %856
+%857 = OpLoad %ulong %840
+%859 = OpBitwiseAnd %ulong %857 %ulong_255
+OpStore %841 %859
+%860 = OpLoad %ulong %845
+%861 = OpLoad %ulong %841
+%862 = OpBitwiseXor %ulong %860 %861
+OpStore %842 %862
+%863 = OpLoad %ulong %842
+%865 = OpIMul %ulong %863 %ulong_1099511628211
+OpStore %843 %865
+%866 = OpLoad %ulong %846
+%867 = OpIAdd %ulong %866 %ulong_1
+OpStore %844 %867
+%868 = OpLoad %ulong %843
+OpStore %845 %868
+%869 = OpLoad %ulong %844
+OpStore %846 %869
+OpBranch %835
+%835 = OpLabel
+OpBranch %832
+OpFunctionEnd
+%5 = OpFunction %ulong None %870
+%871 = OpFunctionParameter %ulong
+%872 = OpFunctionParameter %uchar
+%873 = OpLabel
+%880 = OpVariable %_ptr_Function_ulong Function
+%881 = OpVariable %_ptr_Function_uchar Function
+%882 = OpVariable %_ptr_Function_ulong Function
+%883 = OpVariable %_ptr_Function_bool Function
+%884 = OpVariable %_ptr_Function_ulong Function
+%885 = OpVariable %_ptr_Function_ulong Function
+%886 = OpVariable %_ptr_Function_ulong Function
+%887 = OpVariable %_ptr_Function_ulong Function
+%888 = OpVariable %_ptr_Function_ulong Function
+%889 = OpVariable %_ptr_Function_ulong Function
+%890 = OpVariable %_ptr_Function_ulong Function
+%891 = OpVariable %_ptr_Function_ulong Function
+OpStore %880 %871
+OpStore %881 %872
+%892 = OpLoad %uchar %881
+%893 = OpUConvert %ulong %892
+OpStore %882 %893
+OpBranch %874
+%874 = OpLabel
+%894 = OpLoad %ulong %880
+OpStore %890 %894
+OpStore %891 %ulong_0
+OpBranch %875
+%875 = OpLabel
+%895 = OpLoad %ulong %891
+%896 = OpULessThan %bool %895 %ulong_8
+OpStore %883 %896
+%897 = OpLoad %bool %883
+OpLoopMerge %877 %879 None
+OpBranchConditional %897 %876 %877
+%877 = OpLabel
+OpBranch %878
+%878 = OpLabel
+%898 = OpLoad %ulong %890
+OpReturnValue %898
+%876 = OpLabel
+%899 = OpLoad %ulong %891
+%900 = OpIMul %ulong %899 %ulong_8
+OpStore %884 %900
+%901 = OpLoad %ulong %882
+%902 = OpLoad %ulong %884
+%903 = OpShiftRightLogical %ulong %901 %902
+OpStore %885 %903
+%904 = OpLoad %ulong %885
+%905 = OpBitwiseAnd %ulong %904 %ulong_255
+OpStore %886 %905
+%906 = OpLoad %ulong %890
+%907 = OpLoad %ulong %886
+%908 = OpBitwiseXor %ulong %906 %907
+OpStore %887 %908
+%909 = OpLoad %ulong %887
+%910 = OpIMul %ulong %909 %ulong_1099511628211
+OpStore %888 %910
+%911 = OpLoad %ulong %891
+%912 = OpIAdd %ulong %911 %ulong_1
+OpStore %889 %912
+%913 = OpLoad %ulong %888
+OpStore %890 %913
+%914 = OpLoad %ulong %889
+OpStore %891 %914
+OpBranch %879
+%879 = OpLabel
+OpBranch %875
+OpFunctionEnd
+%6 = OpFunction %ulong None %915
+%916 = OpFunctionParameter %ulong
+%917 = OpFunctionParameter %uint
+%918 = OpLabel
+%925 = OpVariable %_ptr_Function_ulong Function
+%926 = OpVariable %_ptr_Function_uint Function
+%927 = OpVariable %_ptr_Function_ulong Function
+%928 = OpVariable %_ptr_Function_bool Function
+%929 = OpVariable %_ptr_Function_ulong Function
+%930 = OpVariable %_ptr_Function_ulong Function
+%931 = OpVariable %_ptr_Function_ulong Function
+%932 = OpVariable %_ptr_Function_ulong Function
+%933 = OpVariable %_ptr_Function_ulong Function
+%934 = OpVariable %_ptr_Function_ulong Function
+%935 = OpVariable %_ptr_Function_ulong Function
+%936 = OpVariable %_ptr_Function_ulong Function
+OpStore %925 %916
+OpStore %926 %917
+%937 = OpLoad %uint %926
+%938 = OpUConvert %ulong %937
+OpStore %927 %938
+OpBranch %919
+%919 = OpLabel
+%939 = OpLoad %ulong %925
+OpStore %935 %939
+OpStore %936 %ulong_0
+OpBranch %920
+%920 = OpLabel
+%940 = OpLoad %ulong %936
+%941 = OpULessThan %bool %940 %ulong_8
+OpStore %928 %941
+%942 = OpLoad %bool %928
+OpLoopMerge %922 %924 None
+OpBranchConditional %942 %921 %922
+%922 = OpLabel
+OpBranch %923
+%923 = OpLabel
+%943 = OpLoad %ulong %935
+OpReturnValue %943
+%921 = OpLabel
+%944 = OpLoad %ulong %936
+%945 = OpIMul %ulong %944 %ulong_8
+OpStore %929 %945
+%946 = OpLoad %ulong %927
+%947 = OpLoad %ulong %929
+%948 = OpShiftRightLogical %ulong %946 %947
+OpStore %930 %948
+%949 = OpLoad %ulong %930
+%950 = OpBitwiseAnd %ulong %949 %ulong_255
+OpStore %931 %950
+%951 = OpLoad %ulong %935
+%952 = OpLoad %ulong %931
+%953 = OpBitwiseXor %ulong %951 %952
+OpStore %932 %953
+%954 = OpLoad %ulong %932
+%955 = OpIMul %ulong %954 %ulong_1099511628211
+OpStore %933 %955
+%956 = OpLoad %ulong %936
+%957 = OpIAdd %ulong %956 %ulong_1
+OpStore %934 %957
+%958 = OpLoad %ulong %933
+OpStore %935 %958
+%959 = OpLoad %ulong %934
+OpStore %936 %959
+OpBranch %924
+%924 = OpLabel
+OpBranch %920
+OpFunctionEnd
+%7 = OpFunction %ulong None %10
+%960 = OpFunctionParameter %ulong
+%961 = OpFunctionParameter %double
+%962 = OpLabel
+%969 = OpVariable %_ptr_Function_ulong Function
+%970 = OpVariable %_ptr_Function_double Function
+%971 = OpVariable %_ptr_Function_ulong Function
+%972 = OpVariable %_ptr_Function_bool Function
+%973 = OpVariable %_ptr_Function_ulong Function
+%974 = OpVariable %_ptr_Function_ulong Function
+%975 = OpVariable %_ptr_Function_ulong Function
+%976 = OpVariable %_ptr_Function_ulong Function
+%977 = OpVariable %_ptr_Function_ulong Function
+%978 = OpVariable %_ptr_Function_ulong Function
+%979 = OpVariable %_ptr_Function_ulong Function
+%980 = OpVariable %_ptr_Function_ulong Function
+OpStore %969 %960
+OpStore %970 %961
+%981 = OpLoad %double %970
+%982 = OpBitcast %ulong %981
+OpStore %971 %982
+OpBranch %963
+%963 = OpLabel
+%983 = OpLoad %ulong %969
+OpStore %979 %983
+OpStore %980 %ulong_0
+OpBranch %964
+%964 = OpLabel
+%984 = OpLoad %ulong %980
+%985 = OpULessThan %bool %984 %ulong_8
+OpStore %972 %985
+%986 = OpLoad %bool %972
+OpLoopMerge %966 %968 None
+OpBranchConditional %986 %965 %966
+%966 = OpLabel
+OpBranch %967
+%967 = OpLabel
+%987 = OpLoad %ulong %979
+OpReturnValue %987
+%965 = OpLabel
+%988 = OpLoad %ulong %980
+%989 = OpIMul %ulong %988 %ulong_8
+OpStore %973 %989
+%990 = OpLoad %ulong %971
+%991 = OpLoad %ulong %973
+%992 = OpShiftRightLogical %ulong %990 %991
+OpStore %974 %992
+%993 = OpLoad %ulong %974
+%994 = OpBitwiseAnd %ulong %993 %ulong_255
+OpStore %975 %994
+%995 = OpLoad %ulong %979
+%996 = OpLoad %ulong %975
+%997 = OpBitwiseXor %ulong %995 %996
+OpStore %976 %997
+%998 = OpLoad %ulong %976
+%999 = OpIMul %ulong %998 %ulong_1099511628211
+OpStore %977 %999
+%1000 = OpLoad %ulong %980
+%1001 = OpIAdd %ulong %1000 %ulong_1
+OpStore %978 %1001
+%1002 = OpLoad %ulong %977
+OpStore %979 %1002
+%1003 = OpLoad %ulong %978
+OpStore %980 %1003
+OpBranch %968
+%968 = OpLabel
+OpBranch %964
+OpFunctionEnd


### PR DESCRIPTION
Closes #2939.
Closes #2969.

Phi destruction leaves copy-only components whose MIR move widths describe machine materialization, not value types. Preserve source IR type ids on MIR vregs and let the SPIR-V emitter use that authority only for copy destinations still untyped after concrete definitions and typed sources have propagated.

This keeps scalar comparison results as SPIR-V booleans, types parallel-copy temporaries from their source components, restores the three #2939 corpus cells, and covers #2969's exact staged shader.

Verification so far:
- 48 SPIR-V-focused unit tests pass
- exact #2969 driver regression passes
- restored `cmp/branch_nest`, `float/cmp_f32`, and `float/cmp_f64` pass `spirv-val` at debug, O0, and O2
- all three restored layer-B SPIR-V goldens pass