### PR TITLE
chore: release 4.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.21.1] - 2026-08-20
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.21.0"
+version = "4.21.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.21.0";
+pub val MACH_VERSION: str = "4.21.1";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Two user-facing fixes, both from reports where someone was blocked:

- **#3002** — a comptime pack on a body-less `fun` is refused at the declaration, naming the C-variadic form that works, instead of failing at link on a mangled symbol the source never wrote.
- **#2992** — MSVC's biased REL32 relocations (types 5-9) are read, so an ordinary MSVC- or UCRT-built library links.

Both are fixes, so a patch bump.