### PR TITLE
chore: release 4.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.20.1] - 2026-08-20
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.20.0"
+version = "4.20.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.20.0";
+pub val MACH_VERSION: str = "4.20.1";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Patch release for #3010: 4.20.0's leak fix was incomplete for any project with dependencies, leaking ~29.5 KB per reload cycle where the no-dep fixture read zero.

One entry, a fix, so a patch bump. Bumps `mach.toml` and `MACH_VERSION` together.