### PR TITLE
fix(lower): honor coerced character widths

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1007,6 +1007,21 @@ test "mach.lang.driver:unknown_escape_has_location" {
     ret bad;
 }
 
+# a character literal adopts the integer type supplied by its context (#2982)
+#
+# sema already rewrites the literal's expression type during coercion. lowering
+# used to ignore that result and stamp every character constant i8, leaving a
+# wider binary operation with mixed IR operand types. the outer u8 cast in the
+# reported form then selected a usize->u8 truncation for an i8 value, which the
+# always-on verifier rejected as a contradictory conversion width.
+test "mach.lang.driver:coerced_char_literal_lowers_at_context_width" {
+    var bad: i32 = 0;
+    if (!ut_lower_clean("fun f() u64 { ret '0'; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_lower_clean("fun f(v: u64) u8 { ret ('0' + v % 10)::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
+    if (!ut_lower_clean("fun f(v: u64) u8 { ret (v % 10 + '0')::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
+    ret bad;
+}
+
 # a vector op reaching instruction selection always resolves to DEFINED behavior
 # -- never an ICE, never a silent miscompile. driving real vector ops (a pointer
 # lane-wise add and a full-arity literal) through the HOST backend on each CI

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -93,7 +93,7 @@ fun lower_rvalue_kind(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr)
 
     if (k == expr.EXPR_KIND_LIT_INT)        { ret lower_lit_int(ctx, eid, e); }
     if (k == expr.EXPR_KIND_LIT_FLOAT)      { ret lower_lit_float(ctx, eid, e); }
-    if (k == expr.EXPR_KIND_LIT_CHAR)       { ret lower_lit_char(ctx, e); }
+    if (k == expr.EXPR_KIND_LIT_CHAR)       { ret lower_lit_char(ctx, eid, e); }
     if (k == expr.EXPR_KIND_LIT_STR)        { ret lower_lit_str(ctx, e); }
     if (k == expr.EXPR_KIND_LIT_NIL)        { ret lower_lit_nil(ctx, eid); }
     if (k == expr.EXPR_KIND_IDENT)          { ret lower_ident_rvalue(ctx, eid); }
@@ -243,13 +243,14 @@ fun lower_lit_float(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R
     ret R.ok[value.Value, str](value.const_float(e.data.lit_float, R.unwrap_ok[ir_type.IrTypeId, str](res_ir)));
 }
 
-# lower a character literal to an 8-bit integer constant
+# lower a character literal to a constant at the expression's IR type
 # ---
 # ctx: per-module lowering context
+# eid: the literal expression
 # e:   the resolved literal node
 # ret: the constant Value, or an error
-fun lower_lit_char(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value, str] {
-    val res_ir: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 8);
+fun lower_lit_char(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Result[value.Value, str] {
+    val res_ir: R.Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
     if (R.is_err[ir_type.IrTypeId, str](res_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ir)); }
     ret R.ok[value.Value, str](value.const_int(e.data.lit_char::u64, R.unwrap_ok[ir_type.IrTypeId, str](res_ir)));
 }


### PR DESCRIPTION
Closes #2982

## Summary

- lower character literals at the semantic type chosen by literal coercion
- cover direct, left-hand, and right-hand wider-integer contexts

## Verification

- `mach build . --profile debug`
- `out/linux-x86_64/debug/bin/mach test . --profile debug --filter coerced_char_literal_lowers_at_context_width --jobs 1` (1/1)
- `out/linux-x86_64/debug/bin/mach test . --profile debug --filter mach.lang.me.ir.verify.check_convert_width --jobs 1` (4/4)
- `out/linux-x86_64/debug/bin/mach test . --profile debug --jobs 8` (1478/1478)
- `mach build . --profile release`
- `git diff --check origin/dev...HEAD`