### PR TITLE
mach 4.19.0

### DIFF
--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -50,6 +50,12 @@ resolves only when that project declares a `[project] module` surface file
 (e.g. a library `glfw` imported as `use glfw;`); `std` does not - always
 import full `std.*` paths.
 
+An artifact build roots its module graph at `[artifact.*].entry` and compiles only
+that module plus its active transitive `use`/`fwd` dependencies. A sibling source
+file is not part of the build cell merely because it is under `[project].src`, so
+one project may hold artifacts for disjoint targets. `mach test` deliberately roots
+at every own-source module so it can collect otherwise-unreferenced tests.
+
 A file reads top-down: module docstring, `use`/`fwd` lines, declarations.
 
 ### `use` - private import

--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -99,6 +99,12 @@ fwd impl.page_size;
 
 ## Entrypoint and output
 
+An artifact's `out` is literal across every target it names. A cross-platform
+executable therefore uses disjoint artifacts for extension conventions:
+`out = "bin/app"` for non-Windows targets and `out = "bin/app.exe"` for Windows.
+`mach init` emits that split for binary projects. Do not use one `targets = ["*"]`
+artifact when its output must be directly executable on Windows and elsewhere.
+
 The stdlib provides the platform `_start`, which calls whatever function
 exports the linker symbol `main`. `use std.runtime;` is required to link it in
 even though nothing references it by name:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Target-split executables select the right artifact on every host (#2955, #2961, #2981)
+
+Whole-source builds no longer make the first artifact declaration load-bearing.
+The manifest layer now owns primary selection for both current and legacy driver
+paths and chooses the first artifact that declares the resolved target, while an
+explicit artifact remains authoritative and retains the existing incompatibility
+diagnostic. A single-product command such as `mach run` also infers an unnamed
+artifact when exactly one declares the target; multiple runnable artifacts remain
+an ambiguity rather than an order-dependent guess.
+
+`mach init` now demonstrates the extension contract it documents. Binary scaffolds
+use disjoint non-Windows and Windows artifacts, producing `bin/<name>` and
+`bin/<name>.exe` respectively, while library scaffolds keep one all-target artifact.
+mach's own manifest uses the same split, so `mach build .` on Windows produces
+`bin/mach.exe` without an output override and `mach test .` needs no artifact flag.
+
 ## [4.18.3] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.19.0] - 2026-08-10
+
+### Changed
+
+#### Artifact builds compile only their reachable module graph (#2967)
+
+An ordinary artifact build now roots source discovery at that artifact's `entry`
+and follows its active transitive `use` and `fwd` edges. Unreferenced files and
+entries belonging only to another target no longer have to compile for the selected
+build cell, so one project can contain disjoint host and accelerator artifacts.
+
+`mach test` remains the deliberate whole-source check and collection path, while
+tooling unions continue to root every declared artifact entry. The driver represents
+those three contracts as explicit artifact, test, and union root policies rather
+than independent widening flags.
+
 ### Fixed
 
 #### Target-split executables select the right artifact on every host (#2955, #2961, #2981)
@@ -24,6 +40,23 @@ use disjoint non-Windows and Windows artifacts, producing `bin/<name>` and
 `bin/<name>.exe` respectively, while library scaffolds keep one all-target artifact.
 mach's own manifest uses the same split, so `mach build .` on Windows produces
 `bin/mach.exe` without an output override and `mach test .` needs no artifact flag.
+
+#### Character literals lower at their coerced integer width (#2982)
+
+Semantic analysis could coerce a character literal into its surrounding integer
+type, but lowering still emitted the literal as `i8`. Wider arithmetic therefore
+reached IR verification with mismatched operands, and a later conversion could be
+classified from the coerced type while operating on the narrower value. Character
+literals now take their IR width from the resolved expression type, matching integer
+and floating-point literal lowering.
+
+#### Final link requirements retain their exact allocation extent (#2977)
+
+Filtering a link requirement's symbol claims now finalizes ownership in one place.
+When shrinking to the exact retained count fails, the build returns an allocation
+error and releases the original buffer instead of recording a pointer with an extent
+the allocator did not create. Successful finalization records the exact allocation
+used by teardown.
 
 ## [4.18.3] - 2026-08-10
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -284,10 +284,12 @@ mach run <path> [options] [-- args...]
 
 Executes the binary `mach build` already produced for `<path>` — a post-build
 convenience, **not** a rebuild. The same selection flags (`--target`, `--profile`,
-`--bin`) that narrow a build resolve which artifact to run; its path is read from
-the artifact's `out` template and the existing file is exec'd. When the artifact
-does not exist yet, `mach run` errors and points at `mach build` rather than
-building it.
+`--bin`) that narrow a build resolve which artifact to run. With no artifact flag,
+one is inferred when exactly one artifact declares the resolved target; several
+matching artifacts remain an error that asks for `--bin`/`--lib`. Its path is read
+from the artifact's `out` template and the existing file is exec'd. When the
+artifact does not exist yet, `mach run` errors and points at `mach build` rather
+than building it.
 Arguments after a `--` separator are forwarded to the child as its `argv`. The
 child's exit code becomes this command's exit code.
 
@@ -517,7 +519,8 @@ mach init [dir] [options]
 
 Scaffolds a new project in `[dir]` (default: the current directory). Writes a
 complete `mach.toml` with a `[project]` block, `[target.*]` platforms for
-`linux`/`windows`/`darwin` (on the host ISA), one `[artifact.<id>]`,
+`linux`/`windows`/`darwin` (on the host ISA), extension-correct binary artifacts
+(or one library artifact),
 `[profile.debug]`/`[profile.release]` variants, a `[dep.mach-std]` dependency, a
 starter source file, and `dep/mach-std/` cloned from the declared ref (through
 the same path as `mach dep pull`). Refuses to overwrite an existing `mach.toml`,
@@ -528,7 +531,7 @@ before any file is written, so a refused init leaves nothing behind.
 |----------------|-------|--------|
 | `--name <name>`| name  | project id (default: the directory base name) |
 | `--force`      | —     | scaffold even when `mach.toml`, `src/main.mach`, or `src/lib.mach` already exists |
-| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold a `static` `[artifact.<id>]` instead of a `bin` one |
+| `--lib`        | —     | library layout: write `src/lib.mach` instead of `src/main.mach`, and scaffold one `static` `[artifact.<id>]` instead of the target-split binary artifacts |
 
 The first non-flag argument after `init` is the target directory.
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -84,11 +84,14 @@ mach build <path> [options]
 Compiles the project named by `<path>` — a project directory containing a
 `mach.toml` (e.g. `mach build .`).
 With no `--bin`/`--lib`, it builds every declared artifact for the selected target
-and profile. Every reachable module is driven through sema → lower → optimise →
-codegen to one relocatable object, written under the resolved object tree at
+and profile. Each artifact's module graph is rooted at its `entry`; only that module
+and its transitive `use`/`fwd` dependencies belong to the build cell. Other files
+under `src` may back artifacts for different targets and are not compiled for this
+cell. Every reachable module is driven through sema → lower → optimise → codegen to
+one relocatable object, written under the resolved object tree at
 `<out>/obj/<fqn-as-path>.o`. For a `bin` artifact the objects are linked into the
-resolved artifact path (its `out` template); for a `static`/`shared` library (or
-with `--emit obj`) the objects are the deliverable and nothing is linked.
+resolved artifact path (its `out` template); for a `static`/`shared` library (or with
+`--emit obj`) the objects are the deliverable and nothing is linked.
 
 A target whose object format delivers **finished modules** — SPIR-V, whose object
 output is a complete self-contained module rather than a link input — always

--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -43,11 +43,12 @@ function body.
 
 ## Semantics
 
-Every build resolves and type-checks each `test` body. Under `mach test`, each
-test also lowers to a zero-parameter, `i32`-returning function tagged as a test
-entry point so the runner can iterate it. The label is interned and becomes the
-lowered function's name. Ordinary builds omit test bodies from IR and object
-files.
+Every build resolves and type-checks each `test` body in the modules its artifact
+entry reaches. `mach test` roots its build at every module in the current project's
+source tree, so it checks and collects tests in modules no artifact imports. Each
+test then lowers to a zero-parameter, `i32`-returning function tagged as a test entry
+point so the runner can iterate it. The label is interned and becomes the lowered
+function's name. Ordinary builds omit test bodies from IR and object files.
 
 The body is checked against an `i32` return type. A test reports its result
 through that return value, treated as a process-style status:

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -359,6 +359,13 @@ reads the selected artifact's name.
 | `icon` | no | Project-root-relative `.ico` path embedded in a Windows executable's PE resources. Non-empty path string; `bin` artifacts only. |
 | `manifest` | no | Project-root-relative application-manifest path embedded byte-for-byte in a Windows executable's PE resources. Non-empty path string; `bin` artifacts only. |
 
+`entry` is the build cell's source root. The build follows its active `use` and
+`fwd` edges transitively and compiles that reachable module set; another file under
+`src` is not part of the cell merely because it shares the project directory. This
+is what lets one project declare host and accelerator artifacts with disjoint target
+sets. `mach test` is the deliberate whole-source exception: it roots collection at
+every module in the current project's `src` tree.
+
 - **`bin`** links an executable at the resolved `out` path.
 - **`static`** materialises a real `ar` archive at the resolved `out` path — the
   per-module objects with an archive symbol index, the deliverable a consumer links

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -756,9 +756,9 @@ A build cell is one artifact × one target × one profile.
   you to pick one, naming every candidate.
 - `mach test <path>` selects the first artifact that declares the resolved target as
   its primary context. It links the union of all artifacts' referenced entries plus
-  exported dependency entries, filtered to the native target (tests run on native
-  hardware only). If two artifacts' objects collide on symbols in that union, that is
-  an honest link error — restructure the entries.
+  exported dependency entries, filtered to that target. Foreign-target tests require
+  a compatible `--runner`. If two artifacts' objects collide on symbols in that union,
+  that is an honest link error — restructure the entries.
 
 ### Enumerated cells are filtered; named ones are not
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -412,18 +412,16 @@ The artifact **name** differs between the two, so `$bin.name` differs by platfor
 project that reads it sees `app` everywhere and `app-windows` on Windows. Nothing in
 mach's own source reads it, and a project that does needs to expect both.
 
-`mach build` is unaffected by the split: it enumerates artifact-by-target cells and
-builds only the ones that match, so each platform gets its stanza with nothing named on
-the command line. `mach test` is not, today. It links the whole source tree rather than
-one artifact, so it takes the **first declared** artifact as the root of its build, and
-on a host that stanza does not declare it refuses rather than reaching for the other
-one. Until #2961 is fixed, a test run on the platform whose stanza is declared second
-has to name it, as in `mach test . --bin app-windows`.
+`mach build` enumerates artifact-by-target cells and builds only the ones that match,
+so each platform gets its stanza with nothing named on the command line. `mach test`
+links the whole source tree rather than one artifact, but selects its primary context
+from the first artifact that declares the resolved target, so the same split works
+there. `mach run` selects the target's artifact when exactly one matches; if several
+artifacts can run on that target, it still asks for `--bin` rather than guessing.
 
-mach's own `mach.toml` is NOT split yet, deliberately. Splitting it is what found
-#2961, and the repository is not going to ship a shape its own `mach test` cannot run
-on Windows, or the command-line flags that would hide that. It follows once the
-selection is fixed.
+mach's own `mach.toml` is split this way: an ordinary Windows build produces
+`bin/mach.exe`, and its test run selects `mach-windows` as the primary context without
+a command-line workaround.
 
 ### `subsystem` — the windows console/GUI selector
 
@@ -746,12 +744,14 @@ A build cell is one artifact × one target × one profile.
   with every target in its `targets`. `--bin <name>` / `--lib <name>` narrow to one
   artifact; `--target <name>` selects a declared target; `--profile <name>` selects
   a profile.
-- `mach run <path>` and `mach test <path>` build exactly one artifact; with several
-  declared and no `--bin`/`--lib`, they ask you to pick one, naming every candidate.
-- `mach test` links the union of all artifacts' referenced entries plus exported
-  dependency entries, filtered to the native target (tests run on native hardware
-  only). If two artifacts' objects collide on symbols in that union, that is an
-  honest link error — restructure the entries.
+- `mach run <path>` consumes exactly one artifact. With no `--bin`/`--lib`, it selects
+  one when exactly one artifact declares the resolved target; if several do, it asks
+  you to pick one, naming every candidate.
+- `mach test <path>` selects the first artifact that declares the resolved target as
+  its primary context. It links the union of all artifacts' referenced entries plus
+  exported dependency entries, filtered to the native target (tests run on native
+  hardware only). If two artifacts' objects collide on symbols in that union, that is
+  an honest link error — restructure the entries.
 
 ### Enumerated cells are filtered; named ones are not
 

--- a/mach.toml
+++ b/mach.toml
@@ -48,7 +48,15 @@ simd = "scalarize"
 kind = "bin"
 entry = "bin/main.mach"
 out = "bin/mach"
-targets = ["*"]
+targets = ["linux-x86_64", "linux-arm64", "linux-riscv64", "darwin-x86_64", "darwin-aarch64"]
+link = []
+need = []
+
+[artifact.mach-windows]
+kind = "bin"
+entry = "bin/main.mach"
+out = "bin/mach.exe"
+targets = ["windows-x86_64"]
 link = []
 need = []
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.18.3"
+version = "4.19.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -3,9 +3,9 @@
 # Writes a complete `mach.toml` (a `[project]` block with explicit src/dep dirs
 # and output templates, `[target.*]` platforms for linux/windows/darwin on the
 # host isa - each target's abi derived from the os's self-declared native
-# convention, and any os with no composable tuple on the host skipped - one
-# `[artifact.*]` artifact, debug/release profiles, and a `[dep.mach-std]`
-# dependency) plus a starter source module. For a binary the
+# convention, and any os with no composable tuple on the host skipped - an
+# artifact surface split by executable-extension convention, debug/release
+# profiles, and a `[dep.mach-std]` dependency) plus a starter source module. For a binary the
 # generated `src/main.mach` is a standard-library hello world; a library gets a
 # bare `src/lib.mach` root. The command then syncs `mach-std` into `dep/mach-std`
 # through the same machinery as `mach dep pull`, so a fresh scaffold builds
@@ -211,8 +211,8 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 # Emits a `[project]` block (id, version, src/dep dirs, output-path templates,
 # and `module` for a library), `[target.<os>-<isa>]` blocks for linux/windows/darwin
 # on the host isa (each abi derived from the os's native convention, uncomposable
-# oses skipped), one `[artifact.<id>]` (`kind = "bin"` or a library kind), debug/release
-# profiles, and the `[dep.mach-std]` dependency.
+# oses skipped), target-split binary artifacts (or one library artifact),
+# debug/release profiles, and the `[dep.mach-std]` dependency.
 # ---
 # path:   destination path for the manifest
 # id:     project id (already validated)
@@ -242,29 +242,9 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     # the scaffold cannot be written.
     var reg: target.TargetRegistry = target.registry_init();
     if (R.is_err[bool, str](target.register_all(?reg))) { ret false; }
-    emit_targets(?buf, ?reg, target.host_arch_id());
-
-    buf_put(?buf, "[artifact.");
-    buf_put(?buf, id);
-    buf_put(?buf, "]\n");
-    if (is_lib) {
-        buf_put(?buf, "kind = \"static\"\n");
-        buf_put(?buf, "entry = \"lib.mach\"\n");
-        buf_put(?buf, "out = \"lib/");
-        buf_put(?buf, id);
-        buf_put(?buf, "\"\n");
-    }
-    or {
-        buf_put(?buf, "kind = \"bin\"\n");
-        buf_put(?buf, "entry = \"main.mach\"\n");
-        buf_put(?buf, "out = \"bin/");
-        buf_put(?buf, id);
-        buf_put(?buf, "\"\n");
-    }
-    buf_put(?buf, "targets = [\"*\"]\n");
-    buf_put(?buf, "link = []\n");
-    buf_put(?buf, "need = []\n");
-    buf_put(?buf, "\n");
+    val arch_id: u32 = target.host_arch_id();
+    emit_targets(?buf, ?reg, arch_id);
+    emit_artifacts(?buf, ?reg, arch_id, id, is_lib);
 
     buf_put(?buf, "[profile.debug]\n");
     buf_put(?buf, "opt = 0\n");
@@ -288,6 +268,65 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     if (!buf.ok) { ret false; }
     val res_write: O.Option[str] = fs.write_bytes(path, ?storage[0], buf.len, FILE_MODE);
     ret !O.is_some[str](res_write);
+}
+
+# emit the scaffold's artifact surface
+#
+# Libraries keep one all-target artifact. A binary with a composable Windows
+# target gets disjoint artifacts because `out` is literal: non-Windows targets
+# produce `bin/<id>` and Windows produces `bin/<id>.exe` (#2981).
+fun emit_artifacts(b: *Buf, reg: *target.TargetRegistry, arch_id: u32,
+                   id: *u8, is_lib: bool) {
+    if (is_lib) {
+        buf_put(b, "[artifact.");
+        buf_put(b, id);
+        buf_put(b, "]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/");
+        buf_put(b, id);
+        buf_put(b, "\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n");
+        ret;
+    }
+
+    emit_binary_artifact(b, reg, arch_id, id, false);
+    if (!str_empty(scaffold_abi(reg, "windows", arch_id))) {
+        emit_binary_artifact(b, reg, arch_id, id, true);
+    }
+}
+
+# emit one side of a binary scaffold's extension split
+fun emit_binary_artifact(b: *Buf, reg: *target.TargetRegistry, arch_id: u32,
+                         id: *u8, windows: bool) {
+    buf_put(b, "[artifact.");
+    buf_put(b, id);
+    if (windows) { buf_put(b, "-windows"); }
+    buf_put(b, "]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/");
+    buf_put(b, id);
+    if (windows) { buf_put(b, ".exe"); }
+    buf_put(b, "\"\ntargets = [");
+    emit_artifact_targets(b, reg, arch_id, windows);
+    buf_put(b, "]\nlink = []\nneed = []\n\n");
+}
+
+# emit the target-name strings for one side of the extension split
+fun emit_artifact_targets(b: *Buf, reg: *target.TargetRegistry,
+                          arch_id: u32, windows: bool) {
+    var wrote: bool = false;
+    emit_artifact_target(b, reg, "linux", arch_id, windows, ?wrote);
+    emit_artifact_target(b, reg, "windows", arch_id, windows, ?wrote);
+    emit_artifact_target(b, reg, "darwin", arch_id, windows, ?wrote);
+}
+
+# append one supported target name when it belongs to the requested split side
+fun emit_artifact_target(b: *Buf, reg: *target.TargetRegistry, os_name: *u8,
+                         arch_id: u32, windows: bool, wrote: *bool) {
+    val is_windows: bool = str_equals(os_name::str, "windows");
+    if (is_windows != windows || str_empty(scaffold_abi(reg, os_name::str, arch_id))) { ret; }
+    if (@wrote) { buf_put(b, ", "); }
+    buf_put(b, "\"");
+    buf_put(b, os_name);
+    buf_put(b, "-");
+    buf_put(b, isa.arch_name_for(arch_id)::*u8);
+    buf_put(b, "\"");
+    @wrote = true;
 }
 
 # write a null-terminated source template to `path`
@@ -456,6 +495,32 @@ fun scaffold_abi(reg: *target.TargetRegistry, os_name: str, arch_id: u32) str {
     if (str_empty(abi_name)) { ret ""; }
     if (R.is_err[target.Target, str](target.select(reg, isa.arch_name_for(arch_id), os_name, abi_name))) { ret ""; }
     ret abi_name;
+}
+
+# a binary scaffold writes extension-correct artifacts on x86_64, while a
+# library remains one all-target artifact
+test "mach.cli.cmd.init.emit_artifacts:extension_split" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+
+    var bin_storage: [1024]u8;
+    var bin: Buf;
+    bin.ptr = ?bin_storage[0]; bin.cap = 1024; bin.len = 0; bin.ok = true;
+    emit_artifacts(?bin, ?reg, isa.ARCH_X86_64, "demo", false);
+    if (!bin.ok || bin.len >= bin.cap) { ret 1; }
+    bin.ptr[bin.len] = 0;
+    val want_bin: str = "[artifact.demo]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/demo\"\ntargets = [\"linux-x86_64\", \"darwin-x86_64\"]\nlink = []\nneed = []\n\n[artifact.demo-windows]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/demo.exe\"\ntargets = [\"windows-x86_64\"]\nlink = []\nneed = []\n\n";
+    if (!str_equals(bin.ptr::str, want_bin)) { ret 1; }
+
+    var lib_storage: [512]u8;
+    var lib: Buf;
+    lib.ptr = ?lib_storage[0]; lib.cap = 512; lib.len = 0; lib.ok = true;
+    emit_artifacts(?lib, ?reg, isa.ARCH_X86_64, "demo", true);
+    if (!lib.ok || lib.len >= lib.cap) { ret 1; }
+    lib.ptr[lib.len] = 0;
+    val want_lib: str = "[artifact.demo]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/demo\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n";
+    if (!str_equals(lib.ptr::str, want_lib)) { ret 1; }
+    ret 0;
 }
 
 # on an x86_64 host the derived conventions reproduce today's scaffold exactly:

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -956,9 +956,9 @@ fun record_artifact(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, b
 # Reports the module count and total time, plus the linked binary's size when
 # the build produced one (an executable). A library / object-only build - and a
 # finished-module build, whose delivery is the module tree - has no single
-# binary, so the size segment is omitted. The count is the emitted set, not the
-# checked set: a module front-ended but not reachable from the entry contributes
-# nothing to the artifact this line names (#2539).
+# binary, so the size segment is omitted. The count is the back-end set, not a
+# wider test/tooling load set: only emitted modules contribute to the artifact
+# this line names.
 fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress) {
     var out_str: str = "<output>";
     if (st.out_path != nil) { out_str = st.out_path::str; }

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -315,7 +315,8 @@ pub fun release(r: *BuildRequest) bool {
 # binding it to one build unit here would be a category error (#2474). The
 # planner resolves each cell and raises selection errors with the same text.
 # For a test goal with no named artifact, a multi-artifact manifest settles on
-# the first declared artifact (the whole-source test build links them all).
+# the first artifact that declares the resolved target (the whole-source test
+# build still links them all).
 # ---
 # a:    allocator backing the request's link-input vectors and the transient
 #       profile resolution
@@ -334,18 +335,16 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
     r.all_targets  = cli.all_targets;
     r.goal         = goal;
 
-    # a whole-source test build of a multi-artifact manifest is not the
-    # ambiguity a plain build raises: it settles on the first declared
-    # artifact as the primary, mirroring the driver's own test-load rule.
+    # a whole-source test build of a multi-artifact manifest is not the ambiguity
+    # a plain build raises. the manifest owns which compatible artifact supplies
+    # its primary context, shared with the legacy/tooling driver path (#2961).
     var esel: manifest.Selection = @sel;
-    if (test_goal(goal) && !esel.has_artifact && m.artifact_count > 1) {
-        val an_opt: O.Option[str] = intern.lookup(itn, m.artifacts[0].name);
-        if (O.is_none[str](an_opt)) {
-            ret R.err[BuildRequest, outcome.Fail](outcome.internal("primary artifact name not interned"));
+    if (test_goal(goal)) {
+        val psr: R.Result[bool, str] = manifest.select_primary_artifact(a, itn, m, ?esel);
+        if (R.is_err[bool, str](psr)) {
+            ret R.err[BuildRequest, outcome.Fail](
+                outcome.internal(R.unwrap_err[bool, str](psr)));
         }
-        esel.artifact     = O.unwrap[str](an_opt);
-        esel.want_lib     = m.artifacts[0].is_lib;
-        esel.has_artifact = true;
     }
     r.target   = esel.target;
     r.profile  = esel.profile;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -126,19 +126,18 @@ pub fun build_project(s: *session.Session, project_root: str, target_name: str) 
     sel.want_lib     = false;
     sel.has_artifact = false;
     # the doc/tooling entry: load the graph but never run steps (no shell in a doc pass).
-    ret build_project_impl(s, project_root, ?sel, nil, nil, false, false, false);
+    ret build_project_impl(s, project_root, ?sel, nil, nil, project.ROOT_ARTIFACT, false);
 }
 
 # build_project_impl: the shared build pipeline behind both build_project_sel
 # (single target) and build_project_union (all targets). loads the project's
-# root manifest (`<project_root>/mach.toml`). `for_union` records every
-# manifest target's tuple and flips on the union load walk (see load_config /
-# walk_comptime_if_union). `all_own_src` additionally loads every own-source module
-# as a collection root (see load_all_own_src), for `mach test`. the same phase
-# entries the build engine dispatches individually run here in sequence, so a
-# non-engine flow and an engine unit execute identical pieces.
-fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, for_union: bool, all_own_src: bool, run_steps: bool) R.Result[project.Project, outcome.Fail] {
-    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, for_union, all_own_src, all_own_src);
+# root manifest (`<project_root>/mach.toml`). `roots` makes the consumer's graph
+# explicit: one selected artifact, the whole own-source test set, or every artifact
+# entry under the tooling union. The same phase entries the build engine dispatches
+# individually run here in sequence, so a non-engine flow and an engine unit execute
+# identical pieces.
+fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, roots: project.RootSet, run_steps: bool) R.Result[project.Project, outcome.Fail] {
+    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, roots);
     if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
 
@@ -189,23 +188,24 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
     sel.artifact     = req.artifact;
     sel.want_lib     = req.want_lib;
     sel.has_artifact = !str_empty(req.artifact);
-    # every engine build front-ends the whole source tree, so `mach build` and
-    # `mach test` agree on whether the project compiles (#2539). `is_test` stays the
-    # narrower fact - it picks the link surface and the back-end work set.
-    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, false, request.test_goal(req.goal), true);
+    var roots: project.RootSet = project.ROOT_ARTIFACT;
+    if (request.test_goal(req.goal)) { roots = project.ROOT_TEST; }
+    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, roots);
 }
 
 # the shared open: init + query binding + config synthesis + target entry
 #
-# `is_test` selects the `mach test` link surface (the union of every artifact's
-# libs); `all_own_src` loads every own-source module as a load root. They are
-# independent: a `mach build` loads the whole tree to check it while still linking
-# one artifact.
-fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, for_union: bool, is_test: bool, all_own_src: bool) R.Result[project.Project, outcome.Fail] {
+# `roots` is the single source of truth for the consumer's graph. It also selects
+# union configuration and the whole-source test link surface, so independent flags
+# cannot silently widen an artifact build's front-end set again.
+fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, roots: project.RootSet) R.Result[project.Project, outcome.Fail] {
     var p: project.Project;
     project.init_project(?p, s);
-    p.events      = ev;
-    p.all_own_src = all_own_src;
+    p.events = ev;
+    p.roots  = roots;
+
+    val for_union: bool = roots == project.ROOT_UNION;
+    val is_test:   bool = roots == project.ROOT_TEST;
 
     # bind the query db's compute context and register Q_PARSE (once per session)
     # before any module loads, so parse_module can route through the engine.
@@ -348,28 +348,28 @@ pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[session.ModuleId, str](load_r)));
     }
 
-    # union build (#1505): load every other declared artifact's entry into the same
-    # Project so tooling sees the closure over the whole (target x artifact) matrix,
-    # not just the primary artifact's. dfs_load dedups by FQN, so the primary entry
-    # (also present in union_entries) re-loads as a no-op, as do shared modules.
-    var ei: u32 = 0;
-    for (ei < p.union_entry_count) {
-        val ear: R.Result[session.ModuleId, str] = load.dfs_load(p, p.union_entries[ei]);
-        if (R.is_err[session.ModuleId, str](ear)) {
-            ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[session.ModuleId, str](ear)));
+    # tooling union (#1505): load every other declared artifact's entry so the
+    # Project covers the whole (target x artifact) matrix. dfs_load dedups the
+    # primary entry and shared imports.
+    if (p.roots == project.ROOT_UNION) {
+        var ei: u32 = 0;
+        for (ei < p.union_entry_count) {
+            val ear: R.Result[session.ModuleId, str] = load.dfs_load(p, p.union_entries[ei]);
+            if (R.is_err[session.ModuleId, str](ear)) {
+                ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[session.ModuleId, str](ear)));
+            }
+            ei = ei + 1;
         }
-        ei = ei + 1;
     }
 
     # the artifact closure is settled: everything loaded so far is what this build
-    # emits and links, and the whole-source sweep below only appends past it (#2539).
+    # emits and links. A test-rooted whole-source sweep only appends past it.
     p.emit_len = p.topo_len;
 
-    # root the load at the whole source tree, not the entrypoint's import closure,
-    # so a `pub` module with no in-tree `use` consumer is still checked (#2539) and
-    # still has its tests collected (#1863). dfs_load dedups by FQN, so this only
-    # adds the modules the entry/union walks missed.
-    if (p.all_own_src) {
+    # test collection roots at every own-source module, so a test in a module no
+    # artifact imports is still collected (#1863). Artifact builds deliberately do
+    # not enter this path: their build cell is the selected entry's reachable set.
+    if (p.roots == project.ROOT_TEST) {
         val allsrc_r: R.Result[bool, str] = union.load_all_own_src(p);
         if (R.is_err[bool, str](allsrc_r)) {
             ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](allsrc_r)));
@@ -465,14 +465,14 @@ pub fun load_manifest(s: *session.Session, project_root: str) R.Result[manifest.
 # repeatedly on one long-lived Session: sources dedup by path and dnit_project
 # resets the session's module registries (see dnit_project's reload contract)
 pub fun build_project_sel(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
-    ret build_project_impl(s, project_root, sel, nil, nil, false, false, true);
+    ret build_project_impl(s, project_root, sel, nil, nil, project.ROOT_ARTIFACT, true);
 }
 
 # build the module graph for a `mach test` invocation: like build_project_sel, but
 # additionally loads every own-source module under `[project].src` as a collection
 # root, so tests in a module no entrypoint imports are still collected (#1863)
 pub fun build_project_test(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
-    ret build_project_impl(s, project_root, sel, nil, nil, false, true, true);
+    ret build_project_impl(s, project_root, sel, nil, nil, project.ROOT_TEST, true);
 }
 
 # build the union of EVERY manifest target's AND artifact's
@@ -494,7 +494,7 @@ pub fun build_project_union(s: *session.Session, project_root: str) R.Result[pro
     sel.artifact     = "";
     sel.want_lib     = false;
     sel.has_artifact = false;
-    ret build_project_impl(s, project_root, ?sel, nil, nil, true, false, false);
+    ret build_project_impl(s, project_root, ?sel, nil, nil, project.ROOT_UNION, false);
 }
 
 # bind the query db's diagnostic hooks and register the front-half kind the load
@@ -523,4 +523,3 @@ fun bind_queries(s: *session.Session) R.Result[bool, str] {
 # the QueryCtx and bridge its session's `diags` sink. a captured snapshot is a heap
 # diagnostic.DiagList the query entry owns and the engine frees through
 # diag_free_hook.
-

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -64,7 +64,8 @@ use mach.lang.driver.union;
 # rebuilding. Only the manifest is read: no module graph is loaded and no
 # dependencies are resolved. The transient toml table, interner, and manifest are
 # all suballocated from `alloc` and reclaimed when it is (pass an arena); the
-# returned path is owned by `alloc`.
+# returned path is owned by `alloc`. With no artifact selector, exactly one
+# artifact declaring the resolved target is inferred; several remain ambiguous.
 # ---
 # alloc:        allocator for the transient manifest state and the returned path
 # project_root: the resolved project root directory
@@ -84,7 +85,15 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *mani
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
-    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(alloc, ?itn, ?m, @sel);
+    var eff_sel: manifest.Selection = @sel;
+    val ssr: R.Result[bool, str] = manifest.select_sole_target_artifact(
+        alloc, ?itn, ?m, ?eff_sel);
+    if (R.is_err[bool, str](ssr)) {
+        manifest.dnit(?m, alloc);
+        ret R.err[str, str](R.unwrap_err[bool, str](ssr));
+    }
+
+    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(alloc, ?itn, ?m, eff_sel);
     if (R.is_err[manifest.BuildUnit, str](ur)) {
         manifest.dnit(?m, alloc);
         ret R.err[str, str](R.unwrap_err[manifest.BuildUnit, str](ur));

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -156,26 +156,21 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);
 
-    # the primary selection drives the ctx every module resolves under. union mode
-    # (#1505): several declared artifacts with no selector is NOT the ambiguity
-    # `build_project_sel` raises - the union takes the first declared artifact as the
-    # primary (mirroring resolve_native's first-declared-target fallback) and unions
-    # the rest's entries below. a single-artifact or selected build is untouched.
+    # the primary selection drives the ctx every module resolves under. a union or
+    # test build spans artifacts, so the manifest picks one that declares the target
+    # while the rest's entries and link surface are still unioned below (#2961).
     var eff_sel: manifest.Selection;
     eff_sel.target       = sel.target;
     eff_sel.profile      = sel.profile;
     eff_sel.artifact     = sel.artifact;
     eff_sel.want_lib     = sel.want_lib;
     eff_sel.has_artifact = sel.has_artifact;
-    # `mach test` (is_test) links the whole source tree, not one artifact, so like a
-    # union build it takes the first declared artifact as the primary ctx rather than
-    # raising the multi-artifact ambiguity `build_project_sel` would.
-    if ((for_union || is_test) && !eff_sel.has_artifact && m.artifact_count > 1) {
-        val an_opt: O.Option[str] = intern.lookup(?p.s.interner, m.artifacts[0].name);
-        if (O.is_none[str](an_opt)) { ret R.err[bool, str]("internal: union primary artifact name not interned"); }
-        eff_sel.artifact     = O.unwrap[str](an_opt);
-        eff_sel.want_lib     = m.artifacts[0].is_lib;
-        eff_sel.has_artifact = true;
+    if (for_union || is_test) {
+        val psr: R.Result[bool, str] = manifest.select_primary_artifact(
+            p.alloc, ?p.s.interner, m, ?eff_sel);
+        if (R.is_err[bool, str](psr)) {
+            ret R.err[bool, str](R.unwrap_err[bool, str](psr));
+        }
     }
 
     val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(p.alloc, ?p.s.interner, m, eff_sel);

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -454,23 +454,8 @@ pub fun resolve_cascade_libs(p: *project.Project, project_root: str, isa: str, o
     }
 
     free_cascade_scratch(p.alloc, manifests, tables, aliases, order, visited, n);
-
-    if (w == 0) {
-        A.deallocate[manifest.LinkRequirement](p.alloc, buf, max::usize);
-        ret R.ok[bool, str](true);
-    }
-    if (w < max) {
-        val sr: R.Result[*manifest.LinkRequirement, str] =
-            A.reallocate[manifest.LinkRequirement](p.alloc, buf, max::usize, w::usize);
-        if (R.is_ok[*manifest.LinkRequirement, str](sr)) {
-            p.config.cascade_libs      = R.unwrap_ok[*manifest.LinkRequirement, str](sr);
-            p.config.cascade_lib_count = w;
-            ret R.ok[bool, str](true);
-        }
-    }
-    p.config.cascade_libs      = buf;
-    p.config.cascade_lib_count = w;
-    ret R.ok[bool, str](true);
+    ret manifest.finish_link_requirements(p.alloc, buf, max, w,
+        ?p.config.cascade_libs, ?p.config.cascade_lib_count);
 }
 
 # post-order DFS visiting a dep's own declared deps before the dep

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -39,6 +39,18 @@ use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.os;
 
+# the module-root set a driver consumer asks the load walk to discover
+pub def RootSet: u8;
+
+# load only the selected artifact entry and its transitive imports
+pub val ROOT_ARTIFACT: RootSet = 0;
+
+# load every module under the current project's source tree for test collection
+pub val ROOT_TEST:     RootSet = 1;
+
+# load every declared artifact entry under the multi-target tooling context
+pub val ROOT_UNION:    RootSet = 2;
+
 # the kind of artifact a target build produces
 pub def BuildMode: u8;
 
@@ -339,6 +351,7 @@ pub rec TargetTuple {
 # topo_len:          number of entries in topo; the front-end work set
 # topo_cap:          allocated slots in topo
 # emit_len:          length of topo's leading back-end work set (see below)
+# roots:             the consumer-selected module-root policy
 pub rec Project {
     s:            *session.Session;
     alloc:        *A.Allocator;
@@ -368,26 +381,23 @@ pub rec Project {
     topo_len:     u32;
     topo_cap:     u32;
 
-    # the split between checking and emitting (#2539). `topo[0..topo_len)` is the
-    # front-end work set: resolve and sema walk all of it, so every module under
-    # `src` is checked wherever it sits in the tree. `topo[0..emit_len)` is the
-    # back-end work set: lower, codegen, emit and link walk only it, so a module no
-    # artifact entry reaches costs no object code and never enters the artifact.
+    # `topo[0..topo_len)` is the front-end work set selected by `roots`.
+    # `topo[0..emit_len)` is its leading back-end work set: lower, codegen, emit
+    # and link walk only it, so a module outside the produced artifact never
+    # contributes object code.
     #
     # It is a leading prefix because the load phase walks the artifact closure first
-    # and records emit_len there; the whole-source sweep that follows only ever
-    # appends the modules that closure missed. A test build re-records emit_len after
-    # the sweep, since a test dispatcher does link every module.
+    # and records emit_len there. A test-rooted sweep only appends modules that
+    # closure missed; a real test build re-records emit_len after the sweep because
+    # its dispatcher links every module.
     emit_len:     u32;
+
+    roots:        RootSet;
 
     # the invocation's progress-event sink, installed by the engine for the
     # span of one build so the load walk and the passes narrate into it. nil
     # (every non-engine flow) leaves the build silent.
     events:       *readout.Progress;
-
-    # load every own-source module as a collection root (`mach test`, #1863);
-    # recorded at begin so the load phase can run it without re-threading flags.
-    all_own_src:  bool;
 
     # set only while load_all_own_src loads orphan roots, so the load walk knows a
     # top-level `$error` guard it reaches marks a target-gated orphan to exclude
@@ -553,8 +563,8 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.topo_len      = 0;
     p.topo_cap      = 0;
     p.emit_len      = 0;
+    p.roots         = ROOT_ARTIFACT;
     p.events        = nil;
-    p.all_own_src   = false;
     p.loading_orphans = false;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -138,6 +138,11 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
+# a cross-platform executable split by output-extension convention (#2961)
+fun ut_manifest_split() str {
+    ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"linux\"]\nlink = []\nneed = []\n\n[artifact.uniontest-windows]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest.exe\"\ntargets = [\"windows\"]\nlink = []\nneed = []\n";
+}
+
 # a manifest with a windows-only `local` link entry whose path is neither step-backed
 # nor present on disk, for the #1988 cross-target validation-skip test. building for
 # linux must ignore the entry (it filters out), not validate its linux-cell expansion
@@ -3517,6 +3522,62 @@ test "mach.lang.driver:resolve_artifact_path" {
     if (R.is_ok[str, str](pr_bad)) { bad = 1; }
 
     fs.remove_all(?alloc, root);
+
+    # a split manifest has one runnable artifact for each target, so `mach run`
+    # resolves the Windows `.exe` without making the artifact name redundant
+    val split_root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_split(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](split_root_r)) { ret 1; }
+    val split_root: str = R.unwrap_ok[str, str](split_root_r);
+    var split_sel: manifest.Selection;
+    split_sel.target = "windows"; split_sel.profile = ""; split_sel.artifact = "";
+    split_sel.want_lib = false; split_sel.has_artifact = false;
+    val split_pr: R.Result[str, str] = dcfg.resolve_artifact_path(
+        ?alloc, split_root, ?split_sel);
+    if (R.is_err[str, str](split_pr)) { bad = 1; }
+    or {
+        val want_split: str = ut_cc3(
+            ?alloc, split_root, "/", "out/windows/debug/bin/uniontest.exe");
+        if (!str_equals(R.unwrap_ok[str, str](split_pr), want_split)) { bad = 1; }
+    }
+    fs.remove_all(?alloc, split_root);
+    ret bad;
+}
+
+# the legacy/tooling whole-source loader shares the manifest's primary rule: a
+# Windows test over a split manifest roots its context in the Windows artifact
+test "mach.lang.driver:test_primary_artifact_matches_target" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "fun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_split(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var sel: manifest.Selection;
+    sel.target = "windows"; sel.profile = ""; sel.artifact = "";
+    sel.want_lib = false; sel.has_artifact = false;
+    val pr: R.Result[project.Project, outcome.Fail] =
+        driver.build_project_test(?s, root, ?sel);
+    fs.remove_all(?alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val name_opt: O.Option[str] = intern.lookup(?s.interner, p.config.bin_name);
+    if (O.is_none[str](name_opt)
+        || !str_equals(O.unwrap[str](name_opt), "uniontest-windows")) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
     ret bad;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -138,6 +138,12 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
+# the mixed host / SPIR-V project from #2967: two artifacts with disjoint target
+# sets share one source tree, and a third module belongs to neither build cell
+fun ut_manifest_mixed_targets() str {
+    ret "[project]\nid = \"mixtest\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux-x86_64]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.spirv]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\nof = \"spv\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.host]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/mixtest\"\ntargets = [\"linux-x86_64\"]\nlink = []\nneed = []\n\n[artifact.probe_frag]\nkind = \"bin\"\nentry = \"probe_frag.mach\"\nout = \"probe_frag.spv\"\ntargets = [\"spirv\"]\nlink = []\nneed = []\n";
+}
+
 # a manifest with a windows-only `local` link entry whose path is neither step-backed
 # nor present on disk, for the #1988 cross-target validation-skip test. building for
 # linux must ignore the entry (it filters out), not validate its linux-cell expansion
@@ -9168,18 +9174,11 @@ fun ut_stable_of(s: *session.Session, fqn: str) session.StableModuleId {
     ret session.stable_module_id_lookup(s, R.unwrap_ok[intern.StrId, str](idr));
 }
 
-# warm engine: two `execute_warm` calls on one session with unchanged inputs -
-# the second call revalidates instead of recomputing (per-module Q_SEMA /
-# Q_LOWER / Q_CODEGEN and the Q_LINK fingerprint keep their last_changed), and
-# the session stays bounded (interner, SourceMap, and query-shard entry counts
-# do not grow). a third call after an edit recomputes exactly the edited
-# module's back half and re-links, proving the observables are live
-test "mach.lang.build.engine.execute:broken_unreferenced_module_fails_build" {
-    # #2539: a module under `src` that no artifact entry imports must still be
-    # checked. before this, `mach build` compiled only the entry's import closure, so
-    # a hard compile error in an unreferenced module left the build green while
-    # `mach test` - which roots its load at the whole tree - reported it. the two
-    # commands disagreed about whether the project compiled.
+test "mach.lang.build.engine.execute:artifact_build_roots_at_reachable_modules" {
+    # #2967: one project may hold a host artifact and a SPIR-V artifact. Building
+    # the shader cell must never compile the host entry or an unrelated module in
+    # the same src tree. Both carry hard errors so a whole-source front end fails
+    # this fixture before it can emit the valid shader.
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -9187,54 +9186,13 @@ test "mach.lang.build.engine.execute:broken_unreferenced_module_fails_build" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
 
-    var names: [2]str; names[0] = "main.mach"; names[1] = "orphan.mach";
-    var texts: [2]str;
-    # main does NOT import orphan: nothing on the entry's path reaches it
-    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
-    texts[1] = "pub fun broken() i32 { ret no_such_function(); }\n";
-    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
-    val root: str = R.unwrap_ok[str, str](root_r);
-
-    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
-    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
-    var rq: request.BuildRequest = request.defaults();
-    rq.project_root = root;
-    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
-    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
-
-    var bad: i32 = 0;
-    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, nil);
-    if (R.is_ok[outcome.BuildOutcome, outcome.Fail](r)) {
-        # the build reported success while a module in the tree does not compile
-        if (R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
-    }
-
-    fs.remove_all(?alloc, root);
-    session.dnit(?s);
-    ret bad;
-}
-
-test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted" {
-    # the other half of #2539: widening the CHECK must not widen what is EMITTED. a
-    # valid module no artifact entry reaches is front-ended (it has a Q_SEMA entry)
-    # and never lowered or codegen'd (no Q_LOWER / Q_CODEGEN entry), so it costs no
-    # object code and does not enter the artifact.
-    var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
-    val sr: R.Result[session.Session, str] = session.init(?alloc);
-    if (R.is_err[session.Session, str](sr)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
-
-    var names: [3]str; names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "orphan.mach";
+    var names: [3]str;
+    names[0] = "lib.mach"; names[1] = "probe_frag.mach"; names[2] = "other.mach";
     var texts: [3]str;
-    texts[0] = ut_cc3(?alloc, "use uniontest.a.fa;\n#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret fa(); }\n");
-    texts[1] = "pub fun fa() i32 { ret 1; }\n";
-    texts[2] = "pub fun orphan_only() i32 { ret 7; }\n";
-    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    texts[0] = "pub fun hello() i32 { ret missing_host_function(); }\n";
+    texts[1] = "#[output(0)] var out_colour: f32x4;\n\n#[stage(\"fragment\")]\nfun frag_main() {\n    out_colour = f32x4{1.0, 0.0, 0.0, 1.0};\n}\n";
+    texts[2] = "pub fun touch() { missing_unrelated_function(); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_mixed_targets(), ?names[0], ?texts[0], 3);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
@@ -9243,6 +9201,8 @@ test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
+    rq.target       = "spirv";
+    rq.artifact     = "probe_frag";
     val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
     if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
@@ -9252,24 +9212,26 @@ test "mach.lang.build.engine.execute:unreferenced_module_checked_but_not_emitted
     if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     if (!R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
 
-    val st_a:      session.StableModuleId = ut_stable_of(?s, "uniontest.a");
-    val st_orphan: session.StableModuleId = ut_stable_of(?s, "uniontest.orphan");
-    if (st_a == session.STABLE_MODULE_NIL || st_orphan == session.STABLE_MODULE_NIL) { bad = 1; }
-
-    # the reachable module is checked AND emitted
-    if (query.peek_revision(?s.queries, query.Q_SEMA,    st_a::u64) == 0) { bad = 1; }
-    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_a::u64) == 0) { bad = 1; }
-
-    # the unreferenced one is checked but never reaches the back half
-    if (query.peek_revision(?s.queries, query.Q_SEMA,    st_orphan::u64) == 0) { bad = 1; }
-    if (query.peek_revision(?s.queries, query.Q_LOWER,   st_orphan::u64) != 0) { bad = 1; }
-    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_orphan::u64) != 0) { bad = 1; }
+    val st_shader: session.StableModuleId = ut_stable_of(?s, "mixtest.probe_frag");
+    val st_host:   session.StableModuleId = ut_stable_of(?s, "mixtest.lib");
+    val st_other:  session.StableModuleId = ut_stable_of(?s, "mixtest.other");
+    if (st_shader == session.STABLE_MODULE_NIL) { bad = 1; }
+    if (st_host   != session.STABLE_MODULE_NIL) { bad = 1; }
+    if (st_other  != session.STABLE_MODULE_NIL) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_SEMA, st_shader::u64) == 0) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_shader::u64) == 0) { bad = 1; }
 
     fs.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;
 }
 
+# warm engine: two `execute_warm` calls on one session with unchanged inputs -
+# the second call revalidates instead of recomputing (per-module Q_SEMA /
+# Q_LOWER / Q_CODEGEN and the Q_LINK fingerprint keep their last_changed), and
+# the session stays bounded (interner, SourceMap, and query-shard entry counts
+# do not grow). a third call after an edit recomputes exactly the edited
+# module's back half and re-links, proving the observables are live
 test "mach.lang.build.engine.execute_warm:unchanged_rebuild_reuses_and_stays_bounded" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -14895,10 +14857,9 @@ fun ut_attr_probe(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
 }
 
 # ut_attr_probe over the whole-source loader, so the fixture's orphan modules are
-# LOADED without being COMPILED - the state #2539 made routine and #2657 scoped
-# attribution against
+# LOADED without being COMPILED - the state #2657 scoped attribution against
 #
-# `build_project_test` sets all_own_src (every module under src becomes a load
+# `build_project_test` selects ROOT_TEST (every module under src becomes a load
 # root) while the internal default request keeps GOAL_EXECUTE, so `emit_len` stays
 # at the artifact's closure. That combination is what makes loaded-but-not-compiled
 # reachable from a test; plain `build_project` never loads an orphan at all, and a
@@ -17376,13 +17337,14 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
 
-    # three modules: the entry, a plain orphan that survives, and a target-gated
-    # orphan whose load-time `$error` guard fires and is dropped from topo.
+    # A test-list build supplies the whole-source root set this count needs: the
+    # entry, a plain orphan that survives, and a target-gated orphan whose
+    # load-time `$error` guard fires and is dropped from topo.
     var names: [3]str;
     names[0] = "main.mach"; names[1] = "keep.mach"; names[2] = "gated.mach";
     var texts: [3]str;
     texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
-    texts[1] = "pub fun keep() i32 { ret 1; }\n";
+    texts[1] = "pub fun keep() i32 { ret 1; }\n\ntest \"keep\" { ret 0; }\n";
     texts[2] = "$error(\"gated: not for this target\");\n\npub fun gated() i32 { ret 2; }\n";
     val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
@@ -17393,6 +17355,7 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
+    rq.goal         = request.GOAL_TEST_LIST;
     val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
     if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1007,6 +1007,21 @@ test "mach.lang.driver:unknown_escape_has_location" {
     ret bad;
 }
 
+# a character literal adopts the integer type supplied by its context (#2982)
+#
+# sema already rewrites the literal's expression type during coercion. lowering
+# used to ignore that result and stamp every character constant i8, leaving a
+# wider binary operation with mixed IR operand types. the outer u8 cast in the
+# reported form then selected a usize->u8 truncation for an i8 value, which the
+# always-on verifier rejected as a contradictory conversion width.
+test "mach.lang.driver:coerced_char_literal_lowers_at_context_width" {
+    var bad: i32 = 0;
+    if (!ut_lower_clean("fun f() u64 { ret '0'; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_lower_clean("fun f(v: u64) u8 { ret ('0' + v % 10)::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
+    if (!ut_lower_clean("fun f(v: u64) u8 { ret (v % 10 + '0')::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
+    ret bad;
+}
+
 # a vector op reaching instruction selection always resolves to DEFINED behavior
 # -- never an ICE, never a silent miscompile. driving real vector ops (a pointer
 # lane-wise add and a full-arity literal) through the HOST backend on each CI

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -3,10 +3,10 @@
 # The union build (#1391/#1505) unions every manifest target's and artifact's
 # import closure into one deduplicated Project for workspace-wide tooling: it
 # precomputes one TargetTuple per target, loads every declared artifact entry
-# and every own-source module under `[project].src`, and skips a target the
-# compiler cannot cover. It also registers the project's `#[export]` directives
-# and `ext` import libraries onto the session. Sits above the load walk it
-# drives, below the facade orchestration that invokes it.
+# and skips a target the compiler cannot cover. It also owns the separate
+# whole-source enumeration used by test collection and registers the project's
+# `#[export]` directives and `ext` import libraries onto the session. Sits above
+# the load walk it drives, below the facade orchestration that invokes it.
 
 use std.collections.map;
 use std.collections.sort;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -1404,6 +1404,44 @@ pub fun free_link_claims(alloc: *A.Allocator, items: *LinkRequirement, count: u3
     }
 }
 
+# finish an overallocated link-requirement buffer as an exact-size owned array
+#
+# Requirement arrays are torn down by their published count, so a successful result
+# must have that exact allocation extent. A failed shrink keeps the original buffer
+# live; release its populated claims and full capacity before surfacing the error.
+# ---
+# alloc:     allocator owning the buffer and its claim arrays
+# items:     overallocated requirement buffer
+# capacity:  allocation extent of `items`
+# count:     populated prefix to retain
+# out_items: receives the exact-size array, or nil on empty/error
+# out_count: receives `count` on success, or zero on empty/error
+# ret:       true once ownership is transferred, or the shrink error after cleanup
+pub fun finish_link_requirements(alloc: *A.Allocator, items: *LinkRequirement,
+                                 capacity: u32, count: u32,
+                                 out_items: **LinkRequirement,
+                                 out_count: *u32) R.Result[bool, str] {
+    @out_items = nil;
+    @out_count = 0;
+    if (count == 0) {
+        A.deallocate[LinkRequirement](alloc, items, capacity::usize);
+        ret R.ok[bool, str](true);
+    }
+    if (count < capacity) {
+        val sr: R.Result[*LinkRequirement, str] =
+            A.reallocate[LinkRequirement](alloc, items, capacity::usize, count::usize);
+        if (R.is_err[*LinkRequirement, str](sr)) {
+            free_link_claims(alloc, items, count);
+            A.deallocate[LinkRequirement](alloc, items, capacity::usize);
+            ret R.err[bool, str](R.unwrap_err[*LinkRequirement, str](sr));
+        }
+        items = R.unwrap_ok[*LinkRequirement, str](sr);
+    }
+    @out_items = items;
+    @out_count = count;
+    ret R.ok[bool, str](true);
+}
+
 # merge `src`'s symbol claims into an equivalent retained link requirement
 #
 # Dependency and test-link overlays deduplicate the same dynamic library by its
@@ -2384,18 +2422,7 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
         ai = ai + 1;
     }
 
-    if (w == 0) { A.deallocate[LinkRequirement](alloc, buf, max::usize); ret R.ok[bool, str](true); }
-    if (w < max) {
-        val sr: R.Result[*LinkRequirement, str] = A.reallocate[LinkRequirement](alloc, buf, max::usize, w::usize);
-        if (R.is_ok[*LinkRequirement, str](sr)) {
-            @out_items = R.unwrap_ok[*LinkRequirement, str](sr);
-            @out_count = w;
-            ret R.ok[bool, str](true);
-        }
-    }
-    @out_items = buf;
-    @out_count = w;
-    ret R.ok[bool, str](true);
+    ret finish_link_requirements(alloc, buf, max, w, out_items, out_count);
 }
 
 fun artifact_err(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) str {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2451,8 +2451,8 @@ fun requirement_index(buf: *LinkRequirement, count: u32, req: *LinkRequirement) 
 }
 
 # resolve the `mach test` link surface (#1964): the union of every artifact's
-# referenced link entries whose filters match target `t` (the native target for a
-# test build), deduplicated, each retained as a typed link requirement. exported dep entries
+# referenced link entries whose filters match resolved target `t`, deduplicated,
+# each retained as a typed link requirement. exported dep entries
 # are added separately by the driver's cascade pass. on success `out_items` and
 # `out_count` receive the union (nil/0 when empty).
 pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, t: *TargetDef,

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2174,6 +2174,46 @@ pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
     ret R.ok[bool, str](artifact_supports_target(itn, a, rt.target.name));
 }
 
+# select the artifact that supplies a whole-source build's primary context
+#
+# A union or test build spans artifacts but still resolves every module under one
+# artifact context. With no explicit selector, choose the first artifact that
+# declares the resolved target. Falling back to the first declaration when none
+# does preserves `resolve_build_unit`'s existing incompatible-target diagnostic.
+# ---
+# alloc: allocator for target resolution
+# itn:   interner the manifest was parsed into
+# m:     parsed manifest
+# sel:   selection to fill when it has no artifact and the manifest has several
+# ret:   ok(true), or an internal interner error
+pub fun select_primary_artifact(alloc: *A.Allocator, itn: *intern.Interner,
+                                m: *Manifest, sel: *Selection) R.Result[bool, str] {
+    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok[bool, str](true); }
+
+    var primary: *ArtifactDef = ?m.artifacts[0];
+    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
+    if (R.is_ok[ResolvedTarget, str](tr)) {
+        val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
+        var i: u32 = 0;
+        for (i < m.artifact_count) {
+            if (artifact_supports_target(itn, ?m.artifacts[i], rt.target.name)) {
+                primary = ?m.artifacts[i];
+                brk;
+            }
+            i = i + 1;
+        }
+    }
+
+    val name_opt: O.Option[str] = intern.lookup(itn, primary.name);
+    if (O.is_none[str](name_opt)) {
+        ret R.err[bool, str]("primary artifact name not interned");
+    }
+    sel.artifact     = O.unwrap[str](name_opt);
+    sel.want_lib     = primary.is_lib;
+    sel.has_artifact = true;
+    ret R.ok[bool, str](true);
+}
+
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
     # a selection with no `--target` lets its artifact pin the target. resolving
     # the artifact twice keeps the resolution order (and so the diagnostic a
@@ -3852,6 +3892,50 @@ test "mach.lang.manifest.resolve_build_unit:artifact_target_filter" {
 
         val uw: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("windows", "", "app", false, true));
         if (R.is_ok[BuildUnit, str](uw) || !str_contains(R.unwrap_err[BuildUnit, str](uw), "does not support target")) { code = 1; }
+    }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# a whole-source build roots its context in an artifact that declares the selected
+# target, so splitting a cross-platform executable for Windows does not make
+# declaration order load-bearing (#2961)
+test "mach.lang.manifest.select_primary_artifact:first_target_compatible" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    val src: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"linux\"]\nlink=[]\nneed=[]\n[artifact.app-windows]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app.exe\"\ntargets=[\"windows\"]\nlink=[]\nneed=[]\n";
+    val mr: R.Result[Manifest, str] = tparse(?alloc, ?itn, src);
+    if (R.is_err[Manifest, str](mr)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](mr);
+
+        var windows: Selection = mk_sel("windows", "", "", false, false);
+        val wr: R.Result[bool, str] = select_primary_artifact(?alloc, ?itn, ?m, ?windows);
+        if (R.is_err[bool, str](wr) || !windows.has_artifact
+            || !str_equals(windows.artifact, "app-windows")) { code = 1; }
+        or {
+            val wu: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, windows);
+            if (R.is_err[BuildUnit, str](wu)) { code = 1; }
+            or {
+                val unit: BuildUnit = R.unwrap_ok[BuildUnit, str](wu);
+                if (!str_equals(idstr(?itn, unit.bin_path), "out/bin/app.exe")) { code = 1; }
+            }
+        }
+
+        var linux: Selection = mk_sel("linux", "", "", false, false);
+        val lr: R.Result[bool, str] = select_primary_artifact(?alloc, ?itn, ?m, ?linux);
+        if (R.is_err[bool, str](lr) || !linux.has_artifact
+            || !str_equals(linux.artifact, "app")) { code = 1; }
+
+        # an explicit selector remains authoritative, including when it names an
+        # incompatible cell whose diagnostic resolve_build_unit owns
+        var explicit: Selection = mk_sel("windows", "", "app", false, true);
+        val er: R.Result[bool, str] = select_primary_artifact(?alloc, ?itn, ?m, ?explicit);
+        val eu: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, explicit);
+        if (R.is_err[bool, str](er) || !str_equals(explicit.artifact, "app")
+            || R.is_ok[BuildUnit, str](eu)) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2303,13 +2303,27 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, rt.target)) {
                     val req_r: R.Result[LinkRequirement, str] = link_requirement(alloc, itn, found_l, proj_out, ?v);
-                    if (R.is_err[LinkRequirement, str](req_r)) { ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r)); }
+                    if (R.is_err[LinkRequirement, str](req_r)) {
+                        free_link_claims(alloc, matched_items, match_count);
+                        A.deallocate[LinkRequirement](alloc, matched_items, a.link_count::usize);
+                        ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r));
+                    }
                     matched_items[match_count] = R.unwrap_ok[LinkRequirement, str](req_r);
                     match_count = match_count + 1;
                 }
             }
             li = li + 1;
         }
+
+        var exact_items: *LinkRequirement = nil;
+        var exact_count: u32 = 0;
+        val fr: R.Result[bool, str] = finish_link_requirements(alloc, matched_items,
+            a.link_count, match_count, ?exact_items, ?exact_count);
+        if (R.is_err[bool, str](fr)) {
+            ret R.err[BuildUnit, str](R.unwrap_err[bool, str](fr));
+        }
+        matched_items = exact_items;
+        match_count = exact_count;
     }
     u.libs      = matched_items;
     u.lib_count = match_count;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2559,6 +2559,45 @@ fun tinit(backing: *A.Allocator, ar: *arena.Arena, alloc: *A.Allocator, itn: *in
     ret true;
 }
 
+# size-checking allocator probe whose one reallocation always fails
+rec LinkFinishAllocProbe {
+    backing: A.Allocator;
+    items: ptr;
+    items_size: usize;
+    claims: ptr;
+    claims_size: usize;
+    realloc_count: u32;
+    items_freed: bool;
+    claims_freed: bool;
+    mismatch: bool;
+}
+
+fun link_finish_probe_allocate(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
+    val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
+    ret p.backing.fn_allocate(p.backing.ctx, size, align);
+}
+
+fun link_finish_probe_reallocate(ctx: ptr, item: ptr, old_size: usize,
+                                 new_size: usize, align: usize) O.Option[ptr] {
+    val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
+    p.realloc_count = p.realloc_count + 1;
+    if (item != p.items || old_size != p.items_size) { p.mismatch = true; }
+    ret O.none[ptr]();
+}
+
+fun link_finish_probe_deallocate(ctx: ptr, item: ptr, size: usize, align: usize) i64 {
+    val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
+    if (item == p.items) {
+        p.items_freed = true;
+        if (size != p.items_size) { p.mismatch = true; }
+    }
+    if (item == p.claims) {
+        p.claims_freed = true;
+        if (size != p.claims_size) { p.mismatch = true; }
+    }
+    ret p.backing.fn_deallocate(p.backing.ctx, item, size, align);
+}
+
 fun tparse(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manifest, str] {
     val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
     if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
@@ -3819,6 +3858,61 @@ test "mach.lang.manifest.merge_link_claims:stable_owned_union" {
 
     arena.dnit(?ar);
     ret code;
+}
+
+# A shrink failure leaves the original allocation live. The finalizer must free
+# its populated claims and the buffer at its full capacity, then publish no result
+# (#2977). The probe rejects the shrink and records the exact sizes passed to free.
+test "mach.lang.manifest.finish_link_requirements:shrink_failure_frees_full_extent" {
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+
+    var probe: LinkFinishAllocProbe;
+    probe.backing       = backing;
+    probe.items         = nil;
+    probe.items_size    = 0;
+    probe.claims        = nil;
+    probe.claims_size   = 0;
+    probe.realloc_count = 0;
+    probe.items_freed   = false;
+    probe.claims_freed  = false;
+    probe.mismatch      = false;
+
+    var alloc: A.Allocator;
+    var probe_ptr: *LinkFinishAllocProbe = ?probe;
+    alloc.ctx           = probe_ptr::ptr;
+    alloc.fn_allocate   = link_finish_probe_allocate;
+    alloc.fn_reallocate = link_finish_probe_reallocate;
+    alloc.fn_deallocate = link_finish_probe_deallocate;
+
+    val br: R.Result[*LinkRequirement, str] = A.allocate[LinkRequirement](?alloc, 2::usize);
+    if (R.is_err[*LinkRequirement, str](br)) { ret 1; }
+    val items: *LinkRequirement = R.unwrap_ok[*LinkRequirement, str](br);
+    probe.items      = items::ptr;
+    probe.items_size = $size_of(LinkRequirement) * 2;
+
+    val cr: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](?alloc, 1::usize);
+    if (R.is_err[*intern.StrId, str](cr)) {
+        A.deallocate[LinkRequirement](?alloc, items, 2::usize);
+        ret 1;
+    }
+    items[0].symbols      = R.unwrap_ok[*intern.StrId, str](cr);
+    items[0].symbol_count = 1;
+    items[0].symbols[0]   = intern.STR_NIL;
+    probe.claims      = items[0].symbols::ptr;
+    probe.claims_size = $size_of(intern.StrId);
+
+    var out_items: *LinkRequirement = nil;
+    var out_count: u32 = 0;
+    val fr: R.Result[bool, str] =
+        finish_link_requirements(?alloc, items, 2, 1, ?out_items, ?out_count);
+
+    if (R.is_ok[bool, str](fr)) { ret 1; }
+    if (!str_equals(R.unwrap_err[bool, str](fr), "out of memory")) { ret 1; }
+    if (out_items != nil || out_count != 0) { ret 1; }
+    if (probe.realloc_count != 1 || probe.mismatch) { ret 1; }
+    if (!probe.claims_freed || !probe.items_freed) { ret 1; }
+    ret 0;
 }
 
 test "mach.lang.manifest.parse:link_filter_empty_string_error" {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2174,6 +2174,39 @@ pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
     ret R.ok[bool, str](artifact_supports_target(itn, a, rt.target.name));
 }
 
+# find the first artifact that declares the selection's resolved target
+fun first_target_artifact(alloc: *A.Allocator, itn: *intern.Interner,
+                          m: *Manifest, sel: *Selection, count: *u32) *ArtifactDef {
+    @count = 0;
+    var first: *ArtifactDef = nil;
+    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
+    if (R.is_err[ResolvedTarget, str](tr)) { ret nil; }
+    val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
+
+    var i: u32 = 0;
+    for (i < m.artifact_count) {
+        if (artifact_supports_target(itn, ?m.artifacts[i], rt.target.name)) {
+            if (first == nil) { first = ?m.artifacts[i]; }
+            @count = @count + 1;
+        }
+        i = i + 1;
+    }
+    ret first;
+}
+
+# store one resolved artifact as an explicit selection
+fun set_selected_artifact(itn: *intern.Interner, a: *ArtifactDef,
+                          sel: *Selection) R.Result[bool, str] {
+    val name_opt: O.Option[str] = intern.lookup(itn, a.name);
+    if (O.is_none[str](name_opt)) {
+        ret R.err[bool, str]("selected artifact name not interned");
+    }
+    sel.artifact     = O.unwrap[str](name_opt);
+    sel.want_lib     = a.is_lib;
+    sel.has_artifact = true;
+    ret R.ok[bool, str](true);
+}
+
 # select the artifact that supplies a whole-source build's primary context
 #
 # A union or test build spans artifacts but still resolves every module under one
@@ -2190,28 +2223,31 @@ pub fun select_primary_artifact(alloc: *A.Allocator, itn: *intern.Interner,
                                 m: *Manifest, sel: *Selection) R.Result[bool, str] {
     if (sel.has_artifact || m.artifact_count < 2) { ret R.ok[bool, str](true); }
 
-    var primary: *ArtifactDef = ?m.artifacts[0];
-    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
-    if (R.is_ok[ResolvedTarget, str](tr)) {
-        val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
-        var i: u32 = 0;
-        for (i < m.artifact_count) {
-            if (artifact_supports_target(itn, ?m.artifacts[i], rt.target.name)) {
-                primary = ?m.artifacts[i];
-                brk;
-            }
-            i = i + 1;
-        }
-    }
+    var count: u32 = 0;
+    var primary: *ArtifactDef = first_target_artifact(alloc, itn, m, sel, ?count);
+    if (primary == nil) { primary = ?m.artifacts[0]; }
+    ret set_selected_artifact(itn, primary, sel);
+}
 
-    val name_opt: O.Option[str] = intern.lookup(itn, primary.name);
-    if (O.is_none[str](name_opt)) {
-        ret R.err[bool, str]("primary artifact name not interned");
-    }
-    sel.artifact     = O.unwrap[str](name_opt);
-    sel.want_lib     = primary.is_lib;
-    sel.has_artifact = true;
-    ret R.ok[bool, str](true);
+# select an unnamed artifact when exactly one declares the resolved target
+#
+# Used by commands such as `mach run` that consume one build product. A
+# target-split cross-platform executable resolves without a redundant `--bin`,
+# while several runnable artifacts retain the existing ambiguity diagnostic.
+# ---
+# alloc: allocator for target resolution
+# itn:   interner the manifest was parsed into
+# m:     parsed manifest
+# sel:   selection to fill only when its resolved target has one artifact
+# ret:   ok(true), or an internal interner error
+pub fun select_sole_target_artifact(alloc: *A.Allocator, itn: *intern.Interner,
+                                    m: *Manifest, sel: *Selection) R.Result[bool, str] {
+    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok[bool, str](true); }
+
+    var count: u32 = 0;
+    val sole: *ArtifactDef = first_target_artifact(alloc, itn, m, sel, ?count);
+    if (sole == nil || count != 1) { ret R.ok[bool, str](true); }
+    ret set_selected_artifact(itn, sole, sel);
 }
 
 pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
@@ -3929,6 +3965,14 @@ test "mach.lang.manifest.select_primary_artifact:first_target_compatible" {
         if (R.is_err[bool, str](lr) || !linux.has_artifact
             || !str_equals(linux.artifact, "app")) { code = 1; }
 
+        # a single-product consumer reaches the same windows artifact without an
+        # explicit selector when it is the sole artifact for that target
+        var runnable: Selection = mk_sel("windows", "", "", false, false);
+        val rr: R.Result[bool, str] = select_sole_target_artifact(
+            ?alloc, ?itn, ?m, ?runnable);
+        if (R.is_err[bool, str](rr) || !runnable.has_artifact
+            || !str_equals(runnable.artifact, "app-windows")) { code = 1; }
+
         # an explicit selector remains authoritative, including when it names an
         # incompatible cell whose diagnostic resolve_build_unit owns
         var explicit: Selection = mk_sel("windows", "", "app", false, true);
@@ -3936,6 +3980,20 @@ test "mach.lang.manifest.select_primary_artifact:first_target_compatible" {
         val eu: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, explicit);
         if (R.is_err[bool, str](er) || !str_equals(explicit.artifact, "app")
             || R.is_ok[BuildUnit, str](eu)) { code = 1; }
+    }
+
+    # two compatible artifacts remain ambiguous for a single-product consumer;
+    # declaration order is a primary-context tie-breaker, not a `mach run` choice
+    val ambiguous_src: str = sfmt(?alloc, "{}{}", src,
+        "[artifact.tool-windows]\nkind=\"bin\"\nentry=\"tool.mach\"\nout=\"bin/tool.exe\"\ntargets=[\"windows\"]\nlink=[]\nneed=[]\n");
+    val amr: R.Result[Manifest, str] = tparse(?alloc, ?itn, ambiguous_src);
+    if (R.is_err[Manifest, str](amr)) { code = 1; }
+    or {
+        var am: Manifest = R.unwrap_ok[Manifest, str](amr);
+        var ambiguous: Selection = mk_sel("windows", "", "", false, false);
+        val ar_: R.Result[bool, str] = select_sole_target_artifact(
+            ?alloc, ?itn, ?am, ?ambiguous);
+        if (R.is_err[bool, str](ar_) || ambiguous.has_artifact) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2595,7 +2595,8 @@ fun link_finish_probe_reallocate(ctx: ptr, item: ptr, old_size: usize,
                                  new_size: usize, align: usize) O.Option[ptr] {
     val p: *LinkFinishAllocProbe = ctx::*LinkFinishAllocProbe;
     p.realloc_count = p.realloc_count + 1;
-    if (item != p.items || old_size != p.items_size) { p.mismatch = true; }
+    if (item != p.items || old_size != p.items_size
+        || new_size != $size_of(LinkRequirement)) { p.mismatch = true; }
     ret O.none[ptr]();
 }
 
@@ -3916,8 +3917,8 @@ test "mach.lang.manifest.finish_link_requirements:shrink_failure_frees_full_exte
     probe.claims      = items[0].symbols::ptr;
     probe.claims_size = $size_of(intern.StrId);
 
-    var out_items: *LinkRequirement = nil;
-    var out_count: u32 = 0;
+    var out_items: *LinkRequirement = items;
+    var out_count: u32 = 0xFFFFFFFF;
     val fr: R.Result[bool, str] =
         finish_link_requirements(?alloc, items, 2, 1, ?out_items, ?out_count);
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -93,7 +93,7 @@ fun lower_rvalue_kind(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr)
 
     if (k == expr.EXPR_KIND_LIT_INT)        { ret lower_lit_int(ctx, eid, e); }
     if (k == expr.EXPR_KIND_LIT_FLOAT)      { ret lower_lit_float(ctx, eid, e); }
-    if (k == expr.EXPR_KIND_LIT_CHAR)       { ret lower_lit_char(ctx, e); }
+    if (k == expr.EXPR_KIND_LIT_CHAR)       { ret lower_lit_char(ctx, eid, e); }
     if (k == expr.EXPR_KIND_LIT_STR)        { ret lower_lit_str(ctx, e); }
     if (k == expr.EXPR_KIND_LIT_NIL)        { ret lower_lit_nil(ctx, eid); }
     if (k == expr.EXPR_KIND_IDENT)          { ret lower_ident_rvalue(ctx, eid); }
@@ -243,13 +243,14 @@ fun lower_lit_float(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R
     ret R.ok[value.Value, str](value.const_float(e.data.lit_float, R.unwrap_ok[ir_type.IrTypeId, str](res_ir)));
 }
 
-# lower a character literal to an 8-bit integer constant
+# lower a character literal to a constant at the expression's IR type
 # ---
 # ctx: per-module lowering context
+# eid: the literal expression
 # e:   the resolved literal node
 # ret: the constant Value, or an error
-fun lower_lit_char(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value, str] {
-    val res_ir: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 8);
+fun lower_lit_char(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Result[value.Value, str] {
+    val res_ir: R.Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
     if (R.is_err[ir_type.IrTypeId, str](res_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ir)); }
     ret R.ok[value.Value, str](value.const_int(e.data.lit_char::u64, R.unwrap_ok[ir_type.IrTypeId, str](res_ir)));
 }


### PR DESCRIPTION
## Summary

Promote the completed 4.19.0 release from `dev` to `main`.

- compile ordinary artifacts from their reachable module closure while preserving whole-source test collection (#2967)
- select target-compatible primary artifacts and scaffold/run extension-correct Windows executables (#2961, #2981)
- lower coerced character literals at the resolved integer width (#2982)
- retain exact allocation ownership for finalized link requirements (#2977)
- publish the 4.19.0 version and changelog

## Verification

- full suite: 1480 passed, 0 failed
- release three-generation self-host reaches a byte-identical fixpoint
- Linux, Windows, ARM, link, incremental, and target-corpus jobs pass
- native x86_64-Darwin and aarch64-Darwin fixpoint/self-test release gates pass

Related to #2986