### PR TITLE
fix(sema): follow the call chain when deciding the C-variadic contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: the C-variadic contract follows a call chain, not just one hop (#3031)
+
+#3029 made the C promotion rule survive monomorphization for a call one hop from the
+C-variadic callee. Two hops still passed an unpromoted value:
+
+```mach
+fun log1[A](fmt: *u8, a: A)  i32 { ret printf(fmt, a); }
+fun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }
+
+wrap2[u8]("%d\n", c)     # compiled
+```
+
+Neither instance was recorded, for two different reasons. `wrap2[u8]`'s arguments are
+public scalars and its body calls no C-variadic callee **directly**; `log1[A]` is
+recorded from `wrap2`'s template but with an abstract argument, and an all-abstract
+instance is pruned. So the concrete `log1[u8]` never existed as a recorded instance -
+the only thing that could create it was a re-validation of `wrap2[u8]`, which was
+itself never recorded.
+
+The reachability walk is transitive now: a body reaches a C-variadic tail if it calls
+one, or calls a function whose body does. A visited set terminates it on recursive and
+mutually recursive call graphs, and exhausting the visit cap answers **no** rather than
+yes - a miss leaves a check unrun on a chain deeper than the cap, while a false
+positive re-infers a body with nothing concrete and duplicates its template-time
+diagnostics.
+
+In the pack mode (#3025) the recursion follows only calls that CARRY a spread, since
+that is how a pack propagates: an ordinary call to a pack function puts none of this
+pack's elements on any contract.
+
+Measured at no cost: 48.95s of build CPU against a 49.14s baseline.
+
 ## [4.23.0] - 2026-08-21
 
 ### Fixed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21057,3 +21057,44 @@ test "mach.lang.fe.sema:a_pack_forwards_into_a_c_variadic_tail" {
                     "secret value cannot be passed to a") != 0) { bad = 8; }
     ret bad;
 }
+
+# The C-variadic contract follows a call chain, not just one hop (#3031).
+#
+# `wrap2` calling `log1` calling `printf` puts `wrap2`'s arguments on the C promotion
+# contract as surely as calling `printf` itself - and neither instance is recorded by
+# any other rule: `wrap2[u8]`'s arguments are public scalars, and `log1[A]` is pruned
+# as abstract at `wrap2`'s template, so nothing else would ever create the concrete
+# `log1[u8]`. That is the shape `generic_instance_reached_through_generic` documents
+# for the constant-time gates, where it was solved with an argument-side signal that
+# has no analogue here: a `u8` carries nothing saying "this will reach a C tail".
+test "mach.lang.driver:c_variadic_contract_follows_the_call_chain" {
+    var bad: i32 = 0;
+    val d1: str = "ext fun printf(fmt: *u8, ...) i32;\nfun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }\nfun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }\n";
+
+    # two hops
+    if (ut_vec_diag(ut_cc_src(d1, "fun use_it() i32 { var c: u8 = 65; ret wrap2[u8](\"%d\\n\", c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 1; }
+
+    # THREE hops. Two passing is not evidence the walk recurses, only that one hop
+    # does - the first version of this fix caught one and missed two.
+    val d2: str = "ext fun printf(fmt: *u8, ...) i32;\nfun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }\nfun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }\nfun wrap3[A](fmt: *u8, a: A) i32 { ret wrap2[A](fmt, a); }\n";
+    if (ut_vec_diag(ut_cc_src(d2, "fun use_it() i32 { var c: u8 = 65; ret wrap3[u8](\"%d\\n\", c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 2; }
+
+    # a clean value through the same chain still compiles at every depth
+    if (!ut_sema_clean(ut_cc_src(d2, "fun use_it() i32 { ret wrap3[i32](\"%d\\n\", 7::i32); }\n"))) { bad = 3; }
+
+    # MUTUALLY RECURSIVE generics terminate. The visited set is what stops the walk;
+    # without it this is an infinite descent rather than a wrong answer.
+    val d3: str = "ext fun printf(fmt: *u8, ...) i32;\nfun ping[A](n: i32, a: A) i32 { if (n <= 0) { ret printf(\"%d\\n\", a); } ret pong[A](n - 1, a); }\nfun pong[A](n: i32, a: A) i32 { ret ping[A](n - 1, a); }\n";
+    if (ut_vec_diag(ut_cc_src(d3, "fun use_it() i32 { var c: u8 = 65; ret ping[u8](4, c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 4; }
+    if (!ut_sema_clean(ut_cc_src(d3, "fun use_it() i32 { ret ping[i32](4, 7::i32); }\n"))) { bad = 5; }
+
+    # AND THE CHAIN THAT REACHES NOTHING IS STILL PRUNED. Following calls transitively
+    # is precisely how the duplicate-diagnostic trap gets re-opened: a generic calling
+    # a generic that calls no C variadic must still be re-inferred zero times. Exactly
+    # one diagnostic, as `generic_instance_reached_through_generic` requires.
+    if (ut_sema_errs("fun leaf[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun mid[T](v: T) u32 { ret leaf[T](v); }\nfun top[T](v: T) u32 { ret mid[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { top[u32](1); ret 0; }\n") != 1) { bad = 6; }
+    ret bad;
+}

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -653,7 +653,23 @@ fun call_has_spread_arg(a: *ast.Ast, e: *expr.Expr) bool {
     ret false;
 }
 
-fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId, want_spread: bool) bool {
+# resolve a call's callee to its declaring function and continue the reachability
+# walk into its body
+#
+# The transitive step. A callee with no body (an `ext` import that is not itself
+# C-variadic, a call through a value) contributes nothing and answers false.
+fun callee_body_reaches(sc: *SemaContext, rr: *resolve.ResolveResult, callee_eid: id.ExprId,
+                        want_spread: bool, seen: *ReachSeen) bool {
+    if (rr == nil || rr.expr_resolved == nil || rr.symbols == nil) { ret false; }
+    if (callee_eid == id.EXPR_NIL || callee_eid >= rr.expr_count)  { ret false; }
+    val sid: resolve.SymbolId = rr.expr_resolved[callee_eid];
+    if (sid == resolve.SYMBOL_NIL || sid >= rr.symbol_count)       { ret false; }
+    val sym: *resolve.Symbol = ?rr.symbols[sid];
+    if (sym.decl == id.DECL_NIL) { ret false; }
+    ret decl_reaches_c_variadic(sc, sym.origin, sym.decl, want_spread, seen);
+}
+
+fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId, want_spread: bool, seen: *ReachSeen) bool {
     if (eid == id.EXPR_NIL) { ret false; }
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
     if (O.is_none[*expr.Expr](e_opt)) { ret false; }
@@ -661,35 +677,41 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
     val k: expr.ExprKind = e.kind;
 
     if (k == expr.EXPR_KIND_CALL) {
+        val spread_here: bool = call_has_spread_arg(a, e);
         if (callee_is_c_variadic(sc, rr, e.data.call.callee)
-            && (!want_spread || call_has_spread_arg(a, e))) { ret true; }
-        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee, want_spread)) { ret true; }
+            && (!want_spread || spread_here)) { ret true; }
+        # NOT C-variadic itself: the tail may still be one call further down. In the
+        # pack mode only a spread-carrying call propagates THIS pack's elements.
+        if (!want_spread || spread_here) {
+            if (callee_body_reaches(sc, rr, e.data.call.callee, want_spread, seen)) { ret true; }
+        }
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee, want_spread, seen)) { ret true; }
         var i: u32 = 0;
         for (i < e.data.call.args_len) {
             val ix: u32 = e.data.call.args_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
     }
     if (k == expr.EXPR_KIND_BINARY) {
-        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs, want_spread)) { ret true; }
-        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs, want_spread);
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs, want_spread, seen)) { ret true; }
+        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs, want_spread, seen);
     }
-    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand, want_spread); }
-    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object, want_spread); }
-    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object, want_spread); }
-    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object, want_spread); }
-    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner, want_spread); }
-    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value, want_spread); }
-    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value, want_spread); }
+    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand, want_spread, seen); }
+    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object, want_spread, seen); }
+    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object, want_spread, seen); }
+    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object, want_spread, seen); }
+    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner, want_spread, seen); }
+    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value, want_spread, seen); }
+    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value, want_spread, seen); }
     if (k == expr.EXPR_KIND_ARRAY_LIT) {
         var i: u32 = 0;
         for (i < e.data.array_lit.elems_len) {
             val ix: u32 = e.data.array_lit.elems_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -699,7 +721,7 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
         for (i < e.data.vector_lit.elems_len) {
             val ix: u32 = e.data.vector_lit.elems_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -709,7 +731,7 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
         for (i < e.data.struct_lit.fields_len) {
             val ix: u32 = e.data.struct_lit.fields_start + i;
             if (ix::usize < a.field_init_len
-                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value, want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value, want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -754,7 +776,65 @@ pub fun decl_body_spreads_pack_to_c_variadic(sc: *SemaContext, origin: session.M
     ret decl_body_reaches_c_variadic(sc, origin, did, true);
 }
 
+# how many distinct functions one reachability question may visit
+#
+# The visited set is what terminates the walk on a recursive or mutually recursive
+# call graph; the cap bounds the work a single `record_instance` decision can do.
+# Exhausting it answers FALSE rather than true, which is the safe direction for this
+# filter: a miss leaves a check unrun on a call chain more than this deep, while a
+# false positive re-infers a body with nothing concrete and duplicates its
+# template-time diagnostics (#3029, #3031).
+val REACH_MAX_VISITED: u32 = 64;
+
+# the functions one reachability walk has already entered
+# ---
+# origins / decls: parallel arrays identifying each visited function
+# len:             number of entries used
+rec ReachSeen {
+    origins: *u32;
+    decls:   *u32;
+    len:     u32;
+}
+
+# record `(origin, did)` as visited; false when already present or the cap is reached
+fun reach_visit(seen: *ReachSeen, origin: session.ModuleId, did: id.DeclId) bool {
+    var i: u32 = 0;
+    for (i < seen.len) {
+        if (seen.origins[i] == origin::u32 && seen.decls[i] == did::u32) { ret false; }
+        i = i + 1;
+    }
+    if (seen.len >= REACH_MAX_VISITED) { ret false; }
+    seen.origins[seen.len] = origin::u32;
+    seen.decls[seen.len]   = did::u32;
+    seen.len = seen.len + 1;
+    ret true;
+}
+
 fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId, want_spread: bool) bool {
+    var so: [REACH_MAX_VISITED]u32;
+    var sd: [REACH_MAX_VISITED]u32;
+    var seen: ReachSeen;
+    seen.origins = ?so[0];
+    seen.decls   = ?sd[0];
+    seen.len     = 0;
+    ret decl_reaches_c_variadic(sc, origin, did, want_spread, ?seen);
+}
+
+# whether `did`'s body reaches a C-variadic tail, directly or through the generics it
+# calls (#3031)
+#
+# TRANSITIVITY IS THE POINT. `wrap2` calling `log1` calling `printf` puts `wrap2`'s
+# arguments on the C contract just as surely as calling `printf` itself, and neither
+# instance is otherwise recorded: `wrap2[u8]`'s arguments are public scalars, and
+# `log1[A]` is pruned as abstract at `wrap2`'s template. Nothing else would create the
+# concrete `log1[u8]`.
+#
+# In the `want_spread` mode the recursion follows only calls that CARRY a spread,
+# because that is how a pack propagates: an ordinary call to a pack function does not
+# put this pack's elements on any contract.
+fun decl_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId,
+                            want_spread: bool, seen: *ReachSeen) bool {
+    if (!reach_visit(seen, origin, did)) { ret false; }
     var a: *ast.Ast = sc.a;
     if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
     if (a == nil) { ret false; }
@@ -766,7 +846,7 @@ fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_FUN)    { ret false; }
     if (d.data.fun_.body == id.STMT_NIL) { ret false; }
-    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body, want_spread);
+    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body, want_spread, seen);
 }
 
 # the recursive half of `decl_body_calls_c_variadic`, over one statement
@@ -774,36 +854,36 @@ fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did
 # Enumerated rather than defaulted, for the reason `expr_has_c_variadic_call` states:
 # a spurious record duplicates a body's template-time diagnostics, so the
 # conservative direction that is right for `stmt_has_type_directive` is wrong here.
-fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId, want_spread: bool) bool {
+fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId, want_spread: bool, seen: *ReachSeen) bool {
     if (sid == id.STMT_NIL) { ret false; }
     val s_opt: O.Option[*stmt.Stmt] = ast.get_stmt(a, sid);
     if (O.is_none[*stmt.Stmt](s_opt)) { ret false; }
     val s: *stmt.Stmt = O.unwrap[*stmt.Stmt](s_opt);
     val k: stmt.StmtKind = s.kind;
 
-    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr, want_spread); }
-    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value, want_spread); }
+    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr, want_spread, seen); }
+    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value, want_spread, seen); }
     if (k == stmt.STMT_KIND_DECL) {
         val dd_opt: O.Option[*decl.Decl] = ast.get_decl(a, s.data.decl.decl);
         if (O.is_none[*decl.Decl](dd_opt)) { ret false; }
         val dd: *decl.Decl = O.unwrap[*decl.Decl](dd_opt);
         if (dd.kind != decl.DECL_KIND_VAL && dd.kind != decl.DECL_KIND_VAR) { ret false; }
-        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init, want_spread);
+        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init, want_spread, seen);
     }
     if (k == stmt.STMT_KIND_IF) {
-        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond, want_spread))   { ret true; }
-        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block, want_spread)) { ret true; }
-        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block, want_spread);
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond, want_spread, seen))   { ret true; }
+        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block, want_spread, seen)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block, want_spread, seen);
     }
     if (k == stmt.STMT_KIND_FOR) {
-        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond, want_spread)) { ret true; }
-        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body, want_spread);
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond, want_spread, seen)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body, want_spread, seen);
     }
-    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body, want_spread); }
+    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body, want_spread, seen); }
     if (k == stmt.STMT_KIND_BLOCK) {
         var i: u32 = 0;
         for (i < s.data.block.stmts_len) {
-            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i], want_spread)) { ret true; }
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -820,7 +900,7 @@ fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveRes
             val br: *decl.ComptimeBranch = ?a.comptime_branches[s.data.comptime_if.branches_start + bi];
             var si2: u32 = 0;
             for (si2 < br.body_len) {
-                if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[br.body_start + si2], want_spread)) { ret true; }
+                if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[br.body_start + si2], want_spread, seen)) { ret true; }
                 si2 = si2 + 1;
             }
             bi = bi + 1;
@@ -830,7 +910,7 @@ fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveRes
     if (k == stmt.STMT_KIND_COMPTIME_EACH) {
         var ei: u32 = 0;
         for (ei < s.data.comptime_each.body_len) {
-            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.comptime_each.body_start + ei], want_spread)) { ret true; }
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.comptime_each.body_start + ei], want_spread, seen)) { ret true; }
             ei = ei + 1;
         }
         ret false;


### PR DESCRIPTION
Closes #3031. Completes #3029, which fixed the one-hop case.

```mach
fun log1[A](fmt: *u8, a: A)  i32 { ret printf(fmt, a); }
fun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }

wrap2[u8]("%d\n", c)     # compiled; printf read 32 bits of a register holding a byte
```

Neither instance was recorded, for two different reasons: `wrap2[u8]`'s arguments are public scalars and its body calls no C-variadic callee **directly**, while `log1[A]` is recorded from `wrap2`'s template but with an abstract argument, and an all-abstract instance is pruned — correctly, since re-inferring it would find nothing concrete and duplicate its diagnostics. So the concrete `log1[u8]` never existed as a recorded instance: the only thing that could create it was a re-validation of `wrap2[u8]`, itself never recorded.

That is the shape `generic_instance_reached_through_generic` documents for the constant-time gates, where it was solved with an **argument-side** signal — a `^` on the spine records the instance whatever the enclosing filter thinks. There is no analogue here: a `u8` carries nothing saying "this will reach a C tail". So the answer has to come from the call graph.

## Design

The reachability walk is transitive: a body reaches a C-variadic tail if it calls one, or calls a function whose body does.

- **A visited set terminates it** on recursive and mutually recursive call graphs. Without it this is an infinite descent rather than a wrong answer, so the test drives a mutually recursive pair through it.
- **Exhausting the visit cap answers no, not yes.** The directions are not symmetric: a miss leaves a check unrun on a chain deeper than the cap, while a false positive re-infers a body with nothing concrete and duplicates its template-time diagnostics — the trap #3029 already fell into once.
- **In the pack mode (#3025) the recursion follows only spread-carrying calls**, since that is how a pack propagates. An ordinary call to a pack function puts none of *this* pack's elements on any contract.

## Verification

- **1499 passed, 0 failed** (1498 before, 1 new).
- **Codegen corpus 1416 pass, 0 fail.**
- Refused at two hops **and at three** — two passing is not evidence the walk recurses, only that one hop does, and the first version of this fix caught one and missed two.
- Mutually recursive generics both terminate and give the right answer, refused with a `u8` and clean with an `i32`.
- **The chain that reaches nothing is still pruned**, asserted directly: a generic calling a generic calling a non-variadic leaf still yields exactly one diagnostic. Following calls transitively is precisely how the duplicate-diagnostic trap gets re-opened.
- **Mutation-checked:** removing the recursive step fails the new test.
- **No measurable cost:** 48.95s of build CPU against a 49.14s baseline on the same tree.
- **Fixpoint:** three generations byte-identical. `tests.mach` diff purely additive.