### PR TITLE
fix(build): select whole-source primary by target

### DIFF
--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -99,6 +99,12 @@ fwd impl.page_size;
 
 ## Entrypoint and output
 
+An artifact's `out` is literal across every target it names. A cross-platform
+executable therefore uses disjoint artifacts for extension conventions:
+`out = "bin/app"` for non-Windows targets and `out = "bin/app.exe"` for Windows.
+`mach init` emits that split for binary projects. Do not use one `targets = ["*"]`
+artifact when its output must be directly executable on Windows and elsewhere.
+
 The stdlib provides the platform `_start`, which calls whatever function
 exports the linker symbol `main`. `use std.runtime;` is required to link it in
 even though nothing references it by name:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Target-split executables select the right artifact on every host (#2955, #2961, #2981)
+
+Whole-source builds no longer make the first artifact declaration load-bearing.
+The manifest layer now owns primary selection for both current and legacy driver
+paths and chooses the first artifact that declares the resolved target, while an
+explicit artifact remains authoritative and retains the existing incompatibility
+diagnostic. A single-product command such as `mach run` also infers an unnamed
+artifact when exactly one declares the target; multiple runnable artifacts remain
+an ambiguity rather than an order-dependent guess.
+
+`mach init` now demonstrates the extension contract it documents. Binary scaffolds
+use disjoint non-Windows and Windows artifacts, producing `bin/<name>` and
+`bin/<name>.exe` respectively, while library scaffolds keep one all-target artifact.
+mach's own manifest uses the same split, so `mach build .` on Windows produces
+`bin/mach.exe` without an output override and `mach test .` needs no artifact flag.
+
 ## [4.18.3] - 2026-08-10
 
 ### Fixed

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -284,10 +284,12 @@ mach run <path> [options] [-- args...]
 
 Executes the binary `mach build` already produced for `<path>` — a post-build
 convenience, **not** a rebuild. The same selection flags (`--target`, `--profile`,
-`--bin`) that narrow a build resolve which artifact to run; its path is read from
-the artifact's `out` template and the existing file is exec'd. When the artifact
-does not exist yet, `mach run` errors and points at `mach build` rather than
-building it.
+`--bin`) that narrow a build resolve which artifact to run. With no artifact flag,
+one is inferred when exactly one artifact declares the resolved target; several
+matching artifacts remain an error that asks for `--bin`/`--lib`. Its path is read
+from the artifact's `out` template and the existing file is exec'd. When the
+artifact does not exist yet, `mach run` errors and points at `mach build` rather
+than building it.
 Arguments after a `--` separator are forwarded to the child as its `argv`. The
 child's exit code becomes this command's exit code.
 
@@ -517,7 +519,8 @@ mach init [dir] [options]
 
 Scaffolds a new project in `[dir]` (default: the current directory). Writes a
 complete `mach.toml` with a `[project]` block, `[target.*]` platforms for
-`linux`/`windows`/`darwin` (on the host ISA), one `[artifact.<id>]`,
+`linux`/`windows`/`darwin` (on the host ISA), extension-correct binary artifacts
+(or one library artifact),
 `[profile.debug]`/`[profile.release]` variants, a `[dep.mach-std]` dependency, a
 starter source file, and `dep/mach-std/` cloned from the declared ref (through
 the same path as `mach dep pull`). Refuses to overwrite an existing `mach.toml`,
@@ -528,7 +531,7 @@ before any file is written, so a refused init leaves nothing behind.
 |----------------|-------|--------|
 | `--name <name>`| name  | project id (default: the directory base name) |
 | `--force`      | —     | scaffold even when `mach.toml`, `src/main.mach`, or `src/lib.mach` already exists |
-| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold a `static` `[artifact.<id>]` instead of a `bin` one |
+| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold one `static` `[artifact.<id>]` instead of the target-split binary artifacts |
 
 The first non-flag argument after `init` is the target directory.
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -756,9 +756,9 @@ A build cell is one artifact × one target × one profile.
   you to pick one, naming every candidate.
 - `mach test <path>` selects the first artifact that declares the resolved target as
   its primary context. It links the union of all artifacts' referenced entries plus
-  exported dependency entries, filtered to the native target (tests run on native
-  hardware only). If two artifacts' objects collide on symbols in that union, that is
-  an honest link error — restructure the entries.
+  exported dependency entries, filtered to that target. Foreign-target tests require
+  a compatible `--runner`. If two artifacts' objects collide on symbols in that union,
+  that is an honest link error — restructure the entries.
 
 ### Enumerated cells are filtered; named ones are not
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -412,18 +412,16 @@ The artifact **name** differs between the two, so `$bin.name` differs by platfor
 project that reads it sees `app` everywhere and `app-windows` on Windows. Nothing in
 mach's own source reads it, and a project that does needs to expect both.
 
-`mach build` is unaffected by the split: it enumerates artifact-by-target cells and
-builds only the ones that match, so each platform gets its stanza with nothing named on
-the command line. `mach test` is not, today. It links the whole source tree rather than
-one artifact, so it takes the **first declared** artifact as the root of its build, and
-on a host that stanza does not declare it refuses rather than reaching for the other
-one. Until #2961 is fixed, a test run on the platform whose stanza is declared second
-has to name it, as in `mach test . --bin app-windows`.
+`mach build` enumerates artifact-by-target cells and builds only the ones that match,
+so each platform gets its stanza with nothing named on the command line. `mach test`
+links the whole source tree rather than one artifact, but selects its primary context
+from the first artifact that declares the resolved target, so the same split works
+there. `mach run` selects the target's artifact when exactly one matches; if several
+artifacts can run on that target, it still asks for `--bin` rather than guessing.
 
-mach's own `mach.toml` is NOT split yet, deliberately. Splitting it is what found
-#2961, and the repository is not going to ship a shape its own `mach test` cannot run
-on Windows, or the command-line flags that would hide that. It follows once the
-selection is fixed.
+mach's own `mach.toml` is split this way: an ordinary Windows build produces
+`bin/mach.exe`, and its test run selects `mach-windows` as the primary context without
+a command-line workaround.
 
 ### `subsystem` — the windows console/GUI selector
 
@@ -746,12 +744,14 @@ A build cell is one artifact × one target × one profile.
   with every target in its `targets`. `--bin <name>` / `--lib <name>` narrow to one
   artifact; `--target <name>` selects a declared target; `--profile <name>` selects
   a profile.
-- `mach run <path>` and `mach test <path>` build exactly one artifact; with several
-  declared and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
-- `mach test` links the union of all artifacts' referenced entries plus exported
-  dependency entries, filtered to the native target (tests run on native hardware
-  only). If two artifacts' objects collide on symbols in that union, that is an
-  honest link error — restructure the entries.
+- `mach run <path>` consumes exactly one artifact. With no `--bin`/`--lib`, it selects
+  one when exactly one artifact declares the resolved target; if several do, it asks
+  you to pick one, naming every candidate.
+- `mach test <path>` selects the first artifact that declares the resolved target as
+  its primary context. It links the union of all artifacts' referenced entries plus
+  exported dependency entries, filtered to the native target (tests run on native
+  hardware only). If two artifacts' objects collide on symbols in that union, that is
+  an honest link error — restructure the entries.
 
 ### Enumerated cells are filtered; named ones are not
 

--- a/mach.toml
+++ b/mach.toml
@@ -48,7 +48,15 @@ simd = "scalarize"
 kind = "bin"
 entry = "bin/main.mach"
 out = "bin/mach"
-targets = ["*"]
+targets = ["linux-x86_64", "linux-arm64", "linux-riscv64", "darwin-x86_64", "darwin-aarch64"]
+link = []
+need = []
+
+[artifact.mach-windows]
+kind = "bin"
+entry = "bin/main.mach"
+out = "bin/mach.exe"
+targets = ["windows-x86_64"]
 link = []
 need = []
 

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -3,9 +3,9 @@
 # Writes a complete `mach.toml` (a `[project]` block with explicit src/dep dirs
 # and output templates, `[target.*]` platforms for linux/windows/darwin on the
 # host isa - each target's abi derived from the os's self-declared native
-# convention, and any os with no composable tuple on the host skipped - one
-# `[artifact.*]` artifact, debug/release profiles, and a `[dep.mach-std]`
-# dependency) plus a starter source module. For a binary the
+# convention, and any os with no composable tuple on the host skipped - an
+# artifact surface split by executable-extension convention, debug/release
+# profiles, and a `[dep.mach-std]` dependency) plus a starter source module. For a binary the
 # generated `src/main.mach` is a standard-library hello world; a library gets a
 # bare `src/lib.mach` root. The command then syncs `mach-std` into `dep/mach-std`
 # through the same machinery as `mach dep pull`, so a fresh scaffold builds
@@ -211,8 +211,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 # Emits a `[project]` block (id, version, src/dep dirs, output-path templates,
 # and `module` for a library), `[target.<os>-<isa>]` blocks for linux/windows/darwin
 # on the host isa (each abi derived from the os's native convention, uncomposable
-# oses skipped), one `[artifact.<id>]` (`kind = "bin"` or a library kind), debug/release
-# profiles, and the `[dep.mach-std]` dependency.
+# oses skipped), target-split binary artifacts (or one library artifact),
+# debug/release profiles, and the `[dep.mach-std]` dependency.
 # ---
 # path:   destination path for the manifest
 # id:     project id (already validated)
@@ -242,29 +242,9 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     # the scaffold cannot be written.
     var reg: target.TargetRegistry = target.registry_init();
     if (R.is_err[bool, str](target.register_all(?reg))) { ret false; }
-    emit_targets(?buf, ?reg, target.host_arch_id());
-
-    buf_put(?buf, "[artifact.");
-    buf_put(?buf, id);
-    buf_put(?buf, "]\n");
-    if (is_lib) {
-        buf_put(?buf, "kind = \"static\"\n");
-        buf_put(?buf, "entry = \"lib.mach\"\n");
-        buf_put(?buf, "out = \"lib/");
-        buf_put(?buf, id);
-        buf_put(?buf, "\"\n");
-    }
-    or {
-        buf_put(?buf, "kind = \"bin\"\n");
-        buf_put(?buf, "entry = \"main.mach\"\n");
-        buf_put(?buf, "out = \"bin/");
-        buf_put(?buf, id);
-        buf_put(?buf, "\"\n");
-    }
-    buf_put(?buf, "targets = [\"*\"]\n");
-    buf_put(?buf, "link = []\n");
-    buf_put(?buf, "need = []\n");
-    buf_put(?buf, "\n");
+    val arch_id: u32 = target.host_arch_id();
+    emit_targets(?buf, ?reg, arch_id);
+    emit_artifacts(?buf, ?reg, arch_id, id, is_lib);
 
     buf_put(?buf, "[profile.debug]\n");
     buf_put(?buf, "opt = 0\n");
@@ -288,6 +268,65 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     if (!buf.ok) { ret false; }
     val res_write: O.Option[str] = fs.write_bytes(path, ?storage[0], buf.len, FILE_MODE);
     ret !O.is_some[str](res_write);
+}
+
+# emit the scaffold's artifact surface
+#
+# Libraries keep one all-target artifact. A binary with a composable Windows
+# target gets disjoint artifacts because `out` is literal: non-Windows targets
+# produce `bin/<id>` and Windows produces `bin/<id>.exe` (#2981).
+fun emit_artifacts(b: *Buf, reg: *target.TargetRegistry, arch_id: u32,
+                   id: *u8, is_lib: bool) {
+    if (is_lib) {
+        buf_put(b, "[artifact.");
+        buf_put(b, id);
+        buf_put(b, "]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/");
+        buf_put(b, id);
+        buf_put(b, "\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n");
+        ret;
+    }
+
+    emit_binary_artifact(b, reg, arch_id, id, false);
+    if (!str_empty(scaffold_abi(reg, "windows", arch_id))) {
+        emit_binary_artifact(b, reg, arch_id, id, true);
+    }
+}
+
+# emit one side of a binary scaffold's extension split
+fun emit_binary_artifact(b: *Buf, reg: *target.TargetRegistry, arch_id: u32,
+                         id: *u8, windows: bool) {
+    buf_put(b, "[artifact.");
+    buf_put(b, id);
+    if (windows) { buf_put(b, "-windows"); }
+    buf_put(b, "]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/");
+    buf_put(b, id);
+    if (windows) { buf_put(b, ".exe"); }
+    buf_put(b, "\"\ntargets = [");
+    emit_artifact_targets(b, reg, arch_id, windows);
+    buf_put(b, "]\nlink = []\nneed = []\n\n");
+}
+
+# emit the target-name strings for one side of the extension split
+fun emit_artifact_targets(b: *Buf, reg: *target.TargetRegistry,
+                          arch_id: u32, windows: bool) {
+    var wrote: bool = false;
+    emit_artifact_target(b, reg, "linux", arch_id, windows, ?wrote);
+    emit_artifact_target(b, reg, "windows", arch_id, windows, ?wrote);
+    emit_artifact_target(b, reg, "darwin", arch_id, windows, ?wrote);
+}
+
+# append one supported target name when it belongs to the requested split side
+fun emit_artifact_target(b: *Buf, reg: *target.TargetRegistry, os_name: *u8,
+                         arch_id: u32, windows: bool, wrote: *bool) {
+    val is_windows: bool = str_equals(os_name::str, "windows");
+    if (is_windows != windows || str_empty(scaffold_abi(reg, os_name::str, arch_id))) { ret; }
+    if (@wrote) { buf_put(b, ", "); }
+    buf_put(b, "\"");
+    buf_put(b, os_name);
+    buf_put(b, "-");
+    buf_put(b, isa.arch_name_for(arch_id)::*u8);
+    buf_put(b, "\"");
+    @wrote = true;
 }
 
 # write a null-terminated source template to `path`
@@ -456,6 +495,32 @@ fun scaffold_abi(reg: *target.TargetRegistry, os_name: str, arch_id: u32) str {
     if (str_empty(abi_name)) { ret ""; }
     if (R.is_err[target.Target, str](target.select(reg, isa.arch_name_for(arch_id), os_name, abi_name))) { ret ""; }
     ret abi_name;
+}
+
+# a binary scaffold writes extension-correct artifacts on x86_64, while a
+# library remains one all-target artifact
+test "mach.cli.cmd.init.emit_artifacts:extension_split" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+
+    var bin_storage: [1024]u8;
+    var bin: Buf;
+    bin.ptr = ?bin_storage[0]; bin.cap = 1024; bin.len = 0; bin.ok = true;
+    emit_artifacts(?bin, ?reg, isa.ARCH_X86_64, "demo", false);
+    if (!bin.ok || bin.len >= bin.cap) { ret 1; }
+    bin.ptr[bin.len] = 0;
+    val want_bin: str = "[artifact.demo]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/demo\"\ntargets = [\"linux-x86_64\", \"darwin-x86_64\"]\nlink = []\nneed = []\n\n[artifact.demo-windows]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/demo.exe\"\ntargets = [\"windows-x86_64\"]\nlink = []\nneed = []\n\n";
+    if (!str_equals(bin.ptr::str, want_bin)) { ret 1; }
+
+    var lib_storage: [512]u8;
+    var lib: Buf;
+    lib.ptr = ?lib_storage[0]; lib.cap = 512; lib.len = 0; lib.ok = true;
+    emit_artifacts(?lib, ?reg, isa.ARCH_X86_64, "demo", true);
+    if (!lib.ok || lib.len >= lib.cap) { ret 1; }
+    lib.ptr[lib.len] = 0;
+    val want_lib: str = "[artifact.demo]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/demo\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n";
+    if (!str_equals(lib.ptr::str, want_lib)) { ret 1; }
+    ret 0;
 }
 
 # on an x86_64 host the derived conventions reproduce today's scaffold exactly:

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -315,7 +315,8 @@ pub fun release(r: *BuildRequest) bool {
 # binding it to one build unit here would be a category error (#2474). The
 # planner resolves each cell and raises selection errors with the same text.
 # For a test goal with no named artifact, a multi-artifact manifest settles on
-# the first declared artifact (the whole-source test build links them all).
+# the first artifact that declares the resolved target (the whole-source test
+# build still links them all).
 # ---
 # a:    allocator backing the request's link-input vectors and the transient
 #       profile resolution
@@ -334,18 +335,16 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
     r.all_targets  = cli.all_targets;
     r.goal         = goal;
 
-    # a whole-source test build of a multi-artifact manifest is not the
-    # ambiguity a plain build raises: it settles on the first declared
-    # artifact as the primary, mirroring the driver's own test-load rule.
+    # a whole-source test build of a multi-artifact manifest is not the ambiguity
+    # a plain build raises. the manifest owns which compatible artifact supplies
+    # its primary context, shared with the legacy/tooling driver path (#2961).
     var esel: manifest.Selection = @sel;
-    if (test_goal(goal) && !esel.has_artifact && m.artifact_count > 1) {
-        val an_opt: O.Option[str] = intern.lookup(itn, m.artifacts[0].name);
-        if (O.is_none[str](an_opt)) {
-            ret R.err[BuildRequest, outcome.Fail](outcome.internal("primary artifact name not interned"));
+    if (test_goal(goal)) {
+        val psr: R.Result[bool, str] = manifest.select_primary_artifact(a, itn, m, ?esel);
+        if (R.is_err[bool, str](psr)) {
+            ret R.err[BuildRequest, outcome.Fail](
+                outcome.internal(R.unwrap_err[bool, str](psr)));
         }
-        esel.artifact     = O.unwrap[str](an_opt);
-        esel.want_lib     = m.artifacts[0].is_lib;
-        esel.has_artifact = true;
     }
     r.target   = esel.target;
     r.profile  = esel.profile;

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -64,7 +64,8 @@ use mach.lang.driver.union;
 # rebuilding. Only the manifest is read: no module graph is loaded and no
 # dependencies are resolved. The transient toml table, interner, and manifest are
 # all suballocated from `alloc` and reclaimed when it is (pass an arena); the
-# returned path is owned by `alloc`.
+# returned path is owned by `alloc`. With no artifact selector, exactly one
+# artifact declaring the resolved target is inferred; several remain ambiguous.
 # ---
 # alloc:        allocator for the transient manifest state and the returned path
 # project_root: the resolved project root directory
@@ -84,7 +85,15 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *mani
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
-    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(alloc, ?itn, ?m, @sel);
+    var eff_sel: manifest.Selection = @sel;
+    val ssr: R.Result[bool, str] = manifest.select_sole_target_artifact(
+        alloc, ?itn, ?m, ?eff_sel);
+    if (R.is_err[bool, str](ssr)) {
+        manifest.dnit(?m, alloc);
+        ret R.err[str, str](R.unwrap_err[bool, str](ssr));
+    }
+
+    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(alloc, ?itn, ?m, eff_sel);
     if (R.is_err[manifest.BuildUnit, str](ur)) {
         manifest.dnit(?m, alloc);
         ret R.err[str, str](R.unwrap_err[manifest.BuildUnit, str](ur));

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -156,26 +156,21 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);
 
-    # the primary selection drives the ctx every module resolves under. union mode
-    # (#1505): several declared artifacts with no selector is NOT the ambiguity
-    # `build_project_sel` raises - the union takes the first declared artifact as the
-    # primary (mirroring resolve_native's first-declared-target fallback) and unions
-    # the rest's entries below. a single-artifact or selected build is untouched.
+    # the primary selection drives the ctx every module resolves under. a union or
+    # test build spans artifacts, so the manifest picks one that declares the target
+    # while the rest's entries and link surface are still unioned below (#2961).
     var eff_sel: manifest.Selection;
     eff_sel.target       = sel.target;
     eff_sel.profile      = sel.profile;
     eff_sel.artifact     = sel.artifact;
     eff_sel.want_lib     = sel.want_lib;
     eff_sel.has_artifact = sel.has_artifact;
-    # `mach test` (is_test) links the whole source tree, not one artifact, so like a
-    # union build it takes the first declared artifact as the primary ctx rather than
-    # raising the multi-artifact ambiguity `build_project_sel` would.
-    if ((for_union || is_test) && !eff_sel.has_artifact && m.artifact_count > 1) {
-        val an_opt: O.Option[str] = intern.lookup(?p.s.interner, m.artifacts[0].name);
-        if (O.is_none[str](an_opt)) { ret R.err[bool, str]("internal: union primary artifact name not interned"); }
-        eff_sel.artifact     = O.unwrap[str](an_opt);
-        eff_sel.want_lib     = m.artifacts[0].is_lib;
-        eff_sel.has_artifact = true;
+    if (for_union || is_test) {
+        val psr: R.Result[bool, str] = manifest.select_primary_artifact(
+            p.alloc, ?p.s.interner, m, ?eff_sel);
+        if (R.is_err[bool, str](psr)) {
+            ret R.err[bool, str](R.unwrap_err[bool, str](psr));
+        }
     }
 
     val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(p.alloc, ?p.s.interner, m, eff_sel);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -138,6 +138,11 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
+# a cross-platform executable split by output-extension convention (#2961)
+fun ut_manifest_split() str {
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"linux\"]\nlink = []\nneed = []\n\n[artifact.uniontest-windows]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest.exe\"\ntargets = [\"windows\"]\nlink = []\nneed = []\n";
+}
+
 # a manifest with a windows-only `local` link entry whose path is neither step-backed
 # nor present on disk, for the #1988 cross-target validation-skip test. building for
 # linux must ignore the entry (it filters out), not validate its linux-cell expansion
@@ -3517,6 +3522,62 @@ test "mach.lang.driver:resolve_artifact_path" {
     if (R.is_ok[str, str](pr_bad)) { bad = 1; }
 
     fs.remove_all(?alloc, root);
+
+    # a split manifest has one runnable artifact for each target, so `mach run`
+    # resolves the Windows `.exe` without making the artifact name redundant
+    val split_root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_split(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](split_root_r)) { ret 1; }
+    val split_root: str = R.unwrap_ok[str, str](split_root_r);
+    var split_sel: manifest.Selection;
+    split_sel.target = "windows"; split_sel.profile = ""; split_sel.artifact = "";
+    split_sel.want_lib = false; split_sel.has_artifact = false;
+    val split_pr: R.Result[str, str] = dcfg.resolve_artifact_path(
+        ?alloc, split_root, ?split_sel);
+    if (R.is_err[str, str](split_pr)) { bad = 1; }
+    or {
+        val want_split: str = ut_cc3(
+            ?alloc, split_root, "/", "out/windows/debug/bin/uniontest.exe");
+        if (!str_equals(R.unwrap_ok[str, str](split_pr), want_split)) { bad = 1; }
+    }
+    fs.remove_all(?alloc, split_root);
+    ret bad;
+}
+
+# the legacy/tooling whole-source loader shares the manifest's primary rule: a
+# Windows test over a split manifest roots its context in the Windows artifact
+test "mach.lang.driver:test_primary_artifact_matches_target" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "fun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_split(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var sel: manifest.Selection;
+    sel.target = "windows"; sel.profile = ""; sel.artifact = "";
+    sel.want_lib = false; sel.has_artifact = false;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        driver.build_project_test(?s, root, ?sel);
+    fs.remove_all(?alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val name_opt: O.Option[str] = intern.lookup(?s.interner, p.config.bin_name);
+    if (O.is_none[str](name_opt)
+        || !str_equals(O.unwrap[str](name_opt), "uniontest-windows")) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
     ret bad;
 }
 

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2451,8 +2451,8 @@ fun requirement_index(buf: *LinkRequirement, count: u32, req: *LinkRequirement) 
 }
 
 # resolve the `mach test` link surface (#1964): the union of every artifact's
-# referenced link entries whose filters match target `t` (the native target for a
-# test build), deduplicated, each retained as a typed link requirement. exported dep entries
+# referenced link entries whose filters match resolved target `t`, deduplicated,
+# each retained as a typed link requirement. exported dep entries
 # are added separately by the driver's cascade pass. on success `out_items` and
 # `out_count` receive the union (nil/0 when empty).
 pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, t: *TargetDef,

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2174,6 +2174,46 @@ pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
     ret R.ok[bool, str](artifact_supports_target(itn, a, rt.target.name));
 }
 
+# select the artifact that supplies a whole-source build's primary context
+#
+# A union or test build spans artifacts but still resolves every module under one
+# artifact context. With no explicit selector, choose the first artifact that
+# declares the resolved target. Falling back to the first declaration when none
+# does preserves `resolve_build_unit`'s existing incompatible-target diagnostic.
+# ---
+# alloc: allocator for target resolution
+# itn:   interner the manifest was parsed into
+# m:     parsed manifest
+# sel:   selection to fill when it has no artifact and the manifest has several
+# ret:   ok(true), or an internal interner error
+pub fun select_primary_artifact(alloc: *A.Allocator, itn: *intern.Interner,
+                                m: *Manifest, sel: *Selection) R.Result[bool, str] {
+    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok[bool, str](true); }
+
+    var primary: *ArtifactDef = ?m.artifacts[0];
+    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
+    if (R.is_ok[ResolvedTarget, str](tr)) {
+        val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
+        var i: u32 = 0;
+        for (i < m.artifact_count) {
+            if (artifact_supports_target(itn, ?m.artifacts[i], rt.target.name)) {
+                primary = ?m.artifacts[i];
+                brk;
+            }
+            i = i + 1;
+        }
+    }
+
+    val name_opt: O.Option[str] = intern.lookup(itn, primary.name);
+    if (O.is_none[str](name_opt)) {
+        ret R.err[bool, str]("primary artifact name not interned");
+    }
+    sel.artifact     = O.unwrap[str](name_opt);
+    sel.want_lib     = primary.is_lib;
+    sel.has_artifact = true;
+    ret R.ok[bool, str](true);
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     # a selection with no `--target` lets its artifact pin the target. resolving
     # the artifact twice keeps the resolution order (and so the diagnostic a
@@ -3852,6 +3892,50 @@ test "mach.lang.manifest.resolve_build_unit:artifact_target_filter" {
 
         val uw: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
         if (R.is_ok[BuildUnit, str](uw) || !str_contains(R.unwrap_err[BuildUnit, str](uw), "does not support target")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# a whole-source build roots its context in an artifact that declares the selected
+# target, so splitting a cross-platform executable for Windows does not make
+# declaration order load-bearing (#2961)
+test "mach.lang.manifest.select_primary_artifact:first_target_compatible" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"linux\"]\nlink=[]\nneed=[]\n[artifact.app-windows]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app.exe\"\ntargets=[\"windows\"]\nlink=[]\nneed=[]\n";
+    val mr: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](mr);
+
+        var windows: Selection = mk_sel("windows", "", "", false, false);
+        val wr: R.Result[bool, str] = select_primary_artifact(?alloc, ?itn, ?m, ?windows);
+        if (R.is_err[bool, str](wr) || !windows.has_artifact
+            || !str_equals(windows.artifact, "app-windows")) { code = 1; }
+        or {
+            val wu: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, windows);
+            if (R.is_err[BuildUnit, str](wu)) { code = 1; }
+            or {
+                val unit: BuildUnit = R.unwrap_ok[BuildUnit, str](wu);
+                if (!str_equals(idstr(?itn, unit.bin_path), "out/bin/app.exe")) { code = 1; }
+            }
+        }
+
+        var linux: Selection = mk_sel("linux", "", "", false, false);
+        val lr: R.Result[bool, str] = select_primary_artifact(?alloc, ?itn, ?m, ?linux);
+        if (R.is_err[bool, str](lr) || !linux.has_artifact
+            || !str_equals(linux.artifact, "app")) { code = 1; }
+
+        # an explicit selector remains authoritative, including when it names an
+        # incompatible cell whose diagnostic resolve_build_unit owns
+        var explicit: Selection = mk_sel("windows", "", "app", false, true);
+        val er: R.Result[bool, str] = select_primary_artifact(?alloc, ?itn, ?m, ?explicit);
+        val eu: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, explicit);
+        if (R.is_err[bool, str](er) || !str_equals(explicit.artifact, "app")
+            || R.is_ok[BuildUnit, str](eu)) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2174,6 +2174,39 @@ pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
     ret R.ok[bool, str](artifact_supports_target(itn, a, rt.target.name));
 }
 
+# find the first artifact that declares the selection's resolved target
+fun first_target_artifact(alloc: *A.Allocator, itn: *intern.Interner,
+                          m: *Manifest, sel: *Selection, count: *u32) *ArtifactDef {
+    @count = 0;
+    var first: *ArtifactDef = nil;
+    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
+    if (R.is_err[ResolvedTarget, str](tr)) { ret nil; }
+    val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
+
+    var i: u32 = 0;
+    for (i < m.artifact_count) {
+        if (artifact_supports_target(itn, ?m.artifacts[i], rt.target.name)) {
+            if (first == nil) { first = ?m.artifacts[i]; }
+            @count = @count + 1;
+        }
+        i = i + 1;
+    }
+    ret first;
+}
+
+# store one resolved artifact as an explicit selection
+fun set_selected_artifact(itn: *intern.Interner, a: *ArtifactDef,
+                          sel: *Selection) R.Result[bool, str] {
+    val name_opt: O.Option[str] = intern.lookup(itn, a.name);
+    if (O.is_none[str](name_opt)) {
+        ret R.err[bool, str]("selected artifact name not interned");
+    }
+    sel.artifact     = O.unwrap[str](name_opt);
+    sel.want_lib     = a.is_lib;
+    sel.has_artifact = true;
+    ret R.ok[bool, str](true);
+}
+
 # select the artifact that supplies a whole-source build's primary context
 #
 # A union or test build spans artifacts but still resolves every module under one
@@ -2190,28 +2223,31 @@ pub fun select_primary_artifact(alloc: *A.Allocator, itn: *intern.Interner,
                                 m: *Manifest, sel: *Selection) R.Result[bool, str] {
     if (sel.has_artifact || m.artifact_count < 2) { ret R.ok[bool, str](true); }
 
-    var primary: *ArtifactDef = ?m.artifacts[0];
-    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
-    if (R.is_ok[ResolvedTarget, str](tr)) {
-        val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
-        var i: u32 = 0;
-        for (i < m.artifact_count) {
-            if (artifact_supports_target(itn, ?m.artifacts[i], rt.target.name)) {
-                primary = ?m.artifacts[i];
-                brk;
-            }
-            i = i + 1;
-        }
-    }
+    var count: u32 = 0;
+    var primary: *ArtifactDef = first_target_artifact(alloc, itn, m, sel, ?count);
+    if (primary == nil) { primary = ?m.artifacts[0]; }
+    ret set_selected_artifact(itn, primary, sel);
+}
 
-    val name_opt: O.Option[str] = intern.lookup(itn, primary.name);
-    if (O.is_none[str](name_opt)) {
-        ret R.err[bool, str]("primary artifact name not interned");
-    }
-    sel.artifact     = O.unwrap[str](name_opt);
-    sel.want_lib     = primary.is_lib;
-    sel.has_artifact = true;
-    ret R.ok[bool, str](true);
+# select an unnamed artifact when exactly one declares the resolved target
+#
+# Used by commands such as `mach run` that consume one build product. A
+# target-split cross-platform executable resolves without a redundant `--bin`,
+# while several runnable artifacts retain the existing ambiguity diagnostic.
+# ---
+# alloc: allocator for target resolution
+# itn:   interner the manifest was parsed into
+# m:     parsed manifest
+# sel:   selection to fill only when its resolved target has one artifact
+# ret:   ok(true), or an internal interner error
+pub fun select_sole_target_artifact(alloc: *A.Allocator, itn: *intern.Interner,
+                                    m: *Manifest, sel: *Selection) R.Result[bool, str] {
+    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok[bool, str](true); }
+
+    var count: u32 = 0;
+    val sole: *ArtifactDef = first_target_artifact(alloc, itn, m, sel, ?count);
+    if (sole == nil || count != 1) { ret R.ok[bool, str](true); }
+    ret set_selected_artifact(itn, sole, sel);
 }
 
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
@@ -3929,6 +3965,14 @@ test "mach.lang.manifest.select_primary_artifact:first_target_compatible" {
         if (R.is_err[bool, str](lr) || !linux.has_artifact
             || !str_equals(linux.artifact, "app")) { code = 1; }
 
+        # a single-product consumer reaches the same windows artifact without an
+        # explicit selector when it is the sole artifact for that target
+        var runnable: Selection = mk_sel("windows", "", "", false, false);
+        val rr: R.Result[bool, str] = select_sole_target_artifact(
+            ?alloc, ?itn, ?m, ?runnable);
+        if (R.is_err[bool, str](rr) || !runnable.has_artifact
+            || !str_equals(runnable.artifact, "app-windows")) { code = 1; }
+
         # an explicit selector remains authoritative, including when it names an
         # incompatible cell whose diagnostic resolve_build_unit owns
         var explicit: Selection = mk_sel("windows", "", "app", false, true);
@@ -3936,6 +3980,20 @@ test "mach.lang.manifest.select_primary_artifact:first_target_compatible" {
         val eu: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, explicit);
         if (R.is_err[bool, str](er) || !str_equals(explicit.artifact, "app")
             || R.is_ok[BuildUnit, str](eu)) { code = 1; }
+    }
+
+    # two compatible artifacts remain ambiguous for a single-product consumer;
+    # declaration order is a primary-context tie-breaker, not a `mach run` choice
+    val ambiguous_src: str = sfmt(?alloc, "{}{}", src,
+        "[artifact.tool-windows]\nkind=\"bin\"\nentry=\"tool.mach\"\nout=\"bin/tool.exe\"\ntargets=[\"windows\"]\nlink=[]\nneed=[]\n");
+    val amr: R.Result[Manifest, str] = tparse(?alloc, ?itn, ambiguous_src);
+    if (R.is_err[Manifest, str](amr)) { code = 1; }
+    or {
+        var am: Manifest = R.unwrap_ok[Manifest, str](amr);
+        var ambiguous: Selection = mk_sel("windows", "", "", false, false);
+        val ar_: R.Result[bool, str] = select_sole_target_artifact(
+            ?alloc, ?itn, ?am, ?ambiguous);
+        if (R.is_err[bool, str](ar_) || ambiguous.has_artifact) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;


### PR DESCRIPTION
## Summary

- centralize union/test primary-artifact selection in the manifest layer and choose the first artifact that declares the resolved target
- infer an unnamed `mach run` artifact only when exactly one artifact supports the target
- make `mach init` emit disjoint Windows/non-Windows binary artifacts (`.exe` on Windows)
- split the repository manifest and update docs, changelog, and repository skill parity

## Verification

- merged `origin/dev` at `f51b5d68` (including #2967) and reached byte-identical three-generation fixpoints in debug and release
- focused manifest, driver, run-path, and init-template regressions: 4 passed
- full in-source suite: 1480 passed, 0 failed
- Windows-target test collection succeeds without `--bin`: 1480 tests
- repository Windows release build emits `bin/mach.exe` and no extensionless `bin/mach`
- fresh `mach init demo` emits split target stanzas, cross-builds only `demo.exe`, and `mach run demo --target windows-x86_64 --runner true` resolves it without `--bin`
- CI: all required build, release, incremental, test, link, and target-matrix jobs passed (Darwin release gate skipped by workflow policy)

Closes #2961
Closes #2955
Closes #2981