### PR TITLE
fix(sema): a layout intrinsic adopts the width its binding declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### sema: a layout intrinsic adopts the width its binding declares (#2934, #2946)
+
+`$size_of` / `$align_of` / `$length_of` / `$offset_of` folded to a flat `u64`, so
+`val POINT_SIZE: i64 = $size_of(Point);` — **the example in
+`doc/language/comptime-intrinsics.md`** — did not compile, and the prose beside it
+promising the binding's width was simply false.
+
+A layout measurement is now an **untyped comptime integer, exactly like an integer
+literal**. It names a constant the compiler already knows, so putting it in a
+narrower binding is a choice of representation rather than a conversion — the same
+thing `val x: u8 = 5;` has always done. It is refused, never truncated, when the
+measured value does not fit.
+
+**This is what stopped every 32-bit target compiling.** `mach-std` selects
+`usize` from `$mach.build.pointer_width`, which was always correct — 4 on
+riscv32 — so `usize` was `u32` there while `$size_of(usize)` stayed `u64`, and
+`memory.mach`'s `val step: usize = $size_of(usize);` failed inside the dependency
+before any user code was reached. On a 64-bit target the two happened to be the
+same type, so mach-std had been compiling **by coincidence**. It now builds for
+riscv32/ilp32 with no change to mach-std itself.
+
+The measurement is not repeated to do this: the coercion folds through the same
+`layout_fn` resolver an array length and a `$if` gate go through, so a size
+measured in a binding and the same size measured in a gate cannot disagree. The
+fold is speculative and stays silent, so `$size_of(T)` inside a generic body — no
+layout until the instantiation supplies `T` — commits the width and is
+range-checked when the instance is checked.
+
+`$offset_of` moves with its siblings but is checked later: a field's offset is
+decided at lowering, so that is where its value is verified against the binding.
+That check is new, and closes a hole it exposed — a 300-byte offset placed in a
+`u8` was previously written as 44, silently.
+
+An out-of-range diagnostic now names what was actually written: `literal 300` for
+a literal, `value 300` for a measurement or a folded comptime path.
+
 ## [4.20.1] - 2026-08-20
 
 ### Fixed

--- a/doc/language/comptime-intrinsics.md
+++ b/doc/language/comptime-intrinsics.md
@@ -11,6 +11,27 @@ The set is closed; adding a new intrinsic requires a compiler change.
 Return comptime constant unsigned integers. The storage type is whatever
 the binding declares — Mach has no compiler-known `usize`.
 
+A layout measurement is an **untyped comptime integer**, exactly like an integer
+literal: it names a constant the compiler already knows, so putting it in a
+narrower binding is a choice of representation rather than a conversion. It
+adopts the binding's width and signedness, and is **refused** — never truncated —
+when the measured value does not fit:
+
+```mach
+rec Point { x: i64; y: i64; }
+
+val A: u8    = $size_of(Point);   # 16, stored in one byte
+val B: i64   = $size_of(Point);   # the same 16, stored in eight
+val C: usize = $size_of(usize);   # correct at any pointer width
+
+rec Huge { a: [300]u8; }
+val D: u8 = $size_of(Huge);       # error: value 300 is out of range for u8 (0..255)
+```
+
+Without a binding to read a width from — an array length, an `#[align(...)]`
+argument, a comparison against a typed value — the measurement behaves the way a
+literal does in the same position.
+
 ```mach
 $size_of(T)             # byte size of type T
 $length_of(T)           # ELEMENT count of type T
@@ -36,6 +57,12 @@ fun probe[T]() u64 {
 
 `$offset_of`'s **second** argument is the exception: a bare field name, resolved
 against the record's layout, never a type or a value.
+
+`$offset_of` adopts its binding's width like the other three, but its answer is
+decided later than the others': a field's offset is fixed at lowering, so it is
+the one measurement that cannot be read in a `$if` gate, and the check that its
+value fits the binding happens at lowering rather than during type checking. The
+diagnostic is the same either way.
 
 ### `$length_of` — elements, not bytes
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1288,6 +1288,15 @@ fun ut_lower_rejects(src: str, needle: str) i32 {
     ret code;
 }
 
+# concatenate a snippet prologue and body into one `main.mach` source with an
+# entry point, for the layout-intrinsic tests
+fun ut_cc_src(pre: str, body: str) str {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret body; }
+    val head: str = ut_cc3(?alloc, pre, body, "fun main() i32 { ret 0; }\n");
+    ret head;
+}
+
 # 0 when `src` passes sema + lower cleanly (no error on the sink); 1 otherwise. the
 # clean-compile sibling of `ut_lower_rejects`, for confirming a secrecy-transparent
 # instance is NOT required to carry `#[oblivious]` (#2136)
@@ -20748,3 +20757,100 @@ test "mach.lang.driver:retained_reload_cycle_with_a_dependency_is_steady" {
     ret bad;
 }
 
+
+
+# 0 when `src` passes sema and then FAILS lowering with a diagnostic containing
+# `needle`; 1 on any other outcome. `$offset_of` is decided at lowering, so a
+# measurement that does not fit its binding can only be caught there.
+fun ut_lower_diag(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var code: i32 = 1;
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](se)) {
+        passes.run_lower_pass(?p);
+        if (ut_diag_has(?p.s.diags, needle)) { code = 0; }
+    }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret code;
+}
+
+# A LAYOUT INTRINSIC IS AN UNTYPED COMPTIME INTEGER (#2934/#2946).
+#
+# It measures a constant the compiler already knows, so landing it in a narrower
+# binding is a choice of representation, not a conversion - the same thing
+# `val x: u8 = 5;` does. Typed `u64` flat, `val step: usize = $size_of(usize);`
+# compiled only where `usize` happens to BE `u64`, so mach-std built on lp64 by
+# coincidence and no ilp32 target could compile it at all.
+test "mach.lang.fe.sema:layout_intrinsic_adopts_the_binding_width" {
+    var bad: i32 = 0;
+    val pre: str = "rec P { x: i64; y: i64; }\n";
+
+    # $size_of at every integer width, signed and unsigned
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: u8  = $size_of(P);\n"))) { bad = 1; }
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: u16 = $size_of(P);\n"))) { bad = 2; }
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: u32 = $size_of(P);\n"))) { bad = 3; }
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: u64 = $size_of(P);\n"))) { bad = 4; }
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: i32 = $size_of(P);\n"))) { bad = 5; }
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: i64 = $size_of(P);\n"))) { bad = 6; }
+
+    # the other two measurements sema can fold move with it
+    if (!ut_sema_clean(ut_cc_src(pre, "val A: u8  = $align_of(P);\n"))) { bad = 7; }
+    if (!ut_sema_clean(ut_cc_src("", "val A: u16 = $length_of([4]i32);\n"))) { bad = 8; }
+
+    # inside an expression, the measurement adopts the width of what it is
+    # combined with - which is the shape mach-std's `count * $size_of(T)` needs
+    if (!ut_sema_clean(ut_cc_src(pre, "val N: u32 = 3;\nval A: u32 = N * $size_of(P);\n"))) { bad = 9; }
+
+    # and through a generic, where the layout arrives with the instantiation
+    if (!ut_sema_clean(ut_cc_src(pre,
+        "fun sz[T]() u32 { var n: u32 = $size_of(T); ret n; }\nfun use_it() u32 { ret sz[P](); }\n"))) { bad = 10; }
+    ret bad;
+}
+
+# The width is adopted, not the range: a measurement too large for the binding is
+# refused rather than truncated, exactly as an over-large literal is.
+test "mach.lang.fe.sema:layout_intrinsic_too_wide_for_its_binding_is_refused" {
+    var bad: i32 = 0;
+    if (ut_vec_diag("rec Huge { a: [300]u8; }\nval A: u8 = $size_of(Huge);\nfun main() i32 { ret 0; }\n",
+                    "value 300 is out of range for u8") != 0) { bad = 1; }
+    # a signed binding is bounded by its signed maximum, not its bit width
+    if (ut_vec_diag("rec Big { a: [200]u8; }\nval A: i8 = $size_of(Big);\nfun main() i32 { ret 0; }\n",
+                    "is out of range for i8") != 0) { bad = 2; }
+    ret bad;
+}
+
+# A measurement is an integer and takes no other destination; a float binding gets
+# the ordinary mismatch rather than a silent reinterpretation.
+test "mach.lang.fe.sema:layout_intrinsic_declines_a_non_integer_binding" {
+    var bad: i32 = 0;
+    if (ut_vec_diag("rec P { x: i64; }\nval A: f64 = $size_of(P);\nfun main() i32 { ret 0; }\n",
+                    "type mismatch") != 0) { bad = 1; }
+    ret bad;
+}
+
+# `$offset_of` adopts the binding's width like its siblings, but its answer is
+# decided at LOWERING, later than any fold sema has - so the range check that
+# protects the others has to live there too. Without it a 300-byte offset was
+# written into a `u8` as 44, silently.
+test "mach.lang.me.lower:offset_of_too_wide_for_its_binding_is_refused" {
+    var bad: i32 = 0;
+    if (ut_lower_diag("rec Wide { pad: [300]u8; tail: i32; }\nval A: u8 = $offset_of(Wide, tail);\nfun main() i32 { ret 0; }\n",
+                      "a layout measurement does not fit") != 0) { bad = 1; }
+    # a binding wide enough is unaffected
+    if (!ut_sema_clean("rec Wide { pad: [300]u8; tail: i32; }\nval A: u32 = $offset_of(Wide, tail);\nfun main() i32 { ret 0; }\n")) { bad = 2; }
+    ret bad;
+}

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -1473,7 +1473,7 @@ fun declaring_module_fqn(sc: *context.SemaContext, t: type.TypeId) intern.StrId 
 fun report_out_of_range(sc: *context.SemaContext, span: token.Span, cr: coerce.CoerceResult) {
     val res_type: R.Result[str, str] = type_to_str(sc, cr.ty);
     if (R.is_err[str, str](res_type)) {
-        report(sc, span, "integer literal out of range for its type");
+        report(sc, span, "integer value out of range for its type");
         ret;
     }
     val type_str: str            = R.unwrap_ok[str, str](res_type);
@@ -1486,10 +1486,12 @@ fun report_out_of_range(sc: *context.SemaContext, span: token.Span, cr: coerce.C
     if (cr.negated)         { sign = "-"; }
     if (bounds.min_negated) { min_sign = "-"; }
 
-    val res_msg: R.Result[str, str] = format.sprint(sc.s.alloc, "literal {}{} is out of range for {} ({}{}..{})",
-        sign, cr.value::usize, type_str, min_sign, bounds.min_mag::usize, bounds.max_mag::usize);
+    var noun: str = "value";
+    if (cr.literal) { noun = "literal"; }
+    val res_msg: R.Result[str, str] = format.sprint(sc.s.alloc, "{} {}{} is out of range for {} ({}{}..{})",
+        noun, sign, cr.value::usize, type_str, min_sign, bounds.min_mag::usize, bounds.max_mag::usize);
     if (R.is_err[str, str](res_msg)) {
-        report(sc, span, "integer literal out of range for its type");
+        report(sc, span, "integer value out of range for its type");
         type_str_free(sc, type_str);
         ret;
     }

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -88,6 +88,12 @@ pub rec CoerceResult {
     value:   u64;
     negated: bool;
     bounds:  IntBounds;
+
+    # what the out-of-range constant was SPELLED as, so the diagnostic can name it:
+    # true for a literal the author wrote, false for one a fold produced (a layout
+    # measurement, a comptime path). "literal 300" is the wrong noun for
+    # `$size_of(Huge)`, and "value 300" is the weaker one for `300` (#2934).
+    literal: bool;
 }
 
 # a zeroed IntBounds, for results that carry no range
@@ -135,13 +141,14 @@ fun applicable(to: type.TypeId) CoerceResult {
 # negated: whether the literal is negated
 # bounds:  the destination's inclusive value range
 # ret:     a CoerceResult with kind COERCE_OUT_OF_RANGE
-fun out_of_range(to: type.TypeId, value: u64, negated: bool, bounds: IntBounds) CoerceResult {
+fun out_of_range(to: type.TypeId, value: u64, negated: bool, bounds: IntBounds, literal: bool) CoerceResult {
     var r: CoerceResult;
     r.kind    = COERCE_OUT_OF_RANGE;
     r.ty      = to;
     r.value   = value;
     r.negated = negated;
     r.bounds  = bounds;
+    r.literal = literal;
     ret r;
 }
 
@@ -219,10 +226,10 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
     val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
 
     if (e.kind == expr.EXPR_KIND_LIT_INT) {
-        ret coerce_int_literal(sc, eid, e.data.lit_int, to, negated);
+        ret coerce_int_literal(sc, eid, e.data.lit_int, to, negated, true);
     }
     if (e.kind == expr.EXPR_KIND_LIT_CHAR) {
-        ret coerce_int_literal(sc, eid, e.data.lit_char::u64, to, negated);
+        ret coerce_int_literal(sc, eid, e.data.lit_char::u64, to, negated, true);
     }
     if (e.kind == expr.EXPR_KIND_LIT_FLOAT) {
         if (to != type.TYPE_F32 && to != type.TYPE_F64) { ret not_applicable(); }
@@ -238,6 +245,9 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
     }
     if (e.kind == expr.EXPR_KIND_COMPTIME_IDENT || e.kind == expr.EXPR_KIND_MEMBER) {
         ret coerce_comptime_int_path(sc, eid, to, negated);
+    }
+    if (e.kind == expr.EXPR_KIND_CALL) {
+        ret coerce_layout_intrinsic(sc, eid, to, negated);
     }
     if (e.kind == expr.EXPR_KIND_UNARY) {
         ret coerce_unary(sc, eid, ?e.data.unary, to, negated);
@@ -266,11 +276,11 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
 # to:      the destination TypeId
 # negated: true when the literal sits under an odd number of unary `-`
 # ret:     COERCED, OUT_OF_RANGE, or NOT_APPLICABLE per the destination
-fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: type.TypeId, negated: bool) CoerceResult {
+fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: type.TypeId, negated: bool, literal: bool) CoerceResult {
     val opt_bounds: O.Option[IntBounds] = int_bounds_of(sc, to);
     if (O.is_none[IntBounds](opt_bounds)) { ret not_applicable(); }
     val bounds: IntBounds = O.unwrap[IntBounds](opt_bounds);
-    if (!fits_bounds(v, negated, bounds)) { ret out_of_range(to, v, negated, bounds); }
+    if (!fits_bounds(v, negated, bounds)) { ret out_of_range(to, v, negated, bounds, literal); }
     ret commit(sc, eid, to);
 }
 
@@ -297,12 +307,26 @@ fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.
     if (R.is_err[comptime.CTValue, str](res_eval)) { ret not_applicable(); }
     val ctval: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](res_eval);
 
+    ret coerce_ct_int(sc, eid, ctval, to, negated);
+}
+
+# range-check an already-folded comptime integer against `to` and commit
+#
+# The shared tail of every folded-constant arm. The fold already produced a
+# definite value, so its magnitude and sign are derived rather than reading the
+# raw i64 as a u64: a negative signed fold has a real magnitude and an implicit
+# negation that compose with the surrounding unary `-`, and reading it as a
+# near-max u64 would reject values that fit.
+# ---
+# sc:      the active sema context
+# eid:     the expression to retype on success
+# ctval:   the folded constant
+# to:      the destination TypeId
+# negated: true when the expression sits under an odd number of unary `-`
+# ret:     COERCED, OUT_OF_RANGE, or NOT_APPLICABLE per the destination
+fun coerce_ct_int(sc: *context.SemaContext, eid: id.ExprId, ctval: comptime.CTValue, to: type.TypeId, negated: bool) CoerceResult {
     if (ctval.kind != comptime.CT_KIND_INT) { ret not_applicable(); }
 
-    # the path already folded to a definite value, so derive its magnitude and
-    # sign rather than reading the raw i64 as a u64. a negative signed fold has a
-    # real magnitude and an implicit negation that compose with the surrounding
-    # unary `-`; reading it as a near-max u64 would reject values that fit.
     val raw: i64 = ctval.data.i;
     var mag: u64 = raw:~u64;
     var value_negated: bool = false;
@@ -314,7 +338,72 @@ fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.
     var negated_total: bool = negated;
     if (value_negated) { negated_total = !negated; }
 
-    ret coerce_int_literal(sc, eid, mag, to, negated_total);
+    ret coerce_int_literal(sc, eid, mag, to, negated_total, false);
+}
+
+# coerce a layout intrinsic (`$size_of` / `$align_of` / `$length_of`) to a
+# destination integer type
+#
+# A LAYOUT INTRINSIC IS AN UNTYPED COMPTIME INTEGER, exactly like a literal
+# (#2934/#2946). It measures a constant the compiler already knows, so there is no
+# conversion to perform when it lands in a narrower binding - only a choice of
+# representation, which is the same thing `val x: u8 = 5;` does. Typing it `u64`
+# flat meant `val step: usize = $size_of(usize);` compiled only where `usize`
+# happens to BE `u64`, so mach-std built on lp64 by coincidence and no ilp32
+# target could compile it at all.
+#
+# THE MEASUREMENT IS NOT REPEATED HERE. `comptime.eval` routes a layout intrinsic
+# through the `layout_fn` resolver sema installs, which is the same
+# `fold_layout_intrinsic` an array length and a `$if` gate go through - so a size
+# measured in a binding and the same size measured in a gate cannot disagree.
+#
+# `$offset_of` DECLINES, and not by omission: a field's offset is decided at
+# lowering, later than any fold available here, so the evaluator refuses it and
+# this returns NOT_APPLICABLE. It keeps its `u64` typing and an explicit cast,
+# which is the honest answer while sema has no offset to range-check against.
+# ---
+# sc:      the active sema context
+# eid:     the call expression to coerce
+# to:      the destination TypeId
+# negated: true when the call sits under an odd number of unary `-`
+# ret:     COERCED when the measured constant fits `to`, OUT_OF_RANGE when it
+#          overflows an integer `to`, else NOT_APPLICABLE
+fun coerce_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) CoerceResult {
+    # every other call is a runtime value and coerces to nothing
+    if (!comptime.is_layout_intrinsic_call(sc.a, sc.source, eid)) { ret not_applicable(); }
+
+    # a layout measure is an integer and takes no other destination; a float or
+    # pointer slot gets the plain mismatch its own diagnostic describes
+    if (O.is_none[IntBounds](int_bounds_of(sc, to))) { ret not_applicable(); }
+
+    # THE FOLD HERE IS SPECULATIVE AND MUST NOT REPORT. `$size_of(T)` inside a
+    # generic body has no measurable layout until the instantiation supplies `T`,
+    # and an assignability probe is not the place to announce that - the episode
+    # is asking "could this take that type", not "measure this now".
+    val saved_silent: bool = sc.silent;
+    sc.silent = true;
+    val res_eval: R.Result[comptime.CTValue, str] =
+        comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+    sc.silent = saved_silent;
+
+    if (R.is_ok[comptime.CTValue, str](res_eval)) {
+        val ctval: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](res_eval);
+        if (ctval.kind == comptime.CT_KIND_INT) {
+            ret coerce_ct_int(sc, eid, ctval, to, negated);
+        }
+    }
+
+    # MEASURABLE LATER, NOT NEVER. Two intrinsics reach here: `$size_of(T)` on a
+    # generic parameter, whose layout arrives with the instantiation, and
+    # `$offset_of`, whose answer is decided at lowering by design. Both are still
+    # comptime constants of the width the binding declares, so the type commits
+    # here and the VALUE is range-checked where it is finally known - the lowering
+    # fold refuses a measure too wide for the slot rather than truncating it.
+    #
+    # Declining instead would leave them `u64`, which is exactly the defect: on an
+    # ilp32 target `$size_of(T) * count` against a `usize` count is the mismatch
+    # that stopped mach-std compiling at all (#2934).
+    ret commit(sc, eid, to);
 }
 
 # coerce a unary `-`/`~` node by coercing its operand to `to`

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -423,10 +423,25 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
             # fileless message. the diagnostic gates the build; a zero placeholder
             # is still emitted so any reference to this global resolves against a
             # real symbol instead of cascading into spurious errors.
-            val res_diag: R.Result[bool, str] = diag_named(ctx, d.data.bind.name, bare,
-                "global initialiser of `", "` must be a constant expression",
-                "a global initialiser must be a constant expression");
-            if (R.is_err[bool, str](res_diag)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_diag)); }
+            #
+            # A FOLD FAILURE THAT ALREADY EXPLAINS ITSELF IS NOT RESTATED as "must be
+            # a constant expression", which would be false for it: a layout
+            # measurement too wide for its binding IS constant, it just does not fit.
+            # The two are told apart by the `lower:` prefix this module puts on its
+            # internal failures, so a message written for a user surfaces verbatim
+            # and an internal one keeps the located, symbol-naming form (#2934).
+            val fold_err: str = R.unwrap_err[value.Value, str](res_fold);
+            if (is_internal_err(fold_err)) {
+                val res_diag: R.Result[bool, str] = diag_named(ctx, d.data.bind.name, bare,
+                    "global initialiser of `", "` must be a constant expression",
+                    "a global initialiser must be a constant expression");
+                if (R.is_err[bool, str](res_diag)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_diag)); }
+            }
+            or {
+                val res_diag2: R.Result[bool, str] =
+                    diagnostic.error(?ctx.s.diags, ctx.a.file_id, d.data.bind.name, fold_err);
+                if (R.is_err[bool, str](res_diag2)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_diag2)); }
+            }
         }
         or {
             init_val = R.unwrap_ok[value.Value, str](res_fold);
@@ -764,6 +779,28 @@ fun free_pack_param_bufs(ctx: *context.LowerContext, params: *value.Value, total
 # suffix:   text after the name
 # fallback: message used when the name cannot be composed
 # ret:      true once the diagnostic is recorded, or an allocation error
+# whether a fold failure is one of this module's internal messages rather than one
+# written to be read by a user
+#
+# Every internal failure here is spelled with a `lower:` prefix; a message meant
+# for the author of the source carries none. The distinction decides whether a
+# global's initialiser failure is restated as "must be a constant expression" or
+# surfaced as written (#2934).
+# ---
+# msg: the failure message
+# ret: true when the message is internal
+fun is_internal_err(msg: str) bool {
+    val p: str = "lower:";
+    val n: usize = str_len(p);
+    if (str_len(msg) < n) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        if (msg[i] != p[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
 fun diag_named(ctx: *context.LowerContext, span: token.Span, name_id: intern.StrId, prefix: str, suffix: str, fallback: str) R.Result[bool, str] {
     val opt_name: O.Option[str] = intern.lookup(?ctx.s.interner, name_id);
     if (O.is_none[str](opt_name)) {

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1670,6 +1670,30 @@ pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId,
         n = ir_type.byte_offset(?ctx.m.types, op_ir, field_ix, ctx.tgt);
     }
 
+    # THE SLOT MUST HOLD THE MEASURE (#2934). A layout intrinsic adopts the width
+    # the binding declares, so the constant is built at `rt` rather than at a flat
+    # u64 - and a measure too wide for that slot would otherwise be written with
+    # its high bits cut off, silently: a 300-byte offset into a `u8` emitted 44.
+    #
+    # Sema range-checks the three intrinsics it can fold, so in practice only
+    # `$offset_of` reaches here unchecked: a field's offset is decided at lowering,
+    # later than any fold sema has. This is that check, at the one point the value
+    # and the destination width are both known.
+    val dst_ty: type.TypeId = type.strip_secret(?ctx.s.types, context.expr_type_of(ctx, eid));
+    val opt_dst: O.Option[*type.Type] = type.get(?ctx.s.types, dst_ty);
+    if (O.is_some[*type.Type](opt_dst)) {
+        val d: type.PrimDesc = type.prim_desc(O.unwrap[*type.Type](opt_dst).kind);
+        if (d.class == type.PRIM_CLASS_INT) {
+            var max: u64 = 0;
+            if (d.signed) { max = (1::u64 << (d.bits - 1)::usize) - 1; }
+            or            { max = ~(0::u64) >> (64 - d.bits)::usize; }
+            if (n::u64 > max) {
+                ret O.some[R.Result[value.Value, str]](R.err[value.Value, str](
+                    "a layout measurement does not fit the type it is assigned to; widen the binding or cast the measurement"));
+            }
+        }
+    }
+
     ret O.some[R.Result[value.Value, str]](R.ok[value.Value, str](value.const_int(n::u64, rt)));
 }
 


### PR DESCRIPTION
Closes #2934. Closes #2946.

**They are the same defect.** `$size_of` / `$align_of` / `$length_of` / `$offset_of` folded to a flat `u64`, so the example in `doc/language/comptime-intrinsics.md` did not compile and the prose beside it — "the storage type is whatever the binding declares" — was false.

## Why that stopped every 32-bit target

`pointer_width` was never wrong. I checked it directly: it reports 4 on riscv32 and 8 on x86_64, and mach-std correctly selects `usize = u32` from it. The whole failure is the intrinsic's type:

```mach
val step: usize = $size_of(usize);   # mach-std memory.mach:23
```

On lp64 `usize` **is** `u64`, so this compiled by coincidence. On ilp32 `usize` is `u32` and `$size_of` is still `u64`, so it failed inside the dependency before any user code was reached — which is why no 32-bit project could build at all.

## The rule

A layout measurement is an **untyped comptime integer, exactly like an integer literal**. It names a constant the compiler already knows, so a narrower binding is a choice of representation, not a conversion — the same thing `val x: u8 = 5;` has always done. Refused, never truncated, when the value does not fit.

## Design notes

- **The measurement is not duplicated.** `infer.mach` carries an explicit warning that a second copy of "force the layout, then ask `type_extent`" would let a size measured in an array length disagree with the same size in a `$if`. The coercion therefore folds through `comptime.eval`, which routes to the same `layout_fn` resolver sema installs — one measurement, three positions.
- **The fold is speculative, so it is silent.** `$size_of(T)` in a generic body has no layout until the instantiation supplies `T`; an assignability probe is not the place to say so. It commits the width and is range-checked when the instance is checked (verified: a 300-byte `T` into a `u8` is refused at the instantiation).
- **`$offset_of` is checked at lowering**, because that is where its answer is decided — by design, not omission. That check is new, and closes a hole the change exposed: a 300-byte offset placed in a `u8` was previously emitted as `0x2c` = 44, silently.
- A fold failure that explains itself is no longer restated as "must be a constant expression", which is false for a measurement that *is* constant and merely does not fit. Told apart by the `lower:` prefix this module already puts on its internal failures.
- The out-of-range diagnostic now names what was written: `literal 300` for a literal, `value 300` for a measurement or folded path.

## Verification

- **1491 passed, 0 failed** on `release` and `debug` (1487 before, 4 new).
- **Codegen corpus: 1416 pass, 0 fail** — no golden drift. The corpus casts its measurements explicitly, so it was unaffected, but that was worth proving rather than assuming.
- **mach-std compiles for riscv32/ilp32**, with no change to mach-std. rv64 still compiles.
- **The `doc/language/comptime-intrinsics.md` example compiles verbatim**, which is #2946's acceptance criterion.
- **Emitted values checked at the byte level**, not just accepted: a 64-byte record measured into `u8`/`u16`/`u32`/`u64` emits `40`, `4000`, `40000000`, `40…` — right value at every width.
- **Fixpoint:** three generations byte-identical.
- **Mutation-checked, both guards.** Removing the coercion arm fails 3 of the new tests; removing the lowering guard fails exactly the `$offset_of` one.
- The `tests.mach` diff against `dev` is purely additive (no removed lines).