### PR TITLE
chore: release 4.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.23.0] - 2026-08-21
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.22.0"
+version = "4.23.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.22.0";
+pub val MACH_VERSION: str = "4.23.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Two entries since 4.22.0:

- **#3025** — a comptime pack forwards into a C-variadic tail, so a C variadic can be wrapped once instead of once per arity. New capability, so a minor bump.
- **#3029** — the C-variadic promotion rule survives monomorphization; a generic wrapper no longer passes an unpromoted value into a C callee.