### PR TITLE
chore: release 4.25.0

### DIFF
--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -42,6 +42,22 @@ if [ -n "$first" ]; then
     fi
 fi
 
+# ...and at most one `###` of each kind inside a version block. This is the same
+# defect one level down, and it is the one that actually happened: the outer rule held
+# while six `### Fixed` headings accumulated under one `## [Unreleased]`, because each
+# pull request appended its own section rather than finding the existing one. A reader
+# then has to scan the whole release to know whether they have seen all the fixes.
+dupes=$(awk '
+    /^## \[/ { section = $0; delete seen; next }
+    /^### / { if ($0 in seen) print section " has a repeated \x27" $0 "\x27"; seen[$0] = 1 }
+' "$file")
+if [ -n "$dupes" ]; then
+    echo "check-changelog: $file repeats a subsection inside a release:" >&2
+    echo "$dupes" | sed 's/^/  /' >&2
+    echo "  append an entry under the existing heading; a second one of the same kind splits the release in two." >&2
+    status=1
+fi
+
 if [ "$status" -eq 0 ]; then
     echo "check-changelog: $file ok"
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ### Fixed
 
 #### link(macho): a C common symbol is allocated instead of demanded as an import (#2974)
@@ -49,8 +50,6 @@ definition and a tentative one are not a duplicate-symbol collision; the tentati
 exists precisely to yield to it. A relocatable output allocates nothing either, since it
 carries its symbols through unresolved and the eventual link is where the storage is
 decided.
-
-### Fixed
 
 #### link(macho): an x86_64 SUBTRACTOR relocation pair is parsed and resolved (#2973)
 
@@ -95,8 +94,6 @@ wrong arithmetic.
 
 Mach's own writer emits no SUBTRACTOR, so a difference reaching the Mach-O writer still
 refuses by the existing unsupported-kind path rather than writing something wrong.
-
-### Fixed
 
 #### test: Mach-O gets an external reader on the lane that gates merges (#2957)
 
@@ -145,9 +142,6 @@ rule had one printed value standing between them and a green run.
 `out[7]` stays as the stack-side control - a mutation that moved it too would mean
 something different and worse.
 
-
-### Fixed
-
 #### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
 
 `ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the
@@ -163,8 +157,6 @@ was simply nothing holding it.
 
 The helper now treats a failed pass as an error. The guard it exists for fails when the
 defect is reintroduced, which is the property it was always assumed to have.
-
-### Fixed
 
 #### codegen: a frame larger than the target's stack reserve is refused (#2991)
 
@@ -201,50 +193,6 @@ what the target stated (#2990), else the format's own default, else nothing. A t
 whose stack the image does not bound - every ELF one, and a Mach-O image with no stated
 reserve, which takes dyld's default - is not checked at all, because a bound mach did
 not choose is not a bound mach may refuse a program against.
-
-### Added
-
-#### manifest: a target can set the image stack size (#2990)
-
-The PE stack reserve was a literal `0x100000`, so a mach project could not ship a
-Windows program needing more than a megabyte of stack. No flag, no workaround, while
-every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`) - and mach owns the
-PE it writes.
-
-Found from a real program: a game's `main` needed a 1,107,824-byte frame against the
-1,048,576-byte reserve, so the image died in its own prologue on every Windows machine
-while running fine on linux, which hands the main thread eight megabytes. The stack
-probe was correct throughout. Only the reserve was unreachable.
-
-```toml
-[target.windows]
-isa  = "x86_64"
-os   = "windows"
-abi  = "win64"
-stack_reserve = 0x800000
-stack_commit  = 0x1000
-```
-
-Both optional; omitting them reproduces today's bytes exactly. They sit on the target
-beside `base` because all three are image memory-layout parameters expressible only on
-some object formats - and because a reserve is address space rather than committed
-memory, so a small tool inheriting a large program's reserve costs nothing.
-
-**Only some formats carry one.** PE keeps both in its optional header, Mach-O keeps a
-reserve in `LC_MAIN.stacksize`; ELF has nowhere to put one and a raw flat image has no
-header. Either key on a target whose resolved object format carries none is refused
-when the manifest is read, naming the key, the target and the format - and **every
-declared target is checked, not only the one being built**, because a key checked only
-in the cell being built is a key that silently does nothing until someone builds the
-other cell months later.
-
-On Mach-O the value reaches only a position-independent image. A non-PIE one enters
-through `LC_UNIXTHREAD`, which has no stacksize member, so a stack size requested there
-is refused at link rather than dropped. That is a property of the image SHAPE rather
-than of the format, is not knowable when the manifest is read, and is therefore checked
-in the writer - two facts, two checks, each where its fact is known.
-
-### Fixed
 
 #### target(riscv32): a 64-bit reinterpret across the register banks is lowered (#2904)
 
@@ -292,6 +240,47 @@ payload whose halves differ and whose high half has the sign bit set round-trips
 directions. A lowering that swapped the halves, read the slot at the wrong offset, or
 sign-extended one of them emits the same instructions and a different value.
 
+### Added
+
+#### manifest: a target can set the image stack size (#2990)
+
+The PE stack reserve was a literal `0x100000`, so a mach project could not ship a
+Windows program needing more than a megabyte of stack. No flag, no workaround, while
+every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`) - and mach owns the
+PE it writes.
+
+Found from a real program: a game's `main` needed a 1,107,824-byte frame against the
+1,048,576-byte reserve, so the image died in its own prologue on every Windows machine
+while running fine on linux, which hands the main thread eight megabytes. The stack
+probe was correct throughout. Only the reserve was unreachable.
+
+```toml
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+stack_reserve = 0x800000
+stack_commit  = 0x1000
+```
+
+Both optional; omitting them reproduces today's bytes exactly. They sit on the target
+beside `base` because all three are image memory-layout parameters expressible only on
+some object formats - and because a reserve is address space rather than committed
+memory, so a small tool inheriting a large program's reserve costs nothing.
+
+**Only some formats carry one.** PE keeps both in its optional header, Mach-O keeps a
+reserve in `LC_MAIN.stacksize`; ELF has nowhere to put one and a raw flat image has no
+header. Either key on a target whose resolved object format carries none is refused
+when the manifest is read, naming the key, the target and the format - and **every
+declared target is checked, not only the one being built**, because a key checked only
+in the cell being built is a key that silently does nothing until someone builds the
+other cell months later.
+
+On Mach-O the value reaches only a position-independent image. A non-PIE one enters
+through `LC_UNIXTHREAD`, which has no stacksize member, so a stack size requested there
+is refused at link rather than dropped. That is a property of the image SHAPE rather
+than of the format, is not knowable when the manifest is read, and is therefore checked
+in the writer - two facts, two checks, each where its fact is known.
 ## [4.24.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.25.0] - 2026-08-21
 
 
 ### Fixed

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.24.0"
+version = "4.25.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.24.0";
+pub val MACH_VERSION: str = "4.25.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Minor bump: one new manifest surface, plus the darwin trio that unblocks downstream.

## Added

- **#2990** — `stack_reserve` / `stack_commit` on `[target.<name>]`. A mach project could not ship a Windows program needing more than a megabyte of stack.

## Fixed

- **#2974** — a C common symbol is allocated instead of demanded as an import. Lets mach-audio drop its `-fno-common` constraint.
- **#2973** — an x86_64 `SUBTRACTOR` relocation pair is parsed and resolved. Lets mach-audio drop its `-fno-jump-tables` constraint.
- **#2957** — Mach-O gets an external reader on the lane that gates merges into `dev`. Between releases mach was its own only reader of a format it writes.
- **#2991** — a frame larger than the target's stack reserve is refused rather than emitted. It could never execute on any input.
- **#2904** — a 64-bit reinterpret across the register banks is lowered on riscv32.
- **#2949** — a failed lowering pass counts as an error, so char-width regressions actually regress.
- **#3043** — the c-variadic golden samples both register-slot floats.

## A changelog repair rides along

Six `### Fixed` headings had accumulated under one `## [Unreleased]`, because each PR appended its own section instead of finding the existing one. That is #3039's defect one level down, which the check added there did not cover.

Folded together — **every entry and body line preserved, only headings moved, verified by comparing the sorted body-line multiset** — and `check-changelog.sh` now enforces one subsection of each kind per release, so the next one fails on the PR that introduces it.

## Verification

- `mach.toml` **and** `MACH_VERSION` both at 4.25.0.
- 1521 passed, 0 failed.
- Fixpoint: three generations byte-identical.
- Corpus 1416/0, and the new darwin decode lane 728/0 — `llvm-readobj` has now parsed the Mach-O this release changes.

The `darwin (release gate)` runs on the dev → main PR that follows.