### PR TITLE
feat(manifest): let a target set the image stack reserve and commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### manifest: a target can set the image stack size (#2990)
+
+The PE stack reserve was a literal `0x100000`, so a mach project could not ship a
+Windows program needing more than a megabyte of stack. No flag, no workaround, while
+every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`) - and mach owns the
+PE it writes.
+
+Found from a real program: a game's `main` needed a 1,107,824-byte frame against the
+1,048,576-byte reserve, so the image died in its own prologue on every Windows machine
+while running fine on linux, which hands the main thread eight megabytes. The stack
+probe was correct throughout. Only the reserve was unreachable.
+
+```toml
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+stack_reserve = 0x800000
+stack_commit  = 0x1000
+```
+
+Both optional; omitting them reproduces today's bytes exactly. They sit on the target
+beside `base` because all three are image memory-layout parameters expressible only on
+some object formats - and because a reserve is address space rather than committed
+memory, so a small tool inheriting a large program's reserve costs nothing.
+
+**Only some formats carry one.** PE keeps both in its optional header, Mach-O keeps a
+reserve in `LC_MAIN.stacksize`; ELF has nowhere to put one and a raw flat image has no
+header. Either key on a target whose resolved object format carries none is refused
+when the manifest is read, naming the key, the target and the format - and **every
+declared target is checked, not only the one being built**, because a key checked only
+in the cell being built is a key that silently does nothing until someone builds the
+other cell months later.
+
+On Mach-O the value reaches only a position-independent image. A non-PIE one enters
+through `LC_UNIXTHREAD`, which has no stacksize member, so a stack size requested there
+is refused at link rather than dropped. That is a property of the image SHAPE rather
+than of the format, is not knowable when the manifest is read, and is therefore checked
+in the writer - two facts, two checks, each where its fact is known.
+
 ### Fixed
 
 #### target(riscv32): a 64-bit reinterpret across the register banks is lowered (#2904)

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -111,6 +111,50 @@ to whichever *declared* target matches the host.
 | `of`  | no       | Object-format override; defers to the os's format when omitted. See [Object-format override](#object-format-override). |
 | `base` | no      | Load-address override (integer). Overrides the os's default base virtual address; defers to it (`0` for `freestanding`) when omitted. |
 | `platform` | no  | Open platform tag (string), surfaced to comptime as `$mach.build.platform` (empty when unset). A support library keys its backend on it; the compiler treats it as opaque. See [Platform targets](#platform-targets-bare-metal). |
+| `stack_reserve` | no | Thread stack reserve in bytes. See [Image stack size](#image-stack-size). |
+| `stack_commit` | no | Thread stack commit in bytes. See [Image stack size](#image-stack-size). |
+
+### Image stack size
+
+`stack_reserve` and `stack_commit` set the thread stack an image asks its loader for,
+as byte counts:
+
+```toml
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+stack_reserve = 0x800000        # 8 MiB
+stack_commit  = 0x1000          # 4 KiB
+```
+
+Both are optional. Omitting them keeps the format's conventional default, so an image
+built without them is byte-identical to one built before the keys existed. On PE that
+default is a 1 MiB reserve and a 4 KiB commit.
+
+A **reserve** is address space, not committed memory, so raising it costs nothing until
+the stack is actually used. That is also why these live on the target rather than the
+artifact: two artifacts built for one target share the value, and a small tool
+inheriting a large program's reserve pays nothing for it.
+
+**Only some object formats carry a stack size.** PE keeps both in its optional header
+and Mach-O keeps a reserve in `LC_MAIN.stacksize`. ELF has nowhere to put one — a linux
+main thread's stack is the kernel's and `ulimit`'s business — and a raw flat image has
+no header at all. Either key on a target whose resolved object format carries no stack
+size is refused when the manifest is read, naming the key, the target and the format,
+before anything builds:
+
+```
+error: mach.toml: [target.lin].stack_reserve is not expressible on the `elf` object
+format, which carries no stack size in its image headers
+```
+
+Every declared target is checked, not only the one being built, so the mistake is found
+on the first build rather than whenever someone happens to build that cell.
+
+On Mach-O the value reaches only a **position-independent** image. A non-PIE one enters
+through `LC_UNIXTHREAD`, which has no stacksize member, and a stack size requested for
+such an image is refused at link rather than silently dropped.
 
 ### Accepted tuple values
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -792,6 +792,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # the writers decide what the image header needs to be from the OS's own fact,
     # never from the page size (#2895).
     opts.mapped_by_loader = tgt.os.mapped_by_loader;
+    # the image stack sizes ride the resolved target the same way, so no caller
+    # constructing options has to know about them (#2990). 0 leaves the writer's default.
+    opts.stack_reserve = tgt.stack_reserve;
+    opts.stack_commit  = tgt.stack_commit;
     var local_atoms: AtomPlan;
     init_atom_plan(?local_atoms);
     var pre_atoms: *AtomPlan = nil;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -38,6 +38,7 @@ use dwarf: mach.lang.be.codegen.dwarf;
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
 use mach.lang.build.request;
+use std.format;
 use mach.lang.diagnostic;
 use mach.lang.intern;
 use mach.lang.manifest;
@@ -565,7 +566,84 @@ pub fun load_manifest(s: *session.Session, project_root: str) R.Result[manifest.
     # edit, so leaving it to process exit made the reload unbounded (#3001).
     val mr: R.Result[manifest.Manifest, str] = manifest.parse(s.build_alloc, ?s.interner, ?t, true);
     toml.dnit(s.build_alloc, ?t);
-    ret mr;
+    if (R.is_err[manifest.Manifest, str](mr)) { ret mr; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+
+    val sk: R.Result[bool, str] = check_stack_keys(s, ?m);
+    if (R.is_err[bool, str](sk)) {
+        manifest.dnit(?m, s.build_alloc);
+        ret R.err[manifest.Manifest, str](R.unwrap_err[bool, str](sk));
+    }
+    ret R.ok[manifest.Manifest, str](m);
+}
+
+# refuse `stack_reserve` / `stack_commit` on a target whose object format cannot
+# carry one, before anything builds (#2990)
+#
+# CHECKED FOR EVERY DECLARED TARGET, not only the one being built. A key that is
+# meaningless on `[target.linux]` is a mistake whether or not today's command happens
+# to select that target, and finding it on an unrelated build is how it gets found at
+# all - the alternative is a key that silently does nothing until someone builds that
+# cell months later, which is the failure mode this whole issue is about.
+#
+# It keys on the RESOLVED object format, so an `of` override is followed rather than
+# the `os` alone; that resolution is `select_of`'s, so no mapping from os to format is
+# restated here. A target whose tuple does not resolve at all is left alone: naming a
+# stack key on it would report the wrong thing, and `select_of` reports the real
+# problem when the build reaches it.
+# ---
+# s: the session, for its interner and target registry
+# m: the parsed manifest
+# ret: true when every stack key is expressible, or the refusal naming key and target
+fun check_stack_keys(s: *session.Session, m: *manifest.Manifest) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < m.target_count) {
+        val td: *manifest.TargetDef = ?m.targets[i];
+        if (td.stack_reserve == 0 && td.stack_commit == 0) { i = i + 1; cnt; }
+
+        # the registry answers which format a tuple resolves to, so set it up on demand
+        # the way `build_project` does rather than requiring a particular call order.
+        if (isa.registered_count(?s.registry.isa) == 0) {
+            val reg_r: R.Result[bool, str] = setup_registry(?s.registry);
+            if (R.is_err[bool, str](reg_r)) { ret reg_r; }
+        }
+
+        val tr: R.Result[target.Target, str] = target.select_of(?s.registry,
+            intern_or_empty(s, td.isa), intern_or_empty(s, td.os),
+            intern_or_empty(s, td.abi), intern_or_empty(s, td.of));
+        if (R.is_err[target.Target, str](tr)) { i = i + 1; cnt; }
+        val t: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+        if (!t.of.carries_stack_size) {
+            var key: str = "stack_reserve";
+            if (td.stack_reserve == 0) { key = "stack_commit"; }
+            ret R.err[bool, str](stack_key_refusal(s, key, td.name, t.of.name));
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the interned string behind `id`, or "" when it is unset
+fun intern_or_empty(s: *session.Session, id: intern.StrId) str {
+    val o: O.Option[str] = intern.lookup(?s.interner, id);
+    if (O.is_none[str](o)) { ret ""; }
+    ret O.unwrap[str](o);
+}
+
+# the refusal message for a stack key on a format that carries none
+#
+# Names the key, the target it was written on, and the format that cannot carry it, so
+# the reader does not have to work out which of the three is the surprising one.
+fun stack_key_refusal(s: *session.Session, key: str, tname: intern.StrId, of_name: str) str {
+    val n: str = intern_or_empty(s, tname);
+    val r: R.Result[str, str] = format.sprint(s.build_alloc,
+        "mach.toml: [target.{}].{} is not expressible on the `{}` object format, which carries no stack size in its image headers",
+        n, key, of_name);
+    if (R.is_err[str, str](r)) {
+        ret "mach.toml: a stack size is not expressible on this target's object format";
+    }
+    ret R.unwrap_ok[str, str](r);
 }
 
 # build the module graph for one build selection (target,

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -211,6 +211,8 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     entry.of_name       = bu.target.of;
     entry.platform_name = bu.target.platform;
     entry.base          = bu.target.base;
+    entry.stack_reserve = bu.target.stack_reserve;
+    entry.stack_commit  = bu.target.stack_commit;
     entry.entrypoint    = bu.entry;
     entry.mode          = project.MODE_EXECUTABLE;
     if (bu.is_lib) { entry.mode = project.MODE_LIBRARY; }
@@ -588,6 +590,9 @@ pub fun select_target(p: *project.Project, t: *project.TargetEntry) R.Result[boo
     # the manifest base override rides on the resolved target; the linker's
     # os_base_addr prefers it over the os vtable's base_addr when nonzero.
     p.target.base = t.base;
+    # the image stack sizes ride the same way; 0 leaves each writer's own default (#2990)
+    p.target.stack_reserve = t.stack_reserve;
+    p.target.stack_commit  = t.stack_commit;
 
     val rcn: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "mach");
     if (R.is_err[intern.StrId, str](rcn)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rcn)); }

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -105,6 +105,9 @@ pub rec TargetEntry {
     of_name:       intern.StrId;
     platform_name: intern.StrId;
     base:          u64;
+    # image thread-stack sizes threaded from the manifest; 0 keeps the format default (#2990)
+    stack_reserve: u64;
+    stack_commit:  u64;
     entrypoint:    intern.StrId;
     mode:          BuildMode;
     opt:           TargetOpt;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21,7 +21,9 @@ use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
+use bin: mach.lang.target.of.bin;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.path;
@@ -21240,4 +21242,192 @@ test "mach.lang.driver:an_rv32_cross_bank_reinterpret_round_trips_on_the_core" {
     A.deallocate[u8](?alloc, mem, UT_RV32_MEM);
     session.dnit(?s);
     ret bad;
+}
+
+# a manifest with a stack key on an ELF target, beside a windows target that can carry one
+fun ut_manifest_stack_elf() str {
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.win]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\nstack_reserve = 8388608\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# a manifest whose stack keys sit only on a windows target
+fun ut_manifest_stack_pe() str {
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.win]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\nstack_commit = 8192\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk.exe\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# A stack key on a target whose object format carries none is refused AT LOAD (#2990).
+#
+# ELF has nowhere to put a stack size - a linux main thread's stack is the kernel's and
+# `ulimit`'s business - so the key can only ever have done nothing there. The refusal
+# names the key, the target, and the format, because the reader otherwise has to work
+# out which of the three is the surprising one.
+#
+# THE MANIFEST HERE IS VALID FOR THE TARGET SOMEONE WOULD BE BUILDING. `[target.win]`
+# carries the same key legitimately, and the load still fails on `[target.lin]`. That is
+# the point: a key checked only in the cell being built is a key that silently does
+# nothing until someone builds the other cell months later, which is the failure this
+# whole feature exists to end.
+test "mach.lang.driver:a_stack_key_on_a_format_without_one_is_refused_at_load" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+
+    var bad: i32 = 0;
+
+    val bad_root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_elf(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](bad_root_r)) { session.dnit(?s); ret 2; }
+    val bad_root: str = R.unwrap_ok[str, str](bad_root_r);
+
+    val br: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, bad_root);
+    if (R.is_ok[manifest.Manifest, str](br)) {
+        var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](br);
+        manifest.dnit(?m, ?alloc);
+        bad = 3;
+    }
+    or {
+        val msg: str = R.unwrap_err[manifest.Manifest, str](br);
+        # the three facts the message owes the reader
+        if (!str_contains(msg, "stack_reserve") && bad == 0) { bad = 4; }
+        if (!str_contains(msg, "lin")           && bad == 0) { bad = 5; }
+        if (!str_contains(msg, "elf")           && bad == 0) { bad = 6; }
+    }
+    fs.remove_all(?alloc, bad_root);
+
+    # ...and the same keys on a format that CAN carry them load clean, so the refusal
+    # is about the format rather than about the keys existing.
+    if (bad == 0) {
+        val ok_root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_pe(), ?names[0], ?texts[0], 1);
+        if (R.is_err[str, str](ok_root_r)) { session.dnit(?s); ret 7; }
+        val ok_root: str = R.unwrap_ok[str, str](ok_root_r);
+
+        val orr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, ok_root);
+        if (R.is_err[manifest.Manifest, str](orr)) { bad = 8; }
+        or {
+            var m2: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](orr);
+            # the parsed values reach the TargetDef rather than being dropped on the way
+            if (m2.target_count != 1)                    { bad = 9; }
+            or (m2.targets[0].stack_reserve != 8388608)  { bad = 10; }
+            or (m2.targets[0].stack_commit  != 8192)     { bad = 11; }
+            manifest.dnit(?m2, ?alloc);
+        }
+        fs.remove_all(?alloc, ok_root);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# The manifest key reaches the EMITTED IMAGE, across every layer in between (#2990).
+#
+# WHY THIS EXISTS AS WELL AS THE COFF WRITER TEST. That one constructs `ImageOptions`
+# directly and proves the writer honours them; this one starts from `mach.toml`. The
+# gap between the two is the whole delivery chain - TargetDef, TargetEntry, the
+# resolved Target, and the linker filling the options from it - and a mutation that
+# dropped the value in the linker passed the entire suite while the writer test stayed
+# green. A capability nothing carries end to end is a capability that does not exist.
+test "mach.lang.driver:a_manifest_stack_reserve_reaches_the_linked_pe" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_pe(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { bad = 3; }
+    or {
+        val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, "win");
+        if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 4; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            if (ut_run_codegen_ok(?p) != 0) { bad = 5; }
+            or {
+                # the resolved target must carry it before the link can
+                if (p.target.stack_reserve != 8388608) { bad = 6; }
+                or (p.target.stack_commit  != 8192)    { bad = 7; }
+                or {
+                    var res: u64 = 0;
+                    var com: u64 = 0;
+                    if (!ut_pe_stack_of(?p, ?res, ?com)) { bad = 8; }
+                    or (res != 8388608)                  { bad = 9; }
+                    or (com != 8192)                     { bad = 10; }
+                }
+            }
+            project.dnit_project(?p);
+        }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# link `p`'s objects into a PE image and read its stack reserve and commit out of the
+# PE32+ optional header
+fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
+    val alloc: *A.Allocator = p.alloc;
+    if (p.emit_len == 0) { ret false; }
+
+    val ir: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, p.emit_len::usize);
+    if (R.is_err[*of.ObjectImage, str](ir)) { ret false; }
+    val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](ir);
+    var missing: bool = false;
+    var i: u32 = 0;
+    for (i < p.emit_len) {
+        val m: *project.ModuleEntry = ?p.modules[(p.topo[i])::u32];
+        if (m.object_image == nil) { missing = true; }
+        or                         { images[i] = @m.object_image; }
+        i = i + 1;
+    }
+
+    # COFF has no in-memory capture path - only `raw` implements `emit_exec_image` -
+    # so the image goes to a temp file and is read straight back.
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "stk_pe");
+    if (R.is_err[fs.TempFile, str](tf_r)) {
+        A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+        ret false;
+    }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    var linked: bool = false;
+    if (!missing) {
+        val lr: R.Result[bool, str] = linker.link_images(p.s, ?p.target, images,
+            p.emit_len, nil::*of.DynLib, 0, fs.temp_path(?tf)::*u8, "stkprobe"::*u8,
+            linker.LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        linked = R.is_ok[bool, str](lr);
+    }
+    A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+    if (!linked) { fs.temp_close_and_remove(?tf); ret false; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret false; }
+    val img: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    var ok: bool = false;
+    if (img.len > 0x100) {
+        val pe_off: usize = bin.read_u32_le(img.data, 0x3C)::usize;
+        # PE signature (4) + COFF header (20) -> the optional header
+        val oh: usize = pe_off + 24;
+        if (oh + 96 + 8 <= img.len) {
+            @res = bin.read_u64_le(img.data, oh + 72);
+            @com = bin.read_u64_le(img.data, oh + 80);
+            ok = true;
+        }
+    }
+    ret ok;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -71,6 +71,12 @@ pub rec TargetDef {
     of:       intern.StrId;
     platform: intern.StrId;   # user-defined tag surfaced as `$mach.build.platform`; STR_NIL when unset
     base:     u64;            # first-segment load-address override; 0 (unset) defers to the os base_addr
+    # image stack sizes in bytes, beside `base` because all three are image
+    # memory-layout parameters expressible only on some object formats (#2990).
+    # 0 (unset) keeps the format's conventional default, so omitting them reproduces
+    # today's bytes exactly.
+    stack_reserve: u64;
+    stack_commit:  u64;
 }
 
 pub rec ArtifactDef {
@@ -622,7 +628,8 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     }
     if (kind == TK_TARGET) {
         ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi") || str_equals(k, "of")
-            || str_equals(k, "platform") || str_equals(k, "base");
+            || str_equals(k, "platform") || str_equals(k, "base")
+            || str_equals(k, "stack_reserve") || str_equals(k, "stack_commit");
     }
     if (kind == TK_ARTIFACT) {
         if (str_equals(k, "kind") || str_equals(k, "entry") || str_equals(k, "out")
@@ -801,6 +808,18 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         d.base     = 0;
         val base_opt: O.Option[i64] = toml.get_int(sub, "base");
         if (O.is_some[i64](base_opt)) { d.base = O.unwrap[i64](base_opt)::u64; }
+
+        # image stack sizes, byte counts (#2990). Absent leaves 0, which every writer
+        # reads as "keep the format's conventional default" - so a manifest that says
+        # nothing produces the same bytes it always did. Whether the resolved object
+        # format can carry them at all is checked once the registry can answer it; see
+        # `check_stack_keys` in the driver.
+        d.stack_reserve = 0;
+        d.stack_commit  = 0;
+        val sres_opt: O.Option[i64] = toml.get_int(sub, "stack_reserve");
+        if (O.is_some[i64](sres_opt)) { d.stack_reserve = O.unwrap[i64](sres_opt)::u64; }
+        val scom_opt: O.Option[i64] = toml.get_int(sub, "stack_commit");
+        if (O.is_some[i64](scom_opt)) { d.stack_commit = O.unwrap[i64](scom_opt)::u64; }
 
         m.targets[i] = d;
         str_free(alloc, label);

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -318,6 +318,10 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     # no manifest base override by default; the driver overwrites this from the
     # selected target's `base`, and the linker falls back to os_vt.base_addr when 0.
     t.base    = 0;
+    # likewise unset by default; the driver overwrites both from the selected
+    # target's manifest keys and each image writer keeps its own default at 0 (#2990)
+    t.stack_reserve = 0;
+    t.stack_commit  = 0;
     t.isa     = arch_vt;
     # the register-machine contract, or nil for a whole-module emitter. every stage
     # that reads it runs after `codegen_module` forks on `isa.emits_whole_module`.

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -733,6 +733,17 @@ pub rec ImageOptions {
     # fact existed, so a caller that constructs options without stating it keeps the
     # loader-mapped shape rather than silently dropping a segment.
     mapped_by_loader: bool;
+
+    # the image's thread stack reserve and commit in bytes, threaded from the target's
+    # manifest keys by the linker (#2990). 0 means UNSET and each writer keeps its
+    # format's conventional default, so an image built without them is byte-identical
+    # to one built before the keys existed.
+    #
+    # A format that carries no stack size ignores both, and a target cannot state them
+    # there at all - `OfVTable.carries_stack_size` refuses the key when the manifest is
+    # read, so a value silently doing nothing is not a reachable state.
+    stack_reserve: u64;
+    stack_commit:  u64;
 }
 
 # make executable-image options with no optional resources
@@ -744,6 +755,8 @@ pub fun image_options_default(subsystem: Subsystem) ImageOptions {
     opts.attributes = nil;
     opts.attributes_len = 0;
     opts.mapped_by_loader = true;
+    opts.stack_reserve = 0;
+    opts.stack_commit  = 0;
     ret opts;
 }
 
@@ -1158,6 +1171,21 @@ pub rec OfVTable {
     shared_input_ext:    str;
     import_address_prefix: str;
     header_in_first_segment: bool;
+
+    # true when this format's IMAGE HEADERS carry a thread stack size, so a target
+    # may state `stack_reserve` / `stack_commit` (#2990)
+    #
+    # PE carries both in the optional header; Mach-O carries a reserve in
+    # `LC_MAIN.stacksize`. ELF has nowhere to put one - a linux main thread's stack is
+    # the kernel's and `ulimit`'s business - and a raw flat image has no header at all.
+    #
+    # WHAT THIS DOES NOT PROMISE is that every image in this format has the field. A
+    # Mach-O image carries `stacksize` only through LC_MAIN; a non-PIE one enters
+    # through LC_UNIXTHREAD, which has no such member. That is a property of the image
+    # SHAPE rather than of the format, is not known when a manifest is read, and is
+    # refused by the writer instead. Two facts, two checks, each where its fact is
+    # known.
+    carries_stack_size:  bool;
     header_span:         HeaderSpanFn;
     executable_section_location: ExecutableSectionLocationFn;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3423,7 +3423,8 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     # clears RELOCS_STRIPPED and sets DYNAMIC_BASE.
     val pie: bool = dyn != nil && dyn.pie;
     val header_r: R.Result[bool, str] = write_pe_headers(buf, ?lay, segs, seg_count, entry,
-        pie, itn, dyn, debug, debug_count, image_options.subsystem);
+        pie, itn, dyn, debug, debug_count, image_options.subsystem,
+        image_options.stack_reserve, image_options.stack_commit);
     if (R.is_err[bool, str](header_r)) {
         if (resource_ptr != nil) { rs.dnit(alloc, resource_ptr); }
         A.deallocate[u8](alloc, buf, total_size);
@@ -3924,6 +3925,12 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, se
     bin.write_u32_le(buf, pos + 36, chars);
 }
 
+# the conventional PE console stack reserve and commit, used when a target states
+# neither key (#2990). Named rather than repeated so the writer's default and the
+# documentation cannot drift.
+val PE_DEFAULT_STACK_RESERVE: u64 = 0x100000;   # 1 MiB
+val PE_DEFAULT_STACK_COMMIT:  u64 = 0x1000;     # 4 KiB
+
 # write the DOS header + stub, the PE signature, the COFF file
 # header, the PE32+ optional header (ImageBase, alignments, entry, subsystem, the
 # 16 data directories), and the section table. the entry RVA is the program
@@ -3931,7 +3938,7 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, se
 # layout fixed are known
 fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32, entry: u64, pie: bool,
                      itn: *intern.Interner, dyn: *of.DynamicInfo, debug: *of.Section, debug_count: u32,
-                     subsystem: of.Subsystem) R.Result[bool, str] {
+                     subsystem: of.Subsystem, stack_reserve: u64, stack_commit: u64) R.Result[bool, str] {
     # DOS header: 'MZ', e_lfanew (offset 0x3C) -> the PE signature. the rest of
     # the DOS stub is left zero - Windows reads only the magic and e_lfanew.
     buf[0] = 'M'; buf[1] = 'Z';
@@ -3996,10 +4003,21 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     if (pie) { dllchars = dllchars | IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE; }
     bin.write_u16_le(buf, oh + 70, dllchars);
 
-    # stack/heap reserve+commit (PE32+ are 8 bytes each): 1 MiB reserve / 4 KiB
-    # commit for both, the conventional console defaults.
-    bin.write_u64_le(buf, oh + 72, 0x100000); bin.write_u64_le(buf, oh + 80, 0x1000);
-    bin.write_u64_le(buf, oh + 88, 0x100000); bin.write_u64_le(buf, oh + 96, 0x1000);
+    # stack/heap reserve+commit (PE32+ are 8 bytes each). The defaults are the
+    # conventional console ones, 1 MiB reserve / 4 KiB commit, and they are what an
+    # image gets when the manifest states nothing - so omitting the keys reproduces
+    # the bytes this writer emitted before they existed.
+    #
+    # A RESERVE IS ADDRESS SPACE, not committed memory, which is why raising it is
+    # cheap and why the value belongs on the target rather than the artifact (#2990).
+    # The heap pair keeps the literals: mach's runtime does not use the PE heap, so
+    # there is nothing for a project to tune there and no key to reach it.
+    var stack_res: u64 = PE_DEFAULT_STACK_RESERVE;
+    var stack_com: u64 = PE_DEFAULT_STACK_COMMIT;
+    if (stack_reserve != 0) { stack_res = stack_reserve; }
+    if (stack_commit  != 0) { stack_com = stack_commit; }
+    bin.write_u64_le(buf, oh + 72, stack_res); bin.write_u64_le(buf, oh + 80, stack_com);
+    bin.write_u64_le(buf, oh + 88, PE_DEFAULT_STACK_RESERVE); bin.write_u64_le(buf, oh + 96, PE_DEFAULT_STACK_COMMIT);
     bin.write_u32_le(buf, oh + 104, 0);                # LoaderFlags
     bin.write_u32_le(buf, oh + 108, IMAGE_NUMBEROF_DIRECTORY_ENTRIES);
 
@@ -4288,6 +4306,8 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     # the PE writer reserves its own header span inside the first section as
     # prefix padding, so the linker leaves no gap above the image base.
     coff_vtable.header_in_first_segment = false;
+    # the PE32+ optional header carries both the stack reserve and the commit (#2990)
+    coff_vtable.carries_stack_size = true;
     coff_vtable.executable_section_location = pe_executable_section_location;
 
     # the COFF relocation mapping and writer cover x86-64 only today.
@@ -5680,6 +5700,104 @@ test "mach.lang.target.of.coff.coff_emit_exec:subsystem_selection" {
         b = b + 1;
     }
     ret 0;
+}
+
+# The PE optional header carries the target's stack reserve and commit, and NOTHING
+# ELSE MOVES (#2990).
+#
+# The reserve was a literal `0x100000`, so a mach project could not ship a Windows
+# program needing more than a megabyte of stack - no flag, no workaround, while every
+# other linker exposes it (`/STACK`, `--stack`). A game's `main` needed 1,107,824
+# bytes against that reserve and died in its own prologue on every Windows machine
+# while running fine on linux, which hands the main thread eight megabytes.
+#
+# The byte-for-byte half is the acceptance criterion that matters most: a project that
+# states neither key must get the image it always got. Comparing whole images rather
+# than reading two fields is what proves it - a change that shifted a header, resized
+# a directory, or perturbed alignment would pass a field read and fail here.
+test "mach.lang.target.of.coff.coff_emit_exec:stack_reserve_and_commit" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    val base:  u64 = 0x140001000;
+    val entry: u64 = base + 4;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    # stated nothing: the image every build produced before the keys existed
+    var def_opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    val dr: R.Result[Vector[u8], str] = emit_stack_image(?alloc, ?i, ?isa_vt, ?segs[0], entry, ?def_opts);
+    if (R.is_err[Vector[u8], str](dr)) { ret 1; }
+    val dflt: Vector[u8] = R.unwrap_ok[Vector[u8], str](dr);
+
+    var big_opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    big_opts.stack_reserve = 0x800000;
+    big_opts.stack_commit  = 0x2000;
+    val br: R.Result[Vector[u8], str] = emit_stack_image(?alloc, ?i, ?isa_vt, ?segs[0], entry, ?big_opts);
+    if (R.is_err[Vector[u8], str](br)) { ret 1; }
+    val big: Vector[u8] = R.unwrap_ok[Vector[u8], str](br);
+
+    if (dflt.len != big.len) { ret 2; }
+
+    val pe_off: usize = bin.read_u32_le(dflt.data, 0x3C)::usize;
+    val oh:     usize = pe_off + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE;
+
+    # the default is the conventional console pair, unchanged
+    if (bin.read_u64_le(dflt.data, oh + 72) != PE_DEFAULT_STACK_RESERVE) { ret 3; }
+    if (bin.read_u64_le(dflt.data, oh + 80) != PE_DEFAULT_STACK_COMMIT)  { ret 4; }
+    # ...and the stated pair lands in the stack fields
+    if (bin.read_u64_le(big.data, oh + 72) != 0x800000) { ret 5; }
+    if (bin.read_u64_le(big.data, oh + 80) != 0x2000)   { ret 6; }
+
+    # THE HEAP PAIR IS NOT THE STACK PAIR. They sit next to each other at oh+88/+96 and
+    # take the same shape, so a fix that wrote the wrong offset would still produce a
+    # plausible-looking header; mach's runtime does not use the PE heap and no key
+    # reaches it, so both images must keep the literals.
+    if (bin.read_u64_le(big.data, oh + 88) != PE_DEFAULT_STACK_RESERVE) { ret 7; }
+    if (bin.read_u64_le(big.data, oh + 96) != PE_DEFAULT_STACK_COMMIT)  { ret 8; }
+
+    # every byte outside the two stack fields is identical
+    var b: usize = 0;
+    for (b < dflt.len) {
+        val in_stack: bool = (b >= oh + 72 && b < oh + 88);
+        if (!in_stack && dflt.data[b] != big.data[b]) { ret 9; }
+        b = b + 1;
+    }
+    ret 0;
+}
+
+# emit a one-segment static PE under `opts` and read it back, so the stack test can
+# compare two whole images byte for byte
+fun emit_stack_image(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
+                     segs: *of.LoadSegment, entry: u64, opts: *of.ImageOptions) R.Result[Vector[u8], str] {
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "coff_stack");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[Vector[u8], str]("temp create failed"); }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: R.Result[bool, str] = coff_emit_exec(alloc, itn, isa_vt, segs, 1,
+                                                 4096, segs[0].vaddr - PE_SECTION_ALIGN,
+                                                 entry, nil, 0,
+                                                 nil::*of.Section, 0, nil::*of.Section, 0,
+                                                 nil::*of.SymtabEntry, 0,
+                                                 fs.temp_path(?tf)::*u8, "coffstack"::*u8,
+                                                 @opts);
+    if (R.is_err[bool, str](em)) {
+        fs.temp_close_and_remove(?tf);
+        ret R.err[Vector[u8], str](R.unwrap_err[bool, str](em));
+    }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    ret rb;
 }
 
 # emit a one-segment static PE under `subsystem` and read it back, so the

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1662,6 +1662,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # the ELF header and program headers map at the image base ahead of the first
     # section, inside the first PT_LOAD, with no page reserved above the base.
     elf_vtable.header_in_first_segment = false;
+    # ELF has nowhere to put a stack size: a linux main thread's stack is the kernel's
+    # and `ulimit`'s business, not the image's (#2990)
+    elf_vtable.carries_stack_size = false;
     elf_vtable.executable_section_location = nil;
 
     # elf relocates and writes for every isa with an `elf_reloc_type` map.

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1543,6 +1543,9 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # Mach-O image, position-independent or not, so __TEXT lands on the base and
     # __PAGEZERO spans the whole low region below it (#2599).
     macho_vtable.header_in_first_segment = true;
+    # `LC_MAIN.stacksize` carries a reserve on a PIE image; a non-PIE LC_UNIXTHREAD
+    # image has no such member and is refused by the writer, not here (#2990)
+    macho_vtable.carries_stack_size = true;
     macho_vtable.header_span = header_span;
     macho_vtable.executable_section_location = nil;
 
@@ -1968,6 +1971,24 @@ fun reserved_header_span(segs: *of.LoadSegment, seg_count: u32,
 #             accepted for of.ExecFn conformance and ignored - Mach-O's own
 #             symbol table is `LC_SYMTAB`, not implemented here yet
 # ret:        ok(true) on success, or an error string
+# a Mach-O image that enters through LC_UNIXTHREAD carries no stack size (#2990)
+#
+# `LC_MAIN` has a `stacksize` member and `LC_UNIXTHREAD` does not, so whether THIS
+# image can carry the value depends on its entry shape, not on the format. The
+# manifest check cannot answer it - it runs before a build knows whether the image
+# will be position-independent - so the writer answers it here.
+#
+# It REFUSES rather than dropping the value. A stack size that silently does nothing
+# is the exact failure this key exists to end: a game shipped for months against a
+# reserve it could not reach, because nothing said the number was unreachable.
+# ---
+# opts: the image options carrying the requested sizes
+# ret:  ok(true) when nothing was requested, or the refusal
+fun refuse_unixthread_stack(opts: *of.ImageOptions) R.Result[bool, str] {
+    if (opts.stack_reserve == 0 && opts.stack_commit == 0) { ret R.ok[bool, str](true); }
+    ret R.err[bool, str]("macho: a stack size needs an LC_MAIN entry, and this image enters through LC_UNIXTHREAD; `stack_reserve` / `stack_commit` reach only a position-independent Mach-O image");
+}
+
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, image_base: u64, entry: u64,
               funcs: *of.ExecFunction, func_count: u32,
@@ -1977,6 +1998,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
               image_options: of.ImageOptions) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
+    # this writer's image is static and enters through LC_UNIXTHREAD, which has no
+    # stacksize member (#2990).
+    val su: R.Result[bool, str] = refuse_unixthread_stack(?image_options);
+    if (R.is_err[bool, str](su)) { ret su; }
     val arch_id: u32 = isa_vt.id;
     val ct: R.Result[u32, str] = cpu_type_for(arch_id);
     if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
@@ -3515,6 +3540,12 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # in-image absolute pointer. a non-PIE image keeps the fixed-address shape: an
     # LC_UNIXTHREAD entry and no rebase stream.
     val pie: bool = dyn.pie;
+    # a non-PIE image on this path still enters through LC_UNIXTHREAD, which carries
+    # no stacksize; refuse a requested one rather than dropping it (#2990).
+    if (!pie) {
+        val su: R.Result[bool, str] = refuse_unixthread_stack(?image_options);
+        if (R.is_err[bool, str](su)) { ret su; }
+    }
     # the rebase relocations are emitted in a deterministic (segment, offset) order so
     # the signed image is byte-identical across the self-host fixpoint.
     if (pie && dyn.base_reloc_count > 1) {
@@ -3840,11 +3871,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         bin.write_u32_le(buf, lc, LC_MAIN);
         bin.write_u32_le(buf, lc + 4, ENTRY_POINT_CMD_SIZE::u32);
         bin.write_u64_le(buf, lc + 8, entry - lay.text_va);    # entryoff
-        bin.write_u64_le(buf, lc + 16, 0);                     # stacksize
+        # stacksize: the main thread's stack reserve, or 0 to take dyld's default,
+        # which is what every image got before the key existed (#2990)
+        bin.write_u64_le(buf, lc + 16, image_options.stack_reserve);
         lc = lc + ENTRY_POINT_CMD_SIZE;
     }
     or {
         # LC_UNIXTHREAD: the static thread entry, program counter set to the entry.
+        # It carries no stacksize, so a requested one was refused before this ran.
         lc = write_unixthread(buf, lc, arch_id, entry, thread_cmd_size);
     }
 

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -301,6 +301,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.import_address_prefix = "";
     # a flat image is pure content: the loader jumps at the base, no header maps.
     raw_vtable.header_in_first_segment = false;
+    # a flat image has no header to carry one (#2990)
+    raw_vtable.carries_stack_size = false;
     raw_vtable.executable_section_location = nil;
 
     # a flat image carries no machine relocation types, so it is isa-agnostic and

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -118,6 +118,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     spv_vtable.import_address_prefix = "";
     # a SPIR-V module is not a loaded image; it has no header span to reserve.
     spv_vtable.header_in_first_segment = false;
+    # a SPIR-V module is not a loadable image and has no thread stack (#2990)
+    spv_vtable.carries_stack_size = false;
     spv_vtable.executable_section_location = nil;
 
     # only the SPIR-V ISA's whole-module emitter produces the `.spirv` section this

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -82,6 +82,11 @@ pub rec Target {
     debug:    *of.DebugVTable;
     model:    isa.MachineModel;
     base:     u64;
+    # image thread-stack sizes in bytes, threaded from the manifest's
+    # `stack_reserve` / `stack_commit`; 0 means "unset" and each writer keeps its
+    # format's conventional default, so an image is byte-identical without them (#2990)
+    stack_reserve: u64;
+    stack_commit:  u64;
     variadic_args_on_stack: bool;
     fixed_args_natural_size: bool;
 }


### PR DESCRIPTION
Closes #2990. Enables #2991.

`src/lang/target/of/coff.mach` wrote the PE stack reserve as a literal `0x100000`, so a mach project could not ship a Windows program needing more than a megabyte of stack. No flag, no workaround — while every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`), and mach owns the PE it writes.

Found from a real program: a game's `main` needed a 1,107,824-byte frame against the 1,048,576-byte reserve, so the image died in its own prologue on every Windows machine while running fine on linux, which hands the main thread eight megabytes. The stack probe was correct throughout, walking every guard page in order. Only the reserve was unreachable.

```toml
[target.windows]
isa  = "x86_64"
os   = "windows"
abi  = "win64"
stack_reserve = 0x800000
stack_commit  = 0x1000
```

## Shape

The values travel on the **resolved target**, and the linker fills the image options from it — so none of the ten-odd call sites constructing `ImageOptions` had to change, and the value cannot be lost by a caller that forgets. `ImageOptions` documents itself as the place for "future image-level options without extending every writer and linker signature again", which is exactly this.

`OfVTable.carries_stack_size` is the format's declaration: PE and Mach-O true, ELF and raw and SPIR-V false. Nothing re-derives it from the OS.

**Two checks, because there are two different facts.**

- *Can this format carry a stack size?* Known when the manifest is read, so the refusal is there — and it checks **every declared target, not only the one being built**. A key checked only in the cell being built is a key that silently does nothing until someone builds the other cell months later, which is the failure this whole feature exists to end.
- *Does this particular image have the field?* Mach-O carries `stacksize` only through `LC_MAIN`; a non-PIE image enters through `LC_UNIXTHREAD`, which has no such member. That depends on the image **shape**, is not knowable when the manifest is read, and is refused by the writer instead. It refuses rather than dropping the value, for the same reason the issue exists.

```
error: mach.toml: [target.lin].stack_reserve is not expressible on the `elf` object
format, which carries no stack size in its image headers
```

## Verification

**1513 passed, 0 failed** (1510 before). Corpus **1416/0**. Fixpoint byte-identical. `tests.mach` diff purely additive. `doc/manifest.md` documents both keys, the format restriction and the Mach-O PIE restriction.

Confirmed by **reading the emitted PE**: a declared target gets `reserve=0x800000, commit=0x2000`; a target declaring nothing gets exactly `0x100000 / 0x1000`. The writer test compares two **whole images** and asserts every byte outside the two stack fields is identical — a change that shifted a header or resized a directory would pass a field read and fail that.

It also pins the heap pair, which sits immediately after at `oh+88/+96` and takes the same shape: a fix writing the wrong offset would still produce a plausible header.

## A hole the mutation testing found

Five mutations, and the fourth is why this section exists:

| mutation | caught by |
|---|---|
| PE ignores the stated reserve | writer test |
| PE writes the stack pair into the heap offsets | writer test |
| ELF claims it carries a stack size | manifest-refusal test |
| **linker drops the values** | **nothing — passed the entire suite** |
| config drops them a layer earlier | (added test) |

The writer test proved the writer honours its options; the manifest test proved parsing and refusal. Neither covered the chain between them, so a mutation deleting the value in the linker was invisible. **A capability nothing carries end to end is a capability that does not exist.**

Fixed by adding a test that starts from `mach.toml`, builds, links to an image and reads the reserve back out of the optional header. Both previously-uncaught mutations now fail, and at distinct points in the chain.

Worth noting the mechanism: COFF has no in-memory capture path — only `raw` implements `emit_exec_image` — so unlike the rv32 probes this one links to a temp file and reads it back.
