### PR TITLE
chore: release 4.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.22.0] - 2026-08-21
 
 ### Changed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.21.1"
+version = "4.22.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.21.1";
+pub val MACH_VERSION: str = "4.22.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Two entries since 4.21.1:

- **#3024** — every deduplicating COMDAT selection is honored, so C++ libraries link. Mach read only `SELECT_ANY`; MSVC spells a vftable `LARGEST`, so every vague-linkage symbol collided.
- **#2892** — an in-memory link hands back the image and its symbol addresses, and every rv32 probe now runs from a linked image.

#2892 adds a public linker entry point, so a minor bump.