### PR TITLE
test(corpus): give layer A a real skip verdict for raw formats

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -134,7 +134,10 @@ another layer's output.
 pipelines, plus a third `-g` build. `llvm-readobj --file-header --sections --relocs`
 must parse cleanly, and the class, machine and endianness must match the target.
 SPIR-V goes to `spirv-val` under the environment the module itself declares.
-`llvm-dwarfdump --verify` must pass on the debug build.
+`llvm-dwarfdump --verify` must pass on the debug build. A `raw` flat image has no
+external structural oracle wired for it, so layer A records a skip rather than a
+pass: a target reaching this cell needs a `SKIPS` entry, the same as any other
+declared gap.
 
 **Layer B, golden disassembly.** The release pipeline only, to bound churn. The
 case's own object is disassembled by an **external** decoder and diffed against a

--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -506,7 +506,7 @@ def layer_a_cells(proj, tools, m, t, case, built, skips):
             paths.append(artifact)
         out = oracle.layer_a(tools, t, paths, want_dwarf=(profile == "g" and
                                                           t.object_format in ("elf", "macho")))
-        m.add(case, t.name, "a", profile, "PASS" if out.ok else "FAIL", "", out.detail)
+        m.add(case, t.name, "a", profile, out.status, "", out.detail)
 
 
 def layer_b_cells(proj, tools, m, t, case, built, bless, blessed, skips):
@@ -529,7 +529,7 @@ def layer_b_cells(proj, tools, m, t, case, built, bless, blessed, skips):
             with open(golden, "w", encoding="utf-8") as fh:
                 fh.write(text)
             blessed.append((golden, before, text))
-    m.add(case, t.name, "b", "o2", "PASS" if out.ok else "FAIL", "", out.detail)
+    m.add(case, t.name, "b", "o2", out.status, "", out.detail)
 
 
 def layer_c_cells(proj, ref, m, t, case, built, skips):

--- a/test/lib/layers.py
+++ b/test/lib/layers.py
@@ -18,11 +18,17 @@ MACHINE = {
 }
 
 
-class Outcome(object):
-    __slots__ = ("ok", "detail")
+# the three verdicts a layer can hand back. these are exactly the matrix's own
+# status strings, so a caller threads the verdict through rather than collapsing
+# it back to a pass/fail boolean and losing SKIP on the way.
+PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
 
-    def __init__(self, ok, detail):
-        self.ok, self.detail = ok, detail
+
+class Outcome(object):
+    __slots__ = ("status", "detail")
+
+    def __init__(self, status, detail):
+        self.status, self.detail = status, detail
 
 
 def _run(cmd, **kw):
@@ -35,30 +41,31 @@ def layer_a(tools, target, paths, want_dwarf):
     fmt = target.object_format
     for path in paths:
         if not os.path.exists(path):
-            return Outcome(False, "expected artifact was not produced: " + path)
+            return Outcome(FAIL, "expected artifact was not produced: " + path)
         if os.path.getsize(path) == 0:
-            return Outcome(False, "artifact is empty: " + path)
+            return Outcome(FAIL, "artifact is empty: " + path)
     if fmt == "spv":
         rc, out, err = _run(["spirv-val", paths[-1]])
         if rc != 0:
-            return Outcome(False, "spirv-val rejected the module: " + (err or out).strip())
-        return Outcome(True, "spirv-val accepted %d module(s)" % len(paths))
+            return Outcome(FAIL, "spirv-val rejected the module: " + (err or out).strip())
+        return Outcome(PASS, "spirv-val accepted %d module(s)" % len(paths))
     if fmt == "raw":
-        return Outcome(True, "raw image, %d byte(s)" % os.path.getsize(paths[-1]))
+        return Outcome(SKIP, "raw is a mach-only object format with no external "
+                       "structural oracle wired for it")
     for path in paths:
         rc, out, err = _run(["llvm-readobj", "--file-header", "--sections", "--relocs", path])
         if rc != 0:
-            return Outcome(False, "llvm-readobj could not parse %s: %s" % (path, (err or out).strip()))
+            return Outcome(FAIL, "llvm-readobj could not parse %s: %s" % (path, (err or out).strip()))
         bad = _header_mismatch(fmt, target, out)
         if bad:
-            return Outcome(False, "%s: %s" % (os.path.basename(path), bad))
+            return Outcome(FAIL, "%s: %s" % (os.path.basename(path), bad))
     if want_dwarf:
         rc, out, err = _run(["llvm-dwarfdump", "--verify", paths[-1]])
         if rc != 0:
             tail = [l for l in (out + err).splitlines() if l.strip()][-1:] or ["no output"]
-            return Outcome(False, "llvm-dwarfdump --verify failed: " + tail[0].strip())
-        return Outcome(True, "readobj parsed %d file(s), dwarfdump verified" % len(paths))
-    return Outcome(True, "readobj parsed %d file(s)" % len(paths))
+            return Outcome(FAIL, "llvm-dwarfdump --verify failed: " + tail[0].strip())
+        return Outcome(PASS, "readobj parsed %d file(s), dwarfdump verified" % len(paths))
+    return Outcome(PASS, "readobj parsed %d file(s)" % len(paths))
 
 
 def _header_mismatch(fmt, target, text):
@@ -115,17 +122,17 @@ def disassemble(tools, target, case, path):
 def layer_b(tools, target, case, path, golden_path, bless):
     text, err = disassemble(tools, target, case, path)
     if text is None:
-        return Outcome(False, err), None
+        return Outcome(FAIL, err), None
     if bless:
-        return Outcome(True, "blessed %d line(s)" % text.count("\n")), text
+        return Outcome(PASS, "blessed %d line(s)" % text.count("\n")), text
     if not os.path.exists(golden_path):
-        return Outcome(False, "no golden at %s; run --bless and review the diff" % golden_path), text
+        return Outcome(FAIL, "no golden at %s; run --bless and review the diff" % golden_path), text
     with open(golden_path, "r", encoding="utf-8") as fh:
         want = fh.read()
     if want != text:
-        return Outcome(False, "disassembly differs from the golden at " +
+        return Outcome(FAIL, "disassembly differs from the golden at " +
                        _first_difference(want, text)), text
-    return Outcome(True, "%s matched %d line(s)" % (target.disasm, text.count("\n"))), text
+    return Outcome(PASS, "%s matched %d line(s)" % (target.disasm, text.count("\n"))), text
 
 
 def _first_difference(want, got):

--- a/test/lib/project.py
+++ b/test/lib/project.py
@@ -168,6 +168,11 @@ class Project(object):
         return os.path.join(self.root, "o", target.name, profile)
 
     def object_path(self, case, target, profile):
+        # a flat-image format (raw) has no relocatable .o container: mach links the
+        # in-memory codegen images straight to the artifact, so the object IS the
+        # artifact and there is no separate obj/ path to expect.
+        if target.object_format == "raw":
+            return self.artifact_path(case, target, profile)
         base = os.path.join(self.outdir(target, profile), "obj", "corpus", "cases", case)
         return base + (".spv" if target.object_format == "spv" else ".o")
 


### PR DESCRIPTION
## Summary

Layer A returned `PASS` for a `raw` object format on a check that only confirmed the artifact exists and is non-empty, which the caller had already checked immediately above. That verdict overstated what was checked: a green cell that cannot go red.

`Outcome` now carries a `status` of `PASS`, `FAIL` or `SKIP` in place of a bare `ok` boolean, threaded through both call sites in `driver.py` so the matrix records the real verdict instead of collapsing it back to pass/fail. The `raw` branch in `layer_a` now returns `SKIP`, naming the format and the absent oracle, so the cell reads uncovered rather than passing quietly. The existing `driver.gate` empty-column check already treats an uncovered cell as a hole unless a `SKIPS` entry covers it, so this applies the same pressure to a `raw` layer A column as every other layer.

While forcing this path end to end I found `project.py`'s `object_path` assumed every format has a relocatable `.o` container ahead of the format-specific check. A flat-image (`raw`) format links straight to the artifact and never produces a separate object file, so the existence check ahead of the `raw` branch would always fail first and the new `SKIP` verdict could never be reached even once mos6502 builds. `object_path` now returns the artifact path for `raw`, mirroring the same aliasing already done for `spv`.

`mos6502` is the only `raw` row today and its `SKIPS` entry (`* ab`) already declares the whole column away before either changed code path ever runs, so this changes nothing it currently reports.

## Verification

Forced the `raw` path with a temporary `engines.conf` row (`x86_64`/`freestanding`/`of -`/`bin`/`freestanding` entry, engine `none`), reverted before committing, since `mos6502` and `riscv32` are both fully `SKIPS`-blocked and never reach this code today.

- Before the fix, that forced row's layer A rendered `3 pass, 0 fail, 0 skip` and the run exited 0: a real target could grow this cell and stay silently green.
- After the fix, the same row with no `SKIPS` entry rendered `0 pass, 0 fail, 3 skip`, `run.sh --matrix` printed `skip` for the cell, and the run exited 1 through the existing `EMPTY ... has no passing cell and no SKIPS entry` gate.
- Adding a `SKIPS` entry for that row cleared the gate and the run exited 0 again, matching how every other declared skip behaves.
- Full local corpus (`test/run.sh`, no restriction): `1416 pass, 0 fail, 657 skip`, exit 0, identical before and after the change.
- `test/golden/mos6502/SKIPS` is byte-identical (untouched).
- `mach build .` then `mach test .`: `1521 passed, 0 failed, 1521 total`, matching the stated baseline.

## Test plan

- [x] Layer A over a forced `raw` target records a non-passing, non-failing cell naming the format and the absent oracle
- [x] `run.sh --matrix` counts that cell as a skip, not a pass
- [x] A `raw` target with no covering `SKIPS` entry makes the run exit nonzero through the existing empty-column gate
- [x] No target's pass count changed (1416/0/657 before and after); `mos6502`'s `SKIPS` file is unchanged
- [x] `mach build .` / `mach test .` baseline unchanged at 1521 passed, 0 failed

Closes #2956