### PR TITLE
fix(driver): release every dependency's parsed manifest on a reload cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### driver: a reload cycle no longer leaks every dependency's parsed manifest (#3010)
+
+#3001 fixed the retained reload cycle for a project with **no dependencies**. Its
+regression fixture declares no `[dep.*]`, so it never reached dep resolution, the
+cascade scan, or the per-dep export-step walk - each of which parses a
+dependency's `mach.toml` of its own and dropped the table.
+
+The shipped 4.20.0 fix therefore read a clean zero on the fixture and leaked
+**~29.5 KB per cycle on any real project**. Measured on mach itself, 225 modules
+and one `[dep.mach-std]`, through a counting allocator: 29577 bytes per round
+before, zero after.
+
+Four sites: `free_cascade_scratch` released the `tables` array but not the tree
+under each slot, `resolve_dep` released none of its eight return paths, the
+sub-dep scan dropped its table at the end of the block, and the per-dep
+export-step walk plus the two `load_config` entries owned tables they treated as
+borrowed. Three test helpers leaked the same way, which matters because a leaking
+helper can mask a real leak in a counting-allocator test.
+
+**The new fixture declares a real vendored dependency and asserts `dep_count > 0`
+before measuring**, so it cannot quietly degrade into the no-dep fixture it exists
+to complement. That assertion is the actual fix here: the defect was not that four
+teardowns were missed, it was that the only test covering them could not fail.
+
 ## [4.20.0] - 2026-08-20
 
 ### Fixed

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -1567,6 +1567,7 @@ fun ut_manifest_src(a: *A.Allocator, itn: *intern.Interner, src: str, out_m: *ma
     if (R.is_err[toml.Table, str](tr)) { ret false; }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](tr);
     val mr: R.Result[manifest.Manifest, str] = manifest.parse(a, itn, ?t, true);
+    toml.dnit(a, ?t);
     if (R.is_err[manifest.Manifest, str](mr)) { ret false; }
     @out_m = R.unwrap_ok[manifest.Manifest, str](mr);
     ret true;

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -82,6 +82,7 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *mani
 
     var itn: intern.Interner = intern.init(alloc);
     val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t, true);
+    toml.dnit(alloc, ?t);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
@@ -118,7 +119,10 @@ pub fun load_project_config(p: *project.Project, project_root: str, manifest_pat
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[bool, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
-    ret load_config(p, project_root, ?t, sel, for_union, is_test);
+    # the table is this call's own; load_config only borrows it (#3001)
+    val r: R.Result[bool, str] = load_config(p, project_root, ?t, sel, for_union, is_test);
+    toml.dnit(p.alloc, ?t);
+    ret r;
 }
 
 # parse the manifest out of its toml table, synthesize the ProjectConfig, and
@@ -1395,7 +1399,9 @@ pub fun execute_dep_steps(p: *project.Project, isa: str, os: str, abi: str) R.Re
         var tbl: toml.Table = R.unwrap_ok[toml.Table, str](pr);
 
         # a dependency's manifest: as_root false, parsed permissively (#1971).
+        # the Manifest interns everything it keeps, so the table is dead here (#3001).
         val mf_r: R.Result[manifest.Manifest, str] = manifest.parse(p.alloc, ?p.s.interner, ?tbl, false);
+        toml.dnit(p.alloc, ?tbl);
         if (R.is_err[manifest.Manifest, str](mf_r)) { ret R.err[bool, str](R.unwrap_err[manifest.Manifest, str](mf_r)); }
         var mfd: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mf_r);
 

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -173,6 +173,7 @@ fun resolve_deps_recursive(p: *project.Project, current_root: str, dep_names: *m
                     str_free(p.alloc, toml_path);
                     if (R.is_ok[toml.Table, str](tr)) {
                         var t: toml.Table = R.unwrap_ok[toml.Table, str](tr);
+                        fin { toml.dnit(p.alloc, ?t); }
                         val dep_tab: *toml.Table = toml.get_table(?t, "dep");
                         if (dep_tab != nil) {
                             val sub_dep_count: usize = toml.table_len(dep_tab);
@@ -288,6 +289,10 @@ fun free_cascade_scratch(alloc: *A.Allocator, manifests: *manifest.Manifest, tab
     var i: u32 = 0;
     for (i < n) { manifest.dnit(?manifests[i], alloc); i = i + 1; }
     A.deallocate[manifest.Manifest](alloc, manifests, n::usize);
+    # each parsed dep manifest is a per-call tree, not just an array slot: the
+    # slot's storage goes with the array, the tree under it does not (#3001)
+    i = 0;
+    for (i < n) { toml.dnit(alloc, ?tables[i]); i = i + 1; }
     A.deallocate[toml.Table](alloc, tables, n::usize);
     A.deallocate[str](alloc, aliases, n::usize);
     A.deallocate[u32](alloc, order, n::usize);
@@ -568,7 +573,7 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     if (str_empty(id_str)) {
         val msg: str = load.diag_join3(s, "dep '", alias, "' mach.toml is missing [project].id", "dep mach.toml is missing [project].id");
         str_free(s.build_alloc, dep_dir);
-        ret R.err[project.DepEntry, str](msg);
+        toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](msg);
     }
 
     var entry: project.DepEntry;
@@ -576,14 +581,14 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     val ra: R.Result[intern.StrId, str] = intern.intern(?s.interner, alias);
     if (R.is_err[intern.StrId, str](ra)) {
         str_free(s.build_alloc, dep_dir);
-        ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](ra));
+        toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](ra));
     }
     entry.alias = R.unwrap_ok[intern.StrId, str](ra);
 
     val rp: R.Result[intern.StrId, str] = intern.intern(?s.interner, id_str);
     if (R.is_err[intern.StrId, str](rp)) {
         str_free(s.build_alloc, dep_dir);
-        ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rp));
+        toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rp));
     }
     entry.project_id = R.unwrap_ok[intern.StrId, str](rp);
 
@@ -592,7 +597,7 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     val rds: R.Result[intern.StrId, str] = intern_or(?s.interner, toml.get_str(?t, "project.src"), "src");
     if (R.is_err[intern.StrId, str](rds)) {
         str_free(s.build_alloc, dep_dir);
-        ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rds));
+        toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rds));
     }
     entry.project_dir_src = R.unwrap_ok[intern.StrId, str](rds);
 
@@ -636,12 +641,12 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
         if (!module_file_present(s.build_alloc, dep_dir, dep_src_text, dep_entry_file)) {
             val msg: str = load.diag_join_named(s, "dep '", entry.alias, "' mach.toml: default entry names no file", "dep mach.toml: default entry names no file");
             str_free(s.build_alloc, dep_dir);
-            ret R.err[project.DepEntry, str](msg);
+            toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](msg);
         }
         val rmd: R.Result[intern.StrId, str] = intern.intern(?s.interner, dep_entry_file);
         if (R.is_err[intern.StrId, str](rmd)) {
             str_free(s.build_alloc, dep_dir);
-            ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rmd));
+            toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rmd));
         }
         entry.project_module = R.unwrap_ok[intern.StrId, str](rmd);
     }
@@ -649,12 +654,12 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     val rvr: R.Result[intern.StrId, str] = intern.intern(?s.interner, dep_dir);
     if (R.is_err[intern.StrId, str](rvr)) {
         str_free(s.build_alloc, dep_dir);
-        ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rvr));
+        toml.dnit(s.build_alloc, ?t); ret R.err[project.DepEntry, str](R.unwrap_err[intern.StrId, str](rvr));
     }
     entry.vendor_root = R.unwrap_ok[intern.StrId, str](rvr);
 
     str_free(s.build_alloc, dep_dir);
-    ret R.ok[project.DepEntry, str](entry);
+    toml.dnit(s.build_alloc, ?t); ret R.ok[project.DepEntry, str](entry);
 }
 
 # compose a dependency's vendor root path `<project_root>/<dir_dep>/<alias>`

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -20656,3 +20656,95 @@ test "mach.lang.driver:retained_reload_cycle_reaches_steady_state" {
     fs.remove_all(?alloc, root);
     ret bad;
 }
+
+
+# a root manifest that declares one vendored dependency, so the reload cycle
+# reaches the dep-resolution and cascade paths the plain fixture never touches
+fun ut_manifest_with_dep() str {
+    ret "[project]\nid = \"ctxcase\"\nversion = \"1.2.3\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[dep.leaf]\npath = \"dep/leaf\"\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# scaffold `<root>/dep/leaf/` as a vendored dependency beside the project's own
+# sources, matching the layout `mach dep pull` produces
+fun ut_scaffold_dep(alloc: *A.Allocator, root: str) bool {
+    val dep_root: str = ut_cc3(alloc, root, "/dep/", "leaf");
+    if (O.is_some[str](fs.create_dir_all(alloc, dep_root, 493))) { ret false; }
+    val dep_src: str = ut_cc3(alloc, dep_root, "/", "src");
+    if (O.is_some[str](fs.create_dir_all(alloc, dep_src, 493))) { ret false; }
+
+    val dm: str = "[project]\nid = \"leaf\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.leaf]\nkind = \"static\"\nentry = \"leaf.mach\"\nout = \"lib/leaf.a\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    val dmp: str = ut_cc3(alloc, dep_root, "/", manifest.MANIFEST_FILE);
+    if (O.is_some[str](fs.write_bytes(dmp, dm, str_len(dm), 420))) { ret false; }
+
+    val ds: str = "pub fun leaf_value() i32 { ret 7; }\n";
+    val dsp: str = ut_cc3(alloc, dep_src, "/", "leaf.mach");
+    if (O.is_some[str](fs.write_bytes(dsp, ds, str_len(ds), 420))) { ret false; }
+    ret true;
+}
+
+# The dep-bearing twin of the cycle above (#3001).
+#
+# THE FIXTURE'S SHAPE IS THE POINT. A manifest with no `[dep.*]` never reaches
+# dep resolution, the cascade scan, or the per-dep export-step walk, and each of
+# those parses a dependency's `mach.toml` of its own. The first fix left all of
+# them leaking and the plain fixture could not see it: a real project measured
+# ~29.5 KB per round while the no-dep fixture read a clean zero.
+test "mach.lang.driver:retained_reload_cycle_with_a_dependency_is_steady" {
+    var lb: LiveBytes;
+    var alloc: A.Allocator;
+    if (!live_bytes_make(?lb, ?alloc)) { ret 1; }
+
+    var names: [1]str;
+    names[0] = "beta.mach";
+    var texts: [1]str;
+    texts[0] = "use leaf.leaf;\nfun main() i32 { ret leaf.leaf_value(); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(
+        ?alloc, ut_manifest_with_dep(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    if (!ut_scaffold_dep(?alloc, root)) { fs.remove_all(?alloc, root); ret 3; }
+
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { fs.remove_all(?alloc, root); ret 4; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var bad:     i32 = 0;
+    var settled: i64 = 0;
+    var round:   i32 = 0;
+    for (round < 5) {
+        val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+        if (R.is_err[manifest.Manifest, str](mr)) { bad = 5; brk; }
+        var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+        # the dependency must actually be declared, or this is the plain fixture
+        # wearing a different name and proves nothing
+        if (mf.dep_count == 0) { manifest.dnit(?mf, ?alloc); bad = 6; brk; }
+
+        var req: request.BuildRequest = request.defaults();
+        req.project_root = root;
+        req.target       = "windows";
+        req.profile      = "release";
+        req.artifact     = "beta";
+        req.want_lib     = false;
+        req.goal         = request.GOAL_OBJECTS;
+        req.opt          = pipeline.OPT_RELEASE;
+        req.pie          = true;
+
+        val pr: R.Result[project.Project, outcome.Fail] =
+            driver.analyze_project(?s, ?mf, ?req, nil, 0);
+        if (R.is_err[project.Project, outcome.Fail](pr)) {
+            manifest.dnit(?mf, ?alloc); bad = 7; brk;
+        }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p);
+        manifest.dnit(?mf, ?alloc);
+
+        if (round == 2) { settled = lb.live; }
+        if (round > 2 && lb.live != settled) { bad = 8; brk; }
+        round = round + 1;
+    }
+
+    session.dnit(?s);
+    fs.remove_all(?alloc, root);
+    ret bad;
+}
+

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2702,7 +2702,9 @@ fun tparse(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Result[Manife
     val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
     if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
     var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
-    ret parse(alloc, itn, ?tbl, true);
+    val m: R.Result[Manifest, str] = parse(alloc, itn, ?tbl, true);
+    toml.dnit(alloc, ?tbl);
+    ret m;
 }
 
 # parse a manifest permissively, as a dependency's manifest is parsed: used to
@@ -2712,7 +2714,9 @@ fun tparse_lenient(alloc: *A.Allocator, itn: *intern.Interner, src: str) R.Resul
     val tbl_r: R.Result[toml.Table, str] = toml.parse(alloc, src);
     if (R.is_err[toml.Table, str](tbl_r)) { ret R.err[Manifest, str](R.unwrap_err[toml.Table, str](tbl_r)); }
     var tbl: toml.Table = R.unwrap_ok[toml.Table, str](tbl_r);
-    ret parse(alloc, itn, ?tbl, false);
+    val m: R.Result[Manifest, str] = parse(alloc, itn, ?tbl, false);
+    toml.dnit(alloc, ?tbl);
+    ret m;
 }
 
 test "mach.lang.manifest.is_valid_id" {


### PR DESCRIPTION
Closes #3010. Completes #3001, which fixed the cycle only for a project with **no dependencies**.

## The gap

#3001's regression fixture declares no `[dep.*]`. That fixture never reaches dep resolution, the cascade scan, or the per-dep export-step walk — and each of those parses a dependency's `mach.toml` of its own and dropped the table.

So the shipped 4.20.0 fix read a clean zero on the fixture while leaking on every real project. Measured on mach itself (225 modules, one `[dep.mach-std]`) through a counting allocator:

| | 4.20.0 | this PR |
|---|---:|---:|
| no-dep fixture | 0 B/round | 0 B/round |
| **225 modules, one dep** | **29577 B/round** | **0 B/round** |

Under `std.allocator.page`, which maps every allocation separately, ~29.5 KB of requests is a few MiB of RSS per cycle — the same order as #3001's original report, which suggests this was always most of what mach-lsp actually felt.

## Sites

- `free_cascade_scratch` deallocated the `tables` **array** but not the tree under each slot.
- `resolve_dep` released `t` on none of its eight return paths.
- The sub-dep scan dropped its table at the end of the block.
- The per-dep export-step walk, plus `load_project_config` and the doc/union entry, owned tables they treated as borrowed.
- Three test helpers (`ut_manifest_src`, `tparse`, `tparse_lenient`) leaked the same way. Harmless to users, but a leaking helper can mask a real leak in a counting-allocator test.

The two CLI sites (`cmd/clean.mach`, `cmd/dep.mach`) are one-shot commands with no retained session and are deliberately untouched.

## The actual fix

**The new fixture declares a real vendored dependency and asserts `dep_count > 0` before measuring**, so it cannot quietly degrade into the no-dep fixture it exists to complement. The defect was not that four teardowns were missed — it was that the only test covering them could not fail.

## Verification

- **1487 passed, 0 failed** on `release` and `debug`.
- **Fixpoint:** three generations byte-identical.
- **Mutation-checked:** removing the cascade teardown fails the new dep test (exit 8) while the existing no-dep test still passes — reproducing the exact coverage gap that let this ship.
- The tests.mach diff against `dev` is purely additive (no removed lines), checked deliberately after last PR's instrumentation bleed.