### PR TITLE
chore: release 4.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.18.2] - 2026-08-09
+
 ### Fixed
 
 #### SPIR-V copy-only merge values keep their declared type (#2939, #2969)

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.18.1"
+version = "4.18.2"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Promote the fixes from #2965, #2939, and #2969 into the 4.18.2 patch release.

This bumps the project version and promotes the Unreleased changelog entries.