### PR TITLE
fix(sema): refuse a comptime pack on a body-less fun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: a comptime pack on a body-less `fun` is refused where it is written (#3002)
+
+`va: ...` and a bare trailing `...` look alike and mean unrelated things. The first
+is a NAMED parameter carrying a mach comptime pack, monomorphized into one instance
+per call-site type list, each taking a mangled name that carries that list. The
+second is the C variadic an import declares. Only the second can cross a foreign
+boundary.
+
+Combining the first with a body-less `fun` compiled clean through codegen and failed
+at LINK, naming a symbol the source never wrote:
+
+```
+error: dynamic import 'raylib.raylib.TextFormat$pack$i32$i32' has no #[library] attribution
+```
+
+It is refused at the declaration now, and the refusal names the form that works.
+That matters more than the refusal: the two reports this came from (#3000, #2968)
+were not blocked by the language - calling a C variadic function has worked since
+v2.0.0 - they were blocked by not knowing the other spelling existed.
+
+Neither correct form moves. `ext fun printf(fmt: *u8, ...) i32;` and
+`fun fold(h: u64, va: ...) u64 { ... }` are both still accepted, which is what keeps
+this a diagnostic rather than a narrowing of the language.
+
 ## [4.21.0] - 2026-08-20
 
 ### Changed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1042,6 +1042,23 @@ fun ut_vec_diag(src: str, needle: str) i32 {
     ret 1;
 }
 
+# ut_vec_diag over a single module, asserting against the error's NOTE
+fun ut_vec_note(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val hit: bool = ut_diag_note_has(?p.s.diags, needle);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    if (hit) { ret 0; }
+    ret 1;
+}
+
 # ut_vec_diag over a two-module project: `main` is `main.mach`, `lib` is `lib.mach`,
 # reachable from main as `uniontest.lib`
 fun ut_vec_diag2(main: str, lib: str, needle: str) i32 {
@@ -20852,5 +20869,40 @@ test "mach.lang.me.lower:offset_of_too_wide_for_its_binding_is_refused" {
                       "a layout measurement does not fit") != 0) { bad = 1; }
     # a binding wide enough is unaffected
     if (!ut_sema_clean("rec Wide { pad: [300]u8; tail: i32; }\nval A: u32 = $offset_of(Wide, tail);\nfun main() i32 { ret 0; }\n")) { bad = 2; }
+    ret bad;
+}
+
+# A comptime pack and a C variadic look alike and mean unrelated things (#3002).
+#
+# `va: ...` is a NAMED parameter carrying a mach comptime pack, monomorphized into
+# one mangled instance per call-site type list. A bare trailing `...` is the C
+# variadic an import declares. Only the second can cross a foreign boundary, and
+# combining the first with a body-less `fun` used to compile clean through codegen
+# and fail at LINK naming `TextFormat$pack$i32$i32` - a symbol the source never
+# wrote. Two separate user reports reached for the pack because it is the form
+# they found first.
+test "mach.lang.fe.sema:a_pack_on_a_body_less_fun_is_refused" {
+    var bad: i32 = 0;
+
+    if (ut_vec_diag("#[library(\"raylib\")]\next fun TextFormat(text: *u8, va: ...) *u8;\nfun main() i32 { ret 0; }\n",
+                    "cannot appear on a body-less `fun`") != 0) { bad = 1; }
+
+    # the refusal NAMES THE FORM THAT WORKS, which is the whole point of it: the
+    # reports this came from were not blocked by the language, they were blocked by
+    # not knowing the other spelling existed
+    if (ut_vec_note("#[library(\"raylib\")]\next fun TextFormat(text: *u8, va: ...) *u8;\nfun main() i32 { ret 0; }\n",
+                    "ext fun f(a: T, ...)") != 0) { bad = 2; }
+
+    # a pack anywhere in the list, not only last, and with a leading fixed parameter
+    if (ut_vec_diag("ext fun g(a: i32, va: ...) i32;\nfun main() i32 { ret 0; }\n",
+                    "cannot appear on a body-less `fun`") != 0) { bad = 3; }
+
+    # NEITHER CORRECT FORM MOVES. the C-variadic import and the mach-bodied pack
+    # are both still accepted, which is what keeps this a diagnostic rather than a
+    # narrowing of the language.
+    if (!ut_sema_clean("ext fun printf(fmt: *u8, ...) i32;\nfun main() i32 { ret 0; }\n")) { bad = 4; }
+    if (!ut_sema_clean("fun fold(h: u64, va: ...) u64 { ret h; }\nfun main() i32 { ret 0; }\n")) { bad = 5; }
+    # and a body-less fun with no pack at all is untouched
+    if (!ut_sema_clean("ext fun strlen(s: *u8) i64;\nfun main() i32 { ret 0; }\n")) { bad = 6; }
     ret bad;
 }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -39,6 +39,7 @@ use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.ast.module;
 use mach.lang.fe.ast.stmt;
+use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema.check;
@@ -1299,6 +1300,31 @@ fun infer_bodies_in_list(sc: *context.SemaContext, start: u32, len: u32) R.Resul
     ret R.ok[bool, str](true);
 }
 
+# refuse a comptime variadic pack on a body-less `fun`, naming the form that works
+#
+# The two spellings look alike and mean unrelated things: `va: ...` is a NAMED
+# parameter carrying a mach comptime pack, while a bare trailing `...` is the C
+# variadic an import declares. Only the second can cross a foreign boundary.
+# ---
+# sc: the active sema context
+# d:  the body-less function declaration to check
+fun pack_on_import_check(sc: *context.SemaContext, d: *decl.Decl) {
+    var i: u32 = 0;
+    for (i < d.data.fun_.params_len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[d.data.fun_.params_start + i];
+        val opt_t: O.Option[*atype.Type] = ast.get_type(sc.a, tn.ty);
+        if (O.is_some[*atype.Type](opt_t)) {
+            if (O.unwrap[*atype.Type](opt_t).kind == atype.TYPE_KIND_PACK) {
+                context.report_note(sc, d.span,
+                    "a comptime variadic pack `...` cannot appear on a body-less `fun`",
+                    "a pack is monomorphized per call site and takes a mangled name, so no foreign library can export it; for a C function declared with `...`, write the C-variadic form instead: `ext fun f(a: T, ...)`");
+                ret;
+            }
+        }
+        i = i + 1;
+    }
+}
+
 # infer and check one decl's body or initializer
 #
 # Decorator arguments are typed and the decorators validated first, then the
@@ -1334,6 +1360,17 @@ fun infer_one_body(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, str]
             val ret_ty: type.TypeId = context.resolved_type_of(sc, d.data.fun_.return_type);
             ret infer_stmt(sc, d.data.fun_.body, ret_ty);
         }
+        # THE MIRROR OF THE RULE ABOVE (#3002). A body-less `fun` is a foreign
+        # import, and a comptime pack is a MACH calling convention: it is
+        # monomorphized into one instance per call-site type list, and each
+        # instance takes a mangled name carrying that list. No foreign library
+        # exports a mach-mangled pack instance, so the two cannot be combined.
+        #
+        # Left unchecked it compiled clean through codegen and failed at link
+        # naming a symbol the source never wrote - `TextFormat$pack$i32$i32` -
+        # which is as far from the cause as a diagnostic gets. Two separate
+        # reports reached for the pack because it is the form they found first.
+        pack_on_import_check(sc, d);
         ret R.ok[bool, str](true);
     }
     if (d.kind == decl.DECL_KIND_TEST) {


### PR DESCRIPTION
Closes #3002.

`va: ...` and a bare trailing `...` look alike and mean unrelated things. A pack is a **mach** calling convention — monomorphized per call site into an instance whose mangled name carries the call's type list — and a body-less `fun` resolves to a symbol a foreign library exports. No library exports a mach-mangled pack instance, so the two cannot combine.

Left unchecked it compiled clean through codegen and failed at **link**, naming a symbol the source never wrote:

```
error: dynamic import 'raylib.raylib.TextFormat$pack$i32$i32' has no #[library] attribution
```

Now:

```
error: a comptime variadic pack `...` cannot appear on a body-less `fun`
 --> ./src/main.mach:2:1
  = note: a pack is monomorphized per call site and takes a mangled name, so no
    foreign library can export it; for a C function declared with `...`, write the
    C-variadic form instead: `ext fun f(a: T, ...)`
```

**The note is the point of the change, not the refusal.** The two reports this came from (#3000, #2968) were never blocked by the language — calling a C variadic function has worked since v2.0.0 — they were blocked by not knowing the other spelling existed. The test asserts the note's text through `ut_diag_note_has`, not just the message, because a diagnostic whose value *is* the suggestion is only tested by reading the suggestion.

It sits directly beside the mirror rule it completes: sema already refused a C-variadic declaration that carries a body. Both halves of "these two forms do not mix" now live in one place.

## Verification

- **1492 passed, 0 failed** (1491 before, 1 new).
- **Neither correct form moves**, asserted explicitly: `ext fun printf(fmt: *u8, ...) i32;` and `fun fold(h: u64, va: ...) u64 { ... }` both still compile, as does a plain `ext fun` with no pack. That is what keeps this a diagnostic rather than a narrowing of the language.
- **Mutation-checked:** removing the call fails the new test (exit 3).
- The `tests.mach` diff against `dev` is purely additive.