### PR TITLE
fix(build): merge duplicate link symbol claims

### DIFF
--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -425,12 +425,28 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
                     ret R.err[bool, str](R.unwrap_err[manifest.LinkRequirement, str](req_r));
                 }
                 var req: manifest.LinkRequirement = R.unwrap_ok[manifest.LinkRequirement, str](req_r);
-                if (!requirement_in(buf, w, ?req) && !requirement_in(own_libs, own_count, ?req)) {
+                val own_duplicate: i64 = requirement_index(own_libs, own_count, ?req);
+                val dep_duplicate: i64 = requirement_index(buf, w, ?req);
+                if (own_duplicate < 0 && dep_duplicate < 0) {
                     buf[w] = req;
                     w = w + 1;
                 }
-                # a duplicate is dropped here, so its claim copy is released
-                or { manifest.free_link_claims(p.alloc, ?req, 1); }
+                or {
+                    var retained: *manifest.LinkRequirement = nil;
+                    if (own_duplicate >= 0) { retained = ?own_libs[own_duplicate::u32]; }
+                    or { retained = ?buf[dep_duplicate::u32]; }
+                    val mr: R.Result[bool, str] =
+                        manifest.merge_link_claims(p.alloc, retained, ?req);
+                    if (R.is_err[bool, str](mr)) {
+                        manifest.free_link_claims(p.alloc, ?req, 1);
+                        free_cascade_scratch(p.alloc, manifests, tables, aliases,
+                                             order, visited, n);
+                        manifest.free_link_claims(p.alloc, buf, w);
+                        A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
+                        ret R.err[bool, str](R.unwrap_err[bool, str](mr));
+                    }
+                    manifest.free_link_claims(p.alloc, ?req, 1);
+                }
             }
             li = li + 1;
         }
@@ -490,17 +506,17 @@ fun dep_declares(t: *toml.Table, alias: str) bool {
     ret false;
 }
 
-# whether a typed link requirement appears in the first `count` entries of `arr`
-fun requirement_in(arr: *manifest.LinkRequirement, count: u32,
-                   req: *manifest.LinkRequirement) bool {
-    if (arr == nil) { ret false; }
+# index of a typed link requirement in the first `count` entries of `arr`
+fun requirement_index(arr: *manifest.LinkRequirement, count: u32,
+                      req: *manifest.LinkRequirement) i64 {
+    if (arr == nil) { ret -1; }
     var k: u32 = 0;
     for (k < count) {
         if (arr[k].source == req.source && arr[k].text == req.text
-            && arr[k].library == req.library) { ret true; }
+            && arr[k].library == req.library) { ret k::i64; }
         k = k + 1;
     }
-    ret false;
+    ret -1;
 }
 
 # the diagnostic for a dep whose manifest could not be read (#2471)

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -3779,6 +3779,7 @@ test "mach.lang.manifest.merge_link_claims:stable_owned_union" {
     or {
         if (dst.symbol_count != 3 || dst.symbols[0] != a
             || dst.symbols[1] != b || dst.symbols[2] != c) { code = 1; }
+        if (dst.symbols == src_symbols) { code = 1; }
         if (src.symbols != src_symbols || src.symbol_count != 3
             || src.symbols[0] != b || src.symbols[1] != c
             || src.symbols[2] != c) { code = 1; }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1404,6 +1404,77 @@ pub fun free_link_claims(alloc: *A.Allocator, items: *LinkRequirement, count: u3
     }
 }
 
+# merge `src`'s symbol claims into an equivalent retained link requirement
+#
+# Dependency and test-link overlays deduplicate the same dynamic library by its
+# source, loader name, and logical identity. Its claims are cumulative: two
+# native dependencies can use disjoint imports from one DLL, and discarding the
+# later requirement must not discard the only attribution for those imports.
+# The destination keeps its order, followed by each new source claim once.
+# ---
+# alloc: allocator owning the destination claim array
+# dst:   retained requirement, updated in place
+# src:   equivalent requirement whose claims remain independently owned
+# ret:   true after the union is stored, or an allocation/count error
+pub fun merge_link_claims(alloc: *A.Allocator, dst: *LinkRequirement,
+                          src: *LinkRequirement) R.Result[bool, str] {
+    var added: u32 = 0;
+    var i: u32 = 0;
+    for (i < src.symbol_count) {
+        var present: bool = false;
+        var j: u32 = 0;
+        for (j < dst.symbol_count) {
+            if (dst.symbols[j] == src.symbols[i]) { present = true; brk; }
+            j = j + 1;
+        }
+        j = 0;
+        for (!present && j < i) {
+            if (src.symbols[j] == src.symbols[i]) { present = true; brk; }
+            j = j + 1;
+        }
+        if (!present) { added = added + 1; }
+        i = i + 1;
+    }
+    if (added == 0) { ret R.ok[bool, str](true); }
+    if (dst.symbol_count > 0xFFFFFFFF - added) {
+        ret R.err[bool, str]("too many merged link symbol claims");
+    }
+
+    val total: u32 = dst.symbol_count + added;
+    val ar: R.Result[*intern.StrId, str] =
+        A.allocate[intern.StrId](alloc, total::usize);
+    if (R.is_err[*intern.StrId, str](ar)) {
+        ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](ar));
+    }
+    val merged: *intern.StrId = R.unwrap_ok[*intern.StrId, str](ar);
+    var written: u32 = 0;
+    for (written < dst.symbol_count) {
+        merged[written] = dst.symbols[written];
+        written = written + 1;
+    }
+    i = 0;
+    for (i < src.symbol_count) {
+        var present: bool = false;
+        var j: u32 = 0;
+        for (j < written) {
+            if (merged[j] == src.symbols[i]) { present = true; brk; }
+            j = j + 1;
+        }
+        if (!present) {
+            merged[written] = src.symbols[i];
+            written = written + 1;
+        }
+        i = i + 1;
+    }
+
+    if (dst.symbols != nil && dst.symbol_count > 0) {
+        A.deallocate[intern.StrId](alloc, dst.symbols, dst.symbol_count::usize);
+    }
+    dst.symbols = merged;
+    dst.symbol_count = total;
+    ret R.ok[bool, str](true);
+}
+
 fun seg_eq(tmpl: str, start: usize, end: usize, lit: str) bool {
     val ll: usize = str_len(lit);
     if (end - start != ll) { ret false; }
@@ -2241,14 +2312,14 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     ret R.ok[BuildUnit, str](u);
 }
 
-fun requirement_in_buf(buf: *LinkRequirement, count: u32, req: *LinkRequirement) bool {
+fun requirement_index(buf: *LinkRequirement, count: u32, req: *LinkRequirement) i64 {
     var i: u32 = 0;
     for (i < count) {
         if (buf[i].source == req.source && buf[i].text == req.text
-            && buf[i].library == req.library) { ret true; }
+            && buf[i].library == req.library) { ret i::i64; }
         i = i + 1;
     }
-    ret false;
+    ret -1;
 }
 
 # resolve the `mach test` link surface (#1964): the union of every artifact's
@@ -2293,9 +2364,19 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
                         ret R.err[bool, str](R.unwrap_err[LinkRequirement, str](req_r));
                     }
                     var req: LinkRequirement = R.unwrap_ok[LinkRequirement, str](req_r);
-                    if (!requirement_in_buf(buf, w, ?req)) { buf[w] = req; w = w + 1; }
-                    # a duplicate is dropped here, so its claim copy is released
-                    or { free_link_claims(alloc, ?req, 1); }
+                    val duplicate: i64 = requirement_index(buf, w, ?req);
+                    if (duplicate < 0) { buf[w] = req; w = w + 1; }
+                    or {
+                        val mr: R.Result[bool, str] =
+                            merge_link_claims(alloc, ?buf[duplicate::u32], ?req);
+                        if (R.is_err[bool, str](mr)) {
+                            free_link_claims(alloc, ?req, 1);
+                            free_link_claims(alloc, buf, w);
+                            A.deallocate[LinkRequirement](alloc, buf, max::usize);
+                            ret R.err[bool, str](R.unwrap_err[bool, str](mr));
+                        }
+                        free_link_claims(alloc, ?req, 1);
+                    }
                 }
             }
             li = li + 1;
@@ -3656,6 +3737,57 @@ test "mach.lang.manifest.link_requirement:owns_its_claim_array" {
 
     free_link_claims(?alloc, ?req, 1);
     if (req.symbols != nil || req.symbol_count != 0) { code = 1; }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
+test "mach.lang.manifest.merge_link_claims:stable_owned_union" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val a_r: R.Result[intern.StrId, str] = intern.intern(?itn, "A");
+    val b_r: R.Result[intern.StrId, str] = intern.intern(?itn, "B");
+    val c_r: R.Result[intern.StrId, str] = intern.intern(?itn, "C");
+    if (R.is_err[intern.StrId, str](a_r) || R.is_err[intern.StrId, str](b_r)
+        || R.is_err[intern.StrId, str](c_r)) { arena.dnit(?ar); ret 1; }
+    val a: intern.StrId = R.unwrap_ok[intern.StrId, str](a_r);
+    val b: intern.StrId = R.unwrap_ok[intern.StrId, str](b_r);
+    val c: intern.StrId = R.unwrap_ok[intern.StrId, str](c_r);
+
+    val dst_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](?alloc, 2::usize);
+    val src_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](?alloc, 3::usize);
+    if (R.is_err[*intern.StrId, str](dst_r) || R.is_err[*intern.StrId, str](src_r)) {
+        arena.dnit(?ar); ret 1;
+    }
+    var dst: LinkRequirement;
+    dst.symbols = R.unwrap_ok[*intern.StrId, str](dst_r);
+    dst.symbol_count = 2;
+    dst.symbols[0] = a;
+    dst.symbols[1] = b;
+    var src: LinkRequirement;
+    src.symbols = R.unwrap_ok[*intern.StrId, str](src_r);
+    src.symbol_count = 3;
+    src.symbols[0] = b;
+    src.symbols[1] = c;
+    src.symbols[2] = c;
+    val src_symbols: *intern.StrId = src.symbols;
+
+    val merged: R.Result[bool, str] = merge_link_claims(?alloc, ?dst, ?src);
+    if (R.is_err[bool, str](merged)) { code = 1; }
+    or {
+        if (dst.symbol_count != 3 || dst.symbols[0] != a
+            || dst.symbols[1] != b || dst.symbols[2] != c) { code = 1; }
+        if (src.symbols != src_symbols || src.symbol_count != 3
+            || src.symbols[0] != b || src.symbols[1] != c
+            || src.symbols[2] != c) { code = 1; }
+
+        free_link_claims(?alloc, ?src, 1);
+        if (dst.symbol_count != 3 || dst.symbols[0] != a
+            || dst.symbols[1] != b || dst.symbols[2] != c) { code = 1; }
+    }
+    free_link_claims(?alloc, ?dst, 1);
 
     arena.dnit(?ar);
     ret code;

--- a/test/link/cases/pe-import-claim-cascade/case.conf
+++ b/test/link/cases/pe-import-claim-cascade/case.conf
@@ -1,7 +1,8 @@
-# the `export = true` cascade must carry a [link.X]'s `symbols` claims to a
-# consumer that declares no link entries of its own (#2510). the consumer's
-# requirement outlives the dependency manifest it was built from, so this is also
-# the regression guard for the claim array's ownership.
+# the `export = true` cascade must merge claims when several dependencies and the
+# consumer name the same dynamic requirement (#2975). dropping an otherwise
+# duplicate requirement must not drop the only attribution for its unattributed
+# import. each copied claim array outlives its dependency manifest, so this also
+# guards ownership while the retained consumer requirement grows.
 run: pe-imports
 legs: x86_64-linux
 target: x86_64-windows

--- a/test/link/cases/pe-import-claim-cascade/expect.x86_64-windows.txt
+++ b/test/link/cases/pe-import-claim-cascade/expect.x86_64-windows.txt
@@ -1,2 +1,5 @@
+advapi32.dll:RegCloseKey
+advapi32.dll:RegFlushKey
 kernel32.dll:ExitProcess
+kernel32.dll:GetTickCount
 kernel32.dll:Sleep

--- a/test/link/cases/pe-import-claim-cascade/mach.toml
+++ b/test/link/cases/pe-import-claim-cascade/mach.toml
@@ -7,6 +7,9 @@ out = "out/{target.name}/{profile.name}"
 [dep.prov]
 path = "provider"
 
+[dep.prov2]
+path = "provider2"
+
 [target.x86_64-windows]
 isa = "x86_64"
 os  = "windows"
@@ -27,5 +30,15 @@ kind = "bin"
 entry = "main.mach"
 out = "bin/case"
 targets = ["*"]
-link = []
+link = ["kernel32"]
 need = []
+
+[link.kernel32]
+source = "system"
+name = "kernel32.dll"
+library = "kernel32"
+symbols = ["ExitProcess"]
+os = ["windows"]
+isa = ["*"]
+abi = ["*"]
+export = false

--- a/test/link/cases/pe-import-claim-cascade/provider/src/lib.mach
+++ b/test/link/cases/pe-import-claim-cascade/provider/src/lib.mach
@@ -1,7 +1,9 @@
-# no #[library] decorator anywhere: the exported [link.kernel32] entry's `symbols`
-# claim is the only thing that can attribute this import
+# no #[library] decorator anywhere: the exported kernel32 and advapi32 entries'
+# `symbols` claims are the only thing that can attribute these imports
 ext fun Sleep(ms: u32);
+ext fun RegCloseKey(key: ptr) i32;
 
 pub fun provided() {
     Sleep(0);
+    RegCloseKey(nil);
 }

--- a/test/link/cases/pe-import-claim-cascade/provider2/mach.toml
+++ b/test/link/cases/pe-import-claim-cascade/provider2/mach.toml
@@ -1,5 +1,5 @@
 [project]
-id = "prov"
+id = "prov2"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -8,7 +8,7 @@ out = "out/{target.name}/{profile.name}"
 source = "system"
 name = "kernel32.dll"
 library = "kernel32"
-symbols = ["Sleep"]
+symbols = ["GetTickCount"]
 os = ["windows"]
 isa = ["*"]
 abi = ["*"]
@@ -18,7 +18,7 @@ export = true
 source = "system"
 name = "advapi32.dll"
 library = "advapi32"
-symbols = ["RegCloseKey"]
+symbols = ["RegFlushKey"]
 os = ["windows"]
 isa = ["*"]
 abi = ["*"]

--- a/test/link/cases/pe-import-claim-cascade/provider2/src/lib.mach
+++ b/test/link/cases/pe-import-claim-cascade/provider2/src/lib.mach
@@ -1,0 +1,9 @@
+# a second exported claim on the same requirement; it is encountered after the
+# first provider and must be merged rather than discarded with the duplicate
+ext fun GetTickCount() u32;
+ext fun RegFlushKey(key: ptr) i32;
+
+pub fun provided() {
+    GetTickCount();
+    RegFlushKey(nil);
+}

--- a/test/link/cases/pe-import-claim-cascade/src/main.mach
+++ b/test/link/cases/pe-import-claim-cascade/src/main.mach
@@ -1,13 +1,14 @@
-# the consumer declares NO link entries of its own. both the kernel32 dependency
-# and the claim attributing `Sleep` arrive through the dependency's `export = true`
-# cascade, which is the path a requirement outlives its manifest on (#2510)
+# the consumer and two dependencies each claim one import from the same kernel32
+# requirement. the cascade must union all three before either dependency manifest
+# is released (#2975)
 use prov.lib;
+use lib2: prov2.lib;
 
-#[library("kernel32")]
 ext fun ExitProcess(code: u32);
 
 #[symbol("mainCRTStartup")]
 pub fun _start() {
     lib.provided();
+    lib2.provided();
     ExitProcess(0);
 }


### PR DESCRIPTION
Closes #2975

## Summary

- union symbol claims when exact duplicate link requirements are retained
- preserve independently owned claim arrays across dependency cascade teardown
- cover root/dependency and dependency/dependency collisions in the PE linker fixture

## Verification

- `mach build . --profile debug`
- `out/linux-x86_64/debug/bin/mach test . --profile debug` (1476/1476)
- `MACH_LINK_MACH="$PWD/out/linux-x86_64/debug/bin/mach" bash test/link/run.sh --deps pin --case pe-import-claim-cascade --leg x86_64-linux` (2/2)
- Onslaughter Windows release cross-build with mach-audio v0.5.0