### PR TITLE
mach 4.24.0

### DIFF
--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# check-changelog.sh - one `## [Unreleased]`, and it comes first.
+#
+# THE FAILURE THIS CATCHES IS INVISIBLE IN A DIFF. A pull request that prepends its
+# own `## [Unreleased]` block looks correct in isolation - the entry is under an
+# Unreleased heading, which is where an entry goes. The damage only exists in the
+# MERGED file, where several such blocks accumulate between releases. The release step
+# renames the first to the version and every other is stranded inside that release's
+# section, so the published changelog for a shipped version carries headings claiming
+# its own entries are unreleased (mach#3039).
+#
+# Nobody re-reads a changelog after merging it, which is exactly why this is a check
+# and not a convention. It fails on the pull request that adds the second heading,
+# while the fix is one heading deletion - rather than at release time, by which point
+# the two have merged and untangling them means reading both.
+#
+# THE RULE: append a `####` entry under the existing `## [Unreleased]`'s matching
+# `###` subsection. Creating a second `## [Unreleased]` is the defect.
+set -eu
+
+file=${1:-CHANGELOG.md}
+[ -f "$file" ] || { echo "check-changelog: no such file: $file" >&2; exit 1; }
+
+status=0
+
+count=$(grep -c '^## \[Unreleased\]$' "$file" || true)
+if [ "$count" -gt 1 ]; then
+    echo "check-changelog: $file has $count '## [Unreleased]' headings; there must be at most one." >&2
+    grep -n '^## \[Unreleased\]$' "$file" | sed 's/^/  line /' >&2
+    echo "  fold the later ones into the first: an entry is a '####' section under its '###' subsection." >&2
+    status=1
+fi
+
+# ...and it must lead. An Unreleased heading below a version is content that shipped
+# under a heading saying it did not.
+first=$(grep -n '^## \[' "$file" | head -1 | cut -d: -f1)
+if [ -n "$first" ]; then
+    line=$(sed -n "${first}p" "$file")
+    if [ "$line" != '## [Unreleased]' ] && [ "$count" -gt 0 ]; then
+        echo "check-changelog: '## [Unreleased]' appears below '$line'; unreleased content cannot sit inside a released section." >&2
+        status=1
+    fi
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "check-changelog: $file ok"
+fi
+exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ permissions:
 # job below and darwin-lane.yml (shared with cd.yml, so the gate can never drift
 # from the lane CD actually runs).
 jobs:
+  # a repo-hygiene check, deliberately not attached to a build: it costs seconds, needs
+  # no toolchain, and answers on a pull request whose only change is a changelog entry.
+  # what it catches is invisible in a diff - see the script's own header.
+  changelog:
+    name: changelog headings
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: one [Unreleased], and it comes first
+        run: bash .github/scripts/check-changelog.sh
+
   build-linux:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### frontend: a C-variadic function is nameable as a type (#3003)
+
+`ext fun printf(fmt: *u8, ...) i32` already parsed. The identical shape written as a
+type did not:
+
+```
+error: C-style variadic `...` was removed in v2.0.0
+```
+
+That message was a leftover. The form was not removed, it was **narrowed** to `ext`
+declarations - so the diagnostic stated a true-in-2.0 thing that is false today, and
+stated it at the one spelling that ought to work. A C-variadic function could not be
+stored in a variable, passed as a callback, or held in a table.
+
+```mach
+def Printf: fun(*u8, ...) i32;
+
+val p: Printf = printf;
+p("%d\n"::*u8, 42);
+```
+
+The flag was already modelled everywhere except the parser that would set it: it is
+part of the interned type's structural identity, hashed and compared, carried through
+to the IR function type, and `check_call` reads it off the **type** rather than off the
+declaration. The ABI layer classifies from the signature too, so an indirect
+C-variadic call needed no backend work at all.
+
+`fun(*u8, ...) i32` and `fun(*u8) i32` stay distinct types and do not unify. A call
+through the first places its tail by the target's variadic rule and a call through the
+second does not, so unifying them would reach a C callee's `va_arg` with arguments laid
+out the ordinary way - a wrong **value** at run time, not a link error.
+
+A leading bare `...` is refused in a type exactly as it is on a declaration, since a
+C-variadic callee finds its tail relative to its last fixed parameter. That is a
+property of the signature, not of where the signature is written.
+
+Verified by executing an indirect call against a real clang-built `va_arg` callee, not
+by diffing an object: the whole failure mode here is a call that links and runs and
+hands the callee the wrong bytes.
+
 ### Fixed
 
 #### sema: the C-variadic contract follows a call chain, not just one hop (#3031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.24.0] - 2026-08-21
 
 ### Added
 
@@ -102,6 +102,28 @@ by diffing an object: the whole failure mode here is a call that links and runs 
 hands the callee the wrong bytes.
 
 ### Fixed
+
+#### test(link): the c-variadic and narrow-stack-args cases now run on windows (#3005)
+
+Both cases carried `skip: x86_64-windows`, word for word, deferring the same question:
+does the runner expose a bare `cc`? So win64's variadic rule - a tail float duplicated
+into the integer register of its positional slot - and its stack-argument rule were
+checked only by the compiler's own unit tests, which compare mach's model of the ABI
+against itself and cannot catch the model being wrong.
+
+The guess was wrong in both. CI already exports `CC=gcc`. What actually failed was the
+step's own command: a `[step]` cmd runs through the **platform** shell, which on windows
+is `cmd.exe /s /c`, and cmd.exe cannot execute `../../lib/cc.sh`. Every windows run died
+with `'..' is not recognized` before a compiler was ever consulted. The rest of the suite
+already had it right - every `pe-*` case invokes its script as `sh <script>` - and these
+three cc.sh cases were the outliers.
+
+One wrong guess had exempted two cases, so answering it once restored both.
+
+Verified to DISCRIMINATE, not merely run: breaking `float_dup_gp` on a throwaway branch
+fails the case with a golden diff against MinGW's real `va_arg`, while `narrow-stack-args`
+passes under the same mutation. The margin is thinner than the case looks, which is
+tracked separately as #3043.
 
 #### chore(changelog): stray `[Unreleased]` headings stranded inside released sections (#3039)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### diag: a diagnostic carries its fix as an edit, not only as English (#3023)
+
+A mach diagnostic already tells you what to do about it. `help` carries a spelling
+correction, or `value::Type`. An editor cannot act on prose: to offer a one-keystroke
+fix it has to pattern-match the compiler's English and rebuild the edit from it, which
+couples the quick fix to diagnostic **wording** - every rephrasing upstream breaking it
+silently, with no compile error and no test failure to catch it. mach-lsp declined to
+build that, correctly. The compiler already holds the answer at the point it composes
+the sentence, and threw the structure away.
+
+`Diagnostic` now carries `fixes`, alongside `help` rather than instead of it. Terminal
+rendering is unchanged.
+
+```mach
+pub rec Edit { loc: Location; replacement: str; }
+pub rec Fix  { label: str; edits: *Edit; edit_len: usize; edit_cap: usize; }
+```
+
+**Edits are a list.** They apply together or not at all, and the ordinary cast case
+needs two: `(` before the expression and `)::T` after. Applying half of that produces
+source that does not parse, so a one-span shape would either exclude the case or make
+a consumer correlate two separate fixes and hope. Alternatives - cast the value versus
+change the declaration - stay separate `Fix` entries, because those are a choice a
+person makes rather than one atomic edit.
+
+An empty span is an insertion and an empty replacement is a deletion, both falling out
+of the one shape. A fix always carries at least one edit, since `attach_fix` takes the
+first, so "a fix with nothing to apply" is not a state that exists.
+
+Two producers ship with it:
+
+- an unresolved identifier or type name with a near match replaces the misspelling
+- a no-implicit-widening mismatch inserts the cast, **parenthesizing when it must**
+
+That second one is the whole design in miniature. `::` binds tighter than the binary
+operators, so appending `::i64` to `a + a` yields `a + a::i64` - source that compiles,
+casts the wrong operand, and leaves the original error standing. And the range comes
+from the AST node, not from the diagnostic's span: a reporter picks its span to
+underline what reads best, and a `val` declaration's runs past the initializer to the
+`;`, which put the first draft's insertion after the semicolon.
+
+A cast is offered only when it would actually compile. `::` will reinterpret any two
+same-size values, so between two unrelated records it is legal - and offering it would
+turn a real type error into a silent bit pun. A fix that produces a new error, or a new
+wrong program, is worse than none: the editor's keystroke is taken on trust.
+
+Fixes travel through `clone_tail` and `append_all`, so a cached module's replayed
+diagnostics keep them. Otherwise a quick fix would blink out of an editor on an
+unrelated keystroke, with no error message and nothing for a user to report.
+
+Consumer tracking: briar-systems/mach-lsp#165.
+
 ### Fixed
 
 #### sema: the C-variadic contract follows a call chain, not just one hop (#3031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,27 @@ hands the callee the wrong bytes.
 
 ### Fixed
 
+#### chore(changelog): stray `[Unreleased]` headings stranded inside released sections (#3039)
+
+`CHANGELOG.md` carried `## [Unreleased]` headings *inside* already-released sections -
+between 4.23.0 and 4.22.0, and again between 4.22.0 and 4.21.1. A reader of the
+published 4.23.0 section saw an "Unreleased" heading in the middle of it, above entries
+that shipped in 4.23.0.
+
+The cause was the merge workflow, not the release step. Each pull request prepended its
+own `## [Unreleased]` block rather than appending under the existing one, so several
+accumulated between releases; the release step renames only the first, and every other
+became an orphan.
+
+Repaired by folding each stray into the release above it and merging duplicate `###`
+subsections. Every body line is preserved byte for byte - only headings moved.
+
+A CI check now enforces the invariant: at most one `## [Unreleased]`, and it must be
+the first `## [` heading. It fails on the pull request that adds the second one, while
+the fix is a single heading deletion - rather than at release time, when the two have
+already merged. This class of mistake is invisible in a diff, because each PR's own
+diff looks correct in isolation and the damage exists only in the merged file.
+
 #### sema: the C-variadic contract follows a call chain, not just one hop (#3031)
 
 #3029 made the C promotion rule survive monomorphization for a call one hop from the
@@ -163,6 +184,7 @@ Unblocks briar-systems/mach-lsp#141.
 
 ## [4.23.0] - 2026-08-21
 
+
 ### Fixed
 
 #### sema: the C-variadic promotion rule survives monomorphization (#3029)
@@ -199,7 +221,14 @@ the way to wrap a C variadic.
 
 Measured at no cost: 45.57s of build CPU against a 45.72s baseline.
 
-## [Unreleased]
+#### sema: a comptime container no longer masks the C-variadic filter (#3025)
+
+The instance-recording filter #3029 added answered "yes" for any body holding a `$if`
+or `$each` rather than walking its arms. Every body with a comptime container looked
+like it reached a C-variadic tail; the codegen corpus caught it, refusing
+`fold_pack`'s `u8` element in a body that calls no foreign function at all. The arms
+are walked now. The conservative direction is wrong on this filter in both of its
+uses.
 
 ### Added
 
@@ -233,18 +262,6 @@ rather than on a `va...` inside a wrapper they may not have written.
 The obligation attaches only where the pack actually reaches C. An ordinary mach
 variadic still takes a `u8` element, because entering a pack carries no width
 obligation of its own - the obligation comes entirely from the forwarding.
-
-### Fixed
-
-#### sema: a comptime container no longer masks the C-variadic filter (#3025)
-
-The instance-recording filter #3029 added answered "yes" for any body holding a `$if`
-or `$each` rather than walking its arms. Every body with a comptime container looked
-like it reached a C-variadic tail; the codegen corpus caught it, refusing
-`fold_pack`'s `u8` element in a body that calls no foreign function at all. The arms
-are walked now. The conservative direction is wrong on this filter in both of its
-uses.
-
 ## [4.22.0] - 2026-08-21
 
 ### Changed
@@ -277,7 +294,6 @@ enter-at-the-base rule are now one body shared by the file path and the in-memor
 one, so an image held in memory cannot differ from the one a build would have
 written.
 
-## [Unreleased]
 
 ### Fixed
 
@@ -434,6 +450,7 @@ teardowns were missed, it was that the only test covering them could not fail.
 
 ## [4.20.0] - 2026-08-20
 
+
 ### Fixed
 
 #### driver: a retained session's reload cycle returns to a steady state (#3001)
@@ -476,6 +493,13 @@ The regression test asserts an **exact** zero, not a threshold: a cycle that run
 once per keystroke has no such thing as an acceptable per-cycle residue, only a
 longer wait before it matters.
 
+#### Vendored frontends retain Mach's compiler version (#2954)
+
+The driver, `$mach.version`, debug-info producer string, and CLI now read one Mach-owned
+release constant instead of the embedding project's `[project].version`. A frontend
+vendored by another tool therefore reports Mach's version rather than its host package's
+version. Release tests pin the constant to Mach's own manifest.
+
 ### Added
 
 #### Tooling can retain compiler-owned frontend analysis (#2996)
@@ -495,16 +519,6 @@ removed. The check read the embedding project's version when the compiler fronte
 was vendored, so it refused every ordinary `4.x` requirement under tools such as
 mach-lsp. Root manifests now report `mach` as an unknown project key; dependency
 metadata bearing the removed key is ignored. No replacement is planned here.
-
-### Fixed
-
-#### Vendored frontends retain Mach's compiler version (#2954)
-
-The driver, `$mach.version`, debug-info producer string, and CLI now read one Mach-owned
-release constant instead of the embedding project's `[project].version`. A frontend
-vendored by another tool therefore reports Mach's version rather than its host package's
-version. Release tests pin the constant to Mach's own manifest.
-
 ## [4.19.0] - 2026-08-10
 
 ### Changed
@@ -598,6 +612,7 @@ The 4.18.1 release itself was unaffected: CD builds and publishes on the tag and
 
 ## [4.18.1] - 2026-08-09
 
+
 ### Fixed
 
 #### A SPIR-V function body truncated its parameters instead of refusing (#2923)
@@ -609,6 +624,40 @@ The bound was also stated in four places rather than one, which is the defect #2
 **The constant's own documentation was wrong, and that is what sent the issue at the wrong layer.** It said sixteen came from the emitter assembling signature operands into fixed arrays, so removing the bound read as a buffer resize. The real reason is the argument register bank. `abi/spirv.mach` is an identity convention where the argument at position `i` is classified into register `i`, since SPIR-V passes composites natively and has no frame to spill into, so a parameter position is a physical register id on this target. The shared MIR lowering caps those at `MAX_GP_ARG_REGS`, also sixteen. SPIR-V's own universal limit is 255, and reaching it means decoupling a parameter from the register model rather than widening a buffer.
 
 That shared cap turned out to be unguarded in a way no target owner would expect. `abi_gp_arg_reg` reads a convention's bank into a fixed `[16]isa.Register` and range-checks the index **after** the fill, so a convention publishing a wider bank overruns that array before anything rejects it, from a one-line edit in a target's own file. A test now walks every registered convention against a deliberately oversized scratch and fails if any publishes a wider bank, and it refuses to pass if it checked nothing.
+
+#### A COFF long section name was space-padded, and llvm refused the object (#2952)
+The PE/COFF long section-name form is a slash followed by an ASCII decimal offset into the string table. mach right-justified the decimal in the seven bytes after the slash and padded the left with spaces, so a name over eight bytes came out `"/      4"`. binutils reads that by skipping the spaces. llvm does not: `llvm-readobj` and `llvm-objdump` both answer `invalid section name` and decode nothing, so every `x86_64-windows` object carrying a section name that long was unreadable by the tools the corpus is grounded in while `mach build` reported success. `.rodata.cst` is eleven bytes, so this reached every object with a constant pool.
+
+It went unnoticed because nothing external had ever read a mach COFF object. The corpus's `x86_64-windows` column has no goldens on a linux developer host, which declines the target, and its CI leg had never started (#2948), so the first layer A run on that target is what refused. That is the same shape as the ELFCLASS32-on-Elf64 writer that motivated layer A: a format only its own reader had ever checked. The field is now pinned by byte in a unit test, because two readers disagreeing about padding is precisely what stayed invisible.
+
+#### A float constant typed through an alias says why it does not fold (#2937)
+
+`#2918` made a comptime float carry the IEEE width its payload is at, which means the pre-type passes have to read that width from the annotation spelling. That is exact for a literal `f32` or `f64`, because a primitive wins over scope in type position, and it is not readable when the type arrives through a `def` alias: no type exists yet to read the alias through. Such a binding is therefore skipped rather than bound at f64, which would export a constant that disagrees with the one the program computes.
+
+The skip is right. What was wrong is that it left no trace, so a use of the name at that stage reported `identifier is not a comptime constant in scope` - which is false in both halves. `X` is a comptime constant and it is in scope, and only its width is unreadable this early. A reader acting on that message goes looking for a declaration that is already there and already correct.
+
+The pass that skips is the only place that knows why, so it now records the name and the use site reports the reason. Nothing else changes: the value still folds wherever types are known, a name that was never declared still reports absence, and a later pass that does bind the name reports nothing at all.
+
+Following the alias by name in the loading pass would answer sooner and would be wrong: at that stage nothing says which declaration a spelling denotes, and reading a name-keyed table for the answer is the mistake #2764 documents.
+
+#### A folded cast records the signedness of the type it casts to (#2935)
+
+`int_ct` in the lowering fold built its `CTValue` without setting `int_unsigned`, and a `var` record default-initialises to zero, so every constant produced by a folded cast claimed to be signed - including a cast to `u64`. The field exists to tell a negative value from a magnitude above i64 range, and those two share a bit pattern, so a wrong answer there is unrecoverable by anything downstream. Its two sibling constructors, `make_int_value` and `ct_float`, each set every discriminating field they own.
+
+It changes no output today, and that is stated rather than assumed. `int_ct` is reachable only from `convert_const_scalar`, whose single caller reads the destination type for signedness rather than the field, and every other reader of `int_unsigned` is fed by `comptime.eval`, which does not route through it. Compiling the tree with a compiler built before and after produces byte-identical objects, 225 of them, on x86-64.
+
+The issue this closes was filed describing a different defect: that a comptime integer is not evaluated at its declared width, so `val X: u8 = 200 + 100` errors rather than wrapping. That does not reproduce. The constant wraps at its declared width and agrees with the same computation at run time, including through division and shift, which are the operations where narrowing once at the end would differ from narrowing at each step. The refusals in the comptime evaluator fire at i64 and u64 range, matching the literal-range rejection they were built beside, and a `u8` computation never reaches them.
+
+#### The compiler was silent both times a pass dropped a value and missed a use (#2930, #2931)
+`#2749` was an `i32x4` accumulator on x86-64 that came out holding the multiplier. `#2917` was a conditional float merge on riscv64 that read its register undefined. Both were silent wrong answers, both were found by running a program, and `--verify-ir` exited 0 on both reproducers. The pass mistake behind them is ordinary. Being undetectable was not.
+
+The instruction pool keeps every instruction a pass ever created, detached ones included, so an operand naming a dropped value still resolves and reads as an ordinary use. Only the block lists say what reaches the back end, and nothing measured operands against them. The one check that could have was dominance, which walked block bodies and terminators and never phi lists, and returned early for a phi on top of that, so a phi incoming naming a dropped value was invisible twice over. It also rode the `full` flag, so it ran only in the post-DCE stages.
+
+`VC_DANGLING_OPERAND` now builds the live set once per function from the block lists and scans every live instruction's operands against it. It needs no dominator tree and no reachability, so it is always on and holds at every pipeline stage rather than only some of them. Dominance no longer exempts a phi: an incoming is measured at the END of the predecessor the pair names, which is the point the value has to be live out of for the edge copy to read it.
+
+Phi destruction had the matching hole and is what turned the IR defect into wrong code rather than a build failure. `lower_block_phis` searched a phi's operand pairs for the predecessor edge it was emitting and, finding none, moved on with no copy and no error, while the four other malformed inputs in the same function each fail the build. Out-of-SSA is total, so a merge register that is not defined on every path in is a malformed input rather than a case, and it now errors with the phi's block, the predecessor and the result vreg, since the pass that dropped the incoming is well upstream of MIR lowering.
+
+Both are diagnostic. Object output is byte-identical per target across x86-64, aarch64 and riscv64.
 
 ### Changed
 
@@ -653,42 +702,6 @@ Every run of either suite writes a coverage matrix naming the engine behind each
 Three things kept their behaviour and changed address. `int/observability.md` is `doc/design/test-observability.md`, since the relationship between a defect class and the observation that can see it was never a property of a harness. `int/lib/check-determinism.sh` is `test/determinism.sh`, since it guards the incremental build path rather than integration. And `int/lib/cc.sh`, the host and cross C toolchain resolver every foreign-object case builds through, is `test/link/lib/cc.sh`.
 
 Two measurements lost their guard and say so where they are claimed. `doc/language/secrecy.md` recorded a dudect-style timing harness at `int/ct/`. It ran on demand and never in CI, and it is gone, so the empirical claims there are now marked as measurements taken once. The x86-64 flags table in `x64/encode.mach` was transcribed from a probe run against real hardware, and nothing re-runs that probe. Restoring it belongs in a host-executed unit test, since the experiment only means anything on the ISA it executes on.
-### Fixed
-
-#### A COFF long section name was space-padded, and llvm refused the object (#2952)
-The PE/COFF long section-name form is a slash followed by an ASCII decimal offset into the string table. mach right-justified the decimal in the seven bytes after the slash and padded the left with spaces, so a name over eight bytes came out `"/      4"`. binutils reads that by skipping the spaces. llvm does not: `llvm-readobj` and `llvm-objdump` both answer `invalid section name` and decode nothing, so every `x86_64-windows` object carrying a section name that long was unreadable by the tools the corpus is grounded in while `mach build` reported success. `.rodata.cst` is eleven bytes, so this reached every object with a constant pool.
-
-It went unnoticed because nothing external had ever read a mach COFF object. The corpus's `x86_64-windows` column has no goldens on a linux developer host, which declines the target, and its CI leg had never started (#2948), so the first layer A run on that target is what refused. That is the same shape as the ELFCLASS32-on-Elf64 writer that motivated layer A: a format only its own reader had ever checked. The field is now pinned by byte in a unit test, because two readers disagreeing about padding is precisely what stayed invisible.
-
-#### A float constant typed through an alias says why it does not fold (#2937)
-
-`#2918` made a comptime float carry the IEEE width its payload is at, which means the pre-type passes have to read that width from the annotation spelling. That is exact for a literal `f32` or `f64`, because a primitive wins over scope in type position, and it is not readable when the type arrives through a `def` alias: no type exists yet to read the alias through. Such a binding is therefore skipped rather than bound at f64, which would export a constant that disagrees with the one the program computes.
-
-The skip is right. What was wrong is that it left no trace, so a use of the name at that stage reported `identifier is not a comptime constant in scope` - which is false in both halves. `X` is a comptime constant and it is in scope, and only its width is unreadable this early. A reader acting on that message goes looking for a declaration that is already there and already correct.
-
-The pass that skips is the only place that knows why, so it now records the name and the use site reports the reason. Nothing else changes: the value still folds wherever types are known, a name that was never declared still reports absence, and a later pass that does bind the name reports nothing at all.
-
-Following the alias by name in the loading pass would answer sooner and would be wrong: at that stage nothing says which declaration a spelling denotes, and reading a name-keyed table for the answer is the mistake #2764 documents.
-
-#### A folded cast records the signedness of the type it casts to (#2935)
-
-`int_ct` in the lowering fold built its `CTValue` without setting `int_unsigned`, and a `var` record default-initialises to zero, so every constant produced by a folded cast claimed to be signed - including a cast to `u64`. The field exists to tell a negative value from a magnitude above i64 range, and those two share a bit pattern, so a wrong answer there is unrecoverable by anything downstream. Its two sibling constructors, `make_int_value` and `ct_float`, each set every discriminating field they own.
-
-It changes no output today, and that is stated rather than assumed. `int_ct` is reachable only from `convert_const_scalar`, whose single caller reads the destination type for signedness rather than the field, and every other reader of `int_unsigned` is fed by `comptime.eval`, which does not route through it. Compiling the tree with a compiler built before and after produces byte-identical objects, 225 of them, on x86-64.
-
-The issue this closes was filed describing a different defect: that a comptime integer is not evaluated at its declared width, so `val X: u8 = 200 + 100` errors rather than wrapping. That does not reproduce. The constant wraps at its declared width and agrees with the same computation at run time, including through division and shift, which are the operations where narrowing once at the end would differ from narrowing at each step. The refusals in the comptime evaluator fire at i64 and u64 range, matching the literal-range rejection they were built beside, and a `u8` computation never reaches them.
-
-#### The compiler was silent both times a pass dropped a value and missed a use (#2930, #2931)
-`#2749` was an `i32x4` accumulator on x86-64 that came out holding the multiplier. `#2917` was a conditional float merge on riscv64 that read its register undefined. Both were silent wrong answers, both were found by running a program, and `--verify-ir` exited 0 on both reproducers. The pass mistake behind them is ordinary. Being undetectable was not.
-
-The instruction pool keeps every instruction a pass ever created, detached ones included, so an operand naming a dropped value still resolves and reads as an ordinary use. Only the block lists say what reaches the back end, and nothing measured operands against them. The one check that could have was dominance, which walked block bodies and terminators and never phi lists, and returned early for a phi on top of that, so a phi incoming naming a dropped value was invisible twice over. It also rode the `full` flag, so it ran only in the post-DCE stages.
-
-`VC_DANGLING_OPERAND` now builds the live set once per function from the block lists and scans every live instruction's operands against it. It needs no dominator tree and no reachability, so it is always on and holds at every pipeline stage rather than only some of them. Dominance no longer exempts a phi: an incoming is measured at the END of the predecessor the pair names, which is the point the value has to be live out of for the edge copy to read it.
-
-Phi destruction had the matching hole and is what turned the IR defect into wrong code rather than a build failure. `lower_block_phis` searched a phi's operand pairs for the predecessor edge it was emitting and, finding none, moved on with no copy and no error, while the four other malformed inputs in the same function each fail the build. Out-of-SSA is total, so a merge register that is not defined on every path in is a malformed input rather than a case, and it now errors with the phi's block, the predecessor and the result vreg, since the pass that dropped the incoming is well upstream of MIR lowering.
-
-Both are diagnostic. Object output is byte-identical per target across x86-64, aarch64 and riscv64.
-
 ## [4.18.0] - 2026-08-08
 
 #### A whole `#[uniform]` or `#[storage]` block crosses a call by value (#2922, #2926)
@@ -730,6 +743,22 @@ The four refusals the old grammar carried by name survive, re-keyed to the opera
 **The name grammar is gone in the same change.** `sampler2d` and its relatives no longer exist, `src/lang/type.mach` loses 495 lines and carries a target-neutral `TYPE_HANDLE` whose payload is a constructor tag and opaque operand words it never reads, and `#[spirv_op(set, name)]` is now `#[op(target, set, name)]` with no alias. Carrying the target as a string in the source rather than in the directive's name is what leaves the front and middle ends unaware of anything but the machinery.
 
 A textured shader emits a **byte-identical module** across the migration: the sampled-image fixture built with the old spellings and with the new declarations produces the same 3984 bytes, and `spirv-val --target-env vulkan1.3` accepts both.
+
+#### A refused layout intrinsic now says which position refused it, and why (#2857)
+`a layout intrinsic has no value in this position: it measures a type, which only a type position resolves` was true of every position and is now true of one. A **declaration-scope** `$if` still cannot measure, because it selects which declarations exist and that is decided before any type is laid out, so it says that instead and points at the position that does work. `$offset_of` is named apart, since it is unavailable for a different reason - a field offset is decided at lowering - and a message about type checking would be a stale explanation the moment the resolver exists.
+
+Two limits are filed rather than left implicit: `$length_of` still does not fold in a gate (#2875), and no declaration-scope gate can see a type at all, which is shared with type queries and comparisons (#2876).
+
+#### A target now owns the operations it defines (#2888)
+The compiler knew what a SPIR-V instruction was. `src/lang/spirvop.mach` sat outside the target holding 41 hand-written string comparisons that mapped an instruction name to a number, and the front end read it directly. Adding an instruction meant editing the compiler, so a shader library could not add one at all.
+
+The table now hangs off the ISA vtable and the target fills it. It reaches the front end as data on the comptime context beside `pointer_width`, for the reason stated there: it is a target machine fact the frontend needs, and the frontend has no target. So `fe` names no back end, and unlike before it holds no SPIR-V numbers of its own. `src/lang/spirvop.mach` is gone, and the IR carries the set tag and opcode under target-neutral names.
+
+An instruction's arity is now checked, which nothing did before. The decorator's contract is that operands come from the parameters in order, so a declaration whose parameter list is the wrong length assembled the instruction with the wrong operand count. The family looks uniform and is not: `Reflect` takes two operands where `Refract` takes three, and `FMin` two where `FClamp` takes three.
+
+Emitted output is unchanged. Every machine target is byte-identical, 224 objects each across x86-64, arm64 and riscv64, and the SPIR-V fixtures emit the same bytes.
+
+This is the first piece of #2888. Type constructors, the `#[handle]` and `#[op]` declarations, and the bodyless `def` are not here.
 
 ### Fixed
 
@@ -879,6 +908,27 @@ The pass now decides that a memory access is one by finding the address, not by 
 
 mos6502, the other target that legalizes to a narrower ALU, is unaffected: an `i64` there needs a frame slot and the pass refuses the wide `MIR_ALLOCA` before any access is examined.
 
+#### A shader indexing with a `u32` no longer requires `shaderInt64` (#2878)
+A SPIR-V module whose arithmetic was entirely 32-bit declared `OpCapability Int64`, because every array index was widened to the target's pointer width before it reached the emitter. That is right for a byte-addressed machine, where an index is scaled by the element size and added to a base address and so must fill a machine word. SPIR-V addresses logically: an `OpAccessChain` index selects a member, nothing scales it, and the widening bought nothing.
+
+It cost a device requirement. `shaderInt64` is an optional feature, so a shader that performed no 64-bit arithmetic was refused outright by `vkCreateShaderModule` on hardware without it, and was invalid usage on hardware with it unless the application had enabled the feature. Downstream this was worked around by requesting the feature unconditionally and refusing to start without it, which narrowed the hardware the application ran on.
+
+The index width is now taken from `MachineModel.flat_addressing`, the same axis that already gates float address materialization and aggregate member walks (#2655), so the transformation is gated rather than the target. A genuinely 64-bit index still declares `Int64`, since that is what the program asked for. Every machine target's output is byte-identical.
+
+#### riscv64 images claimed an instruction set they did not have (#2828)
+`.riscv.attributes` carried an arch string taken from a per-ISA constant. A constant describes what mach's encoder emits, and an image is not what its encoder emits - it is that plus every object linked into it. A mach image containing a clang object built for `rv64gc` claimed no compressed extension and none of the z-extensions it actually held, so a disassembler configured from the image decoded its compressed float loads as `<unknown>`. This is the same class of false claim `e_flags` carried before #2813, one section over.
+
+Nothing states a string now. An image's claims are derived from the two facts that decide them - the resolved ABI and the emitted bytes - and a linked image's are merged from its inputs. `BuildAttributes` no longer has an arch field at all, so a constant is not merely unused but inexpressible.
+
+The merge rule is the arch's, because a union is right for the ISA string and wrong for everything else. Stack alignment must agree or the inputs cannot be linked. Unaligned access is a permission, so the image permits it if any input needed it. A privileged-spec disagreement leaves the image unable to state one, so it states none. A tag mach does not model survives only while every input that states it agrees. No shared layer can know which tag takes which rule, so the seam hands the arch the whole attribute body and reads none of it; the ELF layer keeps only the container, which the ARM EABI defines identically.
+
+`obj.rehome_remap` copies the body rather than aliasing it. Rehoming exists precisely because the source allocator is going away, so a field holding a pointer into it needs a copy and not an assignment - the note on that function now separates the two failure modes, since a missed scalar reverts to zero on the parallel path while a missed pointer segfaults somewhere else entirely.
+
+#### Two modules could claim one descriptor set and binding with no diagnostic (#2843)
+Within one module a repeated `(set, binding)` is a typo its author can see. Across modules it is neither: two shared libraries can each declare `#[uniform(0, 0)]` without either author seeing the other, and the shader importing both is where the conflict first exists. `spirv-val` does not catch it, because two variables at one pair are well-formed SPIR-V and the conflict is with the pipeline layout, which is not in the module.
+
+The pair is now checked over the set one entry point reaches, across the descriptor roles rather than within one, since a `#[uniform(0, 0)]` and a `#[storage(0, 0)]` are two descriptor types claiming one slot. The Location overlap check widened the same way, and both diagnostics name the declaring **module** when it is not the one being compiled - a message naming two `camera`s tells the one person who can act on it nothing.
+
 ### Added
 
 #### A declaration-scope `$if` that declares nothing can ask about a type (#2876)
@@ -927,38 +977,6 @@ The measurement is not new and deliberately is not duplicated: the comptime eval
 
 Resolve reaches the position through a mechanism that was already there: `bind_comptime_if` defers a chain it cannot fold yet, binding every arm and leaving arm selection to a later pass, which is what a type comparison has always done. A layout gate joins that list rather than introducing a second rule.
 
-### Changed
-
-#### A refused layout intrinsic now says which position refused it, and why (#2857)
-`a layout intrinsic has no value in this position: it measures a type, which only a type position resolves` was true of every position and is now true of one. A **declaration-scope** `$if` still cannot measure, because it selects which declarations exist and that is decided before any type is laid out, so it says that instead and points at the position that does work. `$offset_of` is named apart, since it is unavailable for a different reason - a field offset is decided at lowering - and a message about type checking would be a stale explanation the moment the resolver exists.
-
-Two limits are filed rather than left implicit: `$length_of` still does not fold in a gate (#2875), and no declaration-scope gate can see a type at all, which is shared with type queries and comparisons (#2876).
-
-### Changed
-
-#### A target now owns the operations it defines (#2888)
-The compiler knew what a SPIR-V instruction was. `src/lang/spirvop.mach` sat outside the target holding 41 hand-written string comparisons that mapped an instruction name to a number, and the front end read it directly. Adding an instruction meant editing the compiler, so a shader library could not add one at all.
-
-The table now hangs off the ISA vtable and the target fills it. It reaches the front end as data on the comptime context beside `pointer_width`, for the reason stated there: it is a target machine fact the frontend needs, and the frontend has no target. So `fe` names no back end, and unlike before it holds no SPIR-V numbers of its own. `src/lang/spirvop.mach` is gone, and the IR carries the set tag and opcode under target-neutral names.
-
-An instruction's arity is now checked, which nothing did before. The decorator's contract is that operands come from the parameters in order, so a declaration whose parameter list is the wrong length assembled the instruction with the wrong operand count. The family looks uniform and is not: `Reflect` takes two operands where `Refract` takes three, and `FMin` two where `FClamp` takes three.
-
-Emitted output is unchanged. Every machine target is byte-identical, 224 objects each across x86-64, arm64 and riscv64, and the SPIR-V fixtures emit the same bytes.
-
-This is the first piece of #2888. Type constructors, the `#[handle]` and `#[op]` declarations, and the bodyless `def` are not here.
-
-### Fixed
-
-#### A shader indexing with a `u32` no longer requires `shaderInt64` (#2878)
-A SPIR-V module whose arithmetic was entirely 32-bit declared `OpCapability Int64`, because every array index was widened to the target's pointer width before it reached the emitter. That is right for a byte-addressed machine, where an index is scaled by the element size and added to a base address and so must fill a machine word. SPIR-V addresses logically: an `OpAccessChain` index selects a member, nothing scales it, and the widening bought nothing.
-
-It cost a device requirement. `shaderInt64` is an optional feature, so a shader that performed no 64-bit arithmetic was refused outright by `vkCreateShaderModule` on hardware without it, and was invalid usage on hardware with it unless the application had enabled the feature. Downstream this was worked around by requesting the feature unconditionally and refusing to start without it, which narrowed the hardware the application ran on.
-
-The index width is now taken from `MachineModel.flat_addressing`, the same axis that already gates float address materialization and aggregate member walks (#2655), so the transformation is gated rather than the target. A genuinely 64-bit index still declares `Int64`, since that is what the program asked for. Every machine target's output is byte-identical.
-
-
-### Added
-
 #### RV32 is a target (#2778)
 mach compiles for 32-bit RISC-V. `isa = "riscv32"` with `abi = "ilp32"`, `"ilp32f"` or `"ilp32d"` resolves a full machine description, and `$mach.arch.riscv32` and the three `$mach.abi.ilp32*` tags exist so a body can be guarded for it.
 
@@ -976,24 +994,8 @@ The cause was that `Emit.root` was the module being compiled and every global re
 A drawn-in module contributes globals by **reachability, not membership**, the rule the function table already stated. A shared module may declare a whole descriptor set, and a shader importing it for one helper does not inherit the rest. The root is exempt: its interface list is the module's pipeline contract, declared whole. Existing single-module shaders emit byte-identical modules.
 
 The driver half closes the module set over cross-module **global** references, not only function ones. A shader that reads a shared module's uniform and calls nothing in it must still draw that module in, and before this it could not resolve the variable at all.
-
-### Fixed
-
-#### riscv64 images claimed an instruction set they did not have (#2828)
-`.riscv.attributes` carried an arch string taken from a per-ISA constant. A constant describes what mach's encoder emits, and an image is not what its encoder emits - it is that plus every object linked into it. A mach image containing a clang object built for `rv64gc` claimed no compressed extension and none of the z-extensions it actually held, so a disassembler configured from the image decoded its compressed float loads as `<unknown>`. This is the same class of false claim `e_flags` carried before #2813, one section over.
-
-Nothing states a string now. An image's claims are derived from the two facts that decide them - the resolved ABI and the emitted bytes - and a linked image's are merged from its inputs. `BuildAttributes` no longer has an arch field at all, so a constant is not merely unused but inexpressible.
-
-The merge rule is the arch's, because a union is right for the ISA string and wrong for everything else. Stack alignment must agree or the inputs cannot be linked. Unaligned access is a permission, so the image permits it if any input needed it. A privileged-spec disagreement leaves the image unable to state one, so it states none. A tag mach does not model survives only while every input that states it agrees. No shared layer can know which tag takes which rule, so the seam hands the arch the whole attribute body and reads none of it; the ELF layer keeps only the container, which the ARM EABI defines identically.
-
-`obj.rehome_remap` copies the body rather than aliasing it. Rehoming exists precisely because the source allocator is going away, so a field holding a pointer into it needs a copy and not an assignment - the note on that function now separates the two failure modes, since a missed scalar reverts to zero on the parallel path while a missed pointer segfaults somewhere else entirely.
-
-#### Two modules could claim one descriptor set and binding with no diagnostic (#2843)
-Within one module a repeated `(set, binding)` is a typo its author can see. Across modules it is neither: two shared libraries can each declare `#[uniform(0, 0)]` without either author seeing the other, and the shader importing both is where the conflict first exists. `spirv-val` does not catch it, because two variables at one pair are well-formed SPIR-V and the conflict is with the pipeline layout, which is not in the module.
-
-The pair is now checked over the set one entry point reaches, across the descriptor roles rather than within one, since a `#[uniform(0, 0)]` and a `#[storage(0, 0)]` are two descriptor types claiming one slot. The Location overlap check widened the same way, and both diagnostics name the declaring **module** when it is not the one being compiled - a message naming two `camera`s tells the one person who can act on it nothing.
-
 ## [4.17.0] - 2026-08-08
+
 
 ### Fixed
 
@@ -1182,6 +1184,114 @@ The static writer mapped the ELF header and program-header table **at** `segs[0]
 
 The two paths computed one fact in two places and agreed only by accident. The header-segment base is now a single definition all three writers call, and `header_fits_reserved_page` guards the static path too - it never needed the guard before only because it had no reserved page to overrun. The regression test asserts the general property that **no two load segments overlap in virtual address**, over the emitted headers rather than about one specific pair, so it fails closed for whatever the next segment-layout change does.
 
+#### A scalar `f32` passed in an integer register read back as `NaN` on riscv64 (#2777)
+
+`capture_slot_reg` took the move width for a value captured out of an incoming argument or return register from the machine word rather than from the value, so an `f32` arriving in `a0` was reinterpreted with `fmv.d.x` (a raw 64-bit move) instead of `fmv.w.x`. RISC-V requires a single-precision value in an `f` register to be NaN-boxed, and the raw move does not box, so every subsequent `fmul.s`/`fadd.s` on it produced `NaN`. The placement side already took its width from the value, so the two directions were asymmetric — which is why `f64` in an integer register was correct (its width happened to equal the machine word) and `f32` in an `fa` register was correct (it never took the integer path).
+
+Only reachable once a soft-float member existed, so it was latent rather than a regression. It is the first defect found by the width-versus-register-width split that #2778 exists to stress.
+
+#### A release build now carries a real ELF `.symtab`, so `perf` and a crash reporter can resolve a function name without a `-g` rebuild (#2772)
+Mach emitted no `.symtab` in any build, release or `-g`: `nm` reported nothing, `perf` could not symbolize a profile, and a crash address from a shipped binary mapped to a function only by rebuilding with `-g` and doing a DWARF lookup against the exact matching build - two ordinary workflows a shipping game needs, neither possible before this.
+
+A static ELF executable (`emit_exec`) now carries `.symtab` + `.strtab` with every defined function's mangled name, final virtual address, and byte size, collected by `build_symtab_entries` from the same merged-symbol data `build_exec_functions` already reads for PE unwind tables, and serialized by `elf.build_symtab_bytes`. Function symbols only, not globals: functions cover profiling and crash triage, and a data symbol table costs more file size for less of either. Sizes are real, not zero-filled - `nm` alone cannot see a `st_size` gap, but a profiler attributing an address *inside* a hot loop can, so this repo's own `int/surface/symtab` case asserts a mid-function address resolves correctly, not just a function's entry point.
+
+Trails every `PT_LOAD` segment exactly like `int/surface/debuginfo`'s DWARF sections already do (`readelf -SW`/`-lW` confirm `.symtab`'s file offset never precedes a loaded segment's end), so a release image's runtime bytes are unchanged - the loader ignores non-allocated sections and a release build stays byte-for-byte the same program, just no longer anonymous to a debugger or profiler reading its container. This is a real, measured trade against the previous byte-identical *header-less* release image, though: a build that carried no section-header table at all now carries one whenever it carries a symbol table (which is every static build now), and the compiler's own release binary - a large, real program with 8,408 function symbols - grew by about 611 KiB (7.3%) for it. `perf record`/`perf report` on a release build built with this change resolves `[.] main` by name where it previously showed a raw address; `addr2line -f` on an address in the middle of a function's body (not just its entry) resolves to that function, proving `st_size` is correct and not merely present.
+
+Scoped to ELF's plain static executable writer (`emit_exec`) for now: a PIE/dynamically-linked executable (`emit_dyn_exec`) and a shared library (`emit_shared`) do not carry a symbol table yet, and neither does Mach-O (`LC_SYMTAB`) or PE/COFF (its own, mostly-obsolete-under-PDB symbol table) - both accept the same `of.SymtabEntry` channel for `of.ExecFn` conformance and ignore it. `of.SymtabEntry` (name, final vaddr, byte size, STB_LOCAL/STB_GLOBAL linkage) is the format-neutral shape a future writer for either reads from, so extending coverage is wiring a serializer, not redesigning the data.
+
+#### `--emit-asm` names the symbol an inline-asm statement actually references, instead of a different real one (#2788)
+On x86-64, `--emit-asm` rendered every symbol operand inside an `asm` block wrongly. A memory operand naming a symbol printed a **different, real symbol from the same module** - `[rip + _rt_argc]` came out as `[rip + dbggdbcase]` - and a direct `call symbol` printed a bare `call` with nothing after it. The emitted object was correct in both cases; only the printed text was wrong.
+
+That matters more than it looks, and it cost real investigation time. `--emit-asm` is what someone reaches for when debugging inline asm, which is exactly the code where falling back on reading the source and assuming the obvious is not available. A bare `call` is at least visibly broken; a plausible wrong symbol name gives a reader no signal at all that the output is untrustworthy - an agent chasing an inlining defect followed the printed operand and had to discover independently that the text disagreed with the object.
+
+The cause was one missing thread, in two places. The inline-asm path interned the referenced symbol's name only at *relocation* time, after the instruction had already been built and encoded, so the `isa.Inst` the printer renders from carried no symbol at all: a rip-relative operand went out with `sym_id` 0 (which resolves to a real interned string, hence a real symbol name), and the direct-transfer form was built with no operand whatsoever. The name is now interned once, before the instruction is built, and the same `StrId` reaches both the Inst the printer renders and the relocation the linker reads - so the printed name and the relocated name cannot be two different strings. Naming the direct transfer's target costs no bytes, because `encode_call` / `encode_jmp` write a placeholder rel32 on the direct arm regardless, and it makes the inline-asm `call sym` exactly the `isa.Inst` the compiler-selected one already built - which is why *that* one always printed its target.
+
+aarch64 and riscv64 were already correct; both already threaded the interned id into the printer notification. That is precisely why the new `int/surface/asm-symbol-operands` case covers all three ELF legs rather than the one that was broken: the printers are separate per ISA, so a fix in one says nothing about the others, and the two that were right now have that pinned. The case pairs the symbol names the assembly text prints with the ones the object's relocations name, in file order, so a printer that regresses to naming a *different real symbol* fails it, not merely one that names nothing - and it runs the program too, since a reference that reached the wrong symbol would be a wrong answer as well as wrong text. Objects are byte-identical across the fix, checked directly.
+
+Two existing unit tests asserted the built instruction had **no** operand for `call main` / `jmp main`. Those pinned the defect, and are now the assertions that it names its target.
+
+#### A C `[step]` cross-builds for its leg instead of silently assuming the host toolchain targets it (#2741)
+`int/surface/narrow-stack-args` and `int/surface/c-variadic` shelled out to the bare host `cc` to build a probe object, which happens to target the leg on every CI runner (each builds natively) but not on a developer cross-building locally - `mach --target linux-arm64` on an x86-64 host still ran the host's x86-64 `cc`, silently linking an x86-64 object into an aarch64 image. That surfaced as `error: relocation 'plt32' to 'float_tail' overflows` on narrow-stack-args and a qemu `Illegal instruction` on c-variadic, neither of which names its actual cause.
+
+Both cases now build their probe object through `int/lib/cc.sh`, a general contract for any case with a C `[step]`: it uses the host's own `cc` when the host already targets the leg (preserving the point of these cases, which is to catch a *real* toolchain's ABI diverging from mach's model of it - Apple arm64's stack-argument rule, for one), and falls back to `clang -target <triple> -c` otherwise, since mach does the link itself and a cross-compiled object needs no sysroot or cross-linker to satisfy it. A leg cc.sh has no route for (no host match, and clang is missing) fails the step loudly, naming what's missing, rather than surfacing downstream as an opaque link error.
+
+This also lets both cases build for `linux-riscv64` for the first time, previously exempted only because the host-`cc` gap made it impossible; narrow-stack-args passes there cleanly. c-variadic's riscv64 leg stays exempted, but now for a real reason instead of a stale one: every variadic float/double argument comes back as `0`, a genuine mach ABI bug in riscv64's variadic lowering that this cross-build gap had been hiding coverage of (#2771).
+
+`int/run.sh` also now prints a `SKIP <case> [<target>] (exempt, see case.conf)` line for a case's `exempt:` legs, which previously left no trace in the run's output at all - a leg a case never applies to and a leg it was silently excluded from looked identical.
+
+`m`, the bootstrap output `mach build . -o m` (CONTRIBUTING.md's own instruction) produces, is now gitignored.
+
+#### A whole-variable load from a shader interface variable is typed by the variable (#2794)
+The SPIR-V emitter typed a loaded value from the move's byte width and register class rather than from the object it read. That agrees with the variable's own type for every shape that has a width, which is why it went unnoticed; it cannot express one that does not, and an opaque image handle has no width at all. Inferring one gave a sampled-image load an integer result type - an `OpLoad %ulong` from a sampled-image variable, which a validator rejects and the compiler was happy to write. The store side had always read the variable's type; the load side now does too.
+
+#### A comptime identifier names the declaration it resolves to, not the spelling (#2764)
+The comptime environment is keyed by **name**, and `comptime.eval_ident` looked a bare identifier up in it directly. Resolution identity was never consulted, so a binding was matched by what it is called rather than by which declaration it is. A block-local `val N` shadowing a module-level `val N = 9` therefore read back the **module** constant: `var xs: [N]i64;` under a runtime local `N` compiled as `[9]i64`, and the out-of-bounds diagnostic it later raised named a length the source never wrote.
+
+The evaluator now decides each identifier on the symbol the resolver bound to it. Every pass that owns a name-resolution map installs the same hook, and all of them answer from **one** function, `resolve.symbol_is_runtime`.
+
+That collapses the two rules that existed to compensate for the old reading. `resolve.check_gate_shadowing` is **removed**: it caught a case the evaluator would otherwise get wrong, and there is no such case left to catch. The constant index bound (#2751) no longer walks its operand for runtime leaves before folding, because the fold now fails on them by itself. `sema`'s `$if` gate walk keeps its per-kind diagnostics — a reader needs to hear "parameter" for a parameter and "value" for a binding — but delegates the decision.
+
+Consolidating them surfaced a disagreement the copies had been hiding. An `$each` loop variable is a **comptime** binding that resolve declares as a `SYM_VAL` bearing the comptime flag, and a rule keyed only on module scope classified it as runtime. The constant index bound consequently declined to decide any index driven by one, so `xs[e]` over an element out of range compiled clean and read past the array. It is now refused. `$` marks a comptime binding whatever its kind, and the rule says so once.
+
+A comptime binding that shadows a module constant still resolves innermost-first, which is the half of this that had to be preserved rather than changed: a `$param` or an `$each` variable named after a module constant denotes the inner one.
+
+#### A `#[uniform(...)]` block's offsets are checked against the SPIR-V layout rules (#2746)
+A descriptor block's member offsets were emitted straight from mach's own record layout, and exactly one of the rules Vulkan imposes on that layout was checked. A block whose members disagreed emitted a module a consumer rejects, with no diagnostic — a `rec` inside a block followed by a scalar produced **overlapping members**, and a `rec` inside a block is the natural way to write a camera or a material.
+
+std140 gives a struct member a base alignment of 16 and rounds its extent up to a multiple of 16; mach aligns a record to its largest member and does not round. A vector narrower than the vector register aligns to one lane in mach, where both std140 and std430 align it to two or four, so an `f32x2` or an `f32x3` member was a reachable disagreement in the **storage** posture too, which had been thought correct by construction.
+
+Every emitted offset is now held to the two conditions the specification states — a multiple of the member's base alignment, and past the end of the member before it — and an array stride to the element's extent rounded up to the array's base alignment. The two postures differ only in the 16-byte roundings std140 applies to an array and to a struct.
+
+A disagreement is **refused, never repacked**, which is the posture the one existing check already took and the reason it gave is the one that matters: the block's layout is the host's contract, and repacking would move the members out from under a host writing by `$offset_of`. The refusal names the member, the offset mach gives it, the offset the rules require, and which of the two conditions failed.
+
+#### A fragment stage's integer or 64-bit input carries its `Flat` decoration (#2747)
+Vulkan requires `Flat` on any fragment-stage `Input` of integer or 64-bit float type, because such a value cannot be interpolated. The emitter declared no `Flat` decoration at all, so every one of those was an invalid module. The decoration is now decided over the set of variables each stage can **reach**, which the per-stage reachability pass already computes.
+
+Vulkan also **forbids** `Flat` on a vertex-stage `Input`, so one module-scope variable read by both a vertex stage and a fragment stage has no valid decoration and is refused rather than decorated for one of them. The two readings are not the same value anyway: a vertex stage's input is a vertex attribute and a fragment stage's is the interpolated output of the stage before it.
+
+A `Location` was emitted verbatim and never checked. mach knows each variable's type and so knows how many locations it consumes, and two whose spans overlap within one stage are now refused naming both, rather than surfacing as a validator message naming an `OpEntryPoint` operand index.
+
+#### Recursion and a 15-parameter signature are refused rather than emitted (#2748)
+There was no whole-module well-formedness stage, so a rule about the module — its call graph, its id validity — had nowhere to live, and two reachable from ordinary source emitted invalid modules silently.
+
+A SPIR-V execution model has no call stack, so a cycle in the static call graph is refused before any body is emitted, naming the chain and saying why. This is checked rather than left to `spirv-val`, whose cycle rule is scoped to entry points: a **library** module carrying a cycle validated clean and would have failed in whatever consumer linked it into a pipeline. One had been sitting green in the integration suite.
+
+The parameter limit was two independent literals that disagreed: `emit_function` refused above 16 while `type_fn`'s fixed operand buffer failed above 14 and returned a 0 nobody read, which reached `OpFunction` as the reserved never-valid id. The limit is now stated once as `types.MAX_FN_PARAMS`, both sites read it, 15 and 16 parameters build and validate, and a 0 from `type_fn` is reported instead of passed on.
+
+#### A dead local's stale value survives past its real live range at opt0, and a `ret` statement's line-table row duplicates at function entry (#2779)
+Two opt0-only debug-info defects `int/surface/debugger-gdb` (#2756) caught by driving a real `gdb` session, neither visible to structural DWARF validation because both artifacts are internally consistent, well-formed DWARF that simply describes the wrong thing.
+
+**A variable's `DW_AT_location` was scoped to its lexical extent, not its true live range.** The opt0 allocator reusing a genuinely-dead local's storage is correct codegen (confirmed by checking the runtime value with no debugger involved), but the DWARF location for that local was never bounded to end where the reuse happens, so a debugger stopped after that point read the new occupant's value as though it were still the old variable's. Root cause: `gather_vars` built a variable's location ranges from its own bindings only, so a variable bound once and never rebound kept a stationary location valid to the function's end regardless of what physically happened to its storage afterward. `bound_storage_reuse` now truncates a range to the point some OTHER variable's binding, in the SAME inline site, claims the identical physical home - a stationary home a debugger could no longer trust past that point now reports unavailable instead. Scoping the search to the same inline site is load-bearing, not an optimization: at opt2 with heavy inlining, two variables in unrelated inline instances can land in the same register with no real relationship, and comparing across sites produced exactly that false positive while building this fix's own regression coverage.
+
+**A `ret <expr>;` statement's line-table row was duplicated at the function's own entry address.** `lower_phis` (out-of-SSA phi elimination) runs once, after every block in the function has already been lowered, and stamped its synthesized merge-copy instructions from `ctx.cur_loc` - a cursor left stale at the function's LAST lowered statement by the time phi elimination ran, for every predecessor block's edge regardless of where in the function that predecessor actually was. `break file:22` on a function whose `ret` genuinely lives at line 22 could silently resolve to its entry instead, with no ambiguity warning, reading whatever was left in an uninitialized register. Fixed by stamping from the predecessor block's own terminator location instead, which was already correct when that block was lowered and never went stale.
+
+`int/surface/debugger-gdb` gained two debug-profile-only probes proving both fixes together, asserted as a pair per each bug's own shape: a variable that genuinely dies mid-function now reports unavailable, while a sibling that stays live keeps reading its real value (a fix that reported "unavailable" for both would pass either probe alone); a second breakpoint on a real `ret` statement resolves to its own address and reads the correct value rather than silently landing at the wrong one. Both bugs are specific to opt0's own location and line-table construction and do not reproduce at opt2, so the case's golden is now per-profile (`expect.debug.txt` / `expect.release.txt`) rather than the one `expect.txt` every other `gdb-session` case still uses.
+
+#### A loop-carried vector accumulator through an unpacked operator came out holding the wrong value (#2749)
+The gap expansion (#2726) replaces a vector operator the target has no packed form for with per-lane scalar work and an assembled vector, then points that operator's uses at the assembled value. It rewrote those uses one block at a time, immediately after expanding that block's body. That is correct for every use that follows its definition, and wrong for the one that does not: a loop header's phi names the value the **latch** defines, so its back-edge operand is a forward reference no block order removes.
+
+The phi kept naming the deleted operator. MIR lowering turned the phi edge into a copy from a virtual register nothing defines, and the accumulator came out holding whatever that register happened to be. Measured on x86-64, a loop-carried `i32x4 * i32x4` returned the **multiplier** where the product belonged. aarch64 was right throughout for a reason unrelated to the defect - NEON has `MUL.4s`, so nothing expands there at all - which is why an entire suite of straight-line vector cases passed on every leg while this was live. The lane-access expansion had the identical defect one pass over.
+
+Substitution is now a whole-function step in both passes, after every block has been expanded, because the ordering it needs does not exist.
+
+#### A float or integer memory access refuses a width the target has no form for (#2766)
+A memory access takes a byte width and picks a machine form from it. On aarch64 and riscv64 that pick was a boolean selector with a trailing default, so a width the target has no form for silently got some other form's bytes rather than a diagnostic, the same shape #2733 removed from the float move, negate, arithmetic, compare and conversion encoders, one family over.
+
+riscv64's `fp_mem_funct3` answered 4 with `flw`/`fsw` and **everything else** with `fld`/`fsd`. RV64D has exactly those two float access forms and no vector extension is enabled, so a 16-byte float access had nothing to encode to at all, and it encoded to `fld`, moving eight bytes and losing the other eight. aarch64's `emit_fp_mem` handled 16 in its own arm and then fell through to `use_d = width == 8`, so a 32-byte access took the **S** form and moved four bytes of a slot the surrounding code had already sized at 32.
+
+The fix is a contract change on the access family, not a check at today's callers. The defaulting helpers were shared with the **integer** path, aarch64's `ldst_lo12_kind`, `width_shift` and the three `ldst_base_*` base-word tables were five parallel ladders that each named the narrow widths and each ended in the doubleword row, so validating only the float arms would have left the identical shape live next door under a different name. Each family now comes off **one** form table: aarch64's `int_access` / `fp_access` return a row carrying all three addressing-mode base words, the imm12 shift and the `:lo12:` relocation kind together, and riscv64's `int_mem_funct3` / `fp_mem_funct3` return the funct3 or an error. A width with no row is refused. `emit_mem_access`, `emit_fp_mem` and `mem_access_needs_no_scratch` report rather than emit, and the Q arm that used to sit ahead of the aarch64 default is now the same three lines as S and D, because the difference between them was only ever the row.
+
+The census found the same defect on **x86-64**, which the issue did not name: `emit_float_load`, `emit_float_reg_or_slot_load`, `emit_float_store` and `float_const_operand` each read `mov_op = MOVSD; if (w == 4) { mov_op = MOVSS; }`, so every width other than 4 took the eight-byte MOVSD. It was inert only because `encode_fp_mov` returns its vector arm above them. Nothing in the helpers said so, and `emit_float_load` is reached separately by the arithmetic and seed paths. aarch64's `emit_fp_const` carried the same `use64 = width == 8`.
+
+Every refusal is **driven from a unit test** with a width it must refuse, and the assertion is that the output buffer stayed **empty**, not merely that an error was returned. That distinction is load-bearing here: both `emit_mem_access` implementations materialize an out-of-range offset into the scratch register before the access word, and a folded global emits its `adrp` / `auipc` high half before the low one, so a check placed at the emission point rather than at the top would leave stranded instructions behind the error. Every legitimate width still encodes byte-exactly against `llvm-mc`, including aarch64's Q form at 16 and the sub-word integer forms at 1 and 2 that share the same helpers.
+
+#### An inline-asm operand longer than a register-name scratch buffer is no longer reported as malformed (#2789)
+Each ISA's inline-asm operand parser copied the operand token into a fixed stack buffer before deciding what kind of operand it was, and reported a **well-formed** operand as malformed when the copy did not fit — `[64]u8` on aarch64 and riscv64, `[128]u8` on x86-64. The copy's only consumer was the register-name lookup on the next line; every other branch (a relocation modifier, an address, an immediate, a bare symbol) already read the source region directly and never touched it. Register names are three or four characters; a mangled symbol is not, and dotted mangling's own measured longest symbol (105 bytes) already exceeds the aarch64/riscv64 buffer today.
+
+The buffer is gone, not enlarged: `asm_reg_index` (riscv64), `a64_reg` (aarch64), and `x64_reg` (x86-64) each now compare the register-name table in place against the source region, mirroring the in-place symbol check (`iasm.is_sym_region`) already sitting one branch below them. x86-64's `[symbol]` memory-operand parser had a second, narrower instance of the same shape one layer down: its no-star bracket-content parser copied into a `[32]u8` meant for a base register, and a bare rip-relative symbol reference (`[rip + <symbol>]`, #2788's own repro shape) passed through the same copy, because x86-64's grammar makes a base register and a bare symbol genuinely ambiguous at that position until one or the other is ruled out. Fixed the same way. aarch64 and riscv64 were checked and do not have this second problem: `off(base)` and `[Xn, ...]` both require a register in the base position syntactically, and a bare symbol reaches a structurally different form (`:mod:sym`) that never touches a register buffer.
+
+Verified per ISA with a symbol well past every old limit: it encodes, and encodes **byte-identically** to a short-named operand (instruction bytes never depend on a symbol's name, only its relocation does), with the relocation itself carrying the full, untruncated name. A genuinely malformed operand still refuses, checked alongside the long-operand case so the two cannot be confused.
+
 ### Added
 
 #### `int/observability.md`: what a behavioural golden can never observe, and which surface can (#2822)
@@ -1303,22 +1413,6 @@ Manifests spelling `abi = "lp64"` for riscv64 keep building, but now select **so
 
 C-variadic calls are **refused on every RISC-V member** rather than placed. The psABI's unnamed-argument rule differs per member (a tail `double` takes `a0` under lp64d where a named one takes `fa0`, and the soft-float members differ again), so implementing it would multiply the family's descriptions rather than add to them, for a call form with no user in mach or mach-std. `RiscvAbi.variadic_float_bits` is declared and carries a sentinel so the rule can be filled in later alongside the others; a refusal is exact and cheap to replace, a wrong placement rule is neither. mach's own `va: ...` parameter pack is a different mechanism, expands at compile time, and is unaffected.
 
-### Fixed
-
-#### A scalar `f32` passed in an integer register read back as `NaN` on riscv64 (#2777)
-
-`capture_slot_reg` took the move width for a value captured out of an incoming argument or return register from the machine word rather than from the value, so an `f32` arriving in `a0` was reinterpreted with `fmv.d.x` (a raw 64-bit move) instead of `fmv.w.x`. RISC-V requires a single-precision value in an `f` register to be NaN-boxed, and the raw move does not box, so every subsequent `fmul.s`/`fadd.s` on it produced `NaN`. The placement side already took its width from the value, so the two directions were asymmetric — which is why `f64` in an integer register was correct (its width happened to equal the machine word) and `f32` in an `fa` register was correct (it never took the integer path).
-
-Only reachable once a soft-float member existed, so it was latent rather than a regression. It is the first defect found by the width-versus-register-width split that #2778 exists to stress.
-
-#### A release build now carries a real ELF `.symtab`, so `perf` and a crash reporter can resolve a function name without a `-g` rebuild (#2772)
-Mach emitted no `.symtab` in any build, release or `-g`: `nm` reported nothing, `perf` could not symbolize a profile, and a crash address from a shipped binary mapped to a function only by rebuilding with `-g` and doing a DWARF lookup against the exact matching build - two ordinary workflows a shipping game needs, neither possible before this.
-
-A static ELF executable (`emit_exec`) now carries `.symtab` + `.strtab` with every defined function's mangled name, final virtual address, and byte size, collected by `build_symtab_entries` from the same merged-symbol data `build_exec_functions` already reads for PE unwind tables, and serialized by `elf.build_symtab_bytes`. Function symbols only, not globals: functions cover profiling and crash triage, and a data symbol table costs more file size for less of either. Sizes are real, not zero-filled - `nm` alone cannot see a `st_size` gap, but a profiler attributing an address *inside* a hot loop can, so this repo's own `int/surface/symtab` case asserts a mid-function address resolves correctly, not just a function's entry point.
-
-Trails every `PT_LOAD` segment exactly like `int/surface/debuginfo`'s DWARF sections already do (`readelf -SW`/`-lW` confirm `.symtab`'s file offset never precedes a loaded segment's end), so a release image's runtime bytes are unchanged - the loader ignores non-allocated sections and a release build stays byte-for-byte the same program, just no longer anonymous to a debugger or profiler reading its container. This is a real, measured trade against the previous byte-identical *header-less* release image, though: a build that carried no section-header table at all now carries one whenever it carries a symbol table (which is every static build now), and the compiler's own release binary - a large, real program with 8,408 function symbols - grew by about 611 KiB (7.3%) for it. `perf record`/`perf report` on a release build built with this change resolves `[.] main` by name where it previously showed a raw address; `addr2line -f` on an address in the middle of a function's body (not just its entry) resolves to that function, proving `st_size` is correct and not merely present.
-
-Scoped to ELF's plain static executable writer (`emit_exec`) for now: a PIE/dynamically-linked executable (`emit_dyn_exec`) and a shared library (`emit_shared`) do not carry a symbol table yet, and neither does Mach-O (`LC_SYMTAB`) or PE/COFF (its own, mostly-obsolete-under-PDB symbol table) - both accept the same `of.SymtabEntry` channel for `of.ExecFn` conformance and ignore it. `of.SymtabEntry` (name, final vaddr, byte size, STB_LOCAL/STB_GLOBAL linkage) is the format-neutral shape a future writer for either reads from, so extending coverage is wiring a serializer, not redesigning the data.
 ### Changed
 
 #### BREAKING: linkage names are dotted and readable
@@ -1359,103 +1453,6 @@ Nothing downstream needed teaching: `lower_stmt_list` already stops at a termina
 
 **This is not the fix for the gdb abort that led here.** That was an overlapping-`PT_LOAD` defect in mach's own ELF writer (#2795), unrelated to control flow.
 
-
-### Fixed
-
-#### `--emit-asm` names the symbol an inline-asm statement actually references, instead of a different real one (#2788)
-On x86-64, `--emit-asm` rendered every symbol operand inside an `asm` block wrongly. A memory operand naming a symbol printed a **different, real symbol from the same module** - `[rip + _rt_argc]` came out as `[rip + dbggdbcase]` - and a direct `call symbol` printed a bare `call` with nothing after it. The emitted object was correct in both cases; only the printed text was wrong.
-
-That matters more than it looks, and it cost real investigation time. `--emit-asm` is what someone reaches for when debugging inline asm, which is exactly the code where falling back on reading the source and assuming the obvious is not available. A bare `call` is at least visibly broken; a plausible wrong symbol name gives a reader no signal at all that the output is untrustworthy - an agent chasing an inlining defect followed the printed operand and had to discover independently that the text disagreed with the object.
-
-The cause was one missing thread, in two places. The inline-asm path interned the referenced symbol's name only at *relocation* time, after the instruction had already been built and encoded, so the `isa.Inst` the printer renders from carried no symbol at all: a rip-relative operand went out with `sym_id` 0 (which resolves to a real interned string, hence a real symbol name), and the direct-transfer form was built with no operand whatsoever. The name is now interned once, before the instruction is built, and the same `StrId` reaches both the Inst the printer renders and the relocation the linker reads - so the printed name and the relocated name cannot be two different strings. Naming the direct transfer's target costs no bytes, because `encode_call` / `encode_jmp` write a placeholder rel32 on the direct arm regardless, and it makes the inline-asm `call sym` exactly the `isa.Inst` the compiler-selected one already built - which is why *that* one always printed its target.
-
-aarch64 and riscv64 were already correct; both already threaded the interned id into the printer notification. That is precisely why the new `int/surface/asm-symbol-operands` case covers all three ELF legs rather than the one that was broken: the printers are separate per ISA, so a fix in one says nothing about the others, and the two that were right now have that pinned. The case pairs the symbol names the assembly text prints with the ones the object's relocations name, in file order, so a printer that regresses to naming a *different real symbol* fails it, not merely one that names nothing - and it runs the program too, since a reference that reached the wrong symbol would be a wrong answer as well as wrong text. Objects are byte-identical across the fix, checked directly.
-
-Two existing unit tests asserted the built instruction had **no** operand for `call main` / `jmp main`. Those pinned the defect, and are now the assertions that it names its target.
-
-#### A C `[step]` cross-builds for its leg instead of silently assuming the host toolchain targets it (#2741)
-`int/surface/narrow-stack-args` and `int/surface/c-variadic` shelled out to the bare host `cc` to build a probe object, which happens to target the leg on every CI runner (each builds natively) but not on a developer cross-building locally - `mach --target linux-arm64` on an x86-64 host still ran the host's x86-64 `cc`, silently linking an x86-64 object into an aarch64 image. That surfaced as `error: relocation 'plt32' to 'float_tail' overflows` on narrow-stack-args and a qemu `Illegal instruction` on c-variadic, neither of which names its actual cause.
-
-Both cases now build their probe object through `int/lib/cc.sh`, a general contract for any case with a C `[step]`: it uses the host's own `cc` when the host already targets the leg (preserving the point of these cases, which is to catch a *real* toolchain's ABI diverging from mach's model of it - Apple arm64's stack-argument rule, for one), and falls back to `clang -target <triple> -c` otherwise, since mach does the link itself and a cross-compiled object needs no sysroot or cross-linker to satisfy it. A leg cc.sh has no route for (no host match, and clang is missing) fails the step loudly, naming what's missing, rather than surfacing downstream as an opaque link error.
-
-This also lets both cases build for `linux-riscv64` for the first time, previously exempted only because the host-`cc` gap made it impossible; narrow-stack-args passes there cleanly. c-variadic's riscv64 leg stays exempted, but now for a real reason instead of a stale one: every variadic float/double argument comes back as `0`, a genuine mach ABI bug in riscv64's variadic lowering that this cross-build gap had been hiding coverage of (#2771).
-
-`int/run.sh` also now prints a `SKIP <case> [<target>] (exempt, see case.conf)` line for a case's `exempt:` legs, which previously left no trace in the run's output at all - a leg a case never applies to and a leg it was silently excluded from looked identical.
-
-`m`, the bootstrap output `mach build . -o m` (CONTRIBUTING.md's own instruction) produces, is now gitignored.
-
-#### A whole-variable load from a shader interface variable is typed by the variable (#2794)
-The SPIR-V emitter typed a loaded value from the move's byte width and register class rather than from the object it read. That agrees with the variable's own type for every shape that has a width, which is why it went unnoticed; it cannot express one that does not, and an opaque image handle has no width at all. Inferring one gave a sampled-image load an integer result type - an `OpLoad %ulong` from a sampled-image variable, which a validator rejects and the compiler was happy to write. The store side had always read the variable's type; the load side now does too.
-
-#### A comptime identifier names the declaration it resolves to, not the spelling (#2764)
-The comptime environment is keyed by **name**, and `comptime.eval_ident` looked a bare identifier up in it directly. Resolution identity was never consulted, so a binding was matched by what it is called rather than by which declaration it is. A block-local `val N` shadowing a module-level `val N = 9` therefore read back the **module** constant: `var xs: [N]i64;` under a runtime local `N` compiled as `[9]i64`, and the out-of-bounds diagnostic it later raised named a length the source never wrote.
-
-The evaluator now decides each identifier on the symbol the resolver bound to it. Every pass that owns a name-resolution map installs the same hook, and all of them answer from **one** function, `resolve.symbol_is_runtime`.
-
-That collapses the two rules that existed to compensate for the old reading. `resolve.check_gate_shadowing` is **removed**: it caught a case the evaluator would otherwise get wrong, and there is no such case left to catch. The constant index bound (#2751) no longer walks its operand for runtime leaves before folding, because the fold now fails on them by itself. `sema`'s `$if` gate walk keeps its per-kind diagnostics — a reader needs to hear "parameter" for a parameter and "value" for a binding — but delegates the decision.
-
-Consolidating them surfaced a disagreement the copies had been hiding. An `$each` loop variable is a **comptime** binding that resolve declares as a `SYM_VAL` bearing the comptime flag, and a rule keyed only on module scope classified it as runtime. The constant index bound consequently declined to decide any index driven by one, so `xs[e]` over an element out of range compiled clean and read past the array. It is now refused. `$` marks a comptime binding whatever its kind, and the rule says so once.
-
-A comptime binding that shadows a module constant still resolves innermost-first, which is the half of this that had to be preserved rather than changed: a `$param` or an `$each` variable named after a module constant denotes the inner one.
-
-#### A `#[uniform(...)]` block's offsets are checked against the SPIR-V layout rules (#2746)
-A descriptor block's member offsets were emitted straight from mach's own record layout, and exactly one of the rules Vulkan imposes on that layout was checked. A block whose members disagreed emitted a module a consumer rejects, with no diagnostic — a `rec` inside a block followed by a scalar produced **overlapping members**, and a `rec` inside a block is the natural way to write a camera or a material.
-
-std140 gives a struct member a base alignment of 16 and rounds its extent up to a multiple of 16; mach aligns a record to its largest member and does not round. A vector narrower than the vector register aligns to one lane in mach, where both std140 and std430 align it to two or four, so an `f32x2` or an `f32x3` member was a reachable disagreement in the **storage** posture too, which had been thought correct by construction.
-
-Every emitted offset is now held to the two conditions the specification states — a multiple of the member's base alignment, and past the end of the member before it — and an array stride to the element's extent rounded up to the array's base alignment. The two postures differ only in the 16-byte roundings std140 applies to an array and to a struct.
-
-A disagreement is **refused, never repacked**, which is the posture the one existing check already took and the reason it gave is the one that matters: the block's layout is the host's contract, and repacking would move the members out from under a host writing by `$offset_of`. The refusal names the member, the offset mach gives it, the offset the rules require, and which of the two conditions failed.
-
-#### A fragment stage's integer or 64-bit input carries its `Flat` decoration (#2747)
-Vulkan requires `Flat` on any fragment-stage `Input` of integer or 64-bit float type, because such a value cannot be interpolated. The emitter declared no `Flat` decoration at all, so every one of those was an invalid module. The decoration is now decided over the set of variables each stage can **reach**, which the per-stage reachability pass already computes.
-
-Vulkan also **forbids** `Flat` on a vertex-stage `Input`, so one module-scope variable read by both a vertex stage and a fragment stage has no valid decoration and is refused rather than decorated for one of them. The two readings are not the same value anyway: a vertex stage's input is a vertex attribute and a fragment stage's is the interpolated output of the stage before it.
-
-A `Location` was emitted verbatim and never checked. mach knows each variable's type and so knows how many locations it consumes, and two whose spans overlap within one stage are now refused naming both, rather than surfacing as a validator message naming an `OpEntryPoint` operand index.
-
-#### Recursion and a 15-parameter signature are refused rather than emitted (#2748)
-There was no whole-module well-formedness stage, so a rule about the module — its call graph, its id validity — had nowhere to live, and two reachable from ordinary source emitted invalid modules silently.
-
-A SPIR-V execution model has no call stack, so a cycle in the static call graph is refused before any body is emitted, naming the chain and saying why. This is checked rather than left to `spirv-val`, whose cycle rule is scoped to entry points: a **library** module carrying a cycle validated clean and would have failed in whatever consumer linked it into a pipeline. One had been sitting green in the integration suite.
-
-The parameter limit was two independent literals that disagreed: `emit_function` refused above 16 while `type_fn`'s fixed operand buffer failed above 14 and returned a 0 nobody read, which reached `OpFunction` as the reserved never-valid id. The limit is now stated once as `types.MAX_FN_PARAMS`, both sites read it, 15 and 16 parameters build and validate, and a 0 from `type_fn` is reported instead of passed on.
-
-#### A dead local's stale value survives past its real live range at opt0, and a `ret` statement's line-table row duplicates at function entry (#2779)
-Two opt0-only debug-info defects `int/surface/debugger-gdb` (#2756) caught by driving a real `gdb` session, neither visible to structural DWARF validation because both artifacts are internally consistent, well-formed DWARF that simply describes the wrong thing.
-
-**A variable's `DW_AT_location` was scoped to its lexical extent, not its true live range.** The opt0 allocator reusing a genuinely-dead local's storage is correct codegen (confirmed by checking the runtime value with no debugger involved), but the DWARF location for that local was never bounded to end where the reuse happens, so a debugger stopped after that point read the new occupant's value as though it were still the old variable's. Root cause: `gather_vars` built a variable's location ranges from its own bindings only, so a variable bound once and never rebound kept a stationary location valid to the function's end regardless of what physically happened to its storage afterward. `bound_storage_reuse` now truncates a range to the point some OTHER variable's binding, in the SAME inline site, claims the identical physical home - a stationary home a debugger could no longer trust past that point now reports unavailable instead. Scoping the search to the same inline site is load-bearing, not an optimization: at opt2 with heavy inlining, two variables in unrelated inline instances can land in the same register with no real relationship, and comparing across sites produced exactly that false positive while building this fix's own regression coverage.
-
-**A `ret <expr>;` statement's line-table row was duplicated at the function's own entry address.** `lower_phis` (out-of-SSA phi elimination) runs once, after every block in the function has already been lowered, and stamped its synthesized merge-copy instructions from `ctx.cur_loc` - a cursor left stale at the function's LAST lowered statement by the time phi elimination ran, for every predecessor block's edge regardless of where in the function that predecessor actually was. `break file:22` on a function whose `ret` genuinely lives at line 22 could silently resolve to its entry instead, with no ambiguity warning, reading whatever was left in an uninitialized register. Fixed by stamping from the predecessor block's own terminator location instead, which was already correct when that block was lowered and never went stale.
-
-`int/surface/debugger-gdb` gained two debug-profile-only probes proving both fixes together, asserted as a pair per each bug's own shape: a variable that genuinely dies mid-function now reports unavailable, while a sibling that stays live keeps reading its real value (a fix that reported "unavailable" for both would pass either probe alone); a second breakpoint on a real `ret` statement resolves to its own address and reads the correct value rather than silently landing at the wrong one. Both bugs are specific to opt0's own location and line-table construction and do not reproduce at opt2, so the case's golden is now per-profile (`expect.debug.txt` / `expect.release.txt`) rather than the one `expect.txt` every other `gdb-session` case still uses.
-
-#### A loop-carried vector accumulator through an unpacked operator came out holding the wrong value (#2749)
-The gap expansion (#2726) replaces a vector operator the target has no packed form for with per-lane scalar work and an assembled vector, then points that operator's uses at the assembled value. It rewrote those uses one block at a time, immediately after expanding that block's body. That is correct for every use that follows its definition, and wrong for the one that does not: a loop header's phi names the value the **latch** defines, so its back-edge operand is a forward reference no block order removes.
-
-The phi kept naming the deleted operator. MIR lowering turned the phi edge into a copy from a virtual register nothing defines, and the accumulator came out holding whatever that register happened to be. Measured on x86-64, a loop-carried `i32x4 * i32x4` returned the **multiplier** where the product belonged. aarch64 was right throughout for a reason unrelated to the defect - NEON has `MUL.4s`, so nothing expands there at all - which is why an entire suite of straight-line vector cases passed on every leg while this was live. The lane-access expansion had the identical defect one pass over.
-
-Substitution is now a whole-function step in both passes, after every block has been expanded, because the ordering it needs does not exist.
-
-#### A float or integer memory access refuses a width the target has no form for (#2766)
-A memory access takes a byte width and picks a machine form from it. On aarch64 and riscv64 that pick was a boolean selector with a trailing default, so a width the target has no form for silently got some other form's bytes rather than a diagnostic, the same shape #2733 removed from the float move, negate, arithmetic, compare and conversion encoders, one family over.
-
-riscv64's `fp_mem_funct3` answered 4 with `flw`/`fsw` and **everything else** with `fld`/`fsd`. RV64D has exactly those two float access forms and no vector extension is enabled, so a 16-byte float access had nothing to encode to at all, and it encoded to `fld`, moving eight bytes and losing the other eight. aarch64's `emit_fp_mem` handled 16 in its own arm and then fell through to `use_d = width == 8`, so a 32-byte access took the **S** form and moved four bytes of a slot the surrounding code had already sized at 32.
-
-The fix is a contract change on the access family, not a check at today's callers. The defaulting helpers were shared with the **integer** path, aarch64's `ldst_lo12_kind`, `width_shift` and the three `ldst_base_*` base-word tables were five parallel ladders that each named the narrow widths and each ended in the doubleword row, so validating only the float arms would have left the identical shape live next door under a different name. Each family now comes off **one** form table: aarch64's `int_access` / `fp_access` return a row carrying all three addressing-mode base words, the imm12 shift and the `:lo12:` relocation kind together, and riscv64's `int_mem_funct3` / `fp_mem_funct3` return the funct3 or an error. A width with no row is refused. `emit_mem_access`, `emit_fp_mem` and `mem_access_needs_no_scratch` report rather than emit, and the Q arm that used to sit ahead of the aarch64 default is now the same three lines as S and D, because the difference between them was only ever the row.
-
-The census found the same defect on **x86-64**, which the issue did not name: `emit_float_load`, `emit_float_reg_or_slot_load`, `emit_float_store` and `float_const_operand` each read `mov_op = MOVSD; if (w == 4) { mov_op = MOVSS; }`, so every width other than 4 took the eight-byte MOVSD. It was inert only because `encode_fp_mov` returns its vector arm above them. Nothing in the helpers said so, and `emit_float_load` is reached separately by the arithmetic and seed paths. aarch64's `emit_fp_const` carried the same `use64 = width == 8`.
-
-Every refusal is **driven from a unit test** with a width it must refuse, and the assertion is that the output buffer stayed **empty**, not merely that an error was returned. That distinction is load-bearing here: both `emit_mem_access` implementations materialize an out-of-range offset into the scratch register before the access word, and a folded global emits its `adrp` / `auipc` high half before the low one, so a check placed at the emission point rather than at the top would leave stranded instructions behind the error. Every legitimate width still encodes byte-exactly against `llvm-mc`, including aarch64's Q form at 16 and the sub-word integer forms at 1 and 2 that share the same helpers.
-
-#### An inline-asm operand longer than a register-name scratch buffer is no longer reported as malformed (#2789)
-Each ISA's inline-asm operand parser copied the operand token into a fixed stack buffer before deciding what kind of operand it was, and reported a **well-formed** operand as malformed when the copy did not fit — `[64]u8` on aarch64 and riscv64, `[128]u8` on x86-64. The copy's only consumer was the register-name lookup on the next line; every other branch (a relocation modifier, an address, an immediate, a bare symbol) already read the source region directly and never touched it. Register names are three or four characters; a mangled symbol is not, and dotted mangling's own measured longest symbol (105 bytes) already exceeds the aarch64/riscv64 buffer today.
-
-The buffer is gone, not enlarged: `asm_reg_index` (riscv64), `a64_reg` (aarch64), and `x64_reg` (x86-64) each now compare the register-name table in place against the source region, mirroring the in-place symbol check (`iasm.is_sym_region`) already sitting one branch below them. x86-64's `[symbol]` memory-operand parser had a second, narrower instance of the same shape one layer down: its no-star bracket-content parser copied into a `[32]u8` meant for a base register, and a bare rip-relative symbol reference (`[rip + <symbol>]`, #2788's own repro shape) passed through the same copy, because x86-64's grammar makes a base register and a bare symbol genuinely ambiguous at that position until one or the other is ruled out. Fixed the same way. aarch64 and riscv64 were checked and do not have this second problem: `off(base)` and `[Xn, ...]` both require a register in the base position syntactically, and a bare symbol reaches a structurally different form (`:mod:sym`) that never touches a register buffer.
-
-Verified per ISA with a symbol well past every old limit: it encodes, and encodes **byte-identically** to a short-named operand (instruction bytes never depend on a symbol's name, only its relocation does), with the relocation itself carrying the full, untruncated name. A genuinely malformed operand still refuses, checked alongside the long-operand case so the two cannot be confused.
-
-### Changed
 #### The realization authority answers a lane-count ceiling as well as a lane width (#2749)
 `isa.packed_width` answers a question keyed on the lane **width**, and a SPIR-V Shader module's constraint is a lane **count**: `OpTypeVector` takes 2, 3 or 4 components at every element type. For 8-bit lanes the authority reported a 128-bit packed form, meaning sixteen lanes, which no Shader module may declare - so the authority and the emitter gave different answers about the same shape, and the emitter refused `i8x16`, `u8x16`, `i16x8` and `u16x8` by name.
 
@@ -1520,7 +1517,6 @@ The x86-64 read-only growth is the two 16-byte mask entries, one per width, shar
 Also fixed while here, both without a separate issue: `encode.intern_const` refused to check its interner and dereferenced a null one, crashing inside `intern` rather than naming the encoder that asked, and now reports instead.
 
 And aarch64's memory-access family no longer carries a **width-0 pseudo-width**. Every entry point in it used to open with `if (w == 0) { w = 8; }`, a convention from when a MIR pseudo could reach an access, which #2766 left in place as the one substitution it did not remove. Nothing reaches it: routing 0 into a refused width instead left the whole aarch64 surface green, the unit suite, every `int` case on `linux-arm64` in both profiles, and the compiler's own source cross-built for `linux-arm64` and `darwin-aarch64` at both optimisation levels. A default nothing exercises is not a safety net, it is a silent doubleword waiting for the first caller that means something else by 0, so 0 is now refused like any other width the target has no form for and the refusal is driven from a test that fails with the fallback restored. `is64` keeps its own 0 rule, which selects an ALU register form rather than a memory form and which a pseudo with no value width legitimately reaches.
-
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,29 @@ pack's elements on any contract.
 
 Measured at no cost: 48.95s of build CPU against a 49.14s baseline.
 
+## [Unreleased]
+
+### Fixed
+
+#### driver: a module path is normalized before overlay and source lookup (#2998)
+
+Module loading composed `<root>/<src>/<name>.mach` verbatim, so a manifest carrying
+`src = "./src"` produced `<root>/./src/beta.mach` while an editor supplies the
+canonical `<root>/src/beta.mach`. The same file, two strings - so the overlay lookup
+missed, the **stale on-disk text was parsed instead**, and the unsaved buffer was
+silently ignored. No error; yesterday's source.
+
+The composed path is normalized once at the single place it is built, using
+`path.clean` from mach-std 0.28.1. That one string is what the overlay lookup, the
+disk read, and `load_source`'s SourceFile registration all take, so the three agree by
+construction rather than by three call sites remembering to.
+
+Normalization is purely lexical - no filesystem I/O - which is the right strength for
+comparing two spellings of one path, and keeps it off the syscall path in a loop that
+runs once per module.
+
+Unblocks briar-systems/mach-lsp#141.
+
 ## [4.23.0] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,16 @@ missed, the **stale on-disk text was parsed instead**, and the unsaved buffer wa
 silently ignored. No error; yesterday's source.
 
 The composed path is normalized once at the single place it is built, using
-`path.clean` from mach-std 0.28.1. That one string is what the overlay lookup, the
-disk read, and `load_source`'s SourceFile registration all take, so the three agree by
-construction rather than by three call sites remembering to.
+`path.clean` from mach-std 0.28.1, so the disk read and `load_source`'s SourceFile
+registration agree on one spelling and one file gets one FileId.
+
+That alone would only have moved the mismatch. The two sides that meet in the overlay
+table pick their spelling **independently** - an editor keys a buffer from a URI it
+decoded, the driver composes a path out of manifest text - so canonicalizing the half
+the compiler controls leaves the editor's half free to disagree. The key is therefore
+canonicalized at the table's own boundary, in `set_overlay`, `clear_overlay` and
+`overlay_get` alike, which makes it canonical by construction rather than by every
+producer happening to agree.
 
 Normalization is purely lexical - no filesystem I/O - which is the right strength for
 comparing two spellings of one path, and keeps it off the syscall path in a loop that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: the C-variadic contract follows a call chain, not just one hop (#3031)
+
+#3029 made the C promotion rule survive monomorphization for a call one hop from the
+C-variadic callee. Two hops still passed an unpromoted value:
+
+```mach
+fun log1[A](fmt: *u8, a: A)  i32 { ret printf(fmt, a); }
+fun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }
+
+wrap2[u8]("%d\n", c)     # compiled
+```
+
+Neither instance was recorded, for two different reasons. `wrap2[u8]`'s arguments are
+public scalars and its body calls no C-variadic callee **directly**; `log1[A]` is
+recorded from `wrap2`'s template but with an abstract argument, and an all-abstract
+instance is pruned. So the concrete `log1[u8]` never existed as a recorded instance -
+the only thing that could create it was a re-validation of `wrap2[u8]`, which was
+itself never recorded.
+
+The reachability walk is transitive now: a body reaches a C-variadic tail if it calls
+one, or calls a function whose body does. A visited set terminates it on recursive and
+mutually recursive call graphs, and exhausting the visit cap answers **no** rather than
+yes - a miss leaves a check unrun on a chain deeper than the cap, while a false
+positive re-infers a body with nothing concrete and duplicates its template-time
+diagnostics.
+
+In the pack mode (#3025) the recursion follows only calls that CARRY a spread, since
+that is how a pack propagates: an ordinary call to a pack function puts none of this
+pack's elements on any contract.
+
+Measured at no cost: 48.95s of build CPU against a 49.14s baseline.
+
 ## [4.23.0] - 2026-08-21
 
 ### Fixed

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -48,6 +48,33 @@ ext fun fcntl(fd: i32, cmd: i32, ...) i32;
 The declared parameters are the *fixed* arity. A call must supply all of them and
 may supply any number of further arguments, including none.
 
+### Naming the signature as a type
+
+The same shape is spellable as a function **type**, so a C-variadic function can be
+stored in a variable, passed as a callback, or held in a table:
+
+```mach
+ext fun printf(fmt: *u8, ...) i32;
+
+def Printf: fun(*u8, ...) i32;
+
+fun main() i32 {
+    val p: Printf = printf;
+    ret p("%d\n"::*u8, 42);
+}
+```
+
+The `...` is part of the type's **identity**, not a modifier on it. `fun(*u8, ...) i32`
+and `fun(*u8) i32` are different types and do not unify: a call through the first
+places its tail by the target's variadic rule and a call through the second does not,
+so mixing them would reach a C callee's `va_arg` with arguments laid out the ordinary
+way — a wrong *value* at run time, not a link error. The same two rules as the
+declaration apply: the `...` is bare and trailing, and at least one fixed parameter
+must precede it.
+
+An indirect call through such a type is checked and placed exactly as a direct one is;
+the tail rule is read off the type, since no declaration is in view at the call.
+
 ### Arguments in the variadic tail
 
 A tail argument has no declared parameter type to check against, so it is checked

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "fce25b528bafa3a8392df9e0ad62409f85335183"
+commit = "12c85b2ee07c01a9f9a02f21ea3c7d8f55f5eb42"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.23.0"
+version = "4.24.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -62,7 +62,57 @@ pub rec Related {
     label: str;
 }
 
+# one span-and-text replacement within a fix
+#
+# The span may be empty, which makes the edit a pure INSERTION at that offset, and
+# the replacement may be empty, which makes it a pure DELETION. Both fall out of the
+# one shape rather than needing their own kinds, and both are used: a cast fix
+# inserts `::T` after an expression without needing to know the expression's text.
+#
+# Offsets are byte offsets into the file, matching every other span the compiler
+# reports, so a consumer converts them to its own line/character positions through
+# the source registry exactly as it already does for `loc`.
+# ---
+# loc:         the range to replace
+# replacement: owned text to put in its place, possibly empty
+pub rec Edit {
+    loc:         Location;
+    replacement: str;
+}
+
+# one mechanically applicable fix for a diagnostic
+#
+# EDITS ARE A LIST, NOT A SINGLE SPAN, because the edits of one fix must apply
+# together or not at all. Wrapping an expression in a cast is the ordinary case and
+# needs two: `(` before it and `)::T` after. Applying half of that produces source
+# that does not parse, so a one-span shape would either exclude the case or force a
+# consumer to correlate two separate fixes and hope.
+#
+# A fix always carries at least one edit: `attach_fix` takes the first, so a fix with
+# nothing to apply is not a state that exists. Alternatives - cast the value versus
+# change the declared type - are separate Fix entries, since those are choices a
+# person makes rather than one atomic edit.
+# ---
+# label:    owned title, e.g. "cast the value to `i64`"; what an editor lists
+# edits:    growable array of edits applied together
+# edit_len: number of edits stored
+# edit_cap: allocated slots in edits
+pub rec Fix {
+    label:    str;
+    edits:    *Edit;
+    edit_len: usize;
+    edit_cap: usize;
+}
+
 # a single reported diagnostic tied to a primary location in a source file
+#
+# `help` and `fixes` coexist deliberately: `help` is the rendered sentence a person
+# reads in a terminal, `fixes` is the same advice in a form a program can apply. The
+# alternative is an editor pattern-matching the compiler's English and rebuilding the
+# edit from it, which couples the editor to diagnostic WORDING - every rephrasing
+# upstream silently breaking a quick fix downstream, with no compile error and no test
+# to catch it (#3023). A diagnostic whose advice is not mechanical carries no fix, the
+# same way one with no suggestion carries no help.
 # ---
 # severity:    severity level of the diagnostic
 # loc:         primary location the diagnostic is reported at
@@ -72,6 +122,9 @@ pub rec Related {
 # related:     growable array of secondary locations, or nil when none
 # related_len: number of secondary locations stored (presence count)
 # related_cap: allocated slots in related
+# fixes:       growable array of mechanically applicable fixes, or nil when none
+# fix_len:     number of fixes stored
+# fix_cap:     allocated slots in fixes
 pub rec Diagnostic {
     severity:    Severity;
     loc:         Location;
@@ -81,6 +134,9 @@ pub rec Diagnostic {
     related:     *Related;
     related_len: usize;
     related_cap: usize;
+    fixes:       *Fix;
+    fix_len:     usize;
+    fix_cap:     usize;
 }
 
 # owning list of diagnostics collected across one or more phases
@@ -101,6 +157,16 @@ val INITIAL_CAP: usize = 16;
 
 # initial slot count for a diagnostic's related array on its first secondary span
 val INITIAL_RELATED_CAP: usize = 2;
+
+# initial slot count for a diagnostic's fix array on its first fix
+#
+# One, because a diagnostic offering alternatives is the exception: the array grows
+# by doubling when a second fix arrives, and the common case allocates exactly what
+# it uses.
+val INITIAL_FIX_CAP: usize = 1;
+
+# initial slot count for a fix's edit array on its first edit
+val INITIAL_EDIT_CAP: usize = 2;
 
 # construct an empty diagnostic list backed by the given allocator
 # ---
@@ -141,6 +207,23 @@ pub fun dnit(list: *DiagList) {
         }
         if (d.related != nil && d.related_cap > 0) {
             A.deallocate[Related](list.a, d.related, d.related_cap);
+        }
+        var f: usize = 0;
+        for (f < d.fix_len) {
+            val fx: *Fix = ?d.fixes[f];
+            if (fx.label != nil) { str_free(list.a, fx.label); }
+            var e: usize = 0;
+            for (e < fx.edit_len) {
+                if (fx.edits[e].replacement != nil) { str_free(list.a, fx.edits[e].replacement); }
+                e = e + 1;
+            }
+            if (fx.edits != nil && fx.edit_cap > 0) {
+                A.deallocate[Edit](list.a, fx.edits, fx.edit_cap);
+            }
+            f = f + 1;
+        }
+        if (d.fixes != nil && d.fix_cap > 0) {
+            A.deallocate[Fix](list.a, d.fixes, d.fix_cap);
         }
         i = i + 1;
     }
@@ -287,6 +370,145 @@ pub fun attach_related(list: *DiagList, file_id: source.FileId, span: token.Span
     d.related_len = d.related_len + 1;
 }
 
+# attach a mechanically applicable fix, with its first edit, to the most recently
+# recorded diagnostic
+#
+# The first edit is part of construction rather than a follow-up call, so a fix with
+# nothing to apply is not a reachable state. Further edits belonging to the SAME fix
+# go through attach_fix_edit; a second alternative is a second attach_fix.
+#
+# A no-op when the list is empty. Allocation failure is swallowed and leaves the
+# diagnostic without the fix, matching the other attach helpers: a quick fix is an
+# affordance, and losing one must never change what the compiler reports.
+# ---
+# list:        diagnostic list whose last entry receives the fix
+# label:       title an editor lists the fix under (copied)
+# file_id:     identifier of the file the edit applies to
+# span:        range the edit replaces; an empty range inserts at that offset
+# replacement: text to put in the range (copied); empty deletes
+pub fun attach_fix(list: *DiagList, label: str, file_id: source.FileId, span: token.Span, replacement: str) {
+    if (list == nil || list.len == 0) { ret; }
+    val d: *Diagnostic = ?list.items[list.len - 1];
+
+    # an untitled fix is one an editor cannot list, so it is not attached at all
+    val label_owned: str = dup_or_nil(list.a, label);
+    if (label_owned == nil) { ret; }
+
+    var text: str = replacement;
+    if (text == nil) { text = ""; }
+
+    val edits_r: R.Result[*Edit, str] = A.allocate[Edit](list.a, INITIAL_EDIT_CAP);
+    if (R.is_err[*Edit, str](edits_r)) {
+        str_free(list.a, label_owned);
+        ret;
+    }
+    val edits: *Edit = R.unwrap_ok[*Edit, str](edits_r);
+
+    val rep_r: R.Result[str, str] = str_dup(list.a, text);
+    if (R.is_err[str, str](rep_r)) {
+        A.deallocate[Edit](list.a, edits, INITIAL_EDIT_CAP);
+        str_free(list.a, label_owned);
+        ret;
+    }
+
+    if (d.fixes == nil) {
+        val alloc_r: R.Result[*Fix, str] = A.allocate[Fix](list.a, INITIAL_FIX_CAP);
+        if (R.is_err[*Fix, str](alloc_r)) {
+            str_free(list.a, R.unwrap_ok[str, str](rep_r));
+            A.deallocate[Edit](list.a, edits, INITIAL_EDIT_CAP);
+            str_free(list.a, label_owned);
+            ret;
+        }
+        d.fixes   = R.unwrap_ok[*Fix, str](alloc_r);
+        d.fix_cap = INITIAL_FIX_CAP;
+    }
+    or (d.fix_len == d.fix_cap) {
+        val new_cap: usize = d.fix_cap * 2;
+        val grow_r: R.Result[*Fix, str] = A.reallocate[Fix](list.a, d.fixes, d.fix_cap, new_cap);
+        if (R.is_err[*Fix, str](grow_r)) {
+            str_free(list.a, R.unwrap_ok[str, str](rep_r));
+            A.deallocate[Edit](list.a, edits, INITIAL_EDIT_CAP);
+            str_free(list.a, label_owned);
+            ret;
+        }
+        d.fixes   = R.unwrap_ok[*Fix, str](grow_r);
+        d.fix_cap = new_cap;
+    }
+
+    edits[0].loc.file_id  = file_id;
+    edits[0].loc.span     = span;
+    edits[0].replacement  = R.unwrap_ok[str, str](rep_r);
+
+    var fx: Fix;
+    fx.label    = label_owned;
+    fx.edits    = edits;
+    fx.edit_len = 1;
+    fx.edit_cap = INITIAL_EDIT_CAP;
+    d.fixes[d.fix_len] = fx;
+    d.fix_len = d.fix_len + 1;
+}
+
+# append another edit to the most recently attached fix
+#
+# The edits of one fix apply TOGETHER: wrapping an expression in a cast needs a `(`
+# before it and a `)::T` after, and applying either alone produces source that does
+# not parse. A no-op when the last diagnostic carries no fix yet, so a caller cannot
+# strand an edit on nothing.
+#
+# Allocation failure would leave a HALF-APPLICABLE fix, which is worse than no fix at
+# all, so it drops the whole fix rather than the one edit.
+# ---
+# list:        diagnostic list whose last entry's last fix receives the edit
+# file_id:     identifier of the file the edit applies to
+# span:        range the edit replaces; an empty range inserts at that offset
+# replacement: text to put in the range (copied); empty deletes
+pub fun attach_fix_edit(list: *DiagList, file_id: source.FileId, span: token.Span, replacement: str) {
+    if (list == nil || list.len == 0) { ret; }
+    val d: *Diagnostic = ?list.items[list.len - 1];
+    if (d.fix_len == 0) { ret; }
+    val fx: *Fix = ?d.fixes[d.fix_len - 1];
+
+    if (fx.edit_len == fx.edit_cap) {
+        val new_cap: usize = fx.edit_cap * 2;
+        val grow_r: R.Result[*Edit, str] = A.reallocate[Edit](list.a, fx.edits, fx.edit_cap, new_cap);
+        if (R.is_err[*Edit, str](grow_r)) { drop_last_fix(list, d); ret; }
+        fx.edits    = R.unwrap_ok[*Edit, str](grow_r);
+        fx.edit_cap = new_cap;
+    }
+
+    var text: str = replacement;
+    if (text == nil) { text = ""; }
+    val rep_r: R.Result[str, str] = str_dup(list.a, text);
+    if (R.is_err[str, str](rep_r)) { drop_last_fix(list, d); ret; }
+
+    fx.edits[fx.edit_len].loc.file_id = file_id;
+    fx.edits[fx.edit_len].loc.span    = span;
+    fx.edits[fx.edit_len].replacement = R.unwrap_ok[str, str](rep_r);
+    fx.edit_len = fx.edit_len + 1;
+}
+
+# free and remove the last fix on `d`, leaving the diagnostic itself untouched
+#
+# The recovery path for a fix that could not be completed: a partial fix must never
+# reach a consumer, because applying half of one is a source-corrupting edit.
+# ---
+# list: the owning list, for its allocator
+# d:    the diagnostic whose last fix is dropped
+fun drop_last_fix(list: *DiagList, d: *Diagnostic) {
+    if (d.fix_len == 0) { ret; }
+    val fx: *Fix = ?d.fixes[d.fix_len - 1];
+    if (fx.label != nil) { str_free(list.a, fx.label); }
+    var e: usize = 0;
+    for (e < fx.edit_len) {
+        if (fx.edits[e].replacement != nil) { str_free(list.a, fx.edits[e].replacement); }
+        e = e + 1;
+    }
+    if (fx.edits != nil && fx.edit_cap > 0) {
+        A.deallocate[Edit](list.a, fx.edits, fx.edit_cap);
+    }
+    d.fix_len = d.fix_len - 1;
+}
+
 # whether the list holds at least one error-severity diagnostic
 # ---
 # list: the list to scan
@@ -318,6 +540,21 @@ pub fun suggestion_build(a: *A.Allocator, name: str) str {
     ret R.unwrap_ok[str, str](res_join);
 }
 
+# build an owned `replace with `<name>`` fix label for a spelling correction
+#
+# The rendered help reads `did you mean `helper`?`, which is a question; an editor
+# lists a code action by an imperative title. Both come from the same candidate, so
+# they cannot drift apart, but they are spelled for their own audience.
+# ---
+# a:    allocator backing the returned string
+# name: candidate identifier the fix substitutes
+# ret:  the owned label, or nil on failure
+pub fun fix_label_replace(a: *A.Allocator, name: str) str {
+    val res_join: R.Result[str, str] = str_join(a, "replace with `", name, "`");
+    if (R.is_err[str, str](res_join)) { ret nil; }
+    ret R.unwrap_ok[str, str](res_join);
+}
+
 # deep-copy diagnostic `d` into `dst`, duplicating its owned message, optional
 # note/help lines, and every secondary location
 #
@@ -340,6 +577,23 @@ fun copy_into(dst: *DiagList, d: *Diagnostic) R.Result[bool, str] {
     for (r < d.related_len) {
         attach_related(dst, d.related[r].loc.file_id, d.related[r].loc.span, d.related[r].label);
         r = r + 1;
+    }
+
+    # fixes travel with the copy: the query cache replays a cached module's
+    # diagnostics verbatim, and a quick fix that survived the first build but not a
+    # reused one would blink out of an editor on an unrelated keystroke.
+    var f: usize = 0;
+    for (f < d.fix_len) {
+        val fx: *Fix = ?d.fixes[f];
+        if (fx.edit_len > 0) {
+            attach_fix(dst, fx.label, fx.edits[0].loc.file_id, fx.edits[0].loc.span, fx.edits[0].replacement);
+            var e: usize = 1;
+            for (e < fx.edit_len) {
+                attach_fix_edit(dst, fx.edits[e].loc.file_id, fx.edits[e].loc.span, fx.edits[e].replacement);
+                e = e + 1;
+            }
+        }
+        f = f + 1;
     }
     ret R.ok[bool, str](true);
 }
@@ -440,6 +694,9 @@ fun emit(list: *DiagList, severity: Severity, file_id: source.FileId, span: toke
     d.related      = nil;
     d.related_len  = 0;
     d.related_cap  = 0;
+    d.fixes        = nil;
+    d.fix_len      = 0;
+    d.fix_cap      = 0;
     list.items[list.len] = d;
     list.len = list.len + 1;
 
@@ -640,5 +897,102 @@ test "mach.lang.diagnostic.clone_tail:round_trips_via_append_all" {
     dnit(?dst);
     dnit(snap);
     A.deallocate[DiagList](?a, snap, 1);
+    ret bad;
+}
+
+# A fix survives the copy into another list (#3023).
+#
+# `clone_tail` is how a derived query snapshots the diagnostics it produced so a later
+# reused `get` can replay them. A fix that lived through the first build but not a
+# CACHED one would make an editor's quick fix blink out on an unrelated keystroke -
+# a bug with no error message and no reproducible trigger from the user's side.
+test "mach.lang.diagnostic.attach_fix:survives_a_copy" {
+    var a: A.Allocator;
+    page.make(?a);
+    var src: DiagList = init(?a);
+    var dst: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 4;
+    sp.len    = 5;
+    error(?src, 1, sp, "unresolved identifier `helpr`");
+    attach_help(?src, "did you mean `helper`?");
+    attach_fix(?src, "replace with `helper`", 1, sp, "helper");
+
+    # a second fix on the same diagnostic, with two edits: the alternatives case and
+    # the multi-edit case at once, which is what growth past INITIAL_FIX_CAP exercises
+    var head: token.Span;
+    head.offset = 4;
+    head.len    = 0;
+    var tail: token.Span;
+    tail.offset = 9;
+    tail.len    = 0;
+    attach_fix(?src, "cast the value to `i64`", 1, head, "(");
+    attach_fix_edit(?src, 1, tail, ")::i64");
+
+    # counts are checked BEFORE anything indexes past them: a shape assertion that
+    # faults instead of failing tells the next reader nothing about what broke
+    var bad: i32 = 0;
+    if (src.items[0].fix_len != 2)           { dnit(?src); dnit(?dst); ret 1; }
+    if (src.items[0].fixes[0].edit_len != 1) { dnit(?src); dnit(?dst); ret 2; }
+    if (src.items[0].fixes[1].edit_len != 2) { dnit(?src); dnit(?dst); ret 3; }
+
+    append_all(?dst, ?src);
+    if (dst.len != 1)                 { dnit(?src); dnit(?dst); ret 4; }
+    if (dst.items[0].fix_len != 2)    { dnit(?src); dnit(?dst); ret 5; }
+    if (!str_equals(dst.items[0].fixes[0].label, "replace with `helper`")        && bad == 0) { bad = 6; }
+    if (!str_equals(dst.items[0].fixes[0].edits[0].replacement, "helper")        && bad == 0) { bad = 7; }
+    if (dst.items[0].fixes[0].edits[0].loc.span.offset != 4                      && bad == 0) { bad = 8; }
+    if (dst.items[0].fixes[0].edits[0].loc.span.len != 5                         && bad == 0) { bad = 9; }
+    if (dst.items[0].fixes[1].edit_len != 2) { dnit(?src); dnit(?dst); ret 10; }
+    if (!str_equals(dst.items[0].fixes[1].edits[1].replacement, ")::i64")        && bad == 0) { bad = 11; }
+
+    # the copy owns its strings: freeing the source must not disturb it
+    dnit(?src);
+    if (!str_equals(dst.items[0].fixes[0].edits[0].replacement, "helper")        && bad == 0) { bad = 12; }
+
+    dnit(?dst);
+    ret bad;
+}
+
+# An edit with no fix to belong to is dropped, not stranded (#3023).
+#
+# attach_fix_edit appends to the LAST fix on the LAST diagnostic. With no fix there
+# is no such thing, and a caller that gets the order wrong must not silently attach
+# its `)::i64` to whatever fix a previous diagnostic happens to carry - which would
+# corrupt a fix that was correct.
+test "mach.lang.diagnostic.attach_fix_edit:needs_a_fix_to_belong_to" {
+    var a: A.Allocator;
+    page.make(?a);
+    var list: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = 1;
+
+    # a diagnostic that legitimately carries a fix
+    error(?list, 1, sp, "first");
+    attach_fix(?list, "fix the first", 1, sp, "x");
+
+    # a later one that carries none: the stray edit must not reach back
+    error(?list, 1, sp, "second");
+    attach_fix_edit(?list, 1, sp, "STRAY");
+
+    var bad: i32 = 0;
+    if (list.items[1].fix_len != 0)           { dnit(?list); ret 1; }
+    if (list.items[0].fix_len != 1)           { dnit(?list); ret 2; }
+    if (list.items[0].fixes[0].edit_len != 1) { dnit(?list); ret 3; }
+    if (!str_equals(list.items[0].fixes[0].edits[0].replacement, "x") && bad == 0) { bad = 4; }
+
+    # an untitled fix is one no editor could list, so it is refused outright
+    attach_fix(?list, nil, 1, sp, "y");
+    if (list.items[1].fix_len != 0                          && bad == 0) { bad = 5; }
+
+    # an empty replacement is a DELETION, not an absent one, and is kept
+    attach_fix(?list, "delete it", 1, sp, "");
+    if (list.items[1].fix_len != 1)           { dnit(?list); ret 6; }
+    if (str_len(list.items[1].fixes[0].edits[0].replacement) != 0 && bad == 0) { bad = 7; }
+
+    dnit(?list);
     ret bad;
 }

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -19,6 +19,7 @@ use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
 use std.types.view.View;
+use std.types.path;
 use std.types.string.str;
 use std.types.string.str_ends_with;
 use std.types.string.str_len;
@@ -212,7 +213,21 @@ fun build_module_path(alloc: *A.Allocator, root: str, src_dir: str, dotted_tail:
     k = k + 5;
     buf[k] = 0;
 
-    ret R.ok[str, str](buf::str);
+    # NORMALIZE ONCE, HERE (#2998). This is the single place a module's file path is
+    # composed, and its three consumers - the overlay lookup, the disk read, and the
+    # SourceFile registration `load_source` performs - all take the string this
+    # returns. A manifest's `src = "./src"` otherwise composes `<root>/./src/f.mach`
+    # while an editor supplies the canonical `<root>/src/f.mach`, and the two do not
+    # compare equal: the unsaved buffer is silently missed and the stale on-disk file
+    # is parsed instead.
+    #
+    # Lexical only - `path.clean` performs no filesystem I/O - which is the right
+    # strength for an identity comparison between two spellings of the same path, and
+    # keeps this off the syscall path in a loop that runs once per module.
+    val cr: R.Result[path.Path, str] = path.clean(alloc, buf::str);
+    A.deallocate[u8](alloc, buf, total);
+    if (R.is_err[path.Path, str](cr)) { ret R.err[str, str](R.unwrap_err[path.Path, str](cr)); }
+    ret R.ok[str, str](R.unwrap_ok[path.Path, str](cr));
 }
 
 # build `<a><b><c>` interned on the session, returning a borrowed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21057,3 +21057,44 @@ test "mach.lang.fe.sema:a_pack_forwards_into_a_c_variadic_tail" {
                     "secret value cannot be passed to a") != 0) { bad = 8; }
     ret bad;
 }
+
+# The C-variadic contract follows a call chain, not just one hop (#3031).
+#
+# `wrap2` calling `log1` calling `printf` puts `wrap2`'s arguments on the C promotion
+# contract as surely as calling `printf` itself - and neither instance is recorded by
+# any other rule: `wrap2[u8]`'s arguments are public scalars, and `log1[A]` is pruned
+# as abstract at `wrap2`'s template, so nothing else would ever create the concrete
+# `log1[u8]`. That is the shape `generic_instance_reached_through_generic` documents
+# for the constant-time gates, where it was solved with an argument-side signal that
+# has no analogue here: a `u8` carries nothing saying "this will reach a C tail".
+test "mach.lang.driver:c_variadic_contract_follows_the_call_chain" {
+    var bad: i32 = 0;
+    val d1: str = "ext fun printf(fmt: *u8, ...) i32;\nfun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }\nfun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }\n";
+
+    # two hops
+    if (ut_vec_diag(ut_cc_src(d1, "fun use_it() i32 { var c: u8 = 65; ret wrap2[u8](\"%d\\n\", c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 1; }
+
+    # THREE hops. Two passing is not evidence the walk recurses, only that one hop
+    # does - the first version of this fix caught one and missed two.
+    val d2: str = "ext fun printf(fmt: *u8, ...) i32;\nfun log1[A](fmt: *u8, a: A) i32 { ret printf(fmt, a); }\nfun wrap2[A](fmt: *u8, a: A) i32 { ret log1[A](fmt, a); }\nfun wrap3[A](fmt: *u8, a: A) i32 { ret wrap2[A](fmt, a); }\n";
+    if (ut_vec_diag(ut_cc_src(d2, "fun use_it() i32 { var c: u8 = 65; ret wrap3[u8](\"%d\\n\", c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 2; }
+
+    # a clean value through the same chain still compiles at every depth
+    if (!ut_sema_clean(ut_cc_src(d2, "fun use_it() i32 { ret wrap3[i32](\"%d\\n\", 7::i32); }\n"))) { bad = 3; }
+
+    # MUTUALLY RECURSIVE generics terminate. The visited set is what stops the walk;
+    # without it this is an infinite descent rather than a wrong answer.
+    val d3: str = "ext fun printf(fmt: *u8, ...) i32;\nfun ping[A](n: i32, a: A) i32 { if (n <= 0) { ret printf(\"%d\\n\", a); } ret pong[A](n - 1, a); }\nfun pong[A](n: i32, a: A) i32 { ret ping[A](n - 1, a); }\n";
+    if (ut_vec_diag(ut_cc_src(d3, "fun use_it() i32 { var c: u8 = 65; ret ping[u8](4, c); }\n"),
+                    "is promoted to a 32-bit integer in a C-variadic argument") != 0) { bad = 4; }
+    if (!ut_sema_clean(ut_cc_src(d3, "fun use_it() i32 { ret ping[i32](4, 7::i32); }\n"))) { bad = 5; }
+
+    # AND THE CHAIN THAT REACHES NOTHING IS STILL PRUNED. Following calls transitively
+    # is precisely how the duplicate-diagnostic trap gets re-opened: a generic calling
+    # a generic that calls no C variadic must still be re-inferred zero times. Exactly
+    # one diagnostic, as `generic_instance_reached_through_generic` requires.
+    if (ut_sema_errs("fun leaf[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun mid[T](v: T) u32 { ret leaf[T](v); }\nfun top[T](v: T) u32 { ret mid[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { top[u32](1); ret 0; }\n") != 1) { bad = 6; }
+    ret bad;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21098,3 +21098,72 @@ test "mach.lang.driver:c_variadic_contract_follows_the_call_chain" {
     if (ut_sema_errs("fun leaf[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun mid[T](v: T) u32 { ret leaf[T](v); }\nfun top[T](v: T) u32 { ret mid[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { top[u32](1); ret 0; }\n") != 1) { bad = 6; }
     ret bad;
 }
+
+# a frontend manifest whose `src` is spelled with a leading `./` (#2998)
+fun ut_manifest_dotsrc() str {
+    ret "[project]\nid = \"ctxcase\"\nversion = \"1.2.3\"\nsrc = \"./src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.beta]\nkind = \"bin\"\nentry = \"beta.mach\"\nout = \"bin/beta\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# An editor's overlay is found whatever the manifest spelled `src` as (#2998).
+#
+# Module loading composed `<root>/<src>/<name>.mach` verbatim, so a manifest carrying
+# `src = "./src"` produced `<root>/./src/beta.mach` while an editor supplies the
+# canonical `<root>/src/beta.mach`. The two are the same file and different strings,
+# so the overlay lookup missed, the STALE ON-DISK TEXT was parsed instead, and the
+# unsaved buffer was silently ignored - no error, just yesterday's source.
+#
+# The composed path is normalized once at the single place it is built, which is the
+# same string the disk read and `load_source`'s SourceFile registration take, so all
+# three agree by construction rather than by three matching call sites.
+test "mach.lang.driver:an_overlay_is_found_through_a_dotted_src_spelling" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # on disk: a body that would fail sema. in the editor: one that would not.
+    var names: [1]str;
+    names[0] = "beta.mach";
+    var texts: [1]str;
+    texts[0] = "fun main() i32 { ret no_such_symbol(); }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_dotsrc(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    # the canonical spelling an editor would supply, with no `./` in it
+    val ov_path: str = ut_cc3(?alloc, root, "/src/", "beta.mach");
+    val osr: R.Result[bool, str] = session.set_overlay(?s, ov_path, "fun main() i32 { ret 0; }\n");
+    if (R.is_err[bool, str](osr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 3; }
+
+    var bad: i32 = 0;
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { bad = 4; }
+    or {
+        var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+        var req: request.BuildRequest = request.defaults();
+        req.project_root = root;
+        req.target       = "windows";
+        req.profile      = "release";
+        req.artifact     = "beta";
+        req.goal         = request.GOAL_OBJECTS;
+        req.opt          = pipeline.OPT_RELEASE;
+
+        val pr: R.Result[project.Project, outcome.Fail] = driver.analyze_project(?s, ?mf, ?req, nil, 0);
+        if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 5; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            # THE OVERLAY WON: the on-disk body calls an undefined symbol and the
+            # buffer's does not, so a clean analysis is proof the buffer was read.
+            # Asserting the absence of an error is what makes this test able to fail:
+            # before the fix the disk text was parsed and this reported.
+            if (ut_count_errors(?p.s.diags) != 0) { bad = 6; }
+            project.dnit_project(?p);
+        }
+        manifest.dnit(?mf, ?alloc);
+    }
+
+    session.dnit(?s);
+    fs.remove_all(?alloc, root);
+    ret bad;
+}

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -40,6 +40,9 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
+use std.types.string.str_copy_slice;
+use std.types.string.str_equals;
+use std.types.string.str_region_equals;
 use std.types.string.str_copy;
 use std.types.string.str_index_of;
 use std.types.string.str_join;
@@ -2677,6 +2680,236 @@ test "mach.lang.editor.build:missing_manifest_fails_user" {
     if (!R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
     or (R.unwrap_err[outcome.BuildOutcome, outcome.Fail](r).internal) { bad = 1; }
     if (s.build_alloc != prior_build) { bad = 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# the first fix carried by any diagnostic on `list`, or nil when none carries one
+fun t_first_fix(list: *diagnostic.DiagList) *diagnostic.Fix {
+    var i: usize = 0;
+    for (i < list.len) {
+        if (list.items[i].fix_len > 0) { ret ?list.items[i].fixes[0]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# whether any diagnostic on `list` carries a fix
+fun t_any_fix(list: *diagnostic.DiagList) bool {
+    ret t_first_fix(list) != nil;
+}
+
+# apply every edit of `fx` to `src`, producing the fixed source
+#
+# Edits are applied HIGHEST OFFSET FIRST, so an earlier edit's length change cannot
+# shift a later edit's offset out from under it - the order any editor applies a
+# multi-edit code action in. Returns an owned string, or nil on allocation failure.
+fun t_apply_fix(a: *A.Allocator, src: str, fx: *diagnostic.Fix) str {
+    val cr: R.Result[str, str] = str_copy(a, src);
+    if (R.is_err[str, str](cr)) { ret nil; }
+    var cur: str = R.unwrap_ok[str, str](cr);
+
+    var limit: usize = str_len(src) + 1;
+    var n: usize = 0;
+    for (n < fx.edit_len) {
+        var best:     usize = fx.edit_len;
+        var best_off: usize = 0;
+        var i: usize = 0;
+        for (i < fx.edit_len) {
+            val off: usize = fx.edits[i].loc.span.offset;
+            if (off < limit && (best == fx.edit_len || off > best_off)) {
+                best     = i;
+                best_off = off;
+            }
+            i = i + 1;
+        }
+        if (best == fx.edit_len) { brk; }
+        limit = best_off;
+
+        val tail_start: usize = best_off + fx.edits[best].loc.span.len;
+        val cur_len:    usize = str_len(cur);
+        if (tail_start > cur_len) { ret cur; }
+
+        val hr: R.Result[str, str] = str_copy_slice(a, cur, 0, best_off);
+        if (R.is_err[str, str](hr)) { ret cur; }
+        val tr: R.Result[str, str] = str_copy_slice(a, cur, tail_start, cur_len - tail_start);
+        if (R.is_err[str, str](tr)) { ret cur; }
+        val head: str = R.unwrap_ok[str, str](hr);
+        val tail: str = R.unwrap_ok[str, str](tr);
+
+        val jr: R.Result[str, str] = str_join(a, head, fx.edits[best].replacement, tail);
+        if (R.is_ok[str, str](jr)) { cur = R.unwrap_ok[str, str](jr); }
+        n = n + 1;
+    }
+    ret cur;
+}
+
+# whether `src` resolves and type-checks with no error diagnostic at all
+#
+# The proof a fix is a FIX: applying it must leave source the compiler accepts. A
+# replacement that merely looks right - a cast the callee refuses, a paren in the
+# wrong place - passes a field-by-field assertion and fails this.
+fun t_analyzes_clean(alloc: *A.Allocator, name: str, src: str) bool {
+    val res_session: R.Result[session.Session, str] = t_session(alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, name, src);
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret false; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret false; }
+    val clean: bool = !diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagList, str](res_diags));
+
+    dnit(?es);
+    session.dnit(?s);
+    ret clean;
+}
+
+# A spelling correction is carried as an edit, not only as English (#3023).
+#
+# The help line reads `did you mean `helper`?`. An editor cannot act on that without
+# pattern-matching the compiler's prose and rebuilding the edit from it, which couples
+# a quick fix to diagnostic WORDING: every rephrasing upstream breaks it silently, with
+# no compile error and no test failure anywhere to catch it.
+#
+# The assertion is not that a fix exists but that APPLYING IT WORKS. A replacement
+# that looks right in a field-by-field check and produces source the compiler refuses
+# is precisely the failure this feature exists to prevent.
+test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val src: str = "fun helper() i64 { ret 0; }\nfun main() i64 { ret helpr(); }\n";
+    val res_fid: R.Result[source.FileId, str] = open(?es, "ident.mach", src);
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+
+    var bad: i32 = 0;
+    val list: *diagnostic.DiagList = ?es.s.diags;
+
+    # the terminal line is untouched: the fix is carried ALONGSIDE the prose, not
+    # instead of it, so a plain `mach build` reads exactly as it did before.
+    if (!diag_help_has(list, "did you mean `helper`?") && bad == 0) { bad = 1; }
+
+    val fx: *diagnostic.Fix = t_first_fix(list);
+    if (fx == nil) { dnit(?es); session.dnit(?s); ret 2; }
+
+    # one edit: the misspelling's own range, replaced by the candidate
+    if (fx.edit_len != 1                                              && bad == 0) { bad = 3; }
+    if (!str_equals(fx.label, "replace with `helper`")                && bad == 0) { bad = 4; }
+    if (!str_equals(fx.edits[0].replacement, "helper")                && bad == 0) { bad = 5; }
+    if (!str_region_equals(src, fx.edits[0].loc.span.offset, fx.edits[0].loc.span.len, "helpr") && bad == 0) { bad = 6; }
+
+    val fixed: str = t_apply_fix(?alloc, src, fx);
+    if (fixed == nil) { dnit(?es); session.dnit(?s); ret 7; }
+    if (!t_analyzes_clean(?alloc, "ident.mach", fixed) && bad == 0) { bad = 8; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A cast fix appends to an expression that binds tighter than `::`, and PARENTHESIZES
+# one that does not (#3023).
+#
+# `::` binds tighter than the binary operators, so appending `::i64` to the span of
+# `a + a` yields `a + a::i64` - source that compiles, casts the wrong operand, and
+# leaves the original error standing. Wrapping needs a `(` before and a `)::i64`
+# after, which must apply together or the source does not parse, and which is the
+# whole reason a fix owns a LIST of edits rather than one span.
+test "mach.lang.editor.fix:a_cast_fix_parenthesizes_only_when_it_must" {
+    var alloc: A.Allocator;
+    var bad: i32 = 0;
+
+    # atomic operand: one edit, a pure insertion at the end of the expression
+    val src_a: str = "fun main() i64 { val a: i32 = 1; val b: i64 = a; ret b; }\n";
+    val res_sa: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_sa)) { ret 1; }
+    var sa: session.Session = R.unwrap_ok[session.Session, str](res_sa);
+    var ea: EditorSession = init(?sa);
+    val fa_r: R.Result[source.FileId, str] = open(?ea, "atom.mach", src_a);
+    if (R.is_err[source.FileId, str](fa_r)) { dnit(?ea); session.dnit(?sa); ret 1; }
+    val da_r: R.Result[*diagnostic.DiagList, str] = t_run_sema(?ea, R.unwrap_ok[source.FileId, str](fa_r), 8);
+    if (R.is_err[*diagnostic.DiagList, str](da_r)) { dnit(?ea); session.dnit(?sa); ret 1; }
+    val fxa: *diagnostic.Fix = t_first_fix(R.unwrap_ok[*diagnostic.DiagList, str](da_r));
+    if (fxa == nil) { dnit(?ea); session.dnit(?sa); ret 2; }
+
+    if (fxa.edit_len != 1                                    && bad == 0) { bad = 3; }
+    if (!str_equals(fxa.label, "cast the value to `i64`")    && bad == 0) { bad = 4; }
+    if (!str_equals(fxa.edits[0].replacement, "::i64")       && bad == 0) { bad = 5; }
+    # an INSERTION: an empty range, so nothing of the expression is thrown away
+    if (fxa.edits[0].loc.span.len != 0                       && bad == 0) { bad = 6; }
+    val fixed_a: str = t_apply_fix(?alloc, src_a, fxa);
+    if (fixed_a == nil)                                                   { dnit(?ea); session.dnit(?sa); ret 7; }
+    if (!str_contains(fixed_a, "val b: i64 = a::i64;")       && bad == 0) { bad = 8; }
+    if (!t_analyzes_clean(?alloc, "atom.mach", fixed_a)      && bad == 0) { bad = 9; }
+    dnit(?ea);
+    session.dnit(?sa);
+
+    # compound operand: two edits that wrap it
+    val src_c: str = "fun main() i64 { val a: i32 = 1; val b: i64 = a + a; ret b; }\n";
+    val res_sc: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_sc)) { ret 10; }
+    var sc2: session.Session = R.unwrap_ok[session.Session, str](res_sc);
+    var ec: EditorSession = init(?sc2);
+    val fc_r: R.Result[source.FileId, str] = open(?ec, "compound.mach", src_c);
+    if (R.is_err[source.FileId, str](fc_r)) { dnit(?ec); session.dnit(?sc2); ret 10; }
+    val dc_r: R.Result[*diagnostic.DiagList, str] = t_run_sema(?ec, R.unwrap_ok[source.FileId, str](fc_r), 8);
+    if (R.is_err[*diagnostic.DiagList, str](dc_r)) { dnit(?ec); session.dnit(?sc2); ret 10; }
+    val fxc: *diagnostic.Fix = t_first_fix(R.unwrap_ok[*diagnostic.DiagList, str](dc_r));
+    if (fxc == nil) { dnit(?ec); session.dnit(?sc2); ret 11; }
+
+    if (fxc.edit_len != 2                                    && bad == 0) { bad = 12; }
+    val fixed_c: str = t_apply_fix(?alloc, src_c, fxc);
+    if (fixed_c == nil)                                                   { dnit(?ec); session.dnit(?sc2); ret 13; }
+    # THE POINT: the whole sum is cast, not its right operand
+    if (!str_contains(fixed_c, "val b: i64 = (a + a)::i64;") && bad == 0) { bad = 14; }
+    if (!t_analyzes_clean(?alloc, "compound.mach", fixed_c)  && bad == 0) { bad = 15; }
+    dnit(?ec);
+    session.dnit(?sc2);
+
+    ret bad;
+}
+
+# A mismatch a cast cannot repair carries NO fix (#3023).
+#
+# `::` will reinterpret any two same-size values, so `p::Q` between two unrelated
+# records of equal size is a legal cast - and offering it would turn a real type
+# error into a silent bit pun the compiler accepts. A fix that produces a new error,
+# or worse a new wrong program, is worse than no fix: the editor's one keystroke is
+# taken on trust.
+test "mach.lang.editor.fix:a_mismatch_a_cast_cannot_repair_offers_nothing" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "rec.mach",
+        "rec P { x: i64; }\nrec Q { x: i64; }\nfun main() i64 { var p: P; var q: Q; q = p; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    # the mismatch is still reported...
+    if (!diagnostic.has_errors(list) && bad == 0) { bad = 2; }
+    # ...it just has nothing mechanical to offer
+    if (t_any_fix(list)              && bad == 0) { bad = 3; }
 
     dnit(?es);
     session.dnit(?s);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -2682,3 +2682,106 @@ test "mach.lang.editor.build:missing_manifest_fails_user" {
     session.dnit(?s);
     ret bad;
 }
+
+# A C-variadic function can be named as a TYPE, not only declared (#3003).
+#
+# `ext fun printf(fmt: *u8, ...) i32` already parses; the identical shape written as a
+# type did not, and refused with `C-style variadic ... was removed in v2.0.0`. That
+# form was not removed, it was narrowed to `ext` declarations - so the message stated a
+# true-in-2.0 thing that is false today, at the one spelling that ought to work.
+#
+# The flag was already modelled everywhere except the parser that would set it: it is
+# part of the interned type's identity, hashed and compared, and `check_call` reads it
+# off the type rather than off the declaration. Only the type parser refused it.
+test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
+        "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
+    # the stale message must be gone, since the form it describes is reachable again
+    if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A variadic and a fixed-arity signature of the same shape are DIFFERENT types (#3003).
+#
+# They are not a widening of one another: a call through the variadic type places its
+# tail by the target's variadic rule - SysV's vector count in AL, Apple arm64 stacking
+# every tail argument - and a call through the fixed one does not. Unifying them would
+# let a caller reach a C callee's `va_arg` with arguments placed the ordinary way, which
+# is a WRONG VALUE at run time rather than a link error.
+test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_shape" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "vafix.mach",
+        "ext fun printf(fmt: *u8, ...) i32;\ndef Fixed: fun(*u8) i32;\nfun main() i32 { val p: Fixed = printf; ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    if (!diagnostic.has_errors(list)                                     && bad == 0) { bad = 2; }
+    # the rendered types must SHOW the difference, or the message names two spellings
+    # that read identically and tells the reader nothing
+    if (!diag_has(list, "fun(*u8, ...) i32")                             && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A leading bare `...` in a function type is refused, as it is on a declaration (#3003).
+#
+# A C-variadic callee finds its tail relative to its last fixed parameter, so a
+# signature with nothing ahead of the `...` cannot be called by any ABI. That is a
+# property of the SIGNATURE, not of where the signature is written, which is why the
+# type spelling takes the declaration's rule verbatim rather than a rule of its own.
+test "mach.lang.editor.type:a_leading_variadic_marker_is_refused_in_a_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "lead.mach",
+        "def Bad: fun(...) i32;\nfun main() i32 { ret 0; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_parse: R.Result[*ast.Ast, str] = parse(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse)) { dnit(?es); session.dnit(?s); ret 1; }
+
+    var bad: i32 = 0;
+    val list: *diagnostic.DiagList = ?es.s.diags;
+    if (!diag_has(list, "a C-variadic function type needs at least one fixed parameter before `...`") && bad == 0) { bad = 2; }
+    # ...and NOT the stale removal message, which would send the reader looking for a
+    # feature to re-enable instead of a parameter to add
+    if (diag_has(list, "was removed in v2.0.0")                                                       && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -2781,50 +2781,6 @@ fun t_analyzes_clean(alloc: *A.Allocator, name: str, src: str) bool {
 # that looks right in a field-by-field check and produces source the compiler refuses
 # is precisely the failure this feature exists to prevent.
 test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
-# A C-variadic function can be named as a TYPE, not only declared (#3003).
-#
-# `ext fun printf(fmt: *u8, ...) i32` already parses; the identical shape written as a
-# type did not, and refused with `C-style variadic ... was removed in v2.0.0`. That
-# form was not removed, it was narrowed to `ext` declarations - so the message stated a
-# true-in-2.0 thing that is false today, at the one spelling that ought to work.
-#
-# The flag was already modelled everywhere except the parser that would set it: it is
-# part of the interned type's identity, hashed and compared, and `check_call` reads it
-# off the type rather than off the declaration. Only the type parser refused it.
-test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
-    var alloc: A.Allocator;
-    val res_session: R.Result[session.Session, str] = t_session(?alloc);
-    if (R.is_err[session.Session, str](res_session)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
-    var es: EditorSession = init(?s);
-
-    val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
-        "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
-    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
-
-    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
-    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
-
-    var bad: i32 = 0;
-    if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
-    # the stale message must be gone, since the form it describes is reachable again
-    if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
-
-    dnit(?es);
-    session.dnit(?s);
-    ret bad;
-}
-
-# A variadic and a fixed-arity signature of the same shape are DIFFERENT types (#3003).
-#
-# They are not a widening of one another: a call through the variadic type places its
-# tail by the target's variadic rule - SysV's vector count in AL, Apple arm64 stacking
-# every tail argument - and a call through the fixed one does not. Unifying them would
-# let a caller reach a C callee's `va_arg` with arguments placed the ordinary way, which
-# is a WRONG VALUE at run time rather than a link error.
-test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_shape" {
     var alloc: A.Allocator;
     val res_session: R.Result[session.Session, str] = t_session(?alloc);
     if (R.is_err[session.Session, str](res_session)) { ret 1; }
@@ -2954,6 +2910,62 @@ test "mach.lang.editor.fix:a_mismatch_a_cast_cannot_repair_offers_nothing" {
     if (!diagnostic.has_errors(list) && bad == 0) { bad = 2; }
     # ...it just has nothing mechanical to offer
     if (t_any_fix(list)              && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A C-variadic function can be named as a TYPE, not only declared (#3003).
+#
+# `ext fun printf(fmt: *u8, ...) i32` already parses; the identical shape written as a
+# type did not, and refused with `C-style variadic ... was removed in v2.0.0`. That
+# form was not removed, it was narrowed to `ext` declarations - so the message stated a
+# true-in-2.0 thing that is false today, at the one spelling that ought to work.
+#
+# The flag was already modelled everywhere except the parser that would set it: it is
+# part of the interned type's identity, hashed and compared, and `check_call` reads it
+# off the type rather than off the declaration. Only the type parser refused it.
+test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
+        "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_diags: R.Result[*diagnostic.DiagList, str] = t_run_sema(?es, fid, 8);
+    if (R.is_err[*diagnostic.DiagList, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
+
+    var bad: i32 = 0;
+    if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
+    # the stale message must be gone, since the form it describes is reachable again
+    if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A variadic and a fixed-arity signature of the same shape are DIFFERENT types (#3003).
+#
+# They are not a widening of one another: a call through the variadic type places its
+# tail by the target's variadic rule - SysV's vector count in AL, Apple arm64 stacking
+# every tail argument - and a call through the fixed one does not. Unifying them would
+# let a caller reach a C callee's `va_arg` with arguments placed the ordinary way, which
+# is a WRONG VALUE at run time rather than a link error.
+test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_shape" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
     val res_fid: R.Result[source.FileId, str] = open(?es, "vafix.mach",
         "ext fun printf(fmt: *u8, ...) i32;\ndef Fixed: fun(*u8) i32;\nfun main() i32 { val p: Fixed = printf; ret 0; }\n");
     if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -82,14 +82,23 @@ pub rec TypeArray {
 }
 
 # a function type fun(T, U) R
+#
+# `c_variadic` mirrors the flag an `ext fun f(a: T, ...)` DECLARATION already carries,
+# so a C-variadic function can be named as a type - stored in a variable, passed as a
+# callback (#3003). It is part of the type's identity, not a modifier on it: a variadic
+# and a fixed-arity signature of the same shape are different types and do not unify,
+# because a call through one places its tail by the target's variadic rule and a call
+# through the other does not.
 # ---
 # params_start: start index into ast.type_ids
-# params_len:   number of parameter types
+# params_len:   number of parameter types (the FIXED ones; the tail has no type)
 # ret_type:     return type, or TYPE_NIL for no explicit return
+# c_variadic:   the type ends in a C-style `...` tail
 pub rec TypeFun {
     params_start: u32;
     params_len:   u32;
     ret_type:     id.TypeId;
+    c_variadic:   bool;
 }
 
 # an anonymous record type `rec { name: T; ... }`

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -1479,10 +1479,14 @@ fun parse_fun(p: *state.Parser, start: token.Span) id.TypeId {
     # parse_call).
     var buf: state.ListBuf[id.TypeId] = state.list_buf_init[id.TypeId]();
 
-    # a bare `...` in a function-type parameter list is the legacy C-style
-    # variadic marker, removed in v2.0.0.
+    # THE SAME RULE THE DECLARATION USES (decl.mach's parse_params): a trailing bare
+    # `...` after at least one fixed parameter is the C-variadic tail, and a LEADING
+    # one is refused - a C-variadic callee has no way to find its tail without a fixed
+    # parameter ahead of it, and that is a property of the signature, not of where the
+    # signature is written.
+    var c_variadic: bool = false;
     if (state.at(p, token.KIND_DOT_DOT_DOT)) {
-        state.error_at_current(p, "C-style variadic `...` was removed in v2.0.0");
+        state.error_at_current(p, "a C-variadic function type needs at least one fixed parameter before `...`");
         state.advance(p);
     }
     or (!state.at(p, token.KIND_RPAREN)) {
@@ -1490,7 +1494,7 @@ fun parse_fun(p: *state.Parser, start: token.Span) id.TypeId {
         for (state.eat(p, token.KIND_COMMA)) {
             if (state.at(p, token.KIND_RPAREN)) { brk; }
             if (state.at(p, token.KIND_DOT_DOT_DOT)) {
-                state.error_at_current(p, "C-style variadic `...` was removed in v2.0.0");
+                c_variadic = true;
                 state.advance(p);
                 brk;
             }
@@ -1515,6 +1519,7 @@ fun parse_fun(p: *state.Parser, start: token.Span) id.TypeId {
     fun_.params_start = params_start;
     fun_.params_len   = params_len;
     fun_.ret_type     = ret_type;
+    fun_.c_variadic   = c_variadic;
 
     var t: type.Type;
     t.span      = state.span_of(start, end_span);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2833,7 +2833,7 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) R.Result[b
     val sid: SymbolId = scope_lookup_chain(rc, rc.current_scope, name);
     if (sid == SYMBOL_NIL) {
         val re: R.Result[bool, str] = report_named(rc, span, "unresolved identifier `", name, "`");
-        if (R.is_ok[bool, str](re)) { attach_suggestion(rc, name); }
+        if (R.is_ok[bool, str](re)) { attach_suggestion(rc, span, name); }
     }
     or {
         if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
@@ -2849,8 +2849,9 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) R.Result[b
 # close enough
 # ---
 # rc:     resolver state for the module being resolved
+# span:   the misspelled name's own range, which the fix replaces
 # target: the unresolved name
-fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
+fun attach_suggestion(rc: *ResolveContext, span: token.Span, target: intern.StrId) {
     val to: O.Option[str] = intern.lookup(?rc.s.interner, target);
     if (O.is_none[str](to)) { ret; }
     val tname: str = O.unwrap[str](to);
@@ -2892,6 +2893,16 @@ fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
     val note: str = diagnostic.suggestion_build(rc.s.alloc, bname);
     if (note == nil) { ret; }
     diagnostic.attach_help(?rc.s.diags, note);
+
+    # the same advice a program can apply (#3023). the candidate name is exactly the
+    # replacement and `span` is exactly the text it replaces, so the fix is the note
+    # without the English - and an editor offering it never has to parse that English
+    # back into an edit.
+    val flabel: str = diagnostic.fix_label_replace(rc.s.alloc, bname);
+    if (flabel != nil) {
+        diagnostic.attach_fix(?rc.s.diags, flabel, rc.a.file_id, span, bname);
+        str_free(rc.s.alloc, flabel);
+    }
     str_free(rc.s.alloc, note);
 }
 
@@ -3157,7 +3168,7 @@ fun bind_type_name_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str]
         if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
         if (sid == SYMBOL_NIL) {
             val re: R.Result[bool, str] = report_named(rc, e.span, "unresolved type name `", name, "`");
-            if (R.is_ok[bool, str](re)) { attach_suggestion(rc, name); }
+            if (R.is_ok[bool, str](re)) { attach_suggestion(rc, e.span, name); }
         }
         or {
             if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
@@ -3469,7 +3480,7 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
             # path without a (cross-module) suggestion.
             if (seg_start == path.offset && seg_end >= end) {
                 val re: R.Result[bool, str] = report_named(rc, full, "unresolved type name `", seg_name, "`");
-                if (R.is_ok[bool, str](re)) { attach_suggestion(rc, seg_name); }
+                if (R.is_ok[bool, str](re)) { attach_suggestion(rc, full, seg_name); }
             }
             or {
                 report_named(rc, full, "unresolved type name `", seg_name, "`");

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -30,6 +30,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
@@ -97,7 +98,140 @@ pub fun check_coercible(sc: *context.SemaContext, expected: type.TypeId, eid: id
     }
     var have: type.TypeId = actual;
     if (cr.kind == coerce.COERCE_COERCED) { have = cr.ty; }
-    ret check_assignable(sc, expected, have, span);
+
+    # the mark is what makes the fix safe to attach: the attach helpers land on the
+    # LAST diagnostic in the sink, so on a `silent` episode - or any path that
+    # declines to report - a fix would ride an unrelated earlier diagnostic.
+    val mark: usize = context.diag_mark(sc);
+    val ok: bool = check_assignable(sc, expected, have, span);
+    if (!ok && context.reported_since(sc, mark)) { attach_cast_fix(sc, expected, have, eid); }
+    ret ok;
+}
+
+# offer `value::Type` as a mechanically applicable fix on the just-reported mismatch
+#
+# THE ONLY PLACE THIS IS ATTACHABLE. `check_assignable` is also reached from
+# `check_return`, whose span covers the whole `ret value;` statement rather than the
+# value, so a cast fix there would wrap the statement and produce garbage. Here the
+# span is the offending expression itself, which is exactly what a cast has to wrap.
+#
+# A COMPOUND EXPRESSION IS PARENTHESIZED. `::` binds tighter than the binary
+# operators, so appending `::i64` to the span of `a + b` yields `a + b::i64`, which
+# casts `b` alone - the fix would compile, change the meaning, and leave the original
+# error in place. Two edits, `(` and `)::T`, are why a fix owns a LIST of edits: they
+# apply together or the source does not parse.
+# ---
+# sc:       the active sema context
+# expected: the destination type the cast targets
+# actual:   the value's type, already literal-coerced
+# eid:      the offending expression; supplies both the range and the parenthesization
+fun attach_cast_fix(sc: *context.SemaContext, expected: type.TypeId, actual: type.TypeId, eid: id.ExprId) {
+    if (!cast_would_compile(sc, actual, expected)) { ret; }
+
+    # THE EXPRESSION'S OWN RANGE, NOT THE DIAGNOSTIC'S. A reporter picks its span to
+    # underline what reads best - a `val` declaration's check hands over a range that
+    # runs past the initializer to the `;` - and an edit placed off that lands outside
+    # the expression it was meant to wrap. The node the fix is ABOUT is the only thing
+    # that knows where it starts and ends.
+    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_none[*expr.Expr](opt_expr)) { ret; }
+    val span: token.Span = O.unwrap[*expr.Expr](opt_expr).span;
+    if (span.len == 0) { ret; }
+
+    val ts_r: R.Result[str, str] = type_to_str(sc, expected);
+    if (R.is_err[str, str](ts_r)) { ret; }
+    val ts: str = R.unwrap_ok[str, str](ts_r);
+
+    val label_r: R.Result[str, str] = format.sprint(sc.s.alloc, "cast the value to `{}`", ts);
+    if (R.is_err[str, str](label_r)) { type_str_free(sc, ts); ret; }
+    val label: str = R.unwrap_ok[str, str](label_r);
+
+    var head: token.Span;
+    head.offset = span.offset;
+    head.len    = 0;
+    var tail: token.Span;
+    tail.offset = span.offset + span.len;
+    tail.len    = 0;
+
+    if (expr_binds_tighter_than_cast(O.unwrap[*expr.Expr](opt_expr).kind)) {
+        val sfx_r: R.Result[str, str] = format.sprint(sc.s.alloc, "::{}", ts);
+        if (R.is_ok[str, str](sfx_r)) {
+            val sfx: str = R.unwrap_ok[str, str](sfx_r);
+            diagnostic.attach_fix(?sc.s.diags, label, sc.a.file_id, tail, sfx);
+            A.deallocate[char](sc.s.alloc, sfx, str_len(sfx) + 1);
+        }
+    }
+    or {
+        val sfx_r: R.Result[str, str] = format.sprint(sc.s.alloc, ")::{}", ts);
+        if (R.is_ok[str, str](sfx_r)) {
+            val sfx: str = R.unwrap_ok[str, str](sfx_r);
+            diagnostic.attach_fix(?sc.s.diags, label, sc.a.file_id, head, "(");
+            diagnostic.attach_fix_edit(?sc.s.diags, sc.a.file_id, tail, sfx);
+            A.deallocate[char](sc.s.alloc, sfx, str_len(sfx) + 1);
+        }
+    }
+
+    A.deallocate[char](sc.s.alloc, label, str_len(label) + 1);
+    type_str_free(sc, ts);
+}
+
+# whether `from::to` is a cast that would actually compile
+#
+# A fix that produces a NEW error is worse than no fix at all: the editor's one
+# keystroke would trade a mismatch for `cast: conversion is invalid`. This admits
+# only the numeric conversion the widening advice is about. `::` also reinterprets
+# any two same-size types, but between two unrelated records that is a bit pun, not
+# what a mismatch there means - offering it would launder a real type error into a
+# silent misread of memory.
+# ---
+# sc:   the active sema context
+# from: the value's type
+# to:   the destination type
+# ret:  true when `from::to` is legal and appropriate to suggest
+fun cast_would_compile(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
+    if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret false; }
+    if (from == to)                                       { ret false; }
+    if (!is_numeric(sc, from) || !is_numeric(sc, to))     { ret false; }
+
+    # `::` may neither add nor drop a `^` (#1645), so a cast across the secrecy
+    # boundary is refused and must not be offered.
+    if (type.is_secret(?sc.s.types, from) != type.is_secret(?sc.s.types, to)) { ret false; }
+
+    # a secret operand through the variable-latency FP unit is refused outright (#1646)
+    if (type.is_secret(?sc.s.types, from) && cast_is_fp_conversion(sc, from, to)) { ret false; }
+
+    ret true;
+}
+
+# whether an expression of kind `k` binds tighter than `::`, so a cast may be
+# appended to it without parentheses
+#
+# The postfix and primary forms do; the operator forms do not. An unrecognized kind
+# answers false, which costs a pair of redundant parentheses and never changes what
+# the fixed source means - the safe direction to be wrong in, and the direction a new
+# expression kind added later defaults to.
+# ---
+# k:   the expression's kind
+# ret: true when `<expr>::T` parses as a cast of the whole expression
+fun expr_binds_tighter_than_cast(k: expr.ExprKind) bool {
+    if (k == expr.EXPR_KIND_IDENT)            { ret true; }
+    if (k == expr.EXPR_KIND_COMPTIME_IDENT)   { ret true; }
+    if (k == expr.EXPR_KIND_LIT_INT)          { ret true; }
+    if (k == expr.EXPR_KIND_LIT_FLOAT)        { ret true; }
+    if (k == expr.EXPR_KIND_LIT_CHAR)         { ret true; }
+    if (k == expr.EXPR_KIND_LIT_STR)          { ret true; }
+    if (k == expr.EXPR_KIND_LIT_NIL)          { ret true; }
+    if (k == expr.EXPR_KIND_CALL)             { ret true; }
+    if (k == expr.EXPR_KIND_INDEX)            { ret true; }
+    if (k == expr.EXPR_KIND_MEMBER)           { ret true; }
+    if (k == expr.EXPR_KIND_PROJECT)          { ret true; }
+    if (k == expr.EXPR_KIND_CAST)             { ret true; }
+    if (k == expr.EXPR_KIND_STRIP)            { ret true; }
+    if (k == expr.EXPR_KIND_ARRAY_LIT)        { ret true; }
+    if (k == expr.EXPR_KIND_STRUCT_LIT)       { ret true; }
+    if (k == expr.EXPR_KIND_VECTOR_LIT)       { ret true; }
+    if (k == expr.EXPR_KIND_GENERIC_INSTANCE) { ret true; }
+    ret false;
 }
 
 # checks a call against the callee's function signature

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -653,7 +653,23 @@ fun call_has_spread_arg(a: *ast.Ast, e: *expr.Expr) bool {
     ret false;
 }
 
-fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId, want_spread: bool) bool {
+# resolve a call's callee to its declaring function and continue the reachability
+# walk into its body
+#
+# The transitive step. A callee with no body (an `ext` import that is not itself
+# C-variadic, a call through a value) contributes nothing and answers false.
+fun callee_body_reaches(sc: *SemaContext, rr: *resolve.ResolveResult, callee_eid: id.ExprId,
+                        want_spread: bool, seen: *ReachSeen) bool {
+    if (rr == nil || rr.expr_resolved == nil || rr.symbols == nil) { ret false; }
+    if (callee_eid == id.EXPR_NIL || callee_eid >= rr.expr_count)  { ret false; }
+    val sid: resolve.SymbolId = rr.expr_resolved[callee_eid];
+    if (sid == resolve.SYMBOL_NIL || sid >= rr.symbol_count)       { ret false; }
+    val sym: *resolve.Symbol = ?rr.symbols[sid];
+    if (sym.decl == id.DECL_NIL) { ret false; }
+    ret decl_reaches_c_variadic(sc, sym.origin, sym.decl, want_spread, seen);
+}
+
+fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId, want_spread: bool, seen: *ReachSeen) bool {
     if (eid == id.EXPR_NIL) { ret false; }
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
     if (O.is_none[*expr.Expr](e_opt)) { ret false; }
@@ -661,35 +677,41 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
     val k: expr.ExprKind = e.kind;
 
     if (k == expr.EXPR_KIND_CALL) {
+        val spread_here: bool = call_has_spread_arg(a, e);
         if (callee_is_c_variadic(sc, rr, e.data.call.callee)
-            && (!want_spread || call_has_spread_arg(a, e))) { ret true; }
-        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee, want_spread)) { ret true; }
+            && (!want_spread || spread_here)) { ret true; }
+        # NOT C-variadic itself: the tail may still be one call further down. In the
+        # pack mode only a spread-carrying call propagates THIS pack's elements.
+        if (!want_spread || spread_here) {
+            if (callee_body_reaches(sc, rr, e.data.call.callee, want_spread, seen)) { ret true; }
+        }
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.call.callee, want_spread, seen)) { ret true; }
         var i: u32 = 0;
         for (i < e.data.call.args_len) {
             val ix: u32 = e.data.call.args_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
     }
     if (k == expr.EXPR_KIND_BINARY) {
-        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs, want_spread)) { ret true; }
-        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs, want_spread);
+        if (expr_has_c_variadic_call(sc, a, rr, e.data.binary.lhs, want_spread, seen)) { ret true; }
+        ret expr_has_c_variadic_call(sc, a, rr, e.data.binary.rhs, want_spread, seen);
     }
-    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand, want_spread); }
-    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object, want_spread); }
-    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object, want_spread); }
-    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object, want_spread); }
-    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner, want_spread); }
-    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value, want_spread); }
-    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value, want_spread); }
+    if (k == expr.EXPR_KIND_UNARY)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.unary.operand, want_spread, seen); }
+    if (k == expr.EXPR_KIND_INDEX)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.index.object, want_spread, seen); }
+    if (k == expr.EXPR_KIND_MEMBER) { ret expr_has_c_variadic_call(sc, a, rr, e.data.member.object, want_spread, seen); }
+    if (k == expr.EXPR_KIND_PROJECT){ ret expr_has_c_variadic_call(sc, a, rr, e.data.project.object, want_spread, seen); }
+    if (k == expr.EXPR_KIND_SPREAD) { ret expr_has_c_variadic_call(sc, a, rr, e.data.spread.inner, want_spread, seen); }
+    if (k == expr.EXPR_KIND_CAST)   { ret expr_has_c_variadic_call(sc, a, rr, e.data.cast.value, want_spread, seen); }
+    if (k == expr.EXPR_KIND_STRIP)  { ret expr_has_c_variadic_call(sc, a, rr, e.data.strip.value, want_spread, seen); }
     if (k == expr.EXPR_KIND_ARRAY_LIT) {
         var i: u32 = 0;
         for (i < e.data.array_lit.elems_len) {
             val ix: u32 = e.data.array_lit.elems_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -699,7 +721,7 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
         for (i < e.data.vector_lit.elems_len) {
             val ix: u32 = e.data.vector_lit.elems_start + i;
             if (ix::usize < a.expr_id_len
-                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.expr_ids[ix], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -709,7 +731,7 @@ fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.Resolve
         for (i < e.data.struct_lit.fields_len) {
             val ix: u32 = e.data.struct_lit.fields_start + i;
             if (ix::usize < a.field_init_len
-                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value, want_spread)) { ret true; }
+                && expr_has_c_variadic_call(sc, a, rr, a.field_inits[ix].value, want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -754,7 +776,65 @@ pub fun decl_body_spreads_pack_to_c_variadic(sc: *SemaContext, origin: session.M
     ret decl_body_reaches_c_variadic(sc, origin, did, true);
 }
 
+# how many distinct functions one reachability question may visit
+#
+# The visited set is what terminates the walk on a recursive or mutually recursive
+# call graph; the cap bounds the work a single `record_instance` decision can do.
+# Exhausting it answers FALSE rather than true, which is the safe direction for this
+# filter: a miss leaves a check unrun on a call chain more than this deep, while a
+# false positive re-infers a body with nothing concrete and duplicates its
+# template-time diagnostics (#3029, #3031).
+val REACH_MAX_VISITED: u32 = 64;
+
+# the functions one reachability walk has already entered
+# ---
+# origins / decls: parallel arrays identifying each visited function
+# len:             number of entries used
+rec ReachSeen {
+    origins: *u32;
+    decls:   *u32;
+    len:     u32;
+}
+
+# record `(origin, did)` as visited; false when already present or the cap is reached
+fun reach_visit(seen: *ReachSeen, origin: session.ModuleId, did: id.DeclId) bool {
+    var i: u32 = 0;
+    for (i < seen.len) {
+        if (seen.origins[i] == origin::u32 && seen.decls[i] == did::u32) { ret false; }
+        i = i + 1;
+    }
+    if (seen.len >= REACH_MAX_VISITED) { ret false; }
+    seen.origins[seen.len] = origin::u32;
+    seen.decls[seen.len]   = did::u32;
+    seen.len = seen.len + 1;
+    ret true;
+}
+
 fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId, want_spread: bool) bool {
+    var so: [REACH_MAX_VISITED]u32;
+    var sd: [REACH_MAX_VISITED]u32;
+    var seen: ReachSeen;
+    seen.origins = ?so[0];
+    seen.decls   = ?sd[0];
+    seen.len     = 0;
+    ret decl_reaches_c_variadic(sc, origin, did, want_spread, ?seen);
+}
+
+# whether `did`'s body reaches a C-variadic tail, directly or through the generics it
+# calls (#3031)
+#
+# TRANSITIVITY IS THE POINT. `wrap2` calling `log1` calling `printf` puts `wrap2`'s
+# arguments on the C contract just as surely as calling `printf` itself, and neither
+# instance is otherwise recorded: `wrap2[u8]`'s arguments are public scalars, and
+# `log1[A]` is pruned as abstract at `wrap2`'s template. Nothing else would create the
+# concrete `log1[u8]`.
+#
+# In the `want_spread` mode the recursion follows only calls that CARRY a spread,
+# because that is how a pack propagates: an ordinary call to a pack function does not
+# put this pack's elements on any contract.
+fun decl_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId,
+                            want_spread: bool, seen: *ReachSeen) bool {
+    if (!reach_visit(seen, origin, did)) { ret false; }
     var a: *ast.Ast = sc.a;
     if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
     if (a == nil) { ret false; }
@@ -766,7 +846,7 @@ fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_FUN)    { ret false; }
     if (d.data.fun_.body == id.STMT_NIL) { ret false; }
-    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body, want_spread);
+    ret stmt_calls_c_variadic(sc, a, rr, d.data.fun_.body, want_spread, seen);
 }
 
 # the recursive half of `decl_body_calls_c_variadic`, over one statement
@@ -774,36 +854,36 @@ fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did
 # Enumerated rather than defaulted, for the reason `expr_has_c_variadic_call` states:
 # a spurious record duplicates a body's template-time diagnostics, so the
 # conservative direction that is right for `stmt_has_type_directive` is wrong here.
-fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId, want_spread: bool) bool {
+fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, sid: id.StmtId, want_spread: bool, seen: *ReachSeen) bool {
     if (sid == id.STMT_NIL) { ret false; }
     val s_opt: O.Option[*stmt.Stmt] = ast.get_stmt(a, sid);
     if (O.is_none[*stmt.Stmt](s_opt)) { ret false; }
     val s: *stmt.Stmt = O.unwrap[*stmt.Stmt](s_opt);
     val k: stmt.StmtKind = s.kind;
 
-    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr, want_spread); }
-    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value, want_spread); }
+    if (k == stmt.STMT_KIND_EXPR) { ret expr_has_c_variadic_call(sc, a, rr, s.data.expr.expr, want_spread, seen); }
+    if (k == stmt.STMT_KIND_RET)  { ret expr_has_c_variadic_call(sc, a, rr, s.data.ret_.value, want_spread, seen); }
     if (k == stmt.STMT_KIND_DECL) {
         val dd_opt: O.Option[*decl.Decl] = ast.get_decl(a, s.data.decl.decl);
         if (O.is_none[*decl.Decl](dd_opt)) { ret false; }
         val dd: *decl.Decl = O.unwrap[*decl.Decl](dd_opt);
         if (dd.kind != decl.DECL_KIND_VAL && dd.kind != decl.DECL_KIND_VAR) { ret false; }
-        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init, want_spread);
+        ret expr_has_c_variadic_call(sc, a, rr, dd.data.bind.init, want_spread, seen);
     }
     if (k == stmt.STMT_KIND_IF) {
-        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond, want_spread))   { ret true; }
-        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block, want_spread)) { ret true; }
-        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block, want_spread);
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.if_.cond, want_spread, seen))   { ret true; }
+        if (stmt_calls_c_variadic(sc, a, rr, s.data.if_.then_block, want_spread, seen)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.if_.else_block, want_spread, seen);
     }
     if (k == stmt.STMT_KIND_FOR) {
-        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond, want_spread)) { ret true; }
-        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body, want_spread);
+        if (expr_has_c_variadic_call(sc, a, rr, s.data.for_.cond, want_spread, seen)) { ret true; }
+        ret stmt_calls_c_variadic(sc, a, rr, s.data.for_.body, want_spread, seen);
     }
-    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body, want_spread); }
+    if (k == stmt.STMT_KIND_FIN) { ret stmt_calls_c_variadic(sc, a, rr, s.data.fin_.body, want_spread, seen); }
     if (k == stmt.STMT_KIND_BLOCK) {
         var i: u32 = 0;
         for (i < s.data.block.stmts_len) {
-            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i], want_spread)) { ret true; }
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.block.stmts_start + i], want_spread, seen)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -820,7 +900,7 @@ fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveRes
             val br: *decl.ComptimeBranch = ?a.comptime_branches[s.data.comptime_if.branches_start + bi];
             var si2: u32 = 0;
             for (si2 < br.body_len) {
-                if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[br.body_start + si2], want_spread)) { ret true; }
+                if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[br.body_start + si2], want_spread, seen)) { ret true; }
                 si2 = si2 + 1;
             }
             bi = bi + 1;
@@ -830,7 +910,7 @@ fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveRes
     if (k == stmt.STMT_KIND_COMPTIME_EACH) {
         var ei: u32 = 0;
         for (ei < s.data.comptime_each.body_len) {
-            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.comptime_each.body_start + ei], want_spread)) { ret true; }
+            if (stmt_calls_c_variadic(sc, a, rr, a.stmt_ids[s.data.comptime_each.body_start + ei], want_spread, seen)) { ret true; }
             ei = ei + 1;
         }
         ret false;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -3906,7 +3906,7 @@ fun resolve_type_fun(sc: *context.SemaContext, fn: *atype.TypeFun) type.TypeId {
     if (fn.ret_type != id.TYPE_NIL) { ret_type = resolve_type_ref(sc, fn.ret_type); }
 
     if (fn.params_len == 0) {
-        val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, nil, 0, false);
+        val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, nil, 0, fn.c_variadic);
         if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
         ret R.unwrap_ok[type.TypeId, str](r);
     }
@@ -3922,7 +3922,7 @@ fun resolve_type_fun(sc: *context.SemaContext, fn: *atype.TypeFun) type.TypeId {
         i = i + 1;
     }
 
-    val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, params, fn.params_len, false);
+    val r: R.Result[type.TypeId, str] = type.intern_function(?sc.s.types, ret_type, params, fn.params_len, fn.c_variadic);
     free_params(sc, params, fn.params_len);
     if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
     ret R.unwrap_ok[type.TypeId, str](r);

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -18,6 +18,7 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 
 use A: std.allocator;
+use P: std.types.path;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -951,36 +952,38 @@ pub fun load_source(s: *Session, path: str, text: str) R.Result[source.FileId, s
 # text: the live buffer text to use instead of the file's content
 # ret:  true on success, or an allocation error
 pub fun set_overlay(s: *Session, path: str, text: str) R.Result[bool, str] {
+    val key_r: R.Result[str, str] = overlay_key(s, path);
+    if (R.is_err[str, str](key_r)) { ret R.err[bool, str](R.unwrap_err[str, str](key_r)); }
+    val key: str = R.unwrap_ok[str, str](key_r);
+
     val dup_text_r: R.Result[str, str] = str_dup(s.alloc, text);
-    if (R.is_err[str, str](dup_text_r)) { ret R.err[bool, str](R.unwrap_err[str, str](dup_text_r)); }
+    if (R.is_err[str, str](dup_text_r)) {
+        str_free(s.alloc, key);
+        ret R.err[bool, str](R.unwrap_err[str, str](dup_text_r));
+    }
     val dup_text: str = R.unwrap_ok[str, str](dup_text_r);
 
     # replace an existing overlay's text in place, keeping its path key.
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, path)) {
+        if (str_equals(s.overlays[i].path, key)) {
             str_free(s.alloc, s.overlays[i].text);
             s.overlays[i].text = dup_text;
+            str_free(s.alloc, key);
             ret R.ok[bool, str](true);
         }
         i = i + 1;
     }
 
-    # append a new overlay, growing the array on demand.
-    val dup_path_r: R.Result[str, str] = str_dup(s.alloc, path);
-    if (R.is_err[str, str](dup_path_r)) {
-        str_free(s.alloc, dup_text);
-        ret R.err[bool, str](R.unwrap_err[str, str](dup_path_r));
-    }
-    val dup_path: str = R.unwrap_ok[str, str](dup_path_r);
-
+    # append a new overlay, growing the array on demand. `key` is already owned
+    # by the session allocator, so it becomes the entry's key directly.
     val res_grow: R.Result[bool, str] = overlays_reserve(s, s.overlay_len + 1);
     if (R.is_err[bool, str](res_grow)) {
         str_free(s.alloc, dup_text);
-        str_free(s.alloc, dup_path);
+        str_free(s.alloc, key);
         ret res_grow;
     }
-    s.overlays[s.overlay_len].path = dup_path;
+    s.overlays[s.overlay_len].path = key;
     s.overlays[s.overlay_len].text = dup_text;
     s.overlay_len = s.overlay_len + 1;
     ret R.ok[bool, str](true);
@@ -992,9 +995,14 @@ pub fun set_overlay(s: *Session, path: str, text: str) R.Result[bool, str] {
 # path: the overlaid path to clear
 # ret:  true when an overlay was present and removed, false when none matched
 pub fun clear_overlay(s: *Session, path: str) bool {
+    val key_r: R.Result[str, str] = overlay_key(s, path);
+    if (R.is_err[str, str](key_r)) { ret false; }
+    val key: str = R.unwrap_ok[str, str](key_r);
+
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, path)) {
+        if (str_equals(s.overlays[i].path, key)) {
+            str_free(s.alloc, key);
             str_free(s.alloc, s.overlays[i].path);
             str_free(s.alloc, s.overlays[i].text);
             val last: u32 = s.overlay_len - 1;
@@ -1004,6 +1012,7 @@ pub fun clear_overlay(s: *Session, path: str) bool {
         }
         i = i + 1;
     }
+    str_free(s.alloc, key);
     ret false;
 }
 
@@ -1016,14 +1025,41 @@ pub fun clear_overlay(s: *Session, path: str) bool {
 # path: the path to look up
 # ret:  some(text) when an overlay is set for path, none otherwise
 pub fun overlay_get(s: *Session, path: str) O.Option[str] {
+    val key_r: R.Result[str, str] = overlay_key(s, path);
+    if (R.is_err[str, str](key_r)) { ret O.none[str](); }
+    val key: str = R.unwrap_ok[str, str](key_r);
+
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, path)) {
+        if (str_equals(s.overlays[i].path, key)) {
+            str_free(s.alloc, key);
             ret O.some[str](s.overlays[i].text);
         }
         i = i + 1;
     }
+    str_free(s.alloc, key);
     ret O.none[str]();
+}
+
+# an overlay entry's canonical key, so one file is one entry however it is spelled
+#
+# The table compares keys with `str_equals`, and the two sides that meet in it pick
+# their spelling INDEPENDENTLY: an editor keys a buffer from a URI it decoded, while
+# the driver composes `<root>/<src>/<name>.mach` out of manifest text. `./src/a.mach`,
+# `src/a.mach` and `src\a.mach` are one file and three strings, so a raw comparison
+# missed and the build silently read the STALE DISK TEXT instead of the live buffer
+# (#2998).
+#
+# Normalizing here, at the table's own boundary, is what makes the key canonical by
+# construction. Doing it in the composer instead would only canonicalize the half the
+# compiler controls and leave the editor's half free to disagree - the same defect,
+# moved. Cleaning is lexical, so this stays off the syscall path.
+# ---
+# s:    the session, whose allocator backs the returned key
+# path: the caller's spelling of the path
+# ret:  an owned canonical key the caller frees, or an allocation error
+fun overlay_key(s: *Session, path: str) R.Result[str, str] {
+    ret P.clean(s.alloc, path);
 }
 
 # grow the overlay array to at least `need` slots, doubling from the seed capacity
@@ -1090,6 +1126,62 @@ test "mach.lang.session.overlay:set_get_replace_clear" {
     dnit(?s);
     ret bad;
 }
+
+# One file is one overlay entry however the caller spells its path (#2998).
+#
+# The two sides that meet in this table pick their spelling independently: an
+# editor keys a buffer from a URI it decoded, the driver composes a module path
+# out of manifest text. `str_equals` on raw strings made those disagree, and the
+# build then read the stale disk text with no error at all.
+#
+# The equivalences below are what an editor and a manifest actually produce
+# between them, not synthetic ones: a `./` from `src = "./src"`, a doubled
+# separator from joining a root that already ended in one, and a `..` from a
+# relative include.
+test "mach.lang.session.overlay:one_file_is_one_entry_however_it_is_spelled" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[Session, str] = init(?alloc);
+    if (R.is_err[Session, str](sr)) { ret 1; }
+    var s: Session = R.unwrap_ok[Session, str](sr);
+
+    # the FIRST failure is the reported one; a later check must not overwrite it
+    var bad: i32 = 0;
+
+    if (R.is_err[bool, str](set_overlay(?s, "/x/src/a.mach", "LIVE"))) { dnit(?s); ret 1; }
+
+    # every spelling below names that same file and must find it
+    if (!ut_overlay_is(?s, "/x/./src/a.mach", "LIVE")      && bad == 0) { bad = 1; }
+    if (!ut_overlay_is(?s, "/x//src/a.mach", "LIVE")       && bad == 0) { bad = 2; }
+    if (!ut_overlay_is(?s, "/x/src/./a.mach", "LIVE")      && bad == 0) { bad = 3; }
+    if (!ut_overlay_is(?s, "/x/lib/../src/a.mach", "LIVE") && bad == 0) { bad = 4; }
+
+    # and setting through a different spelling REPLACES rather than shadowing:
+    # two entries for one file would make which text wins depend on scan order.
+    if (R.is_err[bool, str](set_overlay(?s, "/x/./src/a.mach", "NEWER"))) { dnit(?s); ret 1; }
+    if (s.overlay_len != 1                            && bad == 0) { bad = 5; }
+    if (!ut_overlay_is(?s, "/x/src/a.mach", "NEWER")  && bad == 0) { bad = 6; }
+
+    # a genuinely different file is still its own entry
+    if (O.is_some[str](overlay_get(?s, "/x/src/b.mach")) && bad == 0) { bad = 7; }
+    # ...and a `..` that climbs out of the root it started in does not collapse onto it
+    if (O.is_some[str](overlay_get(?s, "/src/a.mach"))   && bad == 0) { bad = 8; }
+
+    # clearing through yet another spelling still removes the one entry
+    if (!clear_overlay(?s, "/x//src/a.mach") && bad == 0) { bad = 9; }
+    if (s.overlay_len != 0                   && bad == 0) { bad = 10; }
+
+    dnit(?s);
+    ret bad;
+}
+
+# whether the overlay registered under `path` reads back as exactly `want`
+fun ut_overlay_is(s: *Session, path: str, want: str) bool {
+    val g: O.Option[str] = overlay_get(s, path);
+    if (O.is_none[str](g)) { ret false; }
+    ret str_equals(O.unwrap[str](g), want);
+}
+
 
 # the link-provider registry keeps link order, does not double-register a name,
 # lets a dynamic registration upgrade a static one, and empties on reset (#2800)

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.23.0";
+pub val MACH_VERSION: str = "4.24.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {

--- a/test/link/cases/c-variadic/case.conf
+++ b/test/link/cases/c-variadic/case.conf
@@ -16,11 +16,21 @@
 # the a bank the probe's `va_arg` actually reads. before that the caller placed
 # them in fa0-fa7 and every float came back as flat 0.
 #
-# exempt windows: `[step]` now runs there (#2578/#2587 fixed it), but this case has
-# not yet been verified against the windows-latest runner's own C toolchain (does it
-# expose a bare `cc`, and does it target win64 the way this case needs?). Re-enable
-# once that's confirmed rather than guessing at it here; win64's variadic rule (a
-# tail float duplicated into its integer register) is otherwise exercised only by
-# the compiler's own unit tests.
+# windows runs since #3005, and the deferred question was answered rather than
+# deleted: windows-latest exposes no bare `cc`, which is the ONLY reason this was
+# exempt. It does carry gcc and clang, both of which take a bare `cc`'s flags, so
+# test/link/lib/cc.sh resolves the host compiler by name instead of assuming one -
+# see host_cc there for why MSVC's `cl` is named in a failure rather than translated.
+#
+# What the leg buys: win64 duplicates a tail float into the integer register of the
+# same positional slot, because a `va_arg` reader walks only the integer slots
+# (target/abi.mach, VA_MODEL_HOME, float_dup_gp). That rule is not shared with any
+# other target, and until this ran it was checked only by the compiler's own unit
+# tests - mach's model of the ABI compared against itself, which cannot catch the
+# model being wrong. The `mixed` and `floats` lines read every tail double back
+# through the runner's real `va_arg`, so a broken duplication is a wrong VALUE here.
+#
+# This matters more than an ordinary coverage gap: the FFI reports that reach us are
+# disproportionately from Windows (#2968, #2992), which is where mach's foreign-code
+# surface is least verified and most exercised.
 run: exec
-skip: x86_64-windows

--- a/test/link/cases/c-variadic/case.conf
+++ b/test/link/cases/c-variadic/case.conf
@@ -17,10 +17,17 @@
 # them in fa0-fa7 and every float came back as flat 0.
 #
 # windows runs since #3005, and the deferred question was answered rather than
-# deleted: windows-latest exposes no bare `cc`, which is the ONLY reason this was
-# exempt. It does carry gcc and clang, both of which take a bare `cc`'s flags, so
-# test/link/lib/cc.sh resolves the host compiler by name instead of assuming one -
-# see host_cc there for why MSVC's `cl` is named in a failure rather than translated.
+# deleted. The answer was not the one the exemption guessed at: the runner's C
+# toolchain was never the obstacle. CI already exports `CC=gcc` (ci-tools.sh, "cc is
+# spelled gcc on this host, per tools.lock"), so a compiler was there all along.
+#
+# WHAT ACTUALLY FAILED WAS THE STEP'S OWN COMMAND. A `[step]` cmd runs through the
+# PLATFORM shell, which on windows is `cmd.exe /s /c` - and cmd.exe cannot execute
+# `../../lib/cc.sh`, so every windows run died with "'..' is not recognized as an
+# internal or external command" before any compiler was consulted. That is a fact
+# about how a step is spelled, not about what the runner has installed, and the rest
+# of this suite already had it right: every `pe-*` case invokes its script as
+# `sh <script>`. These three were the outliers, and now match.
 #
 # What the leg buys: win64 duplicates a tail float into the integer register of the
 # same positional slot, because a `va_arg` reader walks only the integer slots

--- a/test/link/cases/c-variadic/expect.txt
+++ b/test/link/cases/c-variadic/expect.txt
@@ -4,3 +4,4 @@ ptr n=1 4242
 floats n=8 1000 4000 8000
 pair n=1 309
 wide n=1 1234
+indirect n=2 11 500

--- a/test/link/cases/c-variadic/mach.toml
+++ b/test/link/cases/c-variadic/mach.toml
@@ -45,7 +45,7 @@ debug = false
 simd = "scalarize"
 
 [step.probe]
-cmd = "../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+cmd = "sh ../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/c-variadic/src/main.mach
+++ b/test/link/cases/c-variadic/src/main.mach
@@ -21,6 +21,12 @@ rec Wide { a: i64; b: i64; c: i64; d: i64; }
 # `spec` names one character per variadic argument; `out` receives the folded values.
 ext fun va_probe(spec: *u8, out: *i64, ...) i64;
 
+# THE SAME CALLEE NAMED AS A TYPE (mach #3003). An indirect call has no declaration in
+# view, so the tail rule has to come off the TYPE - and it must be the variadic one.
+# A call placed by the ordinary rule links and runs; it just hands `va_arg` the wrong
+# bytes, which is why this has to execute against real C rather than diff an object.
+def Probe: fun(*u8, *i64, ...) i64;
+
 #[symbol("main")]
 fun main(argc: usize, argv: **u8) i64 {
     var out: [8]i64;
@@ -81,6 +87,15 @@ fun main(argc: usize, argv: **u8) i64 {
     s[1] = 0;
     val n5: i64 = va_probe(?s[0], ?out[0], w);
     p.printlnf("wide n={} {}", n5, out[0]);
+
+    # indirect, through the type. mixes an integer and a double so the observable
+    # covers both banks the variadic rule diverges on.
+    val fp: Probe = va_probe;
+    s[0] = 'i'::u8;
+    s[1] = 'd'::u8;
+    s[2] = 0;
+    val n6: i64 = fp(?s[0], ?out[0], 11::i32, 0.5::f64);
+    p.printlnf("indirect n={} {} {}", n6, out[0], out[1]);
 
     ret 0;
 }

--- a/test/link/cases/narrow-stack-args/case.conf
+++ b/test/link/cases/narrow-stack-args/case.conf
@@ -15,10 +15,18 @@
 # is target-independent (see main.mach), so a cross-built probe object proves it just
 # as well as a native one would.
 #
-# exempt windows: `[step]` now runs there (#2578/#2587 fixed it), but this case has
-# not yet been verified against the windows-latest runner's own C toolchain (does it
-# expose a bare `cc`, and does it target win64 the way this case needs?). Re-enable
-# once that's confirmed rather than guessing at it here.
+# windows runs since #3005. The exemption above shared its wording, and its cause,
+# with c-variadic's: the runner's C toolchain was never the obstacle (CI exports
+# `CC=gcc`). The step invoked `../../lib/cc.sh` directly, and a `[step]` runs through
+# the platform shell - `cmd.exe /s /c` on windows, which cannot execute a `.sh` path.
+# Spelled `sh ../../lib/cc.sh`, the way every `pe-*` case in this suite already spells
+# its script, it runs. One wrong guess had exempted two cases, so answering it once
+# restored both.
+#
+# What the leg buys here: win64 gives a stack-passed fixed argument its own natural
+# size and alignment rather than an eight-byte slot, the same axis Apple arm64
+# diverges on (#2598). This case is built to catch exactly that divergence, and the
+# windows rule was previously taken on trust from the compiler's own unit tests.
 #
 # riscv64-linux was exempt twice over a float row of `regs=0 0` / `tail=0 0 0` against
 # a golden of `regs=10 80` / `tail=95 105 115`, blamed first on a variadic-classifier
@@ -42,4 +50,3 @@
 # cc.sh's `-mabi=lp64d` pin (mach#2771), because a soft-float probe object produces the
 # identical row for a completely different reason.
 run: exec
-skip: x86_64-windows

--- a/test/link/cases/narrow-stack-args/mach.toml
+++ b/test/link/cases/narrow-stack-args/mach.toml
@@ -45,7 +45,7 @@ debug = false
 simd = "scalarize"
 
 [step.probe]
-cmd = "../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+cmd = "sh ../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/riscv-pcrel-pair/mach.toml
+++ b/test/link/cases/riscv-pcrel-pair/mach.toml
@@ -28,7 +28,7 @@ debug = false
 simd = "scalarize"
 
 [step.probe]
-cmd = "../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+cmd = "sh ../../lib/cc.sh -c -O1 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/lib/cc.sh
+++ b/test/link/lib/cc.sh
@@ -56,18 +56,17 @@ host_os() {
 # host_cc - the host's own C compiler, by whatever name it answers to.
 #
 # `cc` is the POSIX spelling and every unix runner has one. WINDOWS DOES NOT: neither
-# Git Bash nor the image's Visual Studio install provides a `cc`, and that single
-# missing name is why `c-variadic` carried `skip: x86_64-windows` for so long
-# (mach#3005) - so win64's variadic rule, which duplicates a tail float into the
-# integer register of the same slot, was never executed against a real `va_arg`
-# reader. A rule verified only by the compiler's own unit tests is mach's model of the
-# ABI checked against itself.
+# Git Bash nor the image's Visual Studio install provides that name. CI already works
+# around it by exporting `CC=gcc` from ci-tools.sh ("cc is spelled gcc on this host,
+# per tools.lock"), so the gap only bites a host where nothing sets CC - a developer's
+# own Windows machine, which is where a case is most likely to be run by hand and least
+# likely to have the environment CI builds.
 #
-# gcc and clang accept the same flags a bare `cc` does, so resolving to either needs
-# no argv translation and no case has to know which one answered. MSVC's `cl` does not
-# (`/c`, `/Fo:`), so it is NAMED IN THE FAILURE rather than half-supported: a
-# translation layer for one call site would be a second flag dialect to maintain
-# forever, and every candidate ahead of it produces the same object for this purpose.
+# gcc and clang accept the same flags a bare `cc` does, so resolving to either needs no
+# argv translation and no case has to know which one answered. MSVC's `cl` does not
+# (`/c`, `/Fo:`), so it is NAMED IN THE FAILURE rather than half-supported: a second
+# flag dialect for one call site is a permanent maintenance cost, and every candidate
+# ahead of it produces the same object for this purpose.
 host_cc() {
     if [ -n "${CC:-}" ]; then
         echo "$CC"

--- a/test/link/lib/cc.sh
+++ b/test/link/lib/cc.sh
@@ -53,8 +53,43 @@ host_os() {
     esac
 }
 
+# host_cc - the host's own C compiler, by whatever name it answers to.
+#
+# `cc` is the POSIX spelling and every unix runner has one. WINDOWS DOES NOT: neither
+# Git Bash nor the image's Visual Studio install provides a `cc`, and that single
+# missing name is why `c-variadic` carried `skip: x86_64-windows` for so long
+# (mach#3005) - so win64's variadic rule, which duplicates a tail float into the
+# integer register of the same slot, was never executed against a real `va_arg`
+# reader. A rule verified only by the compiler's own unit tests is mach's model of the
+# ABI checked against itself.
+#
+# gcc and clang accept the same flags a bare `cc` does, so resolving to either needs
+# no argv translation and no case has to know which one answered. MSVC's `cl` does not
+# (`/c`, `/Fo:`), so it is NAMED IN THE FAILURE rather than half-supported: a
+# translation layer for one call site would be a second flag dialect to maintain
+# forever, and every candidate ahead of it produces the same object for this purpose.
+host_cc() {
+    if [ -n "${CC:-}" ]; then
+        echo "$CC"
+        return 0
+    fi
+    for candidate in cc gcc clang; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    if command -v cl >/dev/null 2>&1; then
+        echo "cc.sh: the only host C compiler on PATH is MSVC 'cl', whose flags are spelled differently from a bare 'cc' ('/c', '/Fo:') - this script passes a case's argv through unchanged. put a gcc or clang on PATH, or set CC to one." >&2
+    else
+        echo "cc.sh: no host C compiler on PATH (tried cc, gcc, clang). a case's [step] that compiles C needs one on every leg that runs it." >&2
+    fi
+    return 1
+}
+
 if [ "$(host_isa)" = "$MACH_TARGET_ISA" ] && [ "$(host_os)" = "$MACH_TARGET_OS" ]; then
-    exec "${CC:-cc}" "$@"
+    hostcc=$(host_cc) || exit 1
+    exec "$hostcc" "$@"
 fi
 
 # cross build: the host cannot produce this leg's ISA/OS natively, so route


### PR DESCRIPTION
Release 4.24.0. Merged from `dev` at 671c0705.

This is where the `darwin (release gate)` schedules — `ci.yml` gates it on `base_ref == 'main'`, so it read SKIPPED on every dev-targeted PR in this batch.

## Added

- **#3023** — a diagnostic carries its fix as structured edits (`Fix` owning a list of `Edit`), alongside `help` rather than instead of it. Unblocks briar-systems/mach-lsp#165.
- **#3003** — a C-variadic function is nameable as a type, so `printf` can be stored or passed as a callback.

## Fixed

- **#2998** — an editor's unsaved buffer was silently ignored in favour of stale disk text whenever the manifest spelled `src = "./src"`. Unblocks briar-systems/mach-lsp#141.
- **#3005** — `c-variadic` and `narrow-stack-args` now execute on windows against the runner's real toolchain.
- **#3039** — stray `[Unreleased]` changelog headings folded back into their releases, with a CI check so it cannot recur.

## Verification

17/17 on the dev-targeted PR. 1509 tests, corpus 1416/0, three-generation fixpoint byte-identical, `mach.toml` and `MACH_VERSION` both at 4.24.0.