### PR TITLE
fix(sema): re-check a C-variadic tail against each instance's concrete types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: the C-variadic promotion rule survives monomorphization (#3029)
+
+C promotes anything narrower than `int` to `int` and `f32` to `f64`. Mach adds no
+implicit conversions, so a narrow value in a C-variadic tail is refused with the cast
+named - and that rule was silently skipped whenever the value's type arrived with an
+instantiation:
+
+```mach
+fun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }
+
+log1[u8]("%d\n", c)     # compiled; printf read 32 bits of a register holding a byte
+```
+
+One line away, the identical value passed directly was refused correctly. The rule
+was only ever decided against the **template parameter** `A`, which is not a narrow
+integer because it is not an integer at all, so it declined.
+
+The cause was a layer out. `record_instance` prunes an instance whose arguments are
+all public scalars - its filter asks whether an argument can reach a *secret* - so
+`log1[u8]` was never recorded, its body never re-visited, and no gate ran for that
+instantiation. Same class as #2465, which added its own clause for `$if
+($is_record(T))`: a rule whose answer differs per instance, for arguments the secrecy
+filters do not care about.
+
+A body that calls a C-variadic function is now recorded, so the tail is re-checked
+against each instance's concrete types. **The filter is precise rather than
+conservative**, and deliberately: recording every generic that calls anything re-infers
+bodies with nothing concrete in them and reports their template-time diagnostics a
+second time, which `generic_instance_reached_through_generic` pins. Promotion-clean
+instantiations are unaffected, and one fixed-arity generic wrapper per arity remains
+the way to wrap a C variadic.
+
+Measured at no cost: 45.57s of build CPU against a 45.72s baseline.
+
 ## [4.22.0] - 2026-08-21
 
 ### Changed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -20956,3 +20956,56 @@ test "mach.lang.fe.sema:a_pack_on_a_body_less_fun_is_refused" {
     if (!ut_sema_clean("ext fun strlen(s: *u8) i64;\nfun main() i32 { ret 0; }\n")) { bad = 6; }
     ret bad;
 }
+
+# The C-variadic promotion rule survives monomorphization (#3029).
+#
+# C promotes anything narrower than `int` to `int` and `f32` to `f64`, and mach adds no
+# implicit conversions - so a narrow value in a C-variadic tail is refused, naming the
+# cast. That rule was only ever decided against the TEMPLATE parameter, which is not a
+# narrow integer because it is not an integer at all, so it declined and a generic
+# wrapper passed an unpromoted value straight into a C callee:
+#
+#     fun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }
+#     log1[u8]("%d\n", c)          # compiled; printf read 32 bits of a byte's register
+#
+# The cause was one layer out: `record_instance` prunes an instance whose arguments are
+# all public scalars, so the body was never re-visited and no gate ran for it. This is
+# the same class #2465 fixed for `$if ($is_record(T))` - a rule whose answer differs per
+# instance, for arguments the secrecy filters do not care about.
+test "mach.lang.driver:c_variadic_promotion_survives_monomorphization" {
+    var bad: i32 = 0;
+    val decls: str = "ext fun printf(fmt: *u8, ...) i32;\nfun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }\n";
+
+    # a narrow integer through the wrapper is refused, naming the cast
+    if (ut_vec_diag(ut_cc_src(decls, "fun use_it() i32 { var c: u8 = 65; ret log1[u8](\"%d\\n\", c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 1; }
+
+    # and a narrow float, which promotes to f64 rather than to int
+    if (ut_vec_diag(ut_cc_src(decls, "fun use_it() i32 { ret log1[f32](\"%f\\n\", 1.5::f32); }\n"),
+                    "is promoted to `f64` in a C-variadic argument") != 0) { bad = 2; }
+
+    # THE PROMOTION-CLEAN INSTANTIATIONS STILL COMPILE, which is what keeps this a
+    # check rather than a ban on wrapping a C variadic - one fixed-arity generic
+    # wrapper per arity is the only way to write one, since mach has no runtime
+    # variadics and a pack cannot yet be spread into a C tail (#3025).
+    if (!ut_sema_clean(ut_cc_src(decls, "fun use_it() i32 { ret log1[i32](\"%d\\n\", 7::i32); }\n"))) { bad = 3; }
+    if (!ut_sema_clean(ut_cc_src(decls, "fun use_it() i32 { ret log1[f64](\"%f\\n\", 2.5); }\n"))) { bad = 4; }
+    if (!ut_sema_clean(ut_cc_src(decls, "fun use_it() i32 { ret log1[i64](\"%ld\\n\", 9::i64); }\n"))) { bad = 5; }
+
+    # a pointer rides the tail unpromoted and is unaffected
+    if (!ut_sema_clean(ut_cc_src(decls, "fun use_it() i32 { var p: *u8 = nil; ret log1[*u8](\"%s\\n\", p); }\n"))) { bad = 6; }
+
+    # a two-argument wrapper: the rule reaches every tail slot, not only the first
+    val d2: str = "ext fun printf(fmt: *u8, ...) i32;\nfun log2[A, B](fmt: *u8, a: A, b: B) i32 { ret printf(fmt, a, b); }\n";
+    if (ut_vec_diag(ut_cc_src(d2, "fun use_it() i32 { var c: u8 = 65; ret log2[i32, u8](\"%d %d\\n\", 1::i32, c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 7; }
+    if (!ut_sema_clean(ut_cc_src(d2, "fun use_it() i32 { ret log2[i32, f64](\"%d %f\\n\", 1::i32, 2.5); }\n"))) { bad = 8; }
+
+    # A GENERIC THAT CALLS NOTHING C-VARIADIC IS STILL PRUNED. The filter keys on the
+    # body reaching a C-variadic callee, not on the body calling anything: recording
+    # every calling generic would re-infer bodies with nothing concrete in them and
+    # report their template-time diagnostics a second time, which is what
+    # `generic_instance_reached_through_generic` pins. Exactly one diagnostic here.
+    if (ut_sema_errs("fun inner[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun outer[T](v: T) u32 { ret inner[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { outer[u32](1); ret 0; }\n") != 1) { bad = 9; }
+    ret bad;
+}

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -22,6 +22,7 @@ use R: std.types.result;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
+use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.stmt;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
@@ -574,6 +575,209 @@ pub fun arg_triggers_revalidation(sc: *SemaContext, tid: type.TypeId) bool {
 # origin: module declaring the generic
 # did:    the generic declaration
 # ret:    true when the body carries a directive that may need a per-instance answer
+# the ResolveResult for `origin`, or nil when it is unavailable
+#
+# The live one for the module this episode owns - a transient instance context
+# rebinds `sc.rr`, so reading it rather than the session copy keeps a cross-module
+# instance body resolving against the same table its inference used.
+fun module_rr_for(sc: *SemaContext, origin: session.ModuleId) *resolve.ResolveResult {
+    if (origin == sc.own_module) { ret sc.rr; }
+    val p: ptr = session.module_resolve_ptr(sc.s, origin);
+    if (p == nil) { ret nil; }
+    ret p::*resolve.ResolveResult;
+}
+
+# whether a call's callee is a C-variadic declaration
+#
+# Resolution rather than inference: `expr_resolved` names the symbol the callee
+# spells, the symbol names its declaring module and DeclId, and `DeclFun.c_variadic`
+# is the answer. That chain is available before the body has been typed, which is
+# what this filter needs - it runs while deciding whether an instance is worth
+# re-validating at all.
+#
+# An unresolved callee (an indirect call through a value, an error node) answers
+# false. A function VALUE cannot be C-variadic today: the form is `ext`-only and a
+# function type cannot carry it (#3003), so there is nothing to miss.
+# ---
+# sc:         the sema context
+# rr:         the resolve result for the module owning the callee expression
+# callee_eid: the call's callee expression
+# ret:        true when the callee is declared C-variadic
+fun callee_is_c_variadic(sc: *SemaContext, rr: *resolve.ResolveResult, callee_eid: id.ExprId) bool {
+    if (rr == nil || rr.expr_resolved == nil || rr.symbols == nil) { ret false; }
+    if (callee_eid == id.EXPR_NIL || callee_eid >= rr.expr_count)  { ret false; }
+    val sid: resolve.SymbolId = rr.expr_resolved[callee_eid];
+    if (sid == resolve.SYMBOL_NIL || sid >= rr.symbol_count)       { ret false; }
+    val sym: *resolve.Symbol = ?rr.symbols[sid];
+    if (sym.decl == id.DECL_NIL) { ret false; }
+
+    var da: *ast.Ast = sc.a;
+    if (sym.origin != sc.own_module) { da = session.module_ast(sc.s, sym.origin); }
+    if (da == nil) { ret false; }
+
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(da, sym.decl);
+    if (O.is_none[*decl.Decl](d_opt)) { ret false; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN) { ret false; }
+    ret d.data.fun_.c_variadic;
+}
+
+# whether an expression subtree contains a call to a C-variadic callee
+#
+# TOTAL BY CONSTRUCTION over the expression kinds, and unlike its statement
+# neighbour the conservative default here is FALSE rather than true. The costs are
+# not symmetric: a missed call means a promotion check that never runs, while a
+# spurious one re-validates a body with nothing concrete in it and REPORTS ITS
+# TEMPLATE-TIME DIAGNOSTICS A SECOND TIME (the `generic_instance_reached_through_generic`
+# assertion pins exactly that). So every kind that can hold a child expression is
+# enumerated and recursed; a kind added later is caught by that test rather than by
+# a duplicate-diagnostic report in the field.
+# ---
+# sc:  the sema context
+# a:   the AST owning the expression
+# rr:  the resolve result for that AST's module
+# eid: the expression to inspect
+# ret: true when the subtree calls a C-variadic function
+fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val k: expr.ExprKind = e.kind;
+
+    if (k == expr.EXPR_KIND_CALL) {
+        if (callee_is_c_variadic(sc, rr, e.data.call.callee)) { ret true; }
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee)) { ret true; }
+        var i: u32 = 0;
+        for (i < e.data.call.args_len) {
+            val ix: u32 = e.data.call.args_start + i;
+            if (ix::usize < a.expr_id_len
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix])) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+    if (k == expr.EXPR_KIND_BINARY) {
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs)) { ret true; }
+        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs);
+    }
+    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand); }
+    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object); }
+    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object); }
+    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object); }
+    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner); }
+    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value); }
+    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value); }
+    if (k == expr.EXPR_KIND_ARRAY_LIT) {
+        var i: u32 = 0;
+        for (i < e.data.array_lit.elems_len) {
+            val ix: u32 = e.data.array_lit.elems_start + i;
+            if (ix::usize < a.expr_id_len
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix])) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+    if (k == expr.EXPR_KIND_VECTOR_LIT) {
+        var i: u32 = 0;
+        for (i < e.data.vector_lit.elems_len) {
+            val ix: u32 = e.data.vector_lit.elems_start + i;
+            if (ix::usize < a.expr_id_len
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix])) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+    if (k == expr.EXPR_KIND_STRUCT_LIT) {
+        var i: u32 = 0;
+        for (i < e.data.struct_lit.fields_len) {
+            val ix: u32 = e.data.struct_lit.fields_start + i;
+            if (ix::usize < a.field_init_len
+                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value)) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+
+    # every remaining kind is a leaf carrying no child expression: the literals,
+    # an IDENT, a COMPTIME_IDENT, a TYPE_REF, a GENERIC_INSTANCE, and ERROR.
+    ret false;
+}
+
+# whether a decl's body contains a call to a C-variadic callee
+#
+# The recording filter for the C-variadic promotion rule (#3029). That rule is
+# decided per instance - a `u8` argument is refused where an `i32` is fine - so a
+# body that can reach a C-variadic tail must be re-validated for every
+# instantiation, exactly as #2465's type-directive bodies must be. Without it the
+# rule is only ever decided against the TEMPLATE parameter, which is not an integer
+# at all, so it declines and a `u8` reaches `printf` through a generic wrapper.
+# ---
+# sc:     the sema context
+# origin: ModuleId declaring the generic
+# did:    the generic function's DeclId
+# ret:    true when the body calls a C-variadic function
+fun decl_body_calls_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
+    var a: *ast.Ast = sc.a;
+    if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
+    if (a == nil) { ret false; }
+    val rr: *resolve.ResolveResult = module_rr_for(sc, origin);
+    if (rr == nil) { ret false; }
+
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, did);
+    if (O.is_none[*decl.Decl](d_opt)) { ret false; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN)    { ret false; }
+    if (d.data.fun_.body == id.STMT_NIL) { ret false; }
+    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body);
+}
+
+# the recursive half of `decl_body_calls_c_variadic`, over one statement
+#
+# Enumerated rather than defaulted, for the reason `expr_has_c_variadic_call` states:
+# a spurious record duplicates a body's template-time diagnostics, so the
+# conservative direction that is right for `stmt_has_type_directive` is wrong here.
+fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId) bool {
+    if (sid == id.STMT_NIL) { ret false; }
+    val s_opt: O.Option[*stmt.Stmt] = ast.get_stmt(a, sid);
+    if (O.is_none[*stmt.Stmt](s_opt)) { ret false; }
+    val s: *stmt.Stmt = O.unwrap[*stmt.Stmt](s_opt);
+    val k: stmt.StmtKind = s.kind;
+
+    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr); }
+    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value); }
+    if (k == stmt.STMT_KIND_DECL) {
+        val dd_opt: O.Option[*decl.Decl] = ast.get_decl(a, s.data.decl.decl);
+        if (O.is_none[*decl.Decl](dd_opt)) { ret false; }
+        val dd: *decl.Decl = O.unwrap[*decl.Decl](dd_opt);
+        if (dd.kind != decl.DECL_KIND_VAL && dd.kind != decl.DECL_KIND_VAR) { ret false; }
+        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init);
+    }
+    if (k == stmt.STMT_KIND_IF) {
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond))   { ret true; }
+        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block);
+    }
+    if (k == stmt.STMT_KIND_FOR) {
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body);
+    }
+    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body); }
+    if (k == stmt.STMT_KIND_BLOCK) {
+        var i: u32 = 0;
+        for (i < s.data.block.stmts_len) {
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i])) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+    # a comptime container's arms are statements like any other
+    if (k == stmt.STMT_KIND_COMPTIME_IF || k == stmt.STMT_KIND_COMPTIME_EACH) { ret true; }
+
+    # BRK / CNT / ASM / COMPTIME_ATTR / ERROR carry no call this filter can reach
+    ret false;
+}
+
 fun decl_body_has_type_directive(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
     var a: *ast.Ast = sc.a;
     if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
@@ -745,6 +949,11 @@ pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.Dec
     # Without this `probe[u64]` is never recorded, its body never re-visited, and the
     # gate never evaluated for that instance at all.
     if (!any && decl_body_has_type_directive(sc, origin, decl)) { any = true; }
+    # a body reaching a C-variadic tail needs its arguments checked against the C
+    # promotions per instance, for arguments none of the filters above care about
+    # (#3029) - the rule is decided on the concrete type, and pruning the instance
+    # leaves it decided on the template parameter, which is not an integer at all
+    if (!any && decl_body_calls_c_variadic(sc, origin, decl)) { any = true; }
     if (!any) { ret R.ok[u8, str](RECORD_OK); }
 
     if (sc.insts != nil) {


### PR DESCRIPTION
Closes #3029.

C promotes anything narrower than `int` to `int` and `f32` to `f64`. Mach adds no implicit conversions, so a narrow value in a C-variadic tail is refused with the cast named — and that rule was skipped whenever the value's type arrived with an instantiation:

```mach
fun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }

log1[u8]("%d\n", c)     # compiled; printf read 32 bits of a register holding a byte
```

One line away, the identical value passed directly is refused correctly. Confirmed by reporting the type the check saw: `DBG tail arg type \`A\`` — once, against the template parameter, which is not a narrow integer because it is not an integer at all.

## Cause

`record_instance` prunes an instance whose arguments are all public scalars; its filter asks whether an argument can reach a *secret*. A plain `u8` matches nothing, so the instance was never recorded, the body never re-visited, and no gate ran for that instantiation.

Same class as #2465, which added its own clause for `$if ($is_record(T))` — a rule whose answer differs per instance, for arguments the secrecy filters do not care about.

## Why the filter is precise rather than conservative

I built the coarse version first — record any instance whose body calls anything. Every acceptance case passed, and then it failed `generic_instance_reached_through_generic`, whose final assertion exists for exactly this:

> a purely ABSTRACT argument is pruned … enqueueing it would re-infer a body with nothing concrete and **report its single template-time error a SECOND time**.

So over-recording doesn't merely cost an episode here, it **duplicates diagnostics**. The `stmt_has_type_directive` comment's "cost of being wrong that way is an extra episode" holds for a directive-bearing body and does not generalize. That guard rail did its job, and the new walk is enumerated rather than defaulted for the same reason — its conservative direction is the expensive one.

The callee test is resolution, not inference: `expr_resolved` → `Symbol.decl` → `DeclFun.c_variadic`, all available before the instance body has been typed.

## Verification

- **1497 passed, 0 failed** (1496 before, 1 new).
- Refused: `u8` and `f32` through a wrapper, and a narrow value in the *second* tail slot of a two-argument wrapper — the rule reaches every slot, not only the first.
- Still compiling: `i32`, `i64`, `f64`, and a pointer (which rides the tail unpromoted). One fixed-arity generic wrapper per arity remains the way to wrap a C variadic.
- The pruning-still-works case is asserted directly: a generic calling a non-variadic generic still yields **exactly one** diagnostic.
- **Mutation-checked:** removing the clause fails the new test.
- **No measurable cost:** 45.57s of build CPU against a 45.72s baseline on the same tree.

## Known remaining gap

An instance reached only *through* another generic — `wrap2[u8]` calling `log1[A]` — is still not caught: `wrap2`'s body calls no C-variadic callee directly, and `log1[A]` is pruned as abstract at the template. That is the same transitive shape `generic_instance_reached_through_generic` documents for secrecy, where it was solved by an argument-side signal that has no analogue here. Filed separately rather than stretched into this change.