### PR TITLE
fix(riscv32): lower a 64-bit cross-bank reinterpret through a frame slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### target(riscv32): a 64-bit reinterpret across the register banks is lowered (#2904)
+
+`f64 :~ i64` did not compile on riscv32, and the diagnostic named neither the cause nor
+the instruction that was missing:
+
+```
+error: legalize: operation wider than the target ALU is unsupported (MIR_MOV, 8 bytes wide)
+```
+
+A cross-bank move is as wide as **both** banks. `fmv.x.d` moves all 64 bits between an
+`f` register and a GP one, so it needs a 64-bit GP register and is RV64-only - while
+rv32gc's D extension still puts doubles in `f0-f31`. The write is ordinary and the
+register form does not exist.
+
+The reinterpret is now expanded at MIR lowering into a frame round trip - a store in
+the source's bank and a load in the destination's, since the bits are the same in
+either one:
+
+```
+bits   (f64 :~ i64):  fsd fa0,-0x10(s0)  ->  lw a0,-0x10(s0) ; lw a1,-0xc(s0)
+unbits (i64 :~ f64):  sw a0,-0x10(s0) ; sw a1,-0xc(s0)  ->  fld fa0,-0x10(s0)
+narrow (f32 :~ i32):  fmv.x.w a0, fa0
+```
+
+which is what a C toolchain emits on this target. Nothing downstream needed a new
+clause: the float half is an ordinary float move against a MEM operand, which the
+encoder already handled because a spilled side reaches it the same way, and the integer
+half is an ordinary wide integer move that `be.codegen.legalize` already splits.
+
+**The fact is declared, not derived.** `MachineModel.xbank_widths` names the widths an
+ISA crosses between its float bank and a GP register in one instruction, asked through
+a single accessor the way `vec_mem_widths` is. Deriving it from `flen_bits` and
+`gpr_width` gives the right answer on the riscv members by coincidence and the wrong one
+on x86-64, where a 128-bit XMM would imply a 16-byte crossing `movq` does not perform.
+rv64 keeps `fmv.x.d` / `fmv.d.x`; rv32 declares 4 alone, so `f32 :~ i32` still takes
+`fmv.x.w` and only the 64-bit case goes through memory.
+
+The assumption that let this survive was a comment: *a conversion is the one instruction
+with a value in each bank*. A bit reinterpret is the other, and it is corrected in place
+rather than deleted.
+
+Verified by EXECUTION on the riscv32 reference core, not by matching mnemonics: a
+payload whose halves differ and whose high half has the sign bit set round-trips in both
+directions. A lowering that swapped the halves, read the slot at the wrong offset, or
+sign-extended one of them emits the same instructions and a different value.
+
 ## [4.24.0] - 2026-08-21
 
 ### Added

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -309,9 +309,19 @@ fun function_needs_legalize(f: *mir.MirFunction, mach: *Machine) bool {
 # mach: the machine facts (native lane width, pointer width, shift/multiply capability)
 # ret:  true when the instruction needs legalization
 fun instr_needs_legalize(f: *mir.MirFunction, mi: *mir.MirInstr, mach: *Machine) bool {
-    # A CONVERSION IS THE ONE INSTRUCTION WITH A VALUE IN EACH BANK, so the float-bank
-    # exclusion below cannot decide it: excluding it leaves a wide INTEGER side that the
-    # planner has already split, naming lane vregs nothing defines (#2860).
+    # A CONVERSION IS THE ONE INSTRUCTION THAT REACHES HERE WITH A VALUE IN EACH BANK,
+    # so the float-bank exclusion below cannot decide it: excluding it leaves a wide
+    # INTEGER side that the planner has already split, naming lane vregs nothing
+    # defines (#2860).
+    #
+    # A BIT REINTERPRET IS THE OTHER DUAL-BANK INSTRUCTION, and it used to reach here
+    # too - as a retagged MIR_MOV that this exclusion dropped into the generic width
+    # refusal, naming an opcode the user never wrote (#2904). It no longer does: a
+    # crossing the target has no register form for is expanded into a frame round trip
+    # at MIR lowering, and what arrives here is an ordinary float move against a MEM
+    # operand plus an ordinary wide integer move against one, which the clauses below
+    # already split. The distinction is worth keeping in view - "the one instruction
+    # with a value in each bank" was the assumption that let the gap survive.
     if (conv_is_wide(mach, mi)) { ret true; }
     if (instr_rides_fp_bank(f, mi)) { ret false; }
     if (mi.width > mach.lane_width || mi.src_width > mach.lane_width) { ret true; }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -96,6 +96,7 @@ use mach.lang.me.ir.value;
 use mach.lang.source;
 use treg: mach.lang.target;
 use target: mach.lang.target.resolved;
+use isa: mach.lang.target.isa;
 
 # lower an IR module to a parallel MIR module, one MIR function per IR function
 # ---
@@ -1097,6 +1098,11 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # negate to its dedicated SSE lowering before the generic path.
     if (inst.kind == instr.OP_NEG && lctx.value_is_float(ctx, inst.ty)) {
         ret lower_float_neg(ctx, mb, inst, iid);
+    }
+    # a bit reinterpret across the register banks at a width this machine has no
+    # register-to-register form for goes through the frame instead (#2904).
+    if (inst.kind == instr.OP_BITCAST && bitcast_needs_frame(ctx, inst)) {
+        ret lower_bitcast_via_frame(ctx, mb, inst, iid);
     }
     # integer division / remainder needs the dividend / remainder register wiring
     # the active ISA's division form mandates (x86-64 IDIV/DIV reads the dividend
@@ -2169,6 +2175,97 @@ fun lower_float_op(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
 # inst: the IR float negate instruction
 # iid:  the IR instruction id
 # ret:  true on success, or a lowering / allocation error
+# whether this `:~` crosses the register banks at a width the target cannot cross in
+# one instruction (#2904)
+#
+# A BIT REINTERPRET IS THE SECOND INSTRUCTION WITH A VALUE IN EACH BANK - a conversion
+# was long treated as the only one. A same-bank `:~` is a register copy and a
+# cross-bank one selects to a plain MOV that the encoder dispatches on operand
+# register CLASS, which is true on every target that HAS the instruction. RV32 is the
+# member that does not: the D extension puts 64-bit doubles in f0-f31 while XLEN stays
+# 4, so `f64 :~ i64` is ordinary to write and `fmv.x.d` is RV64-only. It reached
+# `be.codegen.legalize` as a retagged MIR_MOV, missed the lane split because one side
+# is FP-class, and fell out into a generic width refusal naming an opcode the user
+# never wrote.
+#
+# ASKED OF THE TARGET, not derived from the widths. `flen_bits` and `gpr_width` give
+# the right answer on the riscv members by coincidence and the wrong one on x86-64,
+# where a 128-bit XMM would imply a 16-byte crossing that `movq` does not perform.
+# ---
+# ctx:  the lowering context
+# inst: the OP_BITCAST being lowered
+# ret:  true when the crossing has no register form and must go through memory
+fun bitcast_needs_frame(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
+    if (inst.operand_count < 1) { ret false; }
+
+    val dst_float: bool = lctx.value_is_float(ctx, inst.ty);
+    val src_float: bool = lctx.value_is_float(ctx, inst.operands[0].ty);
+    if (dst_float == src_float) { ret false; }
+
+    # a vector side is a different question and a different path: it rides the vector
+    # register file, whose memory crossings `vec_mem_widths` already answers.
+    if (lctx.value_is_vector(ctx, inst.ty))              { ret false; }
+    if (lctx.value_is_vector(ctx, inst.operands[0].ty))  { ret false; }
+
+    val w: u8 = lctx.op_width_of(ctx, inst.ty);
+    if (w == 0) { ret false; }
+    ret !isa.moves_cross_bank(?ctx.tgt.model, w::u32);
+}
+
+# lower a cross-bank `:~` with no register form into a frame round trip (#2904)
+#
+# A store in the SOURCE's bank followed by a load in the DESTINATION's. The bits are
+# the same in either bank, so the two halves need no conversion between them - which
+# is why this is a reinterpret and not `is_int_fp_conv`'s problem. On rv32 the pair
+# encodes as `fsd` then two `lw`, or two `sw` then `fld`, which is what a C toolchain
+# emits on this target.
+#
+# NOTHING BELOW HERE NEEDS TO KNOW. The float side is an ordinary float move against a
+# MEM operand, which the encoder already handles because a spilled side reaches it the
+# same way. The integer side is an ordinary wide integer move against a MEM operand,
+# which `be.codegen.legalize` already splits into lane-width pieces - so the wide half
+# is legalized by the machinery that was refusing it, with no new clause.
+# ---
+# ctx:  the lowering context
+# mb:   the block to append to
+# inst: the OP_BITCAST being lowered
+# iid:  its instruction id, for the result vreg
+# ret:  true on success, or an allocation error
+fun lower_bitcast_via_frame(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[bool, str] {
+    val dst: u32 = lctx.instr_vreg(ctx, iid);
+    if (dst == mir.MIR_VREG_NIL) {
+        ret R.err[bool, str]("mir.lower_ir: cross-bank reinterpret defines no result vreg");
+    }
+    val w: u8 = lctx.op_width_of(ctx, inst.ty);
+
+    # an internal slot-key vreg owns the storage; it is addressed only as a MEM base,
+    # never register-allocated. the slot is the value's own width and alignment, so
+    # both halves are naturally aligned accesses.
+    val skr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](skr)) { ret R.err[bool, str](R.unwrap_err[u32, str](skr)); }
+    val sk: u32 = R.unwrap_ok[u32, str](skr);
+
+    val ar: R.Result[bool, str] = lctx.add_spill_slot_aligned(ctx, sk, w::u64, w::u32);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+
+    val sr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (R.is_err[*mir.MirOperand, str](sr)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](sr)); }
+    val sops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](sr);
+    sops[0] = mir.op_mem_slot(sk, 0);
+    sops[1] = lctx.lower_value(ctx, inst.operands[0]);
+    var si: mir.MirInstr = mir.instr(mir.MIR_MOV, sops, 2, w, w);
+    val spr: R.Result[bool, str] = lctx.push_instr(ctx, mb, si);
+    if (R.is_err[bool, str](spr)) { ret spr; }
+
+    val lr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (R.is_err[*mir.MirOperand, str](lr)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](lr)); }
+    val lops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](lr);
+    lops[0] = mir.op_vreg(dst);
+    lops[1] = mir.op_mem_slot(sk, 0);
+    var li: mir.MirInstr = mir.instr(mir.MIR_MOV, lops, 2, w, w);
+    ret lctx.push_instr(ctx, mb, li);
+}
+
 fun lower_float_neg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[bool, str] {
     if (inst.operand_count < 1) {
         ret R.err[bool, str]("mir.lower_ir: float negate missing operand");

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21167,3 +21167,77 @@ test "mach.lang.driver:an_overlay_is_found_through_a_dotted_src_spelling" {
     fs.remove_all(?alloc, root);
     ret bad;
 }
+
+# riscv32 (#2904): a 64-bit reinterpret ACROSS THE REGISTER BANKS is lowered through a
+# frame slot and executes to the right bits on the reference core
+#
+# WHY THIS TEST EXISTS. `f64 :~ i64` did not compile on rv32 at all: it reached
+# `be.codegen.legalize` as a retagged MIR_MOV, missed the lane split because one side is
+# FP-class, and fell out into "operation wider than the target ALU is unsupported
+# (MIR_MOV, 8 bytes wide)" - naming an opcode the source never wrote and a width that is
+# not the reason.
+#
+# The reason is that a cross-bank move is as wide as BOTH banks. `fmv.x.d` moves all 64
+# bits between an f register and a GP one, so it needs a 64-bit GP register and is
+# RV64-only, while rv32gc's D extension still puts doubles in f0-f31. So the write is
+# ordinary and the register form does not exist, which is a fact about the instruction
+# set and is now declared as `xbank_widths` rather than derived from FLEN and XLEN.
+#
+# EXECUTED, NOT PATTERN-MATCHED. An instruction-sequence assertion would pass on a
+# lowering that stored the halves in the wrong order, or read the slot at the wrong
+# offset, or sign-extended one half - every one of which is a wrong VALUE and none of
+# which changes which mnemonics appear. The core runs the emitted code and the bits are
+# compared against the input.
+fun ut_rv32_xbank_src() str {
+    ret "#[symbol(\"_start\")]\nfun probe(sel: i32, v: i64) i64 {\n    val f: f64 = v :~ f64;\n    if (sel == 0) { ret f :~ i64; }\n    # a round trip through the float bank and back, so BOTH directions run in one\n    # image and a lowering that is wrong in only one of them cannot pass.\n    if (sel == 1) { val g: f64 = (f :~ i64) :~ f64; ret g :~ i64; }\n    # the width the register form DOES exist at on rv32 (fmv.w.x / fmv.x.w), so a\n    # change that routed everything through memory would still be caught here.\n    val n: i32 = v::i32;\n    val s: f32 = n :~ f32;\n    ret (s :~ i32)::i64;\n}\n";
+}
+
+test "mach.lang.driver:an_rv32_cross_bank_reinterpret_round_trips_on_the_core" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val mr: R.Result[*u8, str] = A.allocate[u8](?alloc, UT_RV32_MEM);
+    if (R.is_err[*u8, str](mr)) { session.dnit(?s); ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var bad: i32 = 0;
+    var len: u32 = 0;
+    if (!ut_rv32_build_linked(?s, ?alloc, ut_rv32_xbank_src(), "rv32", mem, ?len)) { bad = 2; }
+    or {
+        # a payload whose two halves DIFFER and whose high half has the sign bit set:
+        # a swapped pair, a truncation, or a sign-extended low half each change it.
+        val payload: u64 = 0xC0FFEE0D_DEADBEEF;
+        var steps: u32 = 0;
+
+        var got: u64 = 0;
+        if (!ut_rv32_run_g(mem, 0, payload, ?got, ?steps)) { bad = 3; }
+        or (got != payload)                                { bad = 4; }
+
+        if (bad == 0) {
+            var got2: u64 = 0;
+            if (!ut_rv32_run_g(mem, 1, payload, ?got2, ?steps)) { bad = 5; }
+            or (got2 != payload)                                { bad = 6; }
+        }
+
+        if (bad == 0) {
+            # the 4-byte case takes the REGISTER form (fmv.w.x / fmv.x.w), which rv32
+            # does have - so a change that routed every crossing through memory, or one
+            # that routed none, is caught here rather than passing quietly.
+            #
+            # The expected value is SIGN-EXTENDED: the payload's low word has bit 31
+            # set, and the trailing `::i64` widens a signed `i32`. Reading it back as a
+            # bare 0xDEADBEEF would be asserting the wrong language semantics, not a
+            # narrower check.
+            var got3: u64 = 0;
+            if (!ut_rv32_run_g(mem, 2, payload, ?got3, ?steps)) { bad = 7; }
+            or (got3 != 0xFFFFFFFFDEADBEEF)                     { bad = 8; }
+        }
+    }
+
+    A.deallocate[u8](?alloc, mem, UT_RV32_MEM);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -434,6 +434,31 @@ pub val VEC_MEM_4_8_16:  u32 = 4 + 8 + 16;
 # register, and every one of them zeroes the lanes above its operand on a load.
 pub val VEC_MEM_ALL_128: u32 = 1 + 2 + 4 + 8 + 16;
 
+# the widths, in bytes, an ISA moves between its FLOAT bank and a GP register in one
+# register-to-register instruction, when it has no such instruction at all
+#
+# Declared by a target with no float register file to cross to (mos6502), and by one
+# with no register file at all (SPIR-V). Every cross-bank reinterpret on such a target
+# is either impossible or not reached.
+pub val XBANK_NONE: u32 = 0;
+
+# the single 4-byte cross-bank move of a machine whose GP register is 4 bytes wide
+#
+# RV32: `fmv.w.x` / `fmv.x.w` exist, and their double-width siblings `fmv.d.x` /
+# `fmv.x.d` DO NOT - they move all 64 bits between an f register and a GP one, and no
+# RV32 GP register is that wide. The D extension is still in the rv32gc baseline, so
+# f0-f31 hold doubles and an `f64 :~ i64` is a perfectly ordinary thing to write; it
+# simply has no register form here and goes through the frame (#2904).
+pub val XBANK_4: u32 = 4;
+
+# both scalar float widths cross to a GP register in one instruction
+#
+# x86-64's `movd` / `movq`, aarch64's `fmov w <-> s` and `fmov x <-> d`, and RV64's
+# `fmv.w.x` / `fmv.d.x` pairs. Note that x86-64 declares 8 and not 16 even though an
+# XMM register is 128 bits wide: `movq` moves the low half, and no single instruction
+# moves a whole XMM to GP registers.
+pub val XBANK_4_8: u32 = 4 + 8;
+
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;
@@ -514,6 +539,34 @@ pub rec MachineModel {
     # still the round trip, which is the opposite of what #2716 assumed when it
     # reasoned from lane alignment rather than from the instruction set.
     vec_mem_widths:    u32;
+
+    # the widths, in bytes, this ISA moves between its FLOAT bank and a GP register in
+    # one REGISTER-TO-REGISTER instruction, as a bitmask whose bit for a width IS that
+    # width (#2904)
+    #
+    # A BIT REINTERPRET IS THE SECOND INSTRUCTION WITH A VALUE IN EACH BANK. A
+    # conversion was long treated as the only one, and a `:~` between a float and an
+    # equal-size integer was assumed to select to a plain MOV on every machine, "so no
+    # dedicated cross opcode is needed". That holds wherever the move exists. RV32 is
+    # where it does not: the D extension puts 64-bit doubles in f0-f31 while XLEN stays
+    # 4, so `f64 :~ i64` is ordinary to write and `fmv.x.d` is RV64-only.
+    #
+    # THE CONTRACT A TARGET SIGNS BY DECLARING A WIDTH: a cross-bank reinterpret at that
+    # width is a single register-to-register instruction the encoder emits, with no
+    # frame slot and no memory traffic. A width NOT declared is lowered through a frame
+    # slot instead - a store in the source's bank and a load in the destination's, which
+    # is what a C toolchain emits on such a target and what the encoder already does
+    # when one side happens to be spilled.
+    #
+    # IT DESCRIBES WHAT THE BACK END EMITS, not what the architecture has, the same way
+    # `vec_mem_widths` does. Declaring a width whose encoder form is missing turns a
+    # working frame round trip into an internal compiler error.
+    #
+    # NOT DERIVED FROM `flen_bits` AND `gpr_width`, though on the riscv members it
+    # happens to equal `min` of the two. x86-64 would derive 16 from a 128-bit XMM and
+    # be wrong: `movq` moves the low half only, and nothing moves a whole XMM to the GP
+    # bank. The question is which instructions exist, and only the target knows.
+    xbank_widths:      u32;
 
     ct_trust_mul:      bool;
 
@@ -747,8 +800,11 @@ pub fun packed_lane_cap(m: *MachineModel, lane_bits: u32) u32 {
     ret w / lane_bits;
 }
 
-# the `vec_mem_widths` bit for a width in bytes, or 0 when the width is not one this
-# encoding describes
+# the width bit for a byte count, or 0 when the width is not one this encoding
+# describes
+#
+# Shared by `vec_mem_widths` and `xbank_widths` (#2904): both are masks whose bit for
+# a width IS that width, so one mapping serves both and the two cannot drift.
 #
 # Widths are powers of two from 1 to 16, which is every width a vector register moves
 # at on any ISA here. Anything else answers 0 and therefore never matches, so a caller
@@ -781,6 +837,29 @@ pub fun moves_vector_memory(m: *MachineModel, bytes: u32) bool {
     val b: u32 = vec_mem_bit(bytes);
     if (b == 0) { ret false; }
     ret (m.vec_mem_widths & b) != 0;
+}
+
+# THE CROSS-BANK QUESTION (#2904): can this target reinterpret `bytes` between the
+# float bank and a GP register in ONE register-to-register instruction
+#
+# The single door onto `xbank_widths`, the same way `moves_vector_memory` is the only
+# door onto `vec_mem_widths`, so no caller reads the mask and - the mistake this
+# prevents - no caller re-derives the answer from `flen_bits` and `gpr_width`. Those
+# two give the right answer on the riscv members by coincidence and the wrong one on
+# x86-64, where a 128-bit XMM would imply a 16-byte move that `movq` does not perform.
+#
+# False means the frame round trip, which is correct on every target: a store in the
+# source's bank and a load in the destination's move the same bits. So a target that
+# declares nothing loses no correctness and only pays the memory traffic, which is why
+# the default is empty and why a target added later needs no change here to be right.
+# ---
+# m:     the target's machine model
+# bytes: the reinterpret width
+# ret:   true when one register-to-register instruction crosses the banks at that width
+pub fun moves_cross_bank(m: *MachineModel, bytes: u32) bool {
+    val b: u32 = vec_mem_bit(bytes);
+    if (b == 0) { ret false; }
+    ret (m.xbank_widths & b) != 0;
 }
 
 # THE PLACEMENT QUESTION (#2727): does a whole `lanes x lane_bits` vector fit in one

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -270,6 +270,9 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # internal compiler error. The encoder emits them now, so the declaration grew to
     # match - and that is the order these two have to move in, never the reverse.
     arm64_model.vec_mem_widths  = isa.VEC_MEM_ALL_128;
+    # `fmov w <-> s` and `fmov x <-> d` cross the banks at 4 and 8 (#2904). The B and H
+    # views have no GP-crossing form, and the Q view would need a register pair.
+    arm64_model.xbank_widths    = isa.XBANK_4_8;
     arm64_packed_gaps[0].op = isa.VEC_OP_MUL; arm64_packed_gaps[0].is_float = false; arm64_packed_gaps[0].lane_bits = 64;
     arm64_model.packed_gaps     = ?arm64_packed_gaps[0];
     arm64_model.packed_gap_len  = 1;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -129,6 +129,8 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
     # no vector register file, so nothing crosses between one and memory (#2716)
     mos6502_model.vec_mem_widths  = isa.VEC_MEM_NONE;
+    # no float register file to cross to, so no width crosses (#2904)
+    mos6502_model.xbank_widths    = isa.XBANK_NONE;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -2863,9 +2863,15 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         # move all 64 bits between an f register and a GP one, which needs the GP
         # register to be 64 bits - so on rv32, where FLEN is 8 and XLEN is 4, the
         # double-width pair simply has no encoding. `fmv.w.x` / `fmv.x.w` at width 4
-        # exist on both machines and are unaffected. A bitcast between `f64` and `i64`
-        # on rv32 goes through memory, which is what the psABI's own soft-float
-        # sequences do; wiring that lowering is #2860's, not this refusal's.
+        # exist on both machines and are unaffected.
+        #
+        # UNREACHABLE FROM SOURCE SINCE #2904, and kept as the tripwire it became. An
+        # `f64 :~ i64` on rv32 is now expanded at MIR lowering into a frame round trip
+        # (`fsd` then two `lw`), because rv32 declares `xbank_widths = XBANK_4` and the
+        # lowering asks. Reaching here therefore means a target declared a width whose
+        # encoder form does not exist - the hazard `xbank_widths`' own doc names - and
+        # this message says which instruction is missing rather than letting the
+        # mis-declaration surface as wrong code.
         if ((dfp || sfp) && w == 8 && xlen(st) == 4) {
             ret R.err[bool, str]("encode: rv32 has no cross-bank move for a 64-bit value (fmv.d.x / fmv.x.d are RV64-only); see briar-systems/mach#2860");
         }

--- a/src/lang/target/isa/riscv/register.mach
+++ b/src/lang/target/isa/riscv/register.mach
@@ -424,6 +424,14 @@ fun build_riscv(reg: *isa.IsaRegistry, arch_id: u32, name: str, xw: u32,
     model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
     # no vector register file, so nothing crosses between one and memory (#2716)
     model.vec_mem_widths  = isa.VEC_MEM_NONE;
+    # THE CROSS-BANK PAIR IS AS WIDE AS BOTH BANKS (#2904). `fmv.w.x` / `fmv.x.w` exist
+    # on both members; `fmv.d.x` / `fmv.x.d` move all 64 bits between an f register and
+    # a GP one, so they need a 64-bit GP register and are RV64-only. On rv32 the D
+    # extension still puts doubles in f0-f31 - `flen_bits` above says so - which is
+    # exactly what makes `f64 :~ i64` ordinary to write here and impossible to encode
+    # in a register pair. Declaring 4 alone routes it through the frame.
+    model.xbank_widths    = isa.XBANK_4;
+    if (xw == 8) { model.xbank_widths = isa.XBANK_4_8; }
     model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -110,6 +110,13 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # logical addressing: a value has no byte footprint and no register to cross from,
     # so the question this field answers does not arise here (#2716)
     spirv_model.vec_mem_widths         = isa.VEC_MEM_NONE;
+    # `OpBitcast` IS the one-instruction form, at every scalar width (#2904). There is no
+    # register file here and therefore no bank to cross: a SPIR-V bitcast reinterprets a
+    # TYPED value in place. Declaring the widths says the true thing - the reinterpret
+    # costs one instruction - and keeps this target off the frame round trip that a
+    # machine without the instruction takes. Declaring NONE would have been read as "the
+    # crossing is impossible", which is the opposite of the case.
+    spirv_model.xbank_widths           = isa.XBANK_4_8;
     # no packed-form gaps (#2726): SPIR-V's arithmetic opcodes are defined over
     # vectors of any component type and count, so `OpIMul` covers every lane width a
     # machine ISA has to special-case. The empty list is a statement about the target,

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -318,6 +318,10 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # covering it needs `pinsrd` / `pextrd`, which are SSE4.1 and this baseline is
     # SSE2, so a 12-byte vector still takes the scratch round trip.
     x64_model.vec_mem_widths  = isa.VEC_MEM_4_8_16;
+    # `movd` / `movq` cross between an XMM and a GP register at 4 and 8 (#2904). NOT 16,
+    # despite the XMM being 128 bits: `movq` moves the low half and no instruction moves
+    # a whole XMM into GP registers.
+    x64_model.xbank_widths    = isa.XBANK_4_8;
     x64_packed_gaps[0].op = isa.VEC_OP_MUL; x64_packed_gaps[0].is_float = false; x64_packed_gaps[0].lane_bits = 8;
     x64_packed_gaps[1].op = isa.VEC_OP_MUL; x64_packed_gaps[1].is_float = false; x64_packed_gaps[1].lane_bits = 32;
     x64_packed_gaps[2].op = isa.VEC_OP_MUL; x64_packed_gaps[2].is_float = false; x64_packed_gaps[2].lane_bits = 64;


### PR DESCRIPTION
Closes #2904. Refs #2860.

`f64 :~ i64` did not compile on riscv32, and the diagnostic named neither the cause nor the missing instruction:

```
error: legalize: operation wider than the target ALU is unsupported (MIR_MOV, 8 bytes wide)
```

A cross-bank move is as wide as **both** banks. `fmv.x.d` moves all 64 bits between an `f` register and a GP one, so it needs a 64-bit GP register and is RV64-only — while rv32gc's D extension still puts doubles in `f0-f31`. The write is perfectly ordinary and the register form does not exist.

## What it emits now

```
bits   (f64 :~ i64):  fsd fa0,-0x10(s0)  ->  lw a0,-0x10(s0) ; lw a1,-0xc(s0)
unbits (i64 :~ f64):  sw a0,-0x10(s0) ; sw a1,-0xc(s0)  ->  fld fa0,-0x10(s0)
narrow (f32 :~ i32):  fmv.x.w a0, fa0
```

which is what a C toolchain emits here. rv64 is untouched: `fmv.x.d` / `fmv.d.x`, single instructions.

## Smaller than the issue expected

#2904 predicted "frame and regalloc territory". It is neither. The expansion happens at **MIR lowering**, where frame slots are already materialized for aggregates, and nothing downstream needed a new clause:

- the float half is an ordinary float move against a MEM operand — the encoder already handled it, because a *spilled* side reaches it exactly the same way
- the integer half is an ordinary wide integer move against a MEM operand — which `be.codegen.legalize` already splits into lane-width pieces

So the wide half is legalized by the very machinery that was refusing it.

I also did **not** add the named refusal the issue asks for in `legalize`. With the lowering in place that path is unreachable from source, and a diagnostic no input can produce is dead code. What I did instead was correct the two comments that had become false — including the encoder's, which now documents itself as a tripwire for a target that *declares* a width whose encoder form is missing.

## The fact is declared, not derived

`MachineModel.xbank_widths` names the widths an ISA crosses between its float bank and a GP register in one instruction, read through a single accessor exactly as `vec_mem_widths` is.

Deriving it from `flen_bits` and `gpr_width` would be right on the riscv members **by coincidence** and wrong on x86-64, where a 128-bit XMM implies a 16-byte crossing that `movq` does not perform. rv32 declares 4 alone, which is why `f32 :~ i32` still takes `fmv.x.w` and only the 64-bit case goes through memory.

One declaration was wrong on the first attempt and the suite caught it: I gave SPIR-V `XBANK_NONE`, which reads as *the crossing is impossible* and sent every SPIR-V bitcast through a frame it does not have. `OpBitcast` **is** the one-instruction form at every scalar width, so SPIR-V declares them.

The assumption that let the whole gap survive was a comment: *a conversion is the one instruction with a value in each bank*. A bit reinterpret is the other one. Corrected in place rather than deleted, because that sentence is why nobody looked.

## Verification

**1510 passed, 0 failed** (1509 before). Corpus **1416/0** — x86-64, aarch64 and rv64 declare 4|8 and take the old path, so their codegen is unchanged. Fixpoint: three generations byte-identical. `tests.mach` diff purely additive.

The regression **executes on the riscv32 reference core** rather than matching mnemonics, using a payload whose halves differ and whose high half has the sign bit set. A lowering that swapped the halves, read the slot at the wrong offset, or sign-extended one of them emits *the same instructions* and a different value.

Mutation-checked, three ways, each failing differently:

| mutation | result |
|---|---|
| rv32 declares `XBANK_4_8` (the pre-fix belief) | build fails — the encoder tripwire fires |
| every crossing routed through the frame | SPIR-V test fails |
| the load reads the slot at offset 4 | **wrong value** on the core |

One thing I could not check locally: the `--target rv32` path has no execution lane beyond the reference core, so the frame round trip is proven against the core's model of rv32 rather than against hardware. The core is an independent implementation of the ISA, not the compiler's own tables, which is what makes it worth executing on.
