### PR TITLE
fix(coff): read MSVC's biased REL32 relocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### link(coff): MSVC's biased REL32 relocations are read (#2992)
+
+Mach defined the x86-64 COFF relocation types 1-4 and 10-11 and skipped **5 through
+9**, so linking an ordinary MSVC-built library failed outright:
+
+```
+error: coff: unsupported relocation type 8
+error: coff: unsupported relocation type 5
+```
+
+Those five are `IMAGE_REL_AMD64_REL32_1 .. _5`: plain `REL32` with the target taken
+N bytes past the next instruction byte, which MSVC emits whenever the instruction
+carries an immediate after the displacement field. Nothing exotic - ordinary calls
+and jumps - which is why any library of size hits them, and why the same project
+failed on type 8 against MSVC and type 5 against UCRT.
+
+They are one family with `REL32` rather than five new kinds: the abstract kind and
+the field width are `REL32`'s, and the only difference is the extra term the addend
+loses, read off the type itself. The write side needs nothing - mach never emits a
+biased REL32, it only has to read them.
+
 ## [4.21.0] - 2026-08-20
 
 ### Changed

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -82,6 +82,14 @@ val IMAGE_REL_AMD64_ADDR64:   u16 = 0x0001;
 val IMAGE_REL_AMD64_ADDR32:   u16 = 0x0002;
 val IMAGE_REL_AMD64_ADDR32NB: u16 = 0x0003;
 val IMAGE_REL_AMD64_REL32:    u16 = 0x0004;
+# REL32_1 .. REL32_5: REL32 with the target taken N bytes PAST the next
+# instruction byte, i.e. `S + A - (P + 4 + N)`. MSVC emits them whenever the
+# instruction carries an immediate after the displacement field, so any sizeable
+# MSVC-built import library contains them (#2992). They are one family with REL32
+# rather than five separate kinds: `rel32_bias` reads N off the type, and the
+# abstract kind and field width are REL32's.
+val IMAGE_REL_AMD64_REL32_1:  u16 = 0x0005;
+val IMAGE_REL_AMD64_REL32_5:  u16 = 0x0009;
 # CodeView debug references: SECTION is the target symbol's 16-bit section index
 # (a 2-byte field), SECREL is its 32-bit offset within that section (a 4-byte
 # field). used by DEBUG_S_LINES / S_GPROC32_ID to point debug records at code
@@ -275,6 +283,25 @@ fun validate_reloc_kinds(img: *of.ObjectImage) R.Result[bool, str] {
 # (absolute), ADDR32NB (image-relative), ADDR32 (absolute), and SECREL carry no
 # P+4 term and are unchanged. SECTION resolves to a 16-bit section index with no
 # addend, so its 2-byte field is never read as one.
+# the extra displacement a biased REL32 carries, in bytes
+#
+# REL32 resolves against `P + 4`; REL32_N against `P + 4 + N` for N in 1..5. The
+# bias is the type's distance from REL32, so the five biased types need no case of
+# their own anywhere - only this reader (#2992).
+# ---
+# r_type: the COFF machine relocation type
+# ret:    N for REL32_1..REL32_5, 0 for REL32 and every non-REL32 type
+fun rel32_bias(r_type: u16) i64 {
+    if (r_type < IMAGE_REL_AMD64_REL32_1 || r_type > IMAGE_REL_AMD64_REL32_5) { ret 0; }
+    ret (r_type - IMAGE_REL_AMD64_REL32)::i64;
+}
+
+# whether `r_type` is REL32 or one of its five biased forms
+fun is_rel32_family(r_type: u16) bool {
+    ret r_type == IMAGE_REL_AMD64_REL32
+        || (r_type >= IMAGE_REL_AMD64_REL32_1 && r_type <= IMAGE_REL_AMD64_REL32_5);
+}
+
 fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     if (sec.bytes == nil)                  { ret 0; }
     if (r_type == IMAGE_REL_AMD64_SECTION) { ret 0; }
@@ -284,7 +311,9 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     }
     if (offset::usize + 4 > sec.len::usize) { ret 0; }
     val field: i64 = (bin.read_u32_le(sec.bytes, offset::usize)::i32)::i64;
-    if (r_type == IMAGE_REL_AMD64_REL32) { ret field - 4; }
+    # a REL32 field is next-byte-relative, and a biased one is N bytes past that,
+    # so the abstract addend loses both terms
+    if (is_rel32_family(r_type)) { ret field - 4 - rel32_bias(r_type); }
     ret field;
 }
 
@@ -295,7 +324,7 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
 # is still rejected, so a foreign 4-byte field is never linked with an 8-byte write
 fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, r_type: u16) R.Result[of.RelocKind, str] {
     if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
-    if (r_type == IMAGE_REL_AMD64_REL32)    { ret R.ok[of.RelocKind, str](of.RK_PC32); }
+    if (is_rel32_family(r_type))            { ret R.ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret R.ok[of.RelocKind, str](of.RK_ADDR32NB); }
     if (r_type == IMAGE_REL_AMD64_ADDR32)   { ret R.ok[of.RelocKind, str](of.RK_ABS32); }
     if (r_type == IMAGE_REL_AMD64_SECREL)   { ret R.ok[of.RelocKind, str](of.RK_SECREL32); }
@@ -7246,4 +7275,71 @@ test "mach.lang.target.of.coff.coff_serialize_image:bigobj_round_trip" {
 
     A.deallocate[of.Section](?alloc, secs, n::usize);
     ret bad;
+}
+
+# MSVC's biased REL32 forms (#2992).
+#
+# `IMAGE_REL_AMD64_REL32_1 .. _5` are REL32 with the target taken N bytes PAST the
+# next instruction byte - `S + A - (P + 4 + N)` - which MSVC emits whenever the
+# instruction carries an immediate after the displacement field. Mach defined types
+# 1-4 and 10-11 and skipped 5-9, so a normal MSVC-built import library was rejected
+# outright with `coff: unsupported relocation type 8`, and a UCRT-built one with
+# type 5. Neither is exotic: they are ordinary calls and jumps.
+test "mach.lang.target.of.coff.read_inplace_addend:rel32_biased_forms" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f0: [4]u8;
+    f0[0] = 0; f0[1] = 0; f0[2] = 0; f0[3] = 0;
+    var sec0: of.Section;
+    sec0.bytes = ?f0[0]; sec0.len = 4;
+
+    # the abstract addend loses the P+4 term AND the bias, so a zero field reads
+    # back as -(4 + N) across the family
+    if (read_inplace_addend(?sec0, IMAGE_REL_AMD64_REL32,     0) != -4)  { ret 1; }
+    if (read_inplace_addend(?sec0, 0x0005, 0) != -5)  { ret 2; }
+    if (read_inplace_addend(?sec0, 0x0006, 0) != -6)  { ret 3; }
+    if (read_inplace_addend(?sec0, 0x0007, 0) != -7)  { ret 4; }
+    if (read_inplace_addend(?sec0, 0x0008, 0) != -8)  { ret 5; }
+    if (read_inplace_addend(?sec0, IMAGE_REL_AMD64_REL32_5,   0) != -9)  { ret 6; }
+
+    # a non-zero field carries through the same subtraction
+    var f7: [4]u8;
+    f7[0] = 7; f7[1] = 0; f7[2] = 0; f7[3] = 0;
+    var sec7: of.Section;
+    sec7.bytes = ?f7[0]; sec7.len = 4;
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32,   0) != 3) { ret 7; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32_1, 0) != 2) { ret 8; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32_5, 0) != -2) { ret 9; }
+
+    # THE NEIGHBOURS ARE UNMOVED. the family is bounded on both sides, so the type
+    # just below it (REL32 itself) and the next defined type above it (SECTION,
+    # 0x0A) keep their own conventions - a bias applied one type too far would read
+    # a CodeView section index as a displacement.
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_SECTION, 0) != 0) { ret 10; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_SECREL,  0) != 7) { ret 11; }
+    ret 0;
+}
+
+# every biased form maps to the same abstract kind REL32 does: the bias is an
+# addend adjustment, not a different relocation
+test "mach.lang.target.of.coff.reloc_kind_for:rel32_biased_forms_are_pc32" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var t: u16 = IMAGE_REL_AMD64_REL32;
+    for (t <= IMAGE_REL_AMD64_REL32_5) {
+        val r: R.Result[of.RelocKind, str] = reloc_kind_for(?itn, ?alloc, t);
+        if (R.is_err[of.RelocKind, str](r)) { ret 1; }
+        if (R.unwrap_ok[of.RelocKind, str](r) != of.RK_PC32) { ret 2; }
+        t = t + 1;
+    }
+
+    # and the type immediately above the family is still the CodeView kind, not
+    # another PC-relative one
+    val sect: R.Result[of.RelocKind, str] = reloc_kind_for(?itn, ?alloc, IMAGE_REL_AMD64_SECTION);
+    if (R.is_err[of.RelocKind, str](sect)) { ret 3; }
+    if (R.unwrap_ok[of.RelocKind, str](sect) == of.RK_PC32) { ret 4; }
+    ret 0;
 }


### PR DESCRIPTION
Closes #2992.

Mach defined the x86-64 COFF relocation types 1-4 and 10-11 and **skipped 5 through 9**, so linking an ordinary MSVC-built library failed outright — the same project failing on type 8 against MSVC and type 5 against UCRT:

```
error: coff: unsupported relocation type 8
error: coff: unsupported relocation type 5
```

Those five are `IMAGE_REL_AMD64_REL32_1 .. _5`: plain `REL32` with the target taken N bytes past the next instruction byte, `S + A - (P + 4 + N)`. MSVC emits them whenever the instruction carries an immediate after the displacement field — ordinary calls and jumps, which is why any library of size contains them.

## Shape

**One family with `REL32`, not five new kinds.** The abstract kind (`RK_PC32`) and the field width are `REL32`'s; the only difference is the extra term the addend loses, and that is read off the type itself (`rel32_bias` = `r_type - REL32`). So the five need no case of their own in the kind map, the field reader, or anywhere downstream.

The write side needs nothing: mach never emits a biased REL32, it only has to read them.

## On the issue's original guess

The report suspected the unicode string in the user's source. It isn't — the error comes from parsing the *library's* object files, before any string content in their source is reachable. Mach's strings are 8-bit byte arrays and FLTK is UTF-8 native, so that half is very likely fine; if it isn't, it is a separate report.

## Verification

- **1493 passed, 0 failed** (1491 before, 2 new).
- The tests pin the arithmetic across the whole family (a zero field reads back as `-(4+N)` for N in 0..5, and a non-zero field carries the same subtraction).
- **The neighbours are asserted unmoved**, which is the part worth testing: the family is bounded on both sides, and a bias applied one type too far would read a CodeView section index (`0x0A`) as a displacement.
- **Mutation-checked:** dropping the bias term fails the addend test (exit 2).