### PR TITLE
fix(macho): parse and resolve an x86_64 SUBTRACTOR relocation pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### link(macho): an x86_64 SUBTRACTOR relocation pair is parsed and resolved (#2973)
+
+Mach refused a normal Apple Clang x86_64 object outright:
+
+```
+error: macho: unsupported relocation type 5
+```
+
+`macho.mach` defined x86_64 relocation types 0-4 and 6-8 and had no representation for
+`X86_64_RELOC_SUBTRACTOR` at all. Apple Clang emits it constantly as an adjacent
+SUBTRACTOR + UNSIGNED pair - most visibly for a switch jump table, whose entries are
+label differences rather than addresses so the table is position-independent - so a
+vendored C translation unit compiled with `-O2` could simply fail to link.
+
+**The difference is now a first-class relocation.** `RK_DIFF32` / `RK_DIFF64` resolve
+`sym - sym2 + addend`, and `Relocation` gains `sym2`, read only for those kinds so a
+zero-initialized record stays correct everywhere else. Two symbols is the fact rather
+than an encoding detail: folding the pair away in the reader is only right when both
+sides are defined in the object being read, so a reader that folded would be correct
+until the first object that is not a jump table.
+
+The reader mirrors the paired-relocation mechanism `ARM64_RELOC_ADDEND` already used -
+the first entry stashes the subtrahend, the second does the work - including the
+accounting that matters: two entries become ONE record, so the relocation count must
+not count the consumed entry or the image carries a zero-filled trailing relocation.
+
+The linker folds the subtrahend into the addend, since `sym - sym2 + A` is
+`sym + (A - addr(sym2))`, which reuses the existing absolute appliers and their
+overflow checks rather than threading a second target through every ISA. The 32-bit
+form resolves through the SIGNED absolute, because a difference is signed whichever way
+the two labels are ordered.
+
+A difference against a symbol the link does not define is refused with its own message.
+That is correct rather than a limitation: the loader chooses that address, so the
+difference is not a link-time constant and no relocation could make it one.
+
+Malformed pairs are refused individually - a missing second half, a second half that is
+not an UNSIGNED, halves patching different addresses, two SUBTRACTORs in a row - because
+the value written depends on both halves, so guessing at one would silently patch the
+wrong arithmetic.
+
+Mach's own writer emits no SUBTRACTOR, so a difference reaching the Mach-O writer still
+refuses by the existing unsupported-kind path rather than writing something wrong.
+
+### Fixed
+
 #### test: Mach-O gets an external reader on the lane that gates merges (#2957)
 
 `test/engines.conf` gave both darwin rows `main` cadence, so `ci-legs.sh pr` emitted no

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4714,6 +4714,67 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
 # atoms:         the dead-atom plan, for the live-offset remap
 # out:           out - the symbol and owning-section location, when live
 # ret:           true when the symbol has a live location, false when atom-dropped
+# the final address of a difference relocation's SUBTRAHEND, or an error (#2973)
+#
+# `sym - sym2 + addend` needs both sides resolved, and only the minuend rides the
+# ordinary path. This resolves the other one the same two ways that path does: an
+# object-private definition through its own module's placement, and anything else by
+# the name that won the link.
+#
+# A DIFFERENCE AGAINST A DYNAMIC IMPORT IS REFUSED, and that is correct rather than a
+# limitation: the subtrahend's address is chosen by the loader, so the difference is
+# not a link-time constant and no relocation the writer could emit would make it one.
+# Apple Clang emits this form for label differences inside one object - a switch jump
+# table - where both sides are always defined here.
+# ---
+# ret: ok(the subtrahend's virtual address), or an error naming the symbol
+fun difference_subtrahend_vaddr(s: *session.Session, modules: *of.ObjectImage, m: u32,
+                                sym2: u32, placements: *Placement, sec_base: *u32,
+                                merged_to_out: *u32, out_img: *of.ObjectImage,
+                                format: *of.OfVTable, image_base: u64, atoms: *AtomPlan,
+                                sym_locs: *map.Map[intern.StrId, SymbolLoc]) R.Result[u64, str] {
+    if (sym2 >= modules[m].symbol_count) {
+        ret R.err[u64, str]("link: a difference relocation names a subtrahend outside the module's symbol table");
+    }
+    val sub: *of.Symbol = ?modules[m].symbols[sym2];
+    val sub_name: intern.StrId = sub.name;
+
+    if ((sub.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0 && sub.section != of.SECTION_EXTERNAL) {
+        var t: rel.RelocTarget = rel.target(0, 0, 0);
+        if (!local_symbol_target(modules, m, sym2, placements, sec_base, merged_to_out,
+                                 out_img, format, image_base, atoms, ?t)) {
+            ret R.err[u64, str](undef_message(s, sub_name));
+        }
+        ret R.ok[u64, str](t.vaddr);
+    }
+
+    val rn: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sub_name);
+    if (R.is_err[intern.StrId, str](rn)) {
+        ret R.err[u64, str](R.unwrap_err[intern.StrId, str](rn));
+    }
+    val resolved_name: intern.StrId = R.unwrap_ok[intern.StrId, str](rn);
+    val sl: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](sym_locs, ?resolved_name);
+    if (R.is_err[*SymbolLoc, str](sl)) {
+        ret R.err[u64, str](difference_import_message(s, sub_name));
+    }
+    ret R.ok[u64, str](R.unwrap_ok[*SymbolLoc, str](sl).vaddr);
+}
+
+# the refusal for a difference whose subtrahend is not defined in this link
+fun difference_import_message(s: *session.Session, name: intern.StrId) str {
+    val n: O.Option[str] = intern.lookup(?s.interner, name);
+    var shown: str = "<unknown>";
+    if (O.is_some[str](n)) { shown = O.unwrap[str](n); }
+    val r: R.Result[str, str] = format.sprint(s.alloc,
+        "link: a difference relocation subtracts `{}`, which this link does not define; the loader chooses its address, so the difference is not a link-time constant",
+        shown);
+    if (R.is_err[str, str](r)) {
+        ret "link: a difference relocation subtracts a symbol this link does not define";
+    }
+    ret R.unwrap_ok[str, str](r);
+}
+
+
 fun local_symbol_target(modules: *of.ObjectImage, m: u32, sy: u32,
                         placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                         out_img: *of.ObjectImage, format: *of.OfVTable,
@@ -5167,8 +5228,24 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             ri = ri + 1; cnt;
         }
 
+        # A DIFFERENCE FOLDS ITS SUBTRAHEND INTO THE ADDEND (#2973). `sym - sym2 + A`
+        # is `sym + (A - addr(sym2))`, so the absolute applier and its overflow check
+        # do the work and no ISA needs a second target threaded through it. The width
+        # carries over: DIFF32 patches four bytes signed, since a difference is signed
+        # whichever way the two labels are ordered.
+        var apply_kind: of.RelocKind = r.kind;
+        if (of.is_difference(r.kind)) {
+            val sv: R.Result[u64, str] = difference_subtrahend_vaddr(
+                s, modules, m, r.sym2, placements, sec_base, merged_to_out, out_img,
+                format, image_base, atoms, sym_locs);
+            if (R.is_err[u64, str](sv)) { ret R.err[bool, str](R.unwrap_err[u64, str](sv)); }
+            apply_addend = apply_addend - R.unwrap_ok[u64, str](sv)::i64;
+            apply_kind = of.RK_ABS32S;
+            if (r.kind == of.RK_DIFF64) { apply_kind = of.RK_ABS64; }
+        }
+
         val pr: R.Result[bool, str] =
-            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, resolved,
+            apply_one(s, apply_kind, dst, patch_off, out_img.sections[out_ix].len, resolved,
                       apply_addend, patch_va, target_name, arch, image_base);
         if (R.is_err[bool, str](pr)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](pr));

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -152,6 +152,31 @@ pub val RK_GOTPCREL_NORELAX: RelocKind = 22;
 # r_length=3), used by an absolute-immediate or pointer-sized data field.
 pub val RK_GOTPCREL64_NORELAX: RelocKind = 23;
 
+# THE DIFFERENCE OF TWO SYMBOL ADDRESSES, `sym - sym2 + addend`, written at the patch
+# site (#2973). The only kinds that read `Relocation.sym2`.
+#
+# Apple Clang emits this constantly as an adjacent `X86_64_RELOC_SUBTRACTOR` +
+# `X86_64_RELOC_UNSIGNED` pair, most visibly for a switch jump table, whose entries are
+# label differences rather than addresses so the table is position-independent. Mach-O
+# is the one format here that spells a difference as a relocation at all: ELF and COFF
+# either fold it at assembly time or use a dedicated section-relative form.
+#
+# TWO SYMBOLS IS THE FACT, not an encoding detail, which is why this widens the neutral
+# model rather than being folded away in the reader. Folding is only correct when both
+# sides are defined in the object being read, and the pair is well-formed when either
+# side is external - so a reader that folded would be right until the first object that
+# is not a jump table.
+pub val RK_DIFF32: RelocKind = 24;
+pub val RK_DIFF64: RelocKind = 25;
+
+# whether `kind` resolves the difference of two symbols, and therefore reads `sym2`
+# ---
+# kind: the relocation kind
+# ret:  true for the difference forms
+pub fun is_difference(kind: RelocKind) bool {
+    ret kind == RK_DIFF32 || kind == RK_DIFF64;
+}
+
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
 # SYM_OBJ_FLAG_GLOBAL:   visible outside the object
@@ -287,12 +312,16 @@ pub rec Symbol {
 # kind:    abstract relocation kind (one of RK_*)
 # sym:     index of the referenced symbol in the image's `symbols` array
 # addend:  constant added to the resolved symbol address
+# sym2:    index of the SUBTRAHEND symbol, read only when `is_difference(kind)` and
+#          meaningless otherwise - a zero-initialized record is therefore correct for
+#          every other kind, which is why this needs no absent sentinel (#2973)
 pub rec Relocation {
     section: u32;
     offset:  u32;
     kind:    RelocKind;
     sym:     u32;
     addend:  i64;
+    sym2:    u32;
 }
 
 # the complete, format-agnostic image the back end builds and the format writer

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -172,6 +172,10 @@ val X86_64_RELOC_SIGNED:   u32 = 1;
 val X86_64_RELOC_BRANCH:   u32 = 2;
 val X86_64_RELOC_GOT_LOAD: u32 = 3;
 val X86_64_RELOC_GOT:      u32 = 4;
+# the subtrahend half of a difference pair: this entry names the symbol SUBTRACTED,
+# and the X86_64_RELOC_UNSIGNED entry that must follow it at the same address names
+# the minuend (#2973)
+val X86_64_RELOC_SUBTRACTOR: u32 = 5;
 val X86_64_RELOC_SIGNED_1: u32 = 6;
 val X86_64_RELOC_SIGNED_2: u32 = 7;
 val X86_64_RELOC_SIGNED_4: u32 = 8;
@@ -4379,6 +4383,11 @@ fun count_relocs(buf: *u8, buf_size: usize, cputype: u32, ncmds: u32) R.Result[u
                     val word: u32 = bin.read_u32_le(buf, reloff + r::usize * RELOC_INFO_SIZE + 4);
                     val r_type: u32 = (word >> 28) & 0xF;
                     if (cputype == CPU_TYPE_ARM64 && r_type == ARM64_RELOC_ADDEND) { r = r + 1; cnt; }
+                    # a SUBTRACTOR pair is TWO entries and ONE neutral relocation, the
+                    # same accounting the ADDEND pair above needs: counting both would
+                    # leave a zero-filled trailing record and over-report reloc_count
+                    # (#2973).
+                    if (cputype == CPU_TYPE_X86_64 && r_type == X86_64_RELOC_SUBTRACTOR) { r = r + 1; cnt; }
                     total = total + 1;
                     r = r + 1;
                 }
@@ -4428,6 +4437,11 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                 val nreloc: u32 = bin.read_u32_le(buf, sh + 60);
                 var pending: i64 = 0;
                 var have_pending: bool = false;
+                # the subtrahend stashed by an X86_64_RELOC_SUBTRACTOR, waiting for the
+                # UNSIGNED entry that completes the pair (#2973)
+                var sub_sym: u32 = 0;
+                var have_sub: bool = false;
+                var sub_addr: u32 = 0;
                 var r: u32 = 0;
                 for (r < nreloc) {
                     val e: usize = reloff + r::usize * RELOC_INFO_SIZE;
@@ -4444,6 +4458,38 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                         have_pending = true;
                         r = r + 1;
                         cnt;
+                    }
+                    # THE SUBTRAHEND ARRIVES FIRST and carries no patch of its own: it
+                    # stashes the symbol to subtract, exactly as ARM64_RELOC_ADDEND above
+                    # stashes an addend, and the next entry does the work (#2973).
+                    if (cputype == CPU_TYPE_X86_64 && r_type == X86_64_RELOC_SUBTRACTOR) {
+                        if (have_sub) {
+                            ret R.err[bool, str]("macho: two X86_64_RELOC_SUBTRACTOR entries in a row; each one pairs with the UNSIGNED that follows it");
+                        }
+                        if (extn == 0) {
+                            ret R.err[bool, str]("macho: X86_64_RELOC_SUBTRACTOR is not symbol-based");
+                        }
+                        if (symnum >= nsyms) { ret R.err[bool, str]("macho: relocation symbol index out of range"); }
+                        if (r_length != 2 && r_length != 3) {
+                            ret R.err[bool, str]("macho: X86_64_RELOC_SUBTRACTOR field is neither 4 nor 8 bytes");
+                        }
+                        sub_sym  = symnum;
+                        sub_addr = address;
+                        have_sub = true;
+                        r = r + 1;
+                        cnt;
+                    }
+                    if (have_sub) {
+                        # the pair is adjacent, at one address, and its second half is an
+                        # UNSIGNED. Anything else is a malformed pair rather than a form
+                        # to guess at: the value written depends on both halves, so a
+                        # mismatched one would silently patch the wrong arithmetic.
+                        if (r_type != X86_64_RELOC_UNSIGNED) {
+                            ret R.err[bool, str]("macho: X86_64_RELOC_SUBTRACTOR is not followed by X86_64_RELOC_UNSIGNED");
+                        }
+                        if (address != sub_addr) {
+                            ret R.err[bool, str]("macho: the halves of an X86_64_RELOC_SUBTRACTOR pair patch different addresses");
+                        }
                     }
                     if (cputype == CPU_TYPE_X86_64 && x64_is_signed(r_type) && pcrel == 0) {
                         ret R.err[bool, str]("macho: x86_64 signed relocation is not pc-relative");
@@ -4489,15 +4535,35 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                         addend = R.unwrap_ok[i64, str](sa);
                     }
 
+                    var out_kind: of.RelocKind = kind;
+                    var out_sym2: u32 = 0;
+                    if (have_sub) {
+                        # the minuend keeps `sym`; the stashed subtrahend becomes `sym2`,
+                        # and the width comes off the UNSIGNED half that writes the field.
+                        if (r_length == 3)      { out_kind = of.RK_DIFF64; }
+                        or (r_length == 2)      { out_kind = of.RK_DIFF32; }
+                        or {
+                            ret R.err[bool, str]("macho: an X86_64_RELOC_SUBTRACTOR pair writes neither 4 nor 8 bytes");
+                        }
+                        out_sym2 = sub_sym;
+                    }
+
                     out.relocations[rel_i].section = sec_i;
                     out.relocations[rel_i].offset  = address;
-                    out.relocations[rel_i].kind    = kind;
+                    out.relocations[rel_i].kind    = out_kind;
                     out.relocations[rel_i].sym     = target;
                     out.relocations[rel_i].addend  = addend;
+                    out.relocations[rel_i].sym2    = out_sym2;
                     rel_i = rel_i + 1;
                     pending = 0;
                     have_pending = false;
+                    sub_sym = 0;
+                    have_sub = false;
+                    sub_addr = 0;
                     r = r + 1;
+                }
+                if (have_sub) {
+                    ret R.err[bool, str]("macho: an X86_64_RELOC_SUBTRACTOR ends the section's relocations with no UNSIGNED to pair with");
                 }
                 sec_i = sec_i + 1;
                 sh = sh + SECTION_64_SIZE;
@@ -7637,4 +7703,225 @@ test "mach.lang.target.of.macho.write_bind_info:abs64_in_place_bind" {
     p = p + 1;
     if (p != end) { ret 1; }
     ret 0;
+}
+
+# emit the same minimal x86_64 object `ts_x64_roundtrip` builds and hand back its bytes
+#
+# Shared by the SUBTRACTOR tests, which need a REAL emitted object to patch rather than
+# a hand-built buffer: everything the parser walks to reach the relocation array - the
+# header, the segment command, the section table, the symbol table - is then genuine,
+# and only the entries under test are synthetic.
+# ---
+# ret: true when the object was emitted and read back into `out`
+fun t_emit_x64_object(alloc: *A.Allocator, i: *intern.Interner, out: *Vector[u8]) bool {
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [24]u8;
+    var k: usize = 0;
+    for (k < 24) { text_bytes[k] = 0; k = k + 1; }
+    text_bytes[0] = 0xE8;
+    var data_bytes: [8]u8;
+    k = 0;
+    for (k < 8) { data_bytes[k] = 0; k = k + 1; }
+
+    var secs: [2]of.Section;
+    secs[0].name = t_intern(i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 24; secs[0].align = 16;
+    secs[1].name = t_intern(i, ".data"); secs[1].kind = of.SK_DATA;
+    secs[1].bytes = ?data_bytes[0]; secs[1].len = 8; secs[1].align = 8;
+
+    var syms: [3]of.Symbol;
+    syms[0].name = t_intern(i, "_main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 24; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(i, "g"); syms[1].section = 1; syms[1].offset = 0;
+    syms[1].size = 8; syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    syms[2].name = t_intern(i, "ext_func"); syms[2].section = of.SECTION_EXTERNAL;
+    syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
+
+    var relocs: [3]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 1;  relocs[0].kind = of.RK_PLT32;
+    relocs[0].sym = 2; relocs[0].addend = -4;
+    relocs[1].section = 0; relocs[1].offset = 8;  relocs[1].kind = of.RK_PC32;
+    relocs[1].sym = 1; relocs[1].addend = -4;
+    relocs[2].section = 0; relocs[2].offset = 16; relocs[2].kind = of.RK_ABS64;
+    relocs[2].sym = 1; relocs[2].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = alloc;
+    img.interner = i;
+    img.name = t_intern(i, "test");
+    img.sections = ?secs[0]; img.section_count = 2;
+    img.symbols = ?syms[0]; img.symbol_count = 3;
+    img.relocations = ?relocs[0]; img.reloc_count = 3;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_sub");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret false; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret false; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret false; }
+    @out = R.unwrap_ok[Vector[u8], str](rb);
+    ret true;
+}
+
+# rewrite one relocation_info entry in an emitted Mach-O buffer
+#
+# The parse side is what #2973 changed, and mach's own writer emits no SUBTRACTOR - so
+# a round trip cannot produce the input under test. Patching the entries of a REAL
+# emitted object is the next best thing and better than a hand-built buffer: every
+# other structure the parser walks to reach the relocations is genuine.
+# ---
+# buf:      the emitted object bytes
+# reloff:   the section's relocation array file offset
+# idx:      which entry to rewrite
+# address:  r_address
+# symnum:   r_symbolnum
+# pcrel:    r_pcrel
+# length:   r_length (log2 of the field width)
+# extn:     r_extern
+# r_type:   the machine relocation type
+fun t_put_reloc(buf: *u8, reloff: usize, idx: u32, address: u32, symnum: u32,
+                pcrel: u32, length: u32, extn: u32, r_type: u32) {
+    val e: usize = reloff + idx::usize * RELOC_INFO_SIZE;
+    bin.write_u32_le(buf, e, address);
+    bin.write_u32_le(buf, e + 4, (symnum & 0xFFFFFF) | (pcrel << 24) | (length << 25)
+                                  | (extn << 27) | (r_type << 28));
+}
+
+# the file offset and count of the first section's relocation array in an emitted
+# object, found by walking the load commands the way the parser does
+fun t_first_reloff(buf: *u8, out_n: *u32) usize {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val cmd: u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SEGMENT_64) {
+            val nsects: u32 = bin.read_u32_le(buf, off + 64);
+            if (nsects > 0) {
+                val sh: usize = off + SEGMENT_CMD_64_SIZE;
+                @out_n = bin.read_u32_le(buf, sh + 60);
+                ret bin.read_u32_le(buf, sh + 56)::usize;
+            }
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+    @out_n = 0;
+    ret 0;
+}
+
+# An adjacent SUBTRACTOR + UNSIGNED pair folds into one difference relocation (#2973).
+#
+# Mach 4.18.1 refused a normal Apple Clang x86_64 object with `unsupported relocation
+# type 5`. Apple Clang emits the pair constantly - most visibly for a switch jump
+# table, whose entries are label differences rather than addresses so the table is
+# position-independent - and mach defined types 0-4 and 6-8 with no representation for
+# 5 at all.
+#
+# TWO ENTRIES BECOME ONE RECORD, which is the part with teeth: the minuend keeps `sym`,
+# the subtrahend becomes `sym2`, and `reloc_count` must not count the consumed entry or
+# the image carries a zero-filled trailing relocation. The ARM64_RELOC_ADDEND pair
+# already had that accounting and this one needs the same.
+test "mach.lang.target.of.macho:x64_subtractor_pair_folds_to_a_difference" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var buf: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?buf)) { ret 1; }
+
+    var nreloc: u32 = 0;
+    val reloff: usize = t_first_reloff(buf.data, ?nreloc);
+    if (reloff == 0 || nreloc < 2) { ret 2; }
+
+    # entry 0 subtracts symbol 1 (`g`), entry 1 adds symbol 0 (`_main`), both at the
+    # 8-byte field at offset 16 - the shape a jump-table entry has.
+    t_put_reloc(buf.data, reloff, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(buf.data, reloff, 1, 16, 0, 0, 3, 1, X86_64_RELOC_UNSIGNED);
+    var z: u32 = 2;
+    for (z < nreloc) {
+        # the remaining entries are harmless absolutes at a distinct address
+        t_put_reloc(buf.data, reloff, z, 0, 0, 0, 3, 1, X86_64_RELOC_UNSIGNED);
+        z = z + 1;
+    }
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 3; }
+
+    var bad: i32 = 0;
+    # the pair produced ONE record, so the count is one below the entry count
+    if (out.reloc_count != nreloc - 1 && bad == 0) { bad = 4; }
+
+    var saw: bool = false;
+    var rj: u32 = 0;
+    for (rj < out.reloc_count) {
+        val rr: *of.Relocation = ?out.relocations[rj];
+        if (rr.kind == of.RK_DIFF64) {
+            saw = true;
+            if (rr.offset != 16 && bad == 0) { bad = 5; }
+            # r_length 3 is the 8-byte field, so the fold must pick the 64-bit form
+            if (!of.is_difference(rr.kind) && bad == 0) { bad = 6; }
+        }
+        rj = rj + 1;
+    }
+    if (!saw && bad == 0) { bad = 7; }
+
+    ret bad;
+}
+
+# A malformed SUBTRACTOR pair is refused rather than guessed at (#2973).
+#
+# The value written depends on BOTH halves, so a pair whose second half is missing, is
+# not an UNSIGNED, or patches a different address would silently produce the wrong
+# arithmetic at the patch site. Each is named separately because each is a different
+# way for a producer to be wrong.
+test "mach.lang.target.of.macho:a_malformed_subtractor_pair_is_refused" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var bad: i32 = 0;
+
+    # a SUBTRACTOR followed by something that is not an UNSIGNED
+    var b1: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b1)) { ret 1; }
+    var n1: u32 = 0;
+    val o1: usize = t_first_reloff(b1.data, ?n1);
+    if (o1 == 0 || n1 < 2) { ret 2; }
+    t_put_reloc(b1.data, o1, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(b1.data, o1, 1, 16, 0, 1, 2, 1, X86_64_RELOC_BRANCH);
+    var out1: of.ObjectImage;
+    if (R.is_ok[bool, str](parse_object(?alloc, ?i, b1.data, b1.len, ?out1)) && bad == 0) { bad = 3; }
+
+    # the two halves patching different addresses
+    var b2: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b2)) { ret 4; }
+    var n2: u32 = 0;
+    val o2: usize = t_first_reloff(b2.data, ?n2);
+    if (o2 == 0 || n2 < 2) { ret 5; }
+    t_put_reloc(b2.data, o2, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(b2.data, o2, 1, 8,  0, 0, 3, 1, X86_64_RELOC_UNSIGNED);
+    var out2: of.ObjectImage;
+    if (R.is_ok[bool, str](parse_object(?alloc, ?i, b2.data, b2.len, ?out2)) && bad == 0) { bad = 6; }
+
+    # two SUBTRACTOR entries in a row
+    var b3: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b3)) { ret 7; }
+    var n3: u32 = 0;
+    val o3: usize = t_first_reloff(b3.data, ?n3);
+    if (o3 == 0 || n3 < 2) { ret 8; }
+    t_put_reloc(b3.data, o3, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(b3.data, o3, 1, 16, 0, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    var out3: of.ObjectImage;
+    if (R.is_ok[bool, str](parse_object(?alloc, ?i, b3.data, b3.len, ?out3)) && bad == 0) { bad = 9; }
+
+    ret bad;
 }


### PR DESCRIPTION
Closes #2973.

Mach refused a normal Apple Clang x86_64 Mach-O object outright:

```
error: macho: unsupported relocation type 5
```

`macho.mach` defined x86_64 relocation types 0–4 and 6–8 and had **no representation for `X86_64_RELOC_SUBTRACTOR` at all**. Apple Clang emits it constantly as an adjacent SUBTRACTOR + UNSIGNED pair — most visibly for a switch jump table, whose entries are label differences rather than addresses so the table is position-independent — so a vendored C translation unit compiled with `-O2` could simply fail to link.

## The difference is a first-class relocation, not a fold

`RK_DIFF32` / `RK_DIFF64` resolve `sym - sym2 + addend`, and `Relocation` gains `sym2`, read only when `is_difference(kind)` — so a zero-initialized record stays correct for every other kind and no absent sentinel is needed.

**Two symbols is the fact, not an encoding detail.** Folding the pair away in the reader is only correct when both sides are defined in the object being read. That is true of a jump table and not true in general, so a reader that folded would be right until the first object that is not one. The issue asks for the same thing: preserve minuend, subtrahend, width and targets in the neutral model, resolve at link.

## Reader

Mirrors the paired-relocation mechanism `ARM64_RELOC_ADDEND` already used: the first entry stashes state and the second does the work. Including the accounting that has teeth — **two entries become one record**, so `count_relocs` must not count the consumed entry, or the image carries a zero-filled trailing relocation. The ADDEND pair already needed that and this one needs the same.

## Linker

`sym - sym2 + A` is `sym + (A - addr(sym2))`, so the subtrahend folds into the addend and the existing absolute appliers do the work with their overflow checks — no second target threaded through every ISA. The 32-bit form resolves through the **signed** absolute, since a difference is signed whichever way the two labels are ordered.

A difference against a symbol this link does not define is refused with its own message. That is correct rather than a limitation: the loader chooses that address, so the difference is not a link-time constant and no relocation could make it one.

## Verification

**1518 passed, 0 failed** (1516 before). Corpus **1416/0**. Fixpoint byte-identical.

The tests patch the relocation entries of a **real mach-emitted object** rather than hand-building a buffer, so every structure the parser walks to reach them — header, segment command, section table, symbol table — is genuine, and only the entries under test are synthetic. That was necessary because mach's own writer emits no SUBTRACTOR, so a round trip cannot produce the input.

Mutation-checked, three ways, each failing distinctly:

| mutation | caught by |
|---|---|
| `count_relocs` counts the SUBTRACTOR entry too | fold test — count is one too high |
| halves at mismatched addresses accepted | malformed-pair test |
| the fold picks DIFF32 regardless of width | fold test |

## What I did not do

Per the maintainer's steer, I have **not** tried to prove this against a real Apple Clang object or a darwin host — the change compiles, the suites are green, and the mach-audio reproduction is for release testing to confirm.

Two stated boundaries rather than silent ones: mach's writer still refuses a difference by the existing unsupported-kind path (it never emits one, and writing something wrong would be worse), and arm64 `ARM64_RELOC_SUBTRACTOR` is untouched — the issue is x86_64 and I would rather add the second ISA when something needs it than guess at its pairing rules now.
