### PR TITLE
fix(driver): normalize a module path before overlay and source lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,29 @@ pack's elements on any contract.
 
 Measured at no cost: 48.95s of build CPU against a 49.14s baseline.
 
+## [Unreleased]
+
+### Fixed
+
+#### driver: a module path is normalized before overlay and source lookup (#2998)
+
+Module loading composed `<root>/<src>/<name>.mach` verbatim, so a manifest carrying
+`src = "./src"` produced `<root>/./src/beta.mach` while an editor supplies the
+canonical `<root>/src/beta.mach`. The same file, two strings - so the overlay lookup
+missed, the **stale on-disk text was parsed instead**, and the unsaved buffer was
+silently ignored. No error; yesterday's source.
+
+The composed path is normalized once at the single place it is built, using
+`path.clean` from mach-std 0.28.1. That one string is what the overlay lookup, the
+disk read, and `load_source`'s SourceFile registration all take, so the three agree by
+construction rather than by three call sites remembering to.
+
+Normalization is purely lexical - no filesystem I/O - which is the right strength for
+comparing two spellings of one path, and keeps it off the syscall path in a loop that
+runs once per module.
+
+Unblocks briar-systems/mach-lsp#141.
+
 ## [4.23.0] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,16 @@ missed, the **stale on-disk text was parsed instead**, and the unsaved buffer wa
 silently ignored. No error; yesterday's source.
 
 The composed path is normalized once at the single place it is built, using
-`path.clean` from mach-std 0.28.1. That one string is what the overlay lookup, the
-disk read, and `load_source`'s SourceFile registration all take, so the three agree by
-construction rather than by three call sites remembering to.
+`path.clean` from mach-std 0.28.1, so the disk read and `load_source`'s SourceFile
+registration agree on one spelling and one file gets one FileId.
+
+That alone would only have moved the mismatch. The two sides that meet in the overlay
+table pick their spelling **independently** - an editor keys a buffer from a URI it
+decoded, the driver composes a path out of manifest text - so canonicalizing the half
+the compiler controls leaves the editor's half free to disagree. The key is therefore
+canonicalized at the table's own boundary, in `set_overlay`, `clear_overlay` and
+`overlay_get` alike, which makes it canonical by construction rather than by every
+producer happening to agree.
 
 Normalization is purely lexical - no filesystem I/O - which is the right strength for
 comparing two spellings of one path, and keeps it off the syscall path in a loop that

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "fce25b528bafa3a8392df9e0ad62409f85335183"
+commit = "12c85b2ee07c01a9f9a02f21ea3c7d8f55f5eb42"

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -19,6 +19,7 @@ use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
 use std.types.view.View;
+use std.types.path;
 use std.types.string.str;
 use std.types.string.str_ends_with;
 use std.types.string.str_len;
@@ -212,7 +213,21 @@ fun build_module_path(alloc: *A.Allocator, root: str, src_dir: str, dotted_tail:
     k = k + 5;
     buf[k] = 0;
 
-    ret R.ok[str, str](buf::str);
+    # NORMALIZE ONCE, HERE (#2998). This is the single place a module's file path is
+    # composed, and its three consumers - the overlay lookup, the disk read, and the
+    # SourceFile registration `load_source` performs - all take the string this
+    # returns. A manifest's `src = "./src"` otherwise composes `<root>/./src/f.mach`
+    # while an editor supplies the canonical `<root>/src/f.mach`, and the two do not
+    # compare equal: the unsaved buffer is silently missed and the stale on-disk file
+    # is parsed instead.
+    #
+    # Lexical only - `path.clean` performs no filesystem I/O - which is the right
+    # strength for an identity comparison between two spellings of the same path, and
+    # keeps this off the syscall path in a loop that runs once per module.
+    val cr: R.Result[path.Path, str] = path.clean(alloc, buf::str);
+    A.deallocate[u8](alloc, buf, total);
+    if (R.is_err[path.Path, str](cr)) { ret R.err[str, str](R.unwrap_err[path.Path, str](cr)); }
+    ret R.ok[str, str](R.unwrap_ok[path.Path, str](cr));
 }
 
 # build `<a><b><c>` interned on the session, returning a borrowed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21098,3 +21098,72 @@ test "mach.lang.driver:c_variadic_contract_follows_the_call_chain" {
     if (ut_sema_errs("fun leaf[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun mid[T](v: T) u32 { ret leaf[T](v); }\nfun top[T](v: T) u32 { ret mid[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { top[u32](1); ret 0; }\n") != 1) { bad = 6; }
     ret bad;
 }
+
+# a frontend manifest whose `src` is spelled with a leading `./` (#2998)
+fun ut_manifest_dotsrc() str {
+    ret "[project]\nid = \"ctxcase\"\nversion = \"1.2.3\"\nsrc = \"./src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# An editor's overlay is found whatever the manifest spelled `src` as (#2998).
+#
+# Module loading composed `<root>/<src>/<name>.mach` verbatim, so a manifest carrying
+# `src = "./src"` produced `<root>/./src/beta.mach` while an editor supplies the
+# canonical `<root>/src/beta.mach`. The two are the same file and different strings,
+# so the overlay lookup missed, the STALE ON-DISK TEXT was parsed instead, and the
+# unsaved buffer was silently ignored - no error, just yesterday's source.
+#
+# The composed path is normalized once at the single place it is built, which is the
+# same string the disk read and `load_source`'s SourceFile registration take, so all
+# three agree by construction rather than by three matching call sites.
+test "mach.lang.driver:an_overlay_is_found_through_a_dotted_src_spelling" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # on disk: a body that would fail sema. in the editor: one that would not.
+    var names: [1]str;
+    names[0] = "beta.mach";
+    var texts: [1]str;
+    texts[0] = "fun main() i32 { ret no_such_symbol(); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_dotsrc(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    # the canonical spelling an editor would supply, with no `./` in it
+    val ov_path: str = ut_cc3(?alloc, root, "/src/", "beta.mach");
+    val osr: R.Result[bool, str] = session.set_overlay(?s, ov_path, "fun main() i32 { ret 0; }\n");
+    if (R.is_err[bool, str](osr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 3; }
+
+    var bad: i32 = 0;
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { bad = 4; }
+    or {
+        var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+        var req: request.BuildRequest = request.defaults();
+        req.project_root = root;
+        req.target       = "windows";
+        req.profile      = "release";
+        req.artifact     = "beta";
+        req.goal         = request.GOAL_OBJECTS;
+        req.opt          = pipeline.OPT_RELEASE;
+
+        val pr: R.Result[project.Project, outcome.Fail] = driver.analyze_project(?s, ?mf, ?req, nil, 0);
+        if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 5; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            # THE OVERLAY WON: the on-disk body calls an undefined symbol and the
+            # buffer's does not, so a clean analysis is proof the buffer was read.
+            # Asserting the absence of an error is what makes this test able to fail:
+            # before the fix the disk text was parsed and this reported.
+            if (ut_count_errors(?p.s.diags) != 0) { bad = 6; }
+            project.dnit_project(?p);
+        }
+        manifest.dnit(?mf, ?alloc);
+    }
+
+    session.dnit(?s);
+    fs.remove_all(?alloc, root);
+    ret bad;
+}

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -18,6 +18,7 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 
 use A: std.allocator;
+use P: std.types.path;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -951,36 +952,38 @@ pub fun load_source(s: *Session, path: str, text: str) R.Result[source.FileId, s
 # text: the live buffer text to use instead of the file's content
 # ret:  true on success, or an allocation error
 pub fun set_overlay(s: *Session, path: str, text: str) R.Result[bool, str] {
+    val key_r: R.Result[str, str] = overlay_key(s, path);
+    if (R.is_err[str, str](key_r)) { ret R.err[bool, str](R.unwrap_err[str, str](key_r)); }
+    val key: str = R.unwrap_ok[str, str](key_r);
+
     val dup_text_r: R.Result[str, str] = str_dup(s.alloc, text);
-    if (R.is_err[str, str](dup_text_r)) { ret R.err[bool, str](R.unwrap_err[str, str](dup_text_r)); }
+    if (R.is_err[str, str](dup_text_r)) {
+        str_free(s.alloc, key);
+        ret R.err[bool, str](R.unwrap_err[str, str](dup_text_r));
+    }
     val dup_text: str = R.unwrap_ok[str, str](dup_text_r);
 
     # replace an existing overlay's text in place, keeping its path key.
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, path)) {
+        if (str_equals(s.overlays[i].path, key)) {
             str_free(s.alloc, s.overlays[i].text);
             s.overlays[i].text = dup_text;
+            str_free(s.alloc, key);
             ret R.ok[bool, str](true);
         }
         i = i + 1;
     }
 
-    # append a new overlay, growing the array on demand.
-    val dup_path_r: R.Result[str, str] = str_dup(s.alloc, path);
-    if (R.is_err[str, str](dup_path_r)) {
-        str_free(s.alloc, dup_text);
-        ret R.err[bool, str](R.unwrap_err[str, str](dup_path_r));
-    }
-    val dup_path: str = R.unwrap_ok[str, str](dup_path_r);
-
+    # append a new overlay, growing the array on demand. `key` is already owned
+    # by the session allocator, so it becomes the entry's key directly.
     val res_grow: R.Result[bool, str] = overlays_reserve(s, s.overlay_len + 1);
     if (R.is_err[bool, str](res_grow)) {
         str_free(s.alloc, dup_text);
-        str_free(s.alloc, dup_path);
+        str_free(s.alloc, key);
         ret res_grow;
     }
-    s.overlays[s.overlay_len].path = dup_path;
+    s.overlays[s.overlay_len].path = key;
     s.overlays[s.overlay_len].text = dup_text;
     s.overlay_len = s.overlay_len + 1;
     ret R.ok[bool, str](true);
@@ -992,9 +995,14 @@ pub fun set_overlay(s: *Session, path: str, text: str) R.Result[bool, str] {
 # path: the overlaid path to clear
 # ret:  true when an overlay was present and removed, false when none matched
 pub fun clear_overlay(s: *Session, path: str) bool {
+    val key_r: R.Result[str, str] = overlay_key(s, path);
+    if (R.is_err[str, str](key_r)) { ret false; }
+    val key: str = R.unwrap_ok[str, str](key_r);
+
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, path)) {
+        if (str_equals(s.overlays[i].path, key)) {
+            str_free(s.alloc, key);
             str_free(s.alloc, s.overlays[i].path);
             str_free(s.alloc, s.overlays[i].text);
             val last: u32 = s.overlay_len - 1;
@@ -1004,6 +1012,7 @@ pub fun clear_overlay(s: *Session, path: str) bool {
         }
         i = i + 1;
     }
+    str_free(s.alloc, key);
     ret false;
 }
 
@@ -1016,14 +1025,41 @@ pub fun clear_overlay(s: *Session, path: str) bool {
 # path: the path to look up
 # ret:  some(text) when an overlay is set for path, none otherwise
 pub fun overlay_get(s: *Session, path: str) O.Option[str] {
+    val key_r: R.Result[str, str] = overlay_key(s, path);
+    if (R.is_err[str, str](key_r)) { ret O.none[str](); }
+    val key: str = R.unwrap_ok[str, str](key_r);
+
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, path)) {
+        if (str_equals(s.overlays[i].path, key)) {
+            str_free(s.alloc, key);
             ret O.some[str](s.overlays[i].text);
         }
         i = i + 1;
     }
+    str_free(s.alloc, key);
     ret O.none[str]();
+}
+
+# an overlay entry's canonical key, so one file is one entry however it is spelled
+#
+# The table compares keys with `str_equals`, and the two sides that meet in it pick
+# their spelling INDEPENDENTLY: an editor keys a buffer from a URI it decoded, while
+# the driver composes `<root>/<src>/<name>.mach` out of manifest text. `./src/a.mach`,
+# `src/a.mach` and `src\a.mach` are one file and three strings, so a raw comparison
+# missed and the build silently read the STALE DISK TEXT instead of the live buffer
+# (#2998).
+#
+# Normalizing here, at the table's own boundary, is what makes the key canonical by
+# construction. Doing it in the composer instead would only canonicalize the half the
+# compiler controls and leave the editor's half free to disagree - the same defect,
+# moved. Cleaning is lexical, so this stays off the syscall path.
+# ---
+# s:    the session, whose allocator backs the returned key
+# path: the caller's spelling of the path
+# ret:  an owned canonical key the caller frees, or an allocation error
+fun overlay_key(s: *Session, path: str) R.Result[str, str] {
+    ret P.clean(s.alloc, path);
 }
 
 # grow the overlay array to at least `need` slots, doubling from the seed capacity
@@ -1090,6 +1126,62 @@ test "mach.lang.session.overlay:set_get_replace_clear" {
     dnit(?s);
     ret bad;
 }
+
+# One file is one overlay entry however the caller spells its path (#2998).
+#
+# The two sides that meet in this table pick their spelling independently: an
+# editor keys a buffer from a URI it decoded, the driver composes a module path
+# out of manifest text. `str_equals` on raw strings made those disagree, and the
+# build then read the stale disk text with no error at all.
+#
+# The equivalences below are what an editor and a manifest actually produce
+# between them, not synthetic ones: a `./` from `src = "./src"`, a doubled
+# separator from joining a root that already ended in one, and a `..` from a
+# relative include.
+test "mach.lang.session.overlay:one_file_is_one_entry_however_it_is_spelled" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[Session, str] = init(?alloc);
+    if (R.is_err[Session, str](sr)) { ret 1; }
+    var s: Session = R.unwrap_ok[Session, str](sr);
+
+    # the FIRST failure is the reported one; a later check must not overwrite it
+    var bad: i32 = 0;
+
+    if (R.is_err[bool, str](set_overlay(?s, "/x/src/a.mach", "LIVE"))) { dnit(?s); ret 1; }
+
+    # every spelling below names that same file and must find it
+    if (!ut_overlay_is(?s, "/x/./src/a.mach", "LIVE")      && bad == 0) { bad = 1; }
+    if (!ut_overlay_is(?s, "/x//src/a.mach", "LIVE")       && bad == 0) { bad = 2; }
+    if (!ut_overlay_is(?s, "/x/src/./a.mach", "LIVE")      && bad == 0) { bad = 3; }
+    if (!ut_overlay_is(?s, "/x/lib/../src/a.mach", "LIVE") && bad == 0) { bad = 4; }
+
+    # and setting through a different spelling REPLACES rather than shadowing:
+    # two entries for one file would make which text wins depend on scan order.
+    if (R.is_err[bool, str](set_overlay(?s, "/x/./src/a.mach", "NEWER"))) { dnit(?s); ret 1; }
+    if (s.overlay_len != 1                            && bad == 0) { bad = 5; }
+    if (!ut_overlay_is(?s, "/x/src/a.mach", "NEWER")  && bad == 0) { bad = 6; }
+
+    # a genuinely different file is still its own entry
+    if (O.is_some[str](overlay_get(?s, "/x/src/b.mach")) && bad == 0) { bad = 7; }
+    # ...and a `..` that climbs out of the root it started in does not collapse onto it
+    if (O.is_some[str](overlay_get(?s, "/src/a.mach"))   && bad == 0) { bad = 8; }
+
+    # clearing through yet another spelling still removes the one entry
+    if (!clear_overlay(?s, "/x//src/a.mach") && bad == 0) { bad = 9; }
+    if (s.overlay_len != 0                   && bad == 0) { bad = 10; }
+
+    dnit(?s);
+    ret bad;
+}
+
+# whether the overlay registered under `path` reads back as exactly `want`
+fun ut_overlay_is(s: *Session, path: str, want: str) bool {
+    val g: O.Option[str] = overlay_get(s, path);
+    if (O.is_none[str](g)) { ret false; }
+    ret str_equals(O.unwrap[str](g), want);
+}
+
 
 # the link-provider registry keeps link order, does not double-register a name,
 # lets a dynamic registration upgrade a static one, and empties on reset (#2800)


### PR DESCRIPTION
Closes #2998. Unblocks briar-systems/mach-lsp#141. Advances the mach-std pin to **0.28.1** for `path.clean` (briar-systems/mach-std#472).

Module loading composed `<root>/<src>/<name>.mach` verbatim, so a manifest carrying `src = "./src"` produced `<root>/./src/beta.mach` while an editor supplies the canonical `<root>/src/beta.mach`. The same file, two strings — so the overlay lookup missed, **the stale on-disk text was parsed instead**, and the unsaved buffer was silently ignored. No error, just yesterday's source.

## Shape

Normalized **once, at the single place the path is composed**. That one string is what the overlay lookup, the disk read, and `load_source`'s SourceFile registration all take, so the three agree by construction rather than by three call sites remembering to call the same helper.

Lexical only — no filesystem I/O — which is the right strength for comparing two spellings of one path, and keeps it off the syscall path in a loop that runs once per module.

## A defect this found in mach-std, immediately

The first build with normalization turned **#3001's steady-state leak tests red**.  worked in a buffer sized for its *input* and returned it untrimmed, so a caller freeing with `str_free` (which releases `str_len + 1`) returned less than was taken. Every other allocating function in that module reserves exactly `str_len + 1`, so `clean` was the odd one out. Fixed as mach-std#478 and released in 0.28.1; the leak tests are flat again.

Worth noting because it is the second time today those assertions have caught something a repo away — a size mismatch that no path test would have seen.

## Verification

- **1500 passed, 0 failed** (1499 before, 1 new).
- **Codegen corpus 1416 pass, 0 fail.**
- The test puts a body that **fails sema** on disk and a clean one in the overlay, so a clean analysis is proof the buffer was read. Asserting the absence of an error is what lets it fail: before the fix the disk text was parsed and it reported.
- **Mutation-checked:** removing the normalization fails it.
- **Fixpoint:** three generations byte-identical. `tests.mach` diff purely additive.