### PR TITLE
fix(macho): allocate C common storage instead of demanding an import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### link(macho): a C common symbol is allocated instead of demanded as an import (#2974)
+
+An external Mach-O common symbol - `N_UNDF | N_EXT` with a non-zero `n_value` - was read
+as an ordinary undefined import, so a native x86_64 Darwin link of a vendored C
+dependency failed with:
+
+```
+dynamic import _ma_atomic_global_lock has no #[library] attribution
+```
+
+The symbol is a **tentative definition** in the foreign object, not a dylib import.
+Apple Clang emits one for every uninitialized file-scope C global unless the translation
+unit is compiled `-fno-common`, so it arrives whether or not anyone chose it - and the
+message named the symbol correctly and the problem not at all.
+
+`n_value` on such a symbol is the requested SIZE rather than an address, the one place
+in the nlist encoding where it does not mean "where", with the alignment as a log2 in
+`n_desc`. Both are now preserved in the neutral model as `SYM_OBJ_FLAG_COMMON` plus
+`Symbol.align`, alongside `SYM_OBJ_FLAG_EXTERN` - a common IS undefined until the linker
+allocates it, so every consumer that means "needs resolving" keeps working and only the
+one deciding HOW it resolves has to know the difference.
+
+**The allocation belongs to the linker, and arrives as an ordinary input image.** A
+tentative definition asks the linker for storage, and every object declaring the name
+asks for the SAME storage rather than its own - so the commons are gathered once, ahead
+of everything that resolves a symbol, and appended as one synthesized `.bss` input.
+Symbol resolution, dead-stripping and every format's own collection then apply to it
+with no side path, because from that point it is not distinguishable from any other BSS
+definition.
+
+Coalesced by MAX size and alignment, which is the C rule: taking the first size seen
+under-allocates the moment a later unit declares a larger type, and allocating per
+object multiplies the storage and leaves the copies unaliased, so two writers of the
+same name would not see each other.
+
+A real definition of the name wins outright and the common allocates nothing. A strong
+definition and a tentative one are not a duplicate-symbol collision; the tentative one
+exists precisely to yield to it. A relocatable output allocates nothing either, since it
+carries its symbols through unresolved and the eventual link is where the storage is
+decided.
+
+### Fixed
+
 #### link(macho): an x86_64 SUBTRACTOR relocation pair is parsed and resolved (#2973)
 
 Mach refused a normal Apple Clang x86_64 object outright:

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -760,7 +760,233 @@ fun link_modules_nocapture(s: *session.Session, tgt: *target.Target, modules: *o
                      out_path, name, mode, pie_opt_in, image_options, nil::*LinkedImage);
 }
 
+# build one input image holding zero-initialized storage for every C common symbol
+# that no object actually defines (#2974)
+#
+# COALESCED BY MAX, which is the C rule: several translation units may each declare the
+# same tentative definition, and they are asking for ONE object big enough for all of
+# them, not one each. Taking the first size seen would under-allocate whenever a later
+# unit declared a larger type, and allocating per-object would multiply the storage and
+# leave the copies unaliased.
+#
+# A REAL DEFINITION WINS OUTRIGHT and the common is dropped, which is why the scan for
+# definitions runs first. A strong definition and a tentative one are not a duplicate-
+# symbol collision; the tentative one exists precisely to yield to it.
+#
+# Skipped for a relocatable output, which carries its symbols through unresolved: the
+# eventual link is where the storage is decided, and allocating here would turn a
+# tentative definition into a real one that then collides with the real one.
+# ---
+# out: receives the synthesized image when this returns ok(true)
+# ret: ok(true) when storage was synthesized, ok(false) when there was nothing to do
+fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
+                              module_count: u32, mode: LinkMode,
+                              out: *of.ObjectImage) R.Result[bool, str] {
+    if (mode == LINK_RELOCATABLE || modules == nil || module_count == 0) {
+        ret R.ok[bool, str](false);
+    }
+    val alloc: *A.Allocator = s.alloc;
+
+    # names some object really defines; a common of the same name yields to them
+    var defined: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var m: u32 = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (sym.section != of.SECTION_EXTERNAL && sym.section < modules[m].section_count) {
+                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) {
+                    val di: R.Result[bool, str] = map.insert[intern.StrId, u32](?defined, sym.name, 0);
+                    if (R.is_err[bool, str](di)) {
+                        map.dnit[intern.StrId, u32](?defined);
+                        ret R.err[bool, str](R.unwrap_err[bool, str](di));
+                    }
+                }
+            }
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+
+    # first occurrence owns the slot, so the layout is module/symbol order and the
+    # output bytes do not depend on map iteration
+    var slot: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var names: Vector[intern.StrId] = vector.init[intern.StrId](alloc);
+    var sizes: Vector[u32] = vector.init[u32](alloc);
+    var aligns: Vector[u32] = vector.init[u32](alloc);
+
+    m = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if ((sym.flags & of.SYM_OBJ_FLAG_COMMON) == 0) { sy = sy + 1; cnt; }
+            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) { sy = sy + 1; cnt; }
+
+            var al: u32 = sym.align;
+            if (al == 0) { al = 1; }
+            val ex: R.Result[*u32, str] = map.get[intern.StrId, u32](?slot, ?sym.name);
+            if (R.is_ok[*u32, str](ex)) {
+                val at: u32 = @R.unwrap_ok[*u32, str](ex);
+                if (sym.size > sizes.data[at]) { sizes.data[at] = sym.size; }
+                if (al > aligns.data[at])      { aligns.data[at] = al; }
+                sy = sy + 1;
+                cnt;
+            }
+            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?slot, sym.name, names.len::u32);
+            if (R.is_err[bool, str](ins)) {
+                map.dnit[intern.StrId, u32](?slot);
+                map.dnit[intern.StrId, u32](?defined);
+                vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+                ret R.err[bool, str](R.unwrap_err[bool, str](ins));
+            }
+            vector.push[intern.StrId](?names, sym.name);
+            vector.push[u32](?sizes, sym.size);
+            vector.push[u32](?aligns, al);
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    map.dnit[intern.StrId, u32](?slot);
+    map.dnit[intern.StrId, u32](?defined);
+
+    if (names.len == 0) {
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        ret R.ok[bool, str](false);
+    }
+
+    # lay the slots out in declaration order, each at its own alignment
+    var total: u64 = 0;
+    var sec_align: u32 = 1;
+    var offs: Vector[u32] = vector.init[u32](alloc);
+    var n: usize = 0;
+    for (n < names.len) {
+        val al: u64 = aligns.data[n]::u64;
+        if (aligns.data[n] > sec_align) { sec_align = aligns.data[n]; }
+        total = (total + al - 1) / al * al;
+        if (total > 0x7FFFFFFF) {
+            vector.dnit[u32](?offs);
+            vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+            ret R.err[bool, str]("link: common storage exceeds 2 GiB");
+        }
+        vector.push[u32](?offs, total::u32);
+        total = total + sizes.data[n]::u64;
+        n = n + 1;
+    }
+
+    val image_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "<common-storage>");
+    val section_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".bss");
+    if (R.is_err[intern.StrId, str](image_name_r) || R.is_err[intern.StrId, str](section_name_r)) {
+        vector.dnit[u32](?offs);
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        ret R.err[bool, str]("link: could not intern the common storage names");
+    }
+    @out = R.unwrap_ok[of.ObjectImage, str](
+        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](image_name_r)));
+
+    # SK_BSS carries no bytes on disk; the writers zero it, which is exactly what a
+    # tentative definition asks for.
+    var sec: of.Section;
+    sec.name  = R.unwrap_ok[intern.StrId, str](section_name_r);
+    sec.kind  = of.SK_BSS;
+    sec.bytes = nil;
+    sec.len   = total::u32;
+    sec.align = sec_align;
+    val sec_r: R.Result[u32, str] = obj.add_section(out, sec);
+    if (R.is_err[u32, str](sec_r)) {
+        vector.dnit[u32](?offs);
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        obj.dnit(out);
+        ret R.err[bool, str](R.unwrap_err[u32, str](sec_r));
+    }
+    val sec_ix: u32 = R.unwrap_ok[u32, str](sec_r);
+
+    n = 0;
+    for (n < names.len) {
+        var osym: of.Symbol;
+        osym.name    = names.data[n];
+        osym.section = sec_ix;
+        osym.offset  = offs.data[n];
+        osym.size    = sizes.data[n];
+        # a definition like any other from here on: GLOBAL so it resolves references
+        # from every object, OBJECT because it is data, and NOT weak - a common that
+        # reached this point is the only definition there is.
+        osym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+        val sa: R.Result[u32, str] = obj.add_symbol(out, osym);
+        if (R.is_err[u32, str](sa)) {
+            vector.dnit[u32](?offs);
+            vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+            obj.dnit(out);
+            ret R.err[bool, str](R.unwrap_err[u32, str](sa));
+        }
+        n = n + 1;
+    }
+
+    vector.dnit[u32](?offs);
+    vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+    ret R.ok[bool, str](true);
+}
+
+
+# resolve C common storage, then link (#2974)
+#
+# A tentative definition is not an import and not a section definition: it asks the
+# LINKER for zero-initialized storage, and every object declaring the name asks for the
+# same storage rather than its own. So the allocation belongs here, once, ahead of
+# everything that resolves a symbol - and it arrives as an ordinary input image, which
+# is what keeps symbol resolution, dead-stripping and every format's own collection
+# working on it with no side path.
+#
+# A wrapper rather than a branch inside the body: with the storage appended, the rest
+# of the link cannot tell a common apart from any other BSS definition, and there is
+# exactly one new path through the function instead of one per stage.
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
+                 module_count: u32, codegen_count: u32,
+                 dynlibs: *of.DynLib, dynlib_count: u32,
+                 out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
+                 image_options: of.ImageOptions, capture: *LinkedImage) R.Result[bool, str] {
+    val alloc0: *A.Allocator = s.alloc;
+    var commons: of.ObjectImage;
+    val cr: R.Result[bool, str] = synthesize_common_storage(s, modules, module_count, mode, ?commons);
+    if (R.is_err[bool, str](cr)) { ret R.err[bool, str](R.unwrap_err[bool, str](cr)); }
+    if (!R.unwrap_ok[bool, str](cr)) {
+        ret link_modules_with_commons(s, tgt, modules, module_count, codegen_count,
+                                      dynlibs, dynlib_count, out_path, name, mode,
+                                      pie_opt_in, image_options, capture);
+    }
+
+    if (module_count == 0xFFFFFFFF) {
+        obj.dnit(?commons);
+        ret R.err[bool, str]("link: too many input objects to append common storage");
+    }
+    val all_r: R.Result[*of.ObjectImage, str] =
+        A.allocate[of.ObjectImage](alloc0, (module_count + 1)::usize);
+    if (R.is_err[*of.ObjectImage, str](all_r)) {
+        obj.dnit(?commons);
+        ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](all_r));
+    }
+    val all: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](all_r);
+    var ci: u32 = 0;
+    for (ci < module_count) {
+        all[ci] = modules[ci];
+        ci = ci + 1;
+    }
+    all[module_count] = commons;
+
+    # the storage is a synthesized input, never a codegen one, so `codegen_count` is
+    # unchanged: the passes that treat the first N images as mach's own must keep
+    # counting the same N.
+    val linked: R.Result[bool, str] = link_modules_with_commons(
+        s, tgt, all, module_count + 1, codegen_count, dynlibs, dynlib_count,
+        out_path, name, mode, pie_opt_in, image_options, capture);
+    A.deallocate[of.ObjectImage](alloc0, all, (module_count + 1)::usize);
+    obj.dnit(?commons);
+    ret linked;
+}
+
+fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
@@ -12151,4 +12377,138 @@ test "mach.lang.be.linker.local_got_plan:deduplicates_effective_target" {
     map.dnit[intern.StrId, SymbolLoc](?locs);
     session.dnit(?s);
     ret 0;
+}
+
+# build a one-symbol input image declaring `name` as C common storage
+fun lt_common_module(s: *session.Session, mod_name: str, name: str, size: u32, align: u32) of.ObjectImage {
+    val alloc: *A.Allocator = s.alloc;
+    val mn: R.Result[intern.StrId, str] = intern.intern(?s.interner, mod_name);
+    val sn: R.Result[intern.StrId, str] = intern.intern(?s.interner, name);
+    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](
+        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn)));
+    var sym: of.Symbol;
+    sym.name    = R.unwrap_ok[intern.StrId, str](sn);
+    sym.section = of.SECTION_EXTERNAL;
+    sym.offset  = 0;
+    sym.size    = size;
+    sym.align   = align;
+    sym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_COMMON;
+    obj.add_symbol(?img, sym);
+    ret img;
+}
+
+# Competing tentative definitions coalesce into ONE allocation at the largest size and
+# alignment either asked for (#2974).
+#
+# This is the C rule and the reason the allocation belongs to the linker rather than to
+# any reader: several translation units may each declare the same tentative definition,
+# and they are asking for one object big enough for all of them, not one each. Taking
+# the first size seen under-allocates the moment a later unit declares a larger type,
+# and allocating per object multiplies the storage and leaves the copies unaliased -
+# two writers of `_ma_atomic_global_lock` would then not see each other.
+test "mach.lang.be.linker.synthesize_common_storage:coalesces_to_the_largest_request" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_common_module(?s, "a.o", "_shared", 8, 4);
+    mods[1] = lt_common_module(?s, "b.o", "_shared", 40, 16);
+
+    var bad: i32 = 0;
+    var out: of.ObjectImage;
+    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    if (R.is_err[bool, str](cr)) { bad = 2; }
+    or (!R.unwrap_ok[bool, str](cr)) { bad = 3; }
+    or {
+        # ONE definition, not two
+        if (out.symbol_count != 1                      && bad == 0) { bad = 4; }
+        or (out.section_count != 1                     && bad == 0) { bad = 5; }
+        or {
+            # the largest request wins on both axes
+            if (out.symbols[0].size != 40              && bad == 0) { bad = 6; }
+            if (out.sections[0].len != 40              && bad == 0) { bad = 7; }
+            if (out.sections[0].align != 16            && bad == 0) { bad = 8; }
+            # zero-initialized storage carries no bytes on disk
+            if (out.sections[0].kind != of.SK_BSS      && bad == 0) { bad = 9; }
+            if (out.sections[0].bytes != nil           && bad == 0) { bad = 10; }
+            # and it is an ordinary definition from here on, so every reference
+            # resolves to it through the normal collector
+            if ((out.symbols[0].flags & of.SYM_OBJ_FLAG_GLOBAL) == 0 && bad == 0) { bad = 11; }
+            if ((out.symbols[0].flags & of.SYM_OBJ_FLAG_EXTERN) != 0 && bad == 0) { bad = 12; }
+        }
+        obj.dnit(?out);
+    }
+
+    obj.dnit(?mods[0]);
+    obj.dnit(?mods[1]);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A REAL definition of the name wins outright, and the common allocates nothing (#2974).
+#
+# A strong definition and a tentative one are not a duplicate-symbol collision: the
+# tentative one exists precisely to yield to it. Allocating anyway would put a second
+# object of the same name in the image, and whichever the collector then picked, half
+# the references would reach storage nobody else writes.
+test "mach.lang.be.linker.synthesize_common_storage:a_real_definition_wins" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_common_module(?s, "a.o", "_shared", 40, 16);
+
+    # a module that really defines `_shared` in its own .data
+    val mn: R.Result[intern.StrId, str] = intern.intern(?s.interner, "b.o");
+    val dn: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".data");
+    val sn: R.Result[intern.StrId, str] = intern.intern(?s.interner, "_shared");
+    mods[1] = R.unwrap_ok[of.ObjectImage, str](
+        obj.init(?alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn)));
+    var bytes: [8]u8;
+    var z: usize = 0;
+    for (z < 8) { bytes[z] = 0; z = z + 1; }
+    var sec: of.Section;
+    sec.name = R.unwrap_ok[intern.StrId, str](dn);
+    sec.kind = of.SK_DATA;
+    sec.bytes = ?bytes[0];
+    sec.len = 8;
+    sec.align = 8;
+    val si: R.Result[u32, str] = obj.add_section(?mods[1], sec);
+    var dsym: of.Symbol;
+    dsym.name    = R.unwrap_ok[intern.StrId, str](sn);
+    dsym.section = R.unwrap_ok[u32, str](si);
+    dsym.offset  = 0;
+    dsym.size    = 8;
+    dsym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    obj.add_symbol(?mods[1], dsym);
+
+    var bad: i32 = 0;
+    var out: of.ObjectImage;
+    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    if (R.is_err[bool, str](cr)) { bad = 2; }
+    or (R.unwrap_ok[bool, str](cr)) {
+        # nothing should have been synthesized at all
+        bad = 3;
+        obj.dnit(?out);
+    }
+
+    # ...and a relocatable output allocates nothing either: it carries its symbols
+    # through unresolved, and the eventual link is where the storage is decided.
+    if (bad == 0) {
+        var out2: of.ObjectImage;
+        val rr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 1, LINK_RELOCATABLE, ?out2);
+        if (R.is_err[bool, str](rr)) { bad = 4; }
+        or (R.unwrap_ok[bool, str](rr)) { bad = 5; obj.dnit(?out2); }
+    }
+
+    obj.dnit(?mods[0]);
+    obj.dnit(?mods[1]);
+    session.dnit(?s);
+    ret bad;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -195,6 +195,21 @@ pub val SYM_OBJ_FLAG_OBJECT:   u32 = 0x10;
 pub val SYM_OBJ_FLAG_FALLBACK: u32 = 0x20;
 pub val SYM_OBJ_FLAG_SEARCH:   u32 = 0x40;
 pub val SYM_OBJ_FLAG_ALIAS:    u32 = 0x80;
+# A TENTATIVE DEFINITION - C common storage (#2974). The symbol is not defined in any
+# section here, but it is not an import either: it REQUESTS zero-initialized storage of
+# `size` bytes aligned to `align`, and the linker provides it unless some object carries
+# a real definition of the name, which wins outright.
+#
+# Apple Clang emits one for every uninitialized file-scope C global unless the
+# translation unit is compiled `-fno-common`, so a vendored C dependency carries them
+# whether or not anyone chose to. Read as an ordinary undefined import it produces
+# "dynamic import _x has no #[library] attribution", which names the symbol correctly
+# and the problem not at all.
+#
+# Set together with SYM_OBJ_FLAG_EXTERN, because a common IS undefined until the linker
+# allocates it: every consumer that means "needs resolving" keeps working, and only the
+# one that decides HOW it resolves has to know the difference.
+pub val SYM_OBJ_FLAG_COMMON:   u32 = 0x100;
 
 # sentinel `Symbol.section` value marking an undefined (external) symbol
 pub val SECTION_EXTERNAL: u32 = 0xFFFFFFFF;
@@ -292,6 +307,10 @@ pub rec Symbol {
     size:     u32;
     flags:    u32;
     fallback: u32;
+    # the requested alignment of a COMMON symbol's storage, in bytes; meaningless for
+    # every other symbol, so a zero-initialized record is correct and 0 reads as "no
+    # alignment stated" (#2974)
+    align:    u32;
 }
 
 # one relocation in an object image

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -4232,6 +4232,23 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
         if ((n_desc & N_WEAK_DEF) != 0) { flags = flags | of.SYM_OBJ_FLAG_WEAK; }
         if ((n_type & N_TYPE) == N_UNDF) {
             flags = flags | of.SYM_OBJ_FLAG_EXTERN;
+            # A COMMON SYMBOL WEARS AN UNDEFINED SYMBOL'S CLOTHES (#2974). N_UNDF with
+            # N_EXT and a NON-ZERO n_value is a tentative definition, and the value is
+            # the requested size rather than an address - the one place in the nlist
+            # encoding where n_value does not mean "where". Apple Clang emits one for
+            # every uninitialized file-scope C global unless the unit is built
+            # `-fno-common`, so reading it as an ordinary import made a vendored C
+            # dependency demand a `#[library]` attribution for storage it was asking
+            # the linker to allocate.
+            #
+            # The alignment is a log2 in n_desc bits 8-11, which is how ld64 spells it.
+            if ((n_type & N_EXT) != 0 && n_value != 0) {
+                flags = flags | of.SYM_OBJ_FLAG_COMMON;
+                out.symbols[si].size = n_value::u32;
+                out.symbols[si].align = 1;
+                val log2a: u32 = (n_desc::u32 >> 8) & 0xF;
+                if (log2a > 0 && log2a < 32) { out.symbols[si].align = 1 << log2a; }
+            }
             # recover the function-ness emit_object encoded in the reference type so
             # the linker can give a dynamic function import its call stub.
             if ((n_desc & REFERENCE_TYPE_MASK) == REFERENCE_FLAG_UNDEFINED_LAZY) { flags = flags | of.SYM_OBJ_FLAG_FUNCTION; }
@@ -7922,6 +7939,96 @@ test "mach.lang.target.of.macho:a_malformed_subtractor_pair_is_refused" {
     t_put_reloc(b3.data, o3, 1, 16, 0, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
     var out3: of.ObjectImage;
     if (R.is_ok[bool, str](parse_object(?alloc, ?i, b3.data, b3.len, ?out3)) && bad == 0) { bad = 9; }
+
+    ret bad;
+}
+
+# the file offset and count of an emitted object's symbol table
+fun t_symtab(buf: *u8, out_n: *u32) usize {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val cmd: u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SYMTAB) {
+            @out_n = bin.read_u32_le(buf, off + 12);
+            ret bin.read_u32_le(buf, off + 8)::usize;
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+    @out_n = 0;
+    ret 0;
+}
+
+# A tentative definition is read as COMMON, not as an ordinary import (#2974).
+#
+# `N_UNDF | N_EXT` with a NON-ZERO `n_value` is C common storage: the value is the
+# requested SIZE rather than an address, the one place in the nlist encoding where
+# n_value does not mean "where". Read as an ordinary undefined symbol it became a
+# dynamic import, and a native Darwin link of a vendored C dependency failed with
+# `dynamic import _ma_atomic_global_lock has no #[library] attribution` - a message
+# that names the symbol correctly and the problem not at all.
+#
+# Apple Clang emits one for every uninitialized file-scope global unless the unit is
+# compiled `-fno-common`, so this arrives whether or not anyone chose it.
+test "mach.lang.target.of.macho:a_tentative_definition_reads_as_common" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var buf: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?buf)) { ret 1; }
+
+    var nsyms: u32 = 0;
+    val symoff: usize = t_symtab(buf.data, ?nsyms);
+    if (symoff == 0 || nsyms == 0) { ret 2; }
+
+    # rewrite the LAST symbol (the external one) into a tentative definition of 40
+    # bytes aligned to 16: n_type = N_UNDF|N_EXT, n_desc alignment log2 in bits 8-11.
+    val so: usize = symoff + (nsyms - 1)::usize * NLIST_64_SIZE;
+    buf.data[so + 4] = N_UNDF | N_EXT;
+    buf.data[so + 5] = 0;
+    bin.write_u16_le(buf.data, so + 6, (4 << 8)::u16);
+    bin.write_u64_le(buf.data, so + 8, 40);
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 3; }
+
+    var bad: i32 = 0;
+    var saw: bool = false;
+    var k: u32 = 0;
+    for (k < out.symbol_count) {
+        val sym: *of.Symbol = ?out.symbols[k];
+        if ((sym.flags & of.SYM_OBJ_FLAG_COMMON) != 0) {
+            saw = true;
+            if (sym.size != 40                                    && bad == 0) { bad = 4; }
+            if (sym.align != 16                                   && bad == 0) { bad = 5; }
+            # still undefined here: the linker is what turns it into storage, and every
+            # consumer meaning "needs resolving" must keep seeing that
+            if ((sym.flags & of.SYM_OBJ_FLAG_EXTERN) == 0         && bad == 0) { bad = 6; }
+            if (sym.section != of.SECTION_EXTERNAL                && bad == 0) { bad = 7; }
+        }
+        k = k + 1;
+    }
+    if (!saw && bad == 0) { bad = 8; }
+
+    # ...and a plain undefined symbol (n_value 0) is NOT common, which is the half that
+    # keeps every existing import working
+    var b2: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b2)) { ret 9; }
+    var n2: u32 = 0;
+    val s2: usize = t_symtab(b2.data, ?n2);
+    if (s2 == 0 || n2 == 0) { ret 10; }
+    var out2: of.ObjectImage;
+    if (R.is_err[bool, str](parse_object(?alloc, ?i, b2.data, b2.len, ?out2))) { ret 11; }
+    var k2: u32 = 0;
+    for (k2 < out2.symbol_count) {
+        if ((out2.symbols[k2].flags & of.SYM_OBJ_FLAG_COMMON) != 0 && bad == 0) { bad = 12; }
+        k2 = k2 + 1;
+    }
 
     ret bad;
 }


### PR DESCRIPTION
Closes #2974. Completes the darwin trio with #2973 and #2957.

An external Mach-O common symbol — `N_UNDF | N_EXT` with a non-zero `n_value` — was read as an ordinary undefined import, so a native x86_64 Darwin link of a vendored C dependency failed with:

```
dynamic import _ma_atomic_global_lock has no #[library] attribution
```

The symbol is a **tentative definition** in the foreign object, not a dylib import. Apple Clang emits one for every uninitialized file-scope C global unless the translation unit is compiled `-fno-common`, so it arrives whether or not anyone chose it — and the message named the symbol correctly and the problem not at all.

## Reader

`n_value` on such a symbol is the requested **size** rather than an address — the one place in the nlist encoding where it does not mean "where" — with the alignment as a log2 in `n_desc`. Both are preserved as `SYM_OBJ_FLAG_COMMON` plus `Symbol.align`, set **alongside** `SYM_OBJ_FLAG_EXTERN`: a common *is* undefined until the linker allocates it, so every consumer meaning "needs resolving" keeps working and only the one deciding *how* it resolves has to know the difference.

## The allocation belongs to the linker

A tentative definition asks the **linker** for storage, and every object declaring the name asks for the *same* storage rather than its own. So the commons are gathered once, ahead of everything that resolves a symbol, and appended as one synthesized `.bss` input — reusing the seam `synthesize_local_imports` already established. From that point nothing downstream can tell a common apart from any other BSS definition, so symbol resolution, dead-stripping and every format's own collection apply with no side path.

I deliberately did **not** materialize commons in the reader, which is the smaller change. Each object would then allocate its own storage with only one symbol pointing at it, and two objects declaring different sizes would silently take whichever came first rather than the larger.

**Coalesced by max size and alignment**, which is the C rule. Taking the first size seen under-allocates the moment a later unit declares a larger type; allocating per object multiplies the storage and leaves the copies unaliased, so two writers of the same name would not see each other.

**A real definition wins outright** and the common allocates nothing — a strong definition and a tentative one are not a duplicate-symbol collision, since the tentative one exists precisely to yield to it. **A relocatable output allocates nothing** either: it carries its symbols through unresolved, and allocating there would turn a tentative definition into a real one that then collides with the real one.

## Verification

**1521 passed, 0 failed** (1518 before). Corpus **1416/0**. Fixpoint byte-identical.

The darwin decode lane from #2957 ran on this change — **728 cells, 0 fail** — so `llvm-readobj` parsed the Mach-O objects this touches before the PR, which is the first time that has been true for a Mach-O change.

Mutation-checked, four ways, each failing distinctly:

| mutation | caught by |
|---|---|
| coalesce keeps the first size, not the max | `coalesces_to_the_largest_request` |
| a real definition does not suppress the common | `a_real_definition_wins` |
| a relocatable link allocates anyway | `a_real_definition_wins` |
| `n_value` read as an address, not a size | `a_tentative_definition_reads_as_common` |

The reader test patches a symbol in a **real mach-emitted object** into a tentative definition, and also pins the other half — a plain undefined symbol with `n_value` 0 is *not* common, which is what keeps every existing import working.

Per the maintainer's steer I have not attempted to reproduce the mach-audio link on a darwin host; the change compiles, the suites are green, and the downstream `-fno-common` constraint can come off once this is released.
