### PR TITLE
test: count a failed lowering pass as an error in ut_lower_clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
+
+`ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the
+lowering pass, and discarded the pass's own result. A pass that fails by **returning** an
+error rather than filing a diagnostic - the always-on IR verifier's conversion-width
+refusal, for one - was therefore invisible to it.
+
+The consequence: every `ut_lower_clean` case guarding that class was passing vacuously.
+Reintroducing #2982's defect (`lower_lit_char` stamping every character constant 8 bits
+instead of reading the type sema settled) left the whole suite green, while a real build
+of the same source refused it with exactly the reported error. The fix was correct; there
+was simply nothing holding it.
+
+The helper now treats a failed pass as an error. The guard it exists for fails when the
+defect is reintroduced, which is the property it was always assumed to have.
+
+### Fixed
+
 #### codegen: a frame larger than the target's stack reserve is refused (#2991)
 
 A function whose own stack frame is larger than the target's whole stack reserve can

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1419,7 +1419,7 @@ test "mach.lang.driver:unknown_escape_has_location" {
     ret bad;
 }
 
-# a character literal adopts the integer type supplied by its context (#2982)
+# a character literal adopts the integer type supplied by its context (#2982, #2949)
 #
 # sema already rewrites the literal's expression type during coercion. lowering
 # used to ignore that result and stamp every character constant i8, leaving a
@@ -1431,6 +1431,13 @@ test "mach.lang.driver:coerced_char_literal_lowers_at_context_width" {
     if (!ut_lower_clean("fun f() u64 { ret '0'; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_lower_clean("fun f(v: u64) u8 { ret ('0' + v % 10)::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
     if (!ut_lower_clean("fun f(v: u64) u8 { ret (v % 10 + '0')::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
+    # A WIDENING DESTINATION ON THE MIXED EXPRESSION, which neither case above reaches:
+    # the first has no binary operation and the other two truncate. #2949 reported the
+    # same defect separately and observed it fired for EVERY destination width - `::u64`
+    # included, where sema sees no conversion at all - which is what places the fault on
+    # the source side. Pinning a destination that is not a truncation keeps a later
+    # regression from passing on the narrowing cases alone.
+    if (!ut_lower_clean("fun f(v: u64) u64 { ret ('0' + v)::u64; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
     ret bad;
 }
 
@@ -7203,8 +7210,15 @@ fun ut_lower_errs(text: str) i32 {
         errs = -1;
         val sem: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
         if (R.is_ok[bool, outcome.Fail](sem)) {
-            passes.run_lower_pass(?p);
+            # A FAILED PASS IS AN ERROR EVEN WHEN IT FILED NO DIAGNOSTIC. This used to
+            # discard the lower pass's result and count the sink alone, so a pass that
+            # fails by RETURNING an error - the always-on IR verifier's conversion-width
+            # refusal, for one - read as clean. Every `ut_lower_clean` case guarding that
+            # class was therefore passing vacuously: reintroducing #2982's defect left
+            # the whole suite green while a real build of the same source refused it.
+            val low: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
             errs = ut_count_errors(?s.diags)::i32;
+            if (R.is_err[bool, outcome.Fail](low) && errs == 0) { errs = 1; }
         }
     }
 


### PR DESCRIPTION
Closes #2949.

**The reported defect is already fixed.** It is the same one as #2982, fixed on 2026-08-10 by da655f85 — one day after #2949 was filed — and #2949 was never closed. #2949's own diagnosis was right:

> Lowering appears to reconstruct the operand's type from the char literal's own 8-bit width rather than from the type sema stamped on the expression.

That is exactly what the fix changed: `lower_lit_char` hardcoded `intern_int(?ctx.m.types, 8)` and now reads `ir_type_of_expr(ctx, eid)`.

Confirmed by attribution rather than by assertion — reverting **only that hunk** on current `dev` reproduces #2949's exact repro and its exact message:

```
error: conversion width: a conversion's result width contradicts its opcode ... (in ch.main.d, at src/main.mach:2:31)
```

Every form in the issue's table builds clean on `dev`, and the values are right (`'0'`=48, `'0'+5`=53, `'0'+9`=57).

## But the regression test was not holding it

This is the part worth landing. Reverting the fix left **the entire suite green** — 1516/0 — while a real build of the same source refused it.

`ut_lower_errs` ran the lowering pass, **discarded its result**, and counted only the diagnostic sink:

```mach
passes.run_lower_pass(?p);
errs = ut_count_errors(?s.diags)::i32;
```

A pass that fails by *returning* an error rather than filing a diagnostic — which is how the always-on IR verifier refuses a contradictory conversion width — was invisible to it. So `ut_lower_clean` meant "lowering filed no diagnostics", not "lowering succeeded", and **every one of its 12 call sites guarding that class was passing vacuously.**

The helper now treats a failed pass as an error. With that, reintroducing the defect fails `coerced_char_literal_lowers_at_context_width` — the property the test was always assumed to have.

## Also

One case added: a **widening** destination on the mixed expression (`('0' + v)::u64`). The three existing cases are a bare literal with no binary operation and two truncations; none reaches a conversion that is not a narrowing. #2949 specifically observed the refusal fired for *every* destination width, `::u64` included, which is what places the fault on the source side — so a later regression should not be able to pass on the narrowing cases alone.

## Verification

**1516 passed, 0 failed.** Corpus **1416/0**. Fixpoint byte-identical.

Mutation-checked, and the mutation is the whole point: reintroducing `intern_int(..., 8)` in `lower_lit_char` passed the suite **before** this change and fails it **after**.

No compiler behaviour changes here — this is a test-harness correction plus one added case.
