### PR TITLE
fix(driver): remove project mach requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### Project manifests no longer declare a minimum Mach version (#2953)
+
+The undocumented `[project].mach` key and its toolchain-version check have been
+removed. The check read the embedding project's version when the compiler frontend
+was vendored, so it refused every ordinary `4.x` requirement under tools such as
+mach-lsp. Root manifests now report `mach` as an unknown project key; dependency
+metadata bearing the removed key is ignored. No replacement is planned here.
+
 ## [4.19.0] - 2026-08-10
 
 ### Changed

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -155,12 +155,6 @@ fun dup_strid_array(alloc: *A.Allocator, src: *intern.StrId, count: u32, out: **
 # owns it (the CLI hands its once-loaded manifest forward; nothing here
 # re-parses or frees it)
 pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifest.Manifest, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
-    # before anything else, and specifically before any source is parsed: a
-    # requirement on the toolchain can be a SYNTAX requirement, and nothing in
-    # source can diagnose source that will not parse (#2714).
-    val tc: R.Result[bool, str] = manifest.check_toolchain(p.alloc, ?p.s.interner, m, load.MACH_VERSION, nil);
-    if (R.is_err[bool, str](tc)) { ret R.err[bool, str](R.unwrap_err[bool, str](tc)); }
-
     val abs_root_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -571,19 +571,6 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
         ret R.err[project.DepEntry, str](msg);
     }
 
-    # the dep's minimum toolchain, checked here rather than in source. this is the
-    # case that matters for #2714: a consumer builds mach-std, not the file inside
-    # it that fails, so the message names the DEPENDENCY that demands the version.
-    val dep_min: str = toml.get_str(?t, "project.mach");
-    if (!str_empty(dep_min)) {
-        val tc: R.Result[bool, str] = manifest.check_toolchain_str(s.build_alloc, dep_min, load.MACH_VERSION, id_str);
-        if (R.is_err[bool, str](tc)) {
-            val msg: str = R.unwrap_err[bool, str](tc);
-            str_free(s.build_alloc, dep_dir);
-            ret R.err[project.DepEntry, str](msg);
-        }
-    }
-
     var entry: project.DepEntry;
 
     val ra: R.Result[intern.StrId, str] = intern.intern(?s.interner, alias);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -4,7 +4,6 @@
 use std.allocator.arena;
 use std.allocator.page;
 use std.data.toml;
-use semver: std.types.semver;
 use std.format;
 use std.text.string.str_free;
 use std.types.bool.bool;
@@ -190,10 +189,6 @@ pub rec StepDef {
 pub rec Manifest {
     id:               intern.StrId;
     version:          intern.StrId;
-    # `[project].mach`: the minimum toolchain, STR_NIL when unstated. checked
-    # before any source is parsed, which is the only point early enough to
-    # diagnose a SYNTAX requirement (#2714).
-    mach_min:         intern.StrId;
     name:             intern.StrId;
     description:      intern.StrId;
     src:              intern.StrId;
@@ -211,59 +206,6 @@ pub rec Manifest {
     link_count:       u32;
     steps:            *StepDef;
     step_count:       u32;
-}
-
-# check a manifest's `[project].mach` against the running toolchain
-#
-# Called BEFORE any source is parsed, which is the only point early enough to
-# diagnose a SYNTAX requirement. A comptime `$if` in source cannot: parsing
-# precedes comptime evaluation, so a file using a spelling the running compiler
-# cannot tokenize fails at the grammar rule and the guard never runs (#2714).
-#
-# `who` names the project that DEMANDS the version. For a dependency that is the
-# dependency, not the project the user invoked - a consumer builds mach-std, so
-# naming their own project would send them to the wrong manifest.
-# ---
-# m:       the parsed manifest to check
-# running: the running toolchain's version
-# who:     project id to name in the message, nil for the root project
-# ret:     ok when satisfied or unstated, otherwise the shortfall
-pub fun check_toolchain(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, running: str, who: str) R.Result[bool, str] {
-    if (m.mach_min == intern.STR_NIL) { ret R.ok[bool, str](true); }
-
-    val req_o: O.Option[str] = intern.lookup(itn, m.mach_min);
-    if (O.is_none[str](req_o)) { ret R.err[bool, str]("internal: [project].mach not interned"); }
-    ret check_toolchain_str(alloc, O.unwrap[str](req_o), running, who);
-}
-
-# the comparison itself, over strings
-#
-# Split out because a dependency's manifest is read as raw toml by the dep
-# resolver rather than through `parse`, and one comparison serving both is what
-# stops the root and dependency paths disagreeing about what satisfies a
-# requirement.
-# ---
-# req_s:   the required minimum, already known non-empty
-# running: the running toolchain's version
-# who:     project id to name, nil for the root project
-pub fun check_toolchain_str(alloc: *A.Allocator, req_s: str, running: str, who: str) R.Result[bool, str] {
-    val rr: R.Result[semver.Semver, str] = semver.semver_parse(req_s, alloc);
-    if (R.is_err[semver.Semver, str](rr)) { ret R.err[bool, str]("mach.toml: [project].mach is not a version"); }
-    var req: semver.Semver = R.unwrap_ok[semver.Semver, str](rr);
-
-    val cr: R.Result[semver.Semver, str] = semver.semver_parse(running, alloc);
-    # an unparseable running version is not the project's fault, so it must not
-    # be reported as a shortfall. a development build with an odd version string
-    # would otherwise be refused by every manifest that states a requirement.
-    if (R.is_err[semver.Semver, str](cr)) { ret R.ok[bool, str](true); }
-    var cur: semver.Semver = R.unwrap_ok[semver.Semver, str](cr);
-
-    if (!semver.semver_is_less(?cur, ?req)) { ret R.ok[bool, str](true); }
-
-    if (who == nil) {
-        ret R.err[bool, str](sfmt(alloc, "this project requires mach {} or newer; running {}", req_s, running));
-    }
-    ret R.err[bool, str](sfmt(alloc, "dependency '{}' requires mach {} or newer; running {}", who, req_s, running));
 }
 
 pub rec Selection {
@@ -646,10 +588,6 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
 fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     if (kind == TK_PROJECT) {
         if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
-        # the minimum toolchain this project needs. optional, and read from a
-        # dependency's manifest too - a dependency is the case that matters, since
-        # a consumer builds the dependency rather than the file that fails (#2714).
-        if (str_equals(k, "mach")) { ret true; }
         # a dependency's manifest (as_root false) tolerates the pre-flag-day
         # name/description metadata the consumer never reads (#1971); the root
         # trims [project] to id/version/src/out. a genuinely unknown key is rejected
@@ -762,20 +700,6 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, as_roo
     if (!is_valid_id(id_str)) { ret R.err[Manifest, str]("mach.toml: [project].id must be an identifier (letters, digits, '_', '-')"); }
     m.id = intern_unwrap(itn, id_str);
     m.version = intern_unwrap(itn, ver_str);
-
-    # optional. absent means no requirement, so every existing manifest is
-    # unchanged. a present but unparseable value is an error rather than an
-    # ignored key - a typo'd requirement that silently permits everything is
-    # worse than no requirement at all.
-    val mach_str: str = toml.get_str(proj, "mach");
-    m.mach_min = intern.STR_NIL;
-    if (!str_empty(mach_str)) {
-        val vr: R.Result[semver.Semver, str] = semver.semver_parse(mach_str, alloc);
-        if (R.is_err[semver.Semver, str](vr)) {
-            ret R.err[Manifest, str]("mach.toml: [project].mach must be a version like \"4.14.0\"");
-        }
-        m.mach_min = intern_unwrap(itn, mach_str);
-    }
     # name/description are not #1964 fields; [project] is id/version/src/out only.
     m.name = intern.STR_NIL;
     m.description = intern.STR_NIL;
@@ -4239,64 +4163,15 @@ test "mach.lang.manifest.cell_supported:enumerated_axis_is_not_pinned_by_the_art
     ret code;
 }
 
-# the toolchain gate compares by precedence, not by string equality, and reports
-# the shortfall in terms of who demanded it. `who` nil is the root project;
-# a name is a dependency, which is the case that matters, since a consumer
-# builds the dependency rather than the file inside it that fails.
-test "mach.lang.manifest.check_toolchain_str:compares_and_attributes" {
+test "mach.lang.manifest.parse:mach_key_is_unknown" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
-
-    # satisfied: newer, and exactly equal
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.0.0",  "4.14.0", nil))) { code = 1; }
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.14.0", "4.14.0", nil))) { code = 1; }
-    # a patch-level shortfall is still a shortfall, and 4.9 is not newer than 4.14
-    if (R.is_ok[bool, str](check_toolchain_str(?alloc, "4.14.1", "4.14.0", nil)))  { code = 1; }
-    if (R.is_ok[bool, str](check_toolchain_str(?alloc, "4.14.0", "4.9.0",  nil)))  { code = 1; }
-    # a string compare would call "4.9.0" newer than "4.14.0" because '9' > '1'
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.9.0", "4.14.0", nil)))  { code = 1; }
-
-    # an unparseable RUNNING version is not the project's fault and must not read
-    # as a shortfall, or a development build would be refused by every manifest
-    # that states a requirement
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.14.0", "not-a-version", nil))) { code = 1; }
-
-    # the shortfall names the dependency, not the project the user invoked
-    val d: R.Result[bool, str] = check_toolchain_str(?alloc, "99.0.0", "4.14.0", "std");
-    if (R.is_ok[bool, str](d)) { code = 1; }
-    or (!str_contains(R.unwrap_err[bool, str](d), "dependency 'std'")) { code = 1; }
-
-    val rt: R.Result[bool, str] = check_toolchain_str(?alloc, "99.0.0", "4.14.0", nil);
-    if (R.is_ok[bool, str](rt)) { code = 1; }
-    or (!str_contains(R.unwrap_err[bool, str](rt), "this project")) { code = 1; }
-
-    arena.dnit(?ar);
-    ret code;
-}
-
-# an absent `[project].mach` is no requirement, so every manifest predating this
-# key keeps working. a present but malformed one is an error rather than an
-# ignored key: a typo'd requirement that silently permits everything is worse
-# than stating none.
-test "mach.lang.manifest.parse:mach_key_optional_and_validated" {
-    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
-    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
-    var code: i32 = 0;
-
-    val base: str = "[project]\nid = \"p\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"o\"\n";
-    val ok_r: R.Result[Manifest, str] = tparse(?alloc, ?itn, base);
-    if (R.is_err[Manifest, str](ok_r)) { code = 1; }
-    or (R.unwrap_ok[Manifest, str](ok_r).mach_min != intern.STR_NIL) { code = 1; }
 
     val with_r: R.Result[Manifest, str] = tparse(?alloc, ?itn,
         "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"4.14.0\"\nsrc = \"src\"\nout = \"o\"\n");
-    if (R.is_err[Manifest, str](with_r)) { code = 1; }
-    or (R.unwrap_ok[Manifest, str](with_r).mach_min == intern.STR_NIL) { code = 1; }
-
-    val bad_r: R.Result[Manifest, str] = tparse(?alloc, ?itn,
-        "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"banana\"\nsrc = \"src\"\nout = \"o\"\n");
-    if (R.is_ok[Manifest, str](bad_r)) { code = 1; }
+    if (R.is_ok[Manifest, str](with_r)) { code = 1; }
+    or (!str_contains(R.unwrap_err[Manifest, str](with_r), "unknown key 'mach' in [project]")) { code = 1; }
 
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -588,6 +588,9 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
 fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     if (kind == TK_PROJECT) {
         if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
+        # tolerate the removed minimum-version key in dependency metadata so an
+        # existing dependency cannot make its consumer fail during migration
+        if (!as_root && str_equals(k, "mach")) { ret true; }
         # a dependency's manifest (as_root false) tolerates the pre-flag-day
         # name/description metadata the consumer never reads (#1971); the root
         # trims [project] to id/version/src/out. a genuinely unknown key is rejected
@@ -4172,6 +4175,11 @@ test "mach.lang.manifest.parse:mach_key_is_unknown" {
         "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"4.14.0\"\nsrc = \"src\"\nout = \"o\"\n");
     if (R.is_ok[Manifest, str](with_r)) { code = 1; }
     or (!str_contains(R.unwrap_err[Manifest, str](with_r), "unknown key 'mach' in [project]")) { code = 1; }
+
+    val dep_r: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn,
+        "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"4.14.0\"\nsrc = \"src\"\nout = \"o\"\n");
+    if (R.is_err[Manifest, str](dep_r)) { code = 1; }
+    or { var dep: Manifest = R.unwrap_ok[Manifest, str](dep_r); dnit(?dep, ?alloc); }
 
     arena.dnit(?ar);
     ret code;


### PR DESCRIPTION
Closes #2953

Removes the undocumented [project].mach key, manifest storage, semver checks, and dependency enforcement. Root manifests now reject the removed key as unknown; dependency metadata is ignored by the dependency reader.

Verification: mach test . (1479 passed)