### PR TITLE
mach 4.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: a comptime pack on a body-less `fun` is refused where it is written (#3002)
+
+`va: ...` and a bare trailing `...` look alike and mean unrelated things. The first
+is a NAMED parameter carrying a mach comptime pack, monomorphized into one instance
+per call-site type list, each taking a mangled name that carries that list. The
+second is the C variadic an import declares. Only the second can cross a foreign
+boundary.
+
+Combining the first with a body-less `fun` compiled clean through codegen and failed
+at LINK, naming a symbol the source never wrote:
+
+```
+error: dynamic import 'raylib.raylib.TextFormat$pack$i32$i32' has no #[library] attribution
+```
+
+It is refused at the declaration now, and the refusal names the form that works.
+That matters more than the refusal: the two reports this came from (#3000, #2968)
+were not blocked by the language - calling a C variadic function has worked since
+v2.0.0 - they were blocked by not knowing the other spelling existed.
+
+Neither correct form moves. `ext fun printf(fmt: *u8, ...) i32;` and
+`fun fold(h: u64, va: ...) u64 { ... }` are both still accepted, which is what keeps
+this a diagnostic rather than a narrowing of the language.
+
 ## [4.21.0] - 2026-08-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.21.1] - 2026-08-20
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### link(coff): MSVC's biased REL32 relocations are read (#2992)
+
+Mach defined the x86-64 COFF relocation types 1-4 and 10-11 and skipped **5 through
+9**, so linking an ordinary MSVC-built library failed outright:
+
+```
+error: coff: unsupported relocation type 8
+error: coff: unsupported relocation type 5
+```
+
+Those five are `IMAGE_REL_AMD64_REL32_1 .. _5`: plain `REL32` with the target taken
+N bytes past the next instruction byte, which MSVC emits whenever the instruction
+carries an immediate after the displacement field. Nothing exotic - ordinary calls
+and jumps - which is why any library of size hits them, and why the same project
+failed on type 8 against MSVC and type 5 against UCRT.
+
+They are one family with `REL32` rather than five new kinds: the abstract kind and
+the field width are `REL32`'s, and the only difference is the extra term the addend
+loses, read off the type itself. The write side needs nothing - mach never emits a
+biased REL32, it only has to read them.
+
 ## [4.21.0] - 2026-08-20
 
 ### Changed

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.21.0"
+version = "4.21.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1042,6 +1042,23 @@ fun ut_vec_diag(src: str, needle: str) i32 {
     ret 1;
 }
 
+# ut_vec_diag over a single module, asserting against the error's NOTE
+fun ut_vec_note(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val hit: bool = ut_diag_note_has(?p.s.diags, needle);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    if (hit) { ret 0; }
+    ret 1;
+}
+
 # ut_vec_diag over a two-module project: `main` is `main.mach`, `lib` is `lib.mach`,
 # reachable from main as `uniontest.lib`
 fun ut_vec_diag2(main: str, lib: str, needle: str) i32 {
@@ -20852,5 +20869,40 @@ test "mach.lang.me.lower:offset_of_too_wide_for_its_binding_is_refused" {
                       "a layout measurement does not fit") != 0) { bad = 1; }
     # a binding wide enough is unaffected
     if (!ut_sema_clean("rec Wide { pad: [300]u8; tail: i32; }\nval A: u32 = $offset_of(Wide, tail);\nfun main() i32 { ret 0; }\n")) { bad = 2; }
+    ret bad;
+}
+
+# A comptime pack and a C variadic look alike and mean unrelated things (#3002).
+#
+# `va: ...` is a NAMED parameter carrying a mach comptime pack, monomorphized into
+# one mangled instance per call-site type list. A bare trailing `...` is the C
+# variadic an import declares. Only the second can cross a foreign boundary, and
+# combining the first with a body-less `fun` used to compile clean through codegen
+# and fail at LINK naming `TextFormat$pack$i32$i32` - a symbol the source never
+# wrote. Two separate user reports reached for the pack because it is the form
+# they found first.
+test "mach.lang.fe.sema:a_pack_on_a_body_less_fun_is_refused" {
+    var bad: i32 = 0;
+
+    if (ut_vec_diag("#[library(\"raylib\")]\next fun TextFormat(text: *u8, va: ...) *u8;\nfun main() i32 { ret 0; }\n",
+                    "cannot appear on a body-less `fun`") != 0) { bad = 1; }
+
+    # the refusal NAMES THE FORM THAT WORKS, which is the whole point of it: the
+    # reports this came from were not blocked by the language, they were blocked by
+    # not knowing the other spelling existed
+    if (ut_vec_note("#[library(\"raylib\")]\next fun TextFormat(text: *u8, va: ...) *u8;\nfun main() i32 { ret 0; }\n",
+                    "ext fun f(a: T, ...)") != 0) { bad = 2; }
+
+    # a pack anywhere in the list, not only last, and with a leading fixed parameter
+    if (ut_vec_diag("ext fun g(a: i32, va: ...) i32;\nfun main() i32 { ret 0; }\n",
+                    "cannot appear on a body-less `fun`") != 0) { bad = 3; }
+
+    # NEITHER CORRECT FORM MOVES. the C-variadic import and the mach-bodied pack
+    # are both still accepted, which is what keeps this a diagnostic rather than a
+    # narrowing of the language.
+    if (!ut_sema_clean("ext fun printf(fmt: *u8, ...) i32;\nfun main() i32 { ret 0; }\n")) { bad = 4; }
+    if (!ut_sema_clean("fun fold(h: u64, va: ...) u64 { ret h; }\nfun main() i32 { ret 0; }\n")) { bad = 5; }
+    # and a body-less fun with no pack at all is untouched
+    if (!ut_sema_clean("ext fun strlen(s: *u8) i64;\nfun main() i32 { ret 0; }\n")) { bad = 6; }
     ret bad;
 }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -39,6 +39,7 @@ use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.ast.module;
 use mach.lang.fe.ast.stmt;
+use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema.check;
@@ -1299,6 +1300,31 @@ fun infer_bodies_in_list(sc: *context.SemaContext, start: u32, len: u32) R.Resul
     ret R.ok[bool, str](true);
 }
 
+# refuse a comptime variadic pack on a body-less `fun`, naming the form that works
+#
+# The two spellings look alike and mean unrelated things: `va: ...` is a NAMED
+# parameter carrying a mach comptime pack, while a bare trailing `...` is the C
+# variadic an import declares. Only the second can cross a foreign boundary.
+# ---
+# sc: the active sema context
+# d:  the body-less function declaration to check
+fun pack_on_import_check(sc: *context.SemaContext, d: *decl.Decl) {
+    var i: u32 = 0;
+    for (i < d.data.fun_.params_len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[d.data.fun_.params_start + i];
+        val opt_t: O.Option[*atype.Type] = ast.get_type(sc.a, tn.ty);
+        if (O.is_some[*atype.Type](opt_t)) {
+            if (O.unwrap[*atype.Type](opt_t).kind == atype.TYPE_KIND_PACK) {
+                context.report_note(sc, d.span,
+                    "a comptime variadic pack `...` cannot appear on a body-less `fun`",
+                    "a pack is monomorphized per call site and takes a mangled name, so no foreign library can export it; for a C function declared with `...`, write the C-variadic form instead: `ext fun f(a: T, ...)`");
+                ret;
+            }
+        }
+        i = i + 1;
+    }
+}
+
 # infer and check one decl's body or initializer
 #
 # Decorator arguments are typed and the decorators validated first, then the
@@ -1334,6 +1360,17 @@ fun infer_one_body(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, str]
             val ret_ty: type.TypeId = context.resolved_type_of(sc, d.data.fun_.return_type);
             ret infer_stmt(sc, d.data.fun_.body, ret_ty);
         }
+        # THE MIRROR OF THE RULE ABOVE (#3002). A body-less `fun` is a foreign
+        # import, and a comptime pack is a MACH calling convention: it is
+        # monomorphized into one instance per call-site type list, and each
+        # instance takes a mangled name carrying that list. No foreign library
+        # exports a mach-mangled pack instance, so the two cannot be combined.
+        #
+        # Left unchecked it compiled clean through codegen and failed at link
+        # naming a symbol the source never wrote - `TextFormat$pack$i32$i32` -
+        # which is as far from the cause as a diagnostic gets. Two separate
+        # reports reached for the pack because it is the form they found first.
+        pack_on_import_check(sc, d);
         ret R.ok[bool, str](true);
     }
     if (d.kind == decl.DECL_KIND_TEST) {

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -82,6 +82,14 @@ val IMAGE_REL_AMD64_ADDR64:   u16 = 0x0001;
 val IMAGE_REL_AMD64_ADDR32:   u16 = 0x0002;
 val IMAGE_REL_AMD64_ADDR32NB: u16 = 0x0003;
 val IMAGE_REL_AMD64_REL32:    u16 = 0x0004;
+# REL32_1 .. REL32_5: REL32 with the target taken N bytes PAST the next
+# instruction byte, i.e. `S + A - (P + 4 + N)`. MSVC emits them whenever the
+# instruction carries an immediate after the displacement field, so any sizeable
+# MSVC-built import library contains them (#2992). They are one family with REL32
+# rather than five separate kinds: `rel32_bias` reads N off the type, and the
+# abstract kind and field width are REL32's.
+val IMAGE_REL_AMD64_REL32_1:  u16 = 0x0005;
+val IMAGE_REL_AMD64_REL32_5:  u16 = 0x0009;
 # CodeView debug references: SECTION is the target symbol's 16-bit section index
 # (a 2-byte field), SECREL is its 32-bit offset within that section (a 4-byte
 # field). used by DEBUG_S_LINES / S_GPROC32_ID to point debug records at code
@@ -275,6 +283,25 @@ fun validate_reloc_kinds(img: *of.ObjectImage) R.Result[bool, str] {
 # (absolute), ADDR32NB (image-relative), ADDR32 (absolute), and SECREL carry no
 # P+4 term and are unchanged. SECTION resolves to a 16-bit section index with no
 # addend, so its 2-byte field is never read as one.
+# the extra displacement a biased REL32 carries, in bytes
+#
+# REL32 resolves against `P + 4`; REL32_N against `P + 4 + N` for N in 1..5. The
+# bias is the type's distance from REL32, so the five biased types need no case of
+# their own anywhere - only this reader (#2992).
+# ---
+# r_type: the COFF machine relocation type
+# ret:    N for REL32_1..REL32_5, 0 for REL32 and every non-REL32 type
+fun rel32_bias(r_type: u16) i64 {
+    if (r_type < IMAGE_REL_AMD64_REL32_1 || r_type > IMAGE_REL_AMD64_REL32_5) { ret 0; }
+    ret (r_type - IMAGE_REL_AMD64_REL32)::i64;
+}
+
+# whether `r_type` is REL32 or one of its five biased forms
+fun is_rel32_family(r_type: u16) bool {
+    ret r_type == IMAGE_REL_AMD64_REL32
+        || (r_type >= IMAGE_REL_AMD64_REL32_1 && r_type <= IMAGE_REL_AMD64_REL32_5);
+}
+
 fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     if (sec.bytes == nil)                  { ret 0; }
     if (r_type == IMAGE_REL_AMD64_SECTION) { ret 0; }
@@ -284,7 +311,9 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
     }
     if (offset::usize + 4 > sec.len::usize) { ret 0; }
     val field: i64 = (bin.read_u32_le(sec.bytes, offset::usize)::i32)::i64;
-    if (r_type == IMAGE_REL_AMD64_REL32) { ret field - 4; }
+    # a REL32 field is next-byte-relative, and a biased one is N bytes past that,
+    # so the abstract addend loses both terms
+    if (is_rel32_family(r_type)) { ret field - 4 - rel32_bias(r_type); }
     ret field;
 }
 
@@ -295,7 +324,7 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
 # is still rejected, so a foreign 4-byte field is never linked with an 8-byte write
 fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, r_type: u16) R.Result[of.RelocKind, str] {
     if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
-    if (r_type == IMAGE_REL_AMD64_REL32)    { ret R.ok[of.RelocKind, str](of.RK_PC32); }
+    if (is_rel32_family(r_type))            { ret R.ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret R.ok[of.RelocKind, str](of.RK_ADDR32NB); }
     if (r_type == IMAGE_REL_AMD64_ADDR32)   { ret R.ok[of.RelocKind, str](of.RK_ABS32); }
     if (r_type == IMAGE_REL_AMD64_SECREL)   { ret R.ok[of.RelocKind, str](of.RK_SECREL32); }
@@ -7246,4 +7275,71 @@ test "mach.lang.target.of.coff.coff_serialize_image:bigobj_round_trip" {
 
     A.deallocate[of.Section](?alloc, secs, n::usize);
     ret bad;
+}
+
+# MSVC's biased REL32 forms (#2992).
+#
+# `IMAGE_REL_AMD64_REL32_1 .. _5` are REL32 with the target taken N bytes PAST the
+# next instruction byte - `S + A - (P + 4 + N)` - which MSVC emits whenever the
+# instruction carries an immediate after the displacement field. Mach defined types
+# 1-4 and 10-11 and skipped 5-9, so a normal MSVC-built import library was rejected
+# outright with `coff: unsupported relocation type 8`, and a UCRT-built one with
+# type 5. Neither is exotic: they are ordinary calls and jumps.
+test "mach.lang.target.of.coff.read_inplace_addend:rel32_biased_forms" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f0: [4]u8;
+    f0[0] = 0; f0[1] = 0; f0[2] = 0; f0[3] = 0;
+    var sec0: of.Section;
+    sec0.bytes = ?f0[0]; sec0.len = 4;
+
+    # the abstract addend loses the P+4 term AND the bias, so a zero field reads
+    # back as -(4 + N) across the family
+    if (read_inplace_addend(?sec0, IMAGE_REL_AMD64_REL32,     0) != -4)  { ret 1; }
+    if (read_inplace_addend(?sec0, 0x0005, 0) != -5)  { ret 2; }
+    if (read_inplace_addend(?sec0, 0x0006, 0) != -6)  { ret 3; }
+    if (read_inplace_addend(?sec0, 0x0007, 0) != -7)  { ret 4; }
+    if (read_inplace_addend(?sec0, 0x0008, 0) != -8)  { ret 5; }
+    if (read_inplace_addend(?sec0, IMAGE_REL_AMD64_REL32_5,   0) != -9)  { ret 6; }
+
+    # a non-zero field carries through the same subtraction
+    var f7: [4]u8;
+    f7[0] = 7; f7[1] = 0; f7[2] = 0; f7[3] = 0;
+    var sec7: of.Section;
+    sec7.bytes = ?f7[0]; sec7.len = 4;
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32,   0) != 3) { ret 7; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32_1, 0) != 2) { ret 8; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_REL32_5, 0) != -2) { ret 9; }
+
+    # THE NEIGHBOURS ARE UNMOVED. the family is bounded on both sides, so the type
+    # just below it (REL32 itself) and the next defined type above it (SECTION,
+    # 0x0A) keep their own conventions - a bias applied one type too far would read
+    # a CodeView section index as a displacement.
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_SECTION, 0) != 0) { ret 10; }
+    if (read_inplace_addend(?sec7, IMAGE_REL_AMD64_SECREL,  0) != 7) { ret 11; }
+    ret 0;
+}
+
+# every biased form maps to the same abstract kind REL32 does: the bias is an
+# addend adjustment, not a different relocation
+test "mach.lang.target.of.coff.reloc_kind_for:rel32_biased_forms_are_pc32" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    var t: u16 = IMAGE_REL_AMD64_REL32;
+    for (t <= IMAGE_REL_AMD64_REL32_5) {
+        val r: R.Result[of.RelocKind, str] = reloc_kind_for(?itn, ?alloc, t);
+        if (R.is_err[of.RelocKind, str](r)) { ret 1; }
+        if (R.unwrap_ok[of.RelocKind, str](r) != of.RK_PC32) { ret 2; }
+        t = t + 1;
+    }
+
+    # and the type immediately above the family is still the CodeView kind, not
+    # another PC-relative one
+    val sect: R.Result[of.RelocKind, str] = reloc_kind_for(?itn, ?alloc, IMAGE_REL_AMD64_SECTION);
+    if (R.is_err[of.RelocKind, str](sect)) { ret 3; }
+    if (R.unwrap_ok[of.RelocKind, str](sect) == of.RK_PC32) { ret 4; }
+    ret 0;
 }

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.21.0";
+pub val MACH_VERSION: str = "4.21.1";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Integration merge of `dev` into `main` for 4.21.1.

- #3002 — a comptime pack on a body-less `fun` is refused where it is written, naming the form that works.
- #2992 — MSVC's biased REL32 relocations (types 5-9) are read.

Throwaway branch head. Runs the darwin release gate.