### PR TITLE
feat(diag): carry a diagnostic's fix as structured edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### diag: a diagnostic carries its fix as an edit, not only as English (#3023)
+
+A mach diagnostic already tells you what to do about it. `help` carries a spelling
+correction, or `value::Type`. An editor cannot act on prose: to offer a one-keystroke
+fix it has to pattern-match the compiler's English and rebuild the edit from it, which
+couples the quick fix to diagnostic **wording** - every rephrasing upstream breaking it
+silently, with no compile error and no test failure to catch it. mach-lsp declined to
+build that, correctly. The compiler already holds the answer at the point it composes
+the sentence, and threw the structure away.
+
+`Diagnostic` now carries `fixes`, alongside `help` rather than instead of it. Terminal
+rendering is unchanged.
+
+```mach
+pub rec Edit { loc: Location; replacement: str; }
+pub rec Fix  { label: str; edits: *Edit; edit_len: usize; edit_cap: usize; }
+```
+
+**Edits are a list.** They apply together or not at all, and the ordinary cast case
+needs two: `(` before the expression and `)::T` after. Applying half of that produces
+source that does not parse, so a one-span shape would either exclude the case or make
+a consumer correlate two separate fixes and hope. Alternatives - cast the value versus
+change the declaration - stay separate `Fix` entries, because those are a choice a
+person makes rather than one atomic edit.
+
+An empty span is an insertion and an empty replacement is a deletion, both falling out
+of the one shape. A fix always carries at least one edit, since `attach_fix` takes the
+first, so "a fix with nothing to apply" is not a state that exists.
+
+Two producers ship with it:
+
+- an unresolved identifier or type name with a near match replaces the misspelling
+- a no-implicit-widening mismatch inserts the cast, **parenthesizing when it must**
+
+That second one is the whole design in miniature. `::` binds tighter than the binary
+operators, so appending `::i64` to `a + a` yields `a + a::i64` - source that compiles,
+casts the wrong operand, and leaves the original error standing. And the range comes
+from the AST node, not from the diagnostic's span: a reporter picks its span to
+underline what reads best, and a `val` declaration's runs past the initializer to the
+`;`, which put the first draft's insertion after the semicolon.
+
+A cast is offered only when it would actually compile. `::` will reinterpret any two
+same-size values, so between two unrelated records it is legal - and offering it would
+turn a real type error into a silent bit pun. A fix that produces a new error, or a new
+wrong program, is worse than none: the editor's keystroke is taken on trust.
+
+Fixes travel through `clone_tail` and `append_all`, so a cached module's replayed
+diagnostics keep them. Otherwise a quick fix would blink out of an editor on an
+unrelated keystroke, with no error message and nothing for a user to report.
+
+Consumer tracking: briar-systems/mach-lsp#165.
+
 ### Fixed
 
 #### sema: the C-variadic contract follows a call chain, not just one hop (#3031)

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -62,7 +62,57 @@ pub rec Related {
     label: str;
 }
 
+# one span-and-text replacement within a fix
+#
+# The span may be empty, which makes the edit a pure INSERTION at that offset, and
+# the replacement may be empty, which makes it a pure DELETION. Both fall out of the
+# one shape rather than needing their own kinds, and both are used: a cast fix
+# inserts `::T` after an expression without needing to know the expression's text.
+#
+# Offsets are byte offsets into the file, matching every other span the compiler
+# reports, so a consumer converts them to its own line/character positions through
+# the source registry exactly as it already does for `loc`.
+# ---
+# loc:         the range to replace
+# replacement: owned text to put in its place, possibly empty
+pub rec Edit {
+    loc:         Location;
+    replacement: str;
+}
+
+# one mechanically applicable fix for a diagnostic
+#
+# EDITS ARE A LIST, NOT A SINGLE SPAN, because the edits of one fix must apply
+# together or not at all. Wrapping an expression in a cast is the ordinary case and
+# needs two: `(` before it and `)::T` after. Applying half of that produces source
+# that does not parse, so a one-span shape would either exclude the case or force a
+# consumer to correlate two separate fixes and hope.
+#
+# A fix always carries at least one edit: `attach_fix` takes the first, so a fix with
+# nothing to apply is not a state that exists. Alternatives - cast the value versus
+# change the declared type - are separate Fix entries, since those are choices a
+# person makes rather than one atomic edit.
+# ---
+# label:    owned title, e.g. "cast the value to `i64`"; what an editor lists
+# edits:    growable array of edits applied together
+# edit_len: number of edits stored
+# edit_cap: allocated slots in edits
+pub rec Fix {
+    label:    str;
+    edits:    *Edit;
+    edit_len: usize;
+    edit_cap: usize;
+}
+
 # a single reported diagnostic tied to a primary location in a source file
+#
+# `help` and `fixes` coexist deliberately: `help` is the rendered sentence a person
+# reads in a terminal, `fixes` is the same advice in a form a program can apply. The
+# alternative is an editor pattern-matching the compiler's English and rebuilding the
+# edit from it, which couples the editor to diagnostic WORDING - every rephrasing
+# upstream silently breaking a quick fix downstream, with no compile error and no test
+# to catch it (#3023). A diagnostic whose advice is not mechanical carries no fix, the
+# same way one with no suggestion carries no help.
 # ---
 # severity:    severity level of the diagnostic
 # loc:         primary location the diagnostic is reported at
@@ -72,6 +122,9 @@ pub rec Related {
 # related:     growable array of secondary locations, or nil when none
 # related_len: number of secondary locations stored (presence count)
 # related_cap: allocated slots in related
+# fixes:       growable array of mechanically applicable fixes, or nil when none
+# fix_len:     number of fixes stored
+# fix_cap:     allocated slots in fixes
 pub rec Diagnostic {
     severity:    Severity;
     loc:         Location;
@@ -81,6 +134,9 @@ pub rec Diagnostic {
     related:     *Related;
     related_len: usize;
     related_cap: usize;
+    fixes:       *Fix;
+    fix_len:     usize;
+    fix_cap:     usize;
 }
 
 # owning list of diagnostics collected across one or more phases
@@ -101,6 +157,16 @@ val INITIAL_CAP: usize = 16;
 
 # initial slot count for a diagnostic's related array on its first secondary span
 val INITIAL_RELATED_CAP: usize = 2;
+
+# initial slot count for a diagnostic's fix array on its first fix
+#
+# One, because a diagnostic offering alternatives is the exception: the array grows
+# by doubling when a second fix arrives, and the common case allocates exactly what
+# it uses.
+val INITIAL_FIX_CAP: usize = 1;
+
+# initial slot count for a fix's edit array on its first edit
+val INITIAL_EDIT_CAP: usize = 2;
 
 # construct an empty diagnostic list backed by the given allocator
 # ---
@@ -141,6 +207,23 @@ pub fun dnit(list: *DiagList) {
         }
         if (d.related != nil && d.related_cap > 0) {
             A.deallocate[Related](list.a, d.related, d.related_cap);
+        }
+        var f: usize = 0;
+        for (f < d.fix_len) {
+            val fx: *Fix = ?d.fixes[f];
+            if (fx.label != nil) { str_free(list.a, fx.label); }
+            var e: usize = 0;
+            for (e < fx.edit_len) {
+                if (fx.edits[e].replacement != nil) { str_free(list.a, fx.edits[e].replacement); }
+                e = e + 1;
+            }
+            if (fx.edits != nil && fx.edit_cap > 0) {
+                A.deallocate[Edit](list.a, fx.edits, fx.edit_cap);
+            }
+            f = f + 1;
+        }
+        if (d.fixes != nil && d.fix_cap > 0) {
+            A.deallocate[Fix](list.a, d.fixes, d.fix_cap);
         }
         i = i + 1;
     }
@@ -287,6 +370,145 @@ pub fun attach_related(list: *DiagList, file_id: source.FileId, span: token.Span
     d.related_len = d.related_len + 1;
 }
 
+# attach a mechanically applicable fix, with its first edit, to the most recently
+# recorded diagnostic
+#
+# The first edit is part of construction rather than a follow-up call, so a fix with
+# nothing to apply is not a reachable state. Further edits belonging to the SAME fix
+# go through attach_fix_edit; a second alternative is a second attach_fix.
+#
+# A no-op when the list is empty. Allocation failure is swallowed and leaves the
+# diagnostic without the fix, matching the other attach helpers: a quick fix is an
+# affordance, and losing one must never change what the compiler reports.
+# ---
+# list:        diagnostic list whose last entry receives the fix
+# label:       title an editor lists the fix under (copied)
+# file_id:     identifier of the file the edit applies to
+# span:        range the edit replaces; an empty range inserts at that offset
+# replacement: text to put in the range (copied); empty deletes
+pub fun attach_fix(list: *DiagList, label: str, file_id: source.FileId, span: token.Span, replacement: str) {
+    if (list == nil || list.len == 0) { ret; }
+    val d: *Diagnostic = ?list.items[list.len - 1];
+
+    # an untitled fix is one an editor cannot list, so it is not attached at all
+    val label_owned: str = dup_or_nil(list.a, label);
+    if (label_owned == nil) { ret; }
+
+    var text: str = replacement;
+    if (text == nil) { text = ""; }
+
+    val edits_r: R.Result[*Edit, str] = A.allocate[Edit](list.a, INITIAL_EDIT_CAP);
+    if (R.is_err[*Edit, str](edits_r)) {
+        str_free(list.a, label_owned);
+        ret;
+    }
+    val edits: *Edit = R.unwrap_ok[*Edit, str](edits_r);
+
+    val rep_r: R.Result[str, str] = str_dup(list.a, text);
+    if (R.is_err[str, str](rep_r)) {
+        A.deallocate[Edit](list.a, edits, INITIAL_EDIT_CAP);
+        str_free(list.a, label_owned);
+        ret;
+    }
+
+    if (d.fixes == nil) {
+        val alloc_r: R.Result[*Fix, str] = A.allocate[Fix](list.a, INITIAL_FIX_CAP);
+        if (R.is_err[*Fix, str](alloc_r)) {
+            str_free(list.a, R.unwrap_ok[str, str](rep_r));
+            A.deallocate[Edit](list.a, edits, INITIAL_EDIT_CAP);
+            str_free(list.a, label_owned);
+            ret;
+        }
+        d.fixes   = R.unwrap_ok[*Fix, str](alloc_r);
+        d.fix_cap = INITIAL_FIX_CAP;
+    }
+    or (d.fix_len == d.fix_cap) {
+        val new_cap: usize = d.fix_cap * 2;
+        val grow_r: R.Result[*Fix, str] = A.reallocate[Fix](list.a, d.fixes, d.fix_cap, new_cap);
+        if (R.is_err[*Fix, str](grow_r)) {
+            str_free(list.a, R.unwrap_ok[str, str](rep_r));
+            A.deallocate[Edit](list.a, edits, INITIAL_EDIT_CAP);
+            str_free(list.a, label_owned);
+            ret;
+        }
+        d.fixes   = R.unwrap_ok[*Fix, str](grow_r);
+        d.fix_cap = new_cap;
+    }
+
+    edits[0].loc.file_id  = file_id;
+    edits[0].loc.span     = span;
+    edits[0].replacement  = R.unwrap_ok[str, str](rep_r);
+
+    var fx: Fix;
+    fx.label    = label_owned;
+    fx.edits    = edits;
+    fx.edit_len = 1;
+    fx.edit_cap = INITIAL_EDIT_CAP;
+    d.fixes[d.fix_len] = fx;
+    d.fix_len = d.fix_len + 1;
+}
+
+# append another edit to the most recently attached fix
+#
+# The edits of one fix apply TOGETHER: wrapping an expression in a cast needs a `(`
+# before it and a `)::T` after, and applying either alone produces source that does
+# not parse. A no-op when the last diagnostic carries no fix yet, so a caller cannot
+# strand an edit on nothing.
+#
+# Allocation failure would leave a HALF-APPLICABLE fix, which is worse than no fix at
+# all, so it drops the whole fix rather than the one edit.
+# ---
+# list:        diagnostic list whose last entry's last fix receives the edit
+# file_id:     identifier of the file the edit applies to
+# span:        range the edit replaces; an empty range inserts at that offset
+# replacement: text to put in the range (copied); empty deletes
+pub fun attach_fix_edit(list: *DiagList, file_id: source.FileId, span: token.Span, replacement: str) {
+    if (list == nil || list.len == 0) { ret; }
+    val d: *Diagnostic = ?list.items[list.len - 1];
+    if (d.fix_len == 0) { ret; }
+    val fx: *Fix = ?d.fixes[d.fix_len - 1];
+
+    if (fx.edit_len == fx.edit_cap) {
+        val new_cap: usize = fx.edit_cap * 2;
+        val grow_r: R.Result[*Edit, str] = A.reallocate[Edit](list.a, fx.edits, fx.edit_cap, new_cap);
+        if (R.is_err[*Edit, str](grow_r)) { drop_last_fix(list, d); ret; }
+        fx.edits    = R.unwrap_ok[*Edit, str](grow_r);
+        fx.edit_cap = new_cap;
+    }
+
+    var text: str = replacement;
+    if (text == nil) { text = ""; }
+    val rep_r: R.Result[str, str] = str_dup(list.a, text);
+    if (R.is_err[str, str](rep_r)) { drop_last_fix(list, d); ret; }
+
+    fx.edits[fx.edit_len].loc.file_id = file_id;
+    fx.edits[fx.edit_len].loc.span    = span;
+    fx.edits[fx.edit_len].replacement = R.unwrap_ok[str, str](rep_r);
+    fx.edit_len = fx.edit_len + 1;
+}
+
+# free and remove the last fix on `d`, leaving the diagnostic itself untouched
+#
+# The recovery path for a fix that could not be completed: a partial fix must never
+# reach a consumer, because applying half of one is a source-corrupting edit.
+# ---
+# list: the owning list, for its allocator
+# d:    the diagnostic whose last fix is dropped
+fun drop_last_fix(list: *DiagList, d: *Diagnostic) {
+    if (d.fix_len == 0) { ret; }
+    val fx: *Fix = ?d.fixes[d.fix_len - 1];
+    if (fx.label != nil) { str_free(list.a, fx.label); }
+    var e: usize = 0;
+    for (e < fx.edit_len) {
+        if (fx.edits[e].replacement != nil) { str_free(list.a, fx.edits[e].replacement); }
+        e = e + 1;
+    }
+    if (fx.edits != nil && fx.edit_cap > 0) {
+        A.deallocate[Edit](list.a, fx.edits, fx.edit_cap);
+    }
+    d.fix_len = d.fix_len - 1;
+}
+
 # whether the list holds at least one error-severity diagnostic
 # ---
 # list: the list to scan
@@ -318,6 +540,21 @@ pub fun suggestion_build(a: *A.Allocator, name: str) str {
     ret R.unwrap_ok[str, str](res_join);
 }
 
+# build an owned `replace with `<name>`` fix label for a spelling correction
+#
+# The rendered help reads `did you mean `helper`?`, which is a question; an editor
+# lists a code action by an imperative title. Both come from the same candidate, so
+# they cannot drift apart, but they are spelled for their own audience.
+# ---
+# a:    allocator backing the returned string
+# name: candidate identifier the fix substitutes
+# ret:  the owned label, or nil on failure
+pub fun fix_label_replace(a: *A.Allocator, name: str) str {
+    val res_join: R.Result[str, str] = str_join(a, "replace with `", name, "`");
+    if (R.is_err[str, str](res_join)) { ret nil; }
+    ret R.unwrap_ok[str, str](res_join);
+}
+
 # deep-copy diagnostic `d` into `dst`, duplicating its owned message, optional
 # note/help lines, and every secondary location
 #
@@ -340,6 +577,23 @@ fun copy_into(dst: *DiagList, d: *Diagnostic) R.Result[bool, str] {
     for (r < d.related_len) {
         attach_related(dst, d.related[r].loc.file_id, d.related[r].loc.span, d.related[r].label);
         r = r + 1;
+    }
+
+    # fixes travel with the copy: the query cache replays a cached module's
+    # diagnostics verbatim, and a quick fix that survived the first build but not a
+    # reused one would blink out of an editor on an unrelated keystroke.
+    var f: usize = 0;
+    for (f < d.fix_len) {
+        val fx: *Fix = ?d.fixes[f];
+        if (fx.edit_len > 0) {
+            attach_fix(dst, fx.label, fx.edits[0].loc.file_id, fx.edits[0].loc.span, fx.edits[0].replacement);
+            var e: usize = 1;
+            for (e < fx.edit_len) {
+                attach_fix_edit(dst, fx.edits[e].loc.file_id, fx.edits[e].loc.span, fx.edits[e].replacement);
+                e = e + 1;
+            }
+        }
+        f = f + 1;
     }
     ret R.ok[bool, str](true);
 }
@@ -440,6 +694,9 @@ fun emit(list: *DiagList, severity: Severity, file_id: source.FileId, span: toke
     d.related      = nil;
     d.related_len  = 0;
     d.related_cap  = 0;
+    d.fixes        = nil;
+    d.fix_len      = 0;
+    d.fix_cap      = 0;
     list.items[list.len] = d;
     list.len = list.len + 1;
 
@@ -640,5 +897,102 @@ test "mach.lang.diagnostic.clone_tail:round_trips_via_append_all" {
     dnit(?dst);
     dnit(snap);
     A.deallocate[DiagList](?a, snap, 1);
+    ret bad;
+}
+
+# A fix survives the copy into another list (#3023).
+#
+# `clone_tail` is how a derived query snapshots the diagnostics it produced so a later
+# reused `get` can replay them. A fix that lived through the first build but not a
+# CACHED one would make an editor's quick fix blink out on an unrelated keystroke -
+# a bug with no error message and no reproducible trigger from the user's side.
+test "mach.lang.diagnostic.attach_fix:survives_a_copy" {
+    var a: A.Allocator;
+    page.make(?a);
+    var src: DiagList = init(?a);
+    var dst: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 4;
+    sp.len    = 5;
+    error(?src, 1, sp, "unresolved identifier `helpr`");
+    attach_help(?src, "did you mean `helper`?");
+    attach_fix(?src, "replace with `helper`", 1, sp, "helper");
+
+    # a second fix on the same diagnostic, with two edits: the alternatives case and
+    # the multi-edit case at once, which is what growth past INITIAL_FIX_CAP exercises
+    var head: token.Span;
+    head.offset = 4;
+    head.len    = 0;
+    var tail: token.Span;
+    tail.offset = 9;
+    tail.len    = 0;
+    attach_fix(?src, "cast the value to `i64`", 1, head, "(");
+    attach_fix_edit(?src, 1, tail, ")::i64");
+
+    # counts are checked BEFORE anything indexes past them: a shape assertion that
+    # faults instead of failing tells the next reader nothing about what broke
+    var bad: i32 = 0;
+    if (src.items[0].fix_len != 2)           { dnit(?src); dnit(?dst); ret 1; }
+    if (src.items[0].fixes[0].edit_len != 1) { dnit(?src); dnit(?dst); ret 2; }
+    if (src.items[0].fixes[1].edit_len != 2) { dnit(?src); dnit(?dst); ret 3; }
+
+    append_all(?dst, ?src);
+    if (dst.len != 1)                 { dnit(?src); dnit(?dst); ret 4; }
+    if (dst.items[0].fix_len != 2)    { dnit(?src); dnit(?dst); ret 5; }
+    if (!str_equals(dst.items[0].fixes[0].label, "replace with `helper`")        && bad == 0) { bad = 6; }
+    if (!str_equals(dst.items[0].fixes[0].edits[0].replacement, "helper")        && bad == 0) { bad = 7; }
+    if (dst.items[0].fixes[0].edits[0].loc.span.offset != 4                      && bad == 0) { bad = 8; }
+    if (dst.items[0].fixes[0].edits[0].loc.span.len != 5                         && bad == 0) { bad = 9; }
+    if (dst.items[0].fixes[1].edit_len != 2) { dnit(?src); dnit(?dst); ret 10; }
+    if (!str_equals(dst.items[0].fixes[1].edits[1].replacement, ")::i64")        && bad == 0) { bad = 11; }
+
+    # the copy owns its strings: freeing the source must not disturb it
+    dnit(?src);
+    if (!str_equals(dst.items[0].fixes[0].edits[0].replacement, "helper")        && bad == 0) { bad = 12; }
+
+    dnit(?dst);
+    ret bad;
+}
+
+# An edit with no fix to belong to is dropped, not stranded (#3023).
+#
+# attach_fix_edit appends to the LAST fix on the LAST diagnostic. With no fix there
+# is no such thing, and a caller that gets the order wrong must not silently attach
+# its `)::i64` to whatever fix a previous diagnostic happens to carry - which would
+# corrupt a fix that was correct.
+test "mach.lang.diagnostic.attach_fix_edit:needs_a_fix_to_belong_to" {
+    var a: A.Allocator;
+    page.make(?a);
+    var list: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = 1;
+
+    # a diagnostic that legitimately carries a fix
+    error(?list, 1, sp, "first");
+    attach_fix(?list, "fix the first", 1, sp, "x");
+
+    # a later one that carries none: the stray edit must not reach back
+    error(?list, 1, sp, "second");
+    attach_fix_edit(?list, 1, sp, "STRAY");
+
+    var bad: i32 = 0;
+    if (list.items[1].fix_len != 0)           { dnit(?list); ret 1; }
+    if (list.items[0].fix_len != 1)           { dnit(?list); ret 2; }
+    if (list.items[0].fixes[0].edit_len != 1) { dnit(?list); ret 3; }
+    if (!str_equals(list.items[0].fixes[0].edits[0].replacement, "x") && bad == 0) { bad = 4; }
+
+    # an untitled fix is one no editor could list, so it is refused outright
+    attach_fix(?list, nil, 1, sp, "y");
+    if (list.items[1].fix_len != 0                          && bad == 0) { bad = 5; }
+
+    # an empty replacement is a DELETION, not an absent one, and is kept
+    attach_fix(?list, "delete it", 1, sp, "");
+    if (list.items[1].fix_len != 1)           { dnit(?list); ret 6; }
+    if (str_len(list.items[1].fixes[0].edits[0].replacement) != 0 && bad == 0) { bad = 7; }
+
+    dnit(?list);
     ret bad;
 }

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -40,6 +40,9 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
+use std.types.string.str_copy_slice;
+use std.types.string.str_equals;
+use std.types.string.str_region_equals;
 use std.types.string.str_copy;
 use std.types.string.str_index_of;
 use std.types.string.str_join;
@@ -2677,6 +2680,236 @@ test "mach.lang.editor.build:missing_manifest_fails_user" {
     if (!R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
     or (R.unwrap_err[outcome.BuildOutcome, outcome.Fail](r).internal) { bad = 1; }
     if (s.build_alloc != prior_build) { bad = 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# the first fix carried by any diagnostic on `list`, or nil when none carries one
+fun t_first_fix(list: *diagnostic.DiagList) *diagnostic.Fix {
+    var i: usize = 0;
+    for (i < list.len) {
+        if (list.items[i].fix_len > 0) { ret ?list.items[i].fixes[0]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# whether any diagnostic on `list` carries a fix
+fun t_any_fix(list: *diagnostic.DiagList) bool {
+    ret t_first_fix(list) != nil;
+}
+
+# apply every edit of `fx` to `src`, producing the fixed source
+#
+# Edits are applied HIGHEST OFFSET FIRST, so an earlier edit's length change cannot
+# shift a later edit's offset out from under it - the order any editor applies a
+# multi-edit code action in. Returns an owned string, or nil on allocation failure.
+fun t_apply_fix(a: *A.Allocator, src: str, fx: *diagnostic.Fix) str {
+    val cr: R.Result[str, str] = str_copy(a, src);
+    if (R.is_err[str, str](cr)) { ret nil; }
+    var cur: str = R.unwrap_ok[str, str](cr);
+
+    var limit: usize = str_len(src) + 1;
+    var n: usize = 0;
+    for (n < fx.edit_len) {
+        var best:     usize = fx.edit_len;
+        var best_off: usize = 0;
+        var i: usize = 0;
+        for (i < fx.edit_len) {
+            val off: usize = fx.edits[i].loc.span.offset;
+            if (off < limit && (best == fx.edit_len || off > best_off)) {
+                best     = i;
+                best_off = off;
+            }
+            i = i + 1;
+        }
+        if (best == fx.edit_len) { brk; }
+        limit = best_off;
+
+        val tail_start: usize = best_off + fx.edits[best].loc.span.len;
+        val cur_len:    usize = str_len(cur);
+        if (tail_start > cur_len) { ret cur; }
+
+        val hr: R.Result[str, str] = str_copy_slice(a, cur, 0, best_off);
+        if (R.is_err[str, str](hr)) { ret cur; }
+        val tr: R.Result[str, str] = str_copy_slice(a, cur, tail_start, cur_len - tail_start);
+        if (R.is_err[str, str](tr)) { ret cur; }
+        val head: str = R.unwrap_ok[str, str](hr);
+        val tail: str = R.unwrap_ok[str, str](tr);
+
+        val jr: R.Result[str, str] = str_join(a, head, fx.edits[best].replacement, tail);
+        if (R.is_ok[str, str](jr)) { cur = R.unwrap_ok[str, str](jr); }
+        n = n + 1;
+    }
+    ret cur;
+}
+
+# whether `src` resolves and type-checks with no error diagnostic at all
+#
+# The proof a fix is a FIX: applying it must leave source the compiler accepts. A
+# replacement that merely looks right - a cast the callee refuses, a paren in the
+# wrong place - passes a field-by-field assertion and fails this.
+fun t_analyzes_clean(alloc: *A.Allocator, name: str, src: str) bool {
+    val res_session: R.Result[session.Session, str] = t_session(alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, name, src);
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret false; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret false; }
+    val clean: bool = !diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagList, str](res_diags));
+
+    dnit(?es);
+    session.dnit(?s);
+    ret clean;
+}
+
+# A spelling correction is carried as an edit, not only as English (#3023).
+#
+# The help line reads `did you mean `helper`?`. An editor cannot act on that without
+# pattern-matching the compiler's prose and rebuilding the edit from it, which couples
+# a quick fix to diagnostic WORDING: every rephrasing upstream breaks it silently, with
+# no compile error and no test failure anywhere to catch it.
+#
+# The assertion is not that a fix exists but that APPLYING IT WORKS. A replacement
+# that looks right in a field-by-field check and produces source the compiler refuses
+# is precisely the failure this feature exists to prevent.
+test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val src: str = "fun helper() i64 { ret 0; }\nfun main() i64 { ret helpr(); }\n";
+    val res_fid: R.Result[source.FileId, str] = open(?es, "ident.mach", src);
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+
+    var bad: i32 = 0;
+    val list: *diagnostic.DiagList = ?es.s.diags;
+
+    # the terminal line is untouched: the fix is carried ALONGSIDE the prose, not
+    # instead of it, so a plain `mach build` reads exactly as it did before.
+    if (!diag_help_has(list, "did you mean `helper`?") && bad == 0) { bad = 1; }
+
+    val fx: *diagnostic.Fix = t_first_fix(list);
+    if (fx == nil) { dnit(?es); session.dnit(?s); ret 2; }
+
+    # one edit: the misspelling's own range, replaced by the candidate
+    if (fx.edit_len != 1                                              && bad == 0) { bad = 3; }
+    if (!str_equals(fx.label, "replace with `helper`")                && bad == 0) { bad = 4; }
+    if (!str_equals(fx.edits[0].replacement, "helper")                && bad == 0) { bad = 5; }
+    if (!str_region_equals(src, fx.edits[0].loc.span.offset, fx.edits[0].loc.span.len, "helpr") && bad == 0) { bad = 6; }
+
+    val fixed: str = t_apply_fix(?alloc, src, fx);
+    if (fixed == nil) { dnit(?es); session.dnit(?s); ret 7; }
+    if (!t_analyzes_clean(?alloc, "ident.mach", fixed) && bad == 0) { bad = 8; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A cast fix appends to an expression that binds tighter than `::`, and PARENTHESIZES
+# one that does not (#3023).
+#
+# `::` binds tighter than the binary operators, so appending `::i64` to the span of
+# `a + a` yields `a + a::i64` - source that compiles, casts the wrong operand, and
+# leaves the original error standing. Wrapping needs a `(` before and a `)::i64`
+# after, which must apply together or the source does not parse, and which is the
+# whole reason a fix owns a LIST of edits rather than one span.
+test "mach.lang.editor.fix:a_cast_fix_parenthesizes_only_when_it_must" {
+    var alloc: A.Allocator;
+    var bad: i32 = 0;
+
+    # atomic operand: one edit, a pure insertion at the end of the expression
+    val src_a: str = "fun main() i64 { val a: i32 = 1; val b: i64 = a; ret b; }\n";
+    val res_sa: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_sa)) { ret 1; }
+    var sa: session.Session = R.unwrap_ok[session.Session, str](res_sa);
+    var ea: EditorSession = init(?sa);
+    val fa_r: R.Result[source.FileId, str] = open(?ea, "atom.mach", src_a);
+    if (R.is_err[source.FileId, str](fa_r)) { dnit(?ea); session.dnit(?sa); ret 1; }
+    val da_r: R.Result[*diagnostic.DiagList, str] = t_run_sema(?ea, R.unwrap_ok[source.FileId, str](fa_r), 8);
+    if (R.is_err[*diagnostic.DiagList, str](da_r)) { dnit(?ea); session.dnit(?sa); ret 1; }
+    val fxa: *diagnostic.Fix = t_first_fix(R.unwrap_ok[*diagnostic.DiagList, str](da_r));
+    if (fxa == nil) { dnit(?ea); session.dnit(?sa); ret 2; }
+
+    if (fxa.edit_len != 1                                    && bad == 0) { bad = 3; }
+    if (!str_equals(fxa.label, "cast the value to `i64`")    && bad == 0) { bad = 4; }
+    if (!str_equals(fxa.edits[0].replacement, "::i64")       && bad == 0) { bad = 5; }
+    # an INSERTION: an empty range, so nothing of the expression is thrown away
+    if (fxa.edits[0].loc.span.len != 0                       && bad == 0) { bad = 6; }
+    val fixed_a: str = t_apply_fix(?alloc, src_a, fxa);
+    if (fixed_a == nil)                                                   { dnit(?ea); session.dnit(?sa); ret 7; }
+    if (!str_contains(fixed_a, "val b: i64 = a::i64;")       && bad == 0) { bad = 8; }
+    if (!t_analyzes_clean(?alloc, "atom.mach", fixed_a)      && bad == 0) { bad = 9; }
+    dnit(?ea);
+    session.dnit(?sa);
+
+    # compound operand: two edits that wrap it
+    val src_c: str = "fun main() i64 { val a: i32 = 1; val b: i64 = a + a; ret b; }\n";
+    val res_sc: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_sc)) { ret 10; }
+    var sc2: session.Session = R.unwrap_ok[session.Session, str](res_sc);
+    var ec: EditorSession = init(?sc2);
+    val fc_r: R.Result[source.FileId, str] = open(?ec, "compound.mach", src_c);
+    if (R.is_err[source.FileId, str](fc_r)) { dnit(?ec); session.dnit(?sc2); ret 10; }
+    val dc_r: R.Result[*diagnostic.DiagList, str] = t_run_sema(?ec, R.unwrap_ok[source.FileId, str](fc_r), 8);
+    if (R.is_err[*diagnostic.DiagList, str](dc_r)) { dnit(?ec); session.dnit(?sc2); ret 10; }
+    val fxc: *diagnostic.Fix = t_first_fix(R.unwrap_ok[*diagnostic.DiagList, str](dc_r));
+    if (fxc == nil) { dnit(?ec); session.dnit(?sc2); ret 11; }
+
+    if (fxc.edit_len != 2                                    && bad == 0) { bad = 12; }
+    val fixed_c: str = t_apply_fix(?alloc, src_c, fxc);
+    if (fixed_c == nil)                                                   { dnit(?ec); session.dnit(?sc2); ret 13; }
+    # THE POINT: the whole sum is cast, not its right operand
+    if (!str_contains(fixed_c, "val b: i64 = (a + a)::i64;") && bad == 0) { bad = 14; }
+    if (!t_analyzes_clean(?alloc, "compound.mach", fixed_c)  && bad == 0) { bad = 15; }
+    dnit(?ec);
+    session.dnit(?sc2);
+
+    ret bad;
+}
+
+# A mismatch a cast cannot repair carries NO fix (#3023).
+#
+# `::` will reinterpret any two same-size values, so `p::Q` between two unrelated
+# records of equal size is a legal cast - and offering it would turn a real type
+# error into a silent bit pun the compiler accepts. A fix that produces a new error,
+# or worse a new wrong program, is worse than no fix: the editor's one keystroke is
+# taken on trust.
+test "mach.lang.editor.fix:a_mismatch_a_cast_cannot_repair_offers_nothing" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "rec.mach",
+        "rec P { x: i64; }\nrec Q { x: i64; }\nfun main() i64 { var p: P; var q: Q; q = p; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    # the mismatch is still reported...
+    if (!diagnostic.has_errors(list) && bad == 0) { bad = 2; }
+    # ...it just has nothing mechanical to offer
+    if (t_any_fix(list)              && bad == 0) { bad = 3; }
 
     dnit(?es);
     session.dnit(?s);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2833,7 +2833,7 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) R.Result[b
     val sid: SymbolId = scope_lookup_chain(rc, rc.current_scope, name);
     if (sid == SYMBOL_NIL) {
         val re: R.Result[bool, str] = report_named(rc, span, "unresolved identifier `", name, "`");
-        if (R.is_ok[bool, str](re)) { attach_suggestion(rc, name); }
+        if (R.is_ok[bool, str](re)) { attach_suggestion(rc, span, name); }
     }
     or {
         if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
@@ -2849,8 +2849,9 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) R.Result[b
 # close enough
 # ---
 # rc:     resolver state for the module being resolved
+# span:   the misspelled name's own range, which the fix replaces
 # target: the unresolved name
-fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
+fun attach_suggestion(rc: *ResolveContext, span: token.Span, target: intern.StrId) {
     val to: O.Option[str] = intern.lookup(?rc.s.interner, target);
     if (O.is_none[str](to)) { ret; }
     val tname: str = O.unwrap[str](to);
@@ -2892,6 +2893,16 @@ fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
     val note: str = diagnostic.suggestion_build(rc.s.alloc, bname);
     if (note == nil) { ret; }
     diagnostic.attach_help(?rc.s.diags, note);
+
+    # the same advice a program can apply (#3023). the candidate name is exactly the
+    # replacement and `span` is exactly the text it replaces, so the fix is the note
+    # without the English - and an editor offering it never has to parse that English
+    # back into an edit.
+    val flabel: str = diagnostic.fix_label_replace(rc.s.alloc, bname);
+    if (flabel != nil) {
+        diagnostic.attach_fix(?rc.s.diags, flabel, rc.a.file_id, span, bname);
+        str_free(rc.s.alloc, flabel);
+    }
     str_free(rc.s.alloc, note);
 }
 
@@ -3157,7 +3168,7 @@ fun bind_type_name_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str]
         if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
         if (sid == SYMBOL_NIL) {
             val re: R.Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
-            if (R.is_ok[bool, str](re)) { attach_suggestion(rc, name); }
+            if (R.is_ok[bool, str](re)) { attach_suggestion(rc, e.span, name); }
         }
         or {
             if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
@@ -3469,7 +3480,7 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
             # path without a (cross-module) suggestion.
             if (seg_start == path.offset && seg_end >= end) {
                 val re: R.Result[bool, str] = report_named(rc, full, "unresolved type name `", seg_name, "`");
-                if (R.is_ok[bool, str](re)) { attach_suggestion(rc, seg_name); }
+                if (R.is_ok[bool, str](re)) { attach_suggestion(rc, full, seg_name); }
             }
             or {
                 report_named(rc, full, "unresolved type name `", seg_name, "`");

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -30,6 +30,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
@@ -97,7 +98,140 @@ pub fun check_coercible(sc: *context.SemaContext, expected: type.TypeId, eid: id
     }
     var have: type.TypeId = actual;
     if (cr.kind == coerce.COERCE_COERCED) { have = cr.ty; }
-    ret check_assignable(sc, expected, have, span);
+
+    # the mark is what makes the fix safe to attach: the attach helpers land on the
+    # LAST diagnostic in the sink, so on a `silent` episode - or any path that
+    # declines to report - a fix would ride an unrelated earlier diagnostic.
+    val mark: usize = context.diag_mark(sc);
+    val ok: bool = check_assignable(sc, expected, have, span);
+    if (!ok && context.reported_since(sc, mark)) { attach_cast_fix(sc, expected, have, eid); }
+    ret ok;
+}
+
+# offer `value::Type` as a mechanically applicable fix on the just-reported mismatch
+#
+# THE ONLY PLACE THIS IS ATTACHABLE. `check_assignable` is also reached from
+# `check_return`, whose span covers the whole `ret value;` statement rather than the
+# value, so a cast fix there would wrap the statement and produce garbage. Here the
+# span is the offending expression itself, which is exactly what a cast has to wrap.
+#
+# A COMPOUND EXPRESSION IS PARENTHESIZED. `::` binds tighter than the binary
+# operators, so appending `::i64` to the span of `a + b` yields `a + b::i64`, which
+# casts `b` alone - the fix would compile, change the meaning, and leave the original
+# error in place. Two edits, `(` and `)::T`, are why a fix owns a LIST of edits: they
+# apply together or the source does not parse.
+# ---
+# sc:       the active sema context
+# expected: the destination type the cast targets
+# actual:   the value's type, already literal-coerced
+# eid:      the offending expression; supplies both the range and the parenthesization
+fun attach_cast_fix(sc: *context.SemaContext, expected: type.TypeId, actual: type.TypeId, eid: id.ExprId) {
+    if (!cast_would_compile(sc, actual, expected)) { ret; }
+
+    # THE EXPRESSION'S OWN RANGE, NOT THE DIAGNOSTIC'S. A reporter picks its span to
+    # underline what reads best - a `val` declaration's check hands over a range that
+    # runs past the initializer to the `;` - and an edit placed off that lands outside
+    # the expression it was meant to wrap. The node the fix is ABOUT is the only thing
+    # that knows where it starts and ends.
+    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_none[*expr.Expr](opt_expr)) { ret; }
+    val span: token.Span = O.unwrap[*expr.Expr](opt_expr).span;
+    if (span.len == 0) { ret; }
+
+    val ts_r: R.Result[str, str] = type_to_str(sc, expected);
+    if (R.is_err[str, str](ts_r)) { ret; }
+    val ts: str = R.unwrap_ok[str, str](ts_r);
+
+    val label_r: R.Result[str, str] = format.sprint(sc.s.alloc, "cast the value to `{}`", ts);
+    if (R.is_err[str, str](label_r)) { type_str_free(sc, ts); ret; }
+    val label: str = R.unwrap_ok[str, str](label_r);
+
+    var head: token.Span;
+    head.offset = span.offset;
+    head.len    = 0;
+    var tail: token.Span;
+    tail.offset = span.offset + span.len;
+    tail.len    = 0;
+
+    if (expr_binds_tighter_than_cast(O.unwrap[*expr.Expr](opt_expr).kind)) {
+        val sfx_r: R.Result[str, str] = format.sprint(sc.s.alloc, "::{}", ts);
+        if (R.is_ok[str, str](sfx_r)) {
+            val sfx: str = R.unwrap_ok[str, str](sfx_r);
+            diagnostic.attach_fix(?sc.s.diags, label, sc.a.file_id, tail, sfx);
+            A.deallocate[char](sc.s.alloc, sfx, str_len(sfx) + 1);
+        }
+    }
+    or {
+        val sfx_r: R.Result[str, str] = format.sprint(sc.s.alloc, ")::{}", ts);
+        if (R.is_ok[str, str](sfx_r)) {
+            val sfx: str = R.unwrap_ok[str, str](sfx_r);
+            diagnostic.attach_fix(?sc.s.diags, label, sc.a.file_id, head, "(");
+            diagnostic.attach_fix_edit(?sc.s.diags, sc.a.file_id, tail, sfx);
+            A.deallocate[char](sc.s.alloc, sfx, str_len(sfx) + 1);
+        }
+    }
+
+    A.deallocate[char](sc.s.alloc, label, str_len(label) + 1);
+    type_str_free(sc, ts);
+}
+
+# whether `from::to` is a cast that would actually compile
+#
+# A fix that produces a NEW error is worse than no fix at all: the editor's one
+# keystroke would trade a mismatch for `cast: conversion is invalid`. This admits
+# only the numeric conversion the widening advice is about. `::` also reinterprets
+# any two same-size types, but between two unrelated records that is a bit pun, not
+# what a mismatch there means - offering it would launder a real type error into a
+# silent misread of memory.
+# ---
+# sc:   the active sema context
+# from: the value's type
+# to:   the destination type
+# ret:  true when `from::to` is legal and appropriate to suggest
+fun cast_would_compile(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
+    if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret false; }
+    if (from == to)                                       { ret false; }
+    if (!is_numeric(sc, from) || !is_numeric(sc, to))     { ret false; }
+
+    # `::` may neither add nor drop a `^` (#1645), so a cast across the secrecy
+    # boundary is refused and must not be offered.
+    if (type.is_secret(?sc.s.types, from) != type.is_secret(?sc.s.types, to)) { ret false; }
+
+    # a secret operand through the variable-latency FP unit is refused outright (#1646)
+    if (type.is_secret(?sc.s.types, from) && cast_is_fp_conversion(sc, from, to)) { ret false; }
+
+    ret true;
+}
+
+# whether an expression of kind `k` binds tighter than `::`, so a cast may be
+# appended to it without parentheses
+#
+# The postfix and primary forms do; the operator forms do not. An unrecognized kind
+# answers false, which costs a pair of redundant parentheses and never changes what
+# the fixed source means - the safe direction to be wrong in, and the direction a new
+# expression kind added later defaults to.
+# ---
+# k:   the expression's kind
+# ret: true when `<expr>::T` parses as a cast of the whole expression
+fun expr_binds_tighter_than_cast(k: expr.ExprKind) bool {
+    if (k == expr.EXPR_KIND_IDENT)            { ret true; }
+    if (k == expr.EXPR_KIND_COMPTIME_IDENT)   { ret true; }
+    if (k == expr.EXPR_KIND_LIT_INT)          { ret true; }
+    if (k == expr.EXPR_KIND_LIT_FLOAT)        { ret true; }
+    if (k == expr.EXPR_KIND_LIT_CHAR)         { ret true; }
+    if (k == expr.EXPR_KIND_LIT_STR)          { ret true; }
+    if (k == expr.EXPR_KIND_LIT_NIL)          { ret true; }
+    if (k == expr.EXPR_KIND_CALL)             { ret true; }
+    if (k == expr.EXPR_KIND_INDEX)            { ret true; }
+    if (k == expr.EXPR_KIND_MEMBER)           { ret true; }
+    if (k == expr.EXPR_KIND_PROJECT)          { ret true; }
+    if (k == expr.EXPR_KIND_CAST)             { ret true; }
+    if (k == expr.EXPR_KIND_STRIP)            { ret true; }
+    if (k == expr.EXPR_KIND_ARRAY_LIT)        { ret true; }
+    if (k == expr.EXPR_KIND_STRUCT_LIT)       { ret true; }
+    if (k == expr.EXPR_KIND_VECTOR_LIT)       { ret true; }
+    if (k == expr.EXPR_KIND_GENERIC_INSTANCE) { ret true; }
+    ret false;
 }
 
 # checks a call against the callee's function signature


### PR DESCRIPTION
Closes #3023. Consumer tracking: briar-systems/mach-lsp#165.

A mach diagnostic already tells you what to do about it. An editor cannot act on prose: to offer a one-keystroke fix it has to pattern-match the compiler's English and rebuild the edit from it, which couples the quick fix to diagnostic **wording** — every rephrasing upstream breaking it silently, with no compile error and no test failure to catch it. The compiler already holds the answer at the point it composes the sentence, and threw the structure away.

`Diagnostic` gains `fixes`, **alongside** `help` rather than instead of it. Terminal rendering is unchanged.

## The one design decision the issue left open

Whether a `Fix` is one span or a list of them, since widening it later changes every consumer. **A list.**

The hard member is not the cast, it is an edit that must touch two places at once — and that turns out to be the *ordinary* case, not an exotic one. `::` binds tighter than the binary operators, so a cast around `a + a` needs `(` before and `)::i64` after. Applying half of that produces source that does not parse. A one-span shape would either exclude the case outright or make a consumer correlate two separate fixes and hope they were meant together.

Alternatives stay separate `Fix` entries — cast the value versus change the declaration is a choice a person makes, not one atomic edit. A shape that conflated the two would have made "apply all of this" and "pick one of these" indistinguishable.

An empty span is an insertion, an empty replacement is a deletion; both fall out of the one shape rather than needing kinds. And a fix always carries at least one edit, because `attach_fix` takes the first — "a fix with nothing to apply" is not a reachable state.

## Two producers, and what they had to get right

- **A spelling correction** replaces the misspelling with the candidate.
- **A no-implicit-widening mismatch** inserts the cast, parenthesizing when it must.

Two things the second one forced, both found by tests rather than by reading:

**The range comes from the AST node, not from the diagnostic.** A reporter picks its span to underline what reads best, and a `val` declaration's runs past the initializer to the `;`. The first draft produced `val b: i64 = a;::i64`. The node the fix is *about* is the only thing that knows where it starts and ends.

**A cast is offered only when it would actually compile.** `::` will reinterpret any two same-size values, so between two unrelated records it is perfectly legal — and offering it would turn a real type error into a silent bit pun. A fix that produces a new error, or worse a new *wrong program*, is worse than no fix at all: the editor's keystroke is taken on trust.

Fixes travel through `clone_tail` / `append_all`, so a cached module's replayed diagnostics keep them. Otherwise a quick fix would blink out of an editor on an unrelated keystroke — a bug with no error message and nothing a user could reproduce.

## Verification

**1504 passed, 0 failed** (1499 before, 5 new).

The editor tests do not assert a fix *exists*, they **apply it and re-analyze**: a replacement that looks right field-by-field and produces source the compiler refuses is exactly the failure this feature exists to prevent. `(a + a)::i64` and `a::i64` both have to compile clean.

Mutation-checked, one per guard:

| mutation | test that caught it |
|---|---|
| `cast_would_compile` admits non-numeric | `a_mismatch_a_cast_cannot_repair_offers_nothing` |
| never parenthesize | `a_cast_fix_parenthesizes_only_when_it_must` |
| `copy_into` drops fixes | `attach_fix:survives_a_copy` |
| a stray edit reaches back to an earlier fix | `attach_fix_edit:needs_a_fix_to_belong_to` |

**Codegen corpus 1416 pass, 0 fail** — the goldens compare rendered diagnostic output, which is the byte-identical-terminal-rendering acceptance criterion. **Fixpoint:** three generations byte-identical.
