### PR TITLE
fix(driver): root builds at artifact reachability

### DIFF
--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -50,6 +50,12 @@ resolves only when that project declares a `[project] module` surface file
 (e.g. a library `glfw` imported as `use glfw;`); `std` does not - always
 import full `std.*` paths.
 
+An artifact build roots its module graph at `[artifact.*].entry` and compiles only
+that module plus its active transitive `use`/`fwd` dependencies. A sibling source
+file is not part of the build cell merely because it is under `[project].src`, so
+one project may hold artifacts for disjoint targets. `mach test` deliberately roots
+at every own-source module so it can collect otherwise-unreferenced tests.
+
 A file reads top-down: module docstring, `use`/`fwd` lines, declarations.
 
 ### `use` - private import

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -84,11 +84,14 @@ mach build <path> [options]
 Compiles the project named by `<path>` — a project directory containing a
 `mach.toml` (e.g. `mach build .`).
 With no `--bin`/`--lib`, it builds every declared artifact for the selected target
-and profile. Every reachable module is driven through sema → lower → optimise →
-codegen to one relocatable object, written under the resolved object tree at
+and profile. Each artifact's module graph is rooted at its `entry`; only that module
+and its transitive `use`/`fwd` dependencies belong to the build cell. Other files
+under `src` may back artifacts for different targets and are not compiled for this
+cell. Every reachable module is driven through sema → lower → optimise → codegen to
+one relocatable object, written under the resolved object tree at
 `<out>/obj/<fqn-as-path>.o`. For a `bin` artifact the objects are linked into the
-resolved artifact path (its `out` template); for a `static`/`shared` library (or
-with `--emit obj`) the objects are the deliverable and nothing is linked.
+resolved artifact path (its `out` template); for a `static`/`shared` library (or with
+`--emit obj`) the objects are the deliverable and nothing is linked.
 
 A target whose object format delivers **finished modules** — SPIR-V, whose object
 output is a complete self-contained module rather than a link input — always

--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -43,11 +43,12 @@ function body.
 
 ## Semantics
 
-Every build resolves and type-checks each `test` body. Under `mach test`, each
-test also lowers to a zero-parameter, `i32`-returning function tagged as a test
-entry point so the runner can iterate it. The label is interned and becomes the
-lowered function's name. Ordinary builds omit test bodies from IR and object
-files.
+Every build resolves and type-checks each `test` body in the modules its artifact
+entry reaches. `mach test` roots its build at every module in the current project's
+source tree, so it checks and collects tests in modules no artifact imports. Each
+test then lowers to a zero-parameter, `i32`-returning function tagged as a test entry
+point so the runner can iterate it. The label is interned and becomes the lowered
+function's name. Ordinary builds omit test bodies from IR and object files.
 
 The body is checked against an `i32` return type. A test reports its result
 through that return value, treated as a process-style status:

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -359,6 +359,13 @@ reads the selected artifact's name.
 | `icon` | no | Project-root-relative `.ico` path embedded in a Windows executable's PE resources. Non-empty path string; `bin` artifacts only. |
 | `manifest` | no | Project-root-relative application-manifest path embedded byte-for-byte in a Windows executable's PE resources. Non-empty path string; `bin` artifacts only. |
 
+`entry` is the build cell's source root. The build follows its active `use` and
+`fwd` edges transitively and compiles that reachable module set; another file under
+`src` is not part of the cell merely because it shares the project directory. This
+is what lets one project declare host and accelerator artifacts with disjoint target
+sets. `mach test` is the deliberate whole-source exception: it roots collection at
+every module in the current project's `src` tree.
+
 - **`bin`** links an executable at the resolved `out` path.
 - **`static`** materialises a real `ar` archive at the resolved `out` path — the
   per-module objects with an archive symbol index, the deliverable a consumer links

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -956,9 +956,9 @@ fun record_artifact(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, b
 # Reports the module count and total time, plus the linked binary's size when
 # the build produced one (an executable). A library / object-only build - and a
 # finished-module build, whose delivery is the module tree - has no single
-# binary, so the size segment is omitted. The count is the emitted set, not the
-# checked set: a module front-ended but not reachable from the entry contributes
-# nothing to the artifact this line names (#2539).
+# binary, so the size segment is omitted. The count is the back-end set, not a
+# wider test/tooling load set: only emitted modules contribute to the artifact
+# this line names.
 fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress) {
     var out_str: str = "<output>";
     if (st.out_path != nil) { out_str = st.out_path::str; }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -126,19 +126,18 @@ pub fun build_project(s: *session.Session, project_root: str, target_name: str) 
     sel.want_lib     = false;
     sel.has_artifact = false;
     # the doc/tooling entry: load the graph but never run steps (no shell in a doc pass).
-    ret build_project_impl(s, project_root, ?sel, nil, nil, false, false, false);
+    ret build_project_impl(s, project_root, ?sel, nil, nil, project.ROOT_ARTIFACT, false);
 }
 
 # build_project_impl: the shared build pipeline behind both build_project_sel
 # (single target) and build_project_union (all targets). loads the project's
-# root manifest (`<project_root>/mach.toml`). `for_union` records every
-# manifest target's tuple and flips on the union load walk (see load_config /
-# walk_comptime_if_union). `all_own_src` additionally loads every own-source module
-# as a collection root (see load_all_own_src), for `mach test`. the same phase
-# entries the build engine dispatches individually run here in sequence, so a
-# non-engine flow and an engine unit execute identical pieces.
-fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, for_union: bool, all_own_src: bool, run_steps: bool) R.Result[project.Project, outcome.Fail] {
-    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, for_union, all_own_src, all_own_src);
+# root manifest (`<project_root>/mach.toml`). `roots` makes the consumer's graph
+# explicit: one selected artifact, the whole own-source test set, or every artifact
+# entry under the tooling union. The same phase entries the build engine dispatches
+# individually run here in sequence, so a non-engine flow and an engine unit execute
+# identical pieces.
+fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, roots: project.RootSet, run_steps: bool) R.Result[project.Project, outcome.Fail] {
+    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, roots);
     if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
 
@@ -189,23 +188,24 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
     sel.artifact     = req.artifact;
     sel.want_lib     = req.want_lib;
     sel.has_artifact = !str_empty(req.artifact);
-    # every engine build front-ends the whole source tree, so `mach build` and
-    # `mach test` agree on whether the project compiles (#2539). `is_test` stays the
-    # narrower fact - it picks the link surface and the back-end work set.
-    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, false, request.test_goal(req.goal), true);
+    var roots: project.RootSet = project.ROOT_ARTIFACT;
+    if (request.test_goal(req.goal)) { roots = project.ROOT_TEST; }
+    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, roots);
 }
 
 # the shared open: init + query binding + config synthesis + target entry
 #
-# `is_test` selects the `mach test` link surface (the union of every artifact's
-# libs); `all_own_src` loads every own-source module as a load root. They are
-# independent: a `mach build` loads the whole tree to check it while still linking
-# one artifact.
-fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, for_union: bool, is_test: bool, all_own_src: bool) R.Result[project.Project, outcome.Fail] {
+# `roots` is the single source of truth for the consumer's graph. It also selects
+# union configuration and the whole-source test link surface, so independent flags
+# cannot silently widen an artifact build's front-end set again.
+fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, roots: project.RootSet) R.Result[project.Project, outcome.Fail] {
     var p: project.Project;
     project.init_project(?p, s);
-    p.events      = ev;
-    p.all_own_src = all_own_src;
+    p.events = ev;
+    p.roots  = roots;
+
+    val for_union: bool = roots == project.ROOT_UNION;
+    val is_test:   bool = roots == project.ROOT_TEST;
 
     # bind the query db's compute context and register Q_PARSE (once per session)
     # before any module loads, so parse_module can route through the engine.
@@ -348,28 +348,28 @@ pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[session.ModuleId, str](load_r)));
     }
 
-    # union build (#1505): load every other declared artifact's entry into the same
-    # Project so tooling sees the closure over the whole (target x artifact) matrix,
-    # not just the primary artifact's. dfs_load dedups by FQN, so the primary entry
-    # (also present in union_entries) re-loads as a no-op, as do shared modules.
-    var ei: u32 = 0;
-    for (ei < p.union_entry_count) {
-        val ear: R.Result[session.ModuleId, str] = load.dfs_load(p, p.union_entries[ei]);
-        if (R.is_err[session.ModuleId, str](ear)) {
-            ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[session.ModuleId, str](ear)));
+    # tooling union (#1505): load every other declared artifact's entry so the
+    # Project covers the whole (target x artifact) matrix. dfs_load dedups the
+    # primary entry and shared imports.
+    if (p.roots == project.ROOT_UNION) {
+        var ei: u32 = 0;
+        for (ei < p.union_entry_count) {
+            val ear: R.Result[session.ModuleId, str] = load.dfs_load(p, p.union_entries[ei]);
+            if (R.is_err[session.ModuleId, str](ear)) {
+                ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[session.ModuleId, str](ear)));
+            }
+            ei = ei + 1;
         }
-        ei = ei + 1;
     }
 
     # the artifact closure is settled: everything loaded so far is what this build
-    # emits and links, and the whole-source sweep below only appends past it (#2539).
+    # emits and links. A test-rooted whole-source sweep only appends past it.
     p.emit_len = p.topo_len;
 
-    # root the load at the whole source tree, not the entrypoint's import closure,
-    # so a `pub` module with no in-tree `use` consumer is still checked (#2539) and
-    # still has its tests collected (#1863). dfs_load dedups by FQN, so this only
-    # adds the modules the entry/union walks missed.
-    if (p.all_own_src) {
+    # test collection roots at every own-source module, so a test in a module no
+    # artifact imports is still collected (#1863). Artifact builds deliberately do
+    # not enter this path: their build cell is the selected entry's reachable set.
+    if (p.roots == project.ROOT_TEST) {
         val allsrc_r: R.Result[bool, str] = union.load_all_own_src(p);
         if (R.is_err[bool, str](allsrc_r)) {
             ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](allsrc_r)));
@@ -465,14 +465,14 @@ pub fun load_manifest(s: *session.Session, project_root: str) R.Result[manifest.
 # repeatedly on one long-lived Session: sources dedup by path and dnit_project
 # resets the session's module registries (see dnit_project's reload contract)
 pub fun build_project_sel(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
-    ret build_project_impl(s, project_root, sel, nil, nil, false, false, true);
+    ret build_project_impl(s, project_root, sel, nil, nil, project.ROOT_ARTIFACT, true);
 }
 
 # build the module graph for a `mach test` invocation: like build_project_sel, but
 # additionally loads every own-source module under `[project].src` as a collection
 # root, so tests in a module no entrypoint imports are still collected (#1863)
 pub fun build_project_test(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
-    ret build_project_impl(s, project_root, sel, nil, nil, false, true, true);
+    ret build_project_impl(s, project_root, sel, nil, nil, project.ROOT_TEST, true);
 }
 
 # build the union of EVERY manifest target's AND artifact's
@@ -494,7 +494,7 @@ pub fun build_project_union(s: *session.Session, project_root: str) R.Result[pro
     sel.artifact     = "";
     sel.want_lib     = false;
     sel.has_artifact = false;
-    ret build_project_impl(s, project_root, ?sel, nil, nil, true, false, false);
+    ret build_project_impl(s, project_root, ?sel, nil, nil, project.ROOT_UNION, false);
 }
 
 # bind the query db's diagnostic hooks and register the front-half kind the load
@@ -523,4 +523,3 @@ fun bind_queries(s: *session.Session) R.Result[bool, str] {
 # the QueryCtx and bridge its session's `diags` sink. a captured snapshot is a heap
 # diagnostic.DiagList the query entry owns and the engine frees through
 # diag_free_hook.
-

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -39,6 +39,18 @@ use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.os;
 
+# the module-root set a driver consumer asks the load walk to discover
+pub def RootSet: u8;
+
+# load only the selected artifact entry and its transitive imports
+pub val ROOT_ARTIFACT: RootSet = 0;
+
+# load every module under the current project's source tree for test collection
+pub val ROOT_TEST:     RootSet = 1;
+
+# load every declared artifact entry under the multi-target tooling context
+pub val ROOT_UNION:    RootSet = 2;
+
 # the kind of artifact a target build produces
 pub def BuildMode: u8;
 
@@ -339,6 +351,7 @@ pub rec TargetTuple {
 # topo_len:          number of entries in topo; the front-end work set
 # topo_cap:          allocated slots in topo
 # emit_len:          length of topo's leading back-end work set (see below)
+# roots:             the consumer-selected module-root policy
 pub rec Project {
     s:            *session.Session;
     alloc:        *A.Allocator;
@@ -368,26 +381,23 @@ pub rec Project {
     topo_len:     u32;
     topo_cap:     u32;
 
-    # the split between checking and emitting (#2539). `topo[0..topo_len)` is the
-    # front-end work set: resolve and sema walk all of it, so every module under
-    # `src` is checked wherever it sits in the tree. `topo[0..emit_len)` is the
-    # back-end work set: lower, codegen, emit and link walk only it, so a module no
-    # artifact entry reaches costs no object code and never enters the artifact.
+    # `topo[0..topo_len)` is the front-end work set selected by `roots`.
+    # `topo[0..emit_len)` is its leading back-end work set: lower, codegen, emit
+    # and link walk only it, so a module outside the produced artifact never
+    # contributes object code.
     #
     # It is a leading prefix because the load phase walks the artifact closure first
-    # and records emit_len there; the whole-source sweep that follows only ever
-    # appends the modules that closure missed. A test build re-records emit_len after
-    # the sweep, since a test dispatcher does link every module.
+    # and records emit_len there. A test-rooted sweep only appends modules that
+    # closure missed; a real test build re-records emit_len after the sweep because
+    # its dispatcher links every module.
     emit_len:     u32;
+
+    roots:        RootSet;
 
     # the invocation's progress-event sink, installed by the engine for the
     # span of one build so the load walk and the passes narrate into it. nil
     # (every non-engine flow) leaves the build silent.
     events:       *readout.Progress;
-
-    # load every own-source module as a collection root (`mach test`, #1863);
-    # recorded at begin so the load phase can run it without re-threading flags.
-    all_own_src:  bool;
 
     # set only while load_all_own_src loads orphan roots, so the load walk knows a
     # top-level `$error` guard it reaches marks a target-gated orphan to exclude
@@ -553,8 +563,8 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.topo_len      = 0;
     p.topo_cap      = 0;
     p.emit_len      = 0;
+    p.roots         = ROOT_ARTIFACT;
     p.events        = nil;
-    p.all_own_src   = false;
     p.loading_orphans = false;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -138,6 +138,12 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
+# the mixed host / SPIR-V project from #2967: two artifacts with disjoint target
+# sets share one source tree, and a third module belongs to neither build cell
+fun ut_manifest_mixed_targets() str {
+    ret "[project]\nid = \"mixtest\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux-x86_64]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.spirv]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\nof = \"spv\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.host]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/mixtest\"\ntargets = [\"linux-x86_64\"]\nlink = []\nneed = []\n\n[artifact.probe_frag]\nkind = \"bin\"\nentry = \"probe_frag.mach\"\nout = \"probe_frag.spv\"\ntargets = [\"spirv\"]\nlink = []\nneed = []\n";
+}
+
 # a manifest with a windows-only `local` link entry whose path is neither step-backed
 # nor present on disk, for the #1988 cross-target validation-skip test. building for
 # linux must ignore the entry (it filters out), not validate its linux-cell expansion
@@ -9168,18 +9174,11 @@ fun ut_stable_of(s: *session.Session, fqn: str) session.StableModuleId {
     ret session.stable_module_id_lookup(s, R.unwrap_ok[intern.StrId, str](idr));
 }
 
-# warm engine: two `execute_warm` calls on one session with unchanged inputs -
-# the second call revalidates instead of recomputing (per-module Q_SEMA /
-# Q_LOWER / Q_CODEGEN and the Q_LINK fingerprint keep their last_changed), and
-# the session stays bounded (interner, SourceMap, and query-shard entry counts
-# do not grow). a third call after an edit recomputes exactly the edited
-# module's back half and re-links, proving the observables are live
-test "mach.lang.build.engine.execute:broken_unreferenced_module_fails_build" {
-    # #2539: a module under `src` that no artifact entry imports must still be
-    # checked. before this, `mach build` compiled only the entry's import closure, so
-    # a hard compile error in an unreferenced module left the build green while
-    # `mach test` - which roots its load at the whole tree - reported it. the two
-    # commands disagreed about whether the project compiled.
+test "mach.lang.build.engine.execute:artifact_build_roots_at_reachable_modules" {
+    # #2967: one project may hold a host artifact and a SPIR-V artifact. Building
+    # the shader cell must never compile the host entry or an unrelated module in
+    # the same src tree. Both carry hard errors so a whole-source front end fails
+    # this fixture before it can emit the valid shader.
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -9187,54 +9186,13 @@ test "mach.lang.build.engine.execute:broken_unreferenced_module_fails_build" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
 
-    var names: [2]str; names[0] = "main.mach"; names[1] = "orphan.mach";
-    var texts: [2]str;
-    # main does NOT import orphan: nothing on the entry's path reaches it
-    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
-    texts[1] = "pub fun broken() i32 { ret no_such_function(); }\n";
-    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
-    val root: str = R.unwrap_ok[str, str](root_r);
-
-    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
-    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
-    var rq: request.BuildRequest = request.defaults();
-    rq.project_root = root;
-    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
-    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
-
-    var bad: i32 = 0;
-    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, nil);
-    if (R.is_ok[outcome.BuildOutcome, outcome.Fail](r)) {
-        # the build reported success while a module in the tree does not compile
-        if (R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
-    }
-
-    fs.remove_all(?alloc, root);
-    session.dnit(?s);
-    ret bad;
-}
-
-test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted" {
-    # the other half of #2539: widening the CHECK must not widen what is EMITTED. a
-    # valid module no artifact entry reaches is front-ended (it has a Q_SEMA entry)
-    # and never lowered or codegen'd (no Q_LOWER / Q_CODEGEN entry), so it costs no
-    # object code and does not enter the artifact.
-    var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
-    val sr: R.Result[session.Session, str] = session.init(?alloc);
-    if (R.is_err[session.Session, str](sr)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
-
-    var names: [3]str; names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "orphan.mach";
+    var names: [3]str;
+    names[0] = "lib.mach"; names[1] = "probe_frag.mach"; names[2] = "other.mach";
     var texts: [3]str;
-    texts[0] = ut_cc3(?alloc, "use uniontest.a.fa;\n#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret fa(); }\n");
-    texts[1] = "pub fun fa() i32 { ret 1; }\n";
-    texts[2] = "pub fun orphan_only() i32 { ret 7; }\n";
-    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    texts[0] = "pub fun hello() i32 { ret missing_host_function(); }\n";
+    texts[1] = "#[output(0)] var out_colour: f32x4;\n\n#[stage(\"fragment\")]\nfun frag_main() {\n    out_colour = f32x4{1.0, 0.0, 0.0, 1.0};\n}\n";
+    texts[2] = "pub fun touch() { missing_unrelated_function(); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_mixed_targets(), ?names[0], ?texts[0], 3);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
@@ -9243,6 +9201,8 @@ test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
+    rq.target       = "spirv";
+    rq.artifact     = "probe_frag";
     val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
     if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
@@ -9252,24 +9212,26 @@ test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted
     if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     if (!R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
 
-    val st_a:      session.StableModuleId = ut_stable_of(?s, "uniontest.a");
-    val st_orphan: session.StableModuleId = ut_stable_of(?s, "uniontest.orphan");
-    if (st_a == session.STABLE_MODULE_NIL || st_orphan == session.STABLE_MODULE_NIL) { bad = 1; }
-
-    # the reachable module is checked AND emitted
-    if (query.peek_revision(?s.queries, query.Q_SEMA,    st_a::u64) == 0) { bad = 1; }
-    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_a::u64) == 0) { bad = 1; }
-
-    # the unreferenced one is checked but never reaches the back half
-    if (query.peek_revision(?s.queries, query.Q_SEMA,    st_orphan::u64) == 0) { bad = 1; }
-    if (query.peek_revision(?s.queries, query.Q_LOWER,   st_orphan::u64) != 0) { bad = 1; }
-    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_orphan::u64) != 0) { bad = 1; }
+    val st_shader: session.StableModuleId = ut_stable_of(?s, "mixtest.probe_frag");
+    val st_host:   session.StableModuleId = ut_stable_of(?s, "mixtest.lib");
+    val st_other:  session.StableModuleId = ut_stable_of(?s, "mixtest.other");
+    if (st_shader == session.STABLE_MODULE_NIL) { bad = 1; }
+    if (st_host   != session.STABLE_MODULE_NIL) { bad = 1; }
+    if (st_other  != session.STABLE_MODULE_NIL) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_SEMA, st_shader::u64) == 0) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_shader::u64) == 0) { bad = 1; }
 
     fs.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;
 }
 
+# warm engine: two `execute_warm` calls on one session with unchanged inputs -
+# the second call revalidates instead of recomputing (per-module Q_SEMA /
+# Q_LOWER / Q_CODEGEN and the Q_LINK fingerprint keep their last_changed), and
+# the session stays bounded (interner, SourceMap, and query-shard entry counts
+# do not grow). a third call after an edit recomputes exactly the edited
+# module's back half and re-links, proving the observables are live
 test "mach.lang.build.engine.execute_warm:unchanged_rebuild_reuses_and_stays_bounded" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -14895,10 +14857,9 @@ fun ut_attr_probe(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
 }
 
 # ut_attr_probe over the whole-source loader, so the fixture's orphan modules are
-# LOADED without being COMPILED - the state #2539 made routine and #2657 scoped
-# attribution against
+# LOADED without being COMPILED - the state #2657 scoped attribution against
 #
-# `build_project_test` sets all_own_src (every module under src becomes a load
+# `build_project_test` selects ROOT_TEST (every module under src becomes a load
 # root) while the internal default request keeps GOAL_EXECUTE, so `emit_len` stays
 # at the artifact's closure. That combination is what makes loaded-but-not-compiled
 # reachable from a test; plain `build_project` never loads an orphan at all, and a
@@ -17376,13 +17337,14 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
 
-    # three modules: the entry, a plain orphan that survives, and a target-gated
-    # orphan whose load-time `$error` guard fires and is dropped from topo.
+    # A test-list build supplies the whole-source root set this count needs: the
+    # entry, a plain orphan that survives, and a target-gated orphan whose
+    # load-time `$error` guard fires and is dropped from topo.
     var names: [3]str;
     names[0] = "main.mach"; names[1] = "keep.mach"; names[2] = "gated.mach";
     var texts: [3]str;
     texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
-    texts[1] = "pub fun keep() i32 { ret 1; }\n";
+    texts[1] = "pub fun keep() i32 { ret 1; }\n\ntest \"keep\" { ret 0; }\n";
     texts[2] = "$error(\"gated: not for this target\");\n\npub fun gated() i32 { ret 2; }\n";
     val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
@@ -17393,6 +17355,7 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
+    rq.goal         = request.GOAL_TEST_LIST;
     val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
     if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -3,10 +3,10 @@
 # The union build (#1391/#1505) unions every manifest target's and artifact's
 # import closure into one deduplicated Project for workspace-wide tooling: it
 # precomputes one TargetTuple per target, loads every declared artifact entry
-# and every own-source module under `[project].src`, and skips a target the
-# compiler cannot cover. It also registers the project's `#[export]` directives
-# and `ext` import libraries onto the session. Sits above the load walk it
-# drives, below the facade orchestration that invokes it.
+# and skips a target the compiler cannot cover. It also owns the separate
+# whole-source enumeration used by test collection and registers the project's
+# `#[export]` directives and `ext` import libraries onto the session. Sits above
+# the load walk it drives, below the facade orchestration that invokes it.
 
 use std.collections.map;
 use std.collections.sort;


### PR DESCRIPTION
Closes #2967

## What changed

Build graph roots are now one explicit policy: the selected artifact entry, the whole own-source test set, or the multi-artifact tooling union. Normal engine builds select the artifact policy, so resolve and sema only see modules transitively reachable from that build cell's `entry`. `mach test` keeps whole-source collection and editor/tooling union loads keep every declared artifact entry.

This removes the independent `for_union` / `all_own_src` / `is_test` booleans that allowed an ordinary artifact build to be widened accidentally. Public CLI, manifest, language-test, and repository-skill documentation now state the same root contract.

## Deliberate reversal of #2539

This explicitly supersedes #2539 / PR #2641's rule that `mach build` front-end-checks every file under `[project].src`. The two #2539 acceptance tests are removed because their assertions are now the defect: a build cell for one target cannot require an unrelated artifact entry—or an unreferenced module—to compile for that target. Host and accelerator artifacts are one project but have intentionally different valid source closures.

Reachability still checks every module the selected artifact can use, through its transitive `use` / `fwd` graph. The tree-wide check has not disappeared from test workflows: `mach test` remains rooted at every own-source module so it checks and collects otherwise-unreferenced tests. The contract is now explicit per consumer instead of treating a produced artifact and a whole-project check as the same operation.

## Regression

The engine test reproduces the reported shape in one project: a linux static artifact, a SPIR-V fragment artifact, and an unrelated module. The two non-shader sources carry hard semantic failures. Building the SPIR-V cell succeeds, emits the shader, and leaves both unreachable modules unregistered. Existing tests independently pin the other two policies: whole-source orphan test collection and multi-artifact tooling union loading.

## Verification

Against `dev` at `4888ae0d`:

- `mach build .`
- `mach test .` — 1477 passed, 0 failed
- focused mixed-target, test-root, union-root, and load-accounting regressions
- self-host rebuild is byte-identical (`3442e8446c0fa576808bad76fb5e6364473fccb6c9faa3d95680d1662a4dac30`)

The branch includes the release base via merge commits.