### PR TITLE
fix(build): preserve exact link buffer ownership

### DIFF
--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -454,23 +454,8 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
     }
 
     free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
-
-    if (w == 0) {
-        A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
-        ret R.ok[bool, str](true);
-    }
-    if (w < max) {
-        val sr: R.Result[*manifest.LinkRequirement, str] =
-            A.reallocate[manifest.LinkRequirement](p.alloc, buf, max::usize, w::usize);
-        if (R.is_ok[*manifest.LinkRequirement, str](sr)) {
-            p.config.cascade_libs      = R.unwrap_ok[*manifest.LinkRequirement, str](sr);
-            p.config.cascade_lib_count = w;
-            ret R.ok[bool, str](true);
-        }
-    }
-    p.config.cascade_libs      = buf;
-    p.config.cascade_lib_count = w;
-    ret R.ok[bool, str](true);
+    ret manifest.finish_link_requirements(p.alloc, buf, max, w,
+        ?p.config.cascade_libs, ?p.config.cascade_lib_count);
 }
 
 # post-order DFS visiting a dep's own declared deps before the dep

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1404,6 +1404,44 @@ pub fun free_link_claims(alloc: *A.Allocator, items: *LinkRequirement, count: u3
     }
 }
 
+# finish an overallocated link-requirement buffer as an exact-size owned array
+#
+# Requirement arrays are torn down by their published count, so a successful result
+# must have that exact allocation extent. A failed shrink keeps the original buffer
+# live; release its populated claims and full capacity before surfacing the error.
+# ---
+# alloc:     allocator owning the buffer and its claim arrays
+# items:     overallocated requirement buffer
+# capacity:  allocation extent of `items`
+# count:     populated prefix to retain
+# out_items: receives the exact-size array, or nil on empty/error
+# out_count: receives `count` on success, or zero on empty/error
+# ret:       true once ownership is transferred, or the shrink error after cleanup
+pub fun finish_link_requirements(alloc: *A.Allocator, items: *LinkRequirement,
+                                 capacity: u32, count: u32,
+                                 out_items: **LinkRequirement,
+                                 out_count: *u32) R.Result[bool, str] {
+    @out_items = nil;
+    @out_count = 0;
+    if (count == 0) {
+        A.deallocate[LinkRequirement](alloc, items, capacity::usize);
+        ret R.ok[bool, str](true);
+    }
+    if (count < capacity) {
+        val sr: R.Result[*LinkRequirement, str] =
+            A.reallocate[LinkRequirement](alloc, items, capacity::usize, count::usize);
+        if (R.is_err[*LinkRequirement, str](sr)) {
+            free_link_claims(alloc, items, count);
+            A.deallocate[LinkRequirement](alloc, items, capacity::usize);
+            ret R.err[bool, str](R.unwrap_err[*LinkRequirement, str](sr));
+        }
+        items = R.unwrap_ok[*LinkRequirement, str](sr);
+    }
+    @out_items = items;
+    @out_count = count;
+    ret R.ok[bool, str](true);
+}
+
 # merge `src`'s symbol claims into an equivalent retained link requirement
 #
 # Dependency and test-link overlays deduplicate the same dynamic library by its
@@ -2384,18 +2422,7 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
         ai = ai + 1;
     }
 
-    if (w == 0) { A.deallocate[LinkRequirement](alloc, buf, max::usize); ret R.ok[bool, str](true); }
-    if (w < max) {
-        val sr: R.Result[*LinkRequirement, str] = A.reallocate[LinkRequirement](alloc, buf, max::usize, w::usize);
-        if (R.is_ok[*LinkRequirement, str](sr)) {
-            @out_items = R.unwrap_ok[*LinkRequirement, str](sr);
-            @out_count = w;
-            ret R.ok[bool, str](true);
-        }
-    }
-    @out_items = buf;
-    @out_count = w;
-    ret R.ok[bool, str](true);
+    ret finish_link_requirements(alloc, buf, max, w, out_items, out_count);
 }
 
 fun artifact_err(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) str {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2303,13 +2303,27 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, rt.target)) {
                     val req_r: R.Result[LinkRequirement, str] = link_requirement(alloc, itn, found_l, proj_out, ?v);
-                    if (R.is_err[LinkRequirement, str](req_r)) { ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r)); }
+                    if (R.is_err[LinkRequirement, str](req_r)) {
+                        free_link_claims(alloc, matched_items, match_count);
+                        A.deallocate[LinkRequirement](alloc, matched_items, a.link_count::usize);
+                        ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r));
+                    }
                     matched_items[match_count] = R.unwrap_ok[LinkRequirement, str](req_r);
                     match_count = match_count + 1;
                 }
             }
             li = li + 1;
         }
+
+        var exact_items: *LinkRequirement = nil;
+        var exact_count: u32 = 0;
+        val fr: R.Result[bool, str] = finish_link_requirements(alloc, matched_items,
+            a.link_count, match_count, ?exact_items, ?exact_count);
+        if (R.is_err[bool, str](fr)) {
+            ret R.err[BuildUnit, str](R.unwrap_err[bool, str](fr));
+        }
+        matched_items = exact_items;
+        match_count = exact_count;
     }
     u.libs      = matched_items;
     u.lib_count = match_count;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2559,6 +2559,45 @@ fun tinit(backing: *A.Allocator, ar: *arena.Arena, alloc: *A.Allocator, itn: *in
     ret true;
 }
 
+# size-checking allocator probe whose one reallocation always fails
+rec LinkFinishAllocProbe {
+    backing: A.Allocator;
+    items: ptr;
+    items_size: usize;
+    claims: ptr;
+    claims_size: usize;
+    realloc_count: u32;
+    items_freed: bool;
+    claims_freed: bool;
+    mismatch: bool;
+}
+
+fun link_finish_probe_allocate(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
+    val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
+    ret p.backing.fn_allocate(p.backing.ctx, size, align);
+}
+
+fun link_finish_probe_reallocate(ctx: ptr, item: ptr, old_size: usize,
+                                 new_size: usize, align: usize) O.Option[ptr] {
+    val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
+    p.realloc_count = p.realloc_count + 1;
+    if (item != p.items || old_size != p.items_size) { p.mismatch = true; }
+    ret O.none[ptr]();
+}
+
+fun link_finish_probe_deallocate(ctx: ptr, item: ptr, size: usize, align: usize) i64 {
+    val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
+    if (item == p.items) {
+        p.items_freed = true;
+        if (size != p.items_size) { p.mismatch = true; }
+    }
+    if (item == p.claims) {
+        p.claims_freed = true;
+        if (size != p.claims_size) { p.mismatch = true; }
+    }
+    ret p.backing.fn_deallocate(p.backing.ctx, item, size, align);
+}
+
 fun tparse(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manifest, str] {
     val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
     if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
@@ -3819,6 +3858,61 @@ test "mach.lang.manifest.merge_link_claims:stable_owned_union" {
 
     arena.dnit(?ar);
     ret code;
+}
+
+# A shrink failure leaves the original allocation live. The finalizer must free
+# its populated claims and the buffer at its full capacity, then publish no result
+# (#2977). The probe rejects the shrink and records the exact sizes passed to free.
+test "mach.lang.manifest.finish_link_requirements:shrink_failure_frees_full_extent" {
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+
+    var probe: LinkFinishAllocProbe;
+    probe.backing       = backing;
+    probe.items         = nil;
+    probe.items_size    = 0;
+    probe.claims        = nil;
+    probe.claims_size   = 0;
+    probe.realloc_count = 0;
+    probe.items_freed   = false;
+    probe.claims_freed  = false;
+    probe.mismatch      = false;
+
+    var alloc: A.Allocator;
+    var probe_ptr: *LinkFinishAllocProbe = ?probe;
+    alloc.ctx           = probe_ptr::ptr;
+    alloc.fn_allocate   = link_finish_probe_allocate;
+    alloc.fn_reallocate = link_finish_probe_reallocate;
+    alloc.fn_deallocate = link_finish_probe_deallocate;
+
+    val br: R.Result[*LinkRequirement, str] = A.allocate[LinkRequirement](?alloc, 2::usize);
+    if (R.is_err[*LinkRequirement, str](br)) { ret 1; }
+    val items: *LinkRequirement = R.unwrap_ok[*LinkRequirement, str](br);
+    probe.items      = items::ptr;
+    probe.items_size = $size_of(LinkRequirement) * 2;
+
+    val cr: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](?alloc, 1::usize);
+    if (R.is_err[*intern.StrId, str](cr)) {
+        A.deallocate[LinkRequirement](?alloc, items, 2::usize);
+        ret 1;
+    }
+    items[0].symbols      = R.unwrap_ok[*intern.StrId, str](cr);
+    items[0].symbol_count = 1;
+    items[0].symbols[0]   = intern.STR_NIL;
+    probe.claims      = items[0].symbols::ptr;
+    probe.claims_size = $size_of(intern.StrId);
+
+    var out_items: *LinkRequirement = nil;
+    var out_count: u32 = 0;
+    val fr: R.Result[bool, str] =
+        finish_link_requirements(?alloc, items, 2, 1, ?out_items, ?out_count);
+
+    if (R.is_ok[bool, str](fr)) { ret 1; }
+    if (!str_equals(R.unwrap_err[bool, str](fr), "out of memory")) { ret 1; }
+    if (out_items != nil || out_count != 0) { ret 1; }
+    if (probe.realloc_count != 1 || probe.mismatch) { ret 1; }
+    if (!probe.claims_freed || !probe.items_freed) { ret 1; }
+    ret 0;
 }
 
 test "mach.lang.manifest.parse:link_filter_empty_string_error" {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2595,7 +2595,8 @@ fun link_finish_probe_reallocate(ctx: ptr, item: ptr, old_size: usize,
                                  new_size: usize, align: usize) O.Option[ptr] {
     val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
     p.realloc_count = p.realloc_count + 1;
-    if (item != p.items || old_size != p.items_size) { p.mismatch = true; }
+    if (item != p.items || old_size != p.items_size
+        || new_size != $size_of(LinkRequirement)) { p.mismatch = true; }
     ret O.none[ptr]();
 }
 
@@ -3916,8 +3917,8 @@ test "mach.lang.manifest.finish_link_requirements:shrink_failure_frees_full_exte
     probe.claims      = items[0].symbols::ptr;
     probe.claims_size = $size_of(intern.StrId);
 
-    var out_items: *LinkRequirement = nil;
-    var out_count: u32 = 0;
+    var out_items: *LinkRequirement = items;
+    var out_count: u32 = 0xFFFFFFFF;
     val fr: R.Result[bool, str] =
         finish_link_requirements(?alloc, items, 2, 1, ?out_items, ?out_count);
 


### PR DESCRIPTION
Closes #2977

## Summary

- centralize exact-size finalization for owned link-requirement buffers
- surface shrink allocation failures only after freeing nested claims and the original full extent
- apply the invariant to ordinary build-unit filtering, test-link unioning, and dependency cascades
- cover failed shrinking with a size-checking allocator probe

## Verification

- `mach build . --profile debug`
- `out/linux-x86_64/debug/bin/mach test . --profile debug` (1477/1477)
- `mach build . --profile release`
- `MACH_LINK_MACH="$PWD/out/linux-x86_64/debug/bin/mach" bash test/link/run.sh --deps pin --case pe-import-claim-cascade --leg x86_64-linux` (2/2)
- independent final diff review: no blockers