### PR TITLE
fix(driver): own the compiler version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,11 +26,13 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
-      - name: tag matches mach.toml version
+      - name: tag matches every release version
         run: |
           set -euo pipefail
           ver="$(sed -n 's/^version = "\(.*\)"$/\1/p' mach.toml | head -1)"
           [ "v$ver" = "$GITHUB_REF_NAME" ] || { echo "::error::tag $GITHUB_REF_NAME != mach.toml version $ver"; exit 1; }
+          compiler_ver="$(sed -n 's/^pub val MACH_VERSION: str = "\(.*\)";$/\1/p' src/lang/version.mach)"
+          [ "$compiler_ver" = "$ver" ] || { echo "::error::compiler version $compiler_ver != mach.toml version $ver"; exit 1; }
 
   build-linux:
     name: build ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
             exit 1
           fi
 
+          bash test/version-vendor.sh ./b .
+
           # hand the fixpoint binary to the test job
           mkdir -p artifact
           cp c artifact/mach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Vendored frontends retain Mach's compiler version (#2954)
+
+The driver, `$mach.version`, debug-info producer string, and CLI now read one Mach-owned
+release constant instead of the embedding project's `[project].version`. A frontend
+vendored by another tool therefore reports Mach's version rather than its host package's
+version. Release tests pin the constant to Mach's own manifest.
+
 ## [4.19.0] - 2026-08-10
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,10 @@ Mach uses [Semantic Versioning](https://semver.org/) (`vMAJOR.MINOR.PATCH`):
 
 Tags are created on `main` after merging from `dev`. The current pre-1.0 convention treats minor bumps as potentially breaking while the language stabilizes.
 
+A release bump updates both `[project].version` in `mach.toml` and
+`MACH_VERSION` in `src/lang/version.mach`. CI and the tag workflow require the
+two values to match.
+
 ### Release Flow
 
 ```

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -18,9 +18,7 @@ use std.types.string.str_len;
 
 use mach.cli.args;
 use mach.cli.util;
-
-# the compiler version string, folded at compile time from the project manifest
-val MACH_VERSION: str = $project.version;
+use mach.lang.version;
 
 # the column a flag's doc text starts at, so a table renders as aligned pairs
 val FLAG_COL: usize = 24;
@@ -113,7 +111,7 @@ fun global_flags() {
 # print the top-level usage summary and the command list
 pub fun usage() {
     print.print("mach ");
-    print.print(MACH_VERSION);
+    print.print(version.MACH_VERSION);
     print.print(" - the Mach compiler\n");
     print.print("\n");
     print.print("usage: mach <command> [options]\n");

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -31,9 +31,7 @@ use mach.lang.target.abi;
 use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.os;
-
-# the compiler version string, folded from the project manifest at compile time
-val MACH_VERSION: str = $project.version;
+use mach.lang.version;
 
 # `mach info` subcommand entry point
 #
@@ -52,7 +50,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (util.flag_reject_unknown(argc, argv, marks, 2, "mach info")) { ret 1; }
 
     if (argc >= 3 && str_equals(argv[2]::str, "--version")) {
-        print.println(MACH_VERSION);
+        print.println(version.MACH_VERSION);
         ret 0;
     }
 
@@ -74,7 +72,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     }
 
     print.print("mach ");
-    print.println(MACH_VERSION);
+    print.println(version.MACH_VERSION);
 
     # the host os/arch fold at compile time to the target this binary was built for.
     print.print("host: ");

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -50,12 +50,13 @@ use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
+use mach.lang.version;
 
 use mach.lang.driver.project;
 use dq: mach.lang.driver.query;
 
 # the compiler's own version string, recorded into each module's comptime ctx
-pub val MACH_VERSION: str = $project.version;
+pub val MACH_VERSION: str = version.MACH_VERSION;
 
 # seed capacities for the per-build growable arrays (module table, a module's pub
 # const list, a module's dep list)

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -7,6 +7,6 @@ use std.types.string.str_equals;
 pub val MACH_VERSION: str = "4.19.0";
 
 test "mach.lang.version:matches_project_release" {
-    if (!str_equals(MACH_VERSION, $project.version)) { ret 1; }
+    if (str_equals($project.id, "mach") && !str_equals(MACH_VERSION, $project.version)) { ret 1; }
     ret 0;
 }

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -1,0 +1,12 @@
+# compiler release identity shared by the driver and command-line surface
+
+use std.types.string.str;
+use std.types.string.str_equals;
+
+# the Mach compiler version, independent of the project embedding the frontend
+pub val MACH_VERSION: str = "4.19.0";
+
+test "mach.lang.version:matches_project_release" {
+    if (!str_equals(MACH_VERSION, $project.version)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -1,12 +1,16 @@
 # compiler release identity shared by the driver and command-line surface
 
 use std.types.string.str;
-use std.types.string.str_equals;
 
 # the Mach compiler version, independent of the project embedding the frontend
 pub val MACH_VERSION: str = "4.19.0";
 
 test "mach.lang.version:matches_project_release" {
-    if (str_equals($project.id, "mach") && !str_equals(MACH_VERSION, $project.version)) { ret 1; }
+    $if ($project.id == "mach") {
+        $if (MACH_VERSION != $project.version) { ret 1; }
+    }
+    $if ($project.id == "mach-version-vendor-test") {
+        $if (MACH_VERSION == $project.version) { ret 1; }
+    }
     ret 0;
 }

--- a/test/determinism.sh
+++ b/test/determinism.sh
@@ -8,8 +8,8 @@
 # drives: a warm rebuild must produce byte-identical output to a clean build, both
 # with no change (cache reuse is sound) and after a source edit (invalidation is
 # sound, the failure mode #2045 recorded, where an incremental build reflected an
-# edit only partially). The edit is the release version bump: it updates both the
-# Mach-owned compiler version and the matching project manifest value.
+# edit only partially). A compiler-source edit and a separate manifest-only
+# fixture cover both invalidation channels without one masking the other.
 set -eu
 
 cc=${1:-}
@@ -20,9 +20,10 @@ if [ -z "$cc" ]; then
 fi
 cc=$(realpath "$cc")
 cd "$dir"
+root=$(pwd)
 
 work=$(mktemp -d)
-trap 'rm -rf "$work" out; cp "$work/mach.toml.bak" mach.toml 2>/dev/null || true; cp "$work/version.mach.bak" src/lang/version.mach 2>/dev/null || true' EXIT
+trap 'rm -rf "$work" out; cp "$work/version.mach.bak" src/lang/version.mach 2>/dev/null || true' EXIT
 
 # a clean baseline, then a warm no-op rebuild over its populated out/
 rm -rf out
@@ -33,25 +34,18 @@ if ! cmp -s "$work/clean" "$work/warm_noop"; then
     exit 1
 fi
 
-# edit-invalidation: bump the release identity, then compare a warm rebuild
-# against a clean rebuild of the same edit
-cp mach.toml "$work/mach.toml.bak"
+# source edit-invalidation: bump the compiler-owned release identity, then compare
+# a warm rebuild against a clean rebuild of the same edit
 cp src/lang/version.mach "$work/version.mach.bak"
-if ! grep -q '^version = ' mach.toml; then
-    echo "::error::no [project].version line to drive the invalidation edit"
-    exit 1
-fi
 if ! grep -q '^pub val MACH_VERSION: str = ' src/lang/version.mach; then
     echo "::error::no compiler version constant to drive the invalidation edit"
     exit 1
 fi
-sed -i 's/^version = "\(.*\)"/version = "\1-det"/' mach.toml
 sed -i 's/^pub val MACH_VERSION: str = "\(.*\)";/pub val MACH_VERSION: str = "\1-det";/' src/lang/version.mach
 
 "$cc" build . -o "$work/inc_edited"
 rm -rf out
 "$cc" build . -o "$work/clean_edited"
-cp "$work/mach.toml.bak" mach.toml
 cp "$work/version.mach.bak" src/lang/version.mach
 
 if ! cmp -s "$work/inc_edited" "$work/clean_edited"; then
@@ -61,7 +55,61 @@ fi
 
 # guard against a false pass: the edit must actually have changed the output
 if cmp -s "$work/clean" "$work/clean_edited"; then
-    echo "::error::the version edit did not change the binary; the check proves nothing"
+    echo "::error::the source edit did not change the binary; the check proves nothing"
+    exit 1
+fi
+
+# manifest edit-invalidation: keep source fixed while `$project.version` changes
+# in a tiny static-library fixture, preserving the manifest-query regression
+proj="$work/project-version"
+mkdir -p "$proj/src"
+case "$(uname -m)" in
+    x86_64)  isa=x86_64; abi=sysv64 ;;
+    aarch64) isa=aarch64; abi=aapcs64 ;;
+    *) echo "::error::unsupported host architecture"; exit 2 ;;
+esac
+cat > "$proj/mach.toml" <<EOF
+[project]
+id = "det"
+version = "1.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+[target.host]
+isa = "$isa"
+os = "linux"
+abi = "$abi"
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+[artifact.det]
+kind = "static"
+entry = "main.mach"
+out = "lib/det"
+targets = ["*"]
+link = []
+need = []
+[dep.mach-std]
+path = "$root/dep/mach-std"
+EOF
+cat > "$proj/src/main.mach" <<'EOF'
+use std.types.string.str;
+
+pub val VERSION: str = $project.version;
+EOF
+
+(cd "$proj" && "$cc" dep pull)
+"$cc" build "$proj" -o "$work/project_clean"
+sed -i 's/^version = "1.0.0"/version = "1.0.1"/' "$proj/mach.toml"
+"$cc" build "$proj" -o "$work/project_inc"
+rm -rf "$proj/out"
+"$cc" build "$proj" -o "$work/project_clean_edited"
+if ! cmp -s "$work/project_inc" "$work/project_clean_edited"; then
+    echo "::error::manifest-only incremental build diverged from a clean build"
+    exit 1
+fi
+if cmp -s "$work/project_clean" "$work/project_clean_edited"; then
+    echo "::error::the manifest edit did not change the fixture; the check proves nothing"
     exit 1
 fi
 

--- a/test/determinism.sh
+++ b/test/determinism.sh
@@ -8,9 +8,8 @@
 # drives: a warm rebuild must produce byte-identical output to a clean build, both
 # with no change (cache reuse is sound) and after a source edit (invalidation is
 # sound, the failure mode #2045 recorded, where an incremental build reflected an
-# edit only partially). The edit is a `[project].version` bump: it flows through
-# `$project.version` into the compiler and rides the comptime-input invalidation
-# path, the subtlest one to get right.
+# edit only partially). The edit is the release version bump: it updates both the
+# Mach-owned compiler version and the matching project manifest value.
 set -eu
 
 cc=${1:-}
@@ -23,7 +22,7 @@ cc=$(realpath "$cc")
 cd "$dir"
 
 work=$(mktemp -d)
-trap 'rm -rf "$work" out; cp "$work/mach.toml.bak" mach.toml 2>/dev/null || true' EXIT
+trap 'rm -rf "$work" out; cp "$work/mach.toml.bak" mach.toml 2>/dev/null || true; cp "$work/version.mach.bak" src/lang/version.mach 2>/dev/null || true' EXIT
 
 # a clean baseline, then a warm no-op rebuild over its populated out/
 rm -rf out
@@ -34,19 +33,26 @@ if ! cmp -s "$work/clean" "$work/warm_noop"; then
     exit 1
 fi
 
-# edit-invalidation: bump [project].version, which $project.version folds into the
-# compiler, then compare a warm rebuild against a clean rebuild of the same edit
+# edit-invalidation: bump the release identity, then compare a warm rebuild
+# against a clean rebuild of the same edit
 cp mach.toml "$work/mach.toml.bak"
+cp src/lang/version.mach "$work/version.mach.bak"
 if ! grep -q '^version = ' mach.toml; then
     echo "::error::no [project].version line to drive the invalidation edit"
     exit 1
 fi
+if ! grep -q '^pub val MACH_VERSION: str = ' src/lang/version.mach; then
+    echo "::error::no compiler version constant to drive the invalidation edit"
+    exit 1
+fi
 sed -i 's/^version = "\(.*\)"/version = "\1-det"/' mach.toml
+sed -i 's/^pub val MACH_VERSION: str = "\(.*\)";/pub val MACH_VERSION: str = "\1-det";/' src/lang/version.mach
 
 "$cc" build . -o "$work/inc_edited"
 rm -rf out
 "$cc" build . -o "$work/clean_edited"
 cp "$work/mach.toml.bak" mach.toml
+cp "$work/version.mach.bak" src/lang/version.mach
 
 if ! cmp -s "$work/inc_edited" "$work/clean_edited"; then
     echo "::error::incremental build after an edit diverged from a clean build (stale invalidation)"

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -66,9 +66,12 @@ EOF
 
 cat > "$work/src/main.mach" <<EOF
 use std.runtime;
+use std.types.string.str_equals;
+use mach.lang.driver.load;
 use mach.lang.version;
 
 test "mach.lang.version:vendored_context" {
+    if (!str_equals(load.MACH_VERSION, "$compiler_ver")) { ret 1; }
     \$if (\$mach.version != "$compiler_ver") { ret 1; }
     \$if (\$mach.version.major != $compiler_major) { ret 1; }
     ret 0;

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -45,7 +45,7 @@ abi = "$abi"
 
 [profile.debug]
 opt = 0
-debug = false
+debug = true
 simd = "scalarize"
 
 [artifact.host]
@@ -90,6 +90,14 @@ vendored_cli="$work/vendored-mach"
 "$cc" build . -o "$vendored_cli"
 if [ "$("$vendored_cli" info --version)" != "$compiler_ver" ]; then
     echo "version-vendor.sh: built vendored CLI reports the embedding project version" >&2
+    exit 1
+fi
+if ! readelf --debug-dump=info "$vendored_cli" 2>/dev/null | grep -Fq "DW_AT_producer"; then
+    echo "version-vendor.sh: vendored CLI has no debug producer metadata" >&2
+    exit 1
+fi
+if ! readelf --debug-dump=info "$vendored_cli" 2>/dev/null | grep -F "DW_AT_producer" | grep -Fq "mach $compiler_ver"; then
+    echo "version-vendor.sh: vendored debug producer reports the embedding project version" >&2
     exit 1
 fi
 "$cc" test . --include-deps --filter mach.lang.version

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+# prove a source-vendored frontend retains Mach's version, not its host's
+set -eu
+
+cc=${1:-}
+root=${2:-.}
+if [ -z "$cc" ]; then
+    echo "usage: version-vendor.sh <compiler> [mach-root]" >&2
+    exit 2
+fi
+
+cc=$(realpath "$cc")
+root=$(realpath "$root")
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/src"
+
+case "$(uname -m)" in
+    x86_64)  isa=x86_64; abi=sysv64 ;;
+    aarch64) isa=aarch64; abi=aapcs64 ;;
+    *) echo "version-vendor.sh: unsupported host architecture" >&2; exit 2 ;;
+esac
+
+cat > "$work/mach.toml" <<EOF
+[project]
+id = "mach-version-vendor-test"
+version = "mach-version-vendor-test"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.host]
+isa = "$isa"
+os = "linux"
+abi = "$abi"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[artifact.host]
+kind = "static"
+entry = "main.mach"
+out = "lib/host"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach]
+path = "$root"
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"
+EOF
+
+cat > "$work/src/main.mach" <<'EOF'
+use std.runtime;
+use mach.lang.version;
+
+#[symbol("main")]
+fun main() i32 { ret 0; }
+EOF
+
+cd "$work"
+"$cc" dep pull
+"$cc" test . --include-deps --filter mach.lang.version

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -49,7 +49,7 @@ debug = false
 simd = "scalarize"
 
 [artifact.host]
-kind = "static"
+kind = "bin"
 entry = "main.mach"
 out = "lib/host"
 targets = ["*"]
@@ -67,6 +67,9 @@ EOF
 cat > "$work/src/main.mach" <<EOF
 use std.runtime;
 use std.types.string.str_equals;
+use std.types.size.usize;
+use std.types.string.str;
+use mach.cli.cmd.dispatch;
 use mach.lang.driver.load;
 use mach.lang.version;
 
@@ -78,9 +81,15 @@ test "mach.lang.version:vendored_context" {
 }
 
 #[symbol("main")]
-fun main() i32 { ret 0; }
+fun main(argc: usize, argv: *str) i64 { ret dispatch(argc, argv); }
 EOF
 
 cd "$work"
 "$cc" dep pull
+vendored_cli="$work/vendored-mach"
+"$cc" build . -o "$vendored_cli"
+if [ "$("$vendored_cli" info --version)" != "$compiler_ver" ]; then
+    echo "version-vendor.sh: built vendored CLI reports the embedding project version" >&2
+    exit 1
+fi
 "$cc" test . --include-deps --filter mach.lang.version

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -11,6 +11,16 @@ fi
 
 cc=$(realpath "$cc")
 root=$(realpath "$root")
+compiler_ver=$(sed -n 's/^pub val MACH_VERSION: str = "\(.*\)";$/\1/p' "$root/src/lang/version.mach")
+if [ -z "$compiler_ver" ]; then
+    echo "version-vendor.sh: compiler version constant not found" >&2
+    exit 2
+fi
+compiler_major=${compiler_ver%%.*}
+if [ "$("$cc" info --version)" != "$compiler_ver" ]; then
+    echo "version-vendor.sh: vendored CLI reports the embedding project version" >&2
+    exit 1
+fi
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/src"
@@ -54,9 +64,15 @@ git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
 EOF
 
-cat > "$work/src/main.mach" <<'EOF'
+cat > "$work/src/main.mach" <<EOF
 use std.runtime;
 use mach.lang.version;
+
+test "mach.lang.version:vendored_context" {
+    \$if (\$mach.version != "$compiler_ver") { ret 1; }
+    \$if (\$mach.version.major != $compiler_major) { ret 1; }
+    ret 0;
+}
 
 #[symbol("main")]
 fun main() i32 { ret 0; }


### PR DESCRIPTION
Closes #2954

Introduces one Mach-owned release constant for the driver and CLI instead of reading the embedding project version. This keeps $mach.version and debug producer metadata correct when the frontend is vendored.

Verification: mach test . (1481 passed)