### PR TITLE
chore: release 4.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.24.0] - 2026-08-21
 
 ### Added
 
@@ -102,6 +102,28 @@ by diffing an object: the whole failure mode here is a call that links and runs 
 hands the callee the wrong bytes.
 
 ### Fixed
+
+#### test(link): the c-variadic and narrow-stack-args cases now run on windows (#3005)
+
+Both cases carried `skip: x86_64-windows`, word for word, deferring the same question:
+does the runner expose a bare `cc`? So win64's variadic rule - a tail float duplicated
+into the integer register of its positional slot - and its stack-argument rule were
+checked only by the compiler's own unit tests, which compare mach's model of the ABI
+against itself and cannot catch the model being wrong.
+
+The guess was wrong in both. CI already exports `CC=gcc`. What actually failed was the
+step's own command: a `[step]` cmd runs through the **platform** shell, which on windows
+is `cmd.exe /s /c`, and cmd.exe cannot execute `../../lib/cc.sh`. Every windows run died
+with `'..' is not recognized` before a compiler was ever consulted. The rest of the suite
+already had it right - every `pe-*` case invokes its script as `sh <script>` - and these
+three cc.sh cases were the outliers.
+
+One wrong guess had exempted two cases, so answering it once restored both.
+
+Verified to DISCRIMINATE, not merely run: breaking `float_dup_gp` on a throwaway branch
+fails the case with a golden diff against MinGW's real `va_arg`, while `narrow-stack-args`
+passes under the same mutation. The margin is thinner than the case looks, which is
+tracked separately as #3043.
 
 #### chore(changelog): stray `[Unreleased]` headings stranded inside released sections (#3039)
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.23.0"
+version = "4.24.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.23.0";
+pub val MACH_VERSION: str = "4.24.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Minor bump: two new language/library surfaces.

## Added

- **#3023** — a diagnostic carries its fix as structured edits, alongside `help` rather than instead of it. `Fix` owns a **list** of edits because the cast case needs two (`(` and `)::T`) and applying half produces source that does not parse. Unblocks briar-systems/mach-lsp#165.
- **#3003** — a C-variadic function is nameable as a type, so `printf` can be stored, passed as a callback, or held in a table. `fun(*u8, ...) i32` and `fun(*u8) i32` stay distinct and do not unify.

## Fixed

- **#2998** — a module path is normalized before overlay and source lookup, and the overlay key is canonicalized at the table's own boundary. An editor's unsaved buffer was silently ignored in favour of stale disk text whenever the manifest spelled `src = "./src"`. Unblocks briar-systems/mach-lsp#141.
- **#3005** — `c-variadic` and `narrow-stack-args` now run on windows. Win64's tail-float duplication and stack-argument rules were previously checked only by the compiler's own unit tests.
- **#3039** — stray `[Unreleased]` headings folded back into their releases, with a CI check so it cannot recur.

## Verification

- `mach.toml` **and** `MACH_VERSION` both at 4.24.0 (`mach.lang.version:matches_project_release` pins them together).
- 1509 passed, 0 failed.
- Fixpoint: three generations byte-identical.
- Codegen corpus 1416/0 on dev; the windows link leg now runs 6 cells with 0 skips.
- `check-changelog.sh` clean — the new job's first real outing on a release PR.

The `darwin (release gate)` runs on the dev → main PR that follows this one.