### PR TITLE
docs(manifest): refresh accepted tuples and RISC-V ABI family

### DIFF
--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -173,9 +173,9 @@ such an image is refused at link rather than silently dropped.
 
 | Axis  | Values |
 |-------|--------|
-| `isa` | `x86_64`, `aarch64`, `riscv64`, `spirv`, `mos6502` |
+| `isa` | `x86_64`, `aarch64`, `riscv64`, `riscv32`, `spirv`, `mos6502` |
 | `os`  | `linux`, `windows`, `darwin`, `freestanding` |
-| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64`, `spirv`, `mos6502` |
+| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64`, `lp64f`, `lp64d`, `ilp32`, `ilp32f`, `ilp32d`, `spirv`, `mos6502` |
 
 `x86_64`/`linux`/`sysv64` is the primary host and target. `aarch64`-linux builds
 and runs natively in CI on every PR; `riscv64`-linux runs under qemu and
@@ -188,6 +188,22 @@ bare-metal platform such as BareMetal (`bmos`) is a `freestanding` target plus a
 not an os of its own. `spirv` is not a machine at all — it
 emits a finished GPU module rather than machine code (see
 [Finished-module targets](#finished-module-targets)).
+
+`lp64`, `lp64f`, `lp64d`, `ilp32`, `ilp32f`, and `ilp32d` are the RISC-V psABI
+calling-convention family, one `abi` per member. The lp64 three target
+`riscv64` and the ilp32 three target `riscv32`; an ilp32 member on a `riscv64`
+target or an lp64 member on `riscv32` is refused at composition, since XLEN is
+part of what the id means. Within each width, the members differ only in how
+floating-point arguments travel: `lp64` and `ilp32` are **soft float** — every
+float argument rides an integer register — while the `f` and `d` suffixes are
+**hard float**, passing `f32` (`f`) or both `f32` and `f64` (`d`) in the
+`fa0`-`fa7` register bank. `lp64d` is what a `riscv64-linux-gnu` toolchain
+means by "riscv64", and is the convention `mach init` scaffolds for a
+`riscv64`/`linux` target; a manifest that wants soft float, or the `f`-only
+convention, must name it explicitly, since `abi` has no default of its own
+(see [Convention, then totality](#convention-then-totality)). `riscv32`
+currently only reaches a `freestanding` target — `mach info targets` lists
+`freestanding-riscv32` and no `linux`/`darwin` riscv32 tuple.
 
 `mach info targets` prints the tuples this binary can actually build; it is
 derived from the same declarations composition reads, so it never advertises a


### PR DESCRIPTION
Closes #2947

## What changed

`doc/manifest.md`'s accepted-tuple table was missing `riscv32` and five RISC-V ABI names. Added them, plus a paragraph explaining the RISC-V psABI family (soft float `lp64`/`ilp32` vs hard float `lp64f`/`lp64d`/`ilp32f`/`ilp32d`, the width split, and that `riscv32` currently only reaches a `freestanding` target) right where a reader picking an ABI will see it.

## Two-way set diff (from-source build, `out/linux-x86_64/debug/bin/mach`, commit 7e06bfcb base)

Compared `mach info` / `mach info targets` output against the doc's accepted-tuple table.

```
$ mach info
isa: x86_64 aarch64 riscv64 riscv32 spirv mos6502
os: linux darwin windows freestanding
abi: sysv64 win64 aapcs64 lp64 lp64f lp64d ilp32 ilp32f ilp32d spirv mos6502
object: elf coff macho raw spv
```

- **isa**: doc had `x86_64, aarch64, riscv64, spirv, mos6502` vs actual `+ riscv32`. Doc missing `riscv32`. No extras in doc. **Fixed.**
- **os**: doc `linux, windows, darwin, freestanding` == actual. No diff.
- **abi**: doc had `sysv64, win64, aapcs64, lp64, spirv, mos6502` vs actual `+ lp64f, lp64d, ilp32, ilp32f, ilp32d`. Doc missing all five. No extras in doc. **Fixed.**
- **object format** (`of` override, doc's "Object-format override" section): doc `elf, coff, macho, raw, spv` == actual. No diff.

After the fix, every value in the doc's tuple table is a value `mach info` prints, and every value `mach info` prints appears in the doc, in both directions.

Spot-checked by building a scratch manifest (`riscv32`/`freestanding`/`ilp32d`) through `mach build --explain`: the tuple resolves. Also confirmed `riscv32`/`linux`/`ilp32d` is refused (`operating system 'linux' does not run on instruction set 'riscv32'`), which is why the new prose says riscv32 currently only reaches `freestanding`.

## `[project]` key set — NOT changed, and here's why

The issue asks to add `mach` (the `#2714` minimum-toolchain key) to the `[project]` key table and schema block. I did not make this change: the feature was fully removed on `dev` before this issue's investigation could have caught it.

- `#2714` / PR #2718 added `[project].mach` on 2026-08-05.
- `#2953` / PR #2994 ("fix(driver): remove project mach requirement"), merged 2026-08-12 and released in 4.19.0/4.20.0, removed it again. Current `src/lang/manifest.mach` (`key_known`, `TK_PROJECT`) only accepts `mach` as a *tolerated, ignored* key in a **dependency's** manifest (`!as_root`); a root manifest naming `[project].mach` gets an unknown-key error, exactly as the doc's existing "exactly these four keys" sentence says.
- The CHANGELOG entry for `#2953` confirms the reasoning: the check read the *embedding* project's version when the frontend was vendored (e.g. under mach-lsp), so it refused ordinary `4.x` requirements, and "no replacement is planned."

So the doc's current `[project]` key table and "exactly these four keys" sentence are **already correct** as of `dev` HEAD. Adding `mach` back would document a feature that doesn't exist. I'm reporting this to the issue owner (@octalide via the coordinating session) rather than editing scope on my own judgment call beyond what I can verify — happy to add a line noting the key was tried and removed if that's wanted, but didn't want to presume the framing.

## Other stale claims found

None beyond the two above. I checked the rest of `doc/manifest.md`'s target/tuple/object-format prose (image stack size, object-format override, finished-module targets, platform targets, and the compiler's-own-manifest example) against source and `mach info` output; no other drift found.

## Verification

- `mach dep pull` + `mach build .` from source (commit 7e06bfcb base).
- `mach test .`: **1521 passed, 0 failed, 1521 total** — unchanged, as expected for a docs-only change.
- Scratch manifest spot-check for `riscv32`/`freestanding`/`ilp32d` via `mach build --explain` (built, resolved, cleaned up under `/tmp/claude-1000/`).