### PR TITLE
EXPERIMENT (do not merge): does the windows c-variadic leg discriminate?

### DIFF
--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -411,7 +411,7 @@ pub fun shadow_space() u64 {
 # ---
 # ret: the win64 call-side variadic model
 pub fun va_model() abi.VaModel {
-    ret abi.va_model_make(abi.VA_MODEL_HOME, true, -1, 64);
+    ret abi.va_model_make(abi.VA_MODEL_HOME, false, -1, 64);
 }
 
 # compute the positional argument slot from the running GP/FP usage counters
@@ -669,7 +669,8 @@ test "mach.lang.target.abi.win64:frame_constants" {
 test "mach.lang.target.abi.win64.va_model:home" {
     val m: abi.VaModel = va_model();
     if (m.kind != abi.VA_MODEL_HOME) { ret 1; }
-    if (!m.float_dup_gp)             { ret 1; }
+    # DISCRIMINATION EXPERIMENT (throwaway): relaxed so the link leg is the signal
+    # if (!m.float_dup_gp)             { ret 1; }
     if (m.vector_count_reg != -1)    { ret 1; }
     ret 0;
 }

--- a/test/link/cases/c-variadic/case.conf
+++ b/test/link/cases/c-variadic/case.conf
@@ -16,11 +16,21 @@
 # the a bank the probe's `va_arg` actually reads. before that the caller placed
 # them in fa0-fa7 and every float came back as flat 0.
 #
-# exempt windows: `[step]` now runs there (#2578/#2587 fixed it), but this case has
-# not yet been verified against the windows-latest runner's own C toolchain (does it
-# expose a bare `cc`, and does it target win64 the way this case needs?). Re-enable
-# once that's confirmed rather than guessing at it here; win64's variadic rule (a
-# tail float duplicated into its integer register) is otherwise exercised only by
-# the compiler's own unit tests.
+# windows runs since #3005, and the deferred question was answered rather than
+# deleted: windows-latest exposes no bare `cc`, which is the ONLY reason this was
+# exempt. It does carry gcc and clang, both of which take a bare `cc`'s flags, so
+# test/link/lib/cc.sh resolves the host compiler by name instead of assuming one -
+# see host_cc there for why MSVC's `cl` is named in a failure rather than translated.
+#
+# What the leg buys: win64 duplicates a tail float into the integer register of the
+# same positional slot, because a `va_arg` reader walks only the integer slots
+# (target/abi.mach, VA_MODEL_HOME, float_dup_gp). That rule is not shared with any
+# other target, and until this ran it was checked only by the compiler's own unit
+# tests - mach's model of the ABI compared against itself, which cannot catch the
+# model being wrong. The `mixed` and `floats` lines read every tail double back
+# through the runner's real `va_arg`, so a broken duplication is a wrong VALUE here.
+#
+# This matters more than an ordinary coverage gap: the FFI reports that reach us are
+# disproportionately from Windows (#2968, #2992), which is where mach's foreign-code
+# surface is least verified and most exercised.
 run: exec
-skip: x86_64-windows

--- a/test/link/cases/c-variadic/case.conf
+++ b/test/link/cases/c-variadic/case.conf
@@ -17,10 +17,17 @@
 # them in fa0-fa7 and every float came back as flat 0.
 #
 # windows runs since #3005, and the deferred question was answered rather than
-# deleted: windows-latest exposes no bare `cc`, which is the ONLY reason this was
-# exempt. It does carry gcc and clang, both of which take a bare `cc`'s flags, so
-# test/link/lib/cc.sh resolves the host compiler by name instead of assuming one -
-# see host_cc there for why MSVC's `cl` is named in a failure rather than translated.
+# deleted. The answer was not the one the exemption guessed at: the runner's C
+# toolchain was never the obstacle. CI already exports `CC=gcc` (ci-tools.sh, "cc is
+# spelled gcc on this host, per tools.lock"), so a compiler was there all along.
+#
+# WHAT ACTUALLY FAILED WAS THE STEP'S OWN COMMAND. A `[step]` cmd runs through the
+# PLATFORM shell, which on windows is `cmd.exe /s /c` - and cmd.exe cannot execute
+# `../../lib/cc.sh`, so every windows run died with "'..' is not recognized as an
+# internal or external command" before any compiler was consulted. That is a fact
+# about how a step is spelled, not about what the runner has installed, and the rest
+# of this suite already had it right: every `pe-*` case invokes its script as
+# `sh <script>`. These three were the outliers, and now match.
 #
 # What the leg buys: win64 duplicates a tail float into the integer register of the
 # same positional slot, because a `va_arg` reader walks only the integer slots

--- a/test/link/cases/c-variadic/mach.toml
+++ b/test/link/cases/c-variadic/mach.toml
@@ -45,7 +45,7 @@ debug = false
 simd = "scalarize"
 
 [step.probe]
-cmd = "../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+cmd = "sh ../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/narrow-stack-args/case.conf
+++ b/test/link/cases/narrow-stack-args/case.conf
@@ -15,10 +15,18 @@
 # is target-independent (see main.mach), so a cross-built probe object proves it just
 # as well as a native one would.
 #
-# exempt windows: `[step]` now runs there (#2578/#2587 fixed it), but this case has
-# not yet been verified against the windows-latest runner's own C toolchain (does it
-# expose a bare `cc`, and does it target win64 the way this case needs?). Re-enable
-# once that's confirmed rather than guessing at it here.
+# windows runs since #3005. The exemption above shared its wording, and its cause,
+# with c-variadic's: the runner's C toolchain was never the obstacle (CI exports
+# `CC=gcc`). The step invoked `../../lib/cc.sh` directly, and a `[step]` runs through
+# the platform shell - `cmd.exe /s /c` on windows, which cannot execute a `.sh` path.
+# Spelled `sh ../../lib/cc.sh`, the way every `pe-*` case in this suite already spells
+# its script, it runs. One wrong guess had exempted two cases, so answering it once
+# restored both.
+#
+# What the leg buys here: win64 gives a stack-passed fixed argument its own natural
+# size and alignment rather than an eight-byte slot, the same axis Apple arm64
+# diverges on (#2598). This case is built to catch exactly that divergence, and the
+# windows rule was previously taken on trust from the compiler's own unit tests.
 #
 # riscv64-linux was exempt twice over a float row of `regs=0 0` / `tail=0 0 0` against
 # a golden of `regs=10 80` / `tail=95 105 115`, blamed first on a variadic-classifier
@@ -42,4 +50,3 @@
 # cc.sh's `-mabi=lp64d` pin (mach#2771), because a soft-float probe object produces the
 # identical row for a completely different reason.
 run: exec
-skip: x86_64-windows

--- a/test/link/cases/narrow-stack-args/mach.toml
+++ b/test/link/cases/narrow-stack-args/mach.toml
@@ -45,7 +45,7 @@ debug = false
 simd = "scalarize"
 
 [step.probe]
-cmd = "../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+cmd = "sh ../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/riscv-pcrel-pair/mach.toml
+++ b/test/link/cases/riscv-pcrel-pair/mach.toml
@@ -28,7 +28,7 @@ debug = false
 simd = "scalarize"
 
 [step.probe]
-cmd = "../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+cmd = "sh ../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/lib/cc.sh
+++ b/test/link/lib/cc.sh
@@ -56,18 +56,17 @@ host_os() {
 # host_cc - the host's own C compiler, by whatever name it answers to.
 #
 # `cc` is the POSIX spelling and every unix runner has one. WINDOWS DOES NOT: neither
-# Git Bash nor the image's Visual Studio install provides a `cc`, and that single
-# missing name is why `c-variadic` carried `skip: x86_64-windows` for so long
-# (mach#3005) - so win64's variadic rule, which duplicates a tail float into the
-# integer register of the same slot, was never executed against a real `va_arg`
-# reader. A rule verified only by the compiler's own unit tests is mach's model of the
-# ABI checked against itself.
+# Git Bash nor the image's Visual Studio install provides that name. CI already works
+# around it by exporting `CC=gcc` from ci-tools.sh ("cc is spelled gcc on this host,
+# per tools.lock"), so the gap only bites a host where nothing sets CC - a developer's
+# own Windows machine, which is where a case is most likely to be run by hand and least
+# likely to have the environment CI builds.
 #
-# gcc and clang accept the same flags a bare `cc` does, so resolving to either needs
-# no argv translation and no case has to know which one answered. MSVC's `cl` does not
-# (`/c`, `/Fo:`), so it is NAMED IN THE FAILURE rather than half-supported: a
-# translation layer for one call site would be a second flag dialect to maintain
-# forever, and every candidate ahead of it produces the same object for this purpose.
+# gcc and clang accept the same flags a bare `cc` does, so resolving to either needs no
+# argv translation and no case has to know which one answered. MSVC's `cl` does not
+# (`/c`, `/Fo:`), so it is NAMED IN THE FAILURE rather than half-supported: a second
+# flag dialect for one call site is a permanent maintenance cost, and every candidate
+# ahead of it produces the same object for this purpose.
 host_cc() {
     if [ -n "${CC:-}" ]; then
         echo "$CC"

--- a/test/link/lib/cc.sh
+++ b/test/link/lib/cc.sh
@@ -53,8 +53,43 @@ host_os() {
     esac
 }
 
+# host_cc - the host's own C compiler, by whatever name it answers to.
+#
+# `cc` is the POSIX spelling and every unix runner has one. WINDOWS DOES NOT: neither
+# Git Bash nor the image's Visual Studio install provides a `cc`, and that single
+# missing name is why `c-variadic` carried `skip: x86_64-windows` for so long
+# (mach#3005) - so win64's variadic rule, which duplicates a tail float into the
+# integer register of the same slot, was never executed against a real `va_arg`
+# reader. A rule verified only by the compiler's own unit tests is mach's model of the
+# ABI checked against itself.
+#
+# gcc and clang accept the same flags a bare `cc` does, so resolving to either needs
+# no argv translation and no case has to know which one answered. MSVC's `cl` does not
+# (`/c`, `/Fo:`), so it is NAMED IN THE FAILURE rather than half-supported: a
+# translation layer for one call site would be a second flag dialect to maintain
+# forever, and every candidate ahead of it produces the same object for this purpose.
+host_cc() {
+    if [ -n "${CC:-}" ]; then
+        echo "$CC"
+        return 0
+    fi
+    for candidate in cc gcc clang; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    if command -v cl >/dev/null 2>&1; then
+        echo "cc.sh: the only host C compiler on PATH is MSVC 'cl', whose flags are spelled differently from a bare 'cc' ('/c', '/Fo:') - this script passes a case's argv through unchanged. put a gcc or clang on PATH, or set CC to one." >&2
+    else
+        echo "cc.sh: no host C compiler on PATH (tried cc, gcc, clang). a case's [step] that compiles C needs one on every leg that runs it." >&2
+    fi
+    return 1
+}
+
 if [ "$(host_isa)" = "$MACH_TARGET_ISA" ] && [ "$(host_os)" = "$MACH_TARGET_OS" ]; then
-    exec "${CC:-cc}" "$@"
+    hostcc=$(host_cc) || exit 1
+    exec "$hostcc" "$@"
 fi
 
 # cross build: the host cannot produce this leg's ISA/OS natively, so route


### PR DESCRIPTION
**Do not merge. This branch exists to be read, then deleted.**

#3005's acceptance asks that a deliberate break of win64's `float_dup_gp` makes the c-variadic case fail — without that, a green leg proves only that it *runs*, not that it would catch anything.

This flips `float_dup_gp` to `false` in `abi/win64.mach`, which stops a tail float being duplicated into the integer register of its positional slot. A `va_arg` reader on win64 walks only the integer slots, so every tail double should come back as garbage.

The unit assertion on the flag is commented out in the same commit, deliberately: it would go red first and predictably, and the thing being measured is the **link leg**, against a real MinGW `va_arg`.

Expected: `targets on windows-latest` fails with a c-variadic golden mismatch on the `mixed` and `floats` lines — not a build error. A build error would make the experiment inconclusive and I'd rerun it.

Result gets reported on #3040, and this branch deleted.