### PR TITLE
driver: expose retained frontend analysis for editor tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Tooling can retain compiler-owned frontend analysis (#2996)
+
+`driver.analyze_project` now runs load, resolve, and sema without executing build
+steps or backend phases, and returns the retained project graph. Optional module
+FQN roots enter the compiler's normal DFS, so open editor buffers outside the
+selected artifact closure receive the same overlays, imports, comptime constants,
+diagnostics, and semantic analysis as ordinary project modules.
+
 ### Changed
 
 #### Project manifests no longer declare a minimum Mach version (#2953)

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -45,6 +45,7 @@ use mach.lang.query;
 use mach.lang.readout;
 use mach.lang.session;
 use mach.lang.target;
+use mach.lang.target.isa;
 use mach.lang.target.of;
 
 use mach.lang.driver.project;
@@ -66,6 +67,7 @@ fwd project.TARGET_OPT_RELEASE;
 fwd project.dnit_project;
 fwd project.fqn_name;
 fwd project.link_name_for;
+fwd load.module_context;
 
 # the union-build entry-count helper, re-exported so `mach test` / tooling
 # consumers keep spelling it as `driver.count_target_gated`
@@ -191,6 +193,66 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
     var roots: project.RootSet = project.ROOT_ARTIFACT;
     if (request.test_goal(req.goal)) { roots = project.ROOT_TEST; }
     ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, roots);
+}
+
+# run the compiler-owned frontend over one selected project and retain its
+# analysis for editor tooling
+#
+# This is the load / resolve / sema half of a normal build. It never executes
+# project or dependency steps and never runs lowering, code generation, emission,
+# or linking. The returned Project owns its graph arrays; its AST, ResolveResult,
+# and SemaResult pointers borrow query-owned values from `s`.
+#
+# Exactly one returned Project may be live on a Session. Calls on the same Session
+# must be serialized, and the caller must `dnit_project` the prior Project before
+# starting another build or analysis: a later query recomputation may replace the
+# borrowed results. The caller must also `dnit_project` the returned value before
+# `session.dnit`. `m` and `req` are borrowed only for this call.
+#
+# The query context is private to this call and is cleared on every return path.
+# A phase failure tears down the partial Project and resets the Session's per-build
+# module registries before returning the failure.
+# ---
+# s:   persistent compiler session that owns the query database and retained values
+# m:   parsed root manifest used to compose `req`
+# req: fully composed request selecting target, profile, and artifact
+# ret: retained frontend Project, or the load / resolve / sema failure
+pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest) R.Result[project.Project, outcome.Fail] {
+    query.set_ctx(?s.queries, nil);
+    fin { query.set_ctx(?s.queries, nil); }
+
+    if (isa.registered_count(?s.registry.isa) == 0) {
+        val reg_r: R.Result[bool, str] = setup_registry(?s.registry);
+        if (R.is_err[bool, str](reg_r)) {
+            ret R.err[project.Project, outcome.Fail](outcome.internal(R.unwrap_err[bool, str](reg_r)));
+        }
+    }
+
+    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build(s, m, req, nil);
+    if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
+
+    var qc: qctx.QueryCtx;
+    qc.s   = s;
+    qc.p   = ?p;
+    qc.req = req;
+    query.set_ctx(?s.queries, (?qc)::ptr);
+
+    val load_r: R.Result[bool, outcome.Fail] = run_load_phase(?p);
+    if (R.is_err[bool, outcome.Fail](load_r)) {
+        val failure: outcome.Fail = R.unwrap_err[bool, outcome.Fail](load_r);
+        project.dnit_project(?p);
+        ret R.err[project.Project, outcome.Fail](failure);
+    }
+
+    val sema_r: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](sema_r)) {
+        val failure: outcome.Fail = R.unwrap_err[bool, outcome.Fail](sema_r);
+        project.dnit_project(?p);
+        ret R.err[project.Project, outcome.Fail](failure);
+    }
+
+    ret R.ok[project.Project, outcome.Fail](p);
 }
 
 # the shared open: init + query binding + config synthesis + target entry

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -38,6 +38,7 @@ use dwarf: mach.lang.be.codegen.dwarf;
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
 use mach.lang.build.request;
+use mach.lang.diagnostic;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.pipeline;
@@ -67,7 +68,6 @@ fwd project.TARGET_OPT_RELEASE;
 fwd project.dnit_project;
 fwd project.fqn_name;
 fwd project.link_name_for;
-fwd load.module_context;
 
 # the union-build entry-count helper, re-exported so `mach test` / tooling
 # consumers keep spelling it as `driver.count_target_gated`
@@ -196,30 +196,45 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
 }
 
 # run the compiler-owned frontend over one selected project and retain its
-# analysis for editor tooling
+# analysis for editor tooling, including optional editor-owned roots
 #
 # This is the load / resolve / sema half of a normal build. It never executes
 # project or dependency steps and never runs lowering, code generation, emission,
-# or linking. The returned Project owns its graph arrays; its AST, ResolveResult,
-# and SemaResult pointers borrow query-owned values from `s`.
+# or linking. `extra_roots` are module FQNs to DFS-load after the artifact closure
+# and before resolve, so an open buffer outside that closure still receives the
+# compiler's exact overlay, import, comptime-constant, resolve, and sema treatment.
+# The returned Project owns its graph arrays; its AST, ResolveResult, and SemaResult
+# pointers borrow query-owned values from `s`.
 #
 # Exactly one returned Project may be live on a Session. Calls on the same Session
 # must be serialized, and the caller must `dnit_project` the prior Project before
 # starting another build or analysis: a later query recomputation may replace the
 # borrowed results. The caller must also `dnit_project` the returned value before
-# `session.dnit`. `m` and `req` are borrowed only for this call.
+# `session.dnit`. `m`, `req`, and `extra_roots` are borrowed only for this call.
 #
-# The query context is private to this call and is cleared on every return path.
-# A phase failure tears down the partial Project and resets the Session's per-build
-# module registries before returning the failure.
+# The diagnostic sink is reset before each analysis; cached query diagnostics are
+# replayed into that clean sink. The query context is private to this call and is
+# cleared on every return path. A phase failure tears down the partial Project and
+# resets the Session's per-build module registries before returning the failure.
 # ---
-# s:   persistent compiler session that owns the query database and retained values
-# m:   parsed root manifest used to compose `req`
-# req: fully composed request selecting target, profile, and artifact
-# ret: retained frontend Project, or the load / resolve / sema failure
-pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest) R.Result[project.Project, outcome.Fail] {
+# s:                persistent session owning the query DB and retained values
+# m:                parsed root manifest used to compose `req`
+# req:              composed request selecting target, profile, and artifact
+# extra_roots:      optional session-interned module FQNs outside the artifact closure
+# extra_root_count: number of FQNs in `extra_roots`; zero accepts nil
+# ret:              retained frontend Project, or the load / resolve / sema failure
+pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
+                        extra_roots: *intern.StrId, extra_root_count: u32) R.Result[project.Project, outcome.Fail] {
     query.set_ctx(?s.queries, nil);
     fin { query.set_ctx(?s.queries, nil); }
+
+    diagnostic.dnit(?s.diags);
+    s.diags = diagnostic.init(s.alloc);
+
+    if (extra_root_count > 0 && extra_roots == nil) {
+        ret R.err[project.Project, outcome.Fail](outcome.internal(
+            "driver: frontend analysis root count requires a root array"));
+    }
 
     if (isa.registered_count(?s.registry.isa) == 0) {
         val reg_r: R.Result[bool, str] = setup_registry(?s.registry);
@@ -238,7 +253,8 @@ pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *reques
     qc.req = req;
     query.set_ctx(?s.queries, (?qc)::ptr);
 
-    val load_r: R.Result[bool, outcome.Fail] = run_load_phase(?p);
+    val load_r: R.Result[bool, outcome.Fail] =
+        run_load_phase_roots(?p, extra_roots, extra_root_count);
     if (R.is_err[bool, outcome.Fail](load_r)) {
         val failure: outcome.Fail = R.unwrap_err[bool, outcome.Fail](load_r);
         project.dnit_project(?p);
@@ -391,6 +407,17 @@ pub fun run_dep_steps_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
 # p:   the opened project
 # ret: ok(true), or the first load/resolve failure
 pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
+    ret run_load_phase_roots(p, nil, 0);
+}
+
+# the shared load / resolve phase with optional compiler-owned frontend roots
+#
+# Extra roots are loaded after the selected artifact closure is recorded in
+# `emit_len`, so they participate in resolve and sema but can never widen a future
+# backend work set. This private entry keeps ordinary build phase dispatch on the
+# no-extra-root contract while `analyze_project` can root open editor buffers.
+fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
+                         extra_root_count: u32) R.Result[bool, outcome.Fail] {
     val te: *project.TargetEntry = p.target_entry;
 
     val fp_r: R.Result[bool, str] = dcfg.select_target(p, te);
@@ -427,6 +454,20 @@ pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
     # the artifact closure is settled: everything loaded so far is what this build
     # emits and links. A test-rooted whole-source sweep only appends past it.
     p.emit_len = p.topo_len;
+
+    # Editor-owned buffers outside the selected artifact closure enter through the
+    # same DFS as every source module. Their overlays, imported pub consts, active
+    # comptime branches, dependency edges and transitive modules are therefore all
+    # established before AST publication, resolve, and sema.
+    var xi: u32 = 0;
+    for (xi < extra_root_count) {
+        val xr: R.Result[session.ModuleId, str] = load.dfs_load(p, extra_roots[xi]);
+        if (R.is_err[session.ModuleId, str](xr)) {
+            ret R.err[bool, outcome.Fail](outcome.user(
+                R.unwrap_err[session.ModuleId, str](xr)));
+        }
+        xi = xi + 1;
+    }
 
     # test collection roots at every own-source module, so a test in a module no
     # artifact imports is still collected (#1863). Artifact builds deliberately do

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -225,16 +225,16 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
 # ret:              retained frontend Project, or the load / resolve / sema failure
 pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
                         extra_roots: *intern.StrId, extra_root_count: u32) R.Result[project.Project, outcome.Fail] {
+    if (extra_root_count > 0 && extra_roots == nil) {
+        ret R.err[project.Project, outcome.Fail](outcome.internal(
+            "driver: frontend analysis root count requires a root array"));
+    }
+
     query.set_ctx(?s.queries, nil);
     fin { query.set_ctx(?s.queries, nil); }
 
     diagnostic.dnit(?s.diags);
     s.diags = diagnostic.init(s.alloc);
-
-    if (extra_root_count > 0 && extra_roots == nil) {
-        ret R.err[project.Project, outcome.Fail](outcome.internal(
-            "driver: frontend analysis root count requires a root array"));
-    }
 
     if (isa.registered_count(?s.registry.isa) == 0) {
         val reg_r: R.Result[bool, str] = setup_registry(?s.registry);

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -335,20 +335,17 @@ pub fun dfs_load(p: *project.Project, fqn: intern.StrId) R.Result[session.Module
     ret R.ok[session.ModuleId, str](mid);
 }
 
-# construct the comptime environment shared by every frontend pass over one
-# module in `p`
+# construct the empty base comptime environment for a module in `p`
 #
-# The result carries the settled request's mode / PIE bit, the selected target's
-# machine facts and operation definitions, the manifest-derived `$project.*` and
-# `$bin.*` roots, and every build define. This is the compiler-owned constructor
-# for tooling that must analyze an additional source buffer under exactly the same
-# environment as the retained project graph. The caller owns the returned context
-# and releases it with `comptime.dnit`.
+# The load walk owns all later module-local and imported public-constant bindings.
+# Keeping this constructor private ensures tooling cannot mistake a build-only base
+# for a loaded module context: additional editor buffers enter through the driver's
+# extra-root DFS and receive the same bindings as every ordinary module.
 # ---
 # p:   loaded project whose selected target and manifest config seed the context
 # req: settled request that opened `p`; must describe the same build selection
 # ret: an owning module context, or the first define-binding / allocation error
-pub fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[comptime.ComptimeCtx, str] {
+fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[comptime.ComptimeCtx, str] {
     if (p == nil || req == nil || p.target_entry == nil) {
         ret R.err[comptime.ComptimeCtx, str]("driver: module context requires an opened project and request");
     }

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -335,6 +335,57 @@ pub fun dfs_load(p: *project.Project, fqn: intern.StrId) R.Result[session.Module
     ret R.ok[session.ModuleId, str](mid);
 }
 
+# construct the comptime environment shared by every frontend pass over one
+# module in `p`
+#
+# The result carries the settled request's mode / PIE bit, the selected target's
+# machine facts and operation definitions, the manifest-derived `$project.*` and
+# `$bin.*` roots, and every build define. This is the compiler-owned constructor
+# for tooling that must analyze an additional source buffer under exactly the same
+# environment as the retained project graph. The caller owns the returned context
+# and releases it with `comptime.dnit`.
+# ---
+# p:   loaded project whose selected target and manifest config seed the context
+# req: settled request that opened `p`; must describe the same build selection
+# ret: an owning module context, or the first define-binding / allocation error
+pub fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[comptime.ComptimeCtx, str] {
+    if (p == nil || req == nil || p.target_entry == nil) {
+        ret R.err[comptime.ComptimeCtx, str]("driver: module context requires an opened project and request");
+    }
+
+    var build_mode_id: u32 = comptime.MODE_DEBUG;
+    if (request.release(req)) { build_mode_id = comptime.MODE_RELEASE; }
+    var build_pie: u32 = 0;
+    if (req.pie) { build_pie = 1; }
+
+    var ctx: comptime.ComptimeCtx = comptime.init(
+        p.alloc,
+        p.target.os_id,
+        p.target.arch_id,
+        p.target.abi_id,
+        build_mode_id,
+        build_pie,
+        p.target.isa.pointer_width,
+        p.target.model.vector_bits,
+        p.compiler_name,
+        p.compiler_ver
+    );
+    comptime.set_target_defs(?ctx, p.target.isa.defs);
+    comptime.set_build_context(?ctx,
+        p.config.id, p.config.version, p.config.name, p.config.description,
+        p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
+        p.target_entry.platform_name,
+        p.config.bin_name);
+
+    val bd_r: R.Result[bool, str] = bind_defines(p, ?ctx);
+    if (R.is_err[bool, str](bd_r)) {
+        val message: str = R.unwrap_err[bool, str](bd_r);
+        comptime.dnit(?ctx);
+        ret R.err[comptime.ComptimeCtx, str](message);
+    }
+    ret R.ok[comptime.ComptimeCtx, str](ctx);
+}
+
 # append a fresh ModuleEntry for `fqn` - assigning its stable id, comptime ctx,
 # and manifest defines - and index it in by_fqn
 fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
@@ -362,6 +413,15 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     val sid_r: R.Result[session.StableModuleId, str] = session.stable_module_id(p.s, fqn);
     if (R.is_err[session.StableModuleId, str](sid_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[session.StableModuleId, str](sid_r)); }
 
+    val qctxp: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    if (qctxp == nil || qctxp.req == nil) {
+        ret R.err[session.ModuleId, str]("driver: module load has no active build request");
+    }
+    val ctx_r: R.Result[comptime.ComptimeCtx, str] = module_context(p, qctxp.req);
+    if (R.is_err[comptime.ComptimeCtx, str](ctx_r)) {
+        ret R.err[session.ModuleId, str](R.unwrap_err[comptime.ComptimeCtx, str](ctx_r));
+    }
+
     var m: project.ModuleEntry;
     m.fqn               = fqn;
     m.file_id           = 0;
@@ -369,24 +429,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     # the AST is borrowed from the session cache; nil until parse_module sets it.
     # teardown never frees m.a, so a never-parsed entry needs no placeholder AST.
     m.a                 = nil;
-    # the active optimization mode for `$mach.build.mode` and the `$mach.build.pie`
-    # bit both come from the settled request: composition already applied the
-    # explicit-flag-over-profile precedence, so the gate matches the pipeline.
-    val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
-    var build_mode_id: u32 = comptime.MODE_DEBUG;
-    if (request.release(ctx.req)) { build_mode_id = comptime.MODE_RELEASE; }
-    var build_pie: u32 = 0;
-    if (ctx.req.pie) { build_pie = 1; }
-    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.target.model.vector_bits, p.compiler_name, p.compiler_ver);
-    comptime.set_target_defs(?m.ctx, p.target.isa.defs);
-    # feed the manifest-derived `$project.*`/`$bin.*` roots (the selected target's
-    # declared tuple lives under `$project.target.*`); the target tuple comes from
-    # the selected entry (set before any module loads).
-    comptime.set_build_context(?m.ctx,
-        p.config.id, p.config.version, p.config.name, p.config.description,
-        p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
-        p.target_entry.platform_name,
-        p.config.bin_name);
+    m.ctx               = R.unwrap_ok[comptime.ComptimeCtx, str](ctx_r);
     m.pub_consts        = nil;
     m.pub_const_count   = 0;
     m.pub_const_cap     = 0;
@@ -404,11 +447,6 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     m.target_gated      = false;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
-
-    # bind the selected unit's manifest defines (#1191) into this module's ctx so
-    # `$if ($mach.build.NAME)` folds identically in every module of the graph.
-    val bd_r: R.Result[bool, str] = bind_defines(p, ?p.modules[mid::u32].ctx);
-    if (R.is_err[bool, str](bd_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](bd_r)); }
 
     val ins_r: R.Result[bool, str] = map.insert[intern.StrId, session.ModuleId](?p.by_fqn, fqn, mid);
     if (R.is_err[bool, str](ins_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](ins_r)); }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -597,8 +597,7 @@ fun ut_id_is(s: *session.Session, id: intern.StrId, text: str) bool {
 
 # the tooling facade retains the compiler's selected load / resolve / sema graph,
 # including imported generic symbols, without stepping into the backend or running
-# a demanded project step. its fresh-context helper reproduces every build axis and
-# define the ordinary module loader installs.
+# a demanded project step. every loaded module carries the selected build axes.
 test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -635,7 +634,7 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     req.pie          = true;
 
     val pr: R.Result[project.Project, outcome.Fail] =
-        driver.analyze_project(?s, ?mf, ?req);
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
         session.dnit(?s); ret 1;
@@ -671,70 +670,190 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
         if (!ut_id_is(?s, c.target_isa, "x86_64")) { bad = 16; }
         if (!ut_id_is(?s, c.target_abi, "win64")) { bad = 17; }
         if (!ut_id_is(?s, c.bin_name, "beta")) { bad = 18; }
-
-        val fresh_r: R.Result[comptime.ComptimeCtx, str] =
-            driver.module_context(?p, ?req);
-        if (R.is_err[comptime.ComptimeCtx, str](fresh_r)) { bad = 19; }
-        or {
-            var fresh: comptime.ComptimeCtx =
-                R.unwrap_ok[comptime.ComptimeCtx, str](fresh_r);
-            if (fresh.target_os_id != c.target_os_id
-                || fresh.target_arch_id != c.target_arch_id
-                || fresh.target_abi_id != c.target_abi_id
-                || fresh.build_mode_id != c.build_mode_id
-                || fresh.build_pie != c.build_pie
-                || fresh.pointer_width != c.pointer_width
-                || fresh.vector_bits != c.vector_bits
-                || fresh.target_defs != c.target_defs
-                || fresh.compiler_name != c.compiler_name
-                || fresh.compiler_ver != c.compiler_ver
-                || fresh.project_id != c.project_id
-                || fresh.project_ver != c.project_ver
-                || fresh.project_name != c.project_name
-                || fresh.project_desc != c.project_desc
-                || fresh.target_os != c.target_os
-                || fresh.target_isa != c.target_isa
-                || fresh.target_abi != c.target_abi
-                || fresh.target_platform != c.target_platform
-                || fresh.bin_name != c.bin_name) { bad = 20; }
-            comptime.dnit(?fresh);
-        }
     }
 
-    # Current v2 manifests preserve the configured define channel even though no
-    # public key populates it yet. Inject one at that boundary to pin that tooling's
-    # fresh context and the ordinary module constructor cannot drift apart again.
-    val defs_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](p.alloc, 1::usize);
-    if (R.is_err[*intern.StrId, str](defs_r)) { bad = 21; }
+    project.dnit_project(?p);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# An open buffer outside the selected artifact closure is an explicit compiler root,
+# not a separately parsed AST. Its filesystem-path overlay enters the normal DFS;
+# an imported public constant selects a branch whose module and generic types must
+# then load, resolve, and sema exactly as they do in an ordinary reachable module.
+test "mach.lang.driver:analyze_project_loads_overlay_extra_root_through_pub_const_gate" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [4]str;
+    names[0] = "main.mach"; names[1] = "extra.mach";
+    names[2] = "flags.mach"; names[3] = "model.mach";
+    var texts: [4]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+    texts[1] = "fun broken() NoSuch { var x: AlsoMissing; ret x; }\n";
+    texts[2] = "pub val ENABLE: i32 = 1;\n";
+    texts[3] = "pub rec Leaf { n: i32; }\npub rec Box[T] { v: T; }\npub fun take[T](b: Box[T]) i32 { ret 7; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    # Without an explicit editor root only the artifact entry exists. This proves
+    # `extra` is genuinely off-closure rather than incidentally reachable.
+    val base_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](base_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var base: project.Project = R.unwrap_ok[project.Project, outcome.Fail](base_r);
+    var bad: i32 = 0;
+    if (ut_has(?base, ?s, "uniontest.extra")) { bad = 1; }
+    if (ut_has(?base, ?s, "uniontest.flags")) { bad = 1; }
+    if (ut_has(?base, ?s, "uniontest.model")) { bad = 1; }
+    project.dnit_project(?base);
+
+    val extra_path: str = ut_cc3(?alloc, root, "/", "src/extra.mach");
+    val overlay: str = "use uniontest.flags.ENABLE;\n$if (ENABLE == 1) { use uniontest.model; }\npub fun probe() i32 { ret 7; }\n";
+    if (R.is_err[bool, str](session.set_overlay(?s, extra_path, overlay))) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    val xid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "uniontest.extra");
+    if (R.is_err[intern.StrId, str](xid_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var extra_roots: [1]intern.StrId;
+    extra_roots[0] = R.unwrap_ok[intern.StrId, str](xid_r);
+
+    val rooted_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, ?extra_roots[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](rooted_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](rooted_r);
+    if (ut_count_errors(?s.diags) != 0) { bad = 2; }
+    if (!ut_has(?p, ?s, "uniontest.extra")) { bad = 3; }
+    if (!ut_has(?p, ?s, "uniontest.flags")) { bad = 4; }
+    if (!ut_has(?p, ?s, "uniontest.model")) { bad = 5; }
+    if (p.emit_len != 1 || p.topo_len <= p.emit_len) { bad = 6; }
+
+    val extra_mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.extra");
+    val model_mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.model");
+    if (extra_mid == session.MODULE_NIL || model_mid == session.MODULE_NIL) { bad = 7; }
     or {
-        p.config.defines = R.unwrap_ok[*intern.StrId, str](defs_r);
-        val did_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE=17");
-        if (R.is_err[intern.StrId, str](did_r)) { bad = 22; }
+        val em: *project.ModuleEntry = ?p.modules[extra_mid::u32];
+        val mm: *project.ModuleEntry = ?p.modules[model_mid::u32];
+        if (!em.resolved || em.resolve_result == nil || em.sema_result == nil) { bad = 8; }
+        if (!mm.resolved || mm.resolve_result == nil || mm.sema_result == nil) { bad = 9; }
+        val eid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "ENABLE");
+        if (R.is_err[intern.StrId, str](eid_r)) { bad = 10; }
         or {
-            p.config.defines[0] = R.unwrap_ok[intern.StrId, str](did_r);
-            p.config.define_count = 1;
-            val dc_r: R.Result[comptime.ComptimeCtx, str] = driver.module_context(?p, ?req);
-            if (R.is_err[comptime.ComptimeCtx, str](dc_r)) { bad = 23; }
+            val enabled: O.Option[*comptime.NamedConst] = comptime.lookup(
+                ?em.ctx, R.unwrap_ok[intern.StrId, str](eid_r));
+            if (O.is_none[*comptime.NamedConst](enabled)) { bad = 11; }
             or {
-                var dc: comptime.ComptimeCtx = R.unwrap_ok[comptime.ComptimeCtx, str](dc_r);
-                val fid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE");
-                if (R.is_err[intern.StrId, str](fid_r)) { bad = 24; }
-                or {
-                    val found: O.Option[*comptime.NamedConst] = comptime.lookup_define(
-                        ?dc, R.unwrap_ok[intern.StrId, str](fid_r));
-                    if (O.is_none[*comptime.NamedConst](found)) { bad = 25; }
-                    or {
-                        val feature: *comptime.NamedConst = O.unwrap[*comptime.NamedConst](found);
-                        if (feature.value.kind != comptime.CT_KIND_INT
-                            || feature.value.data.i != 17) { bad = 26; }
-                    }
-                }
-                comptime.dnit(?dc);
+                val nc: *comptime.NamedConst = O.unwrap[*comptime.NamedConst](enabled);
+                if (nc.value.kind != comptime.CT_KIND_INT || nc.value.data.i != 1) { bad = 12; }
             }
         }
     }
 
     project.dnit_project(?p);
+    manifest.dnit(?mf, ?alloc);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# Every analysis starts with a clean diagnostic sink, but an unchanged query still
+# replays its cached diagnostics. The second retained graph therefore reports one
+# identical snapshot, not zero diagnostics and not an accumulated duplicate.
+test "mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun dup() i32 { ret 1; }\nfun dup() i32 { ret 2; }\nfun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    val cold_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](cold_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var cold_p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](cold_r);
+    val mid: session.ModuleId = ut_mid(?cold_p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL || s.diags.len == 0) {
+        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val stable: session.StableModuleId = cold_p.modules[mid::u32].stable_id;
+    val resolve_rev: query.Revision = query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64);
+    val sema_rev: query.Revision = query.peek_revision(?s.queries, query.Q_SEMA, stable::u64);
+    if (resolve_rev == 0 || sema_rev == 0) {
+        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val snapshot_r: R.Result[*diagnostic.DiagList, str] =
+        diagnostic.clone_tail(?s.diags, 0, ?alloc);
+    if (R.is_err[*diagnostic.DiagList, str](snapshot_r)) {
+        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val snapshot: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](snapshot_r);
+    project.dnit_project(?cold_p);
+
+    val warm_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](warm_r)) {
+        diagnostic.dnit(snapshot); A.deallocate[diagnostic.DiagList](?alloc, snapshot, 1::usize);
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var warm_p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](warm_r);
+    var bad: i32 = 0;
+    if (!ut_diag_list_eq(?s.diags, snapshot)) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64) != resolve_rev) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_SEMA, stable::u64) != sema_rev) { bad = 1; }
+
+    project.dnit_project(?warm_p);
+    diagnostic.dnit(snapshot);
+    A.deallocate[diagnostic.DiagList](?alloc, snapshot, 1::usize);
+    manifest.dnit(?mf, ?alloc);
     fs.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;
@@ -767,7 +886,7 @@ test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
 
     var bad: i32 = 0;
     val failed: R.Result[project.Project, outcome.Fail] =
-        driver.analyze_project(?s, ?mf, ?req);
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
     if (R.is_ok[project.Project, outcome.Fail](failed)) {
         var stray: project.Project = R.unwrap_ok[project.Project, outcome.Fail](failed);
         project.dnit_project(?stray);
@@ -783,7 +902,7 @@ test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
     if (O.is_some[str](write_err)) { bad = 1; }
     or {
         val repaired: R.Result[project.Project, outcome.Fail] =
-            driver.analyze_project(?s, ?mf, ?req);
+            driver.analyze_project(?s, ?mf, ?req, nil, 0);
         if (R.is_err[project.Project, outcome.Fail](repaired)) { bad = 1; }
         or {
             var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](repaired);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -63,6 +63,7 @@ use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
+use isa: mach.lang.target.isa;
 use mach.lang.target.isa.spirv;
 use mach.lang.target.of;
 use mach.lang.type;
@@ -855,6 +856,37 @@ test "mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics" {
     A.deallocate[diagnostic.DiagList](?alloc, snapshot, 1::usize);
     manifest.dnit(?mf, ?alloc);
     fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A nonzero extra-root count without storage is rejected before target setup or
+# project construction, so a malformed tooling request cannot mutate build state.
+test "mach.lang.driver:analyze_project_rejects_missing_extra_root_array" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val invalid: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, nil, nil, nil, 1);
+    var bad: i32 = 0;
+    if (R.is_ok[project.Project, outcome.Fail](invalid)) {
+        var stray: project.Project = R.unwrap_ok[project.Project, outcome.Fail](invalid);
+        project.dnit_project(?stray);
+        bad = 1;
+    }
+    or {
+        val failure: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](invalid);
+        if (!failure.internal
+            || !str_equals(failure.message,
+                "driver: frontend analysis root count requires a root array")) { bad = 1; }
+    }
+    if (s.queries.ctx != nil) { bad = 1; }
+    if (session.module_count(?s) != 0) { bad = 1; }
+    if (isa.registered_count(?s.registry.isa) != 0) { bad = 1; }
+
     session.dnit(?s);
     ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -138,6 +138,13 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
+# a selected-artifact fixture for the retained frontend facade. alpha and the
+# orphan carry hard semantic errors, while beta imports a generic record and
+# function from model. the demanded step is deliberately fatal if executed.
+fun ut_manifest_frontend() str {
+    ret "[project]\nid = \"ctxcase\"\nversion = \"1.2.3\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[step.never]\ncmd = \"false\"\nin = []\nout = [\"{project.out}/never\"]\nneed = []\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = [\"never\"]\n";
+}
+
 # a cross-platform executable split by output-extension convention (#2961)
 fun ut_manifest_split() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"linux\"]\nlink = []\nneed = []\n\n[artifact.uniontest-windows]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest.exe\"\ntargets = [\"windows\"]\nlink = []\nneed = []\n";
@@ -580,6 +587,221 @@ fun ut_ctx(p: *project.Project, s: *session.Session, fqn: str) *comptime.Comptim
     val mid: session.ModuleId = @R.unwrap_ok[*session.ModuleId, str](mr);
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     ret ?m.ctx;
+}
+
+# whether an interned string on `s` equals `text`
+fun ut_id_is(s: *session.Session, id: intern.StrId, text: str) bool {
+    val found: O.Option[str] = intern.lookup(?s.interner, id);
+    ret O.is_some[str](found) && str_equals(O.unwrap[str](found), text);
+}
+
+# the tooling facade retains the compiler's selected load / resolve / sema graph,
+# including imported generic symbols, without stepping into the backend or running
+# a demanded project step. its fresh-context helper reproduces every build axis and
+# define the ordinary module loader installs.
+test "mach.lang.driver:analyze_project_retains_selected_frontend" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [4]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach";
+    names[2] = "model.mach"; names[3] = "orphan.mach";
+    var texts: [4]str;
+    texts[0] = "fun main() i32 { ret no_such(); }\n";
+    texts[1] = "use ctxcase.model;\nfun main() i32 { var b: model.Box[model.Leaf]; ret model.take[model.Leaf](b); }\n";
+    texts[2] = "pub rec Leaf { n: i32; }\npub rec Box[T] { v: T; }\npub fun take[T](b: Box[T]) i32 { ret 7; }\n";
+    texts[3] = "fun broken() NoSuch { var x: AlsoMissing; ret x; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_frontend(), ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "windows";
+    req.profile      = "release";
+    req.artifact     = "beta";
+    req.want_lib     = false;
+    req.goal         = request.GOAL_OBJECTS;
+    req.opt          = pipeline.OPT_RELEASE;
+    req.pie          = true;
+
+    val pr: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    # the retained project owns everything it needs after the call's borrowed
+    # manifest is released.
+    manifest.dnit(?mf, ?alloc);
+
+    var bad: i32 = 0;
+    if (s.queries.ctx != nil) { bad = 2; }
+    if (ut_count_errors(?s.diags) != 0) { bad = 3; }
+    if (ut_has(?p, ?s, "ctxcase.alpha"))  { bad = 4; }
+    if (ut_has(?p, ?s, "ctxcase.orphan")) { bad = 5; }
+
+    val beta:  session.ModuleId = ut_mid(?p, ?s, "ctxcase.beta");
+    val model: session.ModuleId = ut_mid(?p, ?s, "ctxcase.model");
+    if (beta == session.MODULE_NIL || model == session.MODULE_NIL) { bad = 6; }
+    or {
+        val bm: *project.ModuleEntry = ?p.modules[beta::u32];
+        val mm: *project.ModuleEntry = ?p.modules[model::u32];
+        if (!bm.resolved || bm.resolve_result == nil || bm.sema_result == nil) { bad = 7; }
+        if (!mm.resolved || mm.resolve_result == nil || mm.sema_result == nil) { bad = 8; }
+        if (bm.ir_module != nil || bm.object_image != nil) { bad = 9; }
+        if (mm.ir_module != nil || mm.object_image != nil) { bad = 10; }
+
+        val c: *comptime.ComptimeCtx = ?bm.ctx;
+        if (c.build_mode_id != comptime.MODE_RELEASE || c.build_pie != 1) { bad = 11; }
+        if (c.pointer_width != 8) { bad = 12; }
+        if (!ut_id_is(?s, c.project_id, "ctxcase")) { bad = 13; }
+        if (!ut_id_is(?s, c.project_ver, "1.2.3")) { bad = 14; }
+        if (!ut_id_is(?s, c.target_os, "windows")) { bad = 15; }
+        if (!ut_id_is(?s, c.target_isa, "x86_64")) { bad = 16; }
+        if (!ut_id_is(?s, c.target_abi, "win64")) { bad = 17; }
+        if (!ut_id_is(?s, c.bin_name, "beta")) { bad = 18; }
+
+        val fresh_r: R.Result[comptime.ComptimeCtx, str] =
+            driver.module_context(?p, ?req);
+        if (R.is_err[comptime.ComptimeCtx, str](fresh_r)) { bad = 19; }
+        or {
+            var fresh: comptime.ComptimeCtx =
+                R.unwrap_ok[comptime.ComptimeCtx, str](fresh_r);
+            if (fresh.target_os_id != c.target_os_id
+                || fresh.target_arch_id != c.target_arch_id
+                || fresh.target_abi_id != c.target_abi_id
+                || fresh.build_mode_id != c.build_mode_id
+                || fresh.build_pie != c.build_pie
+                || fresh.pointer_width != c.pointer_width
+                || fresh.vector_bits != c.vector_bits
+                || fresh.target_defs != c.target_defs
+                || fresh.compiler_name != c.compiler_name
+                || fresh.compiler_ver != c.compiler_ver
+                || fresh.project_id != c.project_id
+                || fresh.project_ver != c.project_ver
+                || fresh.project_name != c.project_name
+                || fresh.project_desc != c.project_desc
+                || fresh.target_os != c.target_os
+                || fresh.target_isa != c.target_isa
+                || fresh.target_abi != c.target_abi
+                || fresh.target_platform != c.target_platform
+                || fresh.bin_name != c.bin_name) { bad = 20; }
+            comptime.dnit(?fresh);
+        }
+    }
+
+    # Current v2 manifests preserve the configured define channel even though no
+    # public key populates it yet. Inject one at that boundary to pin that tooling's
+    # fresh context and the ordinary module constructor cannot drift apart again.
+    val defs_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](p.alloc, 1::usize);
+    if (R.is_err[*intern.StrId, str](defs_r)) { bad = 21; }
+    or {
+        p.config.defines = R.unwrap_ok[*intern.StrId, str](defs_r);
+        val did_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE=17");
+        if (R.is_err[intern.StrId, str](did_r)) { bad = 22; }
+        or {
+            p.config.defines[0] = R.unwrap_ok[intern.StrId, str](did_r);
+            p.config.define_count = 1;
+            val dc_r: R.Result[comptime.ComptimeCtx, str] = driver.module_context(?p, ?req);
+            if (R.is_err[comptime.ComptimeCtx, str](dc_r)) { bad = 23; }
+            or {
+                var dc: comptime.ComptimeCtx = R.unwrap_ok[comptime.ComptimeCtx, str](dc_r);
+                val fid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE");
+                if (R.is_err[intern.StrId, str](fid_r)) { bad = 24; }
+                or {
+                    val found: O.Option[*comptime.NamedConst] = comptime.lookup_define(
+                        ?dc, R.unwrap_ok[intern.StrId, str](fid_r));
+                    if (O.is_none[*comptime.NamedConst](found)) { bad = 25; }
+                    or {
+                        val feature: *comptime.NamedConst = O.unwrap[*comptime.NamedConst](found);
+                        if (feature.value.kind != comptime.CT_KIND_INT
+                            || feature.value.data.i != 17) { bad = 26; }
+                    }
+                }
+                comptime.dnit(?dc);
+            }
+        }
+    }
+
+    project.dnit_project(?p);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a partial load failure releases its Project, resets the module registry and clears
+# the stack query context; the same Session can immediately analyze a repaired tree.
+test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str; names[0] = "other.mach";
+    var texts: [1]str; texts[0] = "pub fun other() i32 { ret 1; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    var bad: i32 = 0;
+    val failed: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req);
+    if (R.is_ok[project.Project, outcome.Fail](failed)) {
+        var stray: project.Project = R.unwrap_ok[project.Project, outcome.Fail](failed);
+        project.dnit_project(?stray);
+        bad = 1;
+    }
+    if (s.queries.ctx != nil) { bad = 1; }
+    if (session.module_count(?s) != 0) { bad = 1; }
+
+    val main_path: str = ut_cc3(?alloc, root, "/", "src/main.mach");
+    val repaired_text: str = "fun main() i32 { ret 0; }\n";
+    val write_err: O.Option[str] = fs.write_bytes(
+        main_path, repaired_text, str_len(repaired_text), 420);
+    if (O.is_some[str](write_err)) { bad = 1; }
+    or {
+        val repaired: R.Result[project.Project, outcome.Fail] =
+            driver.analyze_project(?s, ?mf, ?req);
+        if (R.is_err[project.Project, outcome.Fail](repaired)) { bad = 1; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](repaired);
+            val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+            if (mid == session.MODULE_NIL) { bad = 1; }
+            or {
+                val me: *project.ModuleEntry = ?p.modules[mid::u32];
+                if (!me.resolved || me.resolve_result == nil || me.sema_result == nil) { bad = 1; }
+            }
+            if (s.queries.ctx != nil) { bad = 1; }
+            project.dnit_project(?p);
+        }
+    }
+
+    manifest.dnit(?mf, ?alloc);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
 }
 
 # number of error-severity diagnostics recorded on the session


### PR DESCRIPTION
Closes #2996

## Summary

- add a compiler-owned `analyze_project` facade that retains load, resolve, and sema results without executing steps or backend phases
- accept optional session-interned module FQN roots and load them through the ordinary DFS, including filesystem overlays, imported public comptime constants, active branches, and transitive imports
- keep the base module-context constructor private so tooling cannot create a partial context outside the loader
- reset the session diagnostic sink per analysis while replaying cached query diagnostics, validate malformed root arrays before build setup, and document retained ownership/lifetime

## Tests

- `mach test . --filter analyze_project --jobs 1 -v` (5 passed)
- `mach test . --jobs 8` (1,484 passed)