### PR TITLE
feat(sema): forward a comptime pack into a C-variadic tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,52 @@ the way to wrap a C variadic.
 
 Measured at no cost: 45.57s of build CPU against a 45.72s baseline.
 
+## [Unreleased]
+
+### Added
+
+#### sema: a comptime pack can be forwarded into a C-variadic tail (#3025)
+
+Mach has no runtime variadics, so wrapping a C variadic function could only be done
+one fixed arity at a time - a generic wrapper per argument count. `va...` now forwards
+into a C tail, which is what every report that reached for a pack was trying to write:
+
+```mach
+ext fun printf(fmt: *u8, ...) i32;
+
+pub fun logf(fmt: *u8, va: ...) i32 { ret printf(fmt, va...); }
+
+logf("%d %f\n", 1::i32, 2.5);
+```
+
+Lowering already spliced a pack's concrete slots into the flat argument list without
+caring what shape the callee was, so the tail placement goes through the target's
+`VaModel` exactly as a written-out tail does. What was missing was the type rule.
+
+**WHERE THE CONTRACT LANDS IS THE DESIGN.** A C tail promotes anything narrower than
+`int`, and mach adds no implicit conversions - so a `u8`, which may sit in a pack
+perfectly legally, may not enter a C tail. But a pack element is only nameable where
+it ENTERS the pack: `TYPE_PACK` is interned payload-free, so the spread site can see
+no element types at all. The rule is therefore applied at the call that BUILDS the
+pack, beside the secrecy gate that already walks the same elements for the same
+structural reason - which also puts the diagnostic on the author's own argument
+rather than on a `va...` inside a wrapper they may not have written.
+
+The obligation attaches only where the pack actually reaches C. An ordinary mach
+variadic still takes a `u8` element, because entering a pack carries no width
+obligation of its own - the obligation comes entirely from the forwarding.
+
+### Fixed
+
+#### sema: a comptime container no longer masks the C-variadic filter (#3025)
+
+The instance-recording filter #3029 added answered "yes" for any body holding a `$if`
+or `$each` rather than walking its arms. Every body with a comptime container looked
+like it reached a C-variadic tail; the codegen corpus caught it, refusing
+`fold_pack`'s `u8` element in a body that calls no foreign function at all. The arms
+are walked now. The conservative direction is wrong on this filter in both of its
+uses.
+
 ## [4.22.0] - 2026-08-21
 
 ### Changed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21009,3 +21009,51 @@ test "mach.lang.driver:c_variadic_promotion_survives_monomorphization" {
     if (ut_sema_errs("fun inner[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun outer[T](v: T) u32 { ret inner[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { outer[u32](1); ret 0; }\n") != 1) { bad = 9; }
     ret bad;
 }
+
+# A comptime pack can be forwarded into a C-variadic tail (#3025).
+#
+# Mach has no runtime variadics, so a wrapper over a C variadic could only ever be
+# written one fixed arity at a time. `va...` now forwards into a C tail, which is the
+# thing every report that reached for a pack was actually trying to write:
+#
+#     pub fun logf(fmt: *u8, va: ...) i32 { ret printf(fmt, va...); }
+#
+# WHERE THE CONTRACT LANDS IS THE DESIGN. A pack element is only nameable where it
+# ENTERS the pack - `TYPE_PACK` is interned payload-free, so the spread site can see
+# no element types at all - so the C promotion rule is applied at the call that builds
+# the pack, beside the secrecy gate that walks the same elements for the same reason.
+# That also puts the diagnostic on the user's own argument rather than on a `va...`
+# inside a wrapper they may not have written.
+test "mach.lang.fe.sema:a_pack_forwards_into_a_c_variadic_tail" {
+    val decls: str = "ext fun printf(fmt: *u8, ...) i32;\npub fun logf(fmt: *u8, va: ...) i32 { ret printf(fmt, va...); }\n";
+    var bad: i32 = 0;
+
+    # the wrapper itself, and a promotion-clean call through it
+    if (!ut_sema_clean(ut_cc_src(decls, "fun use_it() i32 { ret logf(\"%d %f\\n\", 1::i32, 2.5); }\n"))) { bad = 1; }
+    # an empty pack forwards as an empty tail
+    if (!ut_sema_clean(ut_cc_src(decls, "fun use_it() i32 { ret logf(\"hi\\n\"); }\n"))) { bad = 2; }
+
+    # the C contract reaches every element, reported where the element is written
+    if (ut_vec_diag(ut_cc_src(decls, "fun use_it() i32 { var c: u8 = 65; ret logf(\"%d\\n\", c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 3; }
+    if (ut_vec_diag(ut_cc_src(decls, "fun use_it() i32 { ret logf(\"%f\\n\", 1.5::f32); }\n"),
+                    "is promoted to `f64` in a C-variadic argument") != 0) { bad = 4; }
+    # and to a later element, not only the first
+    if (ut_vec_diag(ut_cc_src(decls, "fun use_it() i32 { var c: u8 = 65; ret logf(\"%d %d\\n\", 1::i32, c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 5; }
+
+    # THE BOUNDARY: a pack that does NOT reach a C tail is unaffected. Entering a pack
+    # carries no width obligation of its own - that obligation comes entirely from the
+    # forwarding - so a `u8` in an ordinary mach variadic stays legal.
+    if (!ut_sema_clean("fun plain(h: u64, va: ...) u64 { ret h; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var c: u8 = 65; plain(1, c); ret 0; }\n")) { bad = 6; }
+
+    # a spread into a genuinely fixed-arity callee is still refused, naming the pack
+    if (ut_vec_diag("fun fixed(a: i32) i32 { ret a; }\nfun fwd(va: ...) i32 { ret fixed(va...); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { fwd(1::i32); ret 0; }\n",
+                    "cannot spread `...` into fixed parameters") != 0) { bad = 7; }
+
+    # the secrecy gate on pack entry is untouched: a secret still cannot enter a pack,
+    # and the message is the pack one rather than the C-variadic one
+    if (ut_vec_diag(ut_cc_src(decls, "fun use_it() i32 { var s: ^i32 = 1; ret logf(\"%d\\n\", s); }\n"),
+                    "secret value cannot be passed to a") != 0) { bad = 8; }
+    ret bad;
+}

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -123,8 +123,11 @@ pub fun check_coercible(sc: *context.SemaContext, expected: type.TypeId, eid: id
 # args_start: start index into sc.a.expr_ids for the argument expressions
 # args_len:   number of arguments supplied at the call site
 # span:       source range of the call
+# pack_to_c_tail: the callee is a pack function whose body spreads that pack into a
+#             C-variadic tail, so every element entering the pack takes the C
+#             promotion contract as well (#3025)
 # ret:        true when the call is well-typed, false (with a diagnostic) otherwise
-pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start: u32, args_len: u32, span: token.Span) bool {
+pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start: u32, args_len: u32, span: token.Span, pack_to_c_tail: bool) bool {
     if (callee_sig == type.TYPE_ERROR) { ret true; }
 
     val opt_fun: O.Option[*type.Type] = type.get(?sc.s.types, callee_sig);
@@ -154,7 +157,7 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
     # - before arity and the per-argument check - so a misplaced spread reports
     # its own clear diagnostic rather than an arity mismatch, and a pack operand
     # is never additionally diagnosed against a fixed parameter type.
-    if (!validate_pack_spreads(sc, has_pack, fixed_len, args_start, args_len, span)) {
+    if (!validate_pack_spreads(sc, has_pack || c_variadic, fixed_len, args_start, args_len, span)) {
         ret false;
     }
 
@@ -199,7 +202,15 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
     if (c_variadic) {
         var vi: u32 = params_len;
         for (vi < args_len) {
-            if (!check_c_variadic_arg(sc, sc.a.expr_ids[args_start + vi], span)) { all_ok = false; }
+            val veid: id.ExprId = sc.a.expr_ids[args_start + vi];
+            # A `va...` SPREAD IS NOT A VALUE IN THE TAIL, it is the whole pack being
+            # forwarded, and the pack type is a possibly-secret leaf that this check
+            # would misread as a secret argument. Its elements carry the contract
+            # instead, taken at the call that BUILT the pack - the only place they are
+            # nameable, since `TYPE_PACK` is interned payload-free (#3025).
+            if (!arg_is_spread(sc, veid)) {
+                if (!check_c_variadic_arg(sc, veid, span)) { all_ok = false; }
+            }
             vi = vi + 1;
         }
     }
@@ -216,6 +227,13 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
         for (pk < args_len) {
             val parg_eid: id.ExprId = sc.a.expr_ids[args_start + pk];
             if (!arg_is_spread(sc, parg_eid)) {
+                # the pack this element enters is forwarded into a C tail, so the
+                # element takes the C promotion contract here, where it is written
+                # (#3025). the diagnostic lands on the user's argument rather than on
+                # a `va...` inside a wrapper they may not have written.
+                if (pack_to_c_tail) {
+                    if (!check_c_variadic_arg(sc, parg_eid, span)) { all_ok = false; }
+                }
                 val pactual: type.TypeId = expr_type_of(sc, parg_eid);
                 # DEEP secret check (#2162): a nominal that wraps a secret (`rec P { x:
                 # ^u32 }`, a nested record, an all-secret union, a `Box[^u32]`) carries a

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -638,7 +638,22 @@ fun callee_is_c_variadic(sc: *SemaContext, rr: *resolve.ResolveResult, callee_ei
 # rr:  the resolve result for that AST's module
 # eid: the expression to inspect
 # ret: true when the subtree calls a C-variadic function
-fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId) bool {
+# whether a call expression has a `va...` spread among its arguments
+fun call_has_spread_arg(a: *ast.Ast, e: *expr.Expr) bool {
+    var i: u32 = 0;
+    for (i < e.data.call.args_len) {
+        val ix: u32 = e.data.call.args_start + i;
+        if (ix::usize < a.expr_id_len) {
+            val ao: O.Option[*expr.Expr] = ast.get_expr(a, a.expr_ids[ix]);
+            if (O.is_some[*expr.Expr](ao)
+                && O.unwrap[*expr.Expr](ao).kind == expr.EXPR_KIND_SPREAD) { ret true; }
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId, want_spread: bool) bool {
     if (eid == id.EXPR_NIL) { ret false; }
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
     if (O.is_none[*expr.Expr](e_opt)) { ret false; }
@@ -646,34 +661,35 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
     val k: expr.ExprKind = e.kind;
 
     if (k == expr.EXPR_KIND_CALL) {
-        if (callee_is_c_variadic(sc, rr, e.data.call.callee)) { ret true; }
-        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee)) { ret true; }
+        if (callee_is_c_variadic(sc, rr, e.data.call.callee)
+            && (!want_spread || call_has_spread_arg(a, e))) { ret true; }
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee, want_spread)) { ret true; }
         var i: u32 = 0;
         for (i < e.data.call.args_len) {
             val ix: u32 = e.data.call.args_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix])) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
             i = i + 1;
         }
         ret false;
     }
     if (k == expr.EXPR_KIND_BINARY) {
-        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs)) { ret true; }
-        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs);
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs, want_spread)) { ret true; }
+        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs, want_spread);
     }
-    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand); }
-    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object); }
-    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object); }
-    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object); }
-    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner); }
-    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value); }
-    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value); }
+    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand, want_spread); }
+    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object, want_spread); }
+    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object, want_spread); }
+    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object, want_spread); }
+    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner, want_spread); }
+    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value, want_spread); }
+    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value, want_spread); }
     if (k == expr.EXPR_KIND_ARRAY_LIT) {
         var i: u32 = 0;
         for (i < e.data.array_lit.elems_len) {
             val ix: u32 = e.data.array_lit.elems_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix])) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -683,7 +699,7 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
         for (i < e.data.vector_lit.elems_len) {
             val ix: u32 = e.data.vector_lit.elems_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix])) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -693,7 +709,7 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
         for (i < e.data.struct_lit.fields_len) {
             val ix: u32 = e.data.struct_lit.fields_start + i;
             if (ix::usize < a.field_init_len
-                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value, want_spread)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -718,6 +734,27 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
 # did:    the generic function's DeclId
 # ret:    true when the body calls a C-variadic function
 fun decl_body_calls_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
+    ret decl_body_reaches_c_variadic(sc, origin, did, false);
+}
+
+# whether a decl's body FORWARDS ITS PACK into a C-variadic tail (#3025)
+#
+# The narrower question `decl_body_calls_c_variadic` answers with `want_spread`. A body
+# that spreads `va...` into a C tail puts every element of that pack on the C
+# promotion contract - a `u8` may sit in a pack legally and may not enter a C tail -
+# and the elements are only nameable where they ENTER the pack, at the call that
+# builds it. So the obligation is checked there, beside the secrecy gate that already
+# walks the same elements for the same structural reason.
+# ---
+# sc:     the sema context
+# origin: ModuleId declaring the pack function
+# did:    the pack function's DeclId
+# ret:    true when the body spreads its pack into a C-variadic call
+pub fun decl_body_spreads_pack_to_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
+    ret decl_body_reaches_c_variadic(sc, origin, did, true);
+}
+
+fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId, want_spread: bool) bool {
     var a: *ast.Ast = sc.a;
     if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
     if (a == nil) { ret false; }
@@ -729,7 +766,7 @@ fun decl_body_calls_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: 
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_FUN)    { ret false; }
     if (d.data.fun_.body == id.STMT_NIL) { ret false; }
-    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body);
+    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body, want_spread);
 }
 
 # the recursive half of `decl_body_calls_c_variadic`, over one statement
@@ -737,42 +774,67 @@ fun decl_body_calls_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: 
 # Enumerated rather than defaulted, for the reason `expr_has_c_variadic_call` states:
 # a spurious record duplicates a body's template-time diagnostics, so the
 # conservative direction that is right for `stmt_has_type_directive` is wrong here.
-fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId) bool {
+fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId, want_spread: bool) bool {
     if (sid == id.STMT_NIL) { ret false; }
     val s_opt: O.Option[*stmt.Stmt] = ast.get_stmt(a, sid);
     if (O.is_none[*stmt.Stmt](s_opt)) { ret false; }
     val s: *stmt.Stmt = O.unwrap[*stmt.Stmt](s_opt);
     val k: stmt.StmtKind = s.kind;
 
-    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr); }
-    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value); }
+    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr, want_spread); }
+    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value, want_spread); }
     if (k == stmt.STMT_KIND_DECL) {
         val dd_opt: O.Option[*decl.Decl] = ast.get_decl(a, s.data.decl.decl);
         if (O.is_none[*decl.Decl](dd_opt)) { ret false; }
         val dd: *decl.Decl = O.unwrap[*decl.Decl](dd_opt);
         if (dd.kind != decl.DECL_KIND_VAL && dd.kind != decl.DECL_KIND_VAR) { ret false; }
-        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init);
+        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init, want_spread);
     }
     if (k == stmt.STMT_KIND_IF) {
-        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond))   { ret true; }
-        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block)) { ret true; }
-        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block);
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond, want_spread))   { ret true; }
+        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block, want_spread)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block, want_spread);
     }
     if (k == stmt.STMT_KIND_FOR) {
-        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond)) { ret true; }
-        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body);
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond, want_spread)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body, want_spread);
     }
-    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body); }
+    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body, want_spread); }
     if (k == stmt.STMT_KIND_BLOCK) {
         var i: u32 = 0;
         for (i < s.data.block.stmts_len) {
-            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i])) { ret true; }
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i], want_spread)) { ret true; }
             i = i + 1;
         }
         ret false;
     }
-    # a comptime container's arms are statements like any other
-    if (k == stmt.STMT_KIND_COMPTIME_IF || k == stmt.STMT_KIND_COMPTIME_EACH) { ret true; }
+    # A COMPTIME CONTAINER'S ARMS ARE STATEMENTS LIKE ANY OTHER, and are walked
+    # rather than assumed. Answering `true` here made every body holding a `$each`
+    # look like it reached a C-variadic tail, which put the C promotion contract on
+    # the elements of ordinary mach packs - the codegen corpus's `fold_pack`, whose
+    # `$each x in va` body calls no foreign function at all, was refused for holding
+    # a `u8`. The conservative direction is wrong on this filter in both of its uses.
+    if (k == stmt.STMT_KIND_COMPTIME_IF) {
+        var bi: u32 = 0;
+        for (bi < s.data.comptime_if.branches_len) {
+            val br: *decl.ComptimeBranch = ?a.comptime_branches[s.data.comptime_if.branches_start + bi];
+            var si2: u32 = 0;
+            for (si2 < br.body_len) {
+                if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[br.body_start + si2], want_spread)) { ret true; }
+                si2 = si2 + 1;
+            }
+            bi = bi + 1;
+        }
+        ret false;
+    }
+    if (k == stmt.STMT_KIND_COMPTIME_EACH) {
+        var ei: u32 = 0;
+        for (ei < s.data.comptime_each.body_len) {
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.comptime_each.body_start + ei], want_spread)) { ret true; }
+            ei = ei + 1;
+        }
+        ret false;
+    }
 
     # BRK / CNT / ASM / COMPTIME_ATTR / ERROR carry no call this filter can reach
     ret false;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -2278,8 +2278,18 @@ fun infer_call(sc: *context.SemaContext, c: *expr.ExprCall, span: token.Span) ty
         }
     }
 
-    check.check_call(sc, ct, c.args_start, c.args_len, span);
+    check.check_call(sc, ct, c.args_start, c.args_len, span, callee_packs_to_c_tail(sc, c.callee));
     ret ret_type;
+}
+
+# whether a call's callee is a pack function that forwards its pack into a
+# C-variadic tail (#3025)
+fun callee_packs_to_c_tail(sc: *context.SemaContext, callee: id.ExprId) bool {
+    val so: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, callee);
+    if (O.is_none[*resolve.Symbol](so)) { ret false; }
+    val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
+    if (sym.decl == id.DECL_NIL) { ret false; }
+    ret context.decl_body_spreads_pack_to_c_variadic(sc, sym.origin, sym.decl);
 }
 
 # resolve a call's callee to its DeclFun, reading the origin module's AST for a
@@ -2884,7 +2894,7 @@ fun infer_generic_call(sc: *context.SemaContext, c: *expr.ExprCall, ct: type.Typ
     if (O.is_none[*type.Type](sfn_opt)) { ret type.TYPE_ERROR; }
     val ret_type: type.TypeId = O.unwrap[*type.Type](sfn_opt).data.fn.ret_type;
 
-    check.check_call(sc, sig, c.args_start, c.args_len, span);
+    check.check_call(sc, sig, c.args_start, c.args_len, span, callee_packs_to_c_tail(sc, c.callee));
     ret ret_type;
 }
 


### PR DESCRIPTION
Closes #3025. Built on #3029, whose mechanism it reuses.

Mach has no runtime variadics, so wrapping a C variadic could only be done one fixed arity at a time. `va...` now forwards into a C tail — the thing every report that reached for a pack was trying to write:

```mach
ext fun printf(fmt: *u8, ...) i32;

pub fun logf(fmt: *u8, va: ...) i32 { ret printf(fmt, va...); }

logf("%d %f\n", 1::i32, 2.5);      # emits va.main.logf$pack$i32$f64 calling printf
```

## Two thirds already worked

Lowering's spread path already spliced `ctx.pack_len` concrete slots into the flat argument list without caring whether the callee had a pack parameter or a C tail, so placement goes through the target's `VaModel` exactly as a written-out tail does. The sema gate was the only structural blocker. What was actually missing was the **type rule**.

## Where the contract lands is the design

A C tail promotes anything narrower than `int`, and mach adds no implicit conversions — so a `u8`, which may sit in a pack perfectly legally, may not enter a C tail.

But a pack element is only nameable where it **enters** the pack: `TYPE_PACK` is interned payload-free, so the spread site can see no element types at all. So the rule is applied at the call that *builds* the pack, beside the secrecy gate that already walks the same elements for the same structural reason. That also puts the diagnostic on the author's own argument:

```
error: `u8` is promoted to a 32-bit integer in a C-variadic argument; write the cast
 --> fun start() i32 { var c: u8 = 65; ret logf("%d\n", c); }
                                                        ^
```

not on a `va...` inside a wrapper they may not have written.

The obligation attaches **only where the pack actually reaches C**. An ordinary mach variadic still takes a `u8` element, because entering a pack carries no width obligation of its own — it comes entirely from the forwarding. That boundary is asserted directly.

## A bug this found in #3029

#3029's recording filter answered "yes" for any body holding a `$if` or `$each` rather than walking its arms, so every body with a comptime container looked like it reached a C-variadic tail. **The codegen corpus caught it** — `call/call_variadic` failed 16 cells, refusing `fold_pack`'s `u8` element in a body whose `$each x in va` calls no foreign function at all. The arms are walked now. The conservative direction is wrong on this filter in both of its uses, and that is now stated where it is easy to get wrong again.

That over-approximation is in `dev` and was never released.

## Verification

- **1498 passed, 0 failed** (1497 before, 1 new).
- **Codegen corpus 1416 pass, 0 fail** — back to baseline after the fix above.
- Refused: `u8`, `f32`, and a narrow value in a *later* element, each reported at the author's argument.
- Still compiling: promotion-clean calls, an **empty** pack forwarding as an empty tail, and a `u8` in a non-forwarding mach variadic.
- The spread into a genuinely fixed-arity callee is still refused, and the pack secrecy gate is unchanged — both asserted.
- **Mutation-checked:** removing the pack-entry C check fails the new test.
- **Fixpoint:** three generations byte-identical. `tests.mach` diff is purely additive.