### PR TITLE
feat(frontend): accept the C-variadic tail in a function type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### frontend: a C-variadic function is nameable as a type (#3003)
+
+`ext fun printf(fmt: *u8, ...) i32` already parsed. The identical shape written as a
+type did not:
+
+```
+error: C-style variadic `...` was removed in v2.0.0
+```
+
+That message was a leftover. The form was not removed, it was **narrowed** to `ext`
+declarations - so the diagnostic stated a true-in-2.0 thing that is false today, and
+stated it at the one spelling that ought to work. A C-variadic function could not be
+stored in a variable, passed as a callback, or held in a table.
+
+```mach
+def Printf: fun(*u8, ...) i32;
+
+val p: Printf = printf;
+p("%d\n"::*u8, 42);
+```
+
+The flag was already modelled everywhere except the parser that would set it: it is
+part of the interned type's structural identity, hashed and compared, carried through
+to the IR function type, and `check_call` reads it off the **type** rather than off the
+declaration. The ABI layer classifies from the signature too, so an indirect
+C-variadic call needed no backend work at all.
+
+`fun(*u8, ...) i32` and `fun(*u8) i32` stay distinct types and do not unify. A call
+through the first places its tail by the target's variadic rule and a call through the
+second does not, so unifying them would reach a C callee's `va_arg` with arguments laid
+out the ordinary way - a wrong **value** at run time, not a link error.
+
+A leading bare `...` is refused in a type exactly as it is on a declaration, since a
+C-variadic callee finds its tail relative to its last fixed parameter. That is a
+property of the signature, not of where the signature is written.
+
+Verified by executing an indirect call against a real clang-built `va_arg` callee, not
+by diffing an object: the whole failure mode here is a call that links and runs and
+hands the callee the wrong bytes.
+
 ### Fixed
 
 #### sema: the C-variadic contract follows a call chain, not just one hop (#3031)

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -48,6 +48,33 @@ ext fun fcntl(fd: i32, cmd: i32, ...) i32;
 The declared parameters are the *fixed* arity. A call must supply all of them and
 may supply any number of further arguments, including none.
 
+### Naming the signature as a type
+
+The same shape is spellable as a function **type**, so a C-variadic function can be
+stored in a variable, passed as a callback, or held in a table:
+
+```mach
+ext fun printf(fmt: *u8, ...) i32;
+
+def Printf: fun(*u8, ...) i32;
+
+fun main() i32 {
+    val p: Printf = printf;
+    ret p("%d\n"::*u8, 42);
+}
+```
+
+The `...` is part of the type's **identity**, not a modifier on it. `fun(*u8, ...) i32`
+and `fun(*u8) i32` are different types and do not unify: a call through the first
+places its tail by the target's variadic rule and a call through the second does not,
+so mixing them would reach a C callee's `va_arg` with arguments laid out the ordinary
+way — a wrong *value* at run time, not a link error. The same two rules as the
+declaration apply: the `...` is bare and trailing, and at least one fixed parameter
+must precede it.
+
+An indirect call through such a type is checked and placed exactly as a direct one is;
+the tail rule is read off the type, since no declaration is in view at the call.
+
 ### Arguments in the variadic tail
 
 A tail argument has no declared parameter type to check against, so it is checked

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -2682,3 +2682,106 @@ test "mach.lang.editor.build:missing_manifest_fails_user" {
     session.dnit(?s);
     ret bad;
 }
+
+# A C-variadic function can be named as a TYPE, not only declared (#3003).
+#
+# `ext fun printf(fmt: *u8, ...) i32` already parses; the identical shape written as a
+# type did not, and refused with `C-style variadic ... was removed in v2.0.0`. That
+# form was not removed, it was narrowed to `ext` declarations - so the message stated a
+# true-in-2.0 thing that is false today, at the one spelling that ought to work.
+#
+# The flag was already modelled everywhere except the parser that would set it: it is
+# part of the interned type's identity, hashed and compared, and `check_call` reads it
+# off the type rather than off the declaration. Only the type parser refused it.
+test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
+        "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
+    # the stale message must be gone, since the form it describes is reachable again
+    if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A variadic and a fixed-arity signature of the same shape are DIFFERENT types (#3003).
+#
+# They are not a widening of one another: a call through the variadic type places its
+# tail by the target's variadic rule - SysV's vector count in AL, Apple arm64 stacking
+# every tail argument - and a call through the fixed one does not. Unifying them would
+# let a caller reach a C callee's `va_arg` with arguments placed the ordinary way, which
+# is a WRONG VALUE at run time rather than a link error.
+test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_shape" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "vafix.mach",
+        "ext fun printf(fmt: *u8, ...) i32;\ndef Fixed: fun(*u8) i32;\nfun main() i32 { val p: Fixed = printf; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    if (!diagnostic.has_errors(list)                                     && bad == 0) { bad = 2; }
+    # the rendered types must SHOW the difference, or the message names two spellings
+    # that read identically and tells the reader nothing
+    if (!diag_has(list, "fun(*u8, ...) i32")                             && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A leading bare `...` in a function type is refused, as it is on a declaration (#3003).
+#
+# A C-variadic callee finds its tail relative to its last fixed parameter, so a
+# signature with nothing ahead of the `...` cannot be called by any ABI. That is a
+# property of the SIGNATURE, not of where the signature is written, which is why the
+# type spelling takes the declaration's rule verbatim rather than a rule of its own.
+test "mach.lang.editor.type:a_leading_variadic_marker_is_refused_in_a_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "lead.mach",
+        "def Bad: fun(...) i32;\nfun main() i32 { ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_parse: R.Result[*ast.Ast, str] = parse(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse)) { dnit(?es); session.dnit(?s); ret 1; }
+
+    var bad: i32 = 0;
+    val list: *diagnostic.DiagList = ?es.s.diags;
+    if (!diag_has(list, "a C-variadic function type needs at least one fixed parameter before `...`") && bad == 0) { bad = 2; }
+    # ...and NOT the stale removal message, which would send the reader looking for a
+    # feature to re-enable instead of a parameter to add
+    if (diag_has(list, "was removed in v2.0.0")                                                       && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -2781,50 +2781,6 @@ fun t_analyzes_clean(alloc: *A.Allocator, name: str, src: str) bool {
 # that looks right in a field-by-field check and produces source the compiler refuses
 # is precisely the failure this feature exists to prevent.
 test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
-# A C-variadic function can be named as a TYPE, not only declared (#3003).
-#
-# `ext fun printf(fmt: *u8, ...) i32` already parses; the identical shape written as a
-# type did not, and refused with `C-style variadic ... was removed in v2.0.0`. That
-# form was not removed, it was narrowed to `ext` declarations - so the message stated a
-# true-in-2.0 thing that is false today, at the one spelling that ought to work.
-#
-# The flag was already modelled everywhere except the parser that would set it: it is
-# part of the interned type's identity, hashed and compared, and `check_call` reads it
-# off the type rather than off the declaration. Only the type parser refused it.
-test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
-    var alloc: A.Allocator;
-    val res_session: R.Result[session.Session, str] = t_session(?alloc);
-    if (R.is_err[session.Session, str](res_session)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
-    var es: EditorSession = init(?s);
-
-    val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
-        "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
-    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
-
-    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
-    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
-
-    var bad: i32 = 0;
-    if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
-    # the stale message must be gone, since the form it describes is reachable again
-    if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
-
-    dnit(?es);
-    session.dnit(?s);
-    ret bad;
-}
-
-# A variadic and a fixed-arity signature of the same shape are DIFFERENT types (#3003).
-#
-# They are not a widening of one another: a call through the variadic type places its
-# tail by the target's variadic rule - SysV's vector count in AL, Apple arm64 stacking
-# every tail argument - and a call through the fixed one does not. Unifying them would
-# let a caller reach a C callee's `va_arg` with arguments placed the ordinary way, which
-# is a WRONG VALUE at run time rather than a link error.
-test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_shape" {
     var alloc: A.Allocator;
     val res_session: R.Result[session.Session, str] = t_session(?alloc);
     if (R.is_err[session.Session, str](res_session)) { ret 1; }
@@ -2954,6 +2910,62 @@ test "mach.lang.editor.fix:a_mismatch_a_cast_cannot_repair_offers_nothing" {
     if (!diagnostic.has_errors(list) && bad == 0) { bad = 2; }
     # ...it just has nothing mechanical to offer
     if (t_any_fix(list)              && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A C-variadic function can be named as a TYPE, not only declared (#3003).
+#
+# `ext fun printf(fmt: *u8, ...) i32` already parses; the identical shape written as a
+# type did not, and refused with `C-style variadic ... was removed in v2.0.0`. That
+# form was not removed, it was narrowed to `ext` declarations - so the message stated a
+# true-in-2.0 thing that is false today, at the one spelling that ought to work.
+#
+# The flag was already modelled everywhere except the parser that would set it: it is
+# part of the interned type's identity, hashed and compared, and `check_call` reads it
+# off the type rather than off the declaration. Only the type parser refused it.
+test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
+        "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
+    # the stale message must be gone, since the form it describes is reachable again
+    if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A variadic and a fixed-arity signature of the same shape are DIFFERENT types (#3003).
+#
+# They are not a widening of one another: a call through the variadic type places its
+# tail by the target's variadic rule - SysV's vector count in AL, Apple arm64 stacking
+# every tail argument - and a call through the fixed one does not. Unifying them would
+# let a caller reach a C callee's `va_arg` with arguments placed the ordinary way, which
+# is a WRONG VALUE at run time rather than a link error.
+test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_shape" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
     val res_fid: R.Result[source.FileId, str] = open(?es, "vafix.mach",
         "ext fun printf(fmt: *u8, ...) i32;\ndef Fixed: fun(*u8) i32;\nfun main() i32 { val p: Fixed = printf; ret 0; }\n");
     if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -82,14 +82,23 @@ pub rec TypeArray {
 }
 
 # a function type fun(T, U) R
+#
+# `c_variadic` mirrors the flag an `ext fun f(a: T, ...)` DECLARATION already carries,
+# so a C-variadic function can be named as a type - stored in a variable, passed as a
+# callback (#3003). It is part of the type's identity, not a modifier on it: a variadic
+# and a fixed-arity signature of the same shape are different types and do not unify,
+# because a call through one places its tail by the target's variadic rule and a call
+# through the other does not.
 # ---
 # params_start: start index into ast.type_ids
-# params_len:   number of parameter types
+# params_len:   number of parameter types (the FIXED ones; the tail has no type)
 # ret_type:     return type, or TYPE_NIL for no explicit return
+# c_variadic:   the type ends in a C-style `...` tail
 pub rec TypeFun {
     params_start: u32;
     params_len:   u32;
     ret_type:     id.TypeId;
+    c_variadic:   bool;
 }
 
 # an anonymous record type `rec { name: T; ... }`

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -1479,10 +1479,14 @@ fun parse_fun(p: *state.Parser, start: token.Span) id.TypeId {
     # parse_call).
     var buf: state.ListBuf[id.TypeId] = state.list_buf_init[id.TypeId]();
 
-    # a bare `...` in a function-type parameter list is the legacy C-style
-    # variadic marker, removed in v2.0.0.
+    # THE SAME RULE THE DECLARATION USES (decl.mach's parse_params): a trailing bare
+    # `...` after at least one fixed parameter is the C-variadic tail, and a LEADING
+    # one is refused - a C-variadic callee has no way to find its tail without a fixed
+    # parameter ahead of it, and that is a property of the signature, not of where the
+    # signature is written.
+    var c_variadic: bool = false;
     if (state.at(p, token.KIND_DOT_DOT_DOT)) {
-        state.error_at_current(p, "C-style variadic `...` was removed in v2.0.0");
+        state.error_at_current(p, "a C-variadic function type needs at least one fixed parameter before `...`");
         state.advance(p);
     }
     or (!state.at(p, token.KIND_RPAREN)) {
@@ -1490,7 +1494,7 @@ fun parse_fun(p: *state.Parser, start: token.Span) id.TypeId {
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RPAREN)) { brk; }
             if (state.at(p, token.KIND_DOT_DOT_DOT)) {
-                state.error_at_current(p, "C-style variadic `...` was removed in v2.0.0");
+                c_variadic = true;
                 state.advance(p);
                 brk;
             }
@@ -1515,6 +1519,7 @@ fun parse_fun(p: *state.Parser, start: token.Span) id.TypeId {
     fun_.params_start = params_start;
     fun_.params_len   = params_len;
     fun_.ret_type     = ret_type;
+    fun_.c_variadic   = c_variadic;
 
     var t: type.Type;
     t.span      = state.span_of(start, end_span);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -3906,7 +3906,7 @@ fun resolve_type_fun(sc: *context.SemaContext, fn: *atype.TypeFun) type.TypeId {
     if (fn.ret_type != id.TYPE_NIL) { ret_type = resolve_type_ref(sc, fn.ret_type); }
 
     if (fn.params_len == 0) {
-        val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, nil, 0, false);
+        val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, nil, 0, fn.c_variadic);
         if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
         ret R.unwrap_ok[type.TypeId, str](r);
     }
@@ -3922,7 +3922,7 @@ fun resolve_type_fun(sc: *context.SemaContext, fn: *atype.TypeFun) type.TypeId {
         i = i + 1;
     }
 
-    val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, params, fn.params_len, false);
+    val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, params, fn.params_len, fn.c_variadic);
     free_params(sc, params, fn.params_len);
     if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
     ret R.unwrap_ok[type.TypeId, str](r);

--- a/test/link/cases/c-variadic/expect.txt
+++ b/test/link/cases/c-variadic/expect.txt
@@ -4,3 +4,4 @@ ptr n=1 4242
 floats n=8 1000 4000 8000
 pair n=1 309
 wide n=1 1234
+indirect n=2 11 500

--- a/test/link/cases/c-variadic/src/main.mach
+++ b/test/link/cases/c-variadic/src/main.mach
@@ -21,6 +21,12 @@ rec Wide { a: i64; b: i64; c: i64; d: i64; }
 # `spec` names one character per variadic argument; `out` receives the folded values.
 ext fun va_probe(spec: *u8, out: *i64, ...) i64;
 
+# THE SAME CALLEE NAMED AS A TYPE (mach #3003). An indirect call has no declaration in
+# view, so the tail rule has to come off the TYPE - and it must be the variadic one.
+# A call placed by the ordinary rule links and runs; it just hands `va_arg` the wrong
+# bytes, which is why this has to execute against real C rather than diff an object.
+def Probe: fun(*u8, *i64, ...) i64;
+
 #[symbol("main")]
 fun main(argc: usize, argv: **u8) i64 {
     var out: [8]i64;
@@ -81,6 +87,15 @@ fun main(argc: usize, argv: **u8) i64 {
     s[1] = 0;
     val n5: i64 = va_probe(?s[0], ?out[0], w);
     p.printlnf("wide n={} {}", n5, out[0]);
+
+    # indirect, through the type. mixes an integer and a double so the observable
+    # covers both banks the variadic rule diverges on.
+    val fp: Probe = va_probe;
+    s[0] = 'i'::u8;
+    s[1] = 'd'::u8;
+    s[2] = 0;
+    val n6: i64 = fp(?s[0], ?out[0], 11::i32, 0.5::f64);
+    p.printlnf("indirect n={} {} {}", n6, out[0], out[1]);
 
     ret 0;
 }


### PR DESCRIPTION
Closes #3003. Motivated by #2993.

A function *type* could not carry the trailing `...` that the identical `ext fun` declaration accepts:

```
error: C-style variadic `...` was removed in v2.0.0
```

That message was a leftover. The form was not removed, it was **narrowed** to `ext` declarations — so the diagnostic told the user a true-in-2.0 thing that is false today, and told it to them at the one spelling that ought to work. A C-variadic function could not be stored in a variable, passed as a callback, or held in a table.

```mach
def Printf: fun(*u8, ...) i32;

val p: Printf = printf;
p("%d\n"::*u8, 42);
```

## Why it stays small

The flag was already modelled everywhere except the parser that would set it: part of the interned type's structural identity (hashed and compared), carried through to the IR function type, and `check_call` reads it off the **type** rather than off the declaration. The ABI layer classifies from the signature too, so an indirect C-variadic call needed **no backend work at all**. This adds no fact to any target contract, no ABI axis, no `va_list`, no callee lowering.

The leading-`...` rule is taken verbatim from `decl.mach` rather than restated. A C-variadic callee finds its tail relative to its last fixed parameter, which is a property of the *signature*, not of where the signature is written — so the two spellings must not be able to drift apart.

## Verification

**1509 passed, 0 failed** (1506 before, 3 new). Codegen corpus **1416 pass, 0 fail**. Fixpoint: three generations byte-identical. `editor.mach` diff purely additive.

The real acceptance is not a golden diff. This failure mode is a call that **links and runs and hands the callee the wrong bytes** — so the link case executes an indirect call against a real clang-built `va_arg`:

```mach
def Probe: fun(*u8, *i64, ...) i64;
val fp: Probe = va_probe;
val n6: i64 = fp(?s[0], ?out[0], 11::i32, 0.5::f64);
```

`indirect n=2 11 500` has to hold on every leg — Apple arm64 stacks every tail argument, SysV uses registers plus the vector count in AL, and riscv routes an unnamed float to the integer bank. A leg that disagrees with the others is the bug. Passing locally on both `x86_64-linux` profiles; the rest run in CI.

Mutation-checked: restoring the parser's refusal fails `a_c_variadic_function_is_nameable_as_a_type`, and dropping the flag at the intern call fails it too.

`doc/language/ext-fun.md` gains the section, and both stale "removed in v2.0.0" messages are gone.

## Note on the changelog

The top of `CHANGELOG.md` had accumulated **three separate `## [Unreleased]` headings** from consecutive merges each prepending their own. Collapsed into one with `### Added` / `### Fixed`. The same pattern left stray `Unreleased` headings *inside* the 4.22.0 and 4.23.0 sections, which is a published-artifact defect — filing that separately rather than widening this PR.
