### PR TITLE
mach 4.25.0

### DIFF
--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -42,6 +42,22 @@ if [ -n "$first" ]; then
     fi
 fi
 
+# ...and at most one `###` of each kind inside a version block. This is the same
+# defect one level down, and it is the one that actually happened: the outer rule held
+# while six `### Fixed` headings accumulated under one `## [Unreleased]`, because each
+# pull request appended its own section rather than finding the existing one. A reader
+# then has to scan the whole release to know whether they have seen all the fixes.
+dupes=$(awk '
+    /^## \[/ { section = $0; delete seen; next }
+    /^### / { if ($0 in seen) print section " has a repeated \x27" $0 "\x27"; seen[$0] = 1 }
+' "$file")
+if [ -n "$dupes" ]; then
+    echo "check-changelog: $file repeats a subsection inside a release:" >&2
+    echo "$dupes" | sed 's/^/  /' >&2
+    echo "  append an entry under the existing heading; a second one of the same kind splits the release in two." >&2
+    status=1
+fi
+
 if [ "$status" -eq 0 ]; then
     echo "check-changelog: $file ok"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,19 @@ jobs:
         shell: bash
         run: bash test/run.sh --runner "${{ matrix.runner }}"
 
+      # the rows this runner READS without executing: a format whose own leg runs at
+      # release cadence still gets an external parser on the lane that gates merges
+      # into dev (#2957). layers A and B only - the darwin objects are cross-built here
+      # and decoded here, and nothing pretends they ran.
+      #
+      # COFF is why this is not theoretical: x86_64-windows had a leg that had never
+      # once started, and the first layer A run over it found a section-name form llvm
+      # rejected outright, making every object with a constant pool unreadable (#2952).
+      - name: codegen corpus (decode-only rows)
+        if: matrix.decode != ''
+        shell: bash
+        run: bash test/run.sh --decode "${{ matrix.runner }}"
+
       # no --leg for the link suite: its own selection already agrees with the
       # registry, because it declines a row whose os and isa no host matches and that
       # is every `engine none` row. its spirv cases are declared `legs: x86_64-linux`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ### Fixed
 
 #### link(macho): a C common symbol is allocated instead of demanded as an import (#2974)
@@ -49,8 +50,6 @@ definition and a tentative one are not a duplicate-symbol collision; the tentati
 exists precisely to yield to it. A relocatable output allocates nothing either, since it
 carries its symbols through unresolved and the eventual link is where the storage is
 decided.
-
-### Fixed
 
 #### link(macho): an x86_64 SUBTRACTOR relocation pair is parsed and resolved (#2973)
 
@@ -95,8 +94,6 @@ wrong arithmetic.
 
 Mach's own writer emits no SUBTRACTOR, so a difference reaching the Mach-O writer still
 refuses by the existing unsupported-kind path rather than writing something wrong.
-
-### Fixed
 
 #### test: Mach-O gets an external reader on the lane that gates merges (#2957)
 
@@ -145,9 +142,6 @@ rule had one printed value standing between them and a green run.
 `out[7]` stays as the stack-side control - a mutation that moved it too would mean
 something different and worse.
 
-
-### Fixed
-
 #### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
 
 `ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the
@@ -163,8 +157,6 @@ was simply nothing holding it.
 
 The helper now treats a failed pass as an error. The guard it exists for fails when the
 defect is reintroduced, which is the property it was always assumed to have.
-
-### Fixed
 
 #### codegen: a frame larger than the target's stack reserve is refused (#2991)
 
@@ -201,50 +193,6 @@ what the target stated (#2990), else the format's own default, else nothing. A t
 whose stack the image does not bound - every ELF one, and a Mach-O image with no stated
 reserve, which takes dyld's default - is not checked at all, because a bound mach did
 not choose is not a bound mach may refuse a program against.
-
-### Added
-
-#### manifest: a target can set the image stack size (#2990)
-
-The PE stack reserve was a literal `0x100000`, so a mach project could not ship a
-Windows program needing more than a megabyte of stack. No flag, no workaround, while
-every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`) - and mach owns the
-PE it writes.
-
-Found from a real program: a game's `main` needed a 1,107,824-byte frame against the
-1,048,576-byte reserve, so the image died in its own prologue on every Windows machine
-while running fine on linux, which hands the main thread eight megabytes. The stack
-probe was correct throughout. Only the reserve was unreachable.
-
-```toml
-[target.windows]
-isa  = "x86_64"
-os   = "windows"
-abi  = "win64"
-stack_reserve = 0x800000
-stack_commit  = 0x1000
-```
-
-Both optional; omitting them reproduces today's bytes exactly. They sit on the target
-beside `base` because all three are image memory-layout parameters expressible only on
-some object formats - and because a reserve is address space rather than committed
-memory, so a small tool inheriting a large program's reserve costs nothing.
-
-**Only some formats carry one.** PE keeps both in its optional header, Mach-O keeps a
-reserve in `LC_MAIN.stacksize`; ELF has nowhere to put one and a raw flat image has no
-header. Either key on a target whose resolved object format carries none is refused
-when the manifest is read, naming the key, the target and the format - and **every
-declared target is checked, not only the one being built**, because a key checked only
-in the cell being built is a key that silently does nothing until someone builds the
-other cell months later.
-
-On Mach-O the value reaches only a position-independent image. A non-PIE one enters
-through `LC_UNIXTHREAD`, which has no stacksize member, so a stack size requested there
-is refused at link rather than dropped. That is a property of the image SHAPE rather
-than of the format, is not knowable when the manifest is read, and is therefore checked
-in the writer - two facts, two checks, each where its fact is known.
-
-### Fixed
 
 #### target(riscv32): a 64-bit reinterpret across the register banks is lowered (#2904)
 
@@ -292,6 +240,47 @@ payload whose halves differ and whose high half has the sign bit set round-trips
 directions. A lowering that swapped the halves, read the slot at the wrong offset, or
 sign-extended one of them emits the same instructions and a different value.
 
+### Added
+
+#### manifest: a target can set the image stack size (#2990)
+
+The PE stack reserve was a literal `0x100000`, so a mach project could not ship a
+Windows program needing more than a megabyte of stack. No flag, no workaround, while
+every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`) - and mach owns the
+PE it writes.
+
+Found from a real program: a game's `main` needed a 1,107,824-byte frame against the
+1,048,576-byte reserve, so the image died in its own prologue on every Windows machine
+while running fine on linux, which hands the main thread eight megabytes. The stack
+probe was correct throughout. Only the reserve was unreachable.
+
+```toml
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+stack_reserve = 0x800000
+stack_commit  = 0x1000
+```
+
+Both optional; omitting them reproduces today's bytes exactly. They sit on the target
+beside `base` because all three are image memory-layout parameters expressible only on
+some object formats - and because a reserve is address space rather than committed
+memory, so a small tool inheriting a large program's reserve costs nothing.
+
+**Only some formats carry one.** PE keeps both in its optional header, Mach-O keeps a
+reserve in `LC_MAIN.stacksize`; ELF has nowhere to put one and a raw flat image has no
+header. Either key on a target whose resolved object format carries none is refused
+when the manifest is read, naming the key, the target and the format - and **every
+declared target is checked, not only the one being built**, because a key checked only
+in the cell being built is a key that silently does nothing until someone builds the
+other cell months later.
+
+On Mach-O the value reaches only a position-independent image. A non-PIE one enters
+through `LC_UNIXTHREAD`, which has no stacksize member, so a stack size requested there
+is refused at link rather than dropped. That is a property of the image SHAPE rather
+than of the format, is not knowable when the manifest is read, and is therefore checked
+in the writer - two facts, two checks, each where its fact is known.
 ## [4.24.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### link(macho): a C common symbol is allocated instead of demanded as an import (#2974)
+
+An external Mach-O common symbol - `N_UNDF | N_EXT` with a non-zero `n_value` - was read
+as an ordinary undefined import, so a native x86_64 Darwin link of a vendored C
+dependency failed with:
+
+```
+dynamic import _ma_atomic_global_lock has no #[library] attribution
+```
+
+The symbol is a **tentative definition** in the foreign object, not a dylib import.
+Apple Clang emits one for every uninitialized file-scope C global unless the translation
+unit is compiled `-fno-common`, so it arrives whether or not anyone chose it - and the
+message named the symbol correctly and the problem not at all.
+
+`n_value` on such a symbol is the requested SIZE rather than an address, the one place
+in the nlist encoding where it does not mean "where", with the alignment as a log2 in
+`n_desc`. Both are now preserved in the neutral model as `SYM_OBJ_FLAG_COMMON` plus
+`Symbol.align`, alongside `SYM_OBJ_FLAG_EXTERN` - a common IS undefined until the linker
+allocates it, so every consumer that means "needs resolving" keeps working and only the
+one deciding HOW it resolves has to know the difference.
+
+**The allocation belongs to the linker, and arrives as an ordinary input image.** A
+tentative definition asks the linker for storage, and every object declaring the name
+asks for the SAME storage rather than its own - so the commons are gathered once, ahead
+of everything that resolves a symbol, and appended as one synthesized `.bss` input.
+Symbol resolution, dead-stripping and every format's own collection then apply to it
+with no side path, because from that point it is not distinguishable from any other BSS
+definition.
+
+Coalesced by MAX size and alignment, which is the C rule: taking the first size seen
+under-allocates the moment a later unit declares a larger type, and allocating per
+object multiplies the storage and leaves the copies unaliased, so two writers of the
+same name would not see each other.
+
+A real definition of the name wins outright and the common allocates nothing. A strong
+definition and a tentative one are not a duplicate-symbol collision; the tentative one
+exists precisely to yield to it. A relocatable output allocates nothing either, since it
+carries its symbols through unresolved and the eventual link is where the storage is
+decided.
+
+### Fixed
+
 #### link(macho): an x86_64 SUBTRACTOR relocation pair is parsed and resolved (#2973)
 
 Mach refused a normal Apple Clang x86_64 object outright:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### manifest: a target can set the image stack size (#2990)
+
+The PE stack reserve was a literal `0x100000`, so a mach project could not ship a
+Windows program needing more than a megabyte of stack. No flag, no workaround, while
+every other linker exposes it (`/STACK`, `--stack`, `-Wl,--stack`) - and mach owns the
+PE it writes.
+
+Found from a real program: a game's `main` needed a 1,107,824-byte frame against the
+1,048,576-byte reserve, so the image died in its own prologue on every Windows machine
+while running fine on linux, which hands the main thread eight megabytes. The stack
+probe was correct throughout. Only the reserve was unreachable.
+
+```toml
+[target.windows]
+isa  = "x86_64"
+os   = "windows"
+abi  = "win64"
+stack_reserve = 0x800000
+stack_commit  = 0x1000
+```
+
+Both optional; omitting them reproduces today's bytes exactly. They sit on the target
+beside `base` because all three are image memory-layout parameters expressible only on
+some object formats - and because a reserve is address space rather than committed
+memory, so a small tool inheriting a large program's reserve costs nothing.
+
+**Only some formats carry one.** PE keeps both in its optional header, Mach-O keeps a
+reserve in `LC_MAIN.stacksize`; ELF has nowhere to put one and a raw flat image has no
+header. Either key on a target whose resolved object format carries none is refused
+when the manifest is read, naming the key, the target and the format - and **every
+declared target is checked, not only the one being built**, because a key checked only
+in the cell being built is a key that silently does nothing until someone builds the
+other cell months later.
+
+On Mach-O the value reaches only a position-independent image. A non-PIE one enters
+through `LC_UNIXTHREAD`, which has no stacksize member, so a stack size requested there
+is refused at link rather than dropped. That is a property of the image SHAPE rather
+than of the format, is not knowable when the manifest is read, and is therefore checked
+in the writer - two facts, two checks, each where its fact is known.
+
 ### Fixed
 
 #### target(riscv32): a 64-bit reinterpret across the register banks is lowered (#2904)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### target(riscv32): a 64-bit reinterpret across the register banks is lowered (#2904)
+
+`f64 :~ i64` did not compile on riscv32, and the diagnostic named neither the cause nor
+the instruction that was missing:
+
+```
+error: legalize: operation wider than the target ALU is unsupported (MIR_MOV, 8 bytes wide)
+```
+
+A cross-bank move is as wide as **both** banks. `fmv.x.d` moves all 64 bits between an
+`f` register and a GP one, so it needs a 64-bit GP register and is RV64-only - while
+rv32gc's D extension still puts doubles in `f0-f31`. The write is ordinary and the
+register form does not exist.
+
+The reinterpret is now expanded at MIR lowering into a frame round trip - a store in
+the source's bank and a load in the destination's, since the bits are the same in
+either one:
+
+```
+bits   (f64 :~ i64):  fsd fa0,-0x10(s0)  ->  lw a0,-0x10(s0) ; lw a1,-0xc(s0)
+unbits (i64 :~ f64):  sw a0,-0x10(s0) ; sw a1,-0xc(s0)  ->  fld fa0,-0x10(s0)
+narrow (f32 :~ i32):  fmv.x.w a0, fa0
+```
+
+which is what a C toolchain emits on this target. Nothing downstream needed a new
+clause: the float half is an ordinary float move against a MEM operand, which the
+encoder already handled because a spilled side reaches it the same way, and the integer
+half is an ordinary wide integer move that `be.codegen.legalize` already splits.
+
+**The fact is declared, not derived.** `MachineModel.xbank_widths` names the widths an
+ISA crosses between its float bank and a GP register in one instruction, asked through
+a single accessor the way `vec_mem_widths` is. Deriving it from `flen_bits` and
+`gpr_width` gives the right answer on the riscv members by coincidence and the wrong one
+on x86-64, where a 128-bit XMM would imply a 16-byte crossing `movq` does not perform.
+rv64 keeps `fmv.x.d` / `fmv.d.x`; rv32 declares 4 alone, so `f32 :~ i32` still takes
+`fmv.x.w` and only the 64-bit case goes through memory.
+
+The assumption that let this survive was a comment: *a conversion is the one instruction
+with a value in each bank*. A bit reinterpret is the other, and it is corrected in place
+rather than deleted.
+
+Verified by EXECUTION on the riscv32 reference core, not by matching mnemonics: a
+payload whose halves differ and whose high half has the sign bit set round-trips in both
+directions. A lowering that swapped the halves, read the slot at the wrong offset, or
+sign-extended one of them emits the same instructions and a different value.
+
 ## [4.24.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.25.0] - 2026-08-21
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### test: Mach-O gets an external reader on the lane that gates merges (#2957)
+
+`test/engines.conf` gave both darwin rows `main` cadence, so `ci-legs.sh pr` emitted no
+darwin leg and corpus layer A - the step that runs `llvm-readobj` over a mach-produced
+object - ran on a pull request over ELF and COFF only. A change to
+`src/lang/target/of/macho.mach` could reach `dev` with **no external tool having parsed
+its output**; the first external read was the release merge. Between releases mach was
+its own only reader of a format it writes, and darwin is a shipping target.
+
+COFF is why that is not theoretical. `x86_64-windows` had a leg that had never once
+started, so nothing external had read a mach PE either - and the very first layer A run
+found the long section-name form written right-justified and space-padded, which binutils
+tolerates and llvm rejects outright. Every object with a constant pool was unreadable,
+invisible for as long as it was because no external reader had looked (#2952).
+
+The registry gains a `decode` column: a runner that BUILDS AND READS a row on the pr lane
+without executing it. Both darwin rows name `ubuntu-latest`, so their Mach-O objects are
+cross-built and decoded on every pull request while execution stays on the metered mac
+runners at release cadence. The metered-runner reason for that cadence was real and is
+untouched.
+
+**The rule is enforced, not just written down.** `config.py` refuses a registry where a
+`main`-cadence row has no `pr`-cadence reader of its object format, so a future metered
+row is a visible decision rather than an accident.
+
+Demonstrated the way #2952 was: breaking the Mach-O `cputype` turns the x86_64-darwin
+column red on the pr lane and leaves aarch64-darwin green - a selective failure rather
+than a broken harness - and restoring it returns 728 cells green. No new toolchain: the
+llvm tools layer A already requires are the ones that read it.
+
+### Fixed
+
 #### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
 
 `ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### codegen: a frame larger than the target's stack reserve is refused (#2991)
+
+A function whose own stack frame is larger than the target's whole stack reserve can
+never execute, on any input. mach emitted it and said nothing.
+
+Both numbers were already in hand at build time - the encoder receives the frame size
+to decide whether to emit a stack probe, the object writer writes the reserve - and
+nothing compared them. A game's `main` needed 1,107,824 bytes against the
+1,048,576-byte Windows reserve, overrunning it by 59,248 bytes before executing a
+statement. The build was clean, the PE was structurally valid, and the image died in
+its own prologue on every Windows machine. It shipped that way for months, because
+linux gives the main thread eight megabytes and hides it.
+
+```
+error: frame: `main` needs a 1107824-byte stack frame, which its target's
+1048576-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move
+the large locals off the stack
+```
+
+An error rather than a warning because it is a PROOF: one frame against one reserve,
+no call graph, no input dependence, no false positives. The rejected alternative is
+whole-call-graph depth analysis - recursion and indirect calls make cumulative depth
+undecidable, and a heuristic that reports chains which cannot happen trains people to
+ignore the one report that is exact.
+
+Equal is refused and one byte under builds: a frame exactly the size of the reserve
+leaves nothing for the caller that entered it, its return address, or the guard page
+below.
+
+The check lives with the frame layout rather than in an encoder, so it is one rule for
+every ISA rather than an x86-64 fact. It reads the reserve the image will actually get:
+what the target stated (#2990), else the format's own default, else nothing. A target
+whose stack the image does not bound - every ELF one, and a Mach-O image with no stated
+reserve, which takes dyld's default - is not checked at all, because a bound mach did
+not choose is not a bound mach may refuse a program against.
+
 ### Added
 
 #### manifest: a target can set the image stack size (#2990)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### link(macho): an x86_64 SUBTRACTOR relocation pair is parsed and resolved (#2973)
+
+Mach refused a normal Apple Clang x86_64 object outright:
+
+```
+error: macho: unsupported relocation type 5
+```
+
+`macho.mach` defined x86_64 relocation types 0-4 and 6-8 and had no representation for
+`X86_64_RELOC_SUBTRACTOR` at all. Apple Clang emits it constantly as an adjacent
+SUBTRACTOR + UNSIGNED pair - most visibly for a switch jump table, whose entries are
+label differences rather than addresses so the table is position-independent - so a
+vendored C translation unit compiled with `-O2` could simply fail to link.
+
+**The difference is now a first-class relocation.** `RK_DIFF32` / `RK_DIFF64` resolve
+`sym - sym2 + addend`, and `Relocation` gains `sym2`, read only for those kinds so a
+zero-initialized record stays correct everywhere else. Two symbols is the fact rather
+than an encoding detail: folding the pair away in the reader is only right when both
+sides are defined in the object being read, so a reader that folded would be correct
+until the first object that is not a jump table.
+
+The reader mirrors the paired-relocation mechanism `ARM64_RELOC_ADDEND` already used -
+the first entry stashes the subtrahend, the second does the work - including the
+accounting that matters: two entries become ONE record, so the relocation count must
+not count the consumed entry or the image carries a zero-filled trailing relocation.
+
+The linker folds the subtrahend into the addend, since `sym - sym2 + A` is
+`sym + (A - addr(sym2))`, which reuses the existing absolute appliers and their
+overflow checks rather than threading a second target through every ISA. The 32-bit
+form resolves through the SIGNED absolute, because a difference is signed whichever way
+the two labels are ordered.
+
+A difference against a symbol the link does not define is refused with its own message.
+That is correct rather than a limitation: the loader chooses that address, so the
+difference is not a link-time constant and no relocation could make it one.
+
+Malformed pairs are refused individually - a missing second half, a second half that is
+not an UNSIGNED, halves patching different addresses, two SUBTRACTORs in a row - because
+the value written depends on both halves, so guessing at one would silently patch the
+wrong arithmetic.
+
+Mach's own writer emits no SUBTRACTOR, so a difference reaching the Mach-O writer still
+refuses by the existing unsupported-kind path rather than writing something wrong.
+
+### Fixed
+
 #### test: Mach-O gets an external reader on the lane that gates merges (#2957)
 
 `test/engines.conf` gave both darwin rows `main` cadence, so `ci-legs.sh pr` emitted no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
+
+`ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the
+lowering pass, and discarded the pass's own result. A pass that fails by **returning** an
+error rather than filing a diagnostic - the always-on IR verifier's conversion-width
+refusal, for one - was therefore invisible to it.
+
+The consequence: every `ut_lower_clean` case guarding that class was passing vacuously.
+Reintroducing #2982's defect (`lower_lit_char` stamping every character constant 8 bits
+instead of reading the type sema settled) left the whole suite green, while a real build
+of the same source refused it with exactly the reported error. The fix was correct; there
+was simply nothing holding it.
+
+The helper now treats a failed pass as an error. The guard it exists for fails when the
+defect is reintroduced, which is the property it was always assumed to have.
+
+### Fixed
+
 #### codegen: a frame larger than the target's stack reserve is refused (#2991)
 
 A function whose own stack frame is larger than the target's whole stack reserve can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### test(link): the c-variadic golden samples both register-slot floats (#3043)
+
+The `floats` line reported `out[0]`, `out[3]` and `out[7]`. On win64 only the first four
+POSITIONAL slots have registers, and the two fixed parameters take two of them - so of
+those eight doubles only `out[0]` and `out[1]` ride a register and can expose a broken
+`float_dup_gp`, the rule that duplicates a tail float into the integer register of its
+slot. Eight doubles read like broad coverage of the register/stack boundary and, for
+that rule, were a **one-value check**: `out[1]` is equally broken by the same defect and
+was never printed.
+
+Found by mutation-testing the leg #3005 enabled, not by a failure. Nothing was wrong;
+the margin was simply thinner than the case looked, and the next person to weaken the
+rule had one printed value standing between them and a green run.
+
+`out[7]` stays as the stack-side control - a mutation that moved it too would mean
+something different and worse.
+
+### Fixed
+
 #### test: a failed lowering pass counts as an error, so char-width regressions actually regress (#2949)
 
 `ut_lower_clean` reported "no errors" by counting the DIAGNOSTIC SINK after running the

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -152,6 +152,19 @@ format, which carries no stack size in its image headers
 Every declared target is checked, not only the one being built, so the mistake is found
 on the first build rather than whenever someone happens to build that cell.
 
+A function whose own stack frame exceeds the reserve is refused at build time, naming
+the function, its frame size and the reserve:
+
+```
+error: frame: `main` needs a 1107824-byte stack frame, which its target's
+1048576-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move
+the large locals off the stack
+```
+
+That is a proof rather than an estimate - one frame against one reserve, with no call
+graph and no input dependence - so it is an error and has no false positives. Targets
+whose stack is not bounded by the image, such as every ELF target, are not checked.
+
 On Mach-O the value reaches only a **position-independent** image. A non-PIE one enters
 through `LC_UNIXTHREAD`, which has no stacksize member, and a stack size requested for
 such an image is refused at link rather than silently dropped.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -111,6 +111,50 @@ to whichever *declared* target matches the host.
 | `of`  | no       | Object-format override; defers to the os's format when omitted. See [Object-format override](#object-format-override). |
 | `base` | no      | Load-address override (integer). Overrides the os's default base virtual address; defers to it (`0` for `freestanding`) when omitted. |
 | `platform` | no  | Open platform tag (string), surfaced to comptime as `$mach.build.platform` (empty when unset). A support library keys its backend on it; the compiler treats it as opaque. See [Platform targets](#platform-targets-bare-metal). |
+| `stack_reserve` | no | Thread stack reserve in bytes. See [Image stack size](#image-stack-size). |
+| `stack_commit` | no | Thread stack commit in bytes. See [Image stack size](#image-stack-size). |
+
+### Image stack size
+
+`stack_reserve` and `stack_commit` set the thread stack an image asks its loader for,
+as byte counts:
+
+```toml
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+stack_reserve = 0x800000        # 8 MiB
+stack_commit  = 0x1000          # 4 KiB
+```
+
+Both are optional. Omitting them keeps the format's conventional default, so an image
+built without them is byte-identical to one built before the keys existed. On PE that
+default is a 1 MiB reserve and a 4 KiB commit.
+
+A **reserve** is address space, not committed memory, so raising it costs nothing until
+the stack is actually used. That is also why these live on the target rather than the
+artifact: two artifacts built for one target share the value, and a small tool
+inheriting a large program's reserve pays nothing for it.
+
+**Only some object formats carry a stack size.** PE keeps both in its optional header
+and Mach-O keeps a reserve in `LC_MAIN.stacksize`. ELF has nowhere to put one — a linux
+main thread's stack is the kernel's and `ulimit`'s business — and a raw flat image has
+no header at all. Either key on a target whose resolved object format carries no stack
+size is refused when the manifest is read, naming the key, the target and the format,
+before anything builds:
+
+```
+error: mach.toml: [target.lin].stack_reserve is not expressible on the `elf` object
+format, which carries no stack size in its image headers
+```
+
+Every declared target is checked, not only the one being built, so the mistake is found
+on the first build rather than whenever someone happens to build that cell.
+
+On Mach-O the value reaches only a **position-independent** image. A non-PIE one enters
+through `LC_UNIXTHREAD`, which has no stacksize member, and a stack size requested for
+such an image is refused at link rather than silently dropped.
 
 ### Accepted tuple values
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.24.0"
+version = "4.25.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -35,6 +35,11 @@ use std.types.string.str;
 
 use O: std.types.option;
 use R: std.types.result;
+use std.allocator.page;
+use std.types.string.str_contains;
+use A: std.allocator;
+use std.format;
+use of: mach.lang.target.of;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
@@ -57,6 +62,10 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
 
     val align: u32 = stack_align(tgt);
 
+    # the reserve this target's image will actually get, or 0 when nothing bounds it
+    # at compile time. read once: it is a property of the target, not of a function.
+    val reserve: u64 = of.effective_stack_reserve(tgt.of, tgt.stack_reserve);
+
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val func: *mir.MirFunction = ?m.functions[fi];
@@ -65,10 +74,57 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
         # layout rather than racing it.
         func.frame.omit = omits_frame(func, tgt.model.frame_ptr_reg::u32,
                                       tgt.model.stack_ptr_reg::u32);
+
+        val over: R.Result[bool, str] = check_frame_fits(m, func, reserve);
+        if (R.is_err[bool, str](over)) { ret over; }
         fi = fi + 1;
     }
 
     ret R.ok[bool, str](true);
+}
+
+# refuse a function whose own frame cannot fit in the image's stack reserve (#2991)
+#
+# A PROOF, NOT AN ESTIMATE, which is why it is an error rather than a warning: one
+# frame against one reserve, no call graph, no input dependence, no false positives.
+# A function whose single frame exceeds the whole stack can never execute, on any
+# input, and mach used to emit it and say nothing - a real program shipped for months
+# needing 1,107,824 bytes against a 1,048,576-byte reserve, dying in its own prologue
+# on every Windows machine while running fine on linux, which hands the main thread
+# eight megabytes and hides it.
+#
+# THE REJECTED ALTERNATIVE is whole-call-graph depth analysis. Recursion and indirect
+# calls make cumulative depth undecidable, and a heuristic that reports chains which
+# cannot happen trains people to ignore the one report that is exact.
+#
+# EQUAL IS REFUSED. A frame exactly the size of the reserve leaves nothing for the
+# caller that entered it, the return address it was called through, or the guard page
+# the OS keeps below - so the boundary is `>=`, and one byte under it builds.
+#
+# A zero reserve means nothing bounds the stack at compile time (an ELF target's is
+# the kernel's), and the check does not run.
+# ---
+# m:       the MIR module, for the interner that names the function
+# func:    the laid-out function
+# reserve: the image's effective stack reserve, or 0 to skip
+# ret:     ok(true) when the frame fits, or the refusal naming function, size, reserve
+fun check_frame_fits(m: *mir.MirModule, func: *mir.MirFunction, reserve: u64) R.Result[bool, str] {
+    if (reserve == 0) { ret R.ok[bool, str](true); }
+    if (func.frame.size::u64 < reserve) { ret R.ok[bool, str](true); }
+
+    var name: str = "<unknown>";
+    if (m.interner != nil) {
+        val o: O.Option[str] = intern.lookup(m.interner, func.name);
+        if (O.is_some[str](o)) { name = O.unwrap[str](o); }
+    }
+
+    val r: R.Result[str, str] = format.sprint(m.alloc,
+        "frame: `{}` needs a {}-byte stack frame, which its target's {}-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move the large locals off the stack",
+        name, func.frame.size::u64, reserve);
+    if (R.is_err[str, str](r)) {
+        ret R.err[bool, str]("frame: a function's stack frame exceeds the target's stack reserve");
+    }
+    ret R.err[bool, str](R.unwrap_ok[str, str](r));
 }
 
 # report whether a function needs no compiler-generated prologue or epilogue
@@ -1166,4 +1222,94 @@ test "mach.lang.be.codegen.frame.run:stamps_the_omission_decision" {
     if (!funcs[0].frame.omit) { ret 1; }
     if (funcs[1].frame.omit)  { ret 1; }
     ret 0;
+}
+
+# The frame-versus-reserve boundary is exact, and a zero reserve does not diagnose (#2991).
+#
+# Tested here rather than through a compiled program because the boundary is the claim:
+# source big enough to produce a frame of EXACTLY the reserve is not something a test
+# can write and keep true, since the frame carries saved registers and padding the
+# author does not control. The refusal is a proof about two numbers, so the two numbers
+# are what it is checked against.
+#
+# EQUAL IS REFUSED. A frame exactly the size of the reserve leaves nothing for the
+# caller that entered it, the return address, or the guard page below - and "one byte
+# under builds" is what keeps the rule a proof rather than a margin someone tuned.
+test "mach.lang.be.codegen.frame.check_frame_fits:boundary_is_exact" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var m: mir.MirModule;
+    m.alloc        = ?alloc;
+    m.interner     = ?i;
+    m.srcmap       = nil;
+    m.functions    = nil;
+    m.function_len = 0;
+    m.function_cap = 0;
+
+    val nr: R.Result[intern.StrId, str] = intern.intern(?i, "fat");
+    if (R.is_err[intern.StrId, str](nr)) { ret 1; }
+
+    var f: mir.MirFunction;
+    f.name = R.unwrap_ok[intern.StrId, str](nr);
+
+    var bad: i32 = 0;
+
+    # one byte under the reserve builds
+    f.frame.size = 1048575;
+    if (R.is_err[bool, str](check_frame_fits(?m, ?f, 1048576)) && bad == 0) { bad = 2; }
+
+    # exactly the reserve is refused
+    f.frame.size = 1048576;
+    if (R.is_ok[bool, str](check_frame_fits(?m, ?f, 1048576)) && bad == 0) { bad = 3; }
+
+    # over it is refused, and the message owes the reader three facts: which function,
+    # how big its frame is, and what it was measured against
+    f.frame.size = 1107824;
+    val over: R.Result[bool, str] = check_frame_fits(?m, ?f, 1048576);
+    if (R.is_ok[bool, str](over)) { bad = 4; }
+    or {
+        val msg: str = R.unwrap_err[bool, str](over);
+        if (!str_contains(msg, "fat")     && bad == 0) { bad = 5; }
+        if (!str_contains(msg, "1107824") && bad == 0) { bad = 6; }
+        if (!str_contains(msg, "1048576") && bad == 0) { bad = 7; }
+    }
+
+    # A ZERO RESERVE IS "NOTHING BOUNDS THIS", not "a reserve of zero". An ELF target's
+    # stack is the kernel's and `ulimit`'s, and a Mach-O image with no stated reserve
+    # takes dyld's default - neither is a number mach put in the image, so neither may
+    # refuse a program that runs.
+    f.frame.size = 999999999;
+    if (R.is_err[bool, str](check_frame_fits(?m, ?f, 0)) && bad == 0) { bad = 8; }
+
+    ret bad;
+}
+
+# The effective reserve prefers what a target STATED over what the format defaults to (#2991).
+#
+# The three cases are ordered, and the order is what makes the check honest: a stated
+# reserve is what the writer will put in the image, a format default is what it puts in
+# when nothing is stated, and 0 means mach chose no number at all and must not pretend
+# otherwise.
+test "mach.lang.be.codegen.frame.effective_stack_reserve:stated_beats_default" {
+    var pe: of.OfVTable;
+    pe.carries_stack_size    = true;
+    pe.default_stack_reserve = 0x100000;
+
+    var elf_vt: of.OfVTable;
+    elf_vt.carries_stack_size    = false;
+    elf_vt.default_stack_reserve = 0;
+
+    var bad: i32 = 0;
+    # stated wins over the format default
+    if (of.effective_stack_reserve(?pe, 0x800000) != 0x800000)   { bad = 1; }
+    # unstated falls to the format default
+    if (of.effective_stack_reserve(?pe, 0) != 0x100000          && bad == 0) { bad = 2; }
+    # a format with no default bounds nothing when nothing is stated
+    if (of.effective_stack_reserve(?elf_vt, 0) != 0             && bad == 0) { bad = 3; }
+    # ...but a stated value still stands: the manifest already refused the key where it
+    # cannot be carried, so reaching here with one means the format carries it
+    if (of.effective_stack_reserve(?elf_vt, 0x800000) != 0x800000 && bad == 0) { bad = 4; }
+    ret bad;
 }

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -309,9 +309,19 @@ fun function_needs_legalize(f: *mir.MirFunction, mach: *Machine) bool {
 # mach: the machine facts (native lane width, pointer width, shift/multiply capability)
 # ret:  true when the instruction needs legalization
 fun instr_needs_legalize(f: *mir.MirFunction, mi: *mir.MirInstr, mach: *Machine) bool {
-    # A CONVERSION IS THE ONE INSTRUCTION WITH A VALUE IN EACH BANK, so the float-bank
-    # exclusion below cannot decide it: excluding it leaves a wide INTEGER side that the
-    # planner has already split, naming lane vregs nothing defines (#2860).
+    # A CONVERSION IS THE ONE INSTRUCTION THAT REACHES HERE WITH A VALUE IN EACH BANK,
+    # so the float-bank exclusion below cannot decide it: excluding it leaves a wide
+    # INTEGER side that the planner has already split, naming lane vregs nothing
+    # defines (#2860).
+    #
+    # A BIT REINTERPRET IS THE OTHER DUAL-BANK INSTRUCTION, and it used to reach here
+    # too - as a retagged MIR_MOV that this exclusion dropped into the generic width
+    # refusal, naming an opcode the user never wrote (#2904). It no longer does: a
+    # crossing the target has no register form for is expanded into a frame round trip
+    # at MIR lowering, and what arrives here is an ordinary float move against a MEM
+    # operand plus an ordinary wide integer move against one, which the clauses below
+    # already split. The distinction is worth keeping in view - "the one instruction
+    # with a value in each bank" was the assumption that let the gap survive.
     if (conv_is_wide(mach, mi)) { ret true; }
     if (instr_rides_fp_bank(f, mi)) { ret false; }
     if (mi.width > mach.lane_width || mi.src_width > mach.lane_width) { ret true; }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -96,6 +96,7 @@ use mach.lang.me.ir.value;
 use mach.lang.source;
 use treg: mach.lang.target;
 use target: mach.lang.target.resolved;
+use isa: mach.lang.target.isa;
 
 # lower an IR module to a parallel MIR module, one MIR function per IR function
 # ---
@@ -1097,6 +1098,11 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # negate to its dedicated SSE lowering before the generic path.
     if (inst.kind == instr.OP_NEG && lctx.value_is_float(ctx, inst.ty)) {
         ret lower_float_neg(ctx, mb, inst, iid);
+    }
+    # a bit reinterpret across the register banks at a width this machine has no
+    # register-to-register form for goes through the frame instead (#2904).
+    if (inst.kind == instr.OP_BITCAST && bitcast_needs_frame(ctx, inst)) {
+        ret lower_bitcast_via_frame(ctx, mb, inst, iid);
     }
     # integer division / remainder needs the dividend / remainder register wiring
     # the active ISA's division form mandates (x86-64 IDIV/DIV reads the dividend
@@ -2169,6 +2175,97 @@ fun lower_float_op(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
 # inst: the IR float negate instruction
 # iid:  the IR instruction id
 # ret:  true on success, or a lowering / allocation error
+# whether this `:~` crosses the register banks at a width the target cannot cross in
+# one instruction (#2904)
+#
+# A BIT REINTERPRET IS THE SECOND INSTRUCTION WITH A VALUE IN EACH BANK - a conversion
+# was long treated as the only one. A same-bank `:~` is a register copy and a
+# cross-bank one selects to a plain MOV that the encoder dispatches on operand
+# register CLASS, which is true on every target that HAS the instruction. RV32 is the
+# member that does not: the D extension puts 64-bit doubles in f0-f31 while XLEN stays
+# 4, so `f64 :~ i64` is ordinary to write and `fmv.x.d` is RV64-only. It reached
+# `be.codegen.legalize` as a retagged MIR_MOV, missed the lane split because one side
+# is FP-class, and fell out into a generic width refusal naming an opcode the user
+# never wrote.
+#
+# ASKED OF THE TARGET, not derived from the widths. `flen_bits` and `gpr_width` give
+# the right answer on the riscv members by coincidence and the wrong one on x86-64,
+# where a 128-bit XMM would imply a 16-byte crossing that `movq` does not perform.
+# ---
+# ctx:  the lowering context
+# inst: the OP_BITCAST being lowered
+# ret:  true when the crossing has no register form and must go through memory
+fun bitcast_needs_frame(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
+    if (inst.operand_count < 1) { ret false; }
+
+    val dst_float: bool = lctx.value_is_float(ctx, inst.ty);
+    val src_float: bool = lctx.value_is_float(ctx, inst.operands[0].ty);
+    if (dst_float == src_float) { ret false; }
+
+    # a vector side is a different question and a different path: it rides the vector
+    # register file, whose memory crossings `vec_mem_widths` already answers.
+    if (lctx.value_is_vector(ctx, inst.ty))              { ret false; }
+    if (lctx.value_is_vector(ctx, inst.operands[0].ty))  { ret false; }
+
+    val w: u8 = lctx.op_width_of(ctx, inst.ty);
+    if (w == 0) { ret false; }
+    ret !isa.moves_cross_bank(?ctx.tgt.model, w::u32);
+}
+
+# lower a cross-bank `:~` with no register form into a frame round trip (#2904)
+#
+# A store in the SOURCE's bank followed by a load in the DESTINATION's. The bits are
+# the same in either bank, so the two halves need no conversion between them - which
+# is why this is a reinterpret and not `is_int_fp_conv`'s problem. On rv32 the pair
+# encodes as `fsd` then two `lw`, or two `sw` then `fld`, which is what a C toolchain
+# emits on this target.
+#
+# NOTHING BELOW HERE NEEDS TO KNOW. The float side is an ordinary float move against a
+# MEM operand, which the encoder already handles because a spilled side reaches it the
+# same way. The integer side is an ordinary wide integer move against a MEM operand,
+# which `be.codegen.legalize` already splits into lane-width pieces - so the wide half
+# is legalized by the machinery that was refusing it, with no new clause.
+# ---
+# ctx:  the lowering context
+# mb:   the block to append to
+# inst: the OP_BITCAST being lowered
+# iid:  its instruction id, for the result vreg
+# ret:  true on success, or an allocation error
+fun lower_bitcast_via_frame(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[bool, str] {
+    val dst: u32 = lctx.instr_vreg(ctx, iid);
+    if (dst == mir.MIR_VREG_NIL) {
+        ret R.err[bool, str]("mir.lower_ir: cross-bank reinterpret defines no result vreg");
+    }
+    val w: u8 = lctx.op_width_of(ctx, inst.ty);
+
+    # an internal slot-key vreg owns the storage; it is addressed only as a MEM base,
+    # never register-allocated. the slot is the value's own width and alignment, so
+    # both halves are naturally aligned accesses.
+    val skr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](skr)) { ret R.err[bool, str](R.unwrap_err[u32, str](skr)); }
+    val sk: u32 = R.unwrap_ok[u32, str](skr);
+
+    val ar: R.Result[bool, str] = lctx.add_spill_slot_aligned(ctx, sk, w::u64, w::u32);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+
+    val sr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (R.is_err[*mir.MirOperand, str](sr)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](sr)); }
+    val sops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](sr);
+    sops[0] = mir.op_mem_slot(sk, 0);
+    sops[1] = lctx.lower_value(ctx, inst.operands[0]);
+    var si: mir.MirInstr = mir.instr(mir.MIR_MOV, sops, 2, w, w);
+    val spr: R.Result[bool, str] = lctx.push_instr(ctx, mb, si);
+    if (R.is_err[bool, str](spr)) { ret spr; }
+
+    val lr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (R.is_err[*mir.MirOperand, str](lr)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](lr)); }
+    val lops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](lr);
+    lops[0] = mir.op_vreg(dst);
+    lops[1] = mir.op_mem_slot(sk, 0);
+    var li: mir.MirInstr = mir.instr(mir.MIR_MOV, lops, 2, w, w);
+    ret lctx.push_instr(ctx, mb, li);
+}
+
 fun lower_float_neg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[bool, str] {
     if (inst.operand_count < 1) {
         ret R.err[bool, str]("mir.lower_ir: float negate missing operand");

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -792,6 +792,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # the writers decide what the image header needs to be from the OS's own fact,
     # never from the page size (#2895).
     opts.mapped_by_loader = tgt.os.mapped_by_loader;
+    # the image stack sizes ride the resolved target the same way, so no caller
+    # constructing options has to know about them (#2990). 0 leaves the writer's default.
+    opts.stack_reserve = tgt.stack_reserve;
+    opts.stack_commit  = tgt.stack_commit;
     var local_atoms: AtomPlan;
     init_atom_plan(?local_atoms);
     var pre_atoms: *AtomPlan = nil;

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -760,7 +760,233 @@ fun link_modules_nocapture(s: *session.Session, tgt: *target.Target, modules: *o
                      out_path, name, mode, pie_opt_in, image_options, nil::*LinkedImage);
 }
 
+# build one input image holding zero-initialized storage for every C common symbol
+# that no object actually defines (#2974)
+#
+# COALESCED BY MAX, which is the C rule: several translation units may each declare the
+# same tentative definition, and they are asking for ONE object big enough for all of
+# them, not one each. Taking the first size seen would under-allocate whenever a later
+# unit declared a larger type, and allocating per-object would multiply the storage and
+# leave the copies unaliased.
+#
+# A REAL DEFINITION WINS OUTRIGHT and the common is dropped, which is why the scan for
+# definitions runs first. A strong definition and a tentative one are not a duplicate-
+# symbol collision; the tentative one exists precisely to yield to it.
+#
+# Skipped for a relocatable output, which carries its symbols through unresolved: the
+# eventual link is where the storage is decided, and allocating here would turn a
+# tentative definition into a real one that then collides with the real one.
+# ---
+# out: receives the synthesized image when this returns ok(true)
+# ret: ok(true) when storage was synthesized, ok(false) when there was nothing to do
+fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
+                              module_count: u32, mode: LinkMode,
+                              out: *of.ObjectImage) R.Result[bool, str] {
+    if (mode == LINK_RELOCATABLE || modules == nil || module_count == 0) {
+        ret R.ok[bool, str](false);
+    }
+    val alloc: *A.Allocator = s.alloc;
+
+    # names some object really defines; a common of the same name yields to them
+    var defined: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var m: u32 = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (sym.section != of.SECTION_EXTERNAL && sym.section < modules[m].section_count) {
+                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) {
+                    val di: R.Result[bool, str] = map.insert[intern.StrId, u32](?defined, sym.name, 0);
+                    if (R.is_err[bool, str](di)) {
+                        map.dnit[intern.StrId, u32](?defined);
+                        ret R.err[bool, str](R.unwrap_err[bool, str](di));
+                    }
+                }
+            }
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+
+    # first occurrence owns the slot, so the layout is module/symbol order and the
+    # output bytes do not depend on map iteration
+    var slot: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var names: Vector[intern.StrId] = vector.init[intern.StrId](alloc);
+    var sizes: Vector[u32] = vector.init[u32](alloc);
+    var aligns: Vector[u32] = vector.init[u32](alloc);
+
+    m = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if ((sym.flags & of.SYM_OBJ_FLAG_COMMON) == 0) { sy = sy + 1; cnt; }
+            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) { sy = sy + 1; cnt; }
+
+            var al: u32 = sym.align;
+            if (al == 0) { al = 1; }
+            val ex: R.Result[*u32, str] = map.get[intern.StrId, u32](?slot, ?sym.name);
+            if (R.is_ok[*u32, str](ex)) {
+                val at: u32 = @R.unwrap_ok[*u32, str](ex);
+                if (sym.size > sizes.data[at]) { sizes.data[at] = sym.size; }
+                if (al > aligns.data[at])      { aligns.data[at] = al; }
+                sy = sy + 1;
+                cnt;
+            }
+            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?slot, sym.name, names.len::u32);
+            if (R.is_err[bool, str](ins)) {
+                map.dnit[intern.StrId, u32](?slot);
+                map.dnit[intern.StrId, u32](?defined);
+                vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+                ret R.err[bool, str](R.unwrap_err[bool, str](ins));
+            }
+            vector.push[intern.StrId](?names, sym.name);
+            vector.push[u32](?sizes, sym.size);
+            vector.push[u32](?aligns, al);
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    map.dnit[intern.StrId, u32](?slot);
+    map.dnit[intern.StrId, u32](?defined);
+
+    if (names.len == 0) {
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        ret R.ok[bool, str](false);
+    }
+
+    # lay the slots out in declaration order, each at its own alignment
+    var total: u64 = 0;
+    var sec_align: u32 = 1;
+    var offs: Vector[u32] = vector.init[u32](alloc);
+    var n: usize = 0;
+    for (n < names.len) {
+        val al: u64 = aligns.data[n]::u64;
+        if (aligns.data[n] > sec_align) { sec_align = aligns.data[n]; }
+        total = (total + al - 1) / al * al;
+        if (total > 0x7FFFFFFF) {
+            vector.dnit[u32](?offs);
+            vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+            ret R.err[bool, str]("link: common storage exceeds 2 GiB");
+        }
+        vector.push[u32](?offs, total::u32);
+        total = total + sizes.data[n]::u64;
+        n = n + 1;
+    }
+
+    val image_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "<common-storage>");
+    val section_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".bss");
+    if (R.is_err[intern.StrId, str](image_name_r) || R.is_err[intern.StrId, str](section_name_r)) {
+        vector.dnit[u32](?offs);
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        ret R.err[bool, str]("link: could not intern the common storage names");
+    }
+    @out = R.unwrap_ok[of.ObjectImage, str](
+        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](image_name_r)));
+
+    # SK_BSS carries no bytes on disk; the writers zero it, which is exactly what a
+    # tentative definition asks for.
+    var sec: of.Section;
+    sec.name  = R.unwrap_ok[intern.StrId, str](section_name_r);
+    sec.kind  = of.SK_BSS;
+    sec.bytes = nil;
+    sec.len   = total::u32;
+    sec.align = sec_align;
+    val sec_r: R.Result[u32, str] = obj.add_section(out, sec);
+    if (R.is_err[u32, str](sec_r)) {
+        vector.dnit[u32](?offs);
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        obj.dnit(out);
+        ret R.err[bool, str](R.unwrap_err[u32, str](sec_r));
+    }
+    val sec_ix: u32 = R.unwrap_ok[u32, str](sec_r);
+
+    n = 0;
+    for (n < names.len) {
+        var osym: of.Symbol;
+        osym.name    = names.data[n];
+        osym.section = sec_ix;
+        osym.offset  = offs.data[n];
+        osym.size    = sizes.data[n];
+        # a definition like any other from here on: GLOBAL so it resolves references
+        # from every object, OBJECT because it is data, and NOT weak - a common that
+        # reached this point is the only definition there is.
+        osym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+        val sa: R.Result[u32, str] = obj.add_symbol(out, osym);
+        if (R.is_err[u32, str](sa)) {
+            vector.dnit[u32](?offs);
+            vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+            obj.dnit(out);
+            ret R.err[bool, str](R.unwrap_err[u32, str](sa));
+        }
+        n = n + 1;
+    }
+
+    vector.dnit[u32](?offs);
+    vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+    ret R.ok[bool, str](true);
+}
+
+
+# resolve C common storage, then link (#2974)
+#
+# A tentative definition is not an import and not a section definition: it asks the
+# LINKER for zero-initialized storage, and every object declaring the name asks for the
+# same storage rather than its own. So the allocation belongs here, once, ahead of
+# everything that resolves a symbol - and it arrives as an ordinary input image, which
+# is what keeps symbol resolution, dead-stripping and every format's own collection
+# working on it with no side path.
+#
+# A wrapper rather than a branch inside the body: with the storage appended, the rest
+# of the link cannot tell a common apart from any other BSS definition, and there is
+# exactly one new path through the function instead of one per stage.
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
+                 module_count: u32, codegen_count: u32,
+                 dynlibs: *of.DynLib, dynlib_count: u32,
+                 out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
+                 image_options: of.ImageOptions, capture: *LinkedImage) R.Result[bool, str] {
+    val alloc0: *A.Allocator = s.alloc;
+    var commons: of.ObjectImage;
+    val cr: R.Result[bool, str] = synthesize_common_storage(s, modules, module_count, mode, ?commons);
+    if (R.is_err[bool, str](cr)) { ret R.err[bool, str](R.unwrap_err[bool, str](cr)); }
+    if (!R.unwrap_ok[bool, str](cr)) {
+        ret link_modules_with_commons(s, tgt, modules, module_count, codegen_count,
+                                      dynlibs, dynlib_count, out_path, name, mode,
+                                      pie_opt_in, image_options, capture);
+    }
+
+    if (module_count == 0xFFFFFFFF) {
+        obj.dnit(?commons);
+        ret R.err[bool, str]("link: too many input objects to append common storage");
+    }
+    val all_r: R.Result[*of.ObjectImage, str] =
+        A.allocate[of.ObjectImage](alloc0, (module_count + 1)::usize);
+    if (R.is_err[*of.ObjectImage, str](all_r)) {
+        obj.dnit(?commons);
+        ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](all_r));
+    }
+    val all: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](all_r);
+    var ci: u32 = 0;
+    for (ci < module_count) {
+        all[ci] = modules[ci];
+        ci = ci + 1;
+    }
+    all[module_count] = commons;
+
+    # the storage is a synthesized input, never a codegen one, so `codegen_count` is
+    # unchanged: the passes that treat the first N images as mach's own must keep
+    # counting the same N.
+    val linked: R.Result[bool, str] = link_modules_with_commons(
+        s, tgt, all, module_count + 1, codegen_count, dynlibs, dynlib_count,
+        out_path, name, mode, pie_opt_in, image_options, capture);
+    A.deallocate[of.ObjectImage](alloc0, all, (module_count + 1)::usize);
+    obj.dnit(?commons);
+    ret linked;
+}
+
+fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
@@ -12151,4 +12377,138 @@ test "mach.lang.be.linker.local_got_plan:deduplicates_effective_target" {
     map.dnit[intern.StrId, SymbolLoc](?locs);
     session.dnit(?s);
     ret 0;
+}
+
+# build a one-symbol input image declaring `name` as C common storage
+fun lt_common_module(s: *session.Session, mod_name: str, name: str, size: u32, align: u32) of.ObjectImage {
+    val alloc: *A.Allocator = s.alloc;
+    val mn: R.Result[intern.StrId, str] = intern.intern(?s.interner, mod_name);
+    val sn: R.Result[intern.StrId, str] = intern.intern(?s.interner, name);
+    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](
+        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn)));
+    var sym: of.Symbol;
+    sym.name    = R.unwrap_ok[intern.StrId, str](sn);
+    sym.section = of.SECTION_EXTERNAL;
+    sym.offset  = 0;
+    sym.size    = size;
+    sym.align   = align;
+    sym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_COMMON;
+    obj.add_symbol(?img, sym);
+    ret img;
+}
+
+# Competing tentative definitions coalesce into ONE allocation at the largest size and
+# alignment either asked for (#2974).
+#
+# This is the C rule and the reason the allocation belongs to the linker rather than to
+# any reader: several translation units may each declare the same tentative definition,
+# and they are asking for one object big enough for all of them, not one each. Taking
+# the first size seen under-allocates the moment a later unit declares a larger type,
+# and allocating per object multiplies the storage and leaves the copies unaliased -
+# two writers of `_ma_atomic_global_lock` would then not see each other.
+test "mach.lang.be.linker.synthesize_common_storage:coalesces_to_the_largest_request" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_common_module(?s, "a.o", "_shared", 8, 4);
+    mods[1] = lt_common_module(?s, "b.o", "_shared", 40, 16);
+
+    var bad: i32 = 0;
+    var out: of.ObjectImage;
+    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    if (R.is_err[bool, str](cr)) { bad = 2; }
+    or (!R.unwrap_ok[bool, str](cr)) { bad = 3; }
+    or {
+        # ONE definition, not two
+        if (out.symbol_count != 1                      && bad == 0) { bad = 4; }
+        or (out.section_count != 1                     && bad == 0) { bad = 5; }
+        or {
+            # the largest request wins on both axes
+            if (out.symbols[0].size != 40              && bad == 0) { bad = 6; }
+            if (out.sections[0].len != 40              && bad == 0) { bad = 7; }
+            if (out.sections[0].align != 16            && bad == 0) { bad = 8; }
+            # zero-initialized storage carries no bytes on disk
+            if (out.sections[0].kind != of.SK_BSS      && bad == 0) { bad = 9; }
+            if (out.sections[0].bytes != nil           && bad == 0) { bad = 10; }
+            # and it is an ordinary definition from here on, so every reference
+            # resolves to it through the normal collector
+            if ((out.symbols[0].flags & of.SYM_OBJ_FLAG_GLOBAL) == 0 && bad == 0) { bad = 11; }
+            if ((out.symbols[0].flags & of.SYM_OBJ_FLAG_EXTERN) != 0 && bad == 0) { bad = 12; }
+        }
+        obj.dnit(?out);
+    }
+
+    obj.dnit(?mods[0]);
+    obj.dnit(?mods[1]);
+    session.dnit(?s);
+    ret bad;
+}
+
+# A REAL definition of the name wins outright, and the common allocates nothing (#2974).
+#
+# A strong definition and a tentative one are not a duplicate-symbol collision: the
+# tentative one exists precisely to yield to it. Allocating anyway would put a second
+# object of the same name in the image, and whichever the collector then picked, half
+# the references would reach storage nobody else writes.
+test "mach.lang.be.linker.synthesize_common_storage:a_real_definition_wins" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var mods: [2]of.ObjectImage;
+    mods[0] = lt_common_module(?s, "a.o", "_shared", 40, 16);
+
+    # a module that really defines `_shared` in its own .data
+    val mn: R.Result[intern.StrId, str] = intern.intern(?s.interner, "b.o");
+    val dn: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".data");
+    val sn: R.Result[intern.StrId, str] = intern.intern(?s.interner, "_shared");
+    mods[1] = R.unwrap_ok[of.ObjectImage, str](
+        obj.init(?alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn)));
+    var bytes: [8]u8;
+    var z: usize = 0;
+    for (z < 8) { bytes[z] = 0; z = z + 1; }
+    var sec: of.Section;
+    sec.name = R.unwrap_ok[intern.StrId, str](dn);
+    sec.kind = of.SK_DATA;
+    sec.bytes = ?bytes[0];
+    sec.len = 8;
+    sec.align = 8;
+    val si: R.Result[u32, str] = obj.add_section(?mods[1], sec);
+    var dsym: of.Symbol;
+    dsym.name    = R.unwrap_ok[intern.StrId, str](sn);
+    dsym.section = R.unwrap_ok[u32, str](si);
+    dsym.offset  = 0;
+    dsym.size    = 8;
+    dsym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    obj.add_symbol(?mods[1], dsym);
+
+    var bad: i32 = 0;
+    var out: of.ObjectImage;
+    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    if (R.is_err[bool, str](cr)) { bad = 2; }
+    or (R.unwrap_ok[bool, str](cr)) {
+        # nothing should have been synthesized at all
+        bad = 3;
+        obj.dnit(?out);
+    }
+
+    # ...and a relocatable output allocates nothing either: it carries its symbols
+    # through unresolved, and the eventual link is where the storage is decided.
+    if (bad == 0) {
+        var out2: of.ObjectImage;
+        val rr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 1, LINK_RELOCATABLE, ?out2);
+        if (R.is_err[bool, str](rr)) { bad = 4; }
+        or (R.unwrap_ok[bool, str](rr)) { bad = 5; obj.dnit(?out2); }
+    }
+
+    obj.dnit(?mods[0]);
+    obj.dnit(?mods[1]);
+    session.dnit(?s);
+    ret bad;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4714,6 +4714,67 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
 # atoms:         the dead-atom plan, for the live-offset remap
 # out:           out - the symbol and owning-section location, when live
 # ret:           true when the symbol has a live location, false when atom-dropped
+# the final address of a difference relocation's SUBTRAHEND, or an error (#2973)
+#
+# `sym - sym2 + addend` needs both sides resolved, and only the minuend rides the
+# ordinary path. This resolves the other one the same two ways that path does: an
+# object-private definition through its own module's placement, and anything else by
+# the name that won the link.
+#
+# A DIFFERENCE AGAINST A DYNAMIC IMPORT IS REFUSED, and that is correct rather than a
+# limitation: the subtrahend's address is chosen by the loader, so the difference is
+# not a link-time constant and no relocation the writer could emit would make it one.
+# Apple Clang emits this form for label differences inside one object - a switch jump
+# table - where both sides are always defined here.
+# ---
+# ret: ok(the subtrahend's virtual address), or an error naming the symbol
+fun difference_subtrahend_vaddr(s: *session.Session, modules: *of.ObjectImage, m: u32,
+                                sym2: u32, placements: *Placement, sec_base: *u32,
+                                merged_to_out: *u32, out_img: *of.ObjectImage,
+                                format: *of.OfVTable, image_base: u64, atoms: *AtomPlan,
+                                sym_locs: *map.Map[intern.StrId, SymbolLoc]) R.Result[u64, str] {
+    if (sym2 >= modules[m].symbol_count) {
+        ret R.err[u64, str]("link: a difference relocation names a subtrahend outside the module's symbol table");
+    }
+    val sub: *of.Symbol = ?modules[m].symbols[sym2];
+    val sub_name: intern.StrId = sub.name;
+
+    if ((sub.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0 && sub.section != of.SECTION_EXTERNAL) {
+        var t: rel.RelocTarget = rel.target(0, 0, 0);
+        if (!local_symbol_target(modules, m, sym2, placements, sec_base, merged_to_out,
+                                 out_img, format, image_base, atoms, ?t)) {
+            ret R.err[u64, str](undef_message(s, sub_name));
+        }
+        ret R.ok[u64, str](t.vaddr);
+    }
+
+    val rn: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sub_name);
+    if (R.is_err[intern.StrId, str](rn)) {
+        ret R.err[u64, str](R.unwrap_err[intern.StrId, str](rn));
+    }
+    val resolved_name: intern.StrId = R.unwrap_ok[intern.StrId, str](rn);
+    val sl: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](sym_locs, ?resolved_name);
+    if (R.is_err[*SymbolLoc, str](sl)) {
+        ret R.err[u64, str](difference_import_message(s, sub_name));
+    }
+    ret R.ok[u64, str](R.unwrap_ok[*SymbolLoc, str](sl).vaddr);
+}
+
+# the refusal for a difference whose subtrahend is not defined in this link
+fun difference_import_message(s: *session.Session, name: intern.StrId) str {
+    val n: O.Option[str] = intern.lookup(?s.interner, name);
+    var shown: str = "<unknown>";
+    if (O.is_some[str](n)) { shown = O.unwrap[str](n); }
+    val r: R.Result[str, str] = format.sprint(s.alloc,
+        "link: a difference relocation subtracts `{}`, which this link does not define; the loader chooses its address, so the difference is not a link-time constant",
+        shown);
+    if (R.is_err[str, str](r)) {
+        ret "link: a difference relocation subtracts a symbol this link does not define";
+    }
+    ret R.unwrap_ok[str, str](r);
+}
+
+
 fun local_symbol_target(modules: *of.ObjectImage, m: u32, sy: u32,
                         placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                         out_img: *of.ObjectImage, format: *of.OfVTable,
@@ -5167,8 +5228,24 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             ri = ri + 1; cnt;
         }
 
+        # A DIFFERENCE FOLDS ITS SUBTRAHEND INTO THE ADDEND (#2973). `sym - sym2 + A`
+        # is `sym + (A - addr(sym2))`, so the absolute applier and its overflow check
+        # do the work and no ISA needs a second target threaded through it. The width
+        # carries over: DIFF32 patches four bytes signed, since a difference is signed
+        # whichever way the two labels are ordered.
+        var apply_kind: of.RelocKind = r.kind;
+        if (of.is_difference(r.kind)) {
+            val sv: R.Result[u64, str] = difference_subtrahend_vaddr(
+                s, modules, m, r.sym2, placements, sec_base, merged_to_out, out_img,
+                format, image_base, atoms, sym_locs);
+            if (R.is_err[u64, str](sv)) { ret R.err[bool, str](R.unwrap_err[u64, str](sv)); }
+            apply_addend = apply_addend - R.unwrap_ok[u64, str](sv)::i64;
+            apply_kind = of.RK_ABS32S;
+            if (r.kind == of.RK_DIFF64) { apply_kind = of.RK_ABS64; }
+        }
+
         val pr: R.Result[bool, str] =
-            apply_one(s, r.kind, dst, patch_off, out_img.sections[out_ix].len, resolved,
+            apply_one(s, apply_kind, dst, patch_off, out_img.sections[out_ix].len, resolved,
                       apply_addend, patch_va, target_name, arch, image_base);
         if (R.is_err[bool, str](pr)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](pr));

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -38,6 +38,7 @@ use dwarf: mach.lang.be.codegen.dwarf;
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
 use mach.lang.build.request;
+use std.format;
 use mach.lang.diagnostic;
 use mach.lang.intern;
 use mach.lang.manifest;
@@ -565,7 +566,84 @@ pub fun load_manifest(s: *session.Session, project_root: str) R.Result[manifest.
     # edit, so leaving it to process exit made the reload unbounded (#3001).
     val mr: R.Result[manifest.Manifest, str] = manifest.parse(s.build_alloc, ?s.interner, ?t, true);
     toml.dnit(s.build_alloc, ?t);
-    ret mr;
+    if (R.is_err[manifest.Manifest, str](mr)) { ret mr; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+
+    val sk: R.Result[bool, str] = check_stack_keys(s, ?m);
+    if (R.is_err[bool, str](sk)) {
+        manifest.dnit(?m, s.build_alloc);
+        ret R.err[manifest.Manifest, str](R.unwrap_err[bool, str](sk));
+    }
+    ret R.ok[manifest.Manifest, str](m);
+}
+
+# refuse `stack_reserve` / `stack_commit` on a target whose object format cannot
+# carry one, before anything builds (#2990)
+#
+# CHECKED FOR EVERY DECLARED TARGET, not only the one being built. A key that is
+# meaningless on `[target.linux]` is a mistake whether or not today's command happens
+# to select that target, and finding it on an unrelated build is how it gets found at
+# all - the alternative is a key that silently does nothing until someone builds that
+# cell months later, which is the failure mode this whole issue is about.
+#
+# It keys on the RESOLVED object format, so an `of` override is followed rather than
+# the `os` alone; that resolution is `select_of`'s, so no mapping from os to format is
+# restated here. A target whose tuple does not resolve at all is left alone: naming a
+# stack key on it would report the wrong thing, and `select_of` reports the real
+# problem when the build reaches it.
+# ---
+# s: the session, for its interner and target registry
+# m: the parsed manifest
+# ret: true when every stack key is expressible, or the refusal naming key and target
+fun check_stack_keys(s: *session.Session, m: *manifest.Manifest) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < m.target_count) {
+        val td: *manifest.TargetDef = ?m.targets[i];
+        if (td.stack_reserve == 0 && td.stack_commit == 0) { i = i + 1; cnt; }
+
+        # the registry answers which format a tuple resolves to, so set it up on demand
+        # the way `build_project` does rather than requiring a particular call order.
+        if (isa.registered_count(?s.registry.isa) == 0) {
+            val reg_r: R.Result[bool, str] = setup_registry(?s.registry);
+            if (R.is_err[bool, str](reg_r)) { ret reg_r; }
+        }
+
+        val tr: R.Result[target.Target, str] = target.select_of(?s.registry,
+            intern_or_empty(s, td.isa), intern_or_empty(s, td.os),
+            intern_or_empty(s, td.abi), intern_or_empty(s, td.of));
+        if (R.is_err[target.Target, str](tr)) { i = i + 1; cnt; }
+        val t: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+        if (!t.of.carries_stack_size) {
+            var key: str = "stack_reserve";
+            if (td.stack_reserve == 0) { key = "stack_commit"; }
+            ret R.err[bool, str](stack_key_refusal(s, key, td.name, t.of.name));
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the interned string behind `id`, or "" when it is unset
+fun intern_or_empty(s: *session.Session, id: intern.StrId) str {
+    val o: O.Option[str] = intern.lookup(?s.interner, id);
+    if (O.is_none[str](o)) { ret ""; }
+    ret O.unwrap[str](o);
+}
+
+# the refusal message for a stack key on a format that carries none
+#
+# Names the key, the target it was written on, and the format that cannot carry it, so
+# the reader does not have to work out which of the three is the surprising one.
+fun stack_key_refusal(s: *session.Session, key: str, tname: intern.StrId, of_name: str) str {
+    val n: str = intern_or_empty(s, tname);
+    val r: R.Result[str, str] = format.sprint(s.build_alloc,
+        "mach.toml: [target.{}].{} is not expressible on the `{}` object format, which carries no stack size in its image headers",
+        n, key, of_name);
+    if (R.is_err[str, str](r)) {
+        ret "mach.toml: a stack size is not expressible on this target's object format";
+    }
+    ret R.unwrap_ok[str, str](r);
 }
 
 # build the module graph for one build selection (target,

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -211,6 +211,8 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     entry.of_name       = bu.target.of;
     entry.platform_name = bu.target.platform;
     entry.base          = bu.target.base;
+    entry.stack_reserve = bu.target.stack_reserve;
+    entry.stack_commit  = bu.target.stack_commit;
     entry.entrypoint    = bu.entry;
     entry.mode          = project.MODE_EXECUTABLE;
     if (bu.is_lib) { entry.mode = project.MODE_LIBRARY; }
@@ -588,6 +590,9 @@ pub fun select_target(p: *project.Project, t: *project.TargetEntry) R.Result[boo
     # the manifest base override rides on the resolved target; the linker's
     # os_base_addr prefers it over the os vtable's base_addr when nonzero.
     p.target.base = t.base;
+    # the image stack sizes ride the same way; 0 leaves each writer's own default (#2990)
+    p.target.stack_reserve = t.stack_reserve;
+    p.target.stack_commit  = t.stack_commit;
 
     val rcn: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "mach");
     if (R.is_err[intern.StrId, str](rcn)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rcn)); }

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -105,6 +105,9 @@ pub rec TargetEntry {
     of_name:       intern.StrId;
     platform_name: intern.StrId;
     base:          u64;
+    # image thread-stack sizes threaded from the manifest; 0 keeps the format default (#2990)
+    stack_reserve: u64;
+    stack_commit:  u64;
     entrypoint:    intern.StrId;
     mode:          BuildMode;
     opt:           TargetOpt;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21431,3 +21431,95 @@ fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
     }
     ret ok;
 }
+
+# a manifest with one windows target at the PE default reserve and one that raises it
+fun ut_manifest_stack_two() str {
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# A frame larger than the target's stack reserve fails the build, and raising the
+# reserve makes the same source build (#2991).
+#
+# The function could never execute, on any input: the prologue walks the guard pages
+# correctly right to the end of the reserve and then faults. mach knew both numbers -
+# the encoder receives the frame size to decide whether to probe, the object writer
+# writes the reserve - and never compared them, so a real program shipped for months
+# dying in its own prologue on every Windows machine while running fine on linux,
+# which hands the main thread eight megabytes and hides it.
+#
+# THE THREE CELLS ARE THE WHOLE FEATURE. The same source refuses under the PE default,
+# builds once the target raises the reserve (#2990's lever, which is why that landed
+# first), and is not diagnosed at all on ELF, whose stack is the kernel's and
+# `ulimit`'s rather than a number mach put in the image.
+test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    # a two-megabyte local, which no reasonable frame layout shrinks under a megabyte
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [2000000]u8; big[0] = 1; ret big[0]::i32; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_two(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { bad = 3; }
+    or {
+        # the PE default reserve refuses it
+        if (!ut_build_names_frame_refusal(?s, root, "small") && bad == 0) { bad = 4; }
+        # the same source, with the reserve raised, builds
+        if (ut_build_fails(?s, root, "big")                  && bad == 0) { bad = 5; }
+        # ELF bounds nothing at compile time, so no frame refusal there. the linux cell
+        # fails on its own entry symbol, which is why the assertion is about the MESSAGE
+        # rather than about success: a frame diagnostic must not be what stopped it.
+        if (ut_build_names_frame_refusal(?s, root, "lin")     && bad == 0) { bad = 6; }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# whether building `tgt` fails with the frame-exceeds-reserve refusal, naming the
+# function, its frame size and the reserve
+#
+# It asserts on the MESSAGE rather than on failure, because the linux cell fails for an
+# unrelated reason (its entry symbol) and "the build failed" would pass there while
+# proving the opposite of what this test claims.
+fun ut_build_names_frame_refusal(s: *session.Session, root: str, tgt: str) bool {
+    val msg: str = ut_codegen_fail_msg(s, root, tgt);
+    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "1048576");
+}
+
+# the failure text from building `tgt`, or "" when the build and codegen both succeed
+fun ut_codegen_fail_msg(s: *session.Session, root: str, tgt: str) str {
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, tgt);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        ret R.unwrap_err[project.Project, outcome.Fail](pr).message;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var out: str = "";
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](se)) { out = R.unwrap_err[bool, outcome.Fail](se).message; }
+    or {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_err[bool, outcome.Fail](le)) { out = R.unwrap_err[bool, outcome.Fail](le).message; }
+        or {
+            val ce: R.Result[bool, outcome.Fail] = passes.run_codegen_pass(?p);
+            if (R.is_err[bool, outcome.Fail](ce)) { out = R.unwrap_err[bool, outcome.Fail](ce).message; }
+        }
+    }
+    project.dnit_project(?p);
+    ret out;
+}
+
+# whether building `tgt` fails for any reason at all
+fun ut_build_fails(s: *session.Session, root: str, tgt: str) bool {
+    ret str_len(ut_codegen_fail_msg(s, root, tgt)) != 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1419,7 +1419,7 @@ test "mach.lang.driver:unknown_escape_has_location" {
     ret bad;
 }
 
-# a character literal adopts the integer type supplied by its context (#2982)
+# a character literal adopts the integer type supplied by its context (#2982, #2949)
 #
 # sema already rewrites the literal's expression type during coercion. lowering
 # used to ignore that result and stamp every character constant i8, leaving a
@@ -1431,6 +1431,13 @@ test "mach.lang.driver:coerced_char_literal_lowers_at_context_width" {
     if (!ut_lower_clean("fun f() u64 { ret '0'; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_lower_clean("fun f(v: u64) u8 { ret ('0' + v % 10)::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
     if (!ut_lower_clean("fun f(v: u64) u8 { ret (v % 10 + '0')::u8; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
+    # A WIDENING DESTINATION ON THE MIXED EXPRESSION, which neither case above reaches:
+    # the first has no binary operation and the other two truncate. #2949 reported the
+    # same defect separately and observed it fired for EVERY destination width - `::u64`
+    # included, where sema sees no conversion at all - which is what places the fault on
+    # the source side. Pinning a destination that is not a truncation keeps a later
+    # regression from passing on the narrowing cases alone.
+    if (!ut_lower_clean("fun f(v: u64) u64 { ret ('0' + v)::u64; }\nfun main() i32 { ret f(2)::i32; }\n")) { bad = 1; }
     ret bad;
 }
 
@@ -7203,8 +7210,15 @@ fun ut_lower_errs(text: str) i32 {
         errs = -1;
         val sem: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
         if (R.is_ok[bool, outcome.Fail](sem)) {
-            passes.run_lower_pass(?p);
+            # A FAILED PASS IS AN ERROR EVEN WHEN IT FILED NO DIAGNOSTIC. This used to
+            # discard the lower pass's result and count the sink alone, so a pass that
+            # fails by RETURNING an error - the always-on IR verifier's conversion-width
+            # refusal, for one - read as clean. Every `ut_lower_clean` case guarding that
+            # class was therefore passing vacuously: reintroducing #2982's defect left
+            # the whole suite green while a real build of the same source refused it.
+            val low: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
             errs = ut_count_errors(?s.diags)::i32;
+            if (R.is_err[bool, outcome.Fail](low) && errs == 0) { errs = 1; }
         }
     }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21,7 +21,9 @@ use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
+use bin: mach.lang.target.of.bin;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.path;
@@ -21240,4 +21242,192 @@ test "mach.lang.driver:an_rv32_cross_bank_reinterpret_round_trips_on_the_core" {
     A.deallocate[u8](?alloc, mem, UT_RV32_MEM);
     session.dnit(?s);
     ret bad;
+}
+
+# a manifest with a stack key on an ELF target, beside a windows target that can carry one
+fun ut_manifest_stack_elf() str {
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.win]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\nstack_reserve = 8388608\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# a manifest whose stack keys sit only on a windows target
+fun ut_manifest_stack_pe() str {
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.win]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\nstack_commit = 8192\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk.exe\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# A stack key on a target whose object format carries none is refused AT LOAD (#2990).
+#
+# ELF has nowhere to put a stack size - a linux main thread's stack is the kernel's and
+# `ulimit`'s business - so the key can only ever have done nothing there. The refusal
+# names the key, the target, and the format, because the reader otherwise has to work
+# out which of the three is the surprising one.
+#
+# THE MANIFEST HERE IS VALID FOR THE TARGET SOMEONE WOULD BE BUILDING. `[target.win]`
+# carries the same key legitimately, and the load still fails on `[target.lin]`. That is
+# the point: a key checked only in the cell being built is a key that silently does
+# nothing until someone builds the other cell months later, which is the failure this
+# whole feature exists to end.
+test "mach.lang.driver:a_stack_key_on_a_format_without_one_is_refused_at_load" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+
+    var bad: i32 = 0;
+
+    val bad_root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_elf(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](bad_root_r)) { session.dnit(?s); ret 2; }
+    val bad_root: str = R.unwrap_ok[str, str](bad_root_r);
+
+    val br: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, bad_root);
+    if (R.is_ok[manifest.Manifest, str](br)) {
+        var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](br);
+        manifest.dnit(?m, ?alloc);
+        bad = 3;
+    }
+    or {
+        val msg: str = R.unwrap_err[manifest.Manifest, str](br);
+        # the three facts the message owes the reader
+        if (!str_contains(msg, "stack_reserve") && bad == 0) { bad = 4; }
+        if (!str_contains(msg, "lin")           && bad == 0) { bad = 5; }
+        if (!str_contains(msg, "elf")           && bad == 0) { bad = 6; }
+    }
+    fs.remove_all(?alloc, bad_root);
+
+    # ...and the same keys on a format that CAN carry them load clean, so the refusal
+    # is about the format rather than about the keys existing.
+    if (bad == 0) {
+        val ok_root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_pe(), ?names[0], ?texts[0], 1);
+        if (R.is_err[str, str](ok_root_r)) { session.dnit(?s); ret 7; }
+        val ok_root: str = R.unwrap_ok[str, str](ok_root_r);
+
+        val orr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, ok_root);
+        if (R.is_err[manifest.Manifest, str](orr)) { bad = 8; }
+        or {
+            var m2: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](orr);
+            # the parsed values reach the TargetDef rather than being dropped on the way
+            if (m2.target_count != 1)                    { bad = 9; }
+            or (m2.targets[0].stack_reserve != 8388608)  { bad = 10; }
+            or (m2.targets[0].stack_commit  != 8192)     { bad = 11; }
+            manifest.dnit(?m2, ?alloc);
+        }
+        fs.remove_all(?alloc, ok_root);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# The manifest key reaches the EMITTED IMAGE, across every layer in between (#2990).
+#
+# WHY THIS EXISTS AS WELL AS THE COFF WRITER TEST. That one constructs `ImageOptions`
+# directly and proves the writer honours them; this one starts from `mach.toml`. The
+# gap between the two is the whole delivery chain - TargetDef, TargetEntry, the
+# resolved Target, and the linker filling the options from it - and a mutation that
+# dropped the value in the linker passed the entire suite while the writer test stayed
+# green. A capability nothing carries end to end is a capability that does not exist.
+test "mach.lang.driver:a_manifest_stack_reserve_reaches_the_linked_pe" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_pe(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { bad = 3; }
+    or {
+        val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, "win");
+        if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 4; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            if (ut_run_codegen_ok(?p) != 0) { bad = 5; }
+            or {
+                # the resolved target must carry it before the link can
+                if (p.target.stack_reserve != 8388608) { bad = 6; }
+                or (p.target.stack_commit  != 8192)    { bad = 7; }
+                or {
+                    var res: u64 = 0;
+                    var com: u64 = 0;
+                    if (!ut_pe_stack_of(?p, ?res, ?com)) { bad = 8; }
+                    or (res != 8388608)                  { bad = 9; }
+                    or (com != 8192)                     { bad = 10; }
+                }
+            }
+            project.dnit_project(?p);
+        }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# link `p`'s objects into a PE image and read its stack reserve and commit out of the
+# PE32+ optional header
+fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
+    val alloc: *A.Allocator = p.alloc;
+    if (p.emit_len == 0) { ret false; }
+
+    val ir: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, p.emit_len::usize);
+    if (R.is_err[*of.ObjectImage, str](ir)) { ret false; }
+    val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](ir);
+    var missing: bool = false;
+    var i: u32 = 0;
+    for (i < p.emit_len) {
+        val m: *project.ModuleEntry = ?p.modules[(p.topo[i])::u32];
+        if (m.object_image == nil) { missing = true; }
+        or                         { images[i] = @m.object_image; }
+        i = i + 1;
+    }
+
+    # COFF has no in-memory capture path - only `raw` implements `emit_exec_image` -
+    # so the image goes to a temp file and is read straight back.
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "stk_pe");
+    if (R.is_err[fs.TempFile, str](tf_r)) {
+        A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+        ret false;
+    }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    var linked: bool = false;
+    if (!missing) {
+        val lr: R.Result[bool, str] = linker.link_images(p.s, ?p.target, images,
+            p.emit_len, nil::*of.DynLib, 0, fs.temp_path(?tf)::*u8, "stkprobe"::*u8,
+            linker.LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        linked = R.is_ok[bool, str](lr);
+    }
+    A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+    if (!linked) { fs.temp_close_and_remove(?tf); ret false; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret false; }
+    val img: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    var ok: bool = false;
+    if (img.len > 0x100) {
+        val pe_off: usize = bin.read_u32_le(img.data, 0x3C)::usize;
+        # PE signature (4) + COFF header (20) -> the optional header
+        val oh: usize = pe_off + 24;
+        if (oh + 96 + 8 <= img.len) {
+            @res = bin.read_u64_le(img.data, oh + 72);
+            @com = bin.read_u64_le(img.data, oh + 80);
+            ok = true;
+        }
+    }
+    ret ok;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -21167,3 +21167,77 @@ test "mach.lang.driver:an_overlay_is_found_through_a_dotted_src_spelling" {
     fs.remove_all(?alloc, root);
     ret bad;
 }
+
+# riscv32 (#2904): a 64-bit reinterpret ACROSS THE REGISTER BANKS is lowered through a
+# frame slot and executes to the right bits on the reference core
+#
+# WHY THIS TEST EXISTS. `f64 :~ i64` did not compile on rv32 at all: it reached
+# `be.codegen.legalize` as a retagged MIR_MOV, missed the lane split because one side is
+# FP-class, and fell out into "operation wider than the target ALU is unsupported
+# (MIR_MOV, 8 bytes wide)" - naming an opcode the source never wrote and a width that is
+# not the reason.
+#
+# The reason is that a cross-bank move is as wide as BOTH banks. `fmv.x.d` moves all 64
+# bits between an f register and a GP one, so it needs a 64-bit GP register and is
+# RV64-only, while rv32gc's D extension still puts doubles in f0-f31. So the write is
+# ordinary and the register form does not exist, which is a fact about the instruction
+# set and is now declared as `xbank_widths` rather than derived from FLEN and XLEN.
+#
+# EXECUTED, NOT PATTERN-MATCHED. An instruction-sequence assertion would pass on a
+# lowering that stored the halves in the wrong order, or read the slot at the wrong
+# offset, or sign-extended one half - every one of which is a wrong VALUE and none of
+# which changes which mnemonics appear. The core runs the emitted code and the bits are
+# compared against the input.
+fun ut_rv32_xbank_src() str {
+    ret "#[symbol(\"_start\")]\nfun probe(sel: i32, v: i64) i64 {\n    val f: f64 = v :~ f64;\n    if (sel == 0) { ret f :~ i64; }\n    # a round trip through the float bank and back, so BOTH directions run in one\n    # image and a lowering that is wrong in only one of them cannot pass.\n    if (sel == 1) { val g: f64 = (f :~ i64) :~ f64; ret g :~ i64; }\n    # the width the register form DOES exist at on rv32 (fmv.w.x / fmv.x.w), so a\n    # change that routed everything through memory would still be caught here.\n    val n: i32 = v::i32;\n    val s: f32 = n :~ f32;\n    ret (s :~ i32)::i64;\n}\n";
+}
+
+test "mach.lang.driver:an_rv32_cross_bank_reinterpret_round_trips_on_the_core" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val mr: R.Result[*u8, str] = A.allocate[u8](?alloc, UT_RV32_MEM);
+    if (R.is_err[*u8, str](mr)) { session.dnit(?s); ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var bad: i32 = 0;
+    var len: u32 = 0;
+    if (!ut_rv32_build_linked(?s, ?alloc, ut_rv32_xbank_src(), "rv32", mem, ?len)) { bad = 2; }
+    or {
+        # a payload whose two halves DIFFER and whose high half has the sign bit set:
+        # a swapped pair, a truncation, or a sign-extended low half each change it.
+        val payload: u64 = 0xC0FFEE0D_DEADBEEF;
+        var steps: u32 = 0;
+
+        var got: u64 = 0;
+        if (!ut_rv32_run_g(mem, 0, payload, ?got, ?steps)) { bad = 3; }
+        or (got != payload)                                { bad = 4; }
+
+        if (bad == 0) {
+            var got2: u64 = 0;
+            if (!ut_rv32_run_g(mem, 1, payload, ?got2, ?steps)) { bad = 5; }
+            or (got2 != payload)                                { bad = 6; }
+        }
+
+        if (bad == 0) {
+            # the 4-byte case takes the REGISTER form (fmv.w.x / fmv.x.w), which rv32
+            # does have - so a change that routed every crossing through memory, or one
+            # that routed none, is caught here rather than passing quietly.
+            #
+            # The expected value is SIGN-EXTENDED: the payload's low word has bit 31
+            # set, and the trailing `::i64` widens a signed `i32`. Reading it back as a
+            # bare 0xDEADBEEF would be asserting the wrong language semantics, not a
+            # narrower check.
+            var got3: u64 = 0;
+            if (!ut_rv32_run_g(mem, 2, payload, ?got3, ?steps)) { bad = 7; }
+            or (got3 != 0xFFFFFFFFDEADBEEF)                     { bad = 8; }
+        }
+    }
+
+    A.deallocate[u8](?alloc, mem, UT_RV32_MEM);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -71,6 +71,12 @@ pub rec TargetDef {
     of:       intern.StrId;
     platform: intern.StrId;   # user-defined tag surfaced as `$mach.build.platform`; STR_NIL when unset
     base:     u64;            # first-segment load-address override; 0 (unset) defers to the os base_addr
+    # image stack sizes in bytes, beside `base` because all three are image
+    # memory-layout parameters expressible only on some object formats (#2990).
+    # 0 (unset) keeps the format's conventional default, so omitting them reproduces
+    # today's bytes exactly.
+    stack_reserve: u64;
+    stack_commit:  u64;
 }
 
 pub rec ArtifactDef {
@@ -622,7 +628,8 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
     }
     if (kind == TK_TARGET) {
         ret str_equals(k, "isa") || str_equals(k, "os") || str_equals(k, "abi") || str_equals(k, "of")
-            || str_equals(k, "platform") || str_equals(k, "base");
+            || str_equals(k, "platform") || str_equals(k, "base")
+            || str_equals(k, "stack_reserve") || str_equals(k, "stack_commit");
     }
     if (kind == TK_ARTIFACT) {
         if (str_equals(k, "kind") || str_equals(k, "entry") || str_equals(k, "out")
@@ -801,6 +808,18 @@ fun parse_targets(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m:
         d.base     = 0;
         val base_opt: O.Option[i64] = toml.get_int(sub, "base");
         if (O.is_some[i64](base_opt)) { d.base = O.unwrap[i64](base_opt)::u64; }
+
+        # image stack sizes, byte counts (#2990). Absent leaves 0, which every writer
+        # reads as "keep the format's conventional default" - so a manifest that says
+        # nothing produces the same bytes it always did. Whether the resolved object
+        # format can carry them at all is checked once the registry can answer it; see
+        # `check_stack_keys` in the driver.
+        d.stack_reserve = 0;
+        d.stack_commit  = 0;
+        val sres_opt: O.Option[i64] = toml.get_int(sub, "stack_reserve");
+        if (O.is_some[i64](sres_opt)) { d.stack_reserve = O.unwrap[i64](sres_opt)::u64; }
+        val scom_opt: O.Option[i64] = toml.get_int(sub, "stack_commit");
+        if (O.is_some[i64](scom_opt)) { d.stack_commit = O.unwrap[i64](scom_opt)::u64; }
 
         m.targets[i] = d;
         str_free(alloc, label);

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -318,6 +318,10 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     # no manifest base override by default; the driver overwrites this from the
     # selected target's `base`, and the linker falls back to os_vt.base_addr when 0.
     t.base    = 0;
+    # likewise unset by default; the driver overwrites both from the selected
+    # target's manifest keys and each image writer keeps its own default at 0 (#2990)
+    t.stack_reserve = 0;
+    t.stack_commit  = 0;
     t.isa     = arch_vt;
     # the register-machine contract, or nil for a whole-module emitter. every stage
     # that reads it runs after `codegen_module` forks on `isa.emits_whole_module`.

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -434,6 +434,31 @@ pub val VEC_MEM_4_8_16:  u32 = 4 + 8 + 16;
 # register, and every one of them zeroes the lanes above its operand on a load.
 pub val VEC_MEM_ALL_128: u32 = 1 + 2 + 4 + 8 + 16;
 
+# the widths, in bytes, an ISA moves between its FLOAT bank and a GP register in one
+# register-to-register instruction, when it has no such instruction at all
+#
+# Declared by a target with no float register file to cross to (mos6502), and by one
+# with no register file at all (SPIR-V). Every cross-bank reinterpret on such a target
+# is either impossible or not reached.
+pub val XBANK_NONE: u32 = 0;
+
+# the single 4-byte cross-bank move of a machine whose GP register is 4 bytes wide
+#
+# RV32: `fmv.w.x` / `fmv.x.w` exist, and their double-width siblings `fmv.d.x` /
+# `fmv.x.d` DO NOT - they move all 64 bits between an f register and a GP one, and no
+# RV32 GP register is that wide. The D extension is still in the rv32gc baseline, so
+# f0-f31 hold doubles and an `f64 :~ i64` is a perfectly ordinary thing to write; it
+# simply has no register form here and goes through the frame (#2904).
+pub val XBANK_4: u32 = 4;
+
+# both scalar float widths cross to a GP register in one instruction
+#
+# x86-64's `movd` / `movq`, aarch64's `fmov w <-> s` and `fmov x <-> d`, and RV64's
+# `fmv.w.x` / `fmv.d.x` pairs. Note that x86-64 declares 8 and not 16 even though an
+# XMM register is 128 bits wide: `movq` moves the low half, and no single instruction
+# moves a whole XMM to GP registers.
+pub val XBANK_4_8: u32 = 4 + 8;
+
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;
@@ -514,6 +539,34 @@ pub rec MachineModel {
     # still the round trip, which is the opposite of what #2716 assumed when it
     # reasoned from lane alignment rather than from the instruction set.
     vec_mem_widths:    u32;
+
+    # the widths, in bytes, this ISA moves between its FLOAT bank and a GP register in
+    # one REGISTER-TO-REGISTER instruction, as a bitmask whose bit for a width IS that
+    # width (#2904)
+    #
+    # A BIT REINTERPRET IS THE SECOND INSTRUCTION WITH A VALUE IN EACH BANK. A
+    # conversion was long treated as the only one, and a `:~` between a float and an
+    # equal-size integer was assumed to select to a plain MOV on every machine, "so no
+    # dedicated cross opcode is needed". That holds wherever the move exists. RV32 is
+    # where it does not: the D extension puts 64-bit doubles in f0-f31 while XLEN stays
+    # 4, so `f64 :~ i64` is ordinary to write and `fmv.x.d` is RV64-only.
+    #
+    # THE CONTRACT A TARGET SIGNS BY DECLARING A WIDTH: a cross-bank reinterpret at that
+    # width is a single register-to-register instruction the encoder emits, with no
+    # frame slot and no memory traffic. A width NOT declared is lowered through a frame
+    # slot instead - a store in the source's bank and a load in the destination's, which
+    # is what a C toolchain emits on such a target and what the encoder already does
+    # when one side happens to be spilled.
+    #
+    # IT DESCRIBES WHAT THE BACK END EMITS, not what the architecture has, the same way
+    # `vec_mem_widths` does. Declaring a width whose encoder form is missing turns a
+    # working frame round trip into an internal compiler error.
+    #
+    # NOT DERIVED FROM `flen_bits` AND `gpr_width`, though on the riscv members it
+    # happens to equal `min` of the two. x86-64 would derive 16 from a 128-bit XMM and
+    # be wrong: `movq` moves the low half only, and nothing moves a whole XMM to the GP
+    # bank. The question is which instructions exist, and only the target knows.
+    xbank_widths:      u32;
 
     ct_trust_mul:      bool;
 
@@ -747,8 +800,11 @@ pub fun packed_lane_cap(m: *MachineModel, lane_bits: u32) u32 {
     ret w / lane_bits;
 }
 
-# the `vec_mem_widths` bit for a width in bytes, or 0 when the width is not one this
-# encoding describes
+# the width bit for a byte count, or 0 when the width is not one this encoding
+# describes
+#
+# Shared by `vec_mem_widths` and `xbank_widths` (#2904): both are masks whose bit for
+# a width IS that width, so one mapping serves both and the two cannot drift.
 #
 # Widths are powers of two from 1 to 16, which is every width a vector register moves
 # at on any ISA here. Anything else answers 0 and therefore never matches, so a caller
@@ -781,6 +837,29 @@ pub fun moves_vector_memory(m: *MachineModel, bytes: u32) bool {
     val b: u32 = vec_mem_bit(bytes);
     if (b == 0) { ret false; }
     ret (m.vec_mem_widths & b) != 0;
+}
+
+# THE CROSS-BANK QUESTION (#2904): can this target reinterpret `bytes` between the
+# float bank and a GP register in ONE register-to-register instruction
+#
+# The single door onto `xbank_widths`, the same way `moves_vector_memory` is the only
+# door onto `vec_mem_widths`, so no caller reads the mask and - the mistake this
+# prevents - no caller re-derives the answer from `flen_bits` and `gpr_width`. Those
+# two give the right answer on the riscv members by coincidence and the wrong one on
+# x86-64, where a 128-bit XMM would imply a 16-byte move that `movq` does not perform.
+#
+# False means the frame round trip, which is correct on every target: a store in the
+# source's bank and a load in the destination's move the same bits. So a target that
+# declares nothing loses no correctness and only pays the memory traffic, which is why
+# the default is empty and why a target added later needs no change here to be right.
+# ---
+# m:     the target's machine model
+# bytes: the reinterpret width
+# ret:   true when one register-to-register instruction crosses the banks at that width
+pub fun moves_cross_bank(m: *MachineModel, bytes: u32) bool {
+    val b: u32 = vec_mem_bit(bytes);
+    if (b == 0) { ret false; }
+    ret (m.xbank_widths & b) != 0;
 }
 
 # THE PLACEMENT QUESTION (#2727): does a whole `lanes x lane_bits` vector fit in one

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -270,6 +270,9 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # internal compiler error. The encoder emits them now, so the declaration grew to
     # match - and that is the order these two have to move in, never the reverse.
     arm64_model.vec_mem_widths  = isa.VEC_MEM_ALL_128;
+    # `fmov w <-> s` and `fmov x <-> d` cross the banks at 4 and 8 (#2904). The B and H
+    # views have no GP-crossing form, and the Q view would need a register pair.
+    arm64_model.xbank_widths    = isa.XBANK_4_8;
     arm64_packed_gaps[0].op = isa.VEC_OP_MUL; arm64_packed_gaps[0].is_float = false; arm64_packed_gaps[0].lane_bits = 64;
     arm64_model.packed_gaps     = ?arm64_packed_gaps[0];
     arm64_model.packed_gap_len  = 1;

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -129,6 +129,8 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
     # no vector register file, so nothing crosses between one and memory (#2716)
     mos6502_model.vec_mem_widths  = isa.VEC_MEM_NONE;
+    # no float register file to cross to, so no width crosses (#2904)
+    mos6502_model.xbank_widths    = isa.XBANK_NONE;
     mos6502_model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): no data-independent timing mode.
     mos6502_model.ct_trust_mul = false;

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -2863,9 +2863,15 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         # move all 64 bits between an f register and a GP one, which needs the GP
         # register to be 64 bits - so on rv32, where FLEN is 8 and XLEN is 4, the
         # double-width pair simply has no encoding. `fmv.w.x` / `fmv.x.w` at width 4
-        # exist on both machines and are unaffected. A bitcast between `f64` and `i64`
-        # on rv32 goes through memory, which is what the psABI's own soft-float
-        # sequences do; wiring that lowering is #2860's, not this refusal's.
+        # exist on both machines and are unaffected.
+        #
+        # UNREACHABLE FROM SOURCE SINCE #2904, and kept as the tripwire it became. An
+        # `f64 :~ i64` on rv32 is now expanded at MIR lowering into a frame round trip
+        # (`fsd` then two `lw`), because rv32 declares `xbank_widths = XBANK_4` and the
+        # lowering asks. Reaching here therefore means a target declared a width whose
+        # encoder form does not exist - the hazard `xbank_widths`' own doc names - and
+        # this message says which instruction is missing rather than letting the
+        # mis-declaration surface as wrong code.
         if ((dfp || sfp) && w == 8 && xlen(st) == 4) {
             ret R.err[bool, str]("encode: rv32 has no cross-bank move for a 64-bit value (fmv.d.x / fmv.x.d are RV64-only); see briar-systems/mach#2860");
         }

--- a/src/lang/target/isa/riscv/register.mach
+++ b/src/lang/target/isa/riscv/register.mach
@@ -424,6 +424,14 @@ fun build_riscv(reg: *isa.IsaRegistry, arch_id: u32, name: str, xw: u32,
     model.max_vector_lanes = isa.VECTOR_LANES_UNBOUNDED;
     # no vector register file, so nothing crosses between one and memory (#2716)
     model.vec_mem_widths  = isa.VEC_MEM_NONE;
+    # THE CROSS-BANK PAIR IS AS WIDE AS BOTH BANKS (#2904). `fmv.w.x` / `fmv.x.w` exist
+    # on both members; `fmv.d.x` / `fmv.x.d` move all 64 bits between an f register and
+    # a GP one, so they need a 64-bit GP register and are RV64-only. On rv32 the D
+    # extension still puts doubles in f0-f31 - `flen_bits` above says so - which is
+    # exactly what makes `f64 :~ i64` ordinary to write here and impossible to encode
+    # in a register pair. Declaring 4 alone routes it through the frame.
+    model.xbank_widths    = isa.XBANK_4;
+    if (xw == 8) { model.xbank_widths = isa.XBANK_4_8; }
     model.vector_compute_generic = false;
     # integer multiply is gated on secrets (#1646): rv64 documents no data-independent
     # timing mode, so a secret multiply is always a variable-latency leak here.

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -110,6 +110,13 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # logical addressing: a value has no byte footprint and no register to cross from,
     # so the question this field answers does not arise here (#2716)
     spirv_model.vec_mem_widths         = isa.VEC_MEM_NONE;
+    # `OpBitcast` IS the one-instruction form, at every scalar width (#2904). There is no
+    # register file here and therefore no bank to cross: a SPIR-V bitcast reinterprets a
+    # TYPED value in place. Declaring the widths says the true thing - the reinterpret
+    # costs one instruction - and keeps this target off the frame round trip that a
+    # machine without the instruction takes. Declaring NONE would have been read as "the
+    # crossing is impossible", which is the opposite of the case.
+    spirv_model.xbank_widths           = isa.XBANK_4_8;
     # no packed-form gaps (#2726): SPIR-V's arithmetic opcodes are defined over
     # vectors of any component type and count, so `OpIMul` covers every lane width a
     # machine ISA has to special-case. The empty list is a statement about the target,

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -318,6 +318,10 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # covering it needs `pinsrd` / `pextrd`, which are SSE4.1 and this baseline is
     # SSE2, so a 12-byte vector still takes the scratch round trip.
     x64_model.vec_mem_widths  = isa.VEC_MEM_4_8_16;
+    # `movd` / `movq` cross between an XMM and a GP register at 4 and 8 (#2904). NOT 16,
+    # despite the XMM being 128 bits: `movq` moves the low half and no instruction moves
+    # a whole XMM into GP registers.
+    x64_model.xbank_widths    = isa.XBANK_4_8;
     x64_packed_gaps[0].op = isa.VEC_OP_MUL; x64_packed_gaps[0].is_float = false; x64_packed_gaps[0].lane_bits = 8;
     x64_packed_gaps[1].op = isa.VEC_OP_MUL; x64_packed_gaps[1].is_float = false; x64_packed_gaps[1].lane_bits = 32;
     x64_packed_gaps[2].op = isa.VEC_OP_MUL; x64_packed_gaps[2].is_float = false; x64_packed_gaps[2].lane_bits = 64;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -774,6 +774,28 @@ pub fun image_options_flagged(subsystem: Subsystem, flags: u32) ImageOptions {
     ret opts;
 }
 
+# the stack reserve an image built for `tgt` will actually get, or 0 when nothing
+# bounds it at compile time (#2991)
+#
+# Three cases, in order. A target that STATES a reserve gets that number - the manifest
+# already refused the key on a format that cannot carry it, so a stated value always
+# reaches the image. Otherwise the format's own default applies, which is PE's 1 MiB.
+# Otherwise nothing does: an ELF target's stack is the kernel's and `ulimit`'s, and a
+# Mach-O image with no stated reserve takes dyld's default, which mach did not choose.
+#
+# 0 MEANS "DO NOT DIAGNOSE", and it is the honest answer rather than a conservative
+# one: a check needs a number mach itself put in the image, and asserting a bound the
+# compiler does not own would refuse programs that run.
+# ---
+# tgt_of:        the resolved object-format vtable
+# stated:        the target's `stack_reserve`, or 0 when unstated
+# ret:           the effective reserve in bytes, or 0 when nothing bounds it
+pub fun effective_stack_reserve(tgt_of: *OfVTable, stated: u64) u64 {
+    if (stated != 0) { ret stated; }
+    if (tgt_of == nil) { ret 0; }
+    ret tgt_of.default_stack_reserve;
+}
+
 # a format writer: serializes an `ObjectImage` to a relocatable object file at
 # the given path
 #
@@ -1186,6 +1208,21 @@ pub rec OfVTable {
     # refused by the writer instead. Two facts, two checks, each where its fact is
     # known.
     carries_stack_size:  bool;
+
+    # the stack reserve THIS WRITER puts in an image whose target states none, or 0
+    # when it states nothing of its own (#2991)
+    #
+    # PE writes a 1 MiB reserve by convention, so every PE image has a bounded stack
+    # mach itself chose and a frame larger than it provably cannot run. Mach-O writes
+    # `LC_MAIN.stacksize = 0`, which means "take dyld's default" - mach does not own
+    # that number, so it declares none and a Mach-O image is only checked against a
+    # reserve its target actually stated.
+    #
+    # SEPARATE FROM `carries_stack_size` because they answer different questions. That
+    # one is whether a target MAY state a reserve; this is what the image gets when it
+    # does not. A format can carry a value it has no default for, which is exactly
+    # Mach-O.
+    default_stack_reserve: u64;
     header_span:         HeaderSpanFn;
     executable_section_location: ExecutableSectionLocationFn;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -195,6 +195,21 @@ pub val SYM_OBJ_FLAG_OBJECT:   u32 = 0x10;
 pub val SYM_OBJ_FLAG_FALLBACK: u32 = 0x20;
 pub val SYM_OBJ_FLAG_SEARCH:   u32 = 0x40;
 pub val SYM_OBJ_FLAG_ALIAS:    u32 = 0x80;
+# A TENTATIVE DEFINITION - C common storage (#2974). The symbol is not defined in any
+# section here, but it is not an import either: it REQUESTS zero-initialized storage of
+# `size` bytes aligned to `align`, and the linker provides it unless some object carries
+# a real definition of the name, which wins outright.
+#
+# Apple Clang emits one for every uninitialized file-scope C global unless the
+# translation unit is compiled `-fno-common`, so a vendored C dependency carries them
+# whether or not anyone chose to. Read as an ordinary undefined import it produces
+# "dynamic import _x has no #[library] attribution", which names the symbol correctly
+# and the problem not at all.
+#
+# Set together with SYM_OBJ_FLAG_EXTERN, because a common IS undefined until the linker
+# allocates it: every consumer that means "needs resolving" keeps working, and only the
+# one that decides HOW it resolves has to know the difference.
+pub val SYM_OBJ_FLAG_COMMON:   u32 = 0x100;
 
 # sentinel `Symbol.section` value marking an undefined (external) symbol
 pub val SECTION_EXTERNAL: u32 = 0xFFFFFFFF;
@@ -292,6 +307,10 @@ pub rec Symbol {
     size:     u32;
     flags:    u32;
     fallback: u32;
+    # the requested alignment of a COMMON symbol's storage, in bytes; meaningless for
+    # every other symbol, so a zero-initialized record is correct and 0 reads as "no
+    # alignment stated" (#2974)
+    align:    u32;
 }
 
 # one relocation in an object image

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -733,6 +733,17 @@ pub rec ImageOptions {
     # fact existed, so a caller that constructs options without stating it keeps the
     # loader-mapped shape rather than silently dropping a segment.
     mapped_by_loader: bool;
+
+    # the image's thread stack reserve and commit in bytes, threaded from the target's
+    # manifest keys by the linker (#2990). 0 means UNSET and each writer keeps its
+    # format's conventional default, so an image built without them is byte-identical
+    # to one built before the keys existed.
+    #
+    # A format that carries no stack size ignores both, and a target cannot state them
+    # there at all - `OfVTable.carries_stack_size` refuses the key when the manifest is
+    # read, so a value silently doing nothing is not a reachable state.
+    stack_reserve: u64;
+    stack_commit:  u64;
 }
 
 # make executable-image options with no optional resources
@@ -744,6 +755,8 @@ pub fun image_options_default(subsystem: Subsystem) ImageOptions {
     opts.attributes = nil;
     opts.attributes_len = 0;
     opts.mapped_by_loader = true;
+    opts.stack_reserve = 0;
+    opts.stack_commit  = 0;
     ret opts;
 }
 
@@ -1158,6 +1171,21 @@ pub rec OfVTable {
     shared_input_ext:    str;
     import_address_prefix: str;
     header_in_first_segment: bool;
+
+    # true when this format's IMAGE HEADERS carry a thread stack size, so a target
+    # may state `stack_reserve` / `stack_commit` (#2990)
+    #
+    # PE carries both in the optional header; Mach-O carries a reserve in
+    # `LC_MAIN.stacksize`. ELF has nowhere to put one - a linux main thread's stack is
+    # the kernel's and `ulimit`'s business - and a raw flat image has no header at all.
+    #
+    # WHAT THIS DOES NOT PROMISE is that every image in this format has the field. A
+    # Mach-O image carries `stacksize` only through LC_MAIN; a non-PIE one enters
+    # through LC_UNIXTHREAD, which has no such member. That is a property of the image
+    # SHAPE rather than of the format, is not known when a manifest is read, and is
+    # refused by the writer instead. Two facts, two checks, each where its fact is
+    # known.
+    carries_stack_size:  bool;
     header_span:         HeaderSpanFn;
     executable_section_location: ExecutableSectionLocationFn;
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -152,6 +152,31 @@ pub val RK_GOTPCREL_NORELAX: RelocKind = 22;
 # r_length=3), used by an absolute-immediate or pointer-sized data field.
 pub val RK_GOTPCREL64_NORELAX: RelocKind = 23;
 
+# THE DIFFERENCE OF TWO SYMBOL ADDRESSES, `sym - sym2 + addend`, written at the patch
+# site (#2973). The only kinds that read `Relocation.sym2`.
+#
+# Apple Clang emits this constantly as an adjacent `X86_64_RELOC_SUBTRACTOR` +
+# `X86_64_RELOC_UNSIGNED` pair, most visibly for a switch jump table, whose entries are
+# label differences rather than addresses so the table is position-independent. Mach-O
+# is the one format here that spells a difference as a relocation at all: ELF and COFF
+# either fold it at assembly time or use a dedicated section-relative form.
+#
+# TWO SYMBOLS IS THE FACT, not an encoding detail, which is why this widens the neutral
+# model rather than being folded away in the reader. Folding is only correct when both
+# sides are defined in the object being read, and the pair is well-formed when either
+# side is external - so a reader that folded would be right until the first object that
+# is not a jump table.
+pub val RK_DIFF32: RelocKind = 24;
+pub val RK_DIFF64: RelocKind = 25;
+
+# whether `kind` resolves the difference of two symbols, and therefore reads `sym2`
+# ---
+# kind: the relocation kind
+# ret:  true for the difference forms
+pub fun is_difference(kind: RelocKind) bool {
+    ret kind == RK_DIFF32 || kind == RK_DIFF64;
+}
+
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
 # SYM_OBJ_FLAG_GLOBAL:   visible outside the object
@@ -287,12 +312,16 @@ pub rec Symbol {
 # kind:    abstract relocation kind (one of RK_*)
 # sym:     index of the referenced symbol in the image's `symbols` array
 # addend:  constant added to the resolved symbol address
+# sym2:    index of the SUBTRAHEND symbol, read only when `is_difference(kind)` and
+#          meaningless otherwise - a zero-initialized record is therefore correct for
+#          every other kind, which is why this needs no absent sentinel (#2973)
 pub rec Relocation {
     section: u32;
     offset:  u32;
     kind:    RelocKind;
     sym:     u32;
     addend:  i64;
+    sym2:    u32;
 }
 
 # the complete, format-agnostic image the back end builds and the format writer

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3423,7 +3423,8 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
     # clears RELOCS_STRIPPED and sets DYNAMIC_BASE.
     val pie: bool = dyn != nil && dyn.pie;
     val header_r: R.Result[bool, str] = write_pe_headers(buf, ?lay, segs, seg_count, entry,
-        pie, itn, dyn, debug, debug_count, image_options.subsystem);
+        pie, itn, dyn, debug, debug_count, image_options.subsystem,
+        image_options.stack_reserve, image_options.stack_commit);
     if (R.is_err[bool, str](header_r)) {
         if (resource_ptr != nil) { rs.dnit(alloc, resource_ptr); }
         A.deallocate[u8](alloc, buf, total_size);
@@ -3924,6 +3925,12 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, se
     bin.write_u32_le(buf, pos + 36, chars);
 }
 
+# the conventional PE console stack reserve and commit, used when a target states
+# neither key (#2990). Named rather than repeated so the writer's default and the
+# documentation cannot drift.
+val PE_DEFAULT_STACK_RESERVE: u64 = 0x100000;   # 1 MiB
+val PE_DEFAULT_STACK_COMMIT:  u64 = 0x1000;     # 4 KiB
+
 # write the DOS header + stub, the PE signature, the COFF file
 # header, the PE32+ optional header (ImageBase, alignments, entry, subsystem, the
 # 16 data directories), and the section table. the entry RVA is the program
@@ -3931,7 +3938,7 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, se
 # layout fixed are known
 fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count: u32, entry: u64, pie: bool,
                      itn: *intern.Interner, dyn: *of.DynamicInfo, debug: *of.Section, debug_count: u32,
-                     subsystem: of.Subsystem) R.Result[bool, str] {
+                     subsystem: of.Subsystem, stack_reserve: u64, stack_commit: u64) R.Result[bool, str] {
     # DOS header: 'MZ', e_lfanew (offset 0x3C) -> the PE signature. the rest of
     # the DOS stub is left zero - Windows reads only the magic and e_lfanew.
     buf[0] = 'M'; buf[1] = 'Z';
@@ -3996,10 +4003,21 @@ fun write_pe_headers(buf: *u8, lay: *PeLayout, segs: *of.LoadSegment, seg_count:
     if (pie) { dllchars = dllchars | IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE; }
     bin.write_u16_le(buf, oh + 70, dllchars);
 
-    # stack/heap reserve+commit (PE32+ are 8 bytes each): 1 MiB reserve / 4 KiB
-    # commit for both, the conventional console defaults.
-    bin.write_u64_le(buf, oh + 72, 0x100000); bin.write_u64_le(buf, oh + 80, 0x1000);
-    bin.write_u64_le(buf, oh + 88, 0x100000); bin.write_u64_le(buf, oh + 96, 0x1000);
+    # stack/heap reserve+commit (PE32+ are 8 bytes each). The defaults are the
+    # conventional console ones, 1 MiB reserve / 4 KiB commit, and they are what an
+    # image gets when the manifest states nothing - so omitting the keys reproduces
+    # the bytes this writer emitted before they existed.
+    #
+    # A RESERVE IS ADDRESS SPACE, not committed memory, which is why raising it is
+    # cheap and why the value belongs on the target rather than the artifact (#2990).
+    # The heap pair keeps the literals: mach's runtime does not use the PE heap, so
+    # there is nothing for a project to tune there and no key to reach it.
+    var stack_res: u64 = PE_DEFAULT_STACK_RESERVE;
+    var stack_com: u64 = PE_DEFAULT_STACK_COMMIT;
+    if (stack_reserve != 0) { stack_res = stack_reserve; }
+    if (stack_commit  != 0) { stack_com = stack_commit; }
+    bin.write_u64_le(buf, oh + 72, stack_res); bin.write_u64_le(buf, oh + 80, stack_com);
+    bin.write_u64_le(buf, oh + 88, PE_DEFAULT_STACK_RESERVE); bin.write_u64_le(buf, oh + 96, PE_DEFAULT_STACK_COMMIT);
     bin.write_u32_le(buf, oh + 104, 0);                # LoaderFlags
     bin.write_u32_le(buf, oh + 108, IMAGE_NUMBEROF_DIRECTORY_ENTRIES);
 
@@ -4288,6 +4306,8 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     # the PE writer reserves its own header span inside the first section as
     # prefix padding, so the linker leaves no gap above the image base.
     coff_vtable.header_in_first_segment = false;
+    # the PE32+ optional header carries both the stack reserve and the commit (#2990)
+    coff_vtable.carries_stack_size = true;
     coff_vtable.executable_section_location = pe_executable_section_location;
 
     # the COFF relocation mapping and writer cover x86-64 only today.
@@ -5680,6 +5700,104 @@ test "mach.lang.target.of.coff.coff_emit_exec:subsystem_selection" {
         b = b + 1;
     }
     ret 0;
+}
+
+# The PE optional header carries the target's stack reserve and commit, and NOTHING
+# ELSE MOVES (#2990).
+#
+# The reserve was a literal `0x100000`, so a mach project could not ship a Windows
+# program needing more than a megabyte of stack - no flag, no workaround, while every
+# other linker exposes it (`/STACK`, `--stack`). A game's `main` needed 1,107,824
+# bytes against that reserve and died in its own prologue on every Windows machine
+# while running fine on linux, which hands the main thread eight megabytes.
+#
+# The byte-for-byte half is the acceptance criterion that matters most: a project that
+# states neither key must get the image it always got. Comparing whole images rather
+# than reading two fields is what proves it - a change that shifted a header, resized
+# a directory, or perturbed alignment would pass a field read and fail here.
+test "mach.lang.target.of.coff.coff_emit_exec:stack_reserve_and_commit" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    val base:  u64 = 0x140001000;
+    val entry: u64 = base + 4;
+
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = base; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
+
+    # stated nothing: the image every build produced before the keys existed
+    var def_opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    val dr: R.Result[Vector[u8], str] = emit_stack_image(?alloc, ?i, ?isa_vt, ?segs[0], entry, ?def_opts);
+    if (R.is_err[Vector[u8], str](dr)) { ret 1; }
+    val dflt: Vector[u8] = R.unwrap_ok[Vector[u8], str](dr);
+
+    var big_opts: of.ImageOptions = of.image_options_default(of.SUBSYSTEM_CONSOLE);
+    big_opts.stack_reserve = 0x800000;
+    big_opts.stack_commit  = 0x2000;
+    val br: R.Result[Vector[u8], str] = emit_stack_image(?alloc, ?i, ?isa_vt, ?segs[0], entry, ?big_opts);
+    if (R.is_err[Vector[u8], str](br)) { ret 1; }
+    val big: Vector[u8] = R.unwrap_ok[Vector[u8], str](br);
+
+    if (dflt.len != big.len) { ret 2; }
+
+    val pe_off: usize = bin.read_u32_le(dflt.data, 0x3C)::usize;
+    val oh:     usize = pe_off + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE;
+
+    # the default is the conventional console pair, unchanged
+    if (bin.read_u64_le(dflt.data, oh + 72) != PE_DEFAULT_STACK_RESERVE) { ret 3; }
+    if (bin.read_u64_le(dflt.data, oh + 80) != PE_DEFAULT_STACK_COMMIT)  { ret 4; }
+    # ...and the stated pair lands in the stack fields
+    if (bin.read_u64_le(big.data, oh + 72) != 0x800000) { ret 5; }
+    if (bin.read_u64_le(big.data, oh + 80) != 0x2000)   { ret 6; }
+
+    # THE HEAP PAIR IS NOT THE STACK PAIR. They sit next to each other at oh+88/+96 and
+    # take the same shape, so a fix that wrote the wrong offset would still produce a
+    # plausible-looking header; mach's runtime does not use the PE heap and no key
+    # reaches it, so both images must keep the literals.
+    if (bin.read_u64_le(big.data, oh + 88) != PE_DEFAULT_STACK_RESERVE) { ret 7; }
+    if (bin.read_u64_le(big.data, oh + 96) != PE_DEFAULT_STACK_COMMIT)  { ret 8; }
+
+    # every byte outside the two stack fields is identical
+    var b: usize = 0;
+    for (b < dflt.len) {
+        val in_stack: bool = (b >= oh + 72 && b < oh + 88);
+        if (!in_stack && dflt.data[b] != big.data[b]) { ret 9; }
+        b = b + 1;
+    }
+    ret 0;
+}
+
+# emit a one-segment static PE under `opts` and read it back, so the stack test can
+# compare two whole images byte for byte
+fun emit_stack_image(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
+                     segs: *of.LoadSegment, entry: u64, opts: *of.ImageOptions) R.Result[Vector[u8], str] {
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "coff_stack");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret R.err[Vector[u8], str]("temp create failed"); }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    val em: R.Result[bool, str] = coff_emit_exec(alloc, itn, isa_vt, segs, 1,
+                                                 4096, segs[0].vaddr - PE_SECTION_ALIGN,
+                                                 entry, nil, 0,
+                                                 nil::*of.Section, 0, nil::*of.Section, 0,
+                                                 nil::*of.SymtabEntry, 0,
+                                                 fs.temp_path(?tf)::*u8, "coffstack"::*u8,
+                                                 @opts);
+    if (R.is_err[bool, str](em)) {
+        fs.temp_close_and_remove(?tf);
+        ret R.err[Vector[u8], str](R.unwrap_err[bool, str](em));
+    }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    ret rb;
 }
 
 # emit a one-segment static PE under `subsystem` and read it back, so the

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -4308,6 +4308,9 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.header_in_first_segment = false;
     # the PE32+ optional header carries both the stack reserve and the commit (#2990)
     coff_vtable.carries_stack_size = true;
+    # every PE image gets a bounded stack this writer chose, so a frame larger than it
+    # provably cannot run and is refused at build time (#2991)
+    coff_vtable.default_stack_reserve = PE_DEFAULT_STACK_RESERVE;
     coff_vtable.executable_section_location = pe_executable_section_location;
 
     # the COFF relocation mapping and writer cover x86-64 only today.

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1662,6 +1662,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # the ELF header and program headers map at the image base ahead of the first
     # section, inside the first PT_LOAD, with no page reserved above the base.
     elf_vtable.header_in_first_segment = false;
+    # ELF has nowhere to put a stack size: a linux main thread's stack is the kernel's
+    # and `ulimit`'s business, not the image's (#2990)
+    elf_vtable.carries_stack_size = false;
     elf_vtable.executable_section_location = nil;
 
     # elf relocates and writes for every isa with an `elf_reloc_type` map.

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1665,6 +1665,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # ELF has nowhere to put a stack size: a linux main thread's stack is the kernel's
     # and `ulimit`'s business, not the image's (#2990)
     elf_vtable.carries_stack_size = false;
+    elf_vtable.default_stack_reserve = 0;   # the kernel's and `ulimit`'s (#2991)
     elf_vtable.executable_section_location = nil;
 
     # elf relocates and writes for every isa with an `elf_reloc_type` map.

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1543,6 +1543,9 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # Mach-O image, position-independent or not, so __TEXT lands on the base and
     # __PAGEZERO spans the whole low region below it (#2599).
     macho_vtable.header_in_first_segment = true;
+    # `LC_MAIN.stacksize` carries a reserve on a PIE image; a non-PIE LC_UNIXTHREAD
+    # image has no such member and is refused by the writer, not here (#2990)
+    macho_vtable.carries_stack_size = true;
     macho_vtable.header_span = header_span;
     macho_vtable.executable_section_location = nil;
 
@@ -1968,6 +1971,24 @@ fun reserved_header_span(segs: *of.LoadSegment, seg_count: u32,
 #             accepted for of.ExecFn conformance and ignored - Mach-O's own
 #             symbol table is `LC_SYMTAB`, not implemented here yet
 # ret:        ok(true) on success, or an error string
+# a Mach-O image that enters through LC_UNIXTHREAD carries no stack size (#2990)
+#
+# `LC_MAIN` has a `stacksize` member and `LC_UNIXTHREAD` does not, so whether THIS
+# image can carry the value depends on its entry shape, not on the format. The
+# manifest check cannot answer it - it runs before a build knows whether the image
+# will be position-independent - so the writer answers it here.
+#
+# It REFUSES rather than dropping the value. A stack size that silently does nothing
+# is the exact failure this key exists to end: a game shipped for months against a
+# reserve it could not reach, because nothing said the number was unreachable.
+# ---
+# opts: the image options carrying the requested sizes
+# ret:  ok(true) when nothing was requested, or the refusal
+fun refuse_unixthread_stack(opts: *of.ImageOptions) R.Result[bool, str] {
+    if (opts.stack_reserve == 0 && opts.stack_commit == 0) { ret R.ok[bool, str](true); }
+    ret R.err[bool, str]("macho: a stack size needs an LC_MAIN entry, and this image enters through LC_UNIXTHREAD; `stack_reserve` / `stack_commit` reach only a position-independent Mach-O image");
+}
+
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, image_base: u64, entry: u64,
               funcs: *of.ExecFunction, func_count: u32,
@@ -1977,6 +1998,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
               image_options: of.ImageOptions) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
+    # this writer's image is static and enters through LC_UNIXTHREAD, which has no
+    # stacksize member (#2990).
+    val su: R.Result[bool, str] = refuse_unixthread_stack(?image_options);
+    if (R.is_err[bool, str](su)) { ret su; }
     val arch_id: u32 = isa_vt.id;
     val ct: R.Result[u32, str] = cpu_type_for(arch_id);
     if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
@@ -3515,6 +3540,12 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # in-image absolute pointer. a non-PIE image keeps the fixed-address shape: an
     # LC_UNIXTHREAD entry and no rebase stream.
     val pie: bool = dyn.pie;
+    # a non-PIE image on this path still enters through LC_UNIXTHREAD, which carries
+    # no stacksize; refuse a requested one rather than dropping it (#2990).
+    if (!pie) {
+        val su: R.Result[bool, str] = refuse_unixthread_stack(?image_options);
+        if (R.is_err[bool, str](su)) { ret su; }
+    }
     # the rebase relocations are emitted in a deterministic (segment, offset) order so
     # the signed image is byte-identical across the self-host fixpoint.
     if (pie && dyn.base_reloc_count > 1) {
@@ -3840,11 +3871,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         bin.write_u32_le(buf, lc, LC_MAIN);
         bin.write_u32_le(buf, lc + 4, ENTRY_POINT_CMD_SIZE::u32);
         bin.write_u64_le(buf, lc + 8, entry - lay.text_va);    # entryoff
-        bin.write_u64_le(buf, lc + 16, 0);                     # stacksize
+        # stacksize: the main thread's stack reserve, or 0 to take dyld's default,
+        # which is what every image got before the key existed (#2990)
+        bin.write_u64_le(buf, lc + 16, image_options.stack_reserve);
         lc = lc + ENTRY_POINT_CMD_SIZE;
     }
     or {
         # LC_UNIXTHREAD: the static thread entry, program counter set to the entry.
+        # It carries no stacksize, so a requested one was refused before this ran.
         lc = write_unixthread(buf, lc, arch_id, entry, thread_cmd_size);
     }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1546,6 +1546,9 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # `LC_MAIN.stacksize` carries a reserve on a PIE image; a non-PIE LC_UNIXTHREAD
     # image has no such member and is refused by the writer, not here (#2990)
     macho_vtable.carries_stack_size = true;
+    # `LC_MAIN.stacksize = 0` defers to dyld's default, a number mach does not choose,
+    # so an unstated Mach-O reserve bounds nothing at compile time (#2991)
+    macho_vtable.default_stack_reserve = 0;
     macho_vtable.header_span = header_span;
     macho_vtable.executable_section_location = nil;
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -4232,6 +4232,23 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
         if ((n_desc & N_WEAK_DEF) != 0) { flags = flags | of.SYM_OBJ_FLAG_WEAK; }
         if ((n_type & N_TYPE) == N_UNDF) {
             flags = flags | of.SYM_OBJ_FLAG_EXTERN;
+            # A COMMON SYMBOL WEARS AN UNDEFINED SYMBOL'S CLOTHES (#2974). N_UNDF with
+            # N_EXT and a NON-ZERO n_value is a tentative definition, and the value is
+            # the requested size rather than an address - the one place in the nlist
+            # encoding where n_value does not mean "where". Apple Clang emits one for
+            # every uninitialized file-scope C global unless the unit is built
+            # `-fno-common`, so reading it as an ordinary import made a vendored C
+            # dependency demand a `#[library]` attribution for storage it was asking
+            # the linker to allocate.
+            #
+            # The alignment is a log2 in n_desc bits 8-11, which is how ld64 spells it.
+            if ((n_type & N_EXT) != 0 && n_value != 0) {
+                flags = flags | of.SYM_OBJ_FLAG_COMMON;
+                out.symbols[si].size = n_value::u32;
+                out.symbols[si].align = 1;
+                val log2a: u32 = (n_desc::u32 >> 8) & 0xF;
+                if (log2a > 0 && log2a < 32) { out.symbols[si].align = 1 << log2a; }
+            }
             # recover the function-ness emit_object encoded in the reference type so
             # the linker can give a dynamic function import its call stub.
             if ((n_desc & REFERENCE_TYPE_MASK) == REFERENCE_FLAG_UNDEFINED_LAZY) { flags = flags | of.SYM_OBJ_FLAG_FUNCTION; }
@@ -7922,6 +7939,96 @@ test "mach.lang.target.of.macho:a_malformed_subtractor_pair_is_refused" {
     t_put_reloc(b3.data, o3, 1, 16, 0, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
     var out3: of.ObjectImage;
     if (R.is_ok[bool, str](parse_object(?alloc, ?i, b3.data, b3.len, ?out3)) && bad == 0) { bad = 9; }
+
+    ret bad;
+}
+
+# the file offset and count of an emitted object's symbol table
+fun t_symtab(buf: *u8, out_n: *u32) usize {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val cmd: u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SYMTAB) {
+            @out_n = bin.read_u32_le(buf, off + 12);
+            ret bin.read_u32_le(buf, off + 8)::usize;
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+    @out_n = 0;
+    ret 0;
+}
+
+# A tentative definition is read as COMMON, not as an ordinary import (#2974).
+#
+# `N_UNDF | N_EXT` with a NON-ZERO `n_value` is C common storage: the value is the
+# requested SIZE rather than an address, the one place in the nlist encoding where
+# n_value does not mean "where". Read as an ordinary undefined symbol it became a
+# dynamic import, and a native Darwin link of a vendored C dependency failed with
+# `dynamic import _ma_atomic_global_lock has no #[library] attribution` - a message
+# that names the symbol correctly and the problem not at all.
+#
+# Apple Clang emits one for every uninitialized file-scope global unless the unit is
+# compiled `-fno-common`, so this arrives whether or not anyone chose it.
+test "mach.lang.target.of.macho:a_tentative_definition_reads_as_common" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var buf: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?buf)) { ret 1; }
+
+    var nsyms: u32 = 0;
+    val symoff: usize = t_symtab(buf.data, ?nsyms);
+    if (symoff == 0 || nsyms == 0) { ret 2; }
+
+    # rewrite the LAST symbol (the external one) into a tentative definition of 40
+    # bytes aligned to 16: n_type = N_UNDF|N_EXT, n_desc alignment log2 in bits 8-11.
+    val so: usize = symoff + (nsyms - 1)::usize * NLIST_64_SIZE;
+    buf.data[so + 4] = N_UNDF | N_EXT;
+    buf.data[so + 5] = 0;
+    bin.write_u16_le(buf.data, so + 6, (4 << 8)::u16);
+    bin.write_u64_le(buf.data, so + 8, 40);
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 3; }
+
+    var bad: i32 = 0;
+    var saw: bool = false;
+    var k: u32 = 0;
+    for (k < out.symbol_count) {
+        val sym: *of.Symbol = ?out.symbols[k];
+        if ((sym.flags & of.SYM_OBJ_FLAG_COMMON) != 0) {
+            saw = true;
+            if (sym.size != 40                                    && bad == 0) { bad = 4; }
+            if (sym.align != 16                                   && bad == 0) { bad = 5; }
+            # still undefined here: the linker is what turns it into storage, and every
+            # consumer meaning "needs resolving" must keep seeing that
+            if ((sym.flags & of.SYM_OBJ_FLAG_EXTERN) == 0         && bad == 0) { bad = 6; }
+            if (sym.section != of.SECTION_EXTERNAL                && bad == 0) { bad = 7; }
+        }
+        k = k + 1;
+    }
+    if (!saw && bad == 0) { bad = 8; }
+
+    # ...and a plain undefined symbol (n_value 0) is NOT common, which is the half that
+    # keeps every existing import working
+    var b2: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b2)) { ret 9; }
+    var n2: u32 = 0;
+    val s2: usize = t_symtab(b2.data, ?n2);
+    if (s2 == 0 || n2 == 0) { ret 10; }
+    var out2: of.ObjectImage;
+    if (R.is_err[bool, str](parse_object(?alloc, ?i, b2.data, b2.len, ?out2))) { ret 11; }
+    var k2: u32 = 0;
+    for (k2 < out2.symbol_count) {
+        if ((out2.symbols[k2].flags & of.SYM_OBJ_FLAG_COMMON) != 0 && bad == 0) { bad = 12; }
+        k2 = k2 + 1;
+    }
 
     ret bad;
 }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -172,6 +172,10 @@ val X86_64_RELOC_SIGNED:   u32 = 1;
 val X86_64_RELOC_BRANCH:   u32 = 2;
 val X86_64_RELOC_GOT_LOAD: u32 = 3;
 val X86_64_RELOC_GOT:      u32 = 4;
+# the subtrahend half of a difference pair: this entry names the symbol SUBTRACTED,
+# and the X86_64_RELOC_UNSIGNED entry that must follow it at the same address names
+# the minuend (#2973)
+val X86_64_RELOC_SUBTRACTOR: u32 = 5;
 val X86_64_RELOC_SIGNED_1: u32 = 6;
 val X86_64_RELOC_SIGNED_2: u32 = 7;
 val X86_64_RELOC_SIGNED_4: u32 = 8;
@@ -4379,6 +4383,11 @@ fun count_relocs(buf: *u8, buf_size: usize, cputype: u32, ncmds: u32) R.Result[u
                     val word: u32 = bin.read_u32_le(buf, reloff + r::usize * RELOC_INFO_SIZE + 4);
                     val r_type: u32 = (word >> 28) & 0xF;
                     if (cputype == CPU_TYPE_ARM64 && r_type == ARM64_RELOC_ADDEND) { r = r + 1; cnt; }
+                    # a SUBTRACTOR pair is TWO entries and ONE neutral relocation, the
+                    # same accounting the ADDEND pair above needs: counting both would
+                    # leave a zero-filled trailing record and over-report reloc_count
+                    # (#2973).
+                    if (cputype == CPU_TYPE_X86_64 && r_type == X86_64_RELOC_SUBTRACTOR) { r = r + 1; cnt; }
                     total = total + 1;
                     r = r + 1;
                 }
@@ -4428,6 +4437,11 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                 val nreloc: u32 = bin.read_u32_le(buf, sh + 60);
                 var pending: i64 = 0;
                 var have_pending: bool = false;
+                # the subtrahend stashed by an X86_64_RELOC_SUBTRACTOR, waiting for the
+                # UNSIGNED entry that completes the pair (#2973)
+                var sub_sym: u32 = 0;
+                var have_sub: bool = false;
+                var sub_addr: u32 = 0;
                 var r: u32 = 0;
                 for (r < nreloc) {
                     val e: usize = reloff + r::usize * RELOC_INFO_SIZE;
@@ -4444,6 +4458,38 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                         have_pending = true;
                         r = r + 1;
                         cnt;
+                    }
+                    # THE SUBTRAHEND ARRIVES FIRST and carries no patch of its own: it
+                    # stashes the symbol to subtract, exactly as ARM64_RELOC_ADDEND above
+                    # stashes an addend, and the next entry does the work (#2973).
+                    if (cputype == CPU_TYPE_X86_64 && r_type == X86_64_RELOC_SUBTRACTOR) {
+                        if (have_sub) {
+                            ret R.err[bool, str]("macho: two X86_64_RELOC_SUBTRACTOR entries in a row; each one pairs with the UNSIGNED that follows it");
+                        }
+                        if (extn == 0) {
+                            ret R.err[bool, str]("macho: X86_64_RELOC_SUBTRACTOR is not symbol-based");
+                        }
+                        if (symnum >= nsyms) { ret R.err[bool, str]("macho: relocation symbol index out of range"); }
+                        if (r_length != 2 && r_length != 3) {
+                            ret R.err[bool, str]("macho: X86_64_RELOC_SUBTRACTOR field is neither 4 nor 8 bytes");
+                        }
+                        sub_sym  = symnum;
+                        sub_addr = address;
+                        have_sub = true;
+                        r = r + 1;
+                        cnt;
+                    }
+                    if (have_sub) {
+                        # the pair is adjacent, at one address, and its second half is an
+                        # UNSIGNED. Anything else is a malformed pair rather than a form
+                        # to guess at: the value written depends on both halves, so a
+                        # mismatched one would silently patch the wrong arithmetic.
+                        if (r_type != X86_64_RELOC_UNSIGNED) {
+                            ret R.err[bool, str]("macho: X86_64_RELOC_SUBTRACTOR is not followed by X86_64_RELOC_UNSIGNED");
+                        }
+                        if (address != sub_addr) {
+                            ret R.err[bool, str]("macho: the halves of an X86_64_RELOC_SUBTRACTOR pair patch different addresses");
+                        }
                     }
                     if (cputype == CPU_TYPE_X86_64 && x64_is_signed(r_type) && pcrel == 0) {
                         ret R.err[bool, str]("macho: x86_64 signed relocation is not pc-relative");
@@ -4489,15 +4535,35 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                         addend = R.unwrap_ok[i64, str](sa);
                     }
 
+                    var out_kind: of.RelocKind = kind;
+                    var out_sym2: u32 = 0;
+                    if (have_sub) {
+                        # the minuend keeps `sym`; the stashed subtrahend becomes `sym2`,
+                        # and the width comes off the UNSIGNED half that writes the field.
+                        if (r_length == 3)      { out_kind = of.RK_DIFF64; }
+                        or (r_length == 2)      { out_kind = of.RK_DIFF32; }
+                        or {
+                            ret R.err[bool, str]("macho: an X86_64_RELOC_SUBTRACTOR pair writes neither 4 nor 8 bytes");
+                        }
+                        out_sym2 = sub_sym;
+                    }
+
                     out.relocations[rel_i].section = sec_i;
                     out.relocations[rel_i].offset  = address;
-                    out.relocations[rel_i].kind    = kind;
+                    out.relocations[rel_i].kind    = out_kind;
                     out.relocations[rel_i].sym     = target;
                     out.relocations[rel_i].addend  = addend;
+                    out.relocations[rel_i].sym2    = out_sym2;
                     rel_i = rel_i + 1;
                     pending = 0;
                     have_pending = false;
+                    sub_sym = 0;
+                    have_sub = false;
+                    sub_addr = 0;
                     r = r + 1;
+                }
+                if (have_sub) {
+                    ret R.err[bool, str]("macho: an X86_64_RELOC_SUBTRACTOR ends the section's relocations with no UNSIGNED to pair with");
                 }
                 sec_i = sec_i + 1;
                 sh = sh + SECTION_64_SIZE;
@@ -7637,4 +7703,225 @@ test "mach.lang.target.of.macho.write_bind_info:abs64_in_place_bind" {
     p = p + 1;
     if (p != end) { ret 1; }
     ret 0;
+}
+
+# emit the same minimal x86_64 object `ts_x64_roundtrip` builds and hand back its bytes
+#
+# Shared by the SUBTRACTOR tests, which need a REAL emitted object to patch rather than
+# a hand-built buffer: everything the parser walks to reach the relocation array - the
+# header, the segment command, the section table, the symbol table - is then genuine,
+# and only the entries under test are synthetic.
+# ---
+# ret: true when the object was emitted and read back into `out`
+fun t_emit_x64_object(alloc: *A.Allocator, i: *intern.Interner, out: *Vector[u8]) bool {
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [24]u8;
+    var k: usize = 0;
+    for (k < 24) { text_bytes[k] = 0; k = k + 1; }
+    text_bytes[0] = 0xE8;
+    var data_bytes: [8]u8;
+    k = 0;
+    for (k < 8) { data_bytes[k] = 0; k = k + 1; }
+
+    var secs: [2]of.Section;
+    secs[0].name = t_intern(i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 24; secs[0].align = 16;
+    secs[1].name = t_intern(i, ".data"); secs[1].kind = of.SK_DATA;
+    secs[1].bytes = ?data_bytes[0]; secs[1].len = 8; secs[1].align = 8;
+
+    var syms: [3]of.Symbol;
+    syms[0].name = t_intern(i, "_main"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 24; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(i, "g"); syms[1].section = 1; syms[1].offset = 0;
+    syms[1].size = 8; syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
+    syms[2].name = t_intern(i, "ext_func"); syms[2].section = of.SECTION_EXTERNAL;
+    syms[2].offset = 0; syms[2].size = 0; syms[2].flags = of.SYM_OBJ_FLAG_EXTERN;
+
+    var relocs: [3]of.Relocation;
+    relocs[0].section = 0; relocs[0].offset = 1;  relocs[0].kind = of.RK_PLT32;
+    relocs[0].sym = 2; relocs[0].addend = -4;
+    relocs[1].section = 0; relocs[1].offset = 8;  relocs[1].kind = of.RK_PC32;
+    relocs[1].sym = 1; relocs[1].addend = -4;
+    relocs[2].section = 0; relocs[2].offset = 16; relocs[2].kind = of.RK_ABS64;
+    relocs[2].sym = 1; relocs[2].addend = 0;
+
+    var img: of.ObjectImage;
+    img.alloc = alloc;
+    img.interner = i;
+    img.name = t_intern(i, "test");
+    img.sections = ?secs[0]; img.section_count = 2;
+    img.symbols = ?syms[0]; img.symbol_count = 3;
+    img.relocations = ?relocs[0]; img.reloc_count = 3;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "macho_sub");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret false; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret false; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret false; }
+    @out = R.unwrap_ok[Vector[u8], str](rb);
+    ret true;
+}
+
+# rewrite one relocation_info entry in an emitted Mach-O buffer
+#
+# The parse side is what #2973 changed, and mach's own writer emits no SUBTRACTOR - so
+# a round trip cannot produce the input under test. Patching the entries of a REAL
+# emitted object is the next best thing and better than a hand-built buffer: every
+# other structure the parser walks to reach the relocations is genuine.
+# ---
+# buf:      the emitted object bytes
+# reloff:   the section's relocation array file offset
+# idx:      which entry to rewrite
+# address:  r_address
+# symnum:   r_symbolnum
+# pcrel:    r_pcrel
+# length:   r_length (log2 of the field width)
+# extn:     r_extern
+# r_type:   the machine relocation type
+fun t_put_reloc(buf: *u8, reloff: usize, idx: u32, address: u32, symnum: u32,
+                pcrel: u32, length: u32, extn: u32, r_type: u32) {
+    val e: usize = reloff + idx::usize * RELOC_INFO_SIZE;
+    bin.write_u32_le(buf, e, address);
+    bin.write_u32_le(buf, e + 4, (symnum & 0xFFFFFF) | (pcrel << 24) | (length << 25)
+                                  | (extn << 27) | (r_type << 28));
+}
+
+# the file offset and count of the first section's relocation array in an emitted
+# object, found by walking the load commands the way the parser does
+fun t_first_reloff(buf: *u8, out_n: *u32) usize {
+    val ncmds: u32 = bin.read_u32_le(buf, 16);
+    var off: usize = MACH_HEADER_64_SIZE;
+    var c: u32 = 0;
+    for (c < ncmds) {
+        val cmd: u32 = bin.read_u32_le(buf, off);
+        val cmdsize: usize = bin.read_u32_le(buf, off + 4)::usize;
+        if (cmd == LC_SEGMENT_64) {
+            val nsects: u32 = bin.read_u32_le(buf, off + 64);
+            if (nsects > 0) {
+                val sh: usize = off + SEGMENT_CMD_64_SIZE;
+                @out_n = bin.read_u32_le(buf, sh + 60);
+                ret bin.read_u32_le(buf, sh + 56)::usize;
+            }
+        }
+        off = off + cmdsize;
+        c = c + 1;
+    }
+    @out_n = 0;
+    ret 0;
+}
+
+# An adjacent SUBTRACTOR + UNSIGNED pair folds into one difference relocation (#2973).
+#
+# Mach 4.18.1 refused a normal Apple Clang x86_64 object with `unsupported relocation
+# type 5`. Apple Clang emits the pair constantly - most visibly for a switch jump
+# table, whose entries are label differences rather than addresses so the table is
+# position-independent - and mach defined types 0-4 and 6-8 with no representation for
+# 5 at all.
+#
+# TWO ENTRIES BECOME ONE RECORD, which is the part with teeth: the minuend keeps `sym`,
+# the subtrahend becomes `sym2`, and `reloc_count` must not count the consumed entry or
+# the image carries a zero-filled trailing relocation. The ARM64_RELOC_ADDEND pair
+# already had that accounting and this one needs the same.
+test "mach.lang.target.of.macho:x64_subtractor_pair_folds_to_a_difference" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var buf: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?buf)) { ret 1; }
+
+    var nreloc: u32 = 0;
+    val reloff: usize = t_first_reloff(buf.data, ?nreloc);
+    if (reloff == 0 || nreloc < 2) { ret 2; }
+
+    # entry 0 subtracts symbol 1 (`g`), entry 1 adds symbol 0 (`_main`), both at the
+    # 8-byte field at offset 16 - the shape a jump-table entry has.
+    t_put_reloc(buf.data, reloff, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(buf.data, reloff, 1, 16, 0, 0, 3, 1, X86_64_RELOC_UNSIGNED);
+    var z: u32 = 2;
+    for (z < nreloc) {
+        # the remaining entries are harmless absolutes at a distinct address
+        t_put_reloc(buf.data, reloff, z, 0, 0, 0, 3, 1, X86_64_RELOC_UNSIGNED);
+        z = z + 1;
+    }
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 3; }
+
+    var bad: i32 = 0;
+    # the pair produced ONE record, so the count is one below the entry count
+    if (out.reloc_count != nreloc - 1 && bad == 0) { bad = 4; }
+
+    var saw: bool = false;
+    var rj: u32 = 0;
+    for (rj < out.reloc_count) {
+        val rr: *of.Relocation = ?out.relocations[rj];
+        if (rr.kind == of.RK_DIFF64) {
+            saw = true;
+            if (rr.offset != 16 && bad == 0) { bad = 5; }
+            # r_length 3 is the 8-byte field, so the fold must pick the 64-bit form
+            if (!of.is_difference(rr.kind) && bad == 0) { bad = 6; }
+        }
+        rj = rj + 1;
+    }
+    if (!saw && bad == 0) { bad = 7; }
+
+    ret bad;
+}
+
+# A malformed SUBTRACTOR pair is refused rather than guessed at (#2973).
+#
+# The value written depends on BOTH halves, so a pair whose second half is missing, is
+# not an UNSIGNED, or patches a different address would silently produce the wrong
+# arithmetic at the patch site. Each is named separately because each is a different
+# way for a producer to be wrong.
+test "mach.lang.target.of.macho:a_malformed_subtractor_pair_is_refused" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var bad: i32 = 0;
+
+    # a SUBTRACTOR followed by something that is not an UNSIGNED
+    var b1: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b1)) { ret 1; }
+    var n1: u32 = 0;
+    val o1: usize = t_first_reloff(b1.data, ?n1);
+    if (o1 == 0 || n1 < 2) { ret 2; }
+    t_put_reloc(b1.data, o1, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(b1.data, o1, 1, 16, 0, 1, 2, 1, X86_64_RELOC_BRANCH);
+    var out1: of.ObjectImage;
+    if (R.is_ok[bool, str](parse_object(?alloc, ?i, b1.data, b1.len, ?out1)) && bad == 0) { bad = 3; }
+
+    # the two halves patching different addresses
+    var b2: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b2)) { ret 4; }
+    var n2: u32 = 0;
+    val o2: usize = t_first_reloff(b2.data, ?n2);
+    if (o2 == 0 || n2 < 2) { ret 5; }
+    t_put_reloc(b2.data, o2, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(b2.data, o2, 1, 8,  0, 0, 3, 1, X86_64_RELOC_UNSIGNED);
+    var out2: of.ObjectImage;
+    if (R.is_ok[bool, str](parse_object(?alloc, ?i, b2.data, b2.len, ?out2)) && bad == 0) { bad = 6; }
+
+    # two SUBTRACTOR entries in a row
+    var b3: Vector[u8];
+    if (!t_emit_x64_object(?alloc, ?i, ?b3)) { ret 7; }
+    var n3: u32 = 0;
+    val o3: usize = t_first_reloff(b3.data, ?n3);
+    if (o3 == 0 || n3 < 2) { ret 8; }
+    t_put_reloc(b3.data, o3, 0, 16, 1, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    t_put_reloc(b3.data, o3, 1, 16, 0, 0, 3, 1, X86_64_RELOC_SUBTRACTOR);
+    var out3: of.ObjectImage;
+    if (R.is_ok[bool, str](parse_object(?alloc, ?i, b3.data, b3.len, ?out3)) && bad == 0) { bad = 9; }
+
+    ret bad;
 }

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -301,6 +301,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.import_address_prefix = "";
     # a flat image is pure content: the loader jumps at the base, no header maps.
     raw_vtable.header_in_first_segment = false;
+    # a flat image has no header to carry one (#2990)
+    raw_vtable.carries_stack_size = false;
     raw_vtable.executable_section_location = nil;
 
     # a flat image carries no machine relocation types, so it is isa-agnostic and

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -303,6 +303,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.header_in_first_segment = false;
     # a flat image has no header to carry one (#2990)
     raw_vtable.carries_stack_size = false;
+    raw_vtable.default_stack_reserve = 0;   # bare metal; nothing declares a stack (#2991)
     raw_vtable.executable_section_location = nil;
 
     # a flat image carries no machine relocation types, so it is isa-agnostic and

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -118,6 +118,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     spv_vtable.import_address_prefix = "";
     # a SPIR-V module is not a loaded image; it has no header span to reserve.
     spv_vtable.header_in_first_segment = false;
+    # a SPIR-V module is not a loadable image and has no thread stack (#2990)
+    spv_vtable.carries_stack_size = false;
     spv_vtable.executable_section_location = nil;
 
     # only the SPIR-V ISA's whole-module emitter produces the `.spirv` section this

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -120,6 +120,7 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     spv_vtable.header_in_first_segment = false;
     # a SPIR-V module is not a loadable image and has no thread stack (#2990)
     spv_vtable.carries_stack_size = false;
+    spv_vtable.default_stack_reserve = 0;
     spv_vtable.executable_section_location = nil;
 
     # only the SPIR-V ISA's whole-module emitter produces the `.spirv` section this

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -82,6 +82,11 @@ pub rec Target {
     debug:    *of.DebugVTable;
     model:    isa.MachineModel;
     base:     u64;
+    # image thread-stack sizes in bytes, threaded from the manifest's
+    # `stack_reserve` / `stack_commit`; 0 means "unset" and each writer keeps its
+    # format's conventional default, so an image is byte-identical without them (#2990)
+    stack_reserve: u64;
+    stack_commit:  u64;
     variadic_args_on_stack: bool;
     fixed_args_natural_size: bool;
 }

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.24.0";
+pub val MACH_VERSION: str = "4.25.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {

--- a/test/ci-legs.sh
+++ b/test/ci-legs.sh
@@ -13,7 +13,11 @@
 #
 # prints a compact JSON array the workflow feeds straight to `strategy.matrix.include`:
 #
-#   [{"runner":"ubuntu-latest","legs":"x86_64-linux riscv64-linux ...","qemu":"qemu-riscv64"}]
+#   [{"runner":"ubuntu-latest","legs":"x86_64-linux ...","qemu":"qemu-riscv64","decode":"x86_64-darwin aarch64-darwin"}]
+#
+# `decode` names the rows this runner BUILDS AND READS without executing, which is how
+# a release-cadence format keeps an external reader on the lane that gates merges into
+# `dev` (#2957). Empty when the runner reads nothing beyond its own legs.
 #
 # keys avoid hyphens so `matrix.runner` resolves in the GitHub expression context.
 # `legs` is the link suite's leg list for that runner; `qemu` names the interpreters
@@ -35,7 +39,7 @@ here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 awk -v want="$cadence" '
     /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
     {
-        name = $1; engine = $8; runner = $10; rowcadence = $11
+        name = $1; engine = $8; runner = $10; rowcadence = $11; dec = $12
         if (runner == "-") next
         if (runner in seen && cad[runner] != rowcadence) {
             printf "ci-legs.sh: runner %s carries cadence %s and %s; one runner is one job, so the rows must agree\n", runner, cad[runner], rowcadence > "/dev/stderr"
@@ -44,6 +48,13 @@ awk -v want="$cadence" '
         }
         seen[runner] = 1
         cad[runner] = rowcadence
+        # a decode assignment is independent of the cadence on this row: it names the
+        # runner that READS this row on the pr lane, which is the whole point when the
+        # row itself executes at release cadence (#2957).
+        if (dec != "-" && want == "pr") {
+            if (dec in decodes) decodes[dec] = decodes[dec] " " name; else decodes[dec] = name
+            if (!(dec in seenr)) { seenr[dec] = 1 }
+        }
         if (rowcadence != want) next
         if (runner in legs) legs[runner] = legs[runner] " " name; else { legs[runner] = name; order[++n] = runner }
         if (engine ~ /^qemu:/) {
@@ -58,7 +69,7 @@ awk -v want="$cadence" '
         for (i = 1; i <= n; i++) {
             r = order[i]
             if (i > 1) printf ","
-            printf "{\"runner\":\"%s\",\"legs\":\"%s\",\"qemu\":\"%s\"}", r, legs[r], (r in qemu ? qemu[r] : "")
+            printf "{\"runner\":\"%s\",\"legs\":\"%s\",\"qemu\":\"%s\",\"decode\":\"%s\"}", r, legs[r], (r in qemu ? qemu[r] : ""), (r in decodes ? decodes[r] : "")
         }
         printf "]\n"
     }

--- a/test/engines.conf
+++ b/test/engines.conf
@@ -19,15 +19,27 @@
 #   cadence pr (every pull request) | main (the dev -> main release merge only).
 #           rows sharing a runner share one job, so they must agree here; ci-legs.sh
 #           refuses a runner carrying two cadences rather than picking one.
+#   decode  a runner that BUILDS AND DECODES this row on the pr lane (layers A and B,
+#           never C), or - when the row already runs at pr cadence. it exists because
+#           a `main`-cadence row would otherwise have no external reader between
+#           releases, leaving mach its own only reader of a format it writes.
+#
+#           THE RULE, ENFORCED IN config.py: a row may be `main` cadence only when some
+#           `pr`-cadence row already reads its object format, either by running there
+#           or by naming a decode runner here. COFF is why this is a check and not a
+#           convention - x86_64-windows had a leg that had never once started, so the
+#           first layer A run over it found a long section-name form llvm rejected
+#           outright, making every object with a constant pool unreadable (#2952).
+#           Mach-O was in exactly that state until #2957.
 #   note    why the row reads the way it does
 #
-# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  note
-x86_64-linux      x86_64   linux         sysv64   -    bin     hosted        native             llvm-objdump  ubuntu-latest     pr       the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
-aarch64-linux     aarch64  linux         aapcs64  -    bin     hosted        native             llvm-objdump  ubuntu-24.04-arm  pr       native arm silicon: qemu cannot settle aapcs64 or page-size questions
-riscv64-linux     riscv64  linux         lp64d    -    bin     hosted        qemu:qemu-riscv64  llvm-objdump  ubuntu-latest     pr       compute evidence only, never ABI evidence
-riscv32           riscv32  freestanding  ilp32d   elf  static  direct        none               llvm-objdump  ubuntu-latest     pr       linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
-x86_64-windows    x86_64   windows       win64    -    bin     hosted        native             llvm-objdump  windows-latest    pr       no wine, anywhere, ever
-x86_64-darwin     x86_64   darwin        sysv64   -    bin     hosted        native             llvm-objdump  macos-15-intel    main     metered runner, so the release merge rather than every pull request
-aarch64-darwin    aarch64  darwin        aapcs64  -    bin     hosted        native             llvm-objdump  macos-15          main     metered runner, so the release merge rather than every pull request
-spirv             spirv    freestanding  spirv    -    bin     direct        none               spirv-dis     ubuntu-latest     pr       a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
-mos6502           mos6502  freestanding  mos6502  -    bin     freestanding  none               da65          ubuntu-latest     pr       layers A and B only, and promoting it to an execution engine is follow-up work
+# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  decode         note
+x86_64-linux      x86_64   linux         sysv64   -    bin     hosted        native             llvm-objdump  ubuntu-latest     pr     -              the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
+aarch64-linux     aarch64  linux         aapcs64  -    bin     hosted        native             llvm-objdump  ubuntu-24.04-arm  pr     -              native arm silicon: qemu cannot settle aapcs64 or page-size questions
+riscv64-linux     riscv64  linux         lp64d    -    bin     hosted        qemu:qemu-riscv64  llvm-objdump  ubuntu-latest     pr     -              compute evidence only, never ABI evidence
+riscv32           riscv32  freestanding  ilp32d   elf  static  direct        none               llvm-objdump  ubuntu-latest     pr     -              linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
+x86_64-windows    x86_64   windows       win64    -    bin     hosted        native             llvm-objdump  windows-latest    pr     -              no wine, anywhere, ever
+x86_64-darwin     x86_64   darwin        sysv64   -    bin     hosted        native             llvm-objdump  macos-15-intel    main     ubuntu-latest  metered runner, so the release merge rather than every pull request
+aarch64-darwin    aarch64  darwin        aapcs64  -    bin     hosted        native             llvm-objdump  macos-15          main     ubuntu-latest  metered runner, so the release merge rather than every pull request
+spirv             spirv    freestanding  spirv    -    bin     direct        none               spirv-dis     ubuntu-latest     pr     -              a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
+mos6502           mos6502  freestanding  mos6502  -    bin     freestanding  none               da65          ubuntu-latest     pr     -              layers A and B only, and promoting it to an execution engine is follow-up work

--- a/test/lib/config.py
+++ b/test/lib/config.py
@@ -43,11 +43,11 @@ def _rows(path):
 
 class Target(object):
     __slots__ = ("name", "isa", "os", "abi", "of", "kind", "entry",
-                 "engine", "engine_cmd", "disasm", "runner", "cadence", "note")
+                 "engine", "engine_cmd", "disasm", "runner", "cadence", "decode", "note")
 
     def __init__(self, fields, note):
         (self.name, self.isa, self.os, self.abi, self.of, self.kind,
-         self.entry, engine, self.disasm, self.runner, self.cadence) = fields
+         self.entry, engine, self.disasm, self.runner, self.cadence, self.decode) = fields
         if ":" in engine:
             self.engine, self.engine_cmd = engine.split(":", 1)
         else:
@@ -74,10 +74,10 @@ def load_engines(path):
     targets = []
     seen = set()
     for lineno, line in _rows(path):
-        fields = line.split(None, 11)
-        if len(fields) != 12:
-            raise ConfigError("%s:%d: expected 12 columns, got %d" % (path, lineno, len(fields)))
-        t = Target(fields[:11], fields[11])
+        fields = line.split(None, 12)
+        if len(fields) != 13:
+            raise ConfigError("%s:%d: expected 13 columns, got %d" % (path, lineno, len(fields)))
+        t = Target(fields[:12], fields[12])
         if t.entry not in ("hosted", "direct", "freestanding"):
             raise ConfigError("%s:%d: entry must be hosted|direct|freestanding" % (path, lineno))
         if t.kind not in ("bin", "static"):
@@ -92,7 +92,40 @@ def load_engines(path):
             raise ConfigError("%s:%d: duplicate target name %s" % (path, lineno, t.name))
         seen.add(t.name)
         targets.append(t)
+    _check_pr_reader(path, targets)
     return targets
+
+
+def _check_pr_reader(path, targets):
+    """every object format mach writes is read by an external tool on the pr lane.
+
+    A format defect is introduced on a pull request, and that is where it is cheap to
+    find. COFF is why this is a check rather than a convention: `x86_64-windows` had a
+    leg that had never once started, so nothing external had ever parsed a mach PE, and
+    the very first layer A run over it found a long section-name form that llvm rejected
+    outright - every object with a constant pool unreadable, invisible for as long as
+    it was because no external reader had looked (mach#2952).
+
+    A `main`-cadence row is therefore allowed only when some `pr`-cadence row already
+    reads its format, either by running there itself or by naming a `decode` runner
+    that builds and decodes it. The rule lives here rather than in a comment so a
+    future metered row is a visible decision instead of an accident (mach#2957).
+    """
+    reads_at_pr = set()
+    for t in targets:
+        if t.runner != "-" and t.cadence == "pr":
+            reads_at_pr.add(t.object_format)
+        if t.decode != "-":
+            reads_at_pr.add(t.object_format)
+    for t in targets:
+        if t.runner == "-" or t.cadence == "pr":
+            continue
+        if t.object_format not in reads_at_pr:
+            raise ConfigError(
+                "%s: row %s is main cadence and no pr-cadence row reads the %s format, "
+                "so a defect in it would first be seen at the release merge. give the "
+                "row a `decode` runner that reads it on the pr lane, or move it to pr "
+                "cadence." % (path, t.name, t.object_format))
 
 
 class Tool(object):

--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -30,6 +30,10 @@ USAGE = """usage: run.sh [options]
   (no options)                 every case, every target this host serves, every layer
   --runner <label>             the rows engines.conf assigns to that CI runner, which
                                this host must then be able to serve or the run refuses
+  --decode <label>             the rows engines.conf assigns that runner for DECODING
+                               only: built and read (layers a and b), never executed,
+                               so a release-cadence format still has an external reader
+                               on the pr lane
   --target <t>                 restrict to one target (repeatable)
   --case <group>/<name>        restrict to one case (repeatable)
   --layer a|b|c                restrict to one layer (repeatable)
@@ -156,7 +160,7 @@ def unservable(t, system, machine):
         t.os, t.isa, system, machine)
 
 
-def select_targets(all_targets, only, runner, layers_wanted, check=True):
+def select_targets(all_targets, only, runner, layers_wanted, check=True, decode=""):
     """which rows this run covers, and how that was decided.
 
     assignment and capability are separate questions and only one of them selects.
@@ -170,6 +174,20 @@ def select_targets(all_targets, only, runner, layers_wanted, check=True):
     system, machine = host_pair()
     machine = "aarch64" if machine == "arm64" else machine
     names = [t.name for t in all_targets]
+
+    # `--decode` is a THIRD assignment, and the narrowest: the rows a pr-cadence runner
+    # reads without executing, so a format whose own leg runs at release cadence still
+    # has an external reader on the lane that gates merges (#2957). It never selects
+    # layer C - these rows are assigned here precisely because this host cannot run
+    # them - so the capability check below does not apply and must not.
+    if decode:
+        assigned = [t for t in all_targets if t.decode == decode]
+        if not assigned:
+            die("engines.conf assigns no target to decode runner '%s'; the decode column names %s"
+                % (decode, ", ".join(sorted({t.decode for t in all_targets if t.decode != "-"})) or "nothing"))
+        notes = [("not assigned", t, "engines.conf gives it no decode row on %s" % decode)
+                 for t in all_targets if t.decode != decode]
+        return assigned, notes
 
     if runner:
         assigned = [t for t in all_targets if t.runner == runner]
@@ -231,6 +249,7 @@ def needed_tools(targets, layers_wanted, skips_by_target):
 def main(argv):
     only_targets, only_cases, only_layers = [], [], []
     runner = ""
+    decode = ""
     bless = False
     show_matrix = False
     show_tools = False
@@ -242,6 +261,11 @@ def main(argv):
             if i >= len(argv):
                 die("--runner needs a value")
             runner = argv[i]
+        elif a == "--decode":
+            i += 1
+            if i >= len(argv):
+                die("--decode needs a value")
+            decode = argv[i]
         elif a == "--target":
             i += 1
             only_targets.append(argv[i]) if i < len(argv) else die("--target needs a value")
@@ -270,6 +294,12 @@ def main(argv):
     # other would be a claim about coverage nothing produced.
     if runner and only_targets:
         die("--runner assigns the rows and so does --target; pass one")
+    if decode and (runner or only_targets):
+        die("--decode assigns the rows and so does %s; pass one"
+            % ("--runner" if runner else "--target"))
+    if decode and "c" in only_layers:
+        die("--decode reads rows this host cannot execute, so it serves layers a and b; "
+            "asking for layer c here would be a claim about coverage nothing produced")
 
     if show_tools:
         return list_tools(only_targets, runner, only_layers)
@@ -298,7 +328,7 @@ def main(argv):
 
     with OutLock(out_root):
         return run(out_root, matrix_path, only_targets, runner, only_cases,
-                   wanted_layers_arg, bless)
+                   wanted_layers_arg, bless, decode)
 
 
 def list_tools(only_targets, runner, only_layers):
@@ -333,7 +363,7 @@ def list_tools(only_targets, runner, only_layers):
     return 0
 
 
-def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bless):
+def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bless, decode=""):
     tools = config.load_tools(os.path.join(CORPUS, "tools.lock"))
     all_targets = config.load_engines(os.path.join(CORPUS, "engines.conf"))
     cases = discover_cases(only_cases)
@@ -342,7 +372,10 @@ def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bl
     wanted_layers = only_layers or list(config.LAYERS)
     if bless:
         wanted_layers = ["b"]
-    targets, notes = select_targets(all_targets, only_targets, runner, wanted_layers)
+    # a decode run reads what it cannot execute, so layer C is not on offer
+    if decode:
+        wanted_layers = [l for l in wanted_layers if l != "c"]
+    targets, notes = select_targets(all_targets, only_targets, runner, wanted_layers, decode=decode)
     if not targets:
         die("no target in engines.conf can be served by this host")
 

--- a/test/link/cases/c-variadic/expect.txt
+++ b/test/link/cases/c-variadic/expect.txt
@@ -1,7 +1,7 @@
 none=0
 mixed n=3 7 8 2500
 ptr n=1 4242
-floats n=8 1000 4000 8000
+floats n=8 1000 2000 4000 8000
 pair n=1 309
 wide n=1 1234
 indirect n=2 11 500

--- a/test/link/cases/c-variadic/src/main.mach
+++ b/test/link/cases/c-variadic/src/main.mach
@@ -56,6 +56,19 @@ fun main(argc: usize, argv: **u8) i64 {
     # MORE VARARGS THAN REGISTER SLOTS. eight doubles exhaust both AAPCS64's V bank
     # and SysV's XMM bank, so the tail crosses the register/stack boundary on the
     # legs that have one - and never touches a register at all on Apple arm64.
+    #
+    # WHICH INDICES CARRY THE WIN64 SIGNAL (mach#3043). win64 gives only the first four
+    # POSITIONAL slots registers, and the two fixed parameters (`spec`, `out`) occupy
+    # two of them - so of these eight doubles only out[0] and out[1] ride a register and
+    # can expose a broken `float_dup_gp`, the rule that duplicates a tail float into the
+    # integer register of its slot. The rest ride the stack, where there is no
+    # duplication to get wrong, and are unaffected by that rule either way.
+    #
+    # This line used to report out[0], out[3] and out[7]: one register-slot value and two
+    # stack ones. Eight doubles read like broad coverage of the register/stack boundary
+    # and, for this rule, were a ONE-VALUE check - out[1] is equally broken by the same
+    # defect and was never printed. out[7] stays as the stack-side control: a mutation
+    # that moved IT too would mean something different and worse.
     var i: u32 = 0;
     for (i < 8) {
         s[i] = 'd'::u8;
@@ -65,7 +78,7 @@ fun main(argc: usize, argv: **u8) i64 {
     val n3: i64 = va_probe(?s[0], ?out[0],
                            1.0::f64, 2.0::f64, 3.0::f64, 4.0::f64,
                            5.0::f64, 6.0::f64, 7.0::f64, 8.0::f64);
-    p.printlnf("floats n={} {} {} {}", n3, out[0], out[3], out[7]);
+    p.printlnf("floats n={} {} {} {} {}", n3, out[0], out[1], out[3], out[7]);
 
     # a 16-byte aggregate by value in the tail.
     var pr: Pair;


### PR DESCRIPTION
Release 4.25.0. Merged from `dev`.

This is where the `darwin (release gate)` schedules — and this release is mostly darwin, so it is the run that matters.

## Added

- **#2990** — `stack_reserve` / `stack_commit` on `[target.<name>]`.

## Fixed

- **#2974** — a C common symbol is allocated instead of demanded as an import; mach-audio can drop `-fno-common`.
- **#2973** — an x86_64 `SUBTRACTOR` relocation pair is parsed and resolved; mach-audio can drop `-fno-jump-tables`.
- **#2957** — Mach-O gets an external reader on the pr lane. Between releases mach was its own only reader of a format it writes.
- **#2991** — a frame larger than the target's stack reserve is refused rather than emitted.
- **#2904** — a 64-bit cross-bank reinterpret is lowered on riscv32.
- **#2949** — a failed lowering pass counts as an error, so char-width regressions actually regress.
- **#3043** — the c-variadic golden samples both register-slot floats.

## Verification

17/17 on the dev-targeted PR. 1521 tests, corpus 1416/0, darwin decode lane 728/0, three-generation fixpoint byte-identical, `mach.toml` and `MACH_VERSION` both at 4.25.0.

Note for the darwin gate: #2973 and #2974 change Mach-O reading and linking, and neither was reproduced against a real Apple Clang object locally — by design, per the maintainer's steer. This gate and downstream testing are where that gets confirmed.