### PR TITLE
chore: release 4.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.20.0] - 2026-08-20
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.19.0"
+version = "4.20.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.19.0";
+pub val MACH_VERSION: str = "4.20.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Promotes `[Unreleased]` to `[4.20.0]` and bumps `mach.toml`.

Seven entries since 4.19.0, one of them an addition (retained frontend analysis, #2996), so a minor bump:

- driver: a retained session's reload cycle returns to a steady state (#3001)
- Tooling can retain compiler-owned frontend analysis (#2996)
- Project manifests no longer declare a minimum Mach version (#2953)
- Vendored frontends retain Mach's compiler version (#2954)
- Artifact builds compile only their reachable module graph (#2967)
- Target-split executables select the right artifact on every host (#2955, #2961, #2981)
- Character literals lower at their coerced integer width (#2982)

Also carries the mach-std pin advance to 0.27.0, which #3001 needs for `toml.dnit`.