### PR TITLE
mach 4.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,44 @@ enter-at-the-base rule are now one body shared by the file path and the in-memor
 one, so an image held in memory cannot differ from the one a build would have
 written.
 
+## [Unreleased]
+
+### Fixed
+
+#### link(coff): every deduplicating COMDAT selection is honored, so C++ libraries link (#3024)
+
+Linking any C++ library failed on a symbol no source ever wrote:
+
+```
+msvc:   error: multiple definition of '??_7Fl_Pixmap@@6B@'
+mingw:  error: multiple definition of '_ZTI9Fl_Widget'
+```
+
+Both are **vague-linkage** symbols - an MSVC vftable and a GCC typeinfo. Every
+translation unit that needs one emits its own copy, and the linker keeps one and
+discards the rest. COFF says so with COMDAT, and COMDAT has six *selections*
+describing how to choose.
+
+**Mach honored exactly one of them.** `IMAGE_COMDAT_SELECT_ANY` was the only value
+spelled anywhere in the tree, so a definition under any other selection stayed a
+strong symbol and collided with the next copy. A compiler picks the selection per
+construct, which is why this landed precisely on C++ and why two different
+toolchains failed at the same point in different ways: MSVC spells a vftable
+`LARGEST`, GCC reached mach under another.
+
+`ANY`, `SAME_SIZE`, `EXACT_MATCH` and `LARGEST` all mean "one of N wins" and differ
+only in what they additionally promise about the losers. Mach keeps the first, which
+is what its weak-symbol resolution already does and is observationally identical for
+the definitions these describe - a vtable emitted from one header is the same object
+in every translation unit that emitted it.
+
+`NODUPLICATES` still collides, because that is the selection a compiler picks
+precisely to say a second definition is an error. `ASSOCIATIVE` deduplicates for now
+and is written down as a decision rather than a fallthrough: its real meaning ties a
+section's fate to another COMDAT, which needs section GC to express, and mach
+discards no sections - so the symbol half is correct and the unreferenced-section
+half waits for GC.
+
 ## [4.21.1] - 2026-08-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.22.0] - 2026-08-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### link: an in-memory link hands back the image and its symbol addresses (#2892)
+
+`linker.link_images_captured` performs the same link `link_images` does - identical
+merge, symbol resolution, relocation patching and layout - and stops one step short
+of the file, handing back the image bytes, the base they were laid out at, and the
+address the link assigned to every symbol.
+
+**Those addresses were computed and then thrown away.** `link_modules_core` builds
+them to populate `.symtab` and discarded them at the write, and a flat image carries
+no symbol table, so the only address a consumer could name in a written one was the
+base - which the entry symbol occupies. One linked image therefore admitted exactly
+one entry point.
+
+That limit had a cost in the rv32 reference-core harness: eleven wide-integer probes
+could not run from a linked image at all and fell back to the UNLINKED `.text`, where
+`.data` is absent and no relocation has been applied, so nothing touching a global
+could be executed. **Every rv32 probe now runs from the linked image**, entered
+directly at the address the link gave it - which is what keeps the harness the
+independent party on the calling convention rather than routing probes through a
+dispatcher that would use the compiler's convention on both sides.
+
+The capture is image-producing formats only: `emit_exec_image` is nil elsewhere and
+the call refuses rather than inventing an answer for a container format, where "the
+bytes" is not a question with one answer. The flat writer's layout and its
+enter-at-the-base rule are now one body shared by the file path and the in-memory
+one, so an image held in memory cannot differ from the one a build would have
+written.
+
 ## [4.21.1] - 2026-08-20
 
 ### Fixed

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.21.1"
+version = "4.22.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -355,10 +355,128 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     # the parsed images are owned here (read from disk), so they are torn down
     # after linking regardless of outcome.
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, modules, module_count, 0, dynlibs, dynlib_count,
+        link_modules_nocapture(s, tgt, modules, module_count, 0, dynlibs, dynlib_count,
                      out_path, name, mode, pie, image_options);
     free_modules(alloc, modules, module_count);
     ret r;
+}
+
+# a linked image held in memory, with the addresses the link assigned
+#
+# WHAT THE LINKER ALREADY KNEW AND USED TO THROW AWAY (#2892). `link_modules_core`
+# computes every symbol's final address to build `.symtab`, and the flat writer
+# computes the image base and size to write the file - and both were discarded at
+# the file write. A consumer that wants to enter a linked image somewhere other
+# than its entry point had no way to learn where anything is: a flat image carries
+# no symbol table, so the only address it could name was the base.
+#
+# The caller owns `bytes` and `symbols` and releases both with `linked_image_dnit`.
+# ---
+# bytes:        the laid-out image, exactly what a build would have written
+# len:          the image's length in bytes
+# base:         the address the image was laid out at
+# symbols:      every symbol's final address, as `.symtab` would have carried it
+# symbol_count: number of entries in `symbols`
+pub rec LinkedImage {
+    bytes:        *u8;
+    len:          usize;
+    base:         u64;
+    symbols:      *of.SymtabEntry;
+    symbol_count: u32;
+}
+
+# release a captured image's buffer and symbol array
+# ---
+# img:   the captured image; nil and already-released are both no-ops
+# alloc: the allocator the link was run on
+pub fun linked_image_dnit(img: *LinkedImage, alloc: *A.Allocator) {
+    if (img == nil) { ret; }
+    if (img.bytes != nil && img.len > 0) { A.deallocate[u8](alloc, img.bytes, img.len); }
+    if (img.symbols != nil && img.symbol_count > 0) {
+        A.deallocate[of.SymtabEntry](alloc, img.symbols, img.symbol_count::usize);
+    }
+    img.bytes        = nil;
+    img.len          = 0;
+    img.symbols      = nil;
+    img.symbol_count = 0;
+}
+
+# the address `name` was linked at, or none when the image defines no such symbol
+# ---
+# img:  a captured image
+# itn:  the interner the link ran against
+# name: the symbol's source-level name
+# ret:  the linked address, or none
+pub fun linked_image_symbol(img: *LinkedImage, itn: *intern.Interner, name: str) O.Option[u64] {
+    if (img == nil || img.symbols == nil) { ret O.none[u64](); }
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        val opt: O.Option[str] = intern.lookup(itn, img.symbols[i].name);
+        if (O.is_some[str](opt) && str_equals(O.unwrap[str](opt), name)) {
+            ret O.some[u64](img.symbols[i].vaddr);
+        }
+        i = i + 1;
+    }
+    ret O.none[u64]();
+}
+
+# link in-memory codegen images and hand the result back instead of writing it
+#
+# The same link `link_images` performs - identical merge, symbol resolution,
+# relocation patching and layout - stopping one step short of the file. The caller
+# receives the image bytes, the base they were laid out at, and the address the
+# link assigned to every symbol.
+#
+# WHY THE ADDRESSES ARE THE POINT (#2892). A flat image carries no symbol table, so
+# the only address a consumer could name in a written one is the base, which the
+# entry symbol occupies. One image therefore admitted exactly one entry point, and
+# a harness wanting to enter eleven probes had to fall back to the UNLINKED `.text`
+# - where `.data` is absent and no relocation has been applied, so nothing that
+# touches a global can be executed at all. The linker computed every one of these
+# addresses to build `.symtab` and then discarded them at the write.
+#
+# Image-producing formats only: `emit_exec_image` is nil elsewhere and this refuses
+# rather than inventing an answer for a container format.
+#
+# The caller owns `out` and releases it with `linked_image_dnit`.
+# ---
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target - selects OS base address, entry symbol, and writers
+# images:       the in-memory codegen images, one per module
+# image_count:  number of images
+# dynlibs:      logical names and loader names of dynamic dependencies (or nil)
+# dynlib_count: number of dynamic dependencies
+# name:         null-terminated product name
+# pie:          the build opted into a position-independent executable
+# image_options: format-neutral executable-image options
+# out:          receives the linked image and its symbol addresses
+# ret:          true once the image is captured, or an error string
+pub fun link_images_captured(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
+                             image_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
+                             name: *u8, pie: bool, image_options: of.ImageOptions,
+                             out: *LinkedImage) R.Result[bool, str] {
+    if (out == nil) { ret R.err[bool, str]("link: nil capture target"); }
+    out.bytes        = nil;
+    out.len          = 0;
+    out.base         = 0;
+    out.symbols      = nil;
+    out.symbol_count = 0;
+
+    if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
+    if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
+    if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
+    if (tgt.os == nil) { ret R.err[bool, str]("link: target has no OS vtable"); }
+    if (images == nil || image_count == 0) {
+        ret R.err[bool, str]("link: no input objects");
+    }
+    if (!tgt.of.produces_image || tgt.of.emit_exec_image == nil) {
+        ret R.err[bool, str]("link: this object format cannot hand back a linked image");
+    }
+
+    # the path is unused on this route and never opened, but the writers take one
+    # and a nil would be indistinguishable from a bug at the call below
+    ret link_modules(s, tgt, images, image_count, image_count, dynlibs,
+                     dynlib_count, ""::*u8, name, LINK_EXE, pie, image_options, out);
 }
 
 # combine an array of in-memory codegen images into the requested artifact,
@@ -395,7 +513,7 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     if (images == nil || image_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
-    ret link_modules(s, tgt, images, image_count, image_count, dynlibs,
+    ret link_modules_nocapture(s, tgt, images, image_count, image_count, dynlibs,
                      dynlib_count, out_path, name, mode, pie, image_options);
 }
 
@@ -487,7 +605,7 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
     for (j < ext_count) { combined[image_count + j] = ext[j]; j = j + 1; }
 
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, combined, total, image_count, dynlibs, dynlib_count,
+        link_modules_nocapture(s, tgt, combined, total, image_count, dynlibs, dynlib_count,
                      out_path, name, mode, pie, image_options);
 
     # tear down only the parsed external images (the project images are caller-owned)
@@ -628,11 +746,25 @@ fun image_attributes(s: *session.Session, tgt: *target.Target, modules: *of.Obje
     ret R.ok[*u8, str](acc);
 }
 
+# `link_modules` for every caller that wants the artifact written and nothing back
+#
+# The overwhelming majority: a build links to a path. Kept as its own name rather
+# than making each of them spell a nil capture, so the in-memory path is opt-in at
+# the one call that wants it (#2892).
+fun link_modules_nocapture(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
+                           module_count: u32, codegen_count: u32,
+                           dynlibs: *of.DynLib, dynlib_count: u32,
+                           out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
+                           image_options: of.ImageOptions) R.Result[bool, str] {
+    ret link_modules(s, tgt, modules, module_count, codegen_count, dynlibs, dynlib_count,
+                     out_path, name, mode, pie_opt_in, image_options, nil::*LinkedImage);
+}
+
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
-                 image_options: of.ImageOptions) R.Result[bool, str] {
+                 image_options: of.ImageOptions, capture: *LinkedImage) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     # put every input into the form the appliers resolve, before anything reads a
     # relocation, and for EVERY input regardless of provenance: an image parsed from
@@ -698,7 +830,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         val linked: R.Result[bool, str] = link_modules_core(
             s, tgt, modules, module_count, codegen_count,
             dynlibs, dynlib_count, out_path, name, mode, pie_opt_in, opts,
-            pre_atoms);
+            pre_atoms, capture);
         free_atom_plan(alloc, ?local_atoms);
         ret linked;
     }
@@ -729,7 +861,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val linked: R.Result[bool, str] = link_modules_core(
         s, tgt, all, module_count + 1, codegen_count,
         dynlibs, dynlib_count, out_path, name, mode, pie_opt_in, opts,
-        pre_atoms);
+        pre_atoms, capture);
     A.deallocate[of.ObjectImage](alloc, all, (module_count + 1)::usize);
     obj.dnit(?local_imports);
     free_atom_plan(alloc, ?local_atoms);
@@ -745,7 +877,7 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
                       dynlibs: *of.DynLib, dynlib_count: u32,
                       out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
                       image_options: of.ImageOptions,
-                      pre_atoms: *AtomPlan) R.Result[bool, str] {
+                      pre_atoms: *AtomPlan, capture: *LinkedImage) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     var local_got: LocalGotPlan;
     init_local_got_plan(?local_got);
@@ -1117,10 +1249,10 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
             emit_r = emit_shared_object(s, tgt, ?out_img, merged, ?groups, modules, module_count, ?sym_locs, ?dyn, out_path, image_options);
         }
         or (dynamic) {
-            emit_r = emit_executable(s, tgt, ?out_img, merged, ?groups, ?sym_locs, ?dyn, out_path, name, image_options);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?groups, ?sym_locs, ?dyn, out_path, name, image_options, capture);
         }
         or {
-            emit_r = emit_executable(s, tgt, ?out_img, merged, ?groups, ?sym_locs, nil::*DynState, out_path, name, image_options);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?groups, ?sym_locs, nil::*DynState, out_path, name, image_options, capture);
         }
 
         free_dynstate(alloc, ?dyn);
@@ -1695,8 +1827,11 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
                     merged: *MergedSection, groups: *SectionGroups,
                     sym_locs: *map.Map[intern.StrId, SymbolLoc],
                     dyn: *DynState, out_path: *u8, name: *u8,
-                    image_options: of.ImageOptions) R.Result[bool, str] {
-    if (dyn == nil && tgt.of.emit_exec == nil) {
+                    image_options: of.ImageOptions, capture: *LinkedImage) R.Result[bool, str] {
+    if (capture != nil && tgt.of.emit_exec_image == nil) {
+        ret R.err[bool, str]("link: this object format cannot hand back a linked image");
+    }
+    if (capture == nil && dyn == nil && tgt.of.emit_exec == nil) {
         ret R.err[bool, str]("link: object format cannot write executables");
     }
     if (dyn != nil && tgt.of.emit_dyn_exec == nil) {
@@ -1760,7 +1895,36 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
     }
     val symtab: *of.SymtabEntry = R.unwrap_ok[*of.SymtabEntry, str](ser);
 
-    if (dyn == nil) {
+    # AN IN-MEMORY LINK TAKES THE SAME LAYOUT AND STOPS BEFORE THE WRITE (#2892).
+    # Everything above this point is the shipping link: the merge, symbol
+    # resolution, relocation patching and segment layout a build performs. Only
+    # the last step differs, so an image held in memory cannot be a different
+    # image than the one a build would have written - which is the entire reason
+    # a harness is allowed to use it as evidence about a build.
+    #
+    # `symtab` is the addresses the link assigned, and it is handed to the caller
+    # rather than freed below: it is the half of the answer a flat image cannot
+    # carry in the file at all.
+    if (capture != nil) {
+        if (tgt.of.emit_exec_image == nil) {
+            emit_r = R.err[bool, str]("link: this object format cannot hand back a linked image");
+        }
+        or {
+            var cap_base: u64 = 0;
+            var cap_size: usize = 0;
+            val cb: R.Result[*u8, str] =
+                tgt.of.emit_exec_image(alloc, segs, seg_count, entry, ?cap_base, ?cap_size);
+            if (R.is_err[*u8, str](cb)) { emit_r = R.err[bool, str](R.unwrap_err[*u8, str](cb)); }
+            or {
+                capture.bytes        = R.unwrap_ok[*u8, str](cb);
+                capture.len          = cap_size;
+                capture.base         = cap_base;
+                capture.symbols      = symtab;
+                capture.symbol_count = symtab_count;
+            }
+        }
+    }
+    or (dyn == nil) {
         emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.isa, segs, seg_count,
                                   os_page_size(tgt), os_base_addr(tgt), entry,
                                   funcs, func_count,
@@ -1775,7 +1939,9 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
                                       symtab, symtab_count, out_path, name, image_options);
     }
 
-    if (symtab != nil && symtab_count > 0) { A.deallocate[of.SymtabEntry](alloc, symtab, symtab_count::usize); }
+    # a captured link handed `symtab` to the caller; every other path owns it here
+    val kept: bool = capture != nil && R.is_ok[bool, str](emit_r);
+    if (!kept && symtab != nil && symtab_count > 0) { A.deallocate[of.SymtabEntry](alloc, symtab, symtab_count::usize); }
     if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
     if (exc != nil && exc_count > 0) { A.deallocate[of.Section](alloc, exc, exc_count::usize); }
     if (funcs != nil && func_count > 0) {
@@ -10248,7 +10414,7 @@ test "mach.lang.be.linker.link_modules:input_section_names_survive" {
     val tpath: str = fs.temp_path(?tf);
 
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8,
+        link_modules_nocapture(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8,
                      "macho_names"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 
@@ -10342,7 +10508,7 @@ test "mach.lang.be.linker.link_modules:flat_entry_leads_regardless_of_order" {
 
     # both modules are in-memory codegen images (codegen_count == 2), static exe.
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        link_modules_nocapture(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -10408,7 +10574,7 @@ fun lt_loader_link(s: *session.Session, tgt: *target.Target, mode: LinkMode, pie
     val tpath: str = fs.temp_path(?tf);
 
     val lr: R.Result[bool, str] =
-        link_modules(s, tgt, ?mods[0], 1, 1, dynlibs, dynlib_count, tpath::*u8,
+        link_modules_nocapture(s, tgt, ?mods[0], 1, 1, dynlibs, dynlib_count, tpath::*u8,
                      "loader_req"::*u8, mode, pie,
                      of.image_options_default(of.SUBSYSTEM_CONSOLE));
     if (R.is_err[bool, str](lr)) {
@@ -10636,7 +10802,7 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     var otf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](otf_r);
     val opath: str = fs.temp_path(?otf);
     val olr: R.Result[bool, str] =
-        link_modules(?s, ?etgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, opath::*u8,
+        link_modules_nocapture(?s, ?etgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, opath::*u8,
                      "anon_section_obj"::*u8, LINK_RELOCATABLE, false,
                      of.image_options_default(of.SUBSYSTEM_CONSOLE));
     if (R.is_err[bool, str](olr)) { fs.temp_close_and_remove(?otf); ret 1; }
@@ -10675,7 +10841,7 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     val tpath: str = fs.temp_path(?tf);
 
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, tpath::*u8, "anon_section_syms"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        link_modules_nocapture(?s, ?tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, tpath::*u8, "anon_section_syms"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
@@ -10793,7 +10959,7 @@ test "mach.lang.be.linker.patch_relocations:duplicate_coff_section_symbols_stay_
     val tpath: str = fs.temp_path(?tf);
 
     val lr: R.Result[bool, str] =
-        link_modules(?s, ?tgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, tpath::*u8,
+        link_modules_nocapture(?s, ?tgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, tpath::*u8,
                      "coff_section_syms"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
     if (R.is_err[bool, str](lr)) { fs.temp_close_and_remove(?tf); ret 1; }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -12412,7 +12412,6 @@ fun ut_mos_shift_src(buf: *u8, bits: u32, ty: str, sop: str) usize {
     w = ut_app(buf, w, " { ret v ");
     w = ut_app(buf, w, sop);
     w = ut_app(buf, w, " n; }\n");
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }
@@ -13103,7 +13102,6 @@ fun ut_mos_mul_src(buf: *u8, ty: str) usize {
     w = ut_app(buf, w, ") * (w::");
     w = ut_app(buf, w, ty);
     w = ut_app(buf, w, "))::u64; }\n");
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }
@@ -13237,18 +13235,6 @@ val UT_RV32_CODE:  u32   = 0x1000;
 # cannot reach the code, and inside the image so a runaway push is caught.
 val UT_RV32_STACK: u32   = 0x3FFF0;
 
-# load a built riscv32 image's `.text` into the reference core's memory once
-# ---
-# text: the image's `.text`
-# len:  its length
-# mem:  the reference core's memory image
-fun ut_rv32_load(text: *u8, len: u32, mem: *u8) {
-    var i: usize = 0;
-    for (i < UT_RV32_MEM) { mem[i] = 0; i = i + 1; }
-    i = 0;
-    for (i < len::usize) { mem[UT_RV32_CODE::usize + i] = text[i]; i = i + 1; }
-}
-
 # run one function of a loaded riscv32 image on the reference core
 #
 # THE HARNESS PLACES ARGUMENTS BY THE psABI AS WRITTEN HERE, NOT AS THE COMPILER
@@ -13265,8 +13251,8 @@ fun ut_rv32_load(text: *u8, len: u32, mem: *u8) {
 # wrote `a1` twice and the emitted callee read the same wrong layout back. Entering at
 # the function under test makes this harness the independent party.
 # ---
-# mem:   the memory image, already loaded by `ut_rv32_load`
-# off:   the function's offset within `.text`
+# mem:   the memory image, already loaded by `ut_rv32_link_captured`
+# off:   the function's offset from the image base, as the link assigned it
 # args:  the argument words, low word of a wide value first
 # nargs: how many argument words
 # lo:    receives a0 (the result, or its low word)
@@ -13333,23 +13319,19 @@ fun ut_rv32_run2(mem: *u8, off: u32, a: u64, b: u64, out: *u64, steps: *u32) boo
 # the probe module every riscv32 execution sweep builds
 #
 # One module for every sweep so a single build serves them all. The functions come
-# first and `main` last, because `ut_image_text` returns symbol offsets in ascending
-# order and the sweeps index them positionally.
+# THE ENTRY COMES FIRST, and nothing else about the order matters (#2892). These probes
+# run from a LINKED image now, and a flat image enters at its base - so the `_start`
+# this declares must be the first thing in `.text`, which `reorder_flat_entry_first`
+# guarantees only at section granularity and source order supplies within it. Every
+# other probe is found by the address the LINK assigned it, so probes may be added,
+# removed or reordered here without touching the sweep.
 #
 # NO FLOATS: the core models RV32I and M only, and refuses a float by name rather than
 # skipping it. That is the harness being honest about its coverage rather than an
 # accident to work around, and it is tracked as #2874.
-#
-# NO GLOBALS IN THIS MODULE, which is a property of how it is LOADED rather than of the
-# harness. These probes are entered by symbol offset into the unlinked object image's
-# `.text`, so `.data` is absent and no relocation has been applied. A global is reached
-# instead through the linked-image path below (`ut_rv32_build_linked`), which links the
-# build and loads every allocated section, and where the wide global access #2867
-# repaired is executed and value-checked. Moving these probes onto that path needs the
-# linker to report a symbol's linked address, since a linked flat image carries no
-# symbol table to look one up in (#2892).
 fun ut_rv32_probe_src(buf: *u8) usize {
     var w: usize = 0;
+    w = ut_app(buf, w, "#[symbol(\"_start\")]\nfun start() i32 { ret 0; }\n");
     w = ut_app(buf, w, "fun mul64(a: i64, b: i64) i64 { ret a * b; }\n");
     w = ut_app(buf, w, "fun xor64(a: i64, b: i64) i64 { ret a ^ b; }\n");
     w = ut_app(buf, w, "fun add64(a: i64, b: i64) i64 { ret a + b; }\n");
@@ -13361,12 +13343,13 @@ fun ut_rv32_probe_src(buf: *u8) usize {
     w = ut_app(buf, w, "fun shrs64(a: i64, n: i64) i64 { ret a >> n; }\n");
     w = ut_app(buf, w, "fun divu64(a: u64, b: u64) u64 { ret a / b; }\n");
     w = ut_app(buf, w, "fun remu64(a: u64, b: u64) u64 { ret a % b; }\n");
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }
 
-# the probe functions, in the order `ut_rv32_probe_src` declares them
+# the probe functions. the slot each occupies in the resolved-offset array is this
+# harness's own indexing and no longer mirrors declaration order: each probe's address
+# comes from the LINK, looked up by name (#2892)
 val UT_RV32_MUL:   u32 = 0;
 val UT_RV32_XOR:   u32 = 1;
 val UT_RV32_ADD:   u32 = 2;
@@ -13379,6 +13362,68 @@ val UT_RV32_SHRS:  u32 = 8;
 val UT_RV32_DIVU:  u32 = 9;
 val UT_RV32_REMU:  u32 = 10;
 val UT_RV32_FNS:   u32 = 11;
+
+# the source-level name of each probe, indexed by the UT_RV32_* slots above
+fun ut_rv32_probe_name(slot: u32) str {
+    if (slot == UT_RV32_MUL)  { ret "mul64"; }
+    if (slot == UT_RV32_XOR)  { ret "xor64"; }
+    if (slot == UT_RV32_ADD)  { ret "add64"; }
+    if (slot == UT_RV32_EQ)   { ret "eq64"; }
+    if (slot == UT_RV32_LTU)  { ret "ltu64"; }
+    if (slot == UT_RV32_LTS)  { ret "lts64"; }
+    if (slot == UT_RV32_SHL)  { ret "shl64"; }
+    if (slot == UT_RV32_SHRU) { ret "shru64"; }
+    if (slot == UT_RV32_SHRS) { ret "shrs64"; }
+    if (slot == UT_RV32_DIVU) { ret "divu64"; }
+    ret "remu64";
+}
+
+# the offset into a captured image of the probe whose SOURCE name is `want`
+#
+# A linkage name carries a module prefix this harness did not choose, so the match is
+# on the trailing dotted component rather than on a composed spelling - the harness
+# names what it declared and stays out of the mangler's business (see #1790). An
+# ambiguous match is a failure rather than a first-hit: two probes ending in the same
+# component would silently sweep one function twice.
+# ---
+# img:  the captured image
+# itn:  the interner the link ran against
+# want: the probe's source-level name
+# off:  receives the probe's offset from the image base
+# ret:  true when exactly one symbol matched
+fun ut_rv32_probe_offset(img: *linker.LinkedImage, itn: *intern.Interner, want: str, off: *u32) bool {
+    var hits: u32 = 0;
+    var found: u64 = 0;
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        val opt: O.Option[str] = intern.lookup(itn, img.symbols[i].name);
+        if (O.is_some[str](opt)) {
+            val nm: str = O.unwrap[str](opt);
+            if (ut_name_tail_is(nm, want)) {
+                hits = hits + 1;
+                found = img.symbols[i].vaddr;
+            }
+        }
+        i = i + 1;
+    }
+    if (hits != 1) { ret false; }
+    @off = (found - img.base)::u32;
+    ret true;
+}
+
+# whether `name`'s final dot-separated component is exactly `tail`
+fun ut_name_tail_is(name: str, tail: str) bool {
+    val n: usize = str_len(name);
+    val t: usize = str_len(tail);
+    if (t == 0 || t > n) { ret false; }
+    if (n > t && name[n - t - 1] != '.') { ret false; }
+    var i: usize = 0;
+    for (i < t) {
+        if (name[n - t + i] != tail[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
 
 # riscv32 (#2778): wide integer work BUILDS AND RUNS, executed on a reference RV32IM
 # core with the answers checked against independently computed references
@@ -13424,13 +13469,10 @@ test "mach.lang.driver:wide_integer_executes_on_an_rv32_core_riscv32" {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
         if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
         or {
-            var text: *u8 = nil;
             var tlen: u32 = 0;
             var offs: [16]u32;
-            if (!ut_image_text(?p, ?text, ?tlen, ?offs[0], UT_RV32_FNS)) { bad = 1; }
-            or (UT_RV32_CODE + tlen >= UT_RV32_STACK)                    { bad = 1; }
+            if (!ut_rv32_link_captured(?p, mem, ?tlen, ?offs[0])) { bad = 1; }
             or {
-                ut_rv32_load(text, tlen, mem);
                 if (ut_rv32_sweep(mem, ?offs[0]) != 0) { bad = 1; }
             }
         }
@@ -13572,7 +13614,6 @@ fun ut_rv32_globals_src(buf: *u8) usize {
     w = ut_app(buf, w, "    if (sel == 7) { ret gn - v; }\n");
     w = ut_app(buf, w, "    ret 0;\n");
     w = ut_app(buf, w, "}\n");
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }
@@ -13605,13 +13646,21 @@ val UT_RV32_G_NSUB:  u32 = 7;
 # both code and data pc-relatively, so the whole image moving together preserves every
 # distance inside it, and the loader stays a copy. An absolute relocation into a global
 # would not survive that, which is why the probes hold scalars.
+#
+# THE LINK HANDS BACK THE IMAGE AND ITS SYMBOL ADDRESSES (#2892), so there is no file
+# round-trip and, more importantly, no one-entry-point limit: a flat image carries no
+# symbol table, so a written one could only ever be entered at its base. Every probe is
+# entered DIRECTLY at the address the link gave it, which is what keeps the harness the
+# independent party on the calling convention that #2870 rests on - a dispatcher would
+# hand argument placement back to the compiler on both sides.
 # ---
 # p:       the built project, after codegen
-# root:    the scaffold root the image is written into
 # mem:     the reference core's memory image
 # len_out: receives the flat image's byte length
-# ret:     true when the image linked, fit, and loaded
-fun ut_rv32_link_flat(p: *project.Project, root: str, mem: *u8, len_out: *u32) bool {
+# offs:    receives each probe's offset from the image base, indexed by the UT_RV32_*
+#          slots; nil for a single-entry probe that enters at the base
+# ret:     true when the image linked, every probe resolved, and it fit and loaded
+fun ut_rv32_link_captured(p: *project.Project, mem: *u8, len_out: *u32, offs: *u32) bool {
     val alloc: *A.Allocator = p.alloc;
     if (p.emit_len == 0) { ret false; }
 
@@ -13627,38 +13676,42 @@ fun ut_rv32_link_flat(p: *project.Project, root: str, mem: *u8, len_out: *u32) b
         i = i + 1;
     }
 
+    var cap: linker.LinkedImage;
     var linked: bool = false;
-    val out: str = ut_cc3(alloc, root, "/", "flat.img");
     if (!missing) {
-        val lr: R.Result[bool, str] = linker.link_images(p.s, ?p.target, images, p.emit_len,
-            nil::*of.DynLib, 0, out::*u8, "rv32probe"::*u8, linker.LINK_EXE, false,
-            of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        val lr: R.Result[bool, str] = linker.link_images_captured(p.s, ?p.target, images,
+            p.emit_len, nil::*of.DynLib, 0, "rv32probe"::*u8, false,
+            of.image_options_default(of.SUBSYSTEM_CONSOLE), ?cap);
         linked = R.is_ok[bool, str](lr);
     }
     A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
     if (!linked) { ret false; }
 
-    val br: R.Result[Vector[u8], str] = fs.read_bytes(alloc, out);
-    if (R.is_err[Vector[u8], str](br)) { ret false; }
-    var img: Vector[u8] = R.unwrap_ok[Vector[u8], str](br);
-
-    var ok: bool = img.len > 0 && UT_RV32_CODE::usize + img.len < UT_RV32_STACK::usize;
-    if (ok) {
-        var k: usize = 0;
-        for (k < UT_RV32_MEM) { mem[k] = 0; k = k + 1; }
-        k = 0;
-        for (k < img.len) { mem[UT_RV32_CODE::usize + k] = img.data[k]; k = k + 1; }
-        @len_out = img.len::u32;
+    var ok: bool = cap.len > 0 && UT_RV32_CODE::usize + cap.len < UT_RV32_STACK::usize;
+    if (ok && offs != nil) {
+        var k: u32 = 0;
+        for (k < UT_RV32_FNS) {
+            if (!ut_rv32_probe_offset(?cap, ?p.s.interner, ut_rv32_probe_name(k), ?offs[k])) { ok = false; }
+            k = k + 1;
+        }
     }
-    vector.dnit[u8](?img);
+    if (ok) {
+        var z: usize = 0;
+        for (z < UT_RV32_MEM) { mem[z] = 0; z = z + 1; }
+        z = 0;
+        for (z < cap.len) { mem[UT_RV32_CODE::usize + z] = cap.bytes[z]; z = z + 1; }
+        @len_out = cap.len::u32;
+    }
+    linker.linked_image_dnit(?cap, alloc);
     ret ok;
 }
 
 # build `src` for rv32, link it, and load the linked flat image into the core
 #
-# The scaffold root outlives the link because the image is written into it, which is
-# what `ut_ct_edge_project` cannot do - it removes the tree the moment the project is
-# built.
+# `ut_ct_edge_project` cannot serve here: it removes the scaffold tree the moment the
+# project is built, and the link reads the built objects. Nothing is written INTO the
+# tree any more - the image comes back in memory (#2892) - so the root exists only for
+# the build itself.
 # ---
 # ret: true when the build, the link and the load all succeeded
 fun ut_rv32_build_linked(s: *session.Session, alloc: *A.Allocator, src: str, tgt: str,
@@ -13677,7 +13730,7 @@ fun ut_rv32_build_linked(s: *session.Session, alloc: *A.Allocator, src: str, tgt
         val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, tgt);
         if (R.is_ok[project.Project, outcome.Fail](pr)) {
             var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-            if (ut_run_codegen_ok(?p) == 0) { ok = ut_rv32_link_flat(?p, root, mem, len_out); }
+            if (ut_run_codegen_ok(?p) == 0) { ok = ut_rv32_link_captured(?p, mem, len_out, nil::*u32); }
             project.dnit_project(?p);
         }
     }
@@ -13843,7 +13896,6 @@ fun ut_rv32_float_src(buf: *u8) usize {
     w = ut_app(buf, w, "    if (sel == 17) { fb = v; @ps = ((@pd))::f32; ret fb; }\n");
     w = ut_app(buf, w, "    ret 0;\n");
     w = ut_app(buf, w, "}\n");
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }
@@ -14221,7 +14273,6 @@ fun ut_mos_cmp_src(buf: *u8, uty: str, sty: str) usize {
         w = ut_app(buf, w, "))::u64; }\n");
         k = k + 1;
     }
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }
@@ -14453,7 +14504,6 @@ fun ut_mos_cast_src(buf: *u8, ty: str) usize {
     w = ut_app(buf, w, ")::");
     w = ut_app(buf, w, ty);
     w = ut_app(buf, w, ")::u64; }\n");
-    w = ut_app(buf, w, "fun main() i32 { ret 0; }\n");
     buf[w] = 0;
     ret w;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -1004,6 +1004,27 @@ pub rec HeaderShape {
 # ret:   reserved bytes, a multiple of the page size
 pub def HeaderSpanFn: fun(*HeaderShape, u64) u64;
 
+# hand back an image-producing format's laid-out bytes instead of writing them
+#
+# The in-memory twin of `ExecFn` for a format whose artifact IS the image
+# (`produces_image`). Same layout, same entry rule, no file: the caller receives
+# the buffer, the base it was laid out at, and its length, and owns the buffer.
+#
+# OPTIONAL, and nil on every format that is not image-producing. An ELF or Mach-O
+# executable is a container with headers, sections and a load table, so "the bytes"
+# is not a thing it can hand back without deciding what a consumer wanted; a flat
+# image has exactly one answer. The linker refuses an in-memory link against a
+# format that leaves this nil rather than inventing one (#2892).
+# ---
+# alloc:     allocator the returned buffer is taken from
+# segs:      the laid-out load segments
+# seg_count: number of segments
+# entry:     the resolved entry address, checked against the image base
+# out_base:  receives the address the image was laid out at
+# out_size:  receives the buffer's length in bytes
+# ret:       the image bytes, owned by the caller, or the failure
+pub def ExecImageFn: fun(*A.Allocator, *LoadSegment, u32, u64, *u64, *usize) R.Result[*u8, str];
+
 # maximum number of instruction sets an OfVTable's ISA-coverage list holds
 val OF_ISA_MAX: u32 = 8;
 
@@ -1124,6 +1145,9 @@ pub rec OfVTable {
     emit_object:         WriterFn;
     parse_object:        ParserFn;
     emit_exec:           ExecFn;
+    # the in-memory twin of `emit_exec`, or nil on a format that is not
+    # image-producing (see `ExecImageFn`)
+    emit_exec_image:     ExecImageFn;
     emit_dyn_exec:       DynExecFn;
     emit_shared:         SharedFn;
     covers_isas:         [OF_ISA_MAX]u32;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -70,12 +70,59 @@ val IMAGE_SCN_MEM_EXECUTE:            u32 = 0x20000000;
 val IMAGE_SCN_MEM_READ:               u32 = 0x40000000;
 val IMAGE_SCN_MEM_WRITE:              u32 = 0x80000000;
 
-# COMDAT selection for a section symbol's aux record. ANY keeps one of N
-# identical definitions and discards the rest - the COFF mechanism the mach
-# whole-program linker reads back as a weak (deduplicated) definition, mirroring
-# the ELF STB_WEAK binding. a defined weak symbol is emitted into its own
-# LNK_COMDAT section so the attribute survives the write->read round-trip
-val IMAGE_COMDAT_SELECT_ANY: u8 = 2;
+# COMDAT selection for a section symbol's aux record: how the linker chooses among
+# N definitions of the same COMDAT symbol.
+#
+# FOUR OF THE SIX MEAN "ONE OF N WINS" and differ only in what they additionally
+# promise about the losers - identical bytes, identical size, or nothing at all.
+# Mach reads all four back as a weak (deduplicated) definition, mirroring the ELF
+# STB_WEAK binding, because the choice mach makes is the same in every case: keep
+# the first, discard the rest. A defined weak symbol is emitted into its own
+# LNK_COMDAT section with SELECT_ANY so the attribute survives the
+# write->read round-trip.
+#
+# THE TWO THAT ARE NOT are `NODUPLICATES`, where a second definition is genuinely
+# an error and must still collide, and `ASSOCIATIVE`, where the section's fate is
+# tied to another COMDAT rather than decided on its own.
+#
+# Reading only `ANY` was what stopped every C++ library linking (#3024): a compiler
+# picks the selection per construct, and the two that reached mach first were the
+# two it did not accept - MSVC spells a vftable `LARGEST`, and the resulting
+# `multiple definition of '??_7...@@6B@'` named a symbol no source wrote.
+val IMAGE_COMDAT_SELECT_NODUPLICATES: u8 = 1;
+val IMAGE_COMDAT_SELECT_ANY:          u8 = 2;
+val IMAGE_COMDAT_SELECT_SAME_SIZE:    u8 = 3;
+val IMAGE_COMDAT_SELECT_EXACT_MATCH:  u8 = 4;
+val IMAGE_COMDAT_SELECT_ASSOCIATIVE:  u8 = 5;
+val IMAGE_COMDAT_SELECT_LARGEST:      u8 = 6;
+
+# whether a COMDAT selection means "keep one of N definitions and discard the rest"
+#
+# The question mach actually has to answer about an input COMDAT. The three
+# selections beyond `ANY` that answer yes carry an extra promise about the losing
+# definitions - `SAME_SIZE` that they are the same length, `EXACT_MATCH` that they
+# are byte-identical, `LARGEST` that the biggest is the one to keep. Mach keeps the
+# FIRST rather than verifying the promise or measuring the sizes, which is what its
+# weak-symbol resolution already does and is observationally identical for the
+# vague-linkage definitions these describe: a C++ vtable emitted by one compiler
+# from one header is the same object in every translation unit that emitted it.
+#
+# `ASSOCIATIVE` answers yes here on purpose. Its real meaning is "this section
+# lives or dies with the COMDAT named in the aux record", which needs section GC to
+# express, and mach discards no sections. Treating it as one-of-N keeps the SYMBOL
+# resolution correct - which is the half that blocks a link - and leaves the
+# unreferenced-section half to whenever GC lands. Stated here rather than left as a
+# fallthrough so the next reader knows it was decided.
+# ---
+# sel: the selection byte from a section symbol's aux record
+# ret: true when a duplicate definition is deduplicated rather than an error
+fun comdat_selection_dedups(sel: u8) bool {
+    ret sel == IMAGE_COMDAT_SELECT_ANY
+        || sel == IMAGE_COMDAT_SELECT_SAME_SIZE
+        || sel == IMAGE_COMDAT_SELECT_EXACT_MATCH
+        || sel == IMAGE_COMDAT_SELECT_ASSOCIATIVE
+        || sel == IMAGE_COMDAT_SELECT_LARGEST;
+}
 
 # x86-64 relocation types (IMAGE_REL_AMD64_*)
 val IMAGE_REL_AMD64_ADDR64:   u16 = 0x0001;
@@ -1666,7 +1713,7 @@ fun read_symbol_name(buf: *u8, buf_size: usize, so: usize, strtab_base: usize, s
 # record; returns false when no such record is found. `bigobj` selects the
 # classic 18-byte or /bigobj 20-byte record stride and SectionNumber width
 # (#2147) - it must match the format the caller parsed the header as.
-fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32, sec_num: u32, bigobj: bool) bool {
+fun comdat_dedups_for_section(buf: *u8, symtab_off: usize, num_records: u32, sec_num: u32, bigobj: bool) bool {
     val rsize: usize = sym_record_size(bigobj);
     var ri: u32 = 0;
     for (ri < num_records) {
@@ -1678,7 +1725,7 @@ fun comdat_select_any_for_section(buf: *u8, symtab_off: usize, num_records: u32,
         if (buf[sym_storage_class_off(so, bigobj)] == IMAGE_SYM_CLASS_STATIC && aux >= 1 && (ri + 1) < num_records
             && read_sym_section_number(buf, so, bigobj) == sec_num::i32 && bin.read_u32_le(buf, so + 8) == 0) {
             val ax: usize = so + rsize;
-            ret buf[ax + 14] == IMAGE_COMDAT_SELECT_ANY;
+            ret comdat_selection_dedups(buf[ax + 14]);
         }
         ri = ri + 1 + aux::u32;
     }
@@ -2114,7 +2161,7 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
             && out.symbols[idx].section != of.SECTION_EXTERNAL) {
             val dsh: usize = secthdr_base + out.symbols[idx].section::usize * SECTION_HEADER_SIZE;
             if ((bin.read_u32_le(buf, dsh + 36) & IMAGE_SCN_LNK_COMDAT) != 0
-                && comdat_select_any_for_section(buf, symtab_off, num_records,
+                && comdat_dedups_for_section(buf, symtab_off, num_records,
                                                  out.symbols[idx].section + 1, bigobj)) {
                 flags = flags | of.SYM_OBJ_FLAG_WEAK;
             }
@@ -7341,5 +7388,152 @@ test "mach.lang.target.of.coff.reloc_kind_for:rel32_biased_forms_are_pc32" {
     val sect: R.Result[of.RelocKind, str] = reloc_kind_for(?itn, ?alloc, IMAGE_REL_AMD64_SECTION);
     if (R.is_err[of.RelocKind, str](sect)) { ret 3; }
     if (R.unwrap_ok[of.RelocKind, str](sect) == of.RK_PC32) { ret 4; }
+    ret 0;
+}
+
+# the file offset of the COMDAT selection byte in an emitted object's aux record
+#
+# Walks the symbol table the way `comdat_dedups_for_section` does and returns the
+# aux byte the selection lives in, so a test can rewrite it. Emitting an object with
+# a selection other than `SELECT_ANY` is not possible through the writer - mach only
+# ever produces that one - so a reader test has to patch the byte it would have read.
+# ---
+# buf: the emitted object bytes
+# ret: the offset of the selection byte, or 0 when no COMDAT section symbol is found
+fun t_comdat_selection_off(buf: *u8) usize {
+    val symtab_off:  usize = bin.read_u32_le(buf, 8)::usize;
+    val num_records: u32   = bin.read_u32_le(buf, 12);
+    val rsize: usize = sym_record_size(false);
+    var ri: u32 = 0;
+    for (ri < num_records) {
+        val so: usize = symtab_off + ri::usize * rsize;
+        val aux: u8 = buf[sym_naux_off(so, false)];
+        if (buf[sym_storage_class_off(so, false)] == IMAGE_SYM_CLASS_STATIC
+            && aux >= 1 && (ri + 1) < num_records && bin.read_u32_le(buf, so + 8) == 0) {
+            val secn: i32 = read_sym_section_number(buf, so, false);
+            if (secn >= 1) {
+                val sh: usize = COFF_HEADER_SIZE + (secn - 1)::u32::usize * SECTION_HEADER_SIZE;
+                if ((bin.read_u32_le(buf, sh + 36) & IMAGE_SCN_LNK_COMDAT) != 0) {
+                    ret so + rsize + 14;
+                }
+            }
+        }
+        ri = ri + 1 + aux::u32;
+    }
+    ret 0;
+}
+
+# EVERY SELECTION THAT MEANS "ONE OF N WINS" DEDUPLICATES (#3024).
+#
+# The decision itself, stated over all six values. Reading only `SELECT_ANY` is what
+# stopped every C++ library linking: a compiler picks the selection per construct,
+# and vague-linkage definitions - vtables, typeinfo, inline function bodies - arrive
+# under whichever one that compiler chose. MSVC spells a vftable `LARGEST`, so
+# `??_7Fl_Pixmap@@6B@` collided as a duplicate strong definition and named a symbol
+# no source ever wrote.
+#
+# `NODUPLICATES` is the one that must still collide, and it is asserted here rather
+# than left implied: it is the selection a compiler picks precisely to say a second
+# definition is an error, so treating it like the others would turn a real diagnostic
+# into a silently dropped definition.
+test "mach.lang.target.of.coff.comdat_selection_dedups:every_one_of_n_selection" {
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_ANY))          { ret 1; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_SAME_SIZE))    { ret 2; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_EXACT_MATCH))  { ret 3; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_ASSOCIATIVE))  { ret 4; }
+    if (!comdat_selection_dedups(IMAGE_COMDAT_SELECT_LARGEST))      { ret 5; }
+
+    # the one that is an error by design
+    if (comdat_selection_dedups(IMAGE_COMDAT_SELECT_NODUPLICATES))  { ret 6; }
+
+    # and nothing outside the defined range is admitted: a 0 selection is what an
+    # aux record that is not a COMDAT one reads as, and 7 is past the last value
+    if (comdat_selection_dedups(0)) { ret 7; }
+    if (comdat_selection_dedups(7)) { ret 8; }
+    ret 0;
+}
+
+# the reader honors the selection it actually finds, not the one mach emits
+#
+# The end-to-end half: emit a real object carrying a COMDAT weak body, rewrite the
+# selection byte to each value in turn, and re-parse. A definition under a
+# deduplicating selection comes back WEAK - which is what lets the whole-program
+# linker keep one and discard the rest - and one under `NODUPLICATES` comes back
+# STRONG, so a duplicate still collides.
+test "mach.lang.target.of.coff:comdat_selection_decides_weakness_on_read" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = (0x10 + k)::u8; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    var syms: [2]of.Symbol;
+    syms[0].name = t_intern(?i, "main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 0; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "vtable$T"); syms[1].section = 0; syms[1].offset = 8;
+    syms[1].size = 0;
+    syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION | of.SYM_OBJ_FLAG_WEAK;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "test");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 2;
+    img.relocations = nil; img.reloc_count = 0;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_sel");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val em: R.Result[bool, str] = coff_emit_object(?isa_vt, ?img, fs.temp_path(?tf)::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 2; }
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 3; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    val soff: usize = t_comdat_selection_off(buf.data);
+    # the patch site must exist and must currently hold what mach emits, or the
+    # rewrites below are landing somewhere that means nothing
+    if (soff == 0)                                          { ret 4; }
+    if (buf.data[soff] != IMAGE_COMDAT_SELECT_ANY)          { ret 5; }
+
+    var sels: [6]u8;
+    sels[0] = IMAGE_COMDAT_SELECT_ANY;
+    sels[1] = IMAGE_COMDAT_SELECT_SAME_SIZE;
+    sels[2] = IMAGE_COMDAT_SELECT_EXACT_MATCH;
+    sels[3] = IMAGE_COMDAT_SELECT_ASSOCIATIVE;
+    sels[4] = IMAGE_COMDAT_SELECT_LARGEST;
+    sels[5] = IMAGE_COMDAT_SELECT_NODUPLICATES;
+
+    var si: usize = 0;
+    for (si < 6) {
+        buf.data[soff] = sels[si];
+        var out: of.ObjectImage;
+        val pr: R.Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+        if (R.is_err[bool, str](pr)) { ret 6; }
+
+        var seen: bool = false;
+        var oi: u32 = 0;
+        for (oi < out.symbol_count) {
+            if (out.symbols[oi].name == syms[1].name) {
+                seen = true;
+                val weak: bool = (out.symbols[oi].flags & of.SYM_OBJ_FLAG_WEAK) != 0;
+                # NODUPLICATES is the last entry and is the only one that stays strong
+                if (si == 5 && weak)  { ret 7; }
+                if (si != 5 && !weak) { ret 8; }
+            }
+            oi = oi + 1;
+        }
+        if (!seen) { ret 9; }
+        si = si + 1;
+    }
     ret 0;
 }

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -157,6 +157,40 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 # name:       product name; accepted for of.ExecFn conformance (a flat image is unsigned)
 # image_options: accepted for of.ExecFn conformance; a flat image has no options
 # ret:        ok(true) on success, or an error string
+# lay the segments out and hand back the image bytes (`of.ExecImageFn`)
+#
+# The shared body of the flat writer: `emit_exec` calls it and writes the result,
+# an in-memory link calls it and keeps the result. One layout and ONE entry rule
+# for both, so a caller that holds the image in memory cannot be reading a
+# different image than the one a build would have written (#2892).
+# ---
+# alloc:     allocator the returned buffer is taken from
+# segs:      the laid-out load segments
+# seg_count: number of segments
+# entry:     the resolved entry address, checked against the image base
+# out_base:  receives the base the image was laid out at
+# out_size:  receives the buffer length
+# ret:       the image bytes, owned by the caller, or the failure
+fun exec_image(alloc: *A.Allocator, segs: *of.LoadSegment, seg_count: u32, entry: u64,
+               out_base: *u64, out_size: *usize) R.Result[*u8, str] {
+    var flat_base: u64 = 0;
+    var size: usize = 0;
+    val rb: R.Result[*u8, str] = build_flat_image(alloc, segs, seg_count, ?flat_base, ?size);
+    if (R.is_err[*u8, str](rb)) { ret rb; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+
+    # a flat image has no entry record, so it must enter at its base; an entry
+    # elsewhere cannot be expressed and is an error, not a silent drop.
+    if (entry != flat_base) {
+        A.deallocate[u8](alloc, buf, size);
+        ret R.err[*u8, str]("raw: flat image must enter at its base address");
+    }
+
+    @out_base = flat_base;
+    @out_size = size;
+    ret R.ok[*u8, str](buf);
+}
+
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, image_base: u64, entry: u64,
               funcs: *of.ExecFunction,
@@ -174,16 +208,9 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 
     var flat_base: u64 = 0;
     var size: usize = 0;
-    val rb: R.Result[*u8, str] = build_flat_image(alloc, segs, seg_count, ?flat_base, ?size);
+    val rb: R.Result[*u8, str] = exec_image(alloc, segs, seg_count, entry, ?flat_base, ?size);
     if (R.is_err[*u8, str](rb)) { ret R.err[bool, str](R.unwrap_err[*u8, str](rb)); }
     var buf: *u8 = R.unwrap_ok[*u8, str](rb);
-
-    # a flat image has no entry record, so it must enter at its base; an entry
-    # elsewhere cannot be expressed and is an error, not a silent drop.
-    if (entry != flat_base) {
-        A.deallocate[u8](alloc, buf, size);
-        ret R.err[bool, str]("raw: flat image must enter at its base address");
-    }
 
     val res_file: R.Result[fs.File, str] = fs.create(path, 0o755);
     if (R.is_err[fs.File, str](res_file)) {
@@ -262,6 +289,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.emit_object    = emit_object;
     raw_vtable.parse_object   = parse_object;
     raw_vtable.emit_exec      = emit_exec;
+    raw_vtable.emit_exec_image = exec_image;
     raw_vtable.emit_dyn_exec  = emit_dyn_exec;
 
     # a flat image has no dynamic-import namespace at all.

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.21.1";
+pub val MACH_VERSION: str = "4.22.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Integration merge of `dev` into `main` for 4.22.0.

- #3024 — every deduplicating COMDAT selection is honored, so C++ libraries link.
- #2892 — an in-memory link hands back the image and its symbol addresses; every rv32 probe runs from a linked image.

Throwaway branch head. Runs the darwin release gate.