### PR TITLE
chore(ci): move artifact actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,7 +122,7 @@ jobs:
           tar -C stage -czf "dist/mach-$ver-$TARGET.tar.gz" mach LICENSE
 
       - name: upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: dist/mach-*-${{ matrix.target }}.tar.gz
@@ -176,7 +176,7 @@ jobs:
           Compress-Archive -Path stage/mach.exe, stage/LICENSE -DestinationPath "dist/mach-$ver-${env:TARGET}.zip" -Force
 
       - name: upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: dist/mach-*-${{ matrix.target }}.zip
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: collect archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-*
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           cp c artifact/mach
 
       - name: upload fixpoint result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mach-${{ matrix.target }}
           path: artifact/mach
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the fixpoint result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.target }}
           path: artifact
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the fixpoint result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.target }}
           path: artifact
@@ -210,7 +210,7 @@ jobs:
           Copy-Item c.exe artifact/mach.exe -Force
 
       - name: upload fixpoint result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mach-${{ matrix.target }}
           path: artifact/mach.exe
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the fixpoint result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.target }}
           path: artifact
@@ -439,7 +439,7 @@ jobs:
       # reach" is not answerable from a log line.
       - name: upload the coverage matrices
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: matrix-${{ matrix.runner }}
           path: |
@@ -486,7 +486,7 @@ jobs:
         run: MACH_LINK_MACH=$PWD/m bash test/link/run.sh --deps pin --leg x86_64-linux
       - name: upload the dependency resolution
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: link-deps-pin-linux
           path: test/link/out/deps.txt

--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -48,7 +48,7 @@ jobs:
           ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
 
       - name: upload seed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: seed-${{ matrix.target }}
           path: mach-darwin-seed
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the darwin seed
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: seed-${{ matrix.target }}
           path: seed
@@ -148,7 +148,7 @@ jobs:
 
       - name: upload archive
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: dist/mach-*-${{ matrix.target }}.tar.gz

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -63,7 +63,7 @@ jobs:
           mach dep pull
           mach build . -o m
           ./m build . --target "$root" --profile release -o mach-${{ matrix.runner }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mach-${{ matrix.runner }}
           path: mach-${{ matrix.runner }}
@@ -84,7 +84,7 @@ jobs:
         include: ${{ fromJSON(needs.test-legs.outputs.include) }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.runner }}
 
@@ -132,7 +132,7 @@ jobs:
 
       - name: upload the coverage matrices
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: matrix-${{ matrix.runner }}
           path: |


### PR DESCRIPTION
Closes #2983

## Change

`actions/upload-artifact@v4` and `actions/download-artifact@v4` are pinned to
Node.js 20 and GitHub forces them onto Node.js 24 anyway, which is what emitted
the deprecation annotations in #2980. Bumped all 16 sites across `ci.yml`,
`cd.yml`, `test-main.yml`, and `darwin-lane.yml`:

- `actions/upload-artifact@v4` -> `@v7` (`v7.0.1`, confirmed `runs.using: node24` in its `action.yml`)
- `actions/download-artifact@v4` -> `@v8` (`v8.0.1`, confirmed `runs.using: node24` in its `action.yml`)

These are the current majors of both actions (checked `gh api repos/actions/upload-artifact/releases` and the same for download-artifact) and both default to Node.js 24, unlike v5/v6 of each which only had preliminary Node 24 support while still running Node 20 by default.

No other action reference in these four workflows is on Node 20: `actions/checkout@v6` and `softprops/action-gh-release@v3` (used in `cd.yml`'s release job) are both already `node24`. The two local composite actions (`.github/actions/seed-mach`, `.github/actions/apt-install`) declare `runs: using: composite` and call no other Node-runtime action, so there was nothing to bump there.

## Breaking changes checked between v4 and target

**upload-artifact v4 -> v7**: v5/v6 only changed the runtime (preliminary then default Node 24, no API change). v7 added an opt-in `archive: false` for unzipped single-file uploads and moved the package to ESM internally; default behavior (zip, `name`, `path`, `if-no-files-found`, `retention-days`) is unchanged, so nothing here needed updating.

**download-artifact v4 -> v8**: v5 changed path nesting for single-artifact-by-ID downloads, but nothing in these workflows downloads by `artifact-ids`, only by `name` or by `pattern` with `merge-multiple: true`, both of which the v5 release notes call out as needing no action. v6/v7 were the runtime-only bump. v8 defaults `digest-mismatch` to `error` instead of warn-only, and switches to Content-Type-based decompression instead of always unzipping. Since every artifact here is uploaded and downloaded within the same run by our own upload-artifact step (always zipped, never corrupted in transit under normal operation), this is a fail-closed hardening we want, not a regression risk.

## Producer/consumer pairing table

| Producer (job:line) | Artifact name | Consumer (job:line) | How consumed | Verdict |
|---|---|---|---|---|
| ci.yml build-linux:74 | `mach-${{ matrix.target }}` (x86_64-linux, aarch64-linux) | ci.yml test-linux:97, incremental-linux:125 | exact `name` match, two separate consumer jobs reading the same artifact | OK, exact-name download semantics unchanged v4->v8 |
| ci.yml build-windows:213 | `mach-${{ matrix.target }}` (x86_64-windows) | ci.yml test-windows:237 | exact `name` match | OK |
| ci.yml test-targets:442 | `matrix-${{ matrix.runner }}` (per runner, `if: always()`) | none in-repo (diagnostic artifact for manual inspection) | n/a | OK, no pairing to break |
| ci.yml link-pin:489 | `link-deps-pin-linux` | none in-repo (diagnostic artifact) | n/a | OK |
| cd.yml build-linux:125 | `release-${{ matrix.target }}` (x86_64-linux, aarch64-linux) | cd.yml release:208 | `pattern: release-*`, `merge-multiple: true` | OK |
| cd.yml build-windows:179 | `release-${{ matrix.target }}` (x86_64-windows) | cd.yml release:208 | same pattern download | OK |
| darwin-lane.yml seed:51 | `seed-${{ matrix.target }}` (aarch64-darwin, x86_64-darwin) | darwin-lane.yml build:85 | exact `name` match | OK |
| darwin-lane.yml build:151 (`if: github.event_name == 'push'`) | `release-${{ matrix.target }}` (aarch64-darwin, x86_64-darwin) | cd.yml release:208 (cross-workflow, via `workflow_call`, same run) | same `pattern: release-*` download that also collects the two cd.yml build jobs' artifacts | OK, all five release-* names (`release-x86_64-linux`, `release-aarch64-linux`, `release-x86_64-windows`, `release-aarch64-darwin`, `release-x86_64-darwin`) are distinct, no overwrite, `merge-multiple: true` unaffected by the version bump |
| test-main.yml seed:66 | `mach-${{ matrix.runner }}` | test-main.yml test-targets:87 | exact `name` match | OK |
| test-main.yml test-targets:135 | `matrix-${{ matrix.runner }}` (`if: always()`) | none in-repo (diagnostic artifact) | n/a | OK |

No matrix job uploads under a templated name that collides with another job's templated name, no consumer relies on `artifact-ids`-based download (the one thing v5 of download-artifact changed), and nothing here relies on overwriting an existing artifact name within a run.

## Verification

- YAML parses clean on all four files (`python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" .github/workflows/*.yml`).
- Zero remaining `@v4` artifact-action references, exactly 16 sites changed (confirmed by grep before/after).
- Diff touches only the `uses:` lines named in the issue, nothing else.
- **CI itself is the only real check here** since none of this can be exercised locally. I opened this as a draft and will watch the run to completion, confirm every job is green, and confirm the Node.js 20 deprecation annotations are gone before marking it ready.
