### PR TITLE
test(link): sample both register-slot floats in the c-variadic golden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### test(link): the c-variadic golden samples both register-slot floats (#3043)
+
+The `floats` line reported `out[0]`, `out[3]` and `out[7]`. On win64 only the first four
+POSITIONAL slots have registers, and the two fixed parameters take two of them - so of
+those eight doubles only `out[0]` and `out[1]` ride a register and can expose a broken
+`float_dup_gp`, the rule that duplicates a tail float into the integer register of its
+slot. Eight doubles read like broad coverage of the register/stack boundary and, for
+that rule, were a **one-value check**: `out[1]` is equally broken by the same defect and
+was never printed.
+
+Found by mutation-testing the leg #3005 enabled, not by a failure. Nothing was wrong;
+the margin was simply thinner than the case looked, and the next person to weaken the
+rule had one printed value standing between them and a green run.
+
+`out[7]` stays as the stack-side control - a mutation that moved it too would mean
+something different and worse.
+
+### Fixed
+
 #### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
 
 `ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the

--- a/test/link/cases/c-variadic/expect.txt
+++ b/test/link/cases/c-variadic/expect.txt
@@ -1,7 +1,7 @@
 none=0
 mixed n=3 7 8 2500
 ptr n=1 4242
-floats n=8 1000 4000 8000
+floats n=8 1000 2000 4000 8000
 pair n=1 309
 wide n=1 1234
 indirect n=2 11 500

--- a/test/link/cases/c-variadic/src/main.mach
+++ b/test/link/cases/c-variadic/src/main.mach
@@ -56,6 +56,19 @@ fun main(argc: usize, argv: **u8) i64 {
     # MORE VARARGS THAN REGISTER SLOTS. eight doubles exhaust both AAPCS64's V bank
     # and SysV's XMM bank, so the tail crosses the register/stack boundary on the
     # legs that have one - and never touches a register at all on Apple arm64.
+    #
+    # WHICH INDICES CARRY THE WIN64 SIGNAL (mach#3043). win64 gives only the first four
+    # POSITIONAL slots registers, and the two fixed parameters (`spec`, `out`) occupy
+    # two of them - so of these eight doubles only out[0] and out[1] ride a register and
+    # can expose a broken `float_dup_gp`, the rule that duplicates a tail float into the
+    # integer register of its slot. The rest ride the stack, where there is no
+    # duplication to get wrong, and are unaffected by that rule either way.
+    #
+    # This line used to report out[0], out[3] and out[7]: one register-slot value and two
+    # stack ones. Eight doubles read like broad coverage of the register/stack boundary
+    # and, for this rule, were a ONE-VALUE check - out[1] is equally broken by the same
+    # defect and was never printed. out[7] stays as the stack-side control: a mutation
+    # that moved IT too would mean something different and worse.
     var i: u32 = 0;
     for (i < 8) {
         s[i] = 'd'::u8;
@@ -65,7 +78,7 @@ fun main(argc: usize, argv: **u8) i64 {
     val n3: i64 = va_probe(?s[0], ?out[0],
                            1.0::f64, 2.0::f64, 3.0::f64, 4.0::f64,
                            5.0::f64, 6.0::f64, 7.0::f64, 8.0::f64);
-    p.printlnf("floats n={} {} {} {}", n3, out[0], out[3], out[7]);
+    p.printlnf("floats n={} {} {} {} {}", n3, out[0], out[1], out[3], out[7]);
 
     # a 16-byte aggregate by value in the tail.
     var pr: Pair;


### PR DESCRIPTION
Closes #3043.

The `floats` line reported `out[0]`, `out[3]` and `out[7]`. On win64 only the first four **positional** slots have registers, and the two fixed parameters (`spec`, `out`) take two of them — so of those eight doubles only `out[0]` and `out[1]` ride a register and can expose a broken `float_dup_gp`, the rule duplicating a tail float into the integer register of its slot.

Eight doubles read like broad coverage of the register/stack boundary. For that rule they were a **one-value check**: `out[1]` is equally broken by the same defect and was never printed.

Found by mutation-testing the leg #3005 enabled, not by a failure — nothing is wrong today. The margin was just thinner than the case looked, and the next person to weaken the rule had a single printed value standing between them and a green run.

`out[7]` stays as the stack-side control: a mutation that moved *it* too would mean something different and worse. The comment now records which indices carry the win64 signal and why the later ones cannot, so a future edit to the printed selection does not silently delete the coverage again.

Golden updated on the one added value (`2000`, from `2.0 * 1000`); the observable stays target-independent, so one golden still holds on every leg.

**Verification:** c-variadic passes both profiles on `x86_64-linux`, 2/2 cells. The remaining legs run in CI. Test-only — no compiler change.