### PR TITLE
feat(codegen): refuse a frame larger than the target's stack reserve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### codegen: a frame larger than the target's stack reserve is refused (#2991)
+
+A function whose own stack frame is larger than the target's whole stack reserve can
+never execute, on any input. mach emitted it and said nothing.
+
+Both numbers were already in hand at build time - the encoder receives the frame size
+to decide whether to emit a stack probe, the object writer writes the reserve - and
+nothing compared them. A game's `main` needed 1,107,824 bytes against the
+1,048,576-byte Windows reserve, overrunning it by 59,248 bytes before executing a
+statement. The build was clean, the PE was structurally valid, and the image died in
+its own prologue on every Windows machine. It shipped that way for months, because
+linux gives the main thread eight megabytes and hides it.
+
+```
+error: frame: `main` needs a 1107824-byte stack frame, which its target's
+1048576-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move
+the large locals off the stack
+```
+
+An error rather than a warning because it is a PROOF: one frame against one reserve,
+no call graph, no input dependence, no false positives. The rejected alternative is
+whole-call-graph depth analysis - recursion and indirect calls make cumulative depth
+undecidable, and a heuristic that reports chains which cannot happen trains people to
+ignore the one report that is exact.
+
+Equal is refused and one byte under builds: a frame exactly the size of the reserve
+leaves nothing for the caller that entered it, its return address, or the guard page
+below.
+
+The check lives with the frame layout rather than in an encoder, so it is one rule for
+every ISA rather than an x86-64 fact. It reads the reserve the image will actually get:
+what the target stated (#2990), else the format's own default, else nothing. A target
+whose stack the image does not bound - every ELF one, and a Mach-O image with no stated
+reserve, which takes dyld's default - is not checked at all, because a bound mach did
+not choose is not a bound mach may refuse a program against.
+
 ### Added
 
 #### manifest: a target can set the image stack size (#2990)

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -152,6 +152,19 @@ format, which carries no stack size in its image headers
 Every declared target is checked, not only the one being built, so the mistake is found
 on the first build rather than whenever someone happens to build that cell.
 
+A function whose own stack frame exceeds the reserve is refused at build time, naming
+the function, its frame size and the reserve:
+
+```
+error: frame: `main` needs a 1107824-byte stack frame, which its target's
+1048576-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move
+the large locals off the stack
+```
+
+That is a proof rather than an estimate - one frame against one reserve, with no call
+graph and no input dependence - so it is an error and has no false positives. Targets
+whose stack is not bounded by the image, such as every ELF target, are not checked.
+
 On Mach-O the value reaches only a **position-independent** image. A non-PIE one enters
 through `LC_UNIXTHREAD`, which has no stacksize member, and a stack size requested for
 such an image is refused at link rather than silently dropped.

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -35,6 +35,11 @@ use std.types.string.str;
 
 use O: std.types.option;
 use R: std.types.result;
+use std.allocator.page;
+use std.types.string.str_contains;
+use A: std.allocator;
+use std.format;
+use of: mach.lang.target.of;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
@@ -57,6 +62,10 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
 
     val align: u32 = stack_align(tgt);
 
+    # the reserve this target's image will actually get, or 0 when nothing bounds it
+    # at compile time. read once: it is a property of the target, not of a function.
+    val reserve: u64 = of.effective_stack_reserve(tgt.of, tgt.stack_reserve);
+
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val func: *mir.MirFunction = ?m.functions[fi];
@@ -65,10 +74,57 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
         # layout rather than racing it.
         func.frame.omit = omits_frame(func, tgt.model.frame_ptr_reg::u32,
                                       tgt.model.stack_ptr_reg::u32);
+
+        val over: R.Result[bool, str] = check_frame_fits(m, func, reserve);
+        if (R.is_err[bool, str](over)) { ret over; }
         fi = fi + 1;
     }
 
     ret R.ok[bool, str](true);
+}
+
+# refuse a function whose own frame cannot fit in the image's stack reserve (#2991)
+#
+# A PROOF, NOT AN ESTIMATE, which is why it is an error rather than a warning: one
+# frame against one reserve, no call graph, no input dependence, no false positives.
+# A function whose single frame exceeds the whole stack can never execute, on any
+# input, and mach used to emit it and say nothing - a real program shipped for months
+# needing 1,107,824 bytes against a 1,048,576-byte reserve, dying in its own prologue
+# on every Windows machine while running fine on linux, which hands the main thread
+# eight megabytes and hides it.
+#
+# THE REJECTED ALTERNATIVE is whole-call-graph depth analysis. Recursion and indirect
+# calls make cumulative depth undecidable, and a heuristic that reports chains which
+# cannot happen trains people to ignore the one report that is exact.
+#
+# EQUAL IS REFUSED. A frame exactly the size of the reserve leaves nothing for the
+# caller that entered it, the return address it was called through, or the guard page
+# the OS keeps below - so the boundary is `>=`, and one byte under it builds.
+#
+# A zero reserve means nothing bounds the stack at compile time (an ELF target's is
+# the kernel's), and the check does not run.
+# ---
+# m:       the MIR module, for the interner that names the function
+# func:    the laid-out function
+# reserve: the image's effective stack reserve, or 0 to skip
+# ret:     ok(true) when the frame fits, or the refusal naming function, size, reserve
+fun check_frame_fits(m: *mir.MirModule, func: *mir.MirFunction, reserve: u64) R.Result[bool, str] {
+    if (reserve == 0) { ret R.ok[bool, str](true); }
+    if (func.frame.size::u64 < reserve) { ret R.ok[bool, str](true); }
+
+    var name: str = "<unknown>";
+    if (m.interner != nil) {
+        val o: O.Option[str] = intern.lookup(m.interner, func.name);
+        if (O.is_some[str](o)) { name = O.unwrap[str](o); }
+    }
+
+    val r: R.Result[str, str] = format.sprint(m.alloc,
+        "frame: `{}` needs a {}-byte stack frame, which its target's {}-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move the large locals off the stack",
+        name, func.frame.size::u64, reserve);
+    if (R.is_err[str, str](r)) {
+        ret R.err[bool, str]("frame: a function's stack frame exceeds the target's stack reserve");
+    }
+    ret R.err[bool, str](R.unwrap_ok[str, str](r));
 }
 
 # report whether a function needs no compiler-generated prologue or epilogue
@@ -1166,4 +1222,94 @@ test "mach.lang.be.codegen.frame.run:stamps_the_omission_decision" {
     if (!funcs[0].frame.omit) { ret 1; }
     if (funcs[1].frame.omit)  { ret 1; }
     ret 0;
+}
+
+# The frame-versus-reserve boundary is exact, and a zero reserve does not diagnose (#2991).
+#
+# Tested here rather than through a compiled program because the boundary is the claim:
+# source big enough to produce a frame of EXACTLY the reserve is not something a test
+# can write and keep true, since the frame carries saved registers and padding the
+# author does not control. The refusal is a proof about two numbers, so the two numbers
+# are what it is checked against.
+#
+# EQUAL IS REFUSED. A frame exactly the size of the reserve leaves nothing for the
+# caller that entered it, the return address, or the guard page below - and "one byte
+# under builds" is what keeps the rule a proof rather than a margin someone tuned.
+test "mach.lang.be.codegen.frame.check_frame_fits:boundary_is_exact" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var m: mir.MirModule;
+    m.alloc        = ?alloc;
+    m.interner     = ?i;
+    m.srcmap       = nil;
+    m.functions    = nil;
+    m.function_len = 0;
+    m.function_cap = 0;
+
+    val nr: R.Result[intern.StrId, str] = intern.intern(?i, "fat");
+    if (R.is_err[intern.StrId, str](nr)) { ret 1; }
+
+    var f: mir.MirFunction;
+    f.name = R.unwrap_ok[intern.StrId, str](nr);
+
+    var bad: i32 = 0;
+
+    # one byte under the reserve builds
+    f.frame.size = 1048575;
+    if (R.is_err[bool, str](check_frame_fits(?m, ?f, 1048576)) && bad == 0) { bad = 2; }
+
+    # exactly the reserve is refused
+    f.frame.size = 1048576;
+    if (R.is_ok[bool, str](check_frame_fits(?m, ?f, 1048576)) && bad == 0) { bad = 3; }
+
+    # over it is refused, and the message owes the reader three facts: which function,
+    # how big its frame is, and what it was measured against
+    f.frame.size = 1107824;
+    val over: R.Result[bool, str] = check_frame_fits(?m, ?f, 1048576);
+    if (R.is_ok[bool, str](over)) { bad = 4; }
+    or {
+        val msg: str = R.unwrap_err[bool, str](over);
+        if (!str_contains(msg, "fat")     && bad == 0) { bad = 5; }
+        if (!str_contains(msg, "1107824") && bad == 0) { bad = 6; }
+        if (!str_contains(msg, "1048576") && bad == 0) { bad = 7; }
+    }
+
+    # A ZERO RESERVE IS "NOTHING BOUNDS THIS", not "a reserve of zero". An ELF target's
+    # stack is the kernel's and `ulimit`'s, and a Mach-O image with no stated reserve
+    # takes dyld's default - neither is a number mach put in the image, so neither may
+    # refuse a program that runs.
+    f.frame.size = 999999999;
+    if (R.is_err[bool, str](check_frame_fits(?m, ?f, 0)) && bad == 0) { bad = 8; }
+
+    ret bad;
+}
+
+# The effective reserve prefers what a target STATED over what the format defaults to (#2991).
+#
+# The three cases are ordered, and the order is what makes the check honest: a stated
+# reserve is what the writer will put in the image, a format default is what it puts in
+# when nothing is stated, and 0 means mach chose no number at all and must not pretend
+# otherwise.
+test "mach.lang.be.codegen.frame.effective_stack_reserve:stated_beats_default" {
+    var pe: of.OfVTable;
+    pe.carries_stack_size    = true;
+    pe.default_stack_reserve = 0x100000;
+
+    var elf_vt: of.OfVTable;
+    elf_vt.carries_stack_size    = false;
+    elf_vt.default_stack_reserve = 0;
+
+    var bad: i32 = 0;
+    # stated wins over the format default
+    if (of.effective_stack_reserve(?pe, 0x800000) != 0x800000)   { bad = 1; }
+    # unstated falls to the format default
+    if (of.effective_stack_reserve(?pe, 0) != 0x100000          && bad == 0) { bad = 2; }
+    # a format with no default bounds nothing when nothing is stated
+    if (of.effective_stack_reserve(?elf_vt, 0) != 0             && bad == 0) { bad = 3; }
+    # ...but a stated value still stands: the manifest already refused the key where it
+    # cannot be carried, so reaching here with one means the format carries it
+    if (of.effective_stack_reserve(?elf_vt, 0x800000) != 0x800000 && bad == 0) { bad = 4; }
+    ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21431,3 +21431,95 @@ fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
     }
     ret ok;
 }
+
+# a manifest with one windows target at the PE default reserve and one that raises it
+fun ut_manifest_stack_two() str {
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# A frame larger than the target's stack reserve fails the build, and raising the
+# reserve makes the same source build (#2991).
+#
+# The function could never execute, on any input: the prologue walks the guard pages
+# correctly right to the end of the reserve and then faults. mach knew both numbers -
+# the encoder receives the frame size to decide whether to probe, the object writer
+# writes the reserve - and never compared them, so a real program shipped for months
+# dying in its own prologue on every Windows machine while running fine on linux,
+# which hands the main thread eight megabytes and hides it.
+#
+# THE THREE CELLS ARE THE WHOLE FEATURE. The same source refuses under the PE default,
+# builds once the target raises the reserve (#2990's lever, which is why that landed
+# first), and is not diagnosed at all on ELF, whose stack is the kernel's and
+# `ulimit`'s rather than a number mach put in the image.
+test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    # a two-megabyte local, which no reasonable frame layout shrinks under a megabyte
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [2000000]u8; big[0] = 1; ret big[0]::i32; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_two(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { bad = 3; }
+    or {
+        # the PE default reserve refuses it
+        if (!ut_build_names_frame_refusal(?s, root, "small") && bad == 0) { bad = 4; }
+        # the same source, with the reserve raised, builds
+        if (ut_build_fails(?s, root, "big")                  && bad == 0) { bad = 5; }
+        # ELF bounds nothing at compile time, so no frame refusal there. the linux cell
+        # fails on its own entry symbol, which is why the assertion is about the MESSAGE
+        # rather than about success: a frame diagnostic must not be what stopped it.
+        if (ut_build_names_frame_refusal(?s, root, "lin")     && bad == 0) { bad = 6; }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# whether building `tgt` fails with the frame-exceeds-reserve refusal, naming the
+# function, its frame size and the reserve
+#
+# It asserts on the MESSAGE rather than on failure, because the linux cell fails for an
+# unrelated reason (its entry symbol) and "the build failed" would pass there while
+# proving the opposite of what this test claims.
+fun ut_build_names_frame_refusal(s: *session.Session, root: str, tgt: str) bool {
+    val msg: str = ut_codegen_fail_msg(s, root, tgt);
+    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "1048576");
+}
+
+# the failure text from building `tgt`, or "" when the build and codegen both succeed
+fun ut_codegen_fail_msg(s: *session.Session, root: str, tgt: str) str {
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, tgt);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        ret R.unwrap_err[project.Project, outcome.Fail](pr).message;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var out: str = "";
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](se)) { out = R.unwrap_err[bool, outcome.Fail](se).message; }
+    or {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_err[bool, outcome.Fail](le)) { out = R.unwrap_err[bool, outcome.Fail](le).message; }
+        or {
+            val ce: R.Result[bool, outcome.Fail] = passes.run_codegen_pass(?p);
+            if (R.is_err[bool, outcome.Fail](ce)) { out = R.unwrap_err[bool, outcome.Fail](ce).message; }
+        }
+    }
+    project.dnit_project(?p);
+    ret out;
+}
+
+# whether building `tgt` fails for any reason at all
+fun ut_build_fails(s: *session.Session, root: str, tgt: str) bool {
+    ret str_len(ut_codegen_fail_msg(s, root, tgt)) != 0;
+}

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -774,6 +774,28 @@ pub fun image_options_flagged(subsystem: Subsystem, flags: u32) ImageOptions {
     ret opts;
 }
 
+# the stack reserve an image built for `tgt` will actually get, or 0 when nothing
+# bounds it at compile time (#2991)
+#
+# Three cases, in order. A target that STATES a reserve gets that number - the manifest
+# already refused the key on a format that cannot carry it, so a stated value always
+# reaches the image. Otherwise the format's own default applies, which is PE's 1 MiB.
+# Otherwise nothing does: an ELF target's stack is the kernel's and `ulimit`'s, and a
+# Mach-O image with no stated reserve takes dyld's default, which mach did not choose.
+#
+# 0 MEANS "DO NOT DIAGNOSE", and it is the honest answer rather than a conservative
+# one: a check needs a number mach itself put in the image, and asserting a bound the
+# compiler does not own would refuse programs that run.
+# ---
+# tgt_of:        the resolved object-format vtable
+# stated:        the target's `stack_reserve`, or 0 when unstated
+# ret:           the effective reserve in bytes, or 0 when nothing bounds it
+pub fun effective_stack_reserve(tgt_of: *OfVTable, stated: u64) u64 {
+    if (stated != 0) { ret stated; }
+    if (tgt_of == nil) { ret 0; }
+    ret tgt_of.default_stack_reserve;
+}
+
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path
 #
@@ -1186,6 +1208,21 @@ pub rec OfVTable {
     # refused by the writer instead. Two facts, two checks, each where its fact is
     # known.
     carries_stack_size:  bool;
+
+    # the stack reserve THIS WRITER puts in an image whose target states none, or 0
+    # when it states nothing of its own (#2991)
+    #
+    # PE writes a 1 MiB reserve by convention, so every PE image has a bounded stack
+    # mach itself chose and a frame larger than it provably cannot run. Mach-O writes
+    # `LC_MAIN.stacksize = 0`, which means "take dyld's default" - mach does not own
+    # that number, so it declares none and a Mach-O image is only checked against a
+    # reserve its target actually stated.
+    #
+    # SEPARATE FROM `carries_stack_size` because they answer different questions. That
+    # one is whether a target MAY state a reserve; this is what the image gets when it
+    # does not. A format can carry a value it has no default for, which is exactly
+    # Mach-O.
+    default_stack_reserve: u64;
     header_span:         HeaderSpanFn;
     executable_section_location: ExecutableSectionLocationFn;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -4308,6 +4308,9 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.header_in_first_segment = false;
     # the PE32+ optional header carries both the stack reserve and the commit (#2990)
     coff_vtable.carries_stack_size = true;
+    # every PE image gets a bounded stack this writer chose, so a frame larger than it
+    # provably cannot run and is refused at build time (#2991)
+    coff_vtable.default_stack_reserve = PE_DEFAULT_STACK_RESERVE;
     coff_vtable.executable_section_location = pe_executable_section_location;
 
     # the COFF relocation mapping and writer cover x86-64 only today.

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1665,6 +1665,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # ELF has nowhere to put a stack size: a linux main thread's stack is the kernel's
     # and `ulimit`'s business, not the image's (#2990)
     elf_vtable.carries_stack_size = false;
+    elf_vtable.default_stack_reserve = 0;   # the kernel's and `ulimit`'s (#2991)
     elf_vtable.executable_section_location = nil;
 
     # elf relocates and writes for every isa with an `elf_reloc_type` map.

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1546,6 +1546,9 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # `LC_MAIN.stacksize` carries a reserve on a PIE image; a non-PIE LC_UNIXTHREAD
     # image has no such member and is refused by the writer, not here (#2990)
     macho_vtable.carries_stack_size = true;
+    # `LC_MAIN.stacksize = 0` defers to dyld's default, a number mach does not choose,
+    # so an unstated Mach-O reserve bounds nothing at compile time (#2991)
+    macho_vtable.default_stack_reserve = 0;
     macho_vtable.header_span = header_span;
     macho_vtable.executable_section_location = nil;
 

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -303,6 +303,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.header_in_first_segment = false;
     # a flat image has no header to carry one (#2990)
     raw_vtable.carries_stack_size = false;
+    raw_vtable.default_stack_reserve = 0;   # bare metal; nothing declares a stack (#2991)
     raw_vtable.executable_section_location = nil;
 
     # a flat image carries no machine relocation types, so it is isa-agnostic and

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -120,6 +120,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     spv_vtable.header_in_first_segment = false;
     # a SPIR-V module is not a loadable image and has no thread stack (#2990)
     spv_vtable.carries_stack_size = false;
+    spv_vtable.default_stack_reserve = 0;
     spv_vtable.executable_section_location = nil;
 
     # only the SPIR-V ISA's whole-module emitter produces the `.spirv` section this


### PR DESCRIPTION
Closes #2991. Builds on #2990.

A function whose own stack frame is larger than the target's whole stack reserve can never execute, on any input. mach emitted it and said nothing.

Both numbers were already in hand at build time — the encoder receives the frame size to decide whether to emit a stack probe, the object writer writes the reserve — and nothing compared them. A game's `main` needed 1,107,824 bytes against the 1,048,576-byte Windows reserve. The build was clean, the PE was structurally valid, and the image died in its own prologue on every Windows machine. It shipped that way for months, because linux gives the main thread eight megabytes and hides it.

```
error: frame: `main` needs a 1107824-byte stack frame, which its target's
1048576-byte stack reserve cannot hold; raise `stack_reserve` on the target, or
move the large locals off the stack
```

## Why an error

It is a **proof**, not an estimate: one frame against one reserve, no call graph, no input dependence, no false positives. The rejected alternative is whole-call-graph depth analysis — recursion and indirect calls make cumulative depth undecidable, and a heuristic that reports chains which cannot happen trains people to ignore the one report that is exact.

Equal is refused, one byte under builds. A frame exactly the size of the reserve leaves nothing for the caller that entered it, its return address, or the guard page below.

## Where it lives

With the **frame layout**, not in an encoder. #2991 points at `x64/encode.mach` because that is where the frame size is visible, but a frame-versus-reserve fact is not an x86-64 fact — putting it there would make one ISA's encoder the owner of a rule every ISA needs.

It reads the reserve the image will actually get, in order: what the target stated (#2990), else the format's own default, else nothing. `OfVTable.default_stack_reserve` is a second declaration alongside `carries_stack_size` because they answer different questions — that one is whether a target *may* state a reserve, this is what the image gets when it does not. A format can carry a value it has no default for, which is exactly Mach-O: it writes `LC_MAIN.stacksize = 0`, meaning "take dyld's default", a number mach did not choose and therefore may not refuse a program against.

**Zero means "do not diagnose", not "a reserve of zero".** Every ELF target, and an unstated Mach-O one, are not checked.

## Verification

**1516 passed, 0 failed** (1513 before). Corpus **1416/0**. Fixpoint byte-identical. `tests.mach` diff purely additive.

Confirmed live on three cells of one manifest, which is the whole feature: the same source is **refused** under the PE default reserve, **builds** once the target raises it, and is **not diagnosed** on ELF.

The boundary is tested as a unit rather than through compiled source, deliberately: source that yields a frame of *exactly* the reserve is not something a test can write and keep true, since the frame carries saved registers and padding the author does not control. The refusal is a claim about two numbers, so it is checked against two numbers.

Mutation-checked, four ways:

| mutation | caught by |
|---|---|
| boundary `>` instead of `>=` | boundary unit test |
| the check never runs | boundary + end-to-end |
| the zero-reserve guard removed | **unrelated ELF tests go red** — the false-positive class this design exists to avoid |
| PE declares no default reserve | end-to-end |