### PR TITLE
fix(coff): honor every deduplicating COMDAT selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,44 @@ enter-at-the-base rule are now one body shared by the file path and the in-memor
 one, so an image held in memory cannot differ from the one a build would have
 written.
 
+## [Unreleased]
+
+### Fixed
+
+#### link(coff): every deduplicating COMDAT selection is honored, so C++ libraries link (#3024)
+
+Linking any C++ library failed on a symbol no source ever wrote:
+
+```
+msvc:   error: multiple definition of '??_7Fl_Pixmap@@6B@'
+mingw:  error: multiple definition of '_ZTI9Fl_Widget'
+```
+
+Both are **vague-linkage** symbols - an MSVC vftable and a GCC typeinfo. Every
+translation unit that needs one emits its own copy, and the linker keeps one and
+discards the rest. COFF says so with COMDAT, and COMDAT has six *selections*
+describing how to choose.
+
+**Mach honored exactly one of them.** `IMAGE_COMDAT_SELECT_ANY` was the only value
+spelled anywhere in the tree, so a definition under any other selection stayed a
+strong symbol and collided with the next copy. A compiler picks the selection per
+construct, which is why this landed precisely on C++ and why two different
+toolchains failed at the same point in different ways: MSVC spells a vftable
+`LARGEST`, GCC reached mach under another.
+
+`ANY`, `SAME_SIZE`, `EXACT_MATCH` and `LARGEST` all mean "one of N wins" and differ
+only in what they additionally promise about the losers. Mach keeps the first, which
+is what its weak-symbol resolution already does and is observationally identical for
+the definitions these describe - a vtable emitted from one header is the same object
+in every translation unit that emitted it.
+
+`NODUPLICATES` still collides, because that is the selection a compiler picks
+precisely to say a second definition is an error. `ASSOCIATIVE` deduplicates for now
+and is written down as a decision rather than a fallthrough: its real meaning ties a
+section's fate to another COMDAT, which needs section GC to express, and mach
+discards no sections - so the symbol half is correct and the unreferenced-section
+half waits for GC.
+
 ## [4.21.1] - 2026-08-20
 
 ### Fixed

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -70,12 +70,59 @@ val IMAGE_SCN_MEM_EXECUTE:            u32 = 0x20000000;
 val IMAGE_SCN_MEM_READ:               u32 = 0x40000000;
 val IMAGE_SCN_MEM_WRITE:              u32 = 0x80000000;
 
-# COMDAT selection for a section symbol's aux record. ANY keeps one of N
-# identical definitions and discards the rest - the COFF mechanism the mach
-# whole-program linker reads back as a weak (deduplicated) definition, mirroring
-# the ELF STB_WEAK binding. a defined weak symbol is emitted into its own
-# LNK_COMDAT section so the attribute survives the write->read round-trip
-val IMAGE_COMDAT_SELECT_ANY: u8 = 2;
+# COMDAT selection for a section symbol's aux record: how the linker chooses among
+# N definitions of the same COMDAT symbol.
+#
+# FOUR OF THE SIX MEAN "ONE OF N WINS" and differ only in what they additionally
+# promise about the losers - identical bytes, identical size, or nothing at all.
+# Mach reads all four back as a weak (deduplicated) definition, mirroring the ELF
+# STB_WEAK binding, because the choice mach makes is the same in every case: keep
+# the first, discard the rest. A defined weak symbol is emitted into its own
+# LNK_COMDAT section with SELECT_ANY so the attribute survives the
+# write->read round-trip.
+#
+# THE TWO THAT ARE NOT are `NODUPLICATES`, where a second definition is genuinely
+# an error and must still collide, and `ASSOCIATIVE`, where the section's fate is
+# tied to another COMDAT rather than decided on its own.
+#
+# Reading only `ANY` was what stopped every C++ library linking (#3024): a compiler
+# picks the selection per construct, and the two that reached mach first were the
+# two it did not accept - MSVC spells a vftable `LARGEST`, and the resulting
+# `multiple definition of '??_7...@@6B@'` named a symbol no source wrote.
+val IMAGE_COMDAT_SELECT_NODUPLICATES: u8 = 1;
+val IMAGE_COMDAT_SELECT_ANY:          u8 = 2;
+val IMAGE_COMDAT_SELECT_SAME_SIZE:    u8 = 3;
+val IMAGE_COMDAT_SELECT_EXACT_MATCH:  u8 = 4;
+val IMAGE_COMDAT_SELECT_ASSOCIATIVE:  u8 = 5;
+val IMAGE_COMDAT_SELECT_LARGEST:      u8 = 6;
+
+# whether a COMDAT selection means "keep one of N definitions and discard the rest"
+#
+# The question mach actually has to answer about an input COMDAT. The three
+# selections beyond `ANY` that answer yes carry an extra promise about the losing
+# definitions - `SAME_SIZE` that they are the same length, `EXACT_MATCH` that they
+# are byte-identical, `LARGEST` that the biggest is the one to keep. Mach keeps the
+# FIRST rather than verifying the promise or measuring the sizes, which is what its
+# weak-symbol resolution already does and is observationally identical for the
+# vague-linkage definitions these describe: a C++ vtable emitted by one compiler
+# from one header is the same object in every translation unit that emitted it.
+#
+# `ASSOCIATIVE` answers yes here on purpose. Its real meaning is "this section
+# lives or dies with the COMDAT named in the aux record", which needs section GC to
+# express, and mach discards no sections. Treating it as one-of-N keeps the SYMBOL
+# resolution correct - which is the half that blocks a link - and leaves the
+# unreferenced-section half to whenever GC lands. Stated here rather than left as a
+# fallthrough so the next reader knows it was decided.
+# ---
+# sel: the selection byte from a section symbol's aux record
+# ret: true when a duplicate definition is deduplicated rather than an error
+fun comdat_selection_dedups(sel: u8) bool {
+    ret sel == IMAGE_COMDAT_SELECT_ANY
+        || sel == IMAGE_COMDAT_SELECT_SAME_SIZE
+        || sel == IMAGE_COMDAT_SELECT_EXACT_MATCH
+        || sel == IMAGE_COMDAT_SELECT_ASSOCIATIVE
+        || sel == IMAGE_COMDAT_SELECT_LARGEST;
+}
 
 # x86-64 relocation types (IMAGE_REL_AMD64_*)
 val IMAGE_REL_AMD64_ADDR64:   u16 = 0x0001;
@@ -1666,7 +1713,7 @@ fun read_symbol_name(buf: *u8, buf_size: usize, so: usize, strtab_base: usize, s
 # record; returns false when no such record is found. `bigobj` selects the
 # classic 18-byte or /bigobj 20-byte record stride and SectionNumber width
 # (#2147) - it must match the format the caller parsed the header as.
-fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32, sec_num: u32, bigobj: bool) bool {
+fun comdat_dedups_for_section(buf: *u8, symtab_off: usize, num_records: u32, sec_num: u32, bigobj: bool) bool {
     val rsize: usize = sym_record_size(bigobj);
     var ri: u32 = 0;
     for (ri < num_records) {
@@ -1678,7 +1725,7 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
         if (buf[sym_storage_class_off(so, bigobj)] == IMAGE_SYM_CLASS_STATIC && aux >= 1 && (ri + 1) < num_records
             && read_sym_section_number(buf, so, bigobj) == sec_num::i32 && bin.read_u32_le(buf, so + 8) == 0) {
             val ax: usize = so + rsize;
-            ret buf[ax + 14] == IMAGE_COMDAT_SELECT_ANY;
+            ret comdat_selection_dedups(buf[ax + 14]);
         }
         ri = ri + 1 + aux::u32;
     }
@@ -2114,7 +2161,7 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
             && out.symbols[idx].section != of.SECTION_EXTERNAL) {
             val dsh: usize = secthdr_base + out.symbols[idx].section::usize * SECTION_HEADER_SIZE;
             if ((bin.read_u32_le(buf, dsh + 36) & IMAGE_SCN_LNK_COMDAT) != 0
-                && comdat_select_any_for_section(buf, symtab_off, num_records,
+                && comdat_dedups_for_section(buf, symtab_off, num_records,
                                                  out.symbols[idx].section + 1, bigobj)) {
                 flags = flags | of.SYM_OBJ_FLAG_WEAK;
             }
@@ -7341,5 +7388,152 @@ test "mach.lang.target.of.coff.reloc_kind_for:rel32_biased_forms_are_pc32" {
     val sect: R.Result[of.RelocKind, str] = reloc_kind_for(?itn, ?alloc, IMAGE_REL_AMD64_SECTION);
     if (R.is_err[of.RelocKind, str](sect)) { ret 3; }
     if (R.unwrap_ok[of.RelocKind, str](sect) == of.RK_PC32) { ret 4; }
+    ret 0;
+}
+
+# the file offset of the COMDAT selection byte in an emitted object's aux record
+#
+# Walks the symbol table the way `comdat_dedups_for_section` does and returns the
+# aux byte the selection lives in, so a test can rewrite it. Emitting an object with
+# a selection other than `SELECT_ANY` is not possible through the writer - mach only
+# ever produces that one - so a reader test has to patch the byte it would have read.
+# ---
+# buf: the emitted object bytes
+# ret: the offset of the selection byte, or 0 when no COMDAT section symbol is found
+fun t_comdat_selection_off(buf: *u8) usize {
+    val symtab_off:  usize = bin.read_u32_le(buf, 8)::usize;
+    val num_records: u32   = bin.read_u32_le(buf, 12);
+    val rsize: usize = sym_record_size(false);
+    var ri: u32 = 0;
+    for (ri < num_records) {
+        val so: usize = symtab_off + ri::usize * rsize;
+        val aux: u8 = buf[sym_naux_off(so, false)];
+        if (buf[sym_storage_class_off(so, false)] == IMAGE_SYM_CLASS_STATIC
+            && aux >= 1 && (ri + 1) < num_records && bin.read_u32_le(buf, so + 8) == 0) {
+            val secn: i32 = read_sym_section_number(buf, so, false);
+            if (secn >= 1) {
+                val sh: usize = COFF_HEADER_SIZE + (secn - 1)::u32::usize * SECTION_HEADER_SIZE;
+                if ((bin.read_u32_le(buf, sh + 36) & IMAGE_SCN_LNK_COMDAT) != 0) {
+                    ret so + rsize + 14;
+                }
+            }
+        }
+        ri = ri + 1 + aux::u32;
+    }
+    ret 0;
+}
+
+# EVERY SELECTION THAT MEANS "ONE OF N WINS" DEDUPLICATES (#3024).
+#
+# The decision itself, stated over all six values. Reading only `SELECT_ANY` is what
+# stopped every C++ library linking: a compiler picks the selection per construct,
+# and vague-linkage definitions - vtables, typeinfo, inline function bodies - arrive
+# under whichever one that compiler chose. MSVC spells a vftable `LARGEST`, so
+# `??_7Fl_Pixmap@@6B@` collided as a duplicate strong definition and named a symbol
+# no source ever wrote.
+#
+# `NODUPLICATES` is the one that must still collide, and it is asserted here rather
+# than left implied: it is the selection a compiler picks precisely to say a second
+# definition is an error, so treating it like the others would turn a real diagnostic
+# into a silently dropped definition.
+test "mach.lang.target.of.coff.comdat_selection_dedups:every_one_of_n_selection" {
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_ANY))          { ret 1; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_SAME_SIZE))    { ret 2; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_EXACT_MATCH))  { ret 3; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_ASSOCIATIVE))  { ret 4; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_LARGEST))      { ret 5; }
+
+    # the one that is an error by design
+    if (comdat_selection_dedups(IMAGE_COMDAT_SELECT_NODUPLICATES))  { ret 6; }
+
+    # and nothing outside the defined range is admitted: a 0 selection is what an
+    # aux record that is not a COMDAT one reads as, and 7 is past the last value
+    if (comdat_selection_dedups(0)) { ret 7; }
+    if (comdat_selection_dedups(7)) { ret 8; }
+    ret 0;
+}
+
+# the reader honors the selection it actually finds, not the one mach emits
+#
+# The end-to-end half: emit a real object carrying a COMDAT weak body, rewrite the
+# selection byte to each value in turn, and re-parse. A definition under a
+# deduplicating selection comes back WEAK - which is what lets the whole-program
+# linker keep one and discard the rest - and one under `NODUPLICATES` comes back
+# STRONG, so a duplicate still collides.
+test "mach.lang.target.of.coff:comdat_selection_decides_weakness_on_read" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = (0x10 + k)::u8; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [2]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 0; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "vtable$T"); syms[1].section = 0; syms[1].offset = 8;
+    syms[1].size = 0;
+    syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_WEAK;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 2;
+    img.relocations = nil; img.reloc_count = 0;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_sel");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val em: R.Result[bool, str] = coff_emit_object(?isa_vt, ?img, fs.temp_path(?tf)::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 2; }
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 3; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    val soff: usize = t_comdat_selection_off(buf.data);
+    # the patch site must exist and must currently hold what mach emits, or the
+    # rewrites below are landing somewhere that means nothing
+    if (soff == 0)                                          { ret 4; }
+    if (buf.data[soff] != IMAGE_COMDAT_SELECT_ANY)          { ret 5; }
+
+    var sels: [6]u8;
+    sels[0] = IMAGE_COMDAT_SELECT_ANY;
+    sels[1] = IMAGE_COMDAT_SELECT_SAME_SIZE;
+    sels[2] = IMAGE_COMDAT_SELECT_EXACT_MATCH;
+    sels[3] = IMAGE_COMDAT_SELECT_ASSOCIATIVE;
+    sels[4] = IMAGE_COMDAT_SELECT_LARGEST;
+    sels[5] = IMAGE_COMDAT_SELECT_NODUPLICATES;
+
+    var si: usize = 0;
+    for (si < 6) {
+        buf.data[soff] = sels[si];
+        var out: of.ObjectImage;
+        val pr: R.Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+        if (R.is_err[bool, str](pr)) { ret 6; }
+
+        var seen: bool = false;
+        var oi: u32 = 0;
+        for (oi < out.symbol_count) {
+            if (out.symbols[oi].name == syms[1].name) {
+                seen = true;
+                val weak: bool = (out.symbols[oi].flags & of.SYM_OBJ_FLAG_WEAK) != 0;
+                # NODUPLICATES is the last entry and is the only one that stays strong
+                if (si == 5 && weak)  { ret 7; }
+                if (si != 5 && !weak) { ret 8; }
+            }
+            oi = oi + 1;
+        }
+        if (!seen) { ret 9; }
+        si = si + 1;
+    }
     ret 0;
 }


### PR DESCRIPTION
Closes #3024. Follow-on from #2992, which fixed the relocation half of the same link.

Linking any C++ library failed on a symbol no source ever wrote:

```
msvc:   error: multiple definition of '??_7Fl_Pixmap@@6B@'
mingw:  error: multiple definition of '_ZTI9Fl_Widget'
```

Both are **vague-linkage** symbols — an MSVC vftable and a GCC typeinfo. Every translation unit that needs one emits its own copy and the linker keeps one. COFF says so with COMDAT, and COMDAT has six *selections*.

**Mach honored exactly one.** `IMAGE_COMDAT_SELECT_ANY` was the only value spelled anywhere in the tree:

```mach
ret buf[ax + 14] == IMAGE_COMDAT_SELECT_ANY;
```

Anything else stayed a strong symbol and collided with the next copy. Since a compiler picks the selection per construct, this landed precisely on C++ — and explains why two toolchains failed at the same point in different ways: MSVC spells a vftable `LARGEST`. One missing axis, not two bugs.

## The classification

`ANY`, `SAME_SIZE`, `EXACT_MATCH` and `LARGEST` all mean **one of N wins** and differ only in what they additionally promise about the losers. Mach keeps the first, which is what its weak-symbol resolution already does and is observationally identical for the definitions these describe: a vtable emitted from one header is the same object in every translation unit that emitted it.

`NODUPLICATES` still collides — that is the selection a compiler picks precisely to say a duplicate is an error, so treating it like the others would turn a real diagnostic into a silently dropped definition.

`ASSOCIATIVE` deduplicates, **written down as a decision rather than left as a fallthrough**. Its real meaning ties a section's fate to another COMDAT, which needs section GC to express, and mach discards no sections. The symbol half is the half that blocks a link; the unreferenced-section half waits for GC.

## Verification

- **1496 passed, 0 failed** (1494 before, 2 new).
- The decision is asserted over **all six** values plus two out-of-range ones, including that `NODUPLICATES` does *not* deduplicate.
- The reader is tested end-to-end: emit a real object carrying a COMDAT weak body, rewrite the selection byte to each value in turn, re-parse, and check the recovered symbol's weakness. The test asserts the patch site exists **and currently holds what mach emits**, so a rewrite that landed somewhere meaningless would fail rather than pass quietly.
- **Mutation-checked:** narrowing the predicate back to `ANY` alone fails both tests.

## Known remaining cost

Weakening resolves the symbol, but every losing COMDAT's bytes are still laid out — so a C++ link carries one copy of each vtable per translation unit that mentioned it. Correct output, wasted image. That is section GC's job and is noted in #3024 rather than fixed here.