### PR TITLE
fix(driver): return a retained session's reload cycle to a steady state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### driver: a retained session's reload cycle returns to a steady state (#3001)
+
+`analyze_project` + `dnit_project` on one retained `Session` grew RSS without
+bound, ~7.4 MiB per cycle against a 222-module project. A language server runs that
+cycle once per edit, so the growth was proportional to how long an editing session
+lasted: mach-lsp reached ~550 MiB after 40 edits of one file and kept climbing.
+
+**The report named the retained-analysis path, and 96% of it was the manifest
+reload.** Measuring the two halves separately - the same allocator counting bytes,
+the manifest loaded once outside the loop for one of them - split 7993 bytes per
+round into 7646 in `load_manifest` and 347 in `analyze_project`. Both are fixed;
+the cycle is now byte-for-byte flat.
+
+**The parsed TOML table was never freed.** `load_manifest` parsed `mach.toml` into a
+`toml.Table` and dropped it, because `std.data.toml` had no teardown to call
+(briar-systems/mach-std#474 adds it). `manifest.parse` interns every string it
+keeps, so the `Manifest` borrows nothing from the table and it can be released as
+soon as the parse returns.
+
+**Diagnostics were rendered on the success path.** The manifest parser composed a
+`[target.linux]`-style label for every table it validated, and passed *fully
+rendered error messages* into helpers that use them only on failure - so a
+successful parse built and discarded a complete set of diagnostics. `parse_str_array`
+and `parse_resource_path` now take the label and key and render only when something
+actually fails, which is both the leak fix and the reason the work was pointless to
+begin with.
+
+**Expanded output paths were dropped after interning.** `resolve_build_unit` and
+`check_collisions` expanded `{target.name}`/`{profile.name}` templates, interned the
+result, and leaked the rendering. `join_path_canonical` leaked both of the trimmed
+halves it joins, on every call.
+
+`join_path_canonical` also returned a *borrowed* argument in its two degenerate
+cases and a fresh allocation otherwise, so whether the caller had to free the result
+depended on values no caller can inspect. It now always returns an owned string.
+
+The regression test asserts an **exact** zero, not a threshold: a cycle that runs
+once per keystroke has no such thing as an acceptable per-cycle residue, only a
+longer wait before it matters.
+
 ### Added
 
 #### Tooling can retain compiler-owned frontend analysis (#2996)

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "f6967775d79eb780207140596581abbf7bf78be3"
+commit = "fce25b528bafa3a8392df9e0ad62409f85335183"

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -31,6 +31,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
+use std.text.string.str_free;
 use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_copy;
@@ -696,6 +697,9 @@ fun steps_demanded(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest
     var count: u32  = 0;
     val r: R.Result[bool, str] = manifest.plan_steps(a, itn, m, names, ncount, bu.target, proj_out, ?v, ?order, ?count);
     if (owned) { A.deallocate[intern.StrId](a, names, m.artifact_count::usize); }
+    # `proj_out` is this call's own expansion, borrowed by plan_steps and dead
+    # once it returns (#3001)
+    str_free(a, proj_out);
     if (R.is_err[bool, str](r)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](r)));
     }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -559,7 +559,13 @@ pub fun load_manifest(s: *session.Session, project_root: str) R.Result[manifest.
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[manifest.Manifest, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
-    ret manifest.parse(s.build_alloc, ?s.interner, ?t, true);
+    # the parsed table is a per-call value, not a retained one: `manifest.parse`
+    # interns every string it keeps, so the Manifest borrows nothing from it and
+    # the tree is released here. a retained Session reloads the manifest once per
+    # edit, so leaving it to process exit made the reload unbounded (#3001).
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(s.build_alloc, ?s.interner, ?t, true);
+    toml.dnit(s.build_alloc, ?t);
+    ret mr;
 }
 
 # build the module graph for one build selection (target,

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -26,10 +26,6 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.path;
 
-use std.data.toml;
-use std.text.string.str_free;
-use prnt: std.print;
-use iow: std.io.writer;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -609,11 +605,6 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-
-    val fr: R.Result[fs.File, str] = fs.create("/tmp/leak3001.txt", 0o644);
-    if (R.is_err[fs.File, str](fr)) { ret 1; }
-    val f: fs.File = R.unwrap_ok[fs.File, str](fr);
-    var w: iow.Writer = fs.writer(f);
 
     var names: [4]str;
     names[0] = "alpha.mach"; names[1] = "beta.mach";

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -26,6 +26,10 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.path;
 
+use std.data.toml;
+use std.text.string.str_free;
+use prnt: std.print;
+use iow: std.io.writer;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -605,6 +609,11 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val fr: R.Result[fs.File, str] = fs.create("/tmp/leak3001.txt", 0o644);
+    if (R.is_err[fs.File, str](fr)) { ret 1; }
+    val f: fs.File = R.unwrap_ok[fs.File, str](fr);
+    var w: iow.Writer = fs.writer(f);
 
     var names: [4]str;
     names[0] = "alpha.mach"; names[1] = "beta.mach";
@@ -20531,4 +20540,128 @@ fun ut_spv_var_loads_typed(w: *u32, n: u32) bool {
         i = i + len;
     }
     ret true;
+}
+
+
+# an allocator that reports its outstanding byte count, for the steady-state
+# assertions below
+#
+# It delegates every operation to a page-backed allocator and tracks only the net
+# balance, which is what a leak assertion needs: `live` is bytes allocated minus
+# bytes released, so a cycle that returns everything it took leaves it unchanged.
+# A reallocation is a release of the old extent and a take of the new, matching how
+# the containers underneath account for one.
+# ---
+# backing: the real allocator every call is forwarded to
+# live:    outstanding bytes, allocations minus deallocations
+rec LiveBytes {
+    backing: A.Allocator;
+    live:    i64;
+}
+
+fun live_alloc(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
+    val t: *LiveBytes = ctx::*LiveBytes;
+    val r: O.Option[ptr] = t.backing.fn_allocate(t.backing.ctx, size, align);
+    if (O.is_some[ptr](r)) { t.live = t.live + size::i64; }
+    ret r;
+}
+
+fun live_realloc(ctx: ptr, p: ptr, old_size: usize, new_size: usize, align: usize) O.Option[ptr] {
+    val t: *LiveBytes = ctx::*LiveBytes;
+    val r: O.Option[ptr] = t.backing.fn_reallocate(t.backing.ctx, p, old_size, new_size, align);
+    if (O.is_some[ptr](r)) { t.live = t.live - old_size::i64 + new_size::i64; }
+    ret r;
+}
+
+fun live_dealloc(ctx: ptr, p: ptr, size: usize, align: usize) i64 {
+    val t: *LiveBytes = ctx::*LiveBytes;
+    t.live = t.live - size::i64;
+    ret t.backing.fn_deallocate(t.backing.ctx, p, size, align);
+}
+
+# install a live-byte-counting allocator over a page allocator
+fun live_bytes_make(t: *LiveBytes, a: *A.Allocator) bool {
+    if (O.is_some[str](page.make(?t.backing))) { ret false; }
+    t.live          = 0;
+    a.ctx           = t::ptr;
+    a.fn_allocate   = live_alloc;
+    a.fn_reallocate = live_realloc;
+    a.fn_deallocate = live_dealloc;
+    ret true;
+}
+
+# A retained session's reload cycle returns to a steady state (#3001).
+#
+# THE ASSERTION IS EXACT, not a threshold. An editor integration runs this cycle
+# once per edit, so any per-cycle residue at all is unbounded growth over a session
+# rather than a constant overhead - a bound would only decide how long the session
+# lasts before it mattered. The first rounds are excluded because session-lifetime
+# storage (the interner, the query DB's retained handles) is legitimately populated
+# on the way in and never released; from the third round on, every allocation the
+# cycle makes must be one the cycle also returns.
+#
+# The cycle here is the LSP's: reload the manifest, analyze the artifact's closure,
+# tear the analysis down, release the manifest. It leaked ~8 KB per round before,
+# 96% of it in the manifest reload rather than the retained analysis the report
+# named - a toml table nothing freed, diagnostic labels rendered on every successful
+# parse, and expanded output paths dropped after interning.
+test "mach.lang.driver:retained_reload_cycle_reaches_steady_state" {
+    var lb: LiveBytes;
+    var alloc: A.Allocator;
+    if (!live_bytes_make(?lb, ?alloc)) { ret 1; }
+
+    var names: [4]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach";
+    names[2] = "model.mach"; names[3] = "orphan.mach";
+    var texts: [4]str;
+    texts[0] = "fun main() i32 { ret no_such(); }\n";
+    texts[1] = "use ctxcase.model;\nfun main() i32 { var b: model.Box[model.Leaf]; ret model.take[model.Leaf](b); }\n";
+    texts[2] = "pub rec Leaf { n: i32; }\npub rec Box[T] { v: T; }\npub fun take[T](b: Box[T]) i32 { ret 7; }\n";
+    texts[3] = "fun broken() NoSuch { var x: AlsoMissing; ret x; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_frontend(), ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { fs.remove_all(?alloc, root); ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var bad:      i32 = 0;
+    var settled:  i64 = 0;
+    var round:    i32 = 0;
+    for (round < 5) {
+        val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+        if (R.is_err[manifest.Manifest, str](mr)) { bad = 2; brk; }
+        var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+
+        var req: request.BuildRequest = request.defaults();
+        req.project_root = root;
+        req.target       = "windows";
+        req.profile      = "release";
+        req.artifact     = "beta";
+        req.want_lib     = false;
+        req.goal         = request.GOAL_OBJECTS;
+        req.opt          = pipeline.OPT_RELEASE;
+        req.pie          = true;
+
+        val pr: R.Result[project.Project, outcome.Fail] =
+            driver.analyze_project(?s, ?mf, ?req, nil, 0);
+        if (R.is_err[project.Project, outcome.Fail](pr)) {
+            manifest.dnit(?mf, ?alloc); bad = 3; brk;
+        }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p);
+        manifest.dnit(?mf, ?alloc);
+
+        # round 2 is the first fully warm one: rounds 0 and 1 still populate
+        # session-lifetime storage.
+        if (round == 2) { settled = lb.live; }
+        if (round > 2 && lb.live != settled) { bad = 4; brk; }
+        round = round + 1;
+    }
+
+    session.dnit(?s);
+    fs.remove_all(?alloc, root);
+    ret bad;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -326,7 +326,21 @@ fun intern_opt_unwrap(itn: *intern.Interner, text: str) intern.StrId {
     ret intern_unwrap(itn, text);
 }
 
-fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array, elem_err: str) R.Result[StrArr, str] {
+# `label` / `key` name the table and key for the diagnostic, which is RENDERED ONLY
+# WHEN AN ELEMENT FAILS. it used to arrive pre-rendered, so every successful parse
+# composed a full set of error messages and dropped them - a per-parse cost that a
+# retained session repeated on every reload (#3001)
+# ---
+# alloc:        allocator for the id array and any diagnostic
+# itn:          interner receiving each element
+# arr:          the toml array to read, or nil for an absent key
+# label:        the declaring table's label, e.g. `[artifact.beta]`
+# key:          the key within it, e.g. `targets`
+# allow_scalar: true when the key also accepts a bare string, which the
+#               diagnostic must say
+# ret:          the interned ids, or the first element's failure
+fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array,
+                    label: str, key: str, allow_scalar: bool) R.Result[StrArr, str] {
     var out: StrArr;
     out.items   = nil;
     out.count   = 0;
@@ -346,7 +360,12 @@ fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array
         val v: *toml.Value = toml.array_get(arr, i);
         if (v == nil || v.tag != toml.TYPE_STRING) {
             A.deallocate[intern.StrId](alloc, out.items, n);
-            ret R.err[StrArr, str](elem_err);
+            if (allow_scalar) {
+                ret R.err[StrArr, str](sfmt(alloc,
+                    "mach.toml: {}.{} must be a string or array of strings", label, key));
+            }
+            ret R.err[StrArr, str](sfmt(alloc,
+                "mach.toml: {}.{} must be an array of strings", label, key));
         }
         val res_elem: R.Result[intern.StrId, str] = intern.intern(itn, v.data.string);
         if (R.is_err[intern.StrId, str](res_elem)) {
@@ -400,8 +419,7 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
         out.count = 1;
     }
     or (v.tag == toml.TYPE_ARRAY) {
-        val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array,
-            sfmt(alloc, "mach.toml: {}.{} must be a string or array of strings", label, key));
+        val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array, label, key, true);
         if (R.is_err[StrArr, str](res_arr)) { ret res_arr; }
         val arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
         out.items = arr_v.items;
@@ -537,12 +555,16 @@ fun parse_resource_path(alloc: *A.Allocator, itn: *intern.Interner, label: str,
     val v: *toml.Value = toml.get(sub, key);
     if (v == nil) { ret R.ok[intern.StrId, str](intern.STR_NIL); }
     if (v.tag != toml.TYPE_STRING) {
-        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {} must be a non-empty path string", label));
+        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {}.{} must be a non-empty path string", label, key));
     }
     if (str_empty(v.data.string)) {
-        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {} must not be empty; omit it when unused", label));
+        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {}.{} must not be empty; omit it when unused", label, key));
     }
-    val checked: R.Result[bool, str] = check_path(alloc, v.data.string, label);
+    # the only place the composed `<label>.<key>` field name is actually needed,
+    # reached only when the key is present (#3001)
+    val field: str = sfmt(alloc, "{}.{}", label, key);
+    val checked: R.Result[bool, str] = check_path(alloc, v.data.string, field);
+    str_free(alloc, field);
     if (R.is_err[bool, str](checked)) {
         ret R.err[intern.StrId, str](R.unwrap_err[bool, str](checked));
     }
@@ -781,6 +803,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         if (O.is_some[i64](base_opt)) { d.base = O.unwrap[i64](base_opt)::u64; }
 
         m.targets[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -812,7 +835,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     val v: *toml.Value = toml.table_value(tab, k);
     val label: str = sfmt(alloc, "[artifact.{}]", name);
     if (v == nil || v.tag != toml.TYPE_TABLE) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+        val lbl_msg1: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg1);
     }
     val sub: *toml.Table = ?v.data.table;
 
@@ -832,29 +855,32 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
 
     val kind_s: str = toml.get_str(sub, "kind");
     if (str_empty(kind_s) || !(str_equals(kind_s, "bin") || str_equals(kind_s, "static") || str_equals(kind_s, "shared"))) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {}.kind must be \"bin\", \"static\", or \"shared\"", label));
+        val lbl_msg2: str = sfmt(alloc, "mach.toml: {}.kind must be \"bin\", \"static\", or \"shared\"", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg2);
     }
     a.kind = intern_unwrap(itn, kind_s);
     a.is_lib = !str_equals(kind_s, "bin");
 
     val entry_s: str = toml.get_str(sub, "entry");
     if (str_empty(entry_s)) { ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'entry'", label)); }
-    val res_check_entry: R.Result[bool, str] = check_path(alloc, entry_s, sfmt(alloc, "{}.entry", label));
+    val entry_field: str = sfmt(alloc, "{}.entry", label);
+    val res_check_entry: R.Result[bool, str] = check_path(alloc, entry_s, entry_field);
+    str_free(alloc, entry_field);
     if (R.is_err[bool, str](res_check_entry)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_check_entry)); }
     a.entry = intern_unwrap(itn, entry_s);
 
     val out_s: str = toml.get_str(sub, "out");
     if (str_empty(out_s)) { ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'out'", label)); }
-    val res_check_out: R.Result[bool, str] = check_path(alloc, out_s, sfmt(alloc, "{}.out", label));
+    val out_field: str = sfmt(alloc, "{}.out", label);
+    val res_check_out: R.Result[bool, str] = check_path(alloc, out_s, out_field);
+    str_free(alloc, out_field);
     if (R.is_err[bool, str](res_check_out)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_check_out)); }
     a.out = intern_unwrap(itn, out_s);
 
     val targets_arr: *toml.Array = toml.get_array(sub, "targets");
     if (targets_arr == nil) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'targets'", label));
+        val lbl_msg3: str = sfmt(alloc, "mach.toml: {} is missing required key 'targets'", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg3);
     }
-    val res_targets: R.Result[StrArr, str] = parse_str_array(alloc, itn, targets_arr,
-        sfmt(alloc, "mach.toml: {}.targets must be an array of strings", label));
+    val res_targets: R.Result[StrArr, str] = parse_str_array(alloc, itn, targets_arr, label, "targets", false);
     if (R.is_err[StrArr, str](res_targets)) { ret R.err[ArtifactDef, str](R.unwrap_err[StrArr, str](res_targets)); }
     val targets_val: StrArr = R.unwrap_ok[StrArr, str](res_targets);
     a.targets      = targets_val.items;
@@ -862,11 +888,10 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
 
     val link_arr: *toml.Array = toml.get_array(sub, "link");
     if (link_arr == nil && as_root) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'link' (use [] for none)", label));
+        val lbl_msg4: str = sfmt(alloc, "mach.toml: {} is missing required key 'link' (use [] for none)", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg4);
     }
     if (link_arr != nil) {
-        val res_link: R.Result[StrArr, str] = parse_str_array(alloc, itn, link_arr,
-            sfmt(alloc, "mach.toml: {}.link must be an array of strings", label));
+        val res_link: R.Result[StrArr, str] = parse_str_array(alloc, itn, link_arr, label, "link", false);
         if (R.is_err[StrArr, str](res_link)) { ret R.err[ArtifactDef, str](R.unwrap_err[StrArr, str](res_link)); }
         val link_val: StrArr = R.unwrap_ok[StrArr, str](res_link);
         a.link       = link_val.items;
@@ -875,11 +900,10 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
 
     val need_arr: *toml.Array = toml.get_array(sub, "need");
     if (need_arr == nil && as_root) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label));
+        val lbl_msg5: str = sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg5);
     }
     if (need_arr != nil) {
-        val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
-            sfmt(alloc, "mach.toml: {}.need must be an array of strings", label));
+        val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr, label, "need", false);
         if (R.is_err[StrArr, str](res_need)) { ret R.err[ArtifactDef, str](R.unwrap_err[StrArr, str](res_need)); }
         val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
         a.need       = need_val.items;
@@ -891,16 +915,16 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.subsystem = R.unwrap_ok[of.Subsystem, str](res_subsystem);
 
     val res_icon: R.Result[intern.StrId, str] =
-        parse_resource_path(alloc, itn, sfmt(alloc, "{}.icon", label), sub, "icon");
+        parse_resource_path(alloc, itn, label, sub, "icon");
     if (R.is_err[intern.StrId, str](res_icon)) {
-        ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_icon));
+        str_free(alloc, label); ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_icon));
     }
     a.icon = R.unwrap_ok[intern.StrId, str](res_icon);
 
     val res_manifest: R.Result[intern.StrId, str] =
-        parse_resource_path(alloc, itn, sfmt(alloc, "{}.manifest", label), sub, "manifest");
+        parse_resource_path(alloc, itn, label, sub, "manifest");
     if (R.is_err[intern.StrId, str](res_manifest)) {
-        ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_manifest));
+        str_free(alloc, label); ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_manifest));
     }
     a.app_manifest = R.unwrap_ok[intern.StrId, str](res_manifest);
 
@@ -909,7 +933,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
             "mach.toml: {}.icon and .manifest apply only to kind = \"bin\" artifacts", label));
     }
 
-    ret R.ok[ArtifactDef, str](a);
+    str_free(alloc, label); ret R.ok[ArtifactDef, str](a);
 }
 
 fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
@@ -929,7 +953,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[profile.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg6: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg6);
         }
         val sub: *toml.Table = ?v.data.table;
         val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, as_root);
@@ -958,6 +982,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         pf.float_reassoc = R.unwrap_ok[bool, str](res_fra);
 
         m.profiles[i] = pf;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -980,12 +1005,12 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[dep.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg7: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg7);
         }
         val sub: *toml.Table = ?v.data.table;
 
         if (toml.get(sub, "version") != nil) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.version is reserved for the registry era", label));
+            val lbl_msg8: str = sfmt(alloc, "mach.toml: {}.version is reserved for the registry era", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg8);
         }
         val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
@@ -997,20 +1022,21 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         val has_git:  bool = !str_empty(git_s);
         val has_path: bool = !str_empty(path_s);
         if (has_git == has_path) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} needs exactly one source key: 'git' or 'path'", label));
+            val lbl_msg9: str = sfmt(alloc, "mach.toml: {} needs exactly one source key: 'git' or 'path'", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg9);
         }
         val ref_s: str = toml.get_str(sub, "ref");
         if (has_git && str_empty(ref_s) && as_root) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'ref' for git source", label));
+            val lbl_msg10: str = sfmt(alloc, "mach.toml: {} is missing required key 'ref' for git source", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg10);
         }
         if (has_path && !str_empty(ref_s) && as_root) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.ref is not allowed for path sources", label));
+            val lbl_msg11: str = sfmt(alloc, "mach.toml: {}.ref is not allowed for path sources", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg11);
         }
         d.git  = intern_opt_unwrap(itn, git_s);
         d.path = intern_opt_unwrap(itn, path_s);
         d.ref  = intern_opt_unwrap(itn, ref_s);
 
         m.deps[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1033,7 +1059,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[link.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg12: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg12);
         }
         val sub: *toml.Table = ?v.data.table;
 
@@ -1046,7 +1072,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val source_s: str = toml.get_str(sub, "source");
         if (str_empty(source_s)) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'source'", label)); }
         if (!str_equals(source_s, "system") && !str_equals(source_s, "framework") && !str_equals(source_s, "local")) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.source must be \"system\", \"framework\", or \"local\"", label));
+            val lbl_msg13: str = sfmt(alloc, "mach.toml: {}.source must be \"system\", \"framework\", or \"local\"", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg13);
         }
         d.source = LINK_LOCAL;
         if (str_equals(source_s, "system"))    { d.source = LINK_SYSTEM; }
@@ -1055,11 +1081,11 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val library_v: *toml.Value = toml.get(sub, "library");
         if (library_v != nil) {
             if (library_v.tag != toml.TYPE_STRING) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
+                val lbl_msg14: str = sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg14);
             }
             val library_s: str = library_v.data.string;
             if (str_empty(library_s)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
+                val lbl_msg15: str = sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg15);
             }
             d.library = intern_unwrap(itn, library_s);
         }
@@ -1069,16 +1095,15 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val symbols_v: *toml.Value = toml.get(sub, "symbols");
         if (symbols_v != nil) {
             if (symbols_v.tag != toml.TYPE_ARRAY) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label));
+                val lbl_msg16: str = sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg16);
             }
-            val res_syms: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?symbols_v.data.array,
-                sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label));
+            val res_syms: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?symbols_v.data.array, label, "symbols", false);
             if (R.is_err[StrArr, str](res_syms)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_syms)); }
             val syms: StrArr = R.unwrap_ok[StrArr, str](res_syms);
             var si: u32 = 0;
             for (si < syms.count) {
                 if (str_empty(idstr(itn, syms.items[si]))) {
-                    ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols has an empty symbol name", label));
+                    val lbl_msg17: str = sfmt(alloc, "mach.toml: {}.symbols has an empty symbol name", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg17);
                 }
                 var sj: u32 = 0;
                 for (sj < si) {
@@ -1099,22 +1124,24 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
 
         if (str_equals(source_s, "local")) {
             if (!str_empty(name_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.name is not allowed for local sources", label));
+                val lbl_msg18: str = sfmt(alloc, "mach.toml: {}.name is not allowed for local sources", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg18);
             }
             if (str_empty(path_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'path' for local source", label));
+                val lbl_msg19: str = sfmt(alloc, "mach.toml: {} is missing required key 'path' for local source", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg19);
             }
-            val res_check_path: R.Result[bool, str] = check_path(alloc, path_val, sfmt(alloc, "{}.path", label));
+            val path_field: str = sfmt(alloc, "{}.path", label);
+            val res_check_path: R.Result[bool, str] = check_path(alloc, path_val, path_field);
+            str_free(alloc, path_field);
             if (R.is_err[bool, str](res_check_path)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check_path)); }
             d.path = intern_unwrap(itn, path_val);
             d.lib_name = intern.STR_NIL;
         }
         or {
             if (!str_empty(path_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.path is not allowed for non-local sources", label));
+                val lbl_msg20: str = sfmt(alloc, "mach.toml: {}.path is not allowed for non-local sources", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg20);
             }
             if (str_empty(name_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'name' for non-local source", label));
+                val lbl_msg21: str = sfmt(alloc, "mach.toml: {} is missing required key 'name' for non-local source", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg21);
             }
             d.lib_name = intern_unwrap(itn, name_val);
             d.path = intern.STR_NIL;
@@ -1151,6 +1178,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         or { d.export = export_v.data.boolean; }
 
         m.links[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1173,7 +1201,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[step.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg22: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg22);
         }
         val sub: *toml.Table = ?v.data.table;
 
@@ -1194,8 +1222,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
 
         val in_arr: *toml.Array = toml.get_array(sub, "in");
         if (in_arr == nil) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'in'", label)); }
-        val res_in: R.Result[StrArr, str] = parse_str_array(alloc, itn, in_arr,
-            sfmt(alloc, "mach.toml: {}.in must be an array of strings", label));
+        val res_in: R.Result[StrArr, str] = parse_str_array(alloc, itn, in_arr, label, "in", false);
         if (R.is_err[StrArr, str](res_in)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_in)); }
         val in_val: StrArr = R.unwrap_ok[StrArr, str](res_in);
         d.in = in_val.items;
@@ -1204,15 +1231,16 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         var ii: u32 = 0;
         for (ii < d.in_count) {
             val p: str = idstr(itn, d.in[ii]);
-            val res_check: R.Result[bool, str] = check_path(alloc, p, sfmt(alloc, "{}.in", label));
+            val in_field: str = sfmt(alloc, "{}.in", label);
+            val res_check: R.Result[bool, str] = check_path(alloc, p, in_field);
+            str_free(alloc, in_field);
             if (R.is_err[bool, str](res_check)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check)); }
             ii = ii + 1;
         }
 
         val out_arr: *toml.Array = toml.get_array(sub, "out");
         if (out_arr == nil) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'out'", label)); }
-        val res_out: R.Result[StrArr, str] = parse_str_array(alloc, itn, out_arr,
-            sfmt(alloc, "mach.toml: {}.out must be an array of strings", label));
+        val res_out: R.Result[StrArr, str] = parse_str_array(alloc, itn, out_arr, label, "out", false);
         if (R.is_err[StrArr, str](res_out)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_out)); }
         val out_val: StrArr = R.unwrap_ok[StrArr, str](res_out);
         d.out = out_val.items;
@@ -1223,18 +1251,19 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         for (ii < d.out_count) {
             val p: str = idstr(itn, d.out[ii]);
             if (str_contains_char(p, '*')) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.out cannot contain a glob '*'; outputs must be concrete paths", label)); }
-            val res_check: R.Result[bool, str] = check_path(alloc, p, sfmt(alloc, "{}.out", label));
+            val out_path_field: str = sfmt(alloc, "{}.out", label);
+            val res_check: R.Result[bool, str] = check_path(alloc, p, out_path_field);
+            str_free(alloc, out_path_field);
             if (R.is_err[bool, str](res_check)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check)); }
             ii = ii + 1;
         }
 
         val need_arr: *toml.Array = toml.get_array(sub, "need");
         if (need_arr == nil && as_root) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label));
+            val lbl_msg23: str = sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg23);
         }
         if (need_arr != nil) {
-            val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
-                sfmt(alloc, "mach.toml: {}.need must be an array of strings", label));
+            val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr, label, "need", false);
             if (R.is_err[StrArr, str](res_need)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_need)); }
             val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
             d.need = need_val.items;
@@ -1242,6 +1271,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
 
         m.steps[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1302,6 +1332,24 @@ pub fun dnit(m: *Manifest, alloc: *A.Allocator) {
         A.deallocate[StepDef](alloc, m.steps, m.step_count::usize);
         m.steps = nil;
         m.step_count = 0;
+    }
+}
+
+# release the first `count` composed path strings in `paths`
+#
+# The array itself is the caller's; this frees only what each slot points at.
+# `count` is the populated prefix rather than the capacity, so a partly filled
+# buffer (an error partway through composition) frees exactly what it wrote.
+# ---
+# alloc: allocator the strings were composed on
+# paths: array of composed path strings
+# count: number of populated entries
+fun free_path_strings(alloc: *A.Allocator, paths: *str, count: u32) {
+    if (paths == nil) { ret; }
+    var i: u32 = 0;
+    for (i < count) {
+        str_free(alloc, paths[i]);
+        i = i + 1;
     }
 }
 
@@ -1800,18 +1848,34 @@ pub fun link_matches_target(itn: *intern.Interner, l: *LinkDef, t: *TargetDef) b
     ret true;
 }
 
+# join `a` and `b` with exactly one separator between them
+#
+# THE RESULT IS ALWAYS OWNED BY THE CALLER. The degenerate cases used to hand back
+# the borrowed argument while the joining case returned a fresh allocation, so
+# whether the caller had to free it depended on the values -- which no caller can
+# check. Both now return a copy, so `str_free` on the result is correct always.
+#
+# The two trimmed halves are scratch for the join and are released here (#3001).
+# ---
+# alloc: allocator owning the returned string and the two trimmed halves
+# a:     left side; a single trailing '/' is dropped
+# b:     right side; a single leading '/' is dropped
+# ret:   the joined path, owned by the caller
 fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
-    if (str_empty(a)) { ret b; }
-    if (str_empty(b)) { ret a; }
+    if (str_empty(a)) { ret seg_dup(alloc, b, 0, str_len(b)); }
+    if (str_empty(b)) { ret seg_dup(alloc, a, 0, str_len(a)); }
     val al: usize = str_len(a);
     var end_a: usize = al;
     if (a[al - 1] == '/') { end_a = al - 1; }
     var start_b: usize = 0;
     if (b[0] == '/') { start_b = 1; }
-    
+
     val a_sub: str = seg_dup(alloc, a, 0, end_a);
     val b_sub: str = seg_dup(alloc, b, start_b, str_len(b));
-    ret sfmt(alloc, "{}/{}", a_sub, b_sub);
+    val joined: str = sfmt(alloc, "{}/{}", a_sub, b_sub);
+    str_free(alloc, a_sub);
+    str_free(alloc, b_sub);
+    ret joined;
 }
 
 # resolve a matched link entry without discarding its declared source semantics
@@ -2289,7 +2353,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     var matched_items: *LinkRequirement = nil;
     if (a.link_count > 0) {
         val res_match_arr: R.Result[*LinkRequirement, str] = A.allocate[LinkRequirement](alloc, a.link_count::usize);
-        if (R.is_err[*LinkRequirement, str](res_match_arr)) { ret R.err[BuildUnit, str](R.unwrap_err[*LinkRequirement, str](res_match_arr)); }
+        if (R.is_err[*LinkRequirement, str](res_match_arr)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[*LinkRequirement, str](res_match_arr)); }
         matched_items = R.unwrap_ok[*LinkRequirement, str](res_match_arr);
 
         var li: u32 = 0;
@@ -2309,7 +2373,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
                     if (R.is_err[LinkRequirement, str](req_r)) {
                         free_link_claims(alloc, matched_items, match_count);
                         A.deallocate[LinkRequirement](alloc, matched_items, a.link_count::usize);
-                        ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r));
+                        str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r));
                     }
                     matched_items[match_count] = R.unwrap_ok[LinkRequirement, str](req_r);
                     match_count = match_count + 1;
@@ -2323,7 +2387,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
         val fr: R.Result[bool, str] = finish_link_requirements(alloc, matched_items,
             a.link_count, match_count, ?exact_items, ?exact_count);
         if (R.is_err[bool, str](fr)) {
-            ret R.err[BuildUnit, str](R.unwrap_err[bool, str](fr));
+            str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[bool, str](fr));
         }
         matched_items = exact_items;
         match_count = exact_count;
@@ -2337,30 +2401,37 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     val asm_str: str = sfmt(alloc, "{}/asm", proj_out);
     val test_str: str = sfmt(alloc, "{}/test/{{name}}", proj_out);
 
-    val res_obj: R.Result[intern.StrId, str] = intern.intern(itn, obj_str);
-    if (R.is_err[intern.StrId, str](res_obj)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_obj)); }
-    u.obj_root = R.unwrap_ok[intern.StrId, str](res_obj);
-
-    val res_ir: R.Result[intern.StrId, str] = intern.intern(itn, ir_str);
-    if (R.is_err[intern.StrId, str](res_ir)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_ir)); }
-    u.ir_root = R.unwrap_ok[intern.StrId, str](res_ir);
-
-    val res_asm: R.Result[intern.StrId, str] = intern.intern(itn, asm_str);
-    if (R.is_err[intern.StrId, str](res_asm)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_asm)); }
-    u.asm_root = R.unwrap_ok[intern.StrId, str](res_asm);
-
+    # the four are interned together and released together: each is a per-call
+    # rendering whose only durable form is its StrId (#3001)
+    val res_obj:  R.Result[intern.StrId, str] = intern.intern(itn, obj_str);
+    val res_ir:   R.Result[intern.StrId, str] = intern.intern(itn, ir_str);
+    val res_asm:  R.Result[intern.StrId, str] = intern.intern(itn, asm_str);
     val res_test: R.Result[intern.StrId, str] = intern.intern(itn, test_str);
-    if (R.is_err[intern.StrId, str](res_test)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_test)); }
+    str_free(alloc, obj_str);
+    str_free(alloc, ir_str);
+    str_free(alloc, asm_str);
+    str_free(alloc, test_str);
+
+    if (R.is_err[intern.StrId, str](res_obj)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_obj)); }
+    u.obj_root = R.unwrap_ok[intern.StrId, str](res_obj);
+    if (R.is_err[intern.StrId, str](res_ir)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_ir)); }
+    u.ir_root = R.unwrap_ok[intern.StrId, str](res_ir);
+    if (R.is_err[intern.StrId, str](res_asm)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_asm)); }
+    u.asm_root = R.unwrap_ok[intern.StrId, str](res_asm);
+    if (R.is_err[intern.StrId, str](res_test)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_test)); }
     u.test_root = R.unwrap_ok[intern.StrId, str](res_test);
 
     # Resolve artifact relative path
     val art_out_tmpl: intern.StrId = a.out;
     val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, ?v);
-    if (R.is_err[str, str](res_art_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
+    if (R.is_err[str, str](res_art_out)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
     val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
 
     val final_bin_path: str = join_path_canonical(alloc, proj_out, art_out_rel);
     val res_bin: R.Result[intern.StrId, str] = intern.intern(itn, final_bin_path);
+    str_free(alloc, final_bin_path);
+    str_free(alloc, art_out_rel);
+    str_free(alloc, proj_out);
     if (R.is_err[intern.StrId, str](res_bin)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_bin)); }
     u.bin_path = R.unwrap_ok[intern.StrId, str](res_bin);
 
@@ -2486,9 +2557,15 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
         val a: *ArtifactDef = ?m.artifacts[i];
         val art_out_tmpl: intern.StrId = a.out;
         val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, v);
-        if (R.is_err[str, str](res_art_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_out)); }
+        if (R.is_err[str, str](res_art_out)) {
+            free_path_strings(alloc, paths, i);
+            A.deallocate[str](alloc, paths, m.artifact_count::usize);
+            str_free(alloc, proj_out);
+            ret R.err[bool, str](R.unwrap_err[str, str](res_art_out));
+        }
         val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
         paths[i] = join_path_canonical(alloc, proj_out, art_out_rel);
+        str_free(alloc, art_out_rel);
         i = i + 1;
     }
 
@@ -2511,7 +2588,12 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
         i = i + 1;
     }
 
+    # `paths` holds one composed string per artifact, each owned by this check and
+    # dead once the comparison is done. the collision message is rendered before
+    # they are released, so it carries its own copy (#3001)
+    free_path_strings(alloc, paths, m.artifact_count);
     A.deallocate[str](alloc, paths, m.artifact_count::usize);
+    str_free(alloc, proj_out);
     if (!code) { ret R.err[bool, str](msg); }
     ret R.ok[bool, str](true);
 }


### PR DESCRIPTION
Closes #3001. Requires briar-systems/mach-std#475, released as mach-std 0.27.0; `mach.lock` advances to it here.

## What the measurement said

The issue attributed the growth to the retained-analysis path #2997 added. Measuring the two halves separately — a counting allocator over the real cycle, with the manifest loaded **once outside the loop** for one of the runs — split it differently:

| phase | before | after |
|---|---:|---:|
| `load_manifest` + `manifest.dnit` | 7646 B/round | **0** |
| `analyze_project` + `dnit_project` | 347 B/round | **0** |
| combined cycle | 7993 B/round | **0** |

**96% of it was the manifest reload, not the retained analysis.** That also explains the issue's observation that the leak was independent of invalidation: a manifest reload leaks the same whether or not any source changed, which looked like evidence for a query-DB problem and was evidence against one.

## Causes, all on the success path

- **The parsed TOML table was never freed.** `std.data.toml` had no teardown to call at all (mach-std#474). `manifest.parse` interns every string it keeps, so the `Manifest` borrows nothing from the table and it is released as soon as the parse returns.
- **Diagnostics were rendered on the success path.** The manifest parser composed a `[target.linux]`-style label for every table it validated, and passed *fully rendered error messages* into helpers that use them only on failure. `parse_str_array` and `parse_resource_path` now take the label and key and render only when something fails — which is the leak fix and also the reason the work was pointless.
- **Expanded output paths were dropped after interning**, in `resolve_build_unit` and `check_collisions`.
- **`join_path_canonical` leaked both trimmed halves it joins**, on every call. This was the last 88 B/round.

`join_path_canonical` also returned a *borrowed* argument in its two degenerate cases and a fresh allocation otherwise, so whether the caller had to free the result depended on values no caller can inspect. It now always returns an owned string. I checked `BuildUnit` is entirely `intern.StrId` before freeing anything it was composed from, so none of the new frees can dangle.

## Verification

- **1486 passed, 0 failed** on both `release` and `debug`.
- **Fixpoint:** three generations byte-identical (`sha256 e33ac47a…` for all of A, B, C), so the seed and the from-source compiler agree.
- **Mutation-checked, twice.** Dropping the `toml.dnit` call fails the new test; dropping the `join_path_canonical` frees fails it. It discriminates rather than merely passes.
- The regression test asserts an **exact** zero from the third round on, once session-lifetime storage has settled. Not a threshold: at one cycle per keystroke, a per-cycle residue is unbounded growth and a bound would only set how long the session lasts before it matters.

## Note for the consumer

mach-lsp#159 carries the LSP-level acceptance measurement. It needs its vendored pin advanced past this before RSS-flat-across-edits can be confirmed there.