### PR TITLE
mach 4.20.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,11 +26,13 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
-      - name: tag matches mach.toml version
+      - name: tag matches every release version
         run: |
           set -euo pipefail
           ver="$(sed -n 's/^version = "\(.*\)"$/\1/p' mach.toml | head -1)"
           [ "v$ver" = "$GITHUB_REF_NAME" ] || { echo "::error::tag $GITHUB_REF_NAME != mach.toml version $ver"; exit 1; }
+          compiler_ver="$(sed -n 's/^pub val MACH_VERSION: str = "\(.*\)";$/\1/p' src/lang/version.mach)"
+          [ "$compiler_ver" = "$ver" ] || { echo "::error::compiler version $compiler_ver != mach.toml version $ver"; exit 1; }
 
   build-linux:
     name: build ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
             exit 1
           fi
 
+          bash test/version-vendor.sh ./b .
+
           # hand the fixpoint binary to the test job
           mkdir -p artifact
           cp c artifact/mach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Vendored frontends retain Mach's compiler version (#2954)
+
+The driver, `$mach.version`, debug-info producer string, and CLI now read one Mach-owned
+release constant instead of the embedding project's `[project].version`. A frontend
+vendored by another tool therefore reports Mach's version rather than its host package's
+version. Release tests pin the constant to Mach's own manifest.
+
 ## [4.19.0] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### driver: a retained session's reload cycle returns to a steady state (#3001)
+
+`analyze_project` + `dnit_project` on one retained `Session` grew RSS without
+bound, ~7.4 MiB per cycle against a 222-module project. A language server runs that
+cycle once per edit, so the growth was proportional to how long an editing session
+lasted: mach-lsp reached ~550 MiB after 40 edits of one file and kept climbing.
+
+**The report named the retained-analysis path, and 96% of it was the manifest
+reload.** Measuring the two halves separately - the same allocator counting bytes,
+the manifest loaded once outside the loop for one of them - split 7993 bytes per
+round into 7646 in `load_manifest` and 347 in `analyze_project`. Both are fixed;
+the cycle is now byte-for-byte flat.
+
+**The parsed TOML table was never freed.** `load_manifest` parsed `mach.toml` into a
+`toml.Table` and dropped it, because `std.data.toml` had no teardown to call
+(briar-systems/mach-std#474 adds it). `manifest.parse` interns every string it
+keeps, so the `Manifest` borrows nothing from the table and it can be released as
+soon as the parse returns.
+
+**Diagnostics were rendered on the success path.** The manifest parser composed a
+`[target.linux]`-style label for every table it validated, and passed *fully
+rendered error messages* into helpers that use them only on failure - so a
+successful parse built and discarded a complete set of diagnostics. `parse_str_array`
+and `parse_resource_path` now take the label and key and render only when something
+actually fails, which is both the leak fix and the reason the work was pointless to
+begin with.
+
+**Expanded output paths were dropped after interning.** `resolve_build_unit` and
+`check_collisions` expanded `{target.name}`/`{profile.name}` templates, interned the
+result, and leaked the rendering. `join_path_canonical` leaked both of the trimmed
+halves it joins, on every call.
+
+`join_path_canonical` also returned a *borrowed* argument in its two degenerate
+cases and a fresh allocation otherwise, so whether the caller had to free the result
+depended on values no caller can inspect. It now always returns an owned string.
+
+The regression test asserts an **exact** zero, not a threshold: a cycle that runs
+once per keystroke has no such thing as an acceptable per-cycle residue, only a
+longer wait before it matters.
+
 ### Added
 
 #### Tooling can retain compiler-owned frontend analysis (#2996)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Tooling can retain compiler-owned frontend analysis (#2996)
+
+`driver.analyze_project` now runs load, resolve, and sema without executing build
+steps or backend phases, and returns the retained project graph. Optional module
+FQN roots enter the compiler's normal DFS, so open editor buffers outside the
+selected artifact closure receive the same overlays, imports, comptime constants,
+diagnostics, and semantic analysis as ordinary project modules.
+
 ### Changed
 
 #### Project manifests no longer declare a minimum Mach version (#2953)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.20.0] - 2026-08-20
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### Project manifests no longer declare a minimum Mach version (#2953)
+
+The undocumented `[project].mach` key and its toolchain-version check have been
+removed. The check read the embedding project's version when the compiler frontend
+was vendored, so it refused every ordinary `4.x` requirement under tools such as
+mach-lsp. Root manifests now report `mach` as an unknown project key; dependency
+metadata bearing the removed key is ignored. No replacement is planned here.
+
 ## [4.19.0] - 2026-08-10
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,10 @@ Mach uses [Semantic Versioning](https://semver.org/) (`vMAJOR.MINOR.PATCH`):
 
 Tags are created on `main` after merging from `dev`. The current pre-1.0 convention treats minor bumps as potentially breaking while the language stabilizes.
 
+A release bump updates both `[project].version` in `mach.toml` and
+`MACH_VERSION` in `src/lang/version.mach`. CI and the tag workflow require the
+two values to match.
+
 ### Release Flow
 
 ```

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "f6967775d79eb780207140596581abbf7bf78be3"
+commit = "fce25b528bafa3a8392df9e0ad62409f85335183"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.19.0"
+version = "4.20.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -18,9 +18,7 @@ use std.types.string.str_len;
 
 use mach.cli.args;
 use mach.cli.util;
-
-# the compiler version string, folded at compile time from the project manifest
-val MACH_VERSION: str = $project.version;
+use mach.lang.version;
 
 # the column a flag's doc text starts at, so a table renders as aligned pairs
 val FLAG_COL: usize = 24;
@@ -113,7 +111,7 @@ fun global_flags() {
 # print the top-level usage summary and the command list
 pub fun usage() {
     print.print("mach ");
-    print.print(MACH_VERSION);
+    print.print(version.MACH_VERSION);
     print.print(" - the Mach compiler\n");
     print.print("\n");
     print.print("usage: mach <command> [options]\n");

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -31,9 +31,7 @@ use mach.lang.target.abi;
 use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.os;
-
-# the compiler version string, folded from the project manifest at compile time
-val MACH_VERSION: str = $project.version;
+use mach.lang.version;
 
 # `mach info` subcommand entry point
 #
@@ -52,7 +50,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (util.flag_reject_unknown(argc, argv, marks, 2, "mach info")) { ret 1; }
 
     if (argc >= 3 && str_equals(argv[2]::str, "--version")) {
-        print.println(MACH_VERSION);
+        print.println(version.MACH_VERSION);
         ret 0;
     }
 
@@ -74,7 +72,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     }
 
     print.print("mach ");
-    print.println(MACH_VERSION);
+    print.println(version.MACH_VERSION);
 
     # the host os/arch fold at compile time to the target this binary was built for.
     print.print("host: ");

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -31,6 +31,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
+use std.text.string.str_free;
 use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_copy;
@@ -696,6 +697,9 @@ fun steps_demanded(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest
     var count: u32  = 0;
     val r: R.Result[bool, str] = manifest.plan_steps(a, itn, m, names, ncount, bu.target, proj_out, ?v, ?order, ?count);
     if (owned) { A.deallocate[intern.StrId](a, names, m.artifact_count::usize); }
+    # `proj_out` is this call's own expansion, borrowed by plan_steps and dead
+    # once it returns (#3001)
+    str_free(a, proj_out);
     if (R.is_err[bool, str](r)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](r)));
     }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -559,7 +559,13 @@ pub fun load_manifest(s: *session.Session, project_root: str) R.Result[manifest.
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[manifest.Manifest, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
-    ret manifest.parse(s.build_alloc, ?s.interner, ?t, true);
+    # the parsed table is a per-call value, not a retained one: `manifest.parse`
+    # interns every string it keeps, so the Manifest borrows nothing from it and
+    # the tree is released here. a retained Session reloads the manifest once per
+    # edit, so leaving it to process exit made the reload unbounded (#3001).
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(s.build_alloc, ?s.interner, ?t, true);
+    toml.dnit(s.build_alloc, ?t);
+    ret mr;
 }
 
 # build the module graph for one build selection (target,

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -45,6 +45,7 @@ use mach.lang.query;
 use mach.lang.readout;
 use mach.lang.session;
 use mach.lang.target;
+use mach.lang.target.isa;
 use mach.lang.target.of;
 
 use mach.lang.driver.project;
@@ -66,6 +67,7 @@ fwd project.TARGET_OPT_RELEASE;
 fwd project.dnit_project;
 fwd project.fqn_name;
 fwd project.link_name_for;
+fwd load.module_context;
 
 # the union-build entry-count helper, re-exported so `mach test` / tooling
 # consumers keep spelling it as `driver.count_target_gated`
@@ -191,6 +193,66 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
     var roots: project.RootSet = project.ROOT_ARTIFACT;
     if (request.test_goal(req.goal)) { roots = project.ROOT_TEST; }
     ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, roots);
+}
+
+# run the compiler-owned frontend over one selected project and retain its
+# analysis for editor tooling
+#
+# This is the load / resolve / sema half of a normal build. It never executes
+# project or dependency steps and never runs lowering, code generation, emission,
+# or linking. The returned Project owns its graph arrays; its AST, ResolveResult,
+# and SemaResult pointers borrow query-owned values from `s`.
+#
+# Exactly one returned Project may be live on a Session. Calls on the same Session
+# must be serialized, and the caller must `dnit_project` the prior Project before
+# starting another build or analysis: a later query recomputation may replace the
+# borrowed results. The caller must also `dnit_project` the returned value before
+# `session.dnit`. `m` and `req` are borrowed only for this call.
+#
+# The query context is private to this call and is cleared on every return path.
+# A phase failure tears down the partial Project and resets the Session's per-build
+# module registries before returning the failure.
+# ---
+# s:   persistent compiler session that owns the query database and retained values
+# m:   parsed root manifest used to compose `req`
+# req: fully composed request selecting target, profile, and artifact
+# ret: retained frontend Project, or the load / resolve / sema failure
+pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest) R.Result[project.Project, outcome.Fail] {
+    query.set_ctx(?s.queries, nil);
+    fin { query.set_ctx(?s.queries, nil); }
+
+    if (isa.registered_count(?s.registry.isa) == 0) {
+        val reg_r: R.Result[bool, str] = setup_registry(?s.registry);
+        if (R.is_err[bool, str](reg_r)) {
+            ret R.err[project.Project, outcome.Fail](outcome.internal(R.unwrap_err[bool, str](reg_r)));
+        }
+    }
+
+    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build(s, m, req, nil);
+    if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
+
+    var qc: qctx.QueryCtx;
+    qc.s   = s;
+    qc.p   = ?p;
+    qc.req = req;
+    query.set_ctx(?s.queries, (?qc)::ptr);
+
+    val load_r: R.Result[bool, outcome.Fail] = run_load_phase(?p);
+    if (R.is_err[bool, outcome.Fail](load_r)) {
+        val failure: outcome.Fail = R.unwrap_err[bool, outcome.Fail](load_r);
+        project.dnit_project(?p);
+        ret R.err[project.Project, outcome.Fail](failure);
+    }
+
+    val sema_r: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](sema_r)) {
+        val failure: outcome.Fail = R.unwrap_err[bool, outcome.Fail](sema_r);
+        project.dnit_project(?p);
+        ret R.err[project.Project, outcome.Fail](failure);
+    }
+
+    ret R.ok[project.Project, outcome.Fail](p);
 }
 
 # the shared open: init + query binding + config synthesis + target entry

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -38,6 +38,7 @@ use dwarf: mach.lang.be.codegen.dwarf;
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
 use mach.lang.build.request;
+use mach.lang.diagnostic;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.pipeline;
@@ -67,7 +68,6 @@ fwd project.TARGET_OPT_RELEASE;
 fwd project.dnit_project;
 fwd project.fqn_name;
 fwd project.link_name_for;
-fwd load.module_context;
 
 # the union-build entry-count helper, re-exported so `mach test` / tooling
 # consumers keep spelling it as `driver.count_target_gated`
@@ -196,30 +196,45 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
 }
 
 # run the compiler-owned frontend over one selected project and retain its
-# analysis for editor tooling
+# analysis for editor tooling, including optional editor-owned roots
 #
 # This is the load / resolve / sema half of a normal build. It never executes
 # project or dependency steps and never runs lowering, code generation, emission,
-# or linking. The returned Project owns its graph arrays; its AST, ResolveResult,
-# and SemaResult pointers borrow query-owned values from `s`.
+# or linking. `extra_roots` are module FQNs to DFS-load after the artifact closure
+# and before resolve, so an open buffer outside that closure still receives the
+# compiler's exact overlay, import, comptime-constant, resolve, and sema treatment.
+# The returned Project owns its graph arrays; its AST, ResolveResult, and SemaResult
+# pointers borrow query-owned values from `s`.
 #
 # Exactly one returned Project may be live on a Session. Calls on the same Session
 # must be serialized, and the caller must `dnit_project` the prior Project before
 # starting another build or analysis: a later query recomputation may replace the
 # borrowed results. The caller must also `dnit_project` the returned value before
-# `session.dnit`. `m` and `req` are borrowed only for this call.
+# `session.dnit`. `m`, `req`, and `extra_roots` are borrowed only for this call.
 #
-# The query context is private to this call and is cleared on every return path.
-# A phase failure tears down the partial Project and resets the Session's per-build
-# module registries before returning the failure.
+# The diagnostic sink is reset before each analysis; cached query diagnostics are
+# replayed into that clean sink. The query context is private to this call and is
+# cleared on every return path. A phase failure tears down the partial Project and
+# resets the Session's per-build module registries before returning the failure.
 # ---
-# s:   persistent compiler session that owns the query database and retained values
-# m:   parsed root manifest used to compose `req`
-# req: fully composed request selecting target, profile, and artifact
-# ret: retained frontend Project, or the load / resolve / sema failure
-pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest) R.Result[project.Project, outcome.Fail] {
+# s:                persistent session owning the query DB and retained values
+# m:                parsed root manifest used to compose `req`
+# req:              composed request selecting target, profile, and artifact
+# extra_roots:      optional session-interned module FQNs outside the artifact closure
+# extra_root_count: number of FQNs in `extra_roots`; zero accepts nil
+# ret:              retained frontend Project, or the load / resolve / sema failure
+pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
+                        extra_roots: *intern.StrId, extra_root_count: u32) R.Result[project.Project, outcome.Fail] {
     query.set_ctx(?s.queries, nil);
     fin { query.set_ctx(?s.queries, nil); }
+
+    diagnostic.dnit(?s.diags);
+    s.diags = diagnostic.init(s.alloc);
+
+    if (extra_root_count > 0 && extra_roots == nil) {
+        ret R.err[project.Project, outcome.Fail](outcome.internal(
+            "driver: frontend analysis root count requires a root array"));
+    }
 
     if (isa.registered_count(?s.registry.isa) == 0) {
         val reg_r: R.Result[bool, str] = setup_registry(?s.registry);
@@ -238,7 +253,8 @@ pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *reques
     qc.req = req;
     query.set_ctx(?s.queries, (?qc)::ptr);
 
-    val load_r: R.Result[bool, outcome.Fail] = run_load_phase(?p);
+    val load_r: R.Result[bool, outcome.Fail] =
+        run_load_phase_roots(?p, extra_roots, extra_root_count);
     if (R.is_err[bool, outcome.Fail](load_r)) {
         val failure: outcome.Fail = R.unwrap_err[bool, outcome.Fail](load_r);
         project.dnit_project(?p);
@@ -391,6 +407,17 @@ pub fun run_dep_steps_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
 # p:   the opened project
 # ret: ok(true), or the first load/resolve failure
 pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
+    ret run_load_phase_roots(p, nil, 0);
+}
+
+# the shared load / resolve phase with optional compiler-owned frontend roots
+#
+# Extra roots are loaded after the selected artifact closure is recorded in
+# `emit_len`, so they participate in resolve and sema but can never widen a future
+# backend work set. This private entry keeps ordinary build phase dispatch on the
+# no-extra-root contract while `analyze_project` can root open editor buffers.
+fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
+                         extra_root_count: u32) R.Result[bool, outcome.Fail] {
     val te: *project.TargetEntry = p.target_entry;
 
     val fp_r: R.Result[bool, str] = dcfg.select_target(p, te);
@@ -427,6 +454,20 @@ pub fun run_load_phase(p: *project.Project) R.Result[bool, outcome.Fail] {
     # the artifact closure is settled: everything loaded so far is what this build
     # emits and links. A test-rooted whole-source sweep only appends past it.
     p.emit_len = p.topo_len;
+
+    # Editor-owned buffers outside the selected artifact closure enter through the
+    # same DFS as every source module. Their overlays, imported pub consts, active
+    # comptime branches, dependency edges and transitive modules are therefore all
+    # established before AST publication, resolve, and sema.
+    var xi: u32 = 0;
+    for (xi < extra_root_count) {
+        val xr: R.Result[session.ModuleId, str] = load.dfs_load(p, extra_roots[xi]);
+        if (R.is_err[session.ModuleId, str](xr)) {
+            ret R.err[bool, outcome.Fail](outcome.user(
+                R.unwrap_err[session.ModuleId, str](xr)));
+        }
+        xi = xi + 1;
+    }
 
     # test collection roots at every own-source module, so a test in a module no
     # artifact imports is still collected (#1863). Artifact builds deliberately do

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -225,16 +225,16 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
 # ret:              retained frontend Project, or the load / resolve / sema failure
 pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
                         extra_roots: *intern.StrId, extra_root_count: u32) R.Result[project.Project, outcome.Fail] {
+    if (extra_root_count > 0 && extra_roots == nil) {
+        ret R.err[project.Project, outcome.Fail](outcome.internal(
+            "driver: frontend analysis root count requires a root array"));
+    }
+
     query.set_ctx(?s.queries, nil);
     fin { query.set_ctx(?s.queries, nil); }
 
     diagnostic.dnit(?s.diags);
     s.diags = diagnostic.init(s.alloc);
-
-    if (extra_root_count > 0 && extra_roots == nil) {
-        ret R.err[project.Project, outcome.Fail](outcome.internal(
-            "driver: frontend analysis root count requires a root array"));
-    }
 
     if (isa.registered_count(?s.registry.isa) == 0) {
         val reg_r: R.Result[bool, str] = setup_registry(?s.registry);

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -155,12 +155,6 @@ fun dup_strid_array(alloc: *A.Allocator, src: *intern.StrId, count: u32, out: **
 # owns it (the CLI hands its once-loaded manifest forward; nothing here
 # re-parses or frees it)
 pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifest.Manifest, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[bool, str] {
-    # before anything else, and specifically before any source is parsed: a
-    # requirement on the toolchain can be a SYNTAX requirement, and nothing in
-    # source can diagnose source that will not parse (#2714).
-    val tc: R.Result[bool, str] = manifest.check_toolchain(p.alloc, ?p.s.interner, m, load.MACH_VERSION, nil);
-    if (R.is_err[bool, str](tc)) { ret R.err[bool, str](R.unwrap_err[bool, str](tc)); }
-
     val abs_root_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -571,19 +571,6 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
         ret R.err[project.DepEntry, str](msg);
     }
 
-    # the dep's minimum toolchain, checked here rather than in source. this is the
-    # case that matters for #2714: a consumer builds mach-std, not the file inside
-    # it that fails, so the message names the DEPENDENCY that demands the version.
-    val dep_min: str = toml.get_str(?t, "project.mach");
-    if (!str_empty(dep_min)) {
-        val tc: R.Result[bool, str] = manifest.check_toolchain_str(s.build_alloc, dep_min, load.MACH_VERSION, id_str);
-        if (R.is_err[bool, str](tc)) {
-            val msg: str = R.unwrap_err[bool, str](tc);
-            str_free(s.build_alloc, dep_dir);
-            ret R.err[project.DepEntry, str](msg);
-        }
-    }
-
     var entry: project.DepEntry;
 
     val ra: R.Result[intern.StrId, str] = intern.intern(?s.interner, alias);

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -50,12 +50,13 @@ use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
+use mach.lang.version;
 
 use mach.lang.driver.project;
 use dq: mach.lang.driver.query;
 
 # the compiler's own version string, recorded into each module's comptime ctx
-pub val MACH_VERSION: str = $project.version;
+pub val MACH_VERSION: str = version.MACH_VERSION;
 
 # seed capacities for the per-build growable arrays (module table, a module's pub
 # const list, a module's dep list)

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -335,20 +335,17 @@ pub fun dfs_load(p: *project.Project, fqn: intern.StrId) R.Result[session.Module
     ret R.ok[session.ModuleId, str](mid);
 }
 
-# construct the comptime environment shared by every frontend pass over one
-# module in `p`
+# construct the empty base comptime environment for a module in `p`
 #
-# The result carries the settled request's mode / PIE bit, the selected target's
-# machine facts and operation definitions, the manifest-derived `$project.*` and
-# `$bin.*` roots, and every build define. This is the compiler-owned constructor
-# for tooling that must analyze an additional source buffer under exactly the same
-# environment as the retained project graph. The caller owns the returned context
-# and releases it with `comptime.dnit`.
+# The load walk owns all later module-local and imported public-constant bindings.
+# Keeping this constructor private ensures tooling cannot mistake a build-only base
+# for a loaded module context: additional editor buffers enter through the driver's
+# extra-root DFS and receive the same bindings as every ordinary module.
 # ---
 # p:   loaded project whose selected target and manifest config seed the context
 # req: settled request that opened `p`; must describe the same build selection
 # ret: an owning module context, or the first define-binding / allocation error
-pub fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[comptime.ComptimeCtx, str] {
+fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[comptime.ComptimeCtx, str] {
     if (p == nil || req == nil || p.target_entry == nil) {
         ret R.err[comptime.ComptimeCtx, str]("driver: module context requires an opened project and request");
     }

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -335,6 +335,57 @@ pub fun dfs_load(p: *project.Project, fqn: intern.StrId) R.Result[session.Module
     ret R.ok[session.ModuleId, str](mid);
 }
 
+# construct the comptime environment shared by every frontend pass over one
+# module in `p`
+#
+# The result carries the settled request's mode / PIE bit, the selected target's
+# machine facts and operation definitions, the manifest-derived `$project.*` and
+# `$bin.*` roots, and every build define. This is the compiler-owned constructor
+# for tooling that must analyze an additional source buffer under exactly the same
+# environment as the retained project graph. The caller owns the returned context
+# and releases it with `comptime.dnit`.
+# ---
+# p:   loaded project whose selected target and manifest config seed the context
+# req: settled request that opened `p`; must describe the same build selection
+# ret: an owning module context, or the first define-binding / allocation error
+pub fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[comptime.ComptimeCtx, str] {
+    if (p == nil || req == nil || p.target_entry == nil) {
+        ret R.err[comptime.ComptimeCtx, str]("driver: module context requires an opened project and request");
+    }
+
+    var build_mode_id: u32 = comptime.MODE_DEBUG;
+    if (request.release(req)) { build_mode_id = comptime.MODE_RELEASE; }
+    var build_pie: u32 = 0;
+    if (req.pie) { build_pie = 1; }
+
+    var ctx: comptime.ComptimeCtx = comptime.init(
+        p.alloc,
+        p.target.os_id,
+        p.target.arch_id,
+        p.target.abi_id,
+        build_mode_id,
+        build_pie,
+        p.target.isa.pointer_width,
+        p.target.model.vector_bits,
+        p.compiler_name,
+        p.compiler_ver
+    );
+    comptime.set_target_defs(?ctx, p.target.isa.defs);
+    comptime.set_build_context(?ctx,
+        p.config.id, p.config.version, p.config.name, p.config.description,
+        p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
+        p.target_entry.platform_name,
+        p.config.bin_name);
+
+    val bd_r: R.Result[bool, str] = bind_defines(p, ?ctx);
+    if (R.is_err[bool, str](bd_r)) {
+        val message: str = R.unwrap_err[bool, str](bd_r);
+        comptime.dnit(?ctx);
+        ret R.err[comptime.ComptimeCtx, str](message);
+    }
+    ret R.ok[comptime.ComptimeCtx, str](ctx);
+}
+
 # append a fresh ModuleEntry for `fqn` - assigning its stable id, comptime ctx,
 # and manifest defines - and index it in by_fqn
 fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
@@ -362,6 +413,15 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     val sid_r: R.Result[session.StableModuleId, str] = session.stable_module_id(p.s, fqn);
     if (R.is_err[session.StableModuleId, str](sid_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[session.StableModuleId, str](sid_r)); }
 
+    val qctxp: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    if (qctxp == nil || qctxp.req == nil) {
+        ret R.err[session.ModuleId, str]("driver: module load has no active build request");
+    }
+    val ctx_r: R.Result[comptime.ComptimeCtx, str] = module_context(p, qctxp.req);
+    if (R.is_err[comptime.ComptimeCtx, str](ctx_r)) {
+        ret R.err[session.ModuleId, str](R.unwrap_err[comptime.ComptimeCtx, str](ctx_r));
+    }
+
     var m: project.ModuleEntry;
     m.fqn               = fqn;
     m.file_id           = 0;
@@ -369,24 +429,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     # the AST is borrowed from the session cache; nil until parse_module sets it.
     # teardown never frees m.a, so a never-parsed entry needs no placeholder AST.
     m.a                 = nil;
-    # the active optimization mode for `$mach.build.mode` and the `$mach.build.pie`
-    # bit both come from the settled request: composition already applied the
-    # explicit-flag-over-profile precedence, so the gate matches the pipeline.
-    val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
-    var build_mode_id: u32 = comptime.MODE_DEBUG;
-    if (request.release(ctx.req)) { build_mode_id = comptime.MODE_RELEASE; }
-    var build_pie: u32 = 0;
-    if (ctx.req.pie) { build_pie = 1; }
-    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.target.model.vector_bits, p.compiler_name, p.compiler_ver);
-    comptime.set_target_defs(?m.ctx, p.target.isa.defs);
-    # feed the manifest-derived `$project.*`/`$bin.*` roots (the selected target's
-    # declared tuple lives under `$project.target.*`); the target tuple comes from
-    # the selected entry (set before any module loads).
-    comptime.set_build_context(?m.ctx,
-        p.config.id, p.config.version, p.config.name, p.config.description,
-        p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
-        p.target_entry.platform_name,
-        p.config.bin_name);
+    m.ctx               = R.unwrap_ok[comptime.ComptimeCtx, str](ctx_r);
     m.pub_consts        = nil;
     m.pub_const_count   = 0;
     m.pub_const_cap     = 0;
@@ -404,11 +447,6 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     m.target_gated      = false;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
-
-    # bind the selected unit's manifest defines (#1191) into this module's ctx so
-    # `$if ($mach.build.NAME)` folds identically in every module of the graph.
-    val bd_r: R.Result[bool, str] = bind_defines(p, ?p.modules[mid::u32].ctx);
-    if (R.is_err[bool, str](bd_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](bd_r)); }
 
     val ins_r: R.Result[bool, str] = map.insert[intern.StrId, session.ModuleId](?p.by_fqn, fqn, mid);
     if (R.is_err[bool, str](ins_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](ins_r)); }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -26,10 +26,6 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.path;
 
-use std.data.toml;
-use std.text.string.str_free;
-use prnt: std.print;
-use iow: std.io.writer;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -609,11 +605,6 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-
-    val fr: R.Result[fs.File, str] = fs.create("/tmp/leak3001.txt", 0o644);
-    if (R.is_err[fs.File, str](fr)) { ret 1; }
-    val f: fs.File = R.unwrap_ok[fs.File, str](fr);
-    var w: iow.Writer = fs.writer(f);
 
     var names: [4]str;
     names[0] = "alpha.mach"; names[1] = "beta.mach";

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -26,6 +26,10 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.path;
 
+use std.data.toml;
+use std.text.string.str_free;
+use prnt: std.print;
+use iow: std.io.writer;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -605,6 +609,11 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val fr: R.Result[fs.File, str] = fs.create("/tmp/leak3001.txt", 0o644);
+    if (R.is_err[fs.File, str](fr)) { ret 1; }
+    val f: fs.File = R.unwrap_ok[fs.File, str](fr);
+    var w: iow.Writer = fs.writer(f);
 
     var names: [4]str;
     names[0] = "alpha.mach"; names[1] = "beta.mach";
@@ -20531,4 +20540,128 @@ fun ut_spv_var_loads_typed(w: *u32, n: u32) bool {
         i = i + len;
     }
     ret true;
+}
+
+
+# an allocator that reports its outstanding byte count, for the steady-state
+# assertions below
+#
+# It delegates every operation to a page-backed allocator and tracks only the net
+# balance, which is what a leak assertion needs: `live` is bytes allocated minus
+# bytes released, so a cycle that returns everything it took leaves it unchanged.
+# A reallocation is a release of the old extent and a take of the new, matching how
+# the containers underneath account for one.
+# ---
+# backing: the real allocator every call is forwarded to
+# live:    outstanding bytes, allocations minus deallocations
+rec LiveBytes {
+    backing: A.Allocator;
+    live:    i64;
+}
+
+fun live_alloc(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
+    val t: *LiveBytes = ctx::*LiveBytes;
+    val r: O.Option[ptr] = t.backing.fn_allocate(t.backing.ctx, size, align);
+    if (O.is_some[ptr](r)) { t.live = t.live + size::i64; }
+    ret r;
+}
+
+fun live_realloc(ctx: ptr, p: ptr, old_size: usize, new_size: usize, align: usize) O.Option[ptr] {
+    val t: *LiveBytes = ctx::*LiveBytes;
+    val r: O.Option[ptr] = t.backing.fn_reallocate(t.backing.ctx, p, old_size, new_size, align);
+    if (O.is_some[ptr](r)) { t.live = t.live - old_size::i64 + new_size::i64; }
+    ret r;
+}
+
+fun live_dealloc(ctx: ptr, p: ptr, size: usize, align: usize) i64 {
+    val t: *LiveBytes = ctx::*LiveBytes;
+    t.live = t.live - size::i64;
+    ret t.backing.fn_deallocate(t.backing.ctx, p, size, align);
+}
+
+# install a live-byte-counting allocator over a page allocator
+fun live_bytes_make(t: *LiveBytes, a: *A.Allocator) bool {
+    if (O.is_some[str](page.make(?t.backing))) { ret false; }
+    t.live          = 0;
+    a.ctx           = t::ptr;
+    a.fn_allocate   = live_alloc;
+    a.fn_reallocate = live_realloc;
+    a.fn_deallocate = live_dealloc;
+    ret true;
+}
+
+# A retained session's reload cycle returns to a steady state (#3001).
+#
+# THE ASSERTION IS EXACT, not a threshold. An editor integration runs this cycle
+# once per edit, so any per-cycle residue at all is unbounded growth over a session
+# rather than a constant overhead - a bound would only decide how long the session
+# lasts before it mattered. The first rounds are excluded because session-lifetime
+# storage (the interner, the query DB's retained handles) is legitimately populated
+# on the way in and never released; from the third round on, every allocation the
+# cycle makes must be one the cycle also returns.
+#
+# The cycle here is the LSP's: reload the manifest, analyze the artifact's closure,
+# tear the analysis down, release the manifest. It leaked ~8 KB per round before,
+# 96% of it in the manifest reload rather than the retained analysis the report
+# named - a toml table nothing freed, diagnostic labels rendered on every successful
+# parse, and expanded output paths dropped after interning.
+test "mach.lang.driver:retained_reload_cycle_reaches_steady_state" {
+    var lb: LiveBytes;
+    var alloc: A.Allocator;
+    if (!live_bytes_make(?lb, ?alloc)) { ret 1; }
+
+    var names: [4]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach";
+    names[2] = "model.mach"; names[3] = "orphan.mach";
+    var texts: [4]str;
+    texts[0] = "fun main() i32 { ret no_such(); }\n";
+    texts[1] = "use ctxcase.model;\nfun main() i32 { var b: model.Box[model.Leaf]; ret model.take[model.Leaf](b); }\n";
+    texts[2] = "pub rec Leaf { n: i32; }\npub rec Box[T] { v: T; }\npub fun take[T](b: Box[T]) i32 { ret 7; }\n";
+    texts[3] = "fun broken() NoSuch { var x: AlsoMissing; ret x; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_frontend(), ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { fs.remove_all(?alloc, root); ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var bad:      i32 = 0;
+    var settled:  i64 = 0;
+    var round:    i32 = 0;
+    for (round < 5) {
+        val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+        if (R.is_err[manifest.Manifest, str](mr)) { bad = 2; brk; }
+        var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+
+        var req: request.BuildRequest = request.defaults();
+        req.project_root = root;
+        req.target       = "windows";
+        req.profile      = "release";
+        req.artifact     = "beta";
+        req.want_lib     = false;
+        req.goal         = request.GOAL_OBJECTS;
+        req.opt          = pipeline.OPT_RELEASE;
+        req.pie          = true;
+
+        val pr: R.Result[project.Project, outcome.Fail] =
+            driver.analyze_project(?s, ?mf, ?req, nil, 0);
+        if (R.is_err[project.Project, outcome.Fail](pr)) {
+            manifest.dnit(?mf, ?alloc); bad = 3; brk;
+        }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p);
+        manifest.dnit(?mf, ?alloc);
+
+        # round 2 is the first fully warm one: rounds 0 and 1 still populate
+        # session-lifetime storage.
+        if (round == 2) { settled = lb.live; }
+        if (round > 2 && lb.live != settled) { bad = 4; brk; }
+        round = round + 1;
+    }
+
+    session.dnit(?s);
+    fs.remove_all(?alloc, root);
+    ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -597,8 +597,7 @@ fun ut_id_is(s: *session.Session, id: intern.StrId, text: str) bool {
 
 # the tooling facade retains the compiler's selected load / resolve / sema graph,
 # including imported generic symbols, without stepping into the backend or running
-# a demanded project step. its fresh-context helper reproduces every build axis and
-# define the ordinary module loader installs.
+# a demanded project step. every loaded module carries the selected build axes.
 test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -635,7 +634,7 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     req.pie          = true;
 
     val pr: R.Result[project.Project, outcome.Fail] =
-        driver.analyze_project(?s, ?mf, ?req);
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
         session.dnit(?s); ret 1;
@@ -671,70 +670,190 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
         if (!ut_id_is(?s, c.target_isa, "x86_64")) { bad = 16; }
         if (!ut_id_is(?s, c.target_abi, "win64")) { bad = 17; }
         if (!ut_id_is(?s, c.bin_name, "beta")) { bad = 18; }
-
-        val fresh_r: R.Result[comptime.ComptimeCtx, str] =
-            driver.module_context(?p, ?req);
-        if (R.is_err[comptime.ComptimeCtx, str](fresh_r)) { bad = 19; }
-        or {
-            var fresh: comptime.ComptimeCtx =
-                R.unwrap_ok[comptime.ComptimeCtx, str](fresh_r);
-            if (fresh.target_os_id != c.target_os_id
-                || fresh.target_arch_id != c.target_arch_id
-                || fresh.target_abi_id != c.target_abi_id
-                || fresh.build_mode_id != c.build_mode_id
-                || fresh.build_pie != c.build_pie
-                || fresh.pointer_width != c.pointer_width
-                || fresh.vector_bits != c.vector_bits
-                || fresh.target_defs != c.target_defs
-                || fresh.compiler_name != c.compiler_name
-                || fresh.compiler_ver != c.compiler_ver
-                || fresh.project_id != c.project_id
-                || fresh.project_ver != c.project_ver
-                || fresh.project_name != c.project_name
-                || fresh.project_desc != c.project_desc
-                || fresh.target_os != c.target_os
-                || fresh.target_isa != c.target_isa
-                || fresh.target_abi != c.target_abi
-                || fresh.target_platform != c.target_platform
-                || fresh.bin_name != c.bin_name) { bad = 20; }
-            comptime.dnit(?fresh);
-        }
     }
 
-    # Current v2 manifests preserve the configured define channel even though no
-    # public key populates it yet. Inject one at that boundary to pin that tooling's
-    # fresh context and the ordinary module constructor cannot drift apart again.
-    val defs_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](p.alloc, 1::usize);
-    if (R.is_err[*intern.StrId, str](defs_r)) { bad = 21; }
+    project.dnit_project(?p);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# An open buffer outside the selected artifact closure is an explicit compiler root,
+# not a separately parsed AST. Its filesystem-path overlay enters the normal DFS;
+# an imported public constant selects a branch whose module and generic types must
+# then load, resolve, and sema exactly as they do in an ordinary reachable module.
+test "mach.lang.driver:analyze_project_loads_overlay_extra_root_through_pub_const_gate" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [4]str;
+    names[0] = "main.mach"; names[1] = "extra.mach";
+    names[2] = "flags.mach"; names[3] = "model.mach";
+    var texts: [4]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+    texts[1] = "fun broken() NoSuch { var x: AlsoMissing; ret x; }\n";
+    texts[2] = "pub val ENABLE: i32 = 1;\n";
+    texts[3] = "pub rec Leaf { n: i32; }\npub rec Box[T] { v: T; }\npub fun take[T](b: Box[T]) i32 { ret 7; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    # Without an explicit editor root only the artifact entry exists. This proves
+    # `extra` is genuinely off-closure rather than incidentally reachable.
+    val base_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](base_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var base: project.Project = R.unwrap_ok[project.Project, outcome.Fail](base_r);
+    var bad: i32 = 0;
+    if (ut_has(?base, ?s, "uniontest.extra")) { bad = 1; }
+    if (ut_has(?base, ?s, "uniontest.flags")) { bad = 1; }
+    if (ut_has(?base, ?s, "uniontest.model")) { bad = 1; }
+    project.dnit_project(?base);
+
+    val extra_path: str = ut_cc3(?alloc, root, "/", "src/extra.mach");
+    val overlay: str = "use uniontest.flags.ENABLE;\n$if (ENABLE == 1) { use uniontest.model; }\npub fun probe() i32 { ret 7; }\n";
+    if (R.is_err[bool, str](session.set_overlay(?s, extra_path, overlay))) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    val xid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "uniontest.extra");
+    if (R.is_err[intern.StrId, str](xid_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var extra_roots: [1]intern.StrId;
+    extra_roots[0] = R.unwrap_ok[intern.StrId, str](xid_r);
+
+    val rooted_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, ?extra_roots[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](rooted_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](rooted_r);
+    if (ut_count_errors(?s.diags) != 0) { bad = 2; }
+    if (!ut_has(?p, ?s, "uniontest.extra")) { bad = 3; }
+    if (!ut_has(?p, ?s, "uniontest.flags")) { bad = 4; }
+    if (!ut_has(?p, ?s, "uniontest.model")) { bad = 5; }
+    if (p.emit_len != 1 || p.topo_len <= p.emit_len) { bad = 6; }
+
+    val extra_mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.extra");
+    val model_mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.model");
+    if (extra_mid == session.MODULE_NIL || model_mid == session.MODULE_NIL) { bad = 7; }
     or {
-        p.config.defines = R.unwrap_ok[*intern.StrId, str](defs_r);
-        val did_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE=17");
-        if (R.is_err[intern.StrId, str](did_r)) { bad = 22; }
+        val em: *project.ModuleEntry = ?p.modules[extra_mid::u32];
+        val mm: *project.ModuleEntry = ?p.modules[model_mid::u32];
+        if (!em.resolved || em.resolve_result == nil || em.sema_result == nil) { bad = 8; }
+        if (!mm.resolved || mm.resolve_result == nil || mm.sema_result == nil) { bad = 9; }
+        val eid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "ENABLE");
+        if (R.is_err[intern.StrId, str](eid_r)) { bad = 10; }
         or {
-            p.config.defines[0] = R.unwrap_ok[intern.StrId, str](did_r);
-            p.config.define_count = 1;
-            val dc_r: R.Result[comptime.ComptimeCtx, str] = driver.module_context(?p, ?req);
-            if (R.is_err[comptime.ComptimeCtx, str](dc_r)) { bad = 23; }
+            val enabled: O.Option[*comptime.NamedConst] = comptime.lookup(
+                ?em.ctx, R.unwrap_ok[intern.StrId, str](eid_r));
+            if (O.is_none[*comptime.NamedConst](enabled)) { bad = 11; }
             or {
-                var dc: comptime.ComptimeCtx = R.unwrap_ok[comptime.ComptimeCtx, str](dc_r);
-                val fid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE");
-                if (R.is_err[intern.StrId, str](fid_r)) { bad = 24; }
-                or {
-                    val found: O.Option[*comptime.NamedConst] = comptime.lookup_define(
-                        ?dc, R.unwrap_ok[intern.StrId, str](fid_r));
-                    if (O.is_none[*comptime.NamedConst](found)) { bad = 25; }
-                    or {
-                        val feature: *comptime.NamedConst = O.unwrap[*comptime.NamedConst](found);
-                        if (feature.value.kind != comptime.CT_KIND_INT
-                            || feature.value.data.i != 17) { bad = 26; }
-                    }
-                }
-                comptime.dnit(?dc);
+                val nc: *comptime.NamedConst = O.unwrap[*comptime.NamedConst](enabled);
+                if (nc.value.kind != comptime.CT_KIND_INT || nc.value.data.i != 1) { bad = 12; }
             }
         }
     }
 
     project.dnit_project(?p);
+    manifest.dnit(?mf, ?alloc);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# Every analysis starts with a clean diagnostic sink, but an unchanged query still
+# replays its cached diagnostics. The second retained graph therefore reports one
+# identical snapshot, not zero diagnostics and not an accumulated duplicate.
+test "mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun dup() i32 { ret 1; }\nfun dup() i32 { ret 2; }\nfun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    val cold_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](cold_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var cold_p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](cold_r);
+    val mid: session.ModuleId = ut_mid(?cold_p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL || s.diags.len == 0) {
+        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val stable: session.StableModuleId = cold_p.modules[mid::u32].stable_id;
+    val resolve_rev: query.Revision = query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64);
+    val sema_rev: query.Revision = query.peek_revision(?s.queries, query.Q_SEMA, stable::u64);
+    if (resolve_rev == 0 || sema_rev == 0) {
+        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val snapshot_r: R.Result[*diagnostic.DiagList, str] =
+        diagnostic.clone_tail(?s.diags, 0, ?alloc);
+    if (R.is_err[*diagnostic.DiagList, str](snapshot_r)) {
+        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val snapshot: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](snapshot_r);
+    project.dnit_project(?cold_p);
+
+    val warm_r: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](warm_r)) {
+        diagnostic.dnit(snapshot); A.deallocate[diagnostic.DiagList](?alloc, snapshot, 1::usize);
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var warm_p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](warm_r);
+    var bad: i32 = 0;
+    if (!ut_diag_list_eq(?s.diags, snapshot)) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64) != resolve_rev) { bad = 1; }
+    if (query.peek_revision(?s.queries, query.Q_SEMA, stable::u64) != sema_rev) { bad = 1; }
+
+    project.dnit_project(?warm_p);
+    diagnostic.dnit(snapshot);
+    A.deallocate[diagnostic.DiagList](?alloc, snapshot, 1::usize);
+    manifest.dnit(?mf, ?alloc);
     fs.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;
@@ -767,7 +886,7 @@ test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
 
     var bad: i32 = 0;
     val failed: R.Result[project.Project, outcome.Fail] =
-        driver.analyze_project(?s, ?mf, ?req);
+        driver.analyze_project(?s, ?mf, ?req, nil, 0);
     if (R.is_ok[project.Project, outcome.Fail](failed)) {
         var stray: project.Project = R.unwrap_ok[project.Project, outcome.Fail](failed);
         project.dnit_project(?stray);
@@ -783,7 +902,7 @@ test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
     if (O.is_some[str](write_err)) { bad = 1; }
     or {
         val repaired: R.Result[project.Project, outcome.Fail] =
-            driver.analyze_project(?s, ?mf, ?req);
+            driver.analyze_project(?s, ?mf, ?req, nil, 0);
         if (R.is_err[project.Project, outcome.Fail](repaired)) { bad = 1; }
         or {
             var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](repaired);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -63,6 +63,7 @@ use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
+use isa: mach.lang.target.isa;
 use mach.lang.target.isa.spirv;
 use mach.lang.target.of;
 use mach.lang.type;
@@ -855,6 +856,37 @@ test "mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics" {
     A.deallocate[diagnostic.DiagList](?alloc, snapshot, 1::usize);
     manifest.dnit(?mf, ?alloc);
     fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A nonzero extra-root count without storage is rejected before target setup or
+# project construction, so a malformed tooling request cannot mutate build state.
+test "mach.lang.driver:analyze_project_rejects_missing_extra_root_array" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val invalid: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, nil, nil, nil, 1);
+    var bad: i32 = 0;
+    if (R.is_ok[project.Project, outcome.Fail](invalid)) {
+        var stray: project.Project = R.unwrap_ok[project.Project, outcome.Fail](invalid);
+        project.dnit_project(?stray);
+        bad = 1;
+    }
+    or {
+        val failure: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](invalid);
+        if (!failure.internal
+            || !str_equals(failure.message,
+                "driver: frontend analysis root count requires a root array")) { bad = 1; }
+    }
+    if (s.queries.ctx != nil) { bad = 1; }
+    if (session.module_count(?s) != 0) { bad = 1; }
+    if (isa.registered_count(?s.registry.isa) != 0) { bad = 1; }
+
     session.dnit(?s);
     ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -138,6 +138,13 @@ fun ut_manifest_multi() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
+# a selected-artifact fixture for the retained frontend facade. alpha and the
+# orphan carry hard semantic errors, while beta imports a generic record and
+# function from model. the demanded step is deliberately fatal if executed.
+fun ut_manifest_frontend() str {
+    ret "[project]\nid = \"ctxcase\"\nversion = \"1.2.3\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[step.never]\ncmd = \"false\"\nin = []\nout = [\"{project.out}/never\"]\nneed = []\n\n[artifact.alpha]\nkind = \"bin\"\nentry = \"alpha.mach\"\nout = \"bin/alpha\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = [\"never\"]\n";
+}
+
 # a cross-platform executable split by output-extension convention (#2961)
 fun ut_manifest_split() str {
     ret "[project]\nid = \"uniontest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.uniontest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest\"\ntargets = [\"linux\"]\nlink = []\nneed = []\n\n[artifact.uniontest-windows]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/uniontest.exe\"\ntargets = [\"windows\"]\nlink = []\nneed = []\n";
@@ -580,6 +587,221 @@ fun ut_ctx(p: *project.Project, s: *session.Session, fqn: str) *comptime.Comptim
     val mid: session.ModuleId = @R.unwrap_ok[*session.ModuleId, str](mr);
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     ret ?m.ctx;
+}
+
+# whether an interned string on `s` equals `text`
+fun ut_id_is(s: *session.Session, id: intern.StrId, text: str) bool {
+    val found: O.Option[str] = intern.lookup(?s.interner, id);
+    ret O.is_some[str](found) && str_equals(O.unwrap[str](found), text);
+}
+
+# the tooling facade retains the compiler's selected load / resolve / sema graph,
+# including imported generic symbols, without stepping into the backend or running
+# a demanded project step. its fresh-context helper reproduces every build axis and
+# define the ordinary module loader installs.
+test "mach.lang.driver:analyze_project_retains_selected_frontend" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [4]str;
+    names[0] = "alpha.mach"; names[1] = "beta.mach";
+    names[2] = "model.mach"; names[3] = "orphan.mach";
+    var texts: [4]str;
+    texts[0] = "fun main() i32 { ret no_such(); }\n";
+    texts[1] = "use ctxcase.model;\nfun main() i32 { var b: model.Box[model.Leaf]; ret model.take[model.Leaf](b); }\n";
+    texts[2] = "pub rec Leaf { n: i32; }\npub rec Box[T] { v: T; }\npub fun take[T](b: Box[T]) i32 { ret 7; }\n";
+    texts[3] = "fun broken() NoSuch { var x: AlsoMissing; ret x; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_frontend(), ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "windows";
+    req.profile      = "release";
+    req.artifact     = "beta";
+    req.want_lib     = false;
+    req.goal         = request.GOAL_OBJECTS;
+    req.opt          = pipeline.OPT_RELEASE;
+    req.pie          = true;
+
+    val pr: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    # the retained project owns everything it needs after the call's borrowed
+    # manifest is released.
+    manifest.dnit(?mf, ?alloc);
+
+    var bad: i32 = 0;
+    if (s.queries.ctx != nil) { bad = 2; }
+    if (ut_count_errors(?s.diags) != 0) { bad = 3; }
+    if (ut_has(?p, ?s, "ctxcase.alpha"))  { bad = 4; }
+    if (ut_has(?p, ?s, "ctxcase.orphan")) { bad = 5; }
+
+    val beta:  session.ModuleId = ut_mid(?p, ?s, "ctxcase.beta");
+    val model: session.ModuleId = ut_mid(?p, ?s, "ctxcase.model");
+    if (beta == session.MODULE_NIL || model == session.MODULE_NIL) { bad = 6; }
+    or {
+        val bm: *project.ModuleEntry = ?p.modules[beta::u32];
+        val mm: *project.ModuleEntry = ?p.modules[model::u32];
+        if (!bm.resolved || bm.resolve_result == nil || bm.sema_result == nil) { bad = 7; }
+        if (!mm.resolved || mm.resolve_result == nil || mm.sema_result == nil) { bad = 8; }
+        if (bm.ir_module != nil || bm.object_image != nil) { bad = 9; }
+        if (mm.ir_module != nil || mm.object_image != nil) { bad = 10; }
+
+        val c: *comptime.ComptimeCtx = ?bm.ctx;
+        if (c.build_mode_id != comptime.MODE_RELEASE || c.build_pie != 1) { bad = 11; }
+        if (c.pointer_width != 8) { bad = 12; }
+        if (!ut_id_is(?s, c.project_id, "ctxcase")) { bad = 13; }
+        if (!ut_id_is(?s, c.project_ver, "1.2.3")) { bad = 14; }
+        if (!ut_id_is(?s, c.target_os, "windows")) { bad = 15; }
+        if (!ut_id_is(?s, c.target_isa, "x86_64")) { bad = 16; }
+        if (!ut_id_is(?s, c.target_abi, "win64")) { bad = 17; }
+        if (!ut_id_is(?s, c.bin_name, "beta")) { bad = 18; }
+
+        val fresh_r: R.Result[comptime.ComptimeCtx, str] =
+            driver.module_context(?p, ?req);
+        if (R.is_err[comptime.ComptimeCtx, str](fresh_r)) { bad = 19; }
+        or {
+            var fresh: comptime.ComptimeCtx =
+                R.unwrap_ok[comptime.ComptimeCtx, str](fresh_r);
+            if (fresh.target_os_id != c.target_os_id
+                || fresh.target_arch_id != c.target_arch_id
+                || fresh.target_abi_id != c.target_abi_id
+                || fresh.build_mode_id != c.build_mode_id
+                || fresh.build_pie != c.build_pie
+                || fresh.pointer_width != c.pointer_width
+                || fresh.vector_bits != c.vector_bits
+                || fresh.target_defs != c.target_defs
+                || fresh.compiler_name != c.compiler_name
+                || fresh.compiler_ver != c.compiler_ver
+                || fresh.project_id != c.project_id
+                || fresh.project_ver != c.project_ver
+                || fresh.project_name != c.project_name
+                || fresh.project_desc != c.project_desc
+                || fresh.target_os != c.target_os
+                || fresh.target_isa != c.target_isa
+                || fresh.target_abi != c.target_abi
+                || fresh.target_platform != c.target_platform
+                || fresh.bin_name != c.bin_name) { bad = 20; }
+            comptime.dnit(?fresh);
+        }
+    }
+
+    # Current v2 manifests preserve the configured define channel even though no
+    # public key populates it yet. Inject one at that boundary to pin that tooling's
+    # fresh context and the ordinary module constructor cannot drift apart again.
+    val defs_r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](p.alloc, 1::usize);
+    if (R.is_err[*intern.StrId, str](defs_r)) { bad = 21; }
+    or {
+        p.config.defines = R.unwrap_ok[*intern.StrId, str](defs_r);
+        val did_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE=17");
+        if (R.is_err[intern.StrId, str](did_r)) { bad = 22; }
+        or {
+            p.config.defines[0] = R.unwrap_ok[intern.StrId, str](did_r);
+            p.config.define_count = 1;
+            val dc_r: R.Result[comptime.ComptimeCtx, str] = driver.module_context(?p, ?req);
+            if (R.is_err[comptime.ComptimeCtx, str](dc_r)) { bad = 23; }
+            or {
+                var dc: comptime.ComptimeCtx = R.unwrap_ok[comptime.ComptimeCtx, str](dc_r);
+                val fid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "FEATURE");
+                if (R.is_err[intern.StrId, str](fid_r)) { bad = 24; }
+                or {
+                    val found: O.Option[*comptime.NamedConst] = comptime.lookup_define(
+                        ?dc, R.unwrap_ok[intern.StrId, str](fid_r));
+                    if (O.is_none[*comptime.NamedConst](found)) { bad = 25; }
+                    or {
+                        val feature: *comptime.NamedConst = O.unwrap[*comptime.NamedConst](found);
+                        if (feature.value.kind != comptime.CT_KIND_INT
+                            || feature.value.data.i != 17) { bad = 26; }
+                    }
+                }
+                comptime.dnit(?dc);
+            }
+        }
+    }
+
+    project.dnit_project(?p);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a partial load failure releases its Project, resets the module registry and clears
+# the stack query context; the same Session can immediately analyze a repaired tree.
+test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str; names[0] = "other.mach";
+    var texts: [1]str; texts[0] = "pub fun other() i32 { ret 1; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) {
+        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    var bad: i32 = 0;
+    val failed: R.Result[project.Project, outcome.Fail] =
+        driver.analyze_project(?s, ?mf, ?req);
+    if (R.is_ok[project.Project, outcome.Fail](failed)) {
+        var stray: project.Project = R.unwrap_ok[project.Project, outcome.Fail](failed);
+        project.dnit_project(?stray);
+        bad = 1;
+    }
+    if (s.queries.ctx != nil) { bad = 1; }
+    if (session.module_count(?s) != 0) { bad = 1; }
+
+    val main_path: str = ut_cc3(?alloc, root, "/", "src/main.mach");
+    val repaired_text: str = "fun main() i32 { ret 0; }\n";
+    val write_err: O.Option[str] = fs.write_bytes(
+        main_path, repaired_text, str_len(repaired_text), 420);
+    if (O.is_some[str](write_err)) { bad = 1; }
+    or {
+        val repaired: R.Result[project.Project, outcome.Fail] =
+            driver.analyze_project(?s, ?mf, ?req);
+        if (R.is_err[project.Project, outcome.Fail](repaired)) { bad = 1; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](repaired);
+            val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+            if (mid == session.MODULE_NIL) { bad = 1; }
+            or {
+                val me: *project.ModuleEntry = ?p.modules[mid::u32];
+                if (!me.resolved || me.resolve_result == nil || me.sema_result == nil) { bad = 1; }
+            }
+            if (s.queries.ctx != nil) { bad = 1; }
+            project.dnit_project(?p);
+        }
+    }
+
+    manifest.dnit(?mf, ?alloc);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
 }
 
 # number of error-severity diagnostics recorded on the session

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -326,7 +326,21 @@ fun intern_opt_unwrap(itn: *intern.Interner, text: str) intern.StrId {
     ret intern_unwrap(itn, text);
 }
 
-fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array, elem_err: str) R.Result[StrArr, str] {
+# `label` / `key` name the table and key for the diagnostic, which is RENDERED ONLY
+# WHEN AN ELEMENT FAILS. it used to arrive pre-rendered, so every successful parse
+# composed a full set of error messages and dropped them - a per-parse cost that a
+# retained session repeated on every reload (#3001)
+# ---
+# alloc:        allocator for the id array and any diagnostic
+# itn:          interner receiving each element
+# arr:          the toml array to read, or nil for an absent key
+# label:        the declaring table's label, e.g. `[artifact.beta]`
+# key:          the key within it, e.g. `targets`
+# allow_scalar: true when the key also accepts a bare string, which the
+#               diagnostic must say
+# ret:          the interned ids, or the first element's failure
+fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array,
+                    label: str, key: str, allow_scalar: bool) R.Result[StrArr, str] {
     var out: StrArr;
     out.items   = nil;
     out.count   = 0;
@@ -346,7 +360,12 @@ fun parse_str_array(alloc: *A.Allocator, itn: *intern.Interner, arr: *toml.Array
         val v: *toml.Value = toml.array_get(arr, i);
         if (v == nil || v.tag != toml.TYPE_STRING) {
             A.deallocate[intern.StrId](alloc, out.items, n);
-            ret R.err[StrArr, str](elem_err);
+            if (allow_scalar) {
+                ret R.err[StrArr, str](sfmt(alloc,
+                    "mach.toml: {}.{} must be a string or array of strings", label, key));
+            }
+            ret R.err[StrArr, str](sfmt(alloc,
+                "mach.toml: {}.{} must be an array of strings", label, key));
         }
         val res_elem: R.Result[intern.StrId, str] = intern.intern(itn, v.data.string);
         if (R.is_err[intern.StrId, str](res_elem)) {
@@ -400,8 +419,7 @@ fun parse_filter_axis(alloc: *A.Allocator, itn: *intern.Interner, sub: *toml.Tab
         out.count = 1;
     }
     or (v.tag == toml.TYPE_ARRAY) {
-        val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array,
-            sfmt(alloc, "mach.toml: {}.{} must be a string or array of strings", label, key));
+        val res_arr: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?v.data.array, label, key, true);
         if (R.is_err[StrArr, str](res_arr)) { ret res_arr; }
         val arr_v: StrArr = R.unwrap_ok[StrArr, str](res_arr);
         out.items = arr_v.items;
@@ -537,12 +555,16 @@ fun parse_resource_path(alloc: *A.Allocator, itn: *intern.Interner, label: str,
     val v: *toml.Value = toml.get(sub, key);
     if (v == nil) { ret R.ok[intern.StrId, str](intern.STR_NIL); }
     if (v.tag != toml.TYPE_STRING) {
-        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {} must be a non-empty path string", label));
+        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {}.{} must be a non-empty path string", label, key));
     }
     if (str_empty(v.data.string)) {
-        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {} must not be empty; omit it when unused", label));
+        ret R.err[intern.StrId, str](sfmt(alloc, "mach.toml: {}.{} must not be empty; omit it when unused", label, key));
     }
-    val checked: R.Result[bool, str] = check_path(alloc, v.data.string, label);
+    # the only place the composed `<label>.<key>` field name is actually needed,
+    # reached only when the key is present (#3001)
+    val field: str = sfmt(alloc, "{}.{}", label, key);
+    val checked: R.Result[bool, str] = check_path(alloc, v.data.string, field);
+    str_free(alloc, field);
     if (R.is_err[bool, str](checked)) {
         ret R.err[intern.StrId, str](R.unwrap_err[bool, str](checked));
     }
@@ -781,6 +803,7 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         if (O.is_some[i64](base_opt)) { d.base = O.unwrap[i64](base_opt)::u64; }
 
         m.targets[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -812,7 +835,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     val v: *toml.Value = toml.table_value(tab, k);
     val label: str = sfmt(alloc, "[artifact.{}]", name);
     if (v == nil || v.tag != toml.TYPE_TABLE) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+        val lbl_msg1: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg1);
     }
     val sub: *toml.Table = ?v.data.table;
 
@@ -832,29 +855,32 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
 
     val kind_s: str = toml.get_str(sub, "kind");
     if (str_empty(kind_s) || !(str_equals(kind_s, "bin") || str_equals(kind_s, "static") || str_equals(kind_s, "shared"))) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {}.kind must be \"bin\", \"static\", or \"shared\"", label));
+        val lbl_msg2: str = sfmt(alloc, "mach.toml: {}.kind must be \"bin\", \"static\", or \"shared\"", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg2);
     }
     a.kind = intern_unwrap(itn, kind_s);
     a.is_lib = !str_equals(kind_s, "bin");
 
     val entry_s: str = toml.get_str(sub, "entry");
     if (str_empty(entry_s)) { ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'entry'", label)); }
-    val res_check_entry: R.Result[bool, str] = check_path(alloc, entry_s, sfmt(alloc, "{}.entry", label));
+    val entry_field: str = sfmt(alloc, "{}.entry", label);
+    val res_check_entry: R.Result[bool, str] = check_path(alloc, entry_s, entry_field);
+    str_free(alloc, entry_field);
     if (R.is_err[bool, str](res_check_entry)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_check_entry)); }
     a.entry = intern_unwrap(itn, entry_s);
 
     val out_s: str = toml.get_str(sub, "out");
     if (str_empty(out_s)) { ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'out'", label)); }
-    val res_check_out: R.Result[bool, str] = check_path(alloc, out_s, sfmt(alloc, "{}.out", label));
+    val out_field: str = sfmt(alloc, "{}.out", label);
+    val res_check_out: R.Result[bool, str] = check_path(alloc, out_s, out_field);
+    str_free(alloc, out_field);
     if (R.is_err[bool, str](res_check_out)) { ret R.err[ArtifactDef, str](R.unwrap_err[bool, str](res_check_out)); }
     a.out = intern_unwrap(itn, out_s);
 
     val targets_arr: *toml.Array = toml.get_array(sub, "targets");
     if (targets_arr == nil) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'targets'", label));
+        val lbl_msg3: str = sfmt(alloc, "mach.toml: {} is missing required key 'targets'", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg3);
     }
-    val res_targets: R.Result[StrArr, str] = parse_str_array(alloc, itn, targets_arr,
-        sfmt(alloc, "mach.toml: {}.targets must be an array of strings", label));
+    val res_targets: R.Result[StrArr, str] = parse_str_array(alloc, itn, targets_arr, label, "targets", false);
     if (R.is_err[StrArr, str](res_targets)) { ret R.err[ArtifactDef, str](R.unwrap_err[StrArr, str](res_targets)); }
     val targets_val: StrArr = R.unwrap_ok[StrArr, str](res_targets);
     a.targets      = targets_val.items;
@@ -862,11 +888,10 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
 
     val link_arr: *toml.Array = toml.get_array(sub, "link");
     if (link_arr == nil && as_root) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'link' (use [] for none)", label));
+        val lbl_msg4: str = sfmt(alloc, "mach.toml: {} is missing required key 'link' (use [] for none)", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg4);
     }
     if (link_arr != nil) {
-        val res_link: R.Result[StrArr, str] = parse_str_array(alloc, itn, link_arr,
-            sfmt(alloc, "mach.toml: {}.link must be an array of strings", label));
+        val res_link: R.Result[StrArr, str] = parse_str_array(alloc, itn, link_arr, label, "link", false);
         if (R.is_err[StrArr, str](res_link)) { ret R.err[ArtifactDef, str](R.unwrap_err[StrArr, str](res_link)); }
         val link_val: StrArr = R.unwrap_ok[StrArr, str](res_link);
         a.link       = link_val.items;
@@ -875,11 +900,10 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
 
     val need_arr: *toml.Array = toml.get_array(sub, "need");
     if (need_arr == nil && as_root) {
-        ret R.err[ArtifactDef, str](sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label));
+        val lbl_msg5: str = sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label); str_free(alloc, label); ret R.err[ArtifactDef, str](lbl_msg5);
     }
     if (need_arr != nil) {
-        val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
-            sfmt(alloc, "mach.toml: {}.need must be an array of strings", label));
+        val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr, label, "need", false);
         if (R.is_err[StrArr, str](res_need)) { ret R.err[ArtifactDef, str](R.unwrap_err[StrArr, str](res_need)); }
         val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
         a.need       = need_val.items;
@@ -891,16 +915,16 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
     a.subsystem = R.unwrap_ok[of.Subsystem, str](res_subsystem);
 
     val res_icon: R.Result[intern.StrId, str] =
-        parse_resource_path(alloc, itn, sfmt(alloc, "{}.icon", label), sub, "icon");
+        parse_resource_path(alloc, itn, label, sub, "icon");
     if (R.is_err[intern.StrId, str](res_icon)) {
-        ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_icon));
+        str_free(alloc, label); ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_icon));
     }
     a.icon = R.unwrap_ok[intern.StrId, str](res_icon);
 
     val res_manifest: R.Result[intern.StrId, str] =
-        parse_resource_path(alloc, itn, sfmt(alloc, "{}.manifest", label), sub, "manifest");
+        parse_resource_path(alloc, itn, label, sub, "manifest");
     if (R.is_err[intern.StrId, str](res_manifest)) {
-        ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_manifest));
+        str_free(alloc, label); ret R.err[ArtifactDef, str](R.unwrap_err[intern.StrId, str](res_manifest));
     }
     a.app_manifest = R.unwrap_ok[intern.StrId, str](res_manifest);
 
@@ -909,7 +933,7 @@ fun parse_one_artifact(alloc: *A.Allocator, itn: *intern.Interner, tab: *toml.Ta
             "mach.toml: {}.icon and .manifest apply only to kind = \"bin\" artifacts", label));
     }
 
-    ret R.ok[ArtifactDef, str](a);
+    str_free(alloc, label); ret R.ok[ArtifactDef, str](a);
 }
 
 fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[bool, str] {
@@ -929,7 +953,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[profile.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg6: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg6);
         }
         val sub: *toml.Table = ?v.data.table;
         val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_PROFILE, as_root);
@@ -958,6 +982,7 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         pf.float_reassoc = R.unwrap_ok[bool, str](res_fra);
 
         m.profiles[i] = pf;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -980,12 +1005,12 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[dep.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg7: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg7);
         }
         val sub: *toml.Table = ?v.data.table;
 
         if (toml.get(sub, "version") != nil) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.version is reserved for the registry era", label));
+            val lbl_msg8: str = sfmt(alloc, "mach.toml: {}.version is reserved for the registry era", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg8);
         }
         val res_keys: R.Result[bool, str] = check_keys(alloc, sub, label, TK_DEP, as_root);
         if (R.is_err[bool, str](res_keys)) { ret res_keys; }
@@ -997,20 +1022,21 @@ fun parse_deps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *M
         val has_git:  bool = !str_empty(git_s);
         val has_path: bool = !str_empty(path_s);
         if (has_git == has_path) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} needs exactly one source key: 'git' or 'path'", label));
+            val lbl_msg9: str = sfmt(alloc, "mach.toml: {} needs exactly one source key: 'git' or 'path'", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg9);
         }
         val ref_s: str = toml.get_str(sub, "ref");
         if (has_git && str_empty(ref_s) && as_root) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'ref' for git source", label));
+            val lbl_msg10: str = sfmt(alloc, "mach.toml: {} is missing required key 'ref' for git source", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg10);
         }
         if (has_path && !str_empty(ref_s) && as_root) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.ref is not allowed for path sources", label));
+            val lbl_msg11: str = sfmt(alloc, "mach.toml: {}.ref is not allowed for path sources", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg11);
         }
         d.git  = intern_opt_unwrap(itn, git_s);
         d.path = intern_opt_unwrap(itn, path_s);
         d.ref  = intern_opt_unwrap(itn, ref_s);
 
         m.deps[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1033,7 +1059,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[link.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg12: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg12);
         }
         val sub: *toml.Table = ?v.data.table;
 
@@ -1046,7 +1072,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val source_s: str = toml.get_str(sub, "source");
         if (str_empty(source_s)) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'source'", label)); }
         if (!str_equals(source_s, "system") && !str_equals(source_s, "framework") && !str_equals(source_s, "local")) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.source must be \"system\", \"framework\", or \"local\"", label));
+            val lbl_msg13: str = sfmt(alloc, "mach.toml: {}.source must be \"system\", \"framework\", or \"local\"", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg13);
         }
         d.source = LINK_LOCAL;
         if (str_equals(source_s, "system"))    { d.source = LINK_SYSTEM; }
@@ -1055,11 +1081,11 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val library_v: *toml.Value = toml.get(sub, "library");
         if (library_v != nil) {
             if (library_v.tag != toml.TYPE_STRING) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
+                val lbl_msg14: str = sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg14);
             }
             val library_s: str = library_v.data.string;
             if (str_empty(library_s)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label));
+                val lbl_msg15: str = sfmt(alloc, "mach.toml: {}.library must be a non-empty string", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg15);
             }
             d.library = intern_unwrap(itn, library_s);
         }
@@ -1069,16 +1095,15 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val symbols_v: *toml.Value = toml.get(sub, "symbols");
         if (symbols_v != nil) {
             if (symbols_v.tag != toml.TYPE_ARRAY) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label));
+                val lbl_msg16: str = sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg16);
             }
-            val res_syms: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?symbols_v.data.array,
-                sfmt(alloc, "mach.toml: {}.symbols must be an array of strings", label));
+            val res_syms: R.Result[StrArr, str] = parse_str_array(alloc, itn, ?symbols_v.data.array, label, "symbols", false);
             if (R.is_err[StrArr, str](res_syms)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_syms)); }
             val syms: StrArr = R.unwrap_ok[StrArr, str](res_syms);
             var si: u32 = 0;
             for (si < syms.count) {
                 if (str_empty(idstr(itn, syms.items[si]))) {
-                    ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.symbols has an empty symbol name", label));
+                    val lbl_msg17: str = sfmt(alloc, "mach.toml: {}.symbols has an empty symbol name", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg17);
                 }
                 var sj: u32 = 0;
                 for (sj < si) {
@@ -1099,22 +1124,24 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
 
         if (str_equals(source_s, "local")) {
             if (!str_empty(name_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.name is not allowed for local sources", label));
+                val lbl_msg18: str = sfmt(alloc, "mach.toml: {}.name is not allowed for local sources", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg18);
             }
             if (str_empty(path_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'path' for local source", label));
+                val lbl_msg19: str = sfmt(alloc, "mach.toml: {} is missing required key 'path' for local source", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg19);
             }
-            val res_check_path: R.Result[bool, str] = check_path(alloc, path_val, sfmt(alloc, "{}.path", label));
+            val path_field: str = sfmt(alloc, "{}.path", label);
+            val res_check_path: R.Result[bool, str] = check_path(alloc, path_val, path_field);
+            str_free(alloc, path_field);
             if (R.is_err[bool, str](res_check_path)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check_path)); }
             d.path = intern_unwrap(itn, path_val);
             d.lib_name = intern.STR_NIL;
         }
         or {
             if (!str_empty(path_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.path is not allowed for non-local sources", label));
+                val lbl_msg20: str = sfmt(alloc, "mach.toml: {}.path is not allowed for non-local sources", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg20);
             }
             if (str_empty(name_val)) {
-                ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'name' for non-local source", label));
+                val lbl_msg21: str = sfmt(alloc, "mach.toml: {} is missing required key 'name' for non-local source", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg21);
             }
             d.lib_name = intern_unwrap(itn, name_val);
             d.path = intern.STR_NIL;
@@ -1151,6 +1178,7 @@ fun parse_links(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         or { d.export = export_v.data.boolean; }
 
         m.links[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1173,7 +1201,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         val v: *toml.Value = toml.table_value(tab, i);
         val label: str = sfmt(alloc, "[step.{}]", name);
         if (v == nil || v.tag != toml.TYPE_TABLE) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} must be a table", label));
+            val lbl_msg22: str = sfmt(alloc, "mach.toml: {} must be a table", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg22);
         }
         val sub: *toml.Table = ?v.data.table;
 
@@ -1194,8 +1222,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
 
         val in_arr: *toml.Array = toml.get_array(sub, "in");
         if (in_arr == nil) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'in'", label)); }
-        val res_in: R.Result[StrArr, str] = parse_str_array(alloc, itn, in_arr,
-            sfmt(alloc, "mach.toml: {}.in must be an array of strings", label));
+        val res_in: R.Result[StrArr, str] = parse_str_array(alloc, itn, in_arr, label, "in", false);
         if (R.is_err[StrArr, str](res_in)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_in)); }
         val in_val: StrArr = R.unwrap_ok[StrArr, str](res_in);
         d.in = in_val.items;
@@ -1204,15 +1231,16 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         var ii: u32 = 0;
         for (ii < d.in_count) {
             val p: str = idstr(itn, d.in[ii]);
-            val res_check: R.Result[bool, str] = check_path(alloc, p, sfmt(alloc, "{}.in", label));
+            val in_field: str = sfmt(alloc, "{}.in", label);
+            val res_check: R.Result[bool, str] = check_path(alloc, p, in_field);
+            str_free(alloc, in_field);
             if (R.is_err[bool, str](res_check)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check)); }
             ii = ii + 1;
         }
 
         val out_arr: *toml.Array = toml.get_array(sub, "out");
         if (out_arr == nil) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'out'", label)); }
-        val res_out: R.Result[StrArr, str] = parse_str_array(alloc, itn, out_arr,
-            sfmt(alloc, "mach.toml: {}.out must be an array of strings", label));
+        val res_out: R.Result[StrArr, str] = parse_str_array(alloc, itn, out_arr, label, "out", false);
         if (R.is_err[StrArr, str](res_out)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_out)); }
         val out_val: StrArr = R.unwrap_ok[StrArr, str](res_out);
         d.out = out_val.items;
@@ -1223,18 +1251,19 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         for (ii < d.out_count) {
             val p: str = idstr(itn, d.out[ii]);
             if (str_contains_char(p, '*')) { ret R.err[bool, str](sfmt(alloc, "mach.toml: {}.out cannot contain a glob '*'; outputs must be concrete paths", label)); }
-            val res_check: R.Result[bool, str] = check_path(alloc, p, sfmt(alloc, "{}.out", label));
+            val out_path_field: str = sfmt(alloc, "{}.out", label);
+            val res_check: R.Result[bool, str] = check_path(alloc, p, out_path_field);
+            str_free(alloc, out_path_field);
             if (R.is_err[bool, str](res_check)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_check)); }
             ii = ii + 1;
         }
 
         val need_arr: *toml.Array = toml.get_array(sub, "need");
         if (need_arr == nil && as_root) {
-            ret R.err[bool, str](sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label));
+            val lbl_msg23: str = sfmt(alloc, "mach.toml: {} is missing required key 'need' (use [] for none)", label); str_free(alloc, label); ret R.err[bool, str](lbl_msg23);
         }
         if (need_arr != nil) {
-            val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr,
-                sfmt(alloc, "mach.toml: {}.need must be an array of strings", label));
+            val res_need: R.Result[StrArr, str] = parse_str_array(alloc, itn, need_arr, label, "need", false);
             if (R.is_err[StrArr, str](res_need)) { ret R.err[bool, str](R.unwrap_err[StrArr, str](res_need)); }
             val need_val: StrArr = R.unwrap_ok[StrArr, str](res_need);
             d.need = need_val.items;
@@ -1242,6 +1271,7 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
         }
 
         m.steps[i] = d;
+        str_free(alloc, label);
         i = i + 1;
     }
     ret R.ok[bool, str](true);
@@ -1302,6 +1332,24 @@ pub fun dnit(m: *Manifest, alloc: *A.Allocator) {
         A.deallocate[StepDef](alloc, m.steps, m.step_count::usize);
         m.steps = nil;
         m.step_count = 0;
+    }
+}
+
+# release the first `count` composed path strings in `paths`
+#
+# The array itself is the caller's; this frees only what each slot points at.
+# `count` is the populated prefix rather than the capacity, so a partly filled
+# buffer (an error partway through composition) frees exactly what it wrote.
+# ---
+# alloc: allocator the strings were composed on
+# paths: array of composed path strings
+# count: number of populated entries
+fun free_path_strings(alloc: *A.Allocator, paths: *str, count: u32) {
+    if (paths == nil) { ret; }
+    var i: u32 = 0;
+    for (i < count) {
+        str_free(alloc, paths[i]);
+        i = i + 1;
     }
 }
 
@@ -1800,18 +1848,34 @@ pub fun link_matches_target(itn: *intern.Interner, l: *LinkDef, t: *TargetDef) b
     ret true;
 }
 
+# join `a` and `b` with exactly one separator between them
+#
+# THE RESULT IS ALWAYS OWNED BY THE CALLER. The degenerate cases used to hand back
+# the borrowed argument while the joining case returned a fresh allocation, so
+# whether the caller had to free it depended on the values -- which no caller can
+# check. Both now return a copy, so `str_free` on the result is correct always.
+#
+# The two trimmed halves are scratch for the join and are released here (#3001).
+# ---
+# alloc: allocator owning the returned string and the two trimmed halves
+# a:     left side; a single trailing '/' is dropped
+# b:     right side; a single leading '/' is dropped
+# ret:   the joined path, owned by the caller
 fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
-    if (str_empty(a)) { ret b; }
-    if (str_empty(b)) { ret a; }
+    if (str_empty(a)) { ret seg_dup(alloc, b, 0, str_len(b)); }
+    if (str_empty(b)) { ret seg_dup(alloc, a, 0, str_len(a)); }
     val al: usize = str_len(a);
     var end_a: usize = al;
     if (a[al - 1] == '/') { end_a = al - 1; }
     var start_b: usize = 0;
     if (b[0] == '/') { start_b = 1; }
-    
+
     val a_sub: str = seg_dup(alloc, a, 0, end_a);
     val b_sub: str = seg_dup(alloc, b, start_b, str_len(b));
-    ret sfmt(alloc, "{}/{}", a_sub, b_sub);
+    val joined: str = sfmt(alloc, "{}/{}", a_sub, b_sub);
+    str_free(alloc, a_sub);
+    str_free(alloc, b_sub);
+    ret joined;
 }
 
 # resolve a matched link entry without discarding its declared source semantics
@@ -2289,7 +2353,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     var matched_items: *LinkRequirement = nil;
     if (a.link_count > 0) {
         val res_match_arr: R.Result[*LinkRequirement, str] = A.allocate[LinkRequirement](alloc, a.link_count::usize);
-        if (R.is_err[*LinkRequirement, str](res_match_arr)) { ret R.err[BuildUnit, str](R.unwrap_err[*LinkRequirement, str](res_match_arr)); }
+        if (R.is_err[*LinkRequirement, str](res_match_arr)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[*LinkRequirement, str](res_match_arr)); }
         matched_items = R.unwrap_ok[*LinkRequirement, str](res_match_arr);
 
         var li: u32 = 0;
@@ -2309,7 +2373,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
                     if (R.is_err[LinkRequirement, str](req_r)) {
                         free_link_claims(alloc, matched_items, match_count);
                         A.deallocate[LinkRequirement](alloc, matched_items, a.link_count::usize);
-                        ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r));
+                        str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[LinkRequirement, str](req_r));
                     }
                     matched_items[match_count] = R.unwrap_ok[LinkRequirement, str](req_r);
                     match_count = match_count + 1;
@@ -2323,7 +2387,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
         val fr: R.Result[bool, str] = finish_link_requirements(alloc, matched_items,
             a.link_count, match_count, ?exact_items, ?exact_count);
         if (R.is_err[bool, str](fr)) {
-            ret R.err[BuildUnit, str](R.unwrap_err[bool, str](fr));
+            str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[bool, str](fr));
         }
         matched_items = exact_items;
         match_count = exact_count;
@@ -2337,30 +2401,37 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     val asm_str: str = sfmt(alloc, "{}/asm", proj_out);
     val test_str: str = sfmt(alloc, "{}/test/{{name}}", proj_out);
 
-    val res_obj: R.Result[intern.StrId, str] = intern.intern(itn, obj_str);
-    if (R.is_err[intern.StrId, str](res_obj)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_obj)); }
-    u.obj_root = R.unwrap_ok[intern.StrId, str](res_obj);
-
-    val res_ir: R.Result[intern.StrId, str] = intern.intern(itn, ir_str);
-    if (R.is_err[intern.StrId, str](res_ir)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_ir)); }
-    u.ir_root = R.unwrap_ok[intern.StrId, str](res_ir);
-
-    val res_asm: R.Result[intern.StrId, str] = intern.intern(itn, asm_str);
-    if (R.is_err[intern.StrId, str](res_asm)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_asm)); }
-    u.asm_root = R.unwrap_ok[intern.StrId, str](res_asm);
-
+    # the four are interned together and released together: each is a per-call
+    # rendering whose only durable form is its StrId (#3001)
+    val res_obj:  R.Result[intern.StrId, str] = intern.intern(itn, obj_str);
+    val res_ir:   R.Result[intern.StrId, str] = intern.intern(itn, ir_str);
+    val res_asm:  R.Result[intern.StrId, str] = intern.intern(itn, asm_str);
     val res_test: R.Result[intern.StrId, str] = intern.intern(itn, test_str);
-    if (R.is_err[intern.StrId, str](res_test)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_test)); }
+    str_free(alloc, obj_str);
+    str_free(alloc, ir_str);
+    str_free(alloc, asm_str);
+    str_free(alloc, test_str);
+
+    if (R.is_err[intern.StrId, str](res_obj)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_obj)); }
+    u.obj_root = R.unwrap_ok[intern.StrId, str](res_obj);
+    if (R.is_err[intern.StrId, str](res_ir)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_ir)); }
+    u.ir_root = R.unwrap_ok[intern.StrId, str](res_ir);
+    if (R.is_err[intern.StrId, str](res_asm)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_asm)); }
+    u.asm_root = R.unwrap_ok[intern.StrId, str](res_asm);
+    if (R.is_err[intern.StrId, str](res_test)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_test)); }
     u.test_root = R.unwrap_ok[intern.StrId, str](res_test);
 
     # Resolve artifact relative path
     val art_out_tmpl: intern.StrId = a.out;
     val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, ?v);
-    if (R.is_err[str, str](res_art_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
+    if (R.is_err[str, str](res_art_out)) { str_free(alloc, proj_out); ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
     val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
 
     val final_bin_path: str = join_path_canonical(alloc, proj_out, art_out_rel);
     val res_bin: R.Result[intern.StrId, str] = intern.intern(itn, final_bin_path);
+    str_free(alloc, final_bin_path);
+    str_free(alloc, art_out_rel);
+    str_free(alloc, proj_out);
     if (R.is_err[intern.StrId, str](res_bin)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](res_bin)); }
     u.bin_path = R.unwrap_ok[intern.StrId, str](res_bin);
 
@@ -2486,9 +2557,15 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
         val a: *ArtifactDef = ?m.artifacts[i];
         val art_out_tmpl: intern.StrId = a.out;
         val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, v);
-        if (R.is_err[str, str](res_art_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_out)); }
+        if (R.is_err[str, str](res_art_out)) {
+            free_path_strings(alloc, paths, i);
+            A.deallocate[str](alloc, paths, m.artifact_count::usize);
+            str_free(alloc, proj_out);
+            ret R.err[bool, str](R.unwrap_err[str, str](res_art_out));
+        }
         val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
         paths[i] = join_path_canonical(alloc, proj_out, art_out_rel);
+        str_free(alloc, art_out_rel);
         i = i + 1;
     }
 
@@ -2511,7 +2588,12 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
         i = i + 1;
     }
 
+    # `paths` holds one composed string per artifact, each owned by this check and
+    # dead once the comparison is done. the collision message is rendered before
+    # they are released, so it carries its own copy (#3001)
+    free_path_strings(alloc, paths, m.artifact_count);
     A.deallocate[str](alloc, paths, m.artifact_count::usize);
+    str_free(alloc, proj_out);
     if (!code) { ret R.err[bool, str](msg); }
     ret R.ok[bool, str](true);
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -4,7 +4,6 @@
 use std.allocator.arena;
 use std.allocator.page;
 use std.data.toml;
-use semver: std.types.semver;
 use std.format;
 use std.text.string.str_free;
 use std.types.bool.bool;
@@ -190,10 +189,6 @@ pub rec StepDef {
 pub rec Manifest {
     id:               intern.StrId;
     version:          intern.StrId;
-    # `[project].mach`: the minimum toolchain, STR_NIL when unstated. checked
-    # before any source is parsed, which is the only point early enough to
-    # diagnose a SYNTAX requirement (#2714).
-    mach_min:         intern.StrId;
     name:             intern.StrId;
     description:      intern.StrId;
     src:              intern.StrId;
@@ -211,59 +206,6 @@ pub rec Manifest {
     link_count:       u32;
     steps:            *StepDef;
     step_count:       u32;
-}
-
-# check a manifest's `[project].mach` against the running toolchain
-#
-# Called BEFORE any source is parsed, which is the only point early enough to
-# diagnose a SYNTAX requirement. A comptime `$if` in source cannot: parsing
-# precedes comptime evaluation, so a file using a spelling the running compiler
-# cannot tokenize fails at the grammar rule and the guard never runs (#2714).
-#
-# `who` names the project that DEMANDS the version. For a dependency that is the
-# dependency, not the project the user invoked - a consumer builds mach-std, so
-# naming their own project would send them to the wrong manifest.
-# ---
-# m:       the parsed manifest to check
-# running: the running toolchain's version
-# who:     project id to name in the message, nil for the root project
-# ret:     ok when satisfied or unstated, otherwise the shortfall
-pub fun check_toolchain(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, running: str, who: str) R.Result[bool, str] {
-    if (m.mach_min == intern.STR_NIL) { ret R.ok[bool, str](true); }
-
-    val req_o: O.Option[str] = intern.lookup(itn, m.mach_min);
-    if (O.is_none[str](req_o)) { ret R.err[bool, str]("internal: [project].mach not interned"); }
-    ret check_toolchain_str(alloc, O.unwrap[str](req_o), running, who);
-}
-
-# the comparison itself, over strings
-#
-# Split out because a dependency's manifest is read as raw toml by the dep
-# resolver rather than through `parse`, and one comparison serving both is what
-# stops the root and dependency paths disagreeing about what satisfies a
-# requirement.
-# ---
-# req_s:   the required minimum, already known non-empty
-# running: the running toolchain's version
-# who:     project id to name, nil for the root project
-pub fun check_toolchain_str(alloc: *A.Allocator, req_s: str, running: str, who: str) R.Result[bool, str] {
-    val rr: R.Result[semver.Semver, str] = semver.semver_parse(req_s, alloc);
-    if (R.is_err[semver.Semver, str](rr)) { ret R.err[bool, str]("mach.toml: [project].mach is not a version"); }
-    var req: semver.Semver = R.unwrap_ok[semver.Semver, str](rr);
-
-    val cr: R.Result[semver.Semver, str] = semver.semver_parse(running, alloc);
-    # an unparseable running version is not the project's fault, so it must not
-    # be reported as a shortfall. a development build with an odd version string
-    # would otherwise be refused by every manifest that states a requirement.
-    if (R.is_err[semver.Semver, str](cr)) { ret R.ok[bool, str](true); }
-    var cur: semver.Semver = R.unwrap_ok[semver.Semver, str](cr);
-
-    if (!semver.semver_is_less(?cur, ?req)) { ret R.ok[bool, str](true); }
-
-    if (who == nil) {
-        ret R.err[bool, str](sfmt(alloc, "this project requires mach {} or newer; running {}", req_s, running));
-    }
-    ret R.err[bool, str](sfmt(alloc, "dependency '{}' requires mach {} or newer; running {}", who, req_s, running));
 }
 
 pub rec Selection {
@@ -646,10 +588,6 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
 fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     if (kind == TK_PROJECT) {
         if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
-        # the minimum toolchain this project needs. optional, and read from a
-        # dependency's manifest too - a dependency is the case that matters, since
-        # a consumer builds the dependency rather than the file that fails (#2714).
-        if (str_equals(k, "mach")) { ret true; }
         # a dependency's manifest (as_root false) tolerates the pre-flag-day
         # name/description metadata the consumer never reads (#1971); the root
         # trims [project] to id/version/src/out. a genuinely unknown key is rejected
@@ -762,20 +700,6 @@ pub fun parse(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, as_roo
     if (!is_valid_id(id_str)) { ret R.err[Manifest, str]("mach.toml: [project].id must be an identifier (letters, digits, '_', '-')"); }
     m.id = intern_unwrap(itn, id_str);
     m.version = intern_unwrap(itn, ver_str);
-
-    # optional. absent means no requirement, so every existing manifest is
-    # unchanged. a present but unparseable value is an error rather than an
-    # ignored key - a typo'd requirement that silently permits everything is
-    # worse than no requirement at all.
-    val mach_str: str = toml.get_str(proj, "mach");
-    m.mach_min = intern.STR_NIL;
-    if (!str_empty(mach_str)) {
-        val vr: R.Result[semver.Semver, str] = semver.semver_parse(mach_str, alloc);
-        if (R.is_err[semver.Semver, str](vr)) {
-            ret R.err[Manifest, str]("mach.toml: [project].mach must be a version like \"4.14.0\"");
-        }
-        m.mach_min = intern_unwrap(itn, mach_str);
-    }
     # name/description are not #1964 fields; [project] is id/version/src/out only.
     m.name = intern.STR_NIL;
     m.description = intern.STR_NIL;
@@ -4239,64 +4163,15 @@ test "mach.lang.manifest.cell_supported:enumerated_axis_is_not_pinned_by_the_art
     ret code;
 }
 
-# the toolchain gate compares by precedence, not by string equality, and reports
-# the shortfall in terms of who demanded it. `who` nil is the root project;
-# a name is a dependency, which is the case that matters, since a consumer
-# builds the dependency rather than the file inside it that fails.
-test "mach.lang.manifest.check_toolchain_str:compares_and_attributes" {
+test "mach.lang.manifest.parse:mach_key_is_unknown" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
-
-    # satisfied: newer, and exactly equal
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.0.0",  "4.14.0", nil))) { code = 1; }
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.14.0", "4.14.0", nil))) { code = 1; }
-    # a patch-level shortfall is still a shortfall, and 4.9 is not newer than 4.14
-    if (R.is_ok[bool, str](check_toolchain_str(?alloc, "4.14.1", "4.14.0", nil)))  { code = 1; }
-    if (R.is_ok[bool, str](check_toolchain_str(?alloc, "4.14.0", "4.9.0",  nil)))  { code = 1; }
-    # a string compare would call "4.9.0" newer than "4.14.0" because '9' > '1'
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.9.0", "4.14.0", nil)))  { code = 1; }
-
-    # an unparseable RUNNING version is not the project's fault and must not read
-    # as a shortfall, or a development build would be refused by every manifest
-    # that states a requirement
-    if (R.is_err[bool, str](check_toolchain_str(?alloc, "4.14.0", "not-a-version", nil))) { code = 1; }
-
-    # the shortfall names the dependency, not the project the user invoked
-    val d: R.Result[bool, str] = check_toolchain_str(?alloc, "99.0.0", "4.14.0", "std");
-    if (R.is_ok[bool, str](d)) { code = 1; }
-    or (!str_contains(R.unwrap_err[bool, str](d), "dependency 'std'")) { code = 1; }
-
-    val rt: R.Result[bool, str] = check_toolchain_str(?alloc, "99.0.0", "4.14.0", nil);
-    if (R.is_ok[bool, str](rt)) { code = 1; }
-    or (!str_contains(R.unwrap_err[bool, str](rt), "this project")) { code = 1; }
-
-    arena.dnit(?ar);
-    ret code;
-}
-
-# an absent `[project].mach` is no requirement, so every manifest predating this
-# key keeps working. a present but malformed one is an error rather than an
-# ignored key: a typo'd requirement that silently permits everything is worse
-# than stating none.
-test "mach.lang.manifest.parse:mach_key_optional_and_validated" {
-    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
-    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
-    var code: i32 = 0;
-
-    val base: str = "[project]\nid = \"p\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"o\"\n";
-    val ok_r: R.Result[Manifest, str] = tparse(?alloc, ?itn, base);
-    if (R.is_err[Manifest, str](ok_r)) { code = 1; }
-    or (R.unwrap_ok[Manifest, str](ok_r).mach_min != intern.STR_NIL) { code = 1; }
 
     val with_r: R.Result[Manifest, str] = tparse(?alloc, ?itn,
         "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"4.14.0\"\nsrc = \"src\"\nout = \"o\"\n");
-    if (R.is_err[Manifest, str](with_r)) { code = 1; }
-    or (R.unwrap_ok[Manifest, str](with_r).mach_min == intern.STR_NIL) { code = 1; }
-
-    val bad_r: R.Result[Manifest, str] = tparse(?alloc, ?itn,
-        "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"banana\"\nsrc = \"src\"\nout = \"o\"\n");
-    if (R.is_ok[Manifest, str](bad_r)) { code = 1; }
+    if (R.is_ok[Manifest, str](with_r)) { code = 1; }
+    or (!str_contains(R.unwrap_err[Manifest, str](with_r), "unknown key 'mach' in [project]")) { code = 1; }
 
     arena.dnit(?ar);
     ret code;

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -588,6 +588,9 @@ fun unknown_key_msg(alloc: *A.Allocator, key: str, label: str) str {
 fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     if (kind == TK_PROJECT) {
         if (str_equals(k, "id") || str_equals(k, "version") || str_equals(k, "src") || str_equals(k, "out")) { ret true; }
+        # tolerate the removed minimum-version key in dependency metadata so an
+        # existing dependency cannot make its consumer fail during migration
+        if (!as_root && str_equals(k, "mach")) { ret true; }
         # a dependency's manifest (as_root false) tolerates the pre-flag-day
         # name/description metadata the consumer never reads (#1971); the root
         # trims [project] to id/version/src/out. a genuinely unknown key is rejected
@@ -4172,6 +4175,11 @@ test "mach.lang.manifest.parse:mach_key_is_unknown" {
         "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"4.14.0\"\nsrc = \"src\"\nout = \"o\"\n");
     if (R.is_ok[Manifest, str](with_r)) { code = 1; }
     or (!str_contains(R.unwrap_err[Manifest, str](with_r), "unknown key 'mach' in [project]")) { code = 1; }
+
+    val dep_r: R.Result[Manifest, str] = tparse_lenient(?alloc, ?itn,
+        "[project]\nid = \"p\"\nversion = \"0.1.0\"\nmach = \"4.14.0\"\nsrc = \"src\"\nout = \"o\"\n");
+    if (R.is_err[Manifest, str](dep_r)) { code = 1; }
+    or { var dep: Manifest = R.unwrap_ok[Manifest, str](dep_r); dnit(?dep, ?alloc); }
 
     arena.dnit(?ar);
     ret code;

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -7,6 +7,6 @@ use std.types.string.str_equals;
 pub val MACH_VERSION: str = "4.19.0";
 
 test "mach.lang.version:matches_project_release" {
-    if (!str_equals(MACH_VERSION, $project.version)) { ret 1; }
+    if (str_equals($project.id, "mach") && !str_equals(MACH_VERSION, $project.version)) { ret 1; }
     ret 0;
 }

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.19.0";
+pub val MACH_VERSION: str = "4.20.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -1,0 +1,12 @@
+# compiler release identity shared by the driver and command-line surface
+
+use std.types.string.str;
+use std.types.string.str_equals;
+
+# the Mach compiler version, independent of the project embedding the frontend
+pub val MACH_VERSION: str = "4.19.0";
+
+test "mach.lang.version:matches_project_release" {
+    if (!str_equals(MACH_VERSION, $project.version)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -1,12 +1,16 @@
 # compiler release identity shared by the driver and command-line surface
 
 use std.types.string.str;
-use std.types.string.str_equals;
 
 # the Mach compiler version, independent of the project embedding the frontend
 pub val MACH_VERSION: str = "4.19.0";
 
 test "mach.lang.version:matches_project_release" {
-    if (str_equals($project.id, "mach") && !str_equals(MACH_VERSION, $project.version)) { ret 1; }
+    $if ($project.id == "mach") {
+        $if (MACH_VERSION != $project.version) { ret 1; }
+    }
+    $if ($project.id == "mach-version-vendor-test") {
+        $if (MACH_VERSION == $project.version) { ret 1; }
+    }
     ret 0;
 }

--- a/test/determinism.sh
+++ b/test/determinism.sh
@@ -8,8 +8,8 @@
 # drives: a warm rebuild must produce byte-identical output to a clean build, both
 # with no change (cache reuse is sound) and after a source edit (invalidation is
 # sound, the failure mode #2045 recorded, where an incremental build reflected an
-# edit only partially). The edit is the release version bump: it updates both the
-# Mach-owned compiler version and the matching project manifest value.
+# edit only partially). A compiler-source edit and a separate manifest-only
+# fixture cover both invalidation channels without one masking the other.
 set -eu
 
 cc=${1:-}
@@ -20,9 +20,10 @@ if [ -z "$cc" ]; then
 fi
 cc=$(realpath "$cc")
 cd "$dir"
+root=$(pwd)
 
 work=$(mktemp -d)
-trap 'rm -rf "$work" out; cp "$work/mach.toml.bak" mach.toml 2>/dev/null || true; cp "$work/version.mach.bak" src/lang/version.mach 2>/dev/null || true' EXIT
+trap 'rm -rf "$work" out; cp "$work/version.mach.bak" src/lang/version.mach 2>/dev/null || true' EXIT
 
 # a clean baseline, then a warm no-op rebuild over its populated out/
 rm -rf out
@@ -33,25 +34,18 @@ if ! cmp -s "$work/clean" "$work/warm_noop"; then
     exit 1
 fi
 
-# edit-invalidation: bump the release identity, then compare a warm rebuild
-# against a clean rebuild of the same edit
-cp mach.toml "$work/mach.toml.bak"
+# source edit-invalidation: bump the compiler-owned release identity, then compare
+# a warm rebuild against a clean rebuild of the same edit
 cp src/lang/version.mach "$work/version.mach.bak"
-if ! grep -q '^version = ' mach.toml; then
-    echo "::error::no [project].version line to drive the invalidation edit"
-    exit 1
-fi
 if ! grep -q '^pub val MACH_VERSION: str = ' src/lang/version.mach; then
     echo "::error::no compiler version constant to drive the invalidation edit"
     exit 1
 fi
-sed -i 's/^version = "\(.*\)"/version = "\1-det"/' mach.toml
 sed -i 's/^pub val MACH_VERSION: str = "\(.*\)";/pub val MACH_VERSION: str = "\1-det";/' src/lang/version.mach
 
 "$cc" build . -o "$work/inc_edited"
 rm -rf out
 "$cc" build . -o "$work/clean_edited"
-cp "$work/mach.toml.bak" mach.toml
 cp "$work/version.mach.bak" src/lang/version.mach
 
 if ! cmp -s "$work/inc_edited" "$work/clean_edited"; then
@@ -61,7 +55,61 @@ fi
 
 # guard against a false pass: the edit must actually have changed the output
 if cmp -s "$work/clean" "$work/clean_edited"; then
-    echo "::error::the version edit did not change the binary; the check proves nothing"
+    echo "::error::the source edit did not change the binary; the check proves nothing"
+    exit 1
+fi
+
+# manifest edit-invalidation: keep source fixed while `$project.version` changes
+# in a tiny static-library fixture, preserving the manifest-query regression
+proj="$work/project-version"
+mkdir -p "$proj/src"
+case "$(uname -m)" in
+    x86_64)  isa=x86_64; abi=sysv64 ;;
+    aarch64) isa=aarch64; abi=aapcs64 ;;
+    *) echo "::error::unsupported host architecture"; exit 2 ;;
+esac
+cat > "$proj/mach.toml" <<EOF
+[project]
+id = "det"
+version = "1.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+[target.host]
+isa = "$isa"
+os = "linux"
+abi = "$abi"
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+[artifact.det]
+kind = "static"
+entry = "main.mach"
+out = "lib/det"
+targets = ["*"]
+link = []
+need = []
+[dep.mach-std]
+path = "$root/dep/mach-std"
+EOF
+cat > "$proj/src/main.mach" <<'EOF'
+use std.types.string.str;
+
+pub val VERSION: str = $project.version;
+EOF
+
+(cd "$proj" && "$cc" dep pull)
+"$cc" build "$proj" -o "$work/project_clean"
+sed -i 's/^version = "1.0.0"/version = "1.0.1"/' "$proj/mach.toml"
+"$cc" build "$proj" -o "$work/project_inc"
+rm -rf "$proj/out"
+"$cc" build "$proj" -o "$work/project_clean_edited"
+if ! cmp -s "$work/project_inc" "$work/project_clean_edited"; then
+    echo "::error::manifest-only incremental build diverged from a clean build"
+    exit 1
+fi
+if cmp -s "$work/project_clean" "$work/project_clean_edited"; then
+    echo "::error::the manifest edit did not change the fixture; the check proves nothing"
     exit 1
 fi
 

--- a/test/determinism.sh
+++ b/test/determinism.sh
@@ -8,9 +8,8 @@
 # drives: a warm rebuild must produce byte-identical output to a clean build, both
 # with no change (cache reuse is sound) and after a source edit (invalidation is
 # sound, the failure mode #2045 recorded, where an incremental build reflected an
-# edit only partially). The edit is a `[project].version` bump: it flows through
-# `$project.version` into the compiler and rides the comptime-input invalidation
-# path, the subtlest one to get right.
+# edit only partially). The edit is the release version bump: it updates both the
+# Mach-owned compiler version and the matching project manifest value.
 set -eu
 
 cc=${1:-}
@@ -23,7 +22,7 @@ cc=$(realpath "$cc")
 cd "$dir"
 
 work=$(mktemp -d)
-trap 'rm -rf "$work" out; cp "$work/mach.toml.bak" mach.toml 2>/dev/null || true' EXIT
+trap 'rm -rf "$work" out; cp "$work/mach.toml.bak" mach.toml 2>/dev/null || true; cp "$work/version.mach.bak" src/lang/version.mach 2>/dev/null || true' EXIT
 
 # a clean baseline, then a warm no-op rebuild over its populated out/
 rm -rf out
@@ -34,19 +33,26 @@ if ! cmp -s "$work/clean" "$work/warm_noop"; then
     exit 1
 fi
 
-# edit-invalidation: bump [project].version, which $project.version folds into the
-# compiler, then compare a warm rebuild against a clean rebuild of the same edit
+# edit-invalidation: bump the release identity, then compare a warm rebuild
+# against a clean rebuild of the same edit
 cp mach.toml "$work/mach.toml.bak"
+cp src/lang/version.mach "$work/version.mach.bak"
 if ! grep -q '^version = ' mach.toml; then
     echo "::error::no [project].version line to drive the invalidation edit"
     exit 1
 fi
+if ! grep -q '^pub val MACH_VERSION: str = ' src/lang/version.mach; then
+    echo "::error::no compiler version constant to drive the invalidation edit"
+    exit 1
+fi
 sed -i 's/^version = "\(.*\)"/version = "\1-det"/' mach.toml
+sed -i 's/^pub val MACH_VERSION: str = "\(.*\)";/pub val MACH_VERSION: str = "\1-det";/' src/lang/version.mach
 
 "$cc" build . -o "$work/inc_edited"
 rm -rf out
 "$cc" build . -o "$work/clean_edited"
 cp "$work/mach.toml.bak" mach.toml
+cp "$work/version.mach.bak" src/lang/version.mach
 
 if ! cmp -s "$work/inc_edited" "$work/clean_edited"; then
     echo "::error::incremental build after an edit diverged from a clean build (stale invalidation)"

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -66,9 +66,12 @@ EOF
 
 cat > "$work/src/main.mach" <<EOF
 use std.runtime;
+use std.types.string.str_equals;
+use mach.lang.driver.load;
 use mach.lang.version;
 
 test "mach.lang.version:vendored_context" {
+    if (!str_equals(load.MACH_VERSION, "$compiler_ver")) { ret 1; }
     \$if (\$mach.version != "$compiler_ver") { ret 1; }
     \$if (\$mach.version.major != $compiler_major) { ret 1; }
     ret 0;

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -45,7 +45,7 @@ abi = "$abi"
 
 [profile.debug]
 opt = 0
-debug = false
+debug = true
 simd = "scalarize"
 
 [artifact.host]
@@ -90,6 +90,14 @@ vendored_cli="$work/vendored-mach"
 "$cc" build . -o "$vendored_cli"
 if [ "$("$vendored_cli" info --version)" != "$compiler_ver" ]; then
     echo "version-vendor.sh: built vendored CLI reports the embedding project version" >&2
+    exit 1
+fi
+if ! readelf --debug-dump=info "$vendored_cli" 2>/dev/null | grep -Fq "DW_AT_producer"; then
+    echo "version-vendor.sh: vendored CLI has no debug producer metadata" >&2
+    exit 1
+fi
+if ! readelf --debug-dump=info "$vendored_cli" 2>/dev/null | grep -F "DW_AT_producer" | grep -Fq "mach $compiler_ver"; then
+    echo "version-vendor.sh: vendored debug producer reports the embedding project version" >&2
     exit 1
 fi
 "$cc" test . --include-deps --filter mach.lang.version

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+# prove a source-vendored frontend retains Mach's version, not its host's
+set -eu
+
+cc=${1:-}
+root=${2:-.}
+if [ -z "$cc" ]; then
+    echo "usage: version-vendor.sh <compiler> [mach-root]" >&2
+    exit 2
+fi
+
+cc=$(realpath "$cc")
+root=$(realpath "$root")
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/src"
+
+case "$(uname -m)" in
+    x86_64)  isa=x86_64; abi=sysv64 ;;
+    aarch64) isa=aarch64; abi=aapcs64 ;;
+    *) echo "version-vendor.sh: unsupported host architecture" >&2; exit 2 ;;
+esac
+
+cat > "$work/mach.toml" <<EOF
+[project]
+id = "mach-version-vendor-test"
+version = "mach-version-vendor-test"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.host]
+isa = "$isa"
+os = "linux"
+abi = "$abi"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[artifact.host]
+kind = "static"
+entry = "main.mach"
+out = "lib/host"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach]
+path = "$root"
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"
+EOF
+
+cat > "$work/src/main.mach" <<'EOF'
+use std.runtime;
+use mach.lang.version;
+
+#[symbol("main")]
+fun main() i32 { ret 0; }
+EOF
+
+cd "$work"
+"$cc" dep pull
+"$cc" test . --include-deps --filter mach.lang.version

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -49,7 +49,7 @@ debug = false
 simd = "scalarize"
 
 [artifact.host]
-kind = "static"
+kind = "bin"
 entry = "main.mach"
 out = "lib/host"
 targets = ["*"]
@@ -67,6 +67,9 @@ EOF
 cat > "$work/src/main.mach" <<EOF
 use std.runtime;
 use std.types.string.str_equals;
+use std.types.size.usize;
+use std.types.string.str;
+use mach.cli.cmd.dispatch;
 use mach.lang.driver.load;
 use mach.lang.version;
 
@@ -78,9 +81,15 @@ test "mach.lang.version:vendored_context" {
 }
 
 #[symbol("main")]
-fun main() i32 { ret 0; }
+fun main(argc: usize, argv: *str) i64 { ret dispatch(argc, argv); }
 EOF
 
 cd "$work"
 "$cc" dep pull
+vendored_cli="$work/vendored-mach"
+"$cc" build . -o "$vendored_cli"
+if [ "$("$vendored_cli" info --version)" != "$compiler_ver" ]; then
+    echo "version-vendor.sh: built vendored CLI reports the embedding project version" >&2
+    exit 1
+fi
 "$cc" test . --include-deps --filter mach.lang.version

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -11,6 +11,16 @@ fi
 
 cc=$(realpath "$cc")
 root=$(realpath "$root")
+compiler_ver=$(sed -n 's/^pub val MACH_VERSION: str = "\(.*\)";$/\1/p' "$root/src/lang/version.mach")
+if [ -z "$compiler_ver" ]; then
+    echo "version-vendor.sh: compiler version constant not found" >&2
+    exit 2
+fi
+compiler_major=${compiler_ver%%.*}
+if [ "$("$cc" info --version)" != "$compiler_ver" ]; then
+    echo "version-vendor.sh: vendored CLI reports the embedding project version" >&2
+    exit 1
+fi
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/src"
@@ -54,9 +64,15 @@ git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
 EOF
 
-cat > "$work/src/main.mach" <<'EOF'
+cat > "$work/src/main.mach" <<EOF
 use std.runtime;
 use mach.lang.version;
+
+test "mach.lang.version:vendored_context" {
+    \$if (\$mach.version != "$compiler_ver") { ret 1; }
+    \$if (\$mach.version.major != $compiler_major) { ret 1; }
+    ret 0;
+}
 
 #[symbol("main")]
 fun main() i32 { ret 0; }


### PR DESCRIPTION
Integration merge of `dev` into `main` for the 4.20.0 release.

Seven entries since 4.19.0:

- driver: a retained session's reload cycle returns to a steady state (#3001)
- Tooling can retain compiler-owned frontend analysis (#2996)
- Project manifests no longer declare a minimum Mach version (#2953)
- Vendored frontends retain Mach's compiler version (#2954)
- Artifact builds compile only their reachable module graph (#2967)
- Target-split executables select the right artifact on every host (#2955, #2961, #2981)
- Character literals lower at their coerced integer width (#2982)

Carries the mach-std pin advance to 0.27.0 (briar-systems/mach-std#475), which #3001 needs for `toml.dnit`.

Opened from a throwaway branch rather than `dev` directly so auto-delete-head cannot remove a long-lived branch on merge. This PR runs the darwin lane as the release gate.