### PR TITLE
test: read Mach-O with an external tool on the pr lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,19 @@ jobs:
         shell: bash
         run: bash test/run.sh --runner "${{ matrix.runner }}"
 
+      # the rows this runner READS without executing: a format whose own leg runs at
+      # release cadence still gets an external parser on the lane that gates merges
+      # into dev (#2957). layers A and B only - the darwin objects are cross-built here
+      # and decoded here, and nothing pretends they ran.
+      #
+      # COFF is why this is not theoretical: x86_64-windows had a leg that had never
+      # once started, and the first layer A run over it found a section-name form llvm
+      # rejected outright, making every object with a constant pool unreadable (#2952).
+      - name: codegen corpus (decode-only rows)
+        if: matrix.decode != ''
+        shell: bash
+        run: bash test/run.sh --decode "${{ matrix.runner }}"
+
       # no --leg for the link suite: its own selection already agrees with the
       # registry, because it declines a row whose os and isa no host matches and that
       # is every `engine none` row. its spirv cases are declared `legs: x86_64-linux`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### test: Mach-O gets an external reader on the lane that gates merges (#2957)
+
+`test/engines.conf` gave both darwin rows `main` cadence, so `ci-legs.sh pr` emitted no
+darwin leg and corpus layer A - the step that runs `llvm-readobj` over a mach-produced
+object - ran on a pull request over ELF and COFF only. A change to
+`src/lang/target/of/macho.mach` could reach `dev` with **no external tool having parsed
+its output**; the first external read was the release merge. Between releases mach was
+its own only reader of a format it writes, and darwin is a shipping target.
+
+COFF is why that is not theoretical. `x86_64-windows` had a leg that had never once
+started, so nothing external had read a mach PE either - and the very first layer A run
+found the long section-name form written right-justified and space-padded, which binutils
+tolerates and llvm rejects outright. Every object with a constant pool was unreadable,
+invisible for as long as it was because no external reader had looked (#2952).
+
+The registry gains a `decode` column: a runner that BUILDS AND READS a row on the pr lane
+without executing it. Both darwin rows name `ubuntu-latest`, so their Mach-O objects are
+cross-built and decoded on every pull request while execution stays on the metered mac
+runners at release cadence. The metered-runner reason for that cadence was real and is
+untouched.
+
+**The rule is enforced, not just written down.** `config.py` refuses a registry where a
+`main`-cadence row has no `pr`-cadence reader of its object format, so a future metered
+row is a visible decision rather than an accident.
+
+Demonstrated the way #2952 was: breaking the Mach-O `cputype` turns the x86_64-darwin
+column red on the pr lane and leaves aarch64-darwin green - a selective failure rather
+than a broken harness - and restoring it returns 728 cells green. No new toolchain: the
+llvm tools layer A already requires are the ones that read it.
+
+### Fixed
+
 #### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
 
 `ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the

--- a/test/ci-legs.sh
+++ b/test/ci-legs.sh
@@ -13,7 +13,11 @@
 #
 # prints a compact JSON array the workflow feeds straight to `strategy.matrix.include`:
 #
-#   [{"runner":"ubuntu-latest","legs":"x86_64-linux riscv64-linux ...","qemu":"qemu-riscv64"}]
+#   [{"runner":"ubuntu-latest","legs":"x86_64-linux ...","qemu":"qemu-riscv64","decode":"x86_64-darwin aarch64-darwin"}]
+#
+# `decode` names the rows this runner BUILDS AND READS without executing, which is how
+# a release-cadence format keeps an external reader on the lane that gates merges into
+# `dev` (#2957). Empty when the runner reads nothing beyond its own legs.
 #
 # keys avoid hyphens so `matrix.runner` resolves in the GitHub expression context.
 # `legs` is the link suite's leg list for that runner; `qemu` names the interpreters
@@ -35,7 +39,7 @@ here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 awk -v want="$cadence" '
     /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
     {
-        name = $1; engine = $8; runner = $10; rowcadence = $11
+        name = $1; engine = $8; runner = $10; rowcadence = $11; dec = $12
         if (runner == "-") next
         if (runner in seen && cad[runner] != rowcadence) {
             printf "ci-legs.sh: runner %s carries cadence %s and %s; one runner is one job, so the rows must agree\n", runner, cad[runner], rowcadence > "/dev/stderr"
@@ -44,6 +48,13 @@ awk -v want="$cadence" '
         }
         seen[runner] = 1
         cad[runner] = rowcadence
+        # a decode assignment is independent of the cadence on this row: it names the
+        # runner that READS this row on the pr lane, which is the whole point when the
+        # row itself executes at release cadence (#2957).
+        if (dec != "-" && want == "pr") {
+            if (dec in decodes) decodes[dec] = decodes[dec] " " name; else decodes[dec] = name
+            if (!(dec in seenr)) { seenr[dec] = 1 }
+        }
         if (rowcadence != want) next
         if (runner in legs) legs[runner] = legs[runner] " " name; else { legs[runner] = name; order[++n] = runner }
         if (engine ~ /^qemu:/) {
@@ -58,7 +69,7 @@ awk -v want="$cadence" '
         for (i = 1; i <= n; i++) {
             r = order[i]
             if (i > 1) printf ","
-            printf "{\"runner\":\"%s\",\"legs\":\"%s\",\"qemu\":\"%s\"}", r, legs[r], (r in qemu ? qemu[r] : "")
+            printf "{\"runner\":\"%s\",\"legs\":\"%s\",\"qemu\":\"%s\",\"decode\":\"%s\"}", r, legs[r], (r in qemu ? qemu[r] : ""), (r in decodes ? decodes[r] : "")
         }
         printf "]\n"
     }

--- a/test/engines.conf
+++ b/test/engines.conf
@@ -19,15 +19,27 @@
 #   cadence pr (every pull request) | main (the dev -> main release merge only).
 #           rows sharing a runner share one job, so they must agree here; ci-legs.sh
 #           refuses a runner carrying two cadences rather than picking one.
+#   decode  a runner that BUILDS AND DECODES this row on the pr lane (layers A and B,
+#           never C), or - when the row already runs at pr cadence. it exists because
+#           a `main`-cadence row would otherwise have no external reader between
+#           releases, leaving mach its own only reader of a format it writes.
+#
+#           THE RULE, ENFORCED IN config.py: a row may be `main` cadence only when some
+#           `pr`-cadence row already reads its object format, either by running there
+#           or by naming a decode runner here. COFF is why this is a check and not a
+#           convention - x86_64-windows had a leg that had never once started, so the
+#           first layer A run over it found a long section-name form llvm rejected
+#           outright, making every object with a constant pool unreadable (#2952).
+#           Mach-O was in exactly that state until #2957.
 #   note    why the row reads the way it does
 #
-# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  note
-x86_64-linux      x86_64   linux         sysv64   -    bin     hosted        native             llvm-objdump  ubuntu-latest     pr       the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
-aarch64-linux     aarch64  linux         aapcs64  -    bin     hosted        native             llvm-objdump  ubuntu-24.04-arm  pr       native arm silicon: qemu cannot settle aapcs64 or page-size questions
-riscv64-linux     riscv64  linux         lp64d    -    bin     hosted        qemu:qemu-riscv64  llvm-objdump  ubuntu-latest     pr       compute evidence only, never ABI evidence
-riscv32           riscv32  freestanding  ilp32d   elf  static  direct        none               llvm-objdump  ubuntu-latest     pr       linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
-x86_64-windows    x86_64   windows       win64    -    bin     hosted        native             llvm-objdump  windows-latest    pr       no wine, anywhere, ever
-x86_64-darwin     x86_64   darwin        sysv64   -    bin     hosted        native             llvm-objdump  macos-15-intel    main     metered runner, so the release merge rather than every pull request
-aarch64-darwin    aarch64  darwin        aapcs64  -    bin     hosted        native             llvm-objdump  macos-15          main     metered runner, so the release merge rather than every pull request
-spirv             spirv    freestanding  spirv    -    bin     direct        none               spirv-dis     ubuntu-latest     pr       a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
-mos6502           mos6502  freestanding  mos6502  -    bin     freestanding  none               da65          ubuntu-latest     pr       layers A and B only, and promoting it to an execution engine is follow-up work
+# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  decode         note
+x86_64-linux      x86_64   linux         sysv64   -    bin     hosted        native             llvm-objdump  ubuntu-latest     pr     -              the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
+aarch64-linux     aarch64  linux         aapcs64  -    bin     hosted        native             llvm-objdump  ubuntu-24.04-arm  pr     -              native arm silicon: qemu cannot settle aapcs64 or page-size questions
+riscv64-linux     riscv64  linux         lp64d    -    bin     hosted        qemu:qemu-riscv64  llvm-objdump  ubuntu-latest     pr     -              compute evidence only, never ABI evidence
+riscv32           riscv32  freestanding  ilp32d   elf  static  direct        none               llvm-objdump  ubuntu-latest     pr     -              linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
+x86_64-windows    x86_64   windows       win64    -    bin     hosted        native             llvm-objdump  windows-latest    pr     -              no wine, anywhere, ever
+x86_64-darwin     x86_64   darwin        sysv64   -    bin     hosted        native             llvm-objdump  macos-15-intel    main     ubuntu-latest  metered runner, so the release merge rather than every pull request
+aarch64-darwin    aarch64  darwin        aapcs64  -    bin     hosted        native             llvm-objdump  macos-15          main     ubuntu-latest  metered runner, so the release merge rather than every pull request
+spirv             spirv    freestanding  spirv    -    bin     direct        none               spirv-dis     ubuntu-latest     pr     -              a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
+mos6502           mos6502  freestanding  mos6502  -    bin     freestanding  none               da65          ubuntu-latest     pr     -              layers A and B only, and promoting it to an execution engine is follow-up work

--- a/test/lib/config.py
+++ b/test/lib/config.py
@@ -43,11 +43,11 @@ def _rows(path):
 
 class Target(object):
     __slots__ = ("name", "isa", "os", "abi", "of", "kind", "entry",
-                 "engine", "engine_cmd", "disasm", "runner", "cadence", "note")
+                 "engine", "engine_cmd", "disasm", "runner", "cadence", "decode", "note")
 
     def __init__(self, fields, note):
         (self.name, self.isa, self.os, self.abi, self.of, self.kind,
-         self.entry, engine, self.disasm, self.runner, self.cadence) = fields
+         self.entry, engine, self.disasm, self.runner, self.cadence, self.decode) = fields
         if ":" in engine:
             self.engine, self.engine_cmd = engine.split(":", 1)
         else:
@@ -74,10 +74,10 @@ def load_engines(path):
     targets = []
     seen = set()
     for lineno, line in _rows(path):
-        fields = line.split(None, 11)
-        if len(fields) != 12:
-            raise ConfigError("%s:%d: expected 12 columns, got %d" % (path, lineno, len(fields)))
-        t = Target(fields[:11], fields[11])
+        fields = line.split(None, 12)
+        if len(fields) != 13:
+            raise ConfigError("%s:%d: expected 13 columns, got %d" % (path, lineno, len(fields)))
+        t = Target(fields[:12], fields[12])
         if t.entry not in ("hosted", "direct", "freestanding"):
             raise ConfigError("%s:%d: entry must be hosted|direct|freestanding" % (path, lineno))
         if t.kind not in ("bin", "static"):
@@ -92,7 +92,40 @@ def load_engines(path):
             raise ConfigError("%s:%d: duplicate target name %s" % (path, lineno, t.name))
         seen.add(t.name)
         targets.append(t)
+    _check_pr_reader(path, targets)
     return targets
+
+
+def _check_pr_reader(path, targets):
+    """every object format mach writes is read by an external tool on the pr lane.
+
+    A format defect is introduced on a pull request, and that is where it is cheap to
+    find. COFF is why this is a check rather than a convention: `x86_64-windows` had a
+    leg that had never once started, so nothing external had ever parsed a mach PE, and
+    the very first layer A run over it found a long section-name form that llvm rejected
+    outright - every object with a constant pool unreadable, invisible for as long as
+    it was because no external reader had looked (mach#2952).
+
+    A `main`-cadence row is therefore allowed only when some `pr`-cadence row already
+    reads its format, either by running there itself or by naming a `decode` runner
+    that builds and decodes it. The rule lives here rather than in a comment so a
+    future metered row is a visible decision instead of an accident (mach#2957).
+    """
+    reads_at_pr = set()
+    for t in targets:
+        if t.runner != "-" and t.cadence == "pr":
+            reads_at_pr.add(t.object_format)
+        if t.decode != "-":
+            reads_at_pr.add(t.object_format)
+    for t in targets:
+        if t.runner == "-" or t.cadence == "pr":
+            continue
+        if t.object_format not in reads_at_pr:
+            raise ConfigError(
+                "%s: row %s is main cadence and no pr-cadence row reads the %s format, "
+                "so a defect in it would first be seen at the release merge. give the "
+                "row a `decode` runner that reads it on the pr lane, or move it to pr "
+                "cadence." % (path, t.name, t.object_format))
 
 
 class Tool(object):

--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -30,6 +30,10 @@ USAGE = """usage: run.sh [options]
   (no options)                 every case, every target this host serves, every layer
   --runner <label>             the rows engines.conf assigns to that CI runner, which
                                this host must then be able to serve or the run refuses
+  --decode <label>             the rows engines.conf assigns that runner for DECODING
+                               only: built and read (layers a and b), never executed,
+                               so a release-cadence format still has an external reader
+                               on the pr lane
   --target <t>                 restrict to one target (repeatable)
   --case <group>/<name>        restrict to one case (repeatable)
   --layer a|b|c                restrict to one layer (repeatable)
@@ -156,7 +160,7 @@ def unservable(t, system, machine):
         t.os, t.isa, system, machine)
 
 
-def select_targets(all_targets, only, runner, layers_wanted, check=True):
+def select_targets(all_targets, only, runner, layers_wanted, check=True, decode=""):
     """which rows this run covers, and how that was decided.
 
     assignment and capability are separate questions and only one of them selects.
@@ -170,6 +174,20 @@ def select_targets(all_targets, only, runner, layers_wanted, check=True):
     system, machine = host_pair()
     machine = "aarch64" if machine == "arm64" else machine
     names = [t.name for t in all_targets]
+
+    # `--decode` is a THIRD assignment, and the narrowest: the rows a pr-cadence runner
+    # reads without executing, so a format whose own leg runs at release cadence still
+    # has an external reader on the lane that gates merges (#2957). It never selects
+    # layer C - these rows are assigned here precisely because this host cannot run
+    # them - so the capability check below does not apply and must not.
+    if decode:
+        assigned = [t for t in all_targets if t.decode == decode]
+        if not assigned:
+            die("engines.conf assigns no target to decode runner '%s'; the decode column names %s"
+                % (decode, ", ".join(sorted({t.decode for t in all_targets if t.decode != "-"})) or "nothing"))
+        notes = [("not assigned", t, "engines.conf gives it no decode row on %s" % decode)
+                 for t in all_targets if t.decode != decode]
+        return assigned, notes
 
     if runner:
         assigned = [t for t in all_targets if t.runner == runner]
@@ -231,6 +249,7 @@ def needed_tools(targets, layers_wanted, skips_by_target):
 def main(argv):
     only_targets, only_cases, only_layers = [], [], []
     runner = ""
+    decode = ""
     bless = False
     show_matrix = False
     show_tools = False
@@ -242,6 +261,11 @@ def main(argv):
             if i >= len(argv):
                 die("--runner needs a value")
             runner = argv[i]
+        elif a == "--decode":
+            i += 1
+            if i >= len(argv):
+                die("--decode needs a value")
+            decode = argv[i]
         elif a == "--target":
             i += 1
             only_targets.append(argv[i]) if i < len(argv) else die("--target needs a value")
@@ -270,6 +294,12 @@ def main(argv):
     # other would be a claim about coverage nothing produced.
     if runner and only_targets:
         die("--runner assigns the rows and so does --target; pass one")
+    if decode and (runner or only_targets):
+        die("--decode assigns the rows and so does %s; pass one"
+            % ("--runner" if runner else "--target"))
+    if decode and "c" in only_layers:
+        die("--decode reads rows this host cannot execute, so it serves layers a and b; "
+            "asking for layer c here would be a claim about coverage nothing produced")
 
     if show_tools:
         return list_tools(only_targets, runner, only_layers)
@@ -298,7 +328,7 @@ def main(argv):
 
     with OutLock(out_root):
         return run(out_root, matrix_path, only_targets, runner, only_cases,
-                   wanted_layers_arg, bless)
+                   wanted_layers_arg, bless, decode)
 
 
 def list_tools(only_targets, runner, only_layers):
@@ -333,7 +363,7 @@ def list_tools(only_targets, runner, only_layers):
     return 0
 
 
-def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bless):
+def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bless, decode=""):
     tools = config.load_tools(os.path.join(CORPUS, "tools.lock"))
     all_targets = config.load_engines(os.path.join(CORPUS, "engines.conf"))
     cases = discover_cases(only_cases)
@@ -342,7 +372,10 @@ def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bl
     wanted_layers = only_layers or list(config.LAYERS)
     if bless:
         wanted_layers = ["b"]
-    targets, notes = select_targets(all_targets, only_targets, runner, wanted_layers)
+    # a decode run reads what it cannot execute, so layer C is not on offer
+    if decode:
+        wanted_layers = [l for l in wanted_layers if l != "c"]
+    targets, notes = select_targets(all_targets, only_targets, runner, wanted_layers, decode=decode)
     if not targets:
         die("no target in engines.conf can be served by this host")
 


### PR DESCRIPTION
Closes #2957.

`test/engines.conf` gives both darwin rows `main` cadence, so `ci-legs.sh pr` emits no darwin leg and corpus **layer A** — the step that runs `llvm-readobj` over a mach-produced object — runs on a pull request over ELF and COFF only. A change to `src/lang/target/of/macho.mach` could reach `dev` with **no external tool having parsed its output**. The first external read was the release merge, so between releases mach was its own only reader of a format it writes, and darwin is a shipping target.

COFF is why that is not theoretical. `x86_64-windows` had a leg that had never once started (#2948), so nothing external had read a mach PE either — and the very first layer A run over it found the long section-name form written right-justified and space-padded, `"/      4"`, where the form is a slash followed by the decimal and nothing else. binutils tolerates the padding; `llvm-readobj` and `llvm-objdump` answer `invalid section name` and decode nothing. Every object with a section name over eight bytes was unreadable, and `.rodata.cst` is eleven — so every object with a constant pool, invisible for as long as it was because no external reader had looked (#2952).

## The change

Option 1 from the issue, which it called "the cheapest correct answer and probably the right one".

`engines.conf` gains a **`decode`** column: a runner that builds and reads a row on the pr lane **without executing it**. Both darwin rows name `ubuntu-latest`, so their Mach-O objects are cross-built and decoded on every pull request, while layer C stays on the metered mac runners at release cadence. The metered-runner reason for that cadence is real and is untouched.

The driver's model already separated *assignment* from *capability* and only layer C needs an engine, so a decode assignment fits without bending anything: `--decode <label>` selects those rows and drops layer C, and asking for `--layer c` alongside it is refused rather than silently narrowed.

**The rule is enforced, not just documented.** `config.py` refuses a registry where a `main`-cadence row has no `pr`-cadence reader of its object format:

```
test/engines.conf: row x86_64-darwin is main cadence and no pr-cadence row reads the
macho format, so a defect in it would first be seen at the release merge. give the row
a `decode` runner that reads it on the pr lane, or move it to pr cadence.
```

That is the issue's second acceptance criterion — a future metered row is a visible decision rather than an accident.

## Verification

**No new toolchain.** The llvm tools layer A already requires are the ones that read Mach-O; nothing is installed that was not already there.

Demonstrated the way #2952 was, which is the first acceptance criterion:

- clean: `--decode ubuntu-latest` runs **728 cells, 0 fail** across both darwin columns
- break the Mach-O `cputype`: **364 pass, 364 fail** — the x86_64-darwin column goes red and aarch64-darwin stays green, a *selective* failure rather than a broken harness
- restore: green again

Also checked the schema change did not disturb what already worked: the normal corpus is **1416/0**, and the link suite still passes (it reads columns 1–10 by index, all before the insertion point). The rule itself is mutation-checked — removing the decode assignment refuses the registry outright.

Per the maintainer's constraint I have deliberately **not** gone looking for Mach-O defects with this. It gives the pr lane an external reader; finding what that reader says is for CI and the people testing darwin builds.
