### PR TITLE
fix(dep): pull the project named on the command line

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -431,7 +431,7 @@ symlink so the build resolves it by the same vendor layout.
 
 | Action   | Args | Effect |
 |----------|------|--------|
-| `pull`   | — | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; safe to re-run. |
+| `pull`   | `[<path>]` | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; safe to re-run. |
 | `update` | `<name> \| --all` | the only lock-advancer: re-resolve branch refs to current remote tips. Tag/commit refs are an immutable no-op. Never edits the manifest. |
 | `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[dep.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
 | `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `dep/<name>/`. |
@@ -439,6 +439,13 @@ symlink so the build resolves it by the same vendor layout.
 
 `sync` is the pre-`pull` name, kept one cycle as a hidden alias that prints a
 deprecation note and runs `pull`.
+
+`pull` takes a project directory, resolved by the same rules as `mach build
+<path>`, and defaults to the current directory when none is given. A path that is
+not a project directory is a hard error, so the dep tree a build refuses over is
+always the dep tree `pull` realises, and the refusal names the root to pass
+(#2936).
+Every other action acts on the current directory's project.
 
 ### Transport policy
 

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -2,9 +2,11 @@
 #
 # Reads argv[2] as the sub-action and dispatches: `pull` realizes the manifest's
 # intent (clone missing git deps, re-resolve a changed ref, repair
-# checkout-vs-lock drift, write the lock); `update` is the only lock-advancer
-# (branch refs to current remote tips); `add` / `remove` mutate the manifest;
-# `list` reports each dep's source form, ref, locked commit, and state.
+# checkout-vs-lock drift, write the lock) for the project named by its optional
+# path positional, defaulting to the current directory; `update` is the only
+# lock-advancer (branch refs to current remote tips); `add` / `remove` mutate the
+# manifest; `list` reports each dep's source form, ref, locked commit, and state.
+# Every action but `pull` acts on the current directory's project.
 #
 # A dependency stanza `[dep.<name>]` carries exactly one source key: a `git` url
 # plus an optional `ref`, acquired into `dep/<name>/` with plain git operations
@@ -74,12 +76,21 @@ val ENV_COUNT: usize = 21;
 # files. `req` names the manifest that required this node, for the conflict
 # diagnostic. `commit` is the resolved sha (git nodes only), filled while the
 # node is processed.
+#
+# `dir` and `rel` name the same directory in the two frames the pull needs. Every
+# filesystem touch goes through `dir`, which is reached from the process's
+# working directory. A path dep's symlink records `rel`, which is reached from
+# the project root, because the link is read from inside the project by whoever
+# builds it later and must survive the tree moving as a whole (#1370). The two
+# coincide only when the pull runs from the project root, which every pull did
+# while the root was hardcoded, and that is what made them look like one field.
 # ---
 # name:    owned dependency name as written in `[dep.<name>]`
 # git_url: owned git url, "" for a path node
 # path:    owned source path as declared, "" for a git node
 # ref:     owned git ref, "" when omitted
 # dir:     owned on-disk directory holding the dep's own mach.toml
+# rel:     owned same directory relative to the project root, or absolute
 # req:     owned name of the requiring manifest
 # commit:  owned resolved commit sha, "" until a git node is processed
 # is_git:  true for a git source, false for a path source
@@ -89,6 +100,7 @@ rec DepNode {
     path:    str;
     ref:     str;
     dir:     str;
+    rel:     str;
     req:     str;
     commit:  str;
     is_git:  bool;
@@ -170,13 +182,13 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     }
     if (str_equals(action, "pull")) {
         if (util.flag_reject_unknown(argc, argv, marks, 3, "mach dep pull")) { ret 1; }
-        ret pull_project(".", quiet);
+        ret pull_action(argc, argv, marks, quiet);
     }
     if (str_equals(action, "sync")) {
         if (util.flag_reject_unknown(argc, argv, marks, 3, "mach dep sync")) { ret 1; }
         # `sync` is the pre-rename name; kept one cycle as a hidden alias.
         print.eprint("note: `mach dep sync` is deprecated; use `mach dep pull`\n");
-        ret pull_project(".", quiet);
+        ret pull_action(argc, argv, marks, quiet);
     }
 
     print.eprint("error: unknown dep action '");
@@ -184,6 +196,40 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     print.eprint("'\n");
     print.eprint("usage: mach dep <pull|update|add|remove|list>\n");
     ret 1;
+}
+
+# resolve `mach dep pull`'s project path and realize that project
+#
+# The positional names a project directory, the same shape `mach build <path>`
+# takes and resolved by the same rules; with none given the project is the
+# current directory, so a bare `mach dep pull` keeps its meaning. The positional
+# used to be accepted and ignored, so a pull aimed at a project you were not
+# standing in reported on the current directory instead and left the named
+# project unrealized - and the build that sent you there kept sending you back
+# (#2936).
+# ---
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the positional scan
+# quiet: suppress routine per-dep lines
+# ret:   0 on success, 1 on a user error, 2 on an internal error
+fun pull_action(argc: usize, argv: **u8, marks: *bool, quiet: bool) i64 {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) {
+        err_line("failed to initialise allocator");
+        ret 2;
+    }
+
+    val pix: usize = util.arg_index_positional(argc, argv, marks, 3);
+    var arg: str = ".";
+    if (pix < argc) { arg = argv[pix]::str; }
+
+    val res_root: R.Result[str, str] = util.resolve_project_root(?a, arg);
+    if (R.is_err[str, str](res_root)) {
+        err_line(R.unwrap_err[str, str](res_root));
+        ret 1;
+    }
+    ret pull_project(R.unwrap_ok[str, str](res_root), quiet);
 }
 
 # realize the manifest's dependency intent for the project rooted at `root`
@@ -227,7 +273,7 @@ pub fun pull_project(root: str, quiet: bool) i64 {
     if (R.is_err[bool, str](res_nv)) { ret err_oom(); }
 
     # seed the flat tree from the top-level manifest's `[dep.*]`.
-    val res_seed: R.Result[bool, str] = enqueue_manifest(?nv, root, dep_root, ?mt, project_id);
+    val res_seed: R.Result[bool, str] = enqueue_manifest(?nv, root, "", dep_root, dep_name, ?mt, project_id);
     if (R.is_err[bool, str](res_seed)) {
         err_line(R.unwrap_err[bool, str](res_seed));
         ret 1;
@@ -261,7 +307,7 @@ pub fun pull_project(root: str, quiet: bool) i64 {
         val res_sub: R.Result[toml.Table, str] = read_dep_manifest(?a, nv.data[i].dir);
         if (R.is_ok[toml.Table, str](res_sub)) {
             var sub: toml.Table = R.unwrap_ok[toml.Table, str](res_sub);
-            val res_enqueue: R.Result[bool, str] = enqueue_manifest(?nv, nv.data[i].dir, dep_root, ?sub, nv.data[i].name);
+            val res_enqueue: R.Result[bool, str] = enqueue_manifest(?nv, nv.data[i].dir, nv.data[i].rel, dep_root, dep_name, ?sub, nv.data[i].name);
             if (R.is_err[bool, str](res_enqueue)) {
                 err_line(R.unwrap_err[bool, str](res_enqueue));
                 ret 1;
@@ -459,7 +505,7 @@ fun materialize_path_node(a: *A.Allocator, node: *DepNode, dep_root: str, dep_na
         ret 1;
     }
 
-    val res_target: R.Result[str, str] = link_target(a, dep_name, node.dir);
+    val res_target: R.Result[str, str] = link_target(a, dep_name, node.rel);
     if (R.is_err[str, str](res_target)) { ret err_oom(); }
     val target: str = R.unwrap_ok[str, str](res_target);
 
@@ -885,6 +931,7 @@ fun read_dep_spec(a: *A.Allocator, sub: *toml.Table, name: str) R.Result[DepNode
     node.path    = "";
     node.ref     = "";
     node.dir     = "";
+    node.rel     = "";
     node.req     = "";
     node.commit  = "";
     node.is_git  = false;
@@ -913,14 +960,21 @@ fun read_dep_spec(a: *A.Allocator, sub: *toml.Table, name: str) R.Result[DepNode
 # when absolute, else resolved relative to the requiring manifest. A name already
 # present must match its source and ref exactly, else it is a conflict naming both
 # requirers.
+#
+# Each directory is resolved twice, once from the working directory and once from
+# the project root, filling the node's `dir` and `rel`. The requiring manifest is
+# named in both frames for the same reason: a dep declared by a dep resolves its
+# relative path against the requirer, whichever frame is being built.
 # ---
 # nv:           the flat tree to grow
 # manifest_dir: directory of the manifest being read (for relative path deps)
+# manifest_rel: the same directory relative to the project root, "" for the root
 # dep_root:     flat dep tree root for git deps
+# dep_rel:      the same root relative to the project root (the dep dir name)
 # mt:           the parsed manifest table
 # req:          name of the manifest requiring these deps
 # ret:          ok(true), or a conflict / malformed-stanza error
-fun enqueue_manifest(nv: *NodeVec, manifest_dir: str, dep_root: str, mt: *toml.Table, req: str) R.Result[bool, str] {
+fun enqueue_manifest(nv: *NodeVec, manifest_dir: str, manifest_rel: str, dep_root: str, dep_rel: str, mt: *toml.Table, req: str) R.Result[bool, str] {
     val deps: *toml.Table = toml.get_table(mt, "dep");
     if (deps == nil) { ret R.ok[bool, str](true); }
     val len: usize = toml.table_len(deps);
@@ -939,15 +993,24 @@ fun enqueue_manifest(nv: *NodeVec, manifest_dir: str, dep_root: str, mt: *toml.T
         node.req = own(nv.a, req);
 
         var res_dir: R.Result[str, str];
+        var res_rel: R.Result[str, str];
         if (node.is_git) {
             res_dir = join2(nv.a, dep_root, node.name::*u8);
+            res_rel = join2(nv.a, dep_rel,  node.name::*u8);
         }
         or {
-            if (path_is_absolute(node.path)) { res_dir = R.ok[str, str](own(nv.a, node.path)); }
-            or                               { res_dir = join2(nv.a, manifest_dir, node.path::*u8); }
+            if (path_is_absolute(node.path)) {
+                res_dir = R.ok[str, str](own(nv.a, node.path));
+                res_rel = R.ok[str, str](own(nv.a, node.path));
+            }
+            or {
+                res_dir = join2(nv.a, manifest_dir, node.path::*u8);
+                res_rel = join2(nv.a, manifest_rel, node.path::*u8);
+            }
         }
-        if (R.is_err[str, str](res_dir)) { ret R.err[bool, str]("out of memory"); }
+        if (R.is_err[str, str](res_dir) || R.is_err[str, str](res_rel)) { ret R.err[bool, str]("out of memory"); }
         node.dir = R.unwrap_ok[str, str](res_dir);
+        node.rel = R.unwrap_ok[str, str](res_rel);
 
         val existing: i64 = nv_find(nv, node.name);
         if (existing >= 0) {
@@ -2182,7 +2245,7 @@ test "mach.cli.cmd.dep.enqueue_manifest:absolute_path_verbatim" {
     var nv: NodeVec;
     if (R.is_err[bool, str](nv_init(?a, ?nv, 4))) { ret 1; }
 
-    val res_enq: R.Result[bool, str] = enqueue_manifest(?nv, "/project/root", "/project/root/dep", ?mt, "root");
+    val res_enq: R.Result[bool, str] = enqueue_manifest(?nv, "/project/root", "", "/project/root/dep", "dep", ?mt, "root");
     if (R.is_err[bool, str](res_enq)) { ret 1; }
     if (nv.len != 2) { ret 1; }
 
@@ -2191,6 +2254,114 @@ test "mach.cli.cmd.dep.enqueue_manifest:absolute_path_verbatim" {
     if (i_abs < 0 || i_rel < 0) { ret 1; }
     if (!str_equals(nv.data[i_abs::usize].dir, "/abs/somewhere/lib"))       { ret 1; }
     if (!str_equals(nv.data[i_rel::usize].dir, "/project/root/../lib-rel")) { ret 1; }
+    ret 0;
+}
+
+# a node's `rel` names its directory from the project root while `dir` names it
+# from the working directory, so the symlink a path dep records resolves from
+# inside the project no matter where the pull was run (#2936). an absolute path
+# is the same in both frames, and a transitive dep resolves against its
+# requirer's `rel`, not the root
+test "mach.cli.cmd.dep.enqueue_manifest:rel_is_root_relative" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+
+    val res_mt: R.Result[toml.Table, str] = toml.parse(?a,
+        "[dep.p]\npath = \"../lib-p\"\n[dep.g]\ngit = \"u\"\n[dep.abs]\npath = \"/abs/lib\"\n");
+    if (R.is_err[toml.Table, str](res_mt)) { ret 1; }
+    var mt: toml.Table = R.unwrap_ok[toml.Table, str](res_mt);
+
+    var nv: NodeVec;
+    if (R.is_err[bool, str](nv_init(?a, ?nv, 4))) { ret 1; }
+
+    # the pull runs two directories away from the project it was given.
+    val res_enq: R.Result[bool, str] = enqueue_manifest(?nv, "../../proj", "", "../../proj/dep", "dep", ?mt, "root");
+    if (R.is_err[bool, str](res_enq)) { ret 1; }
+
+    val i_p: i64 = nv_find(?nv, "p");
+    val i_g: i64 = nv_find(?nv, "g");
+    val i_abs: i64 = nv_find(?nv, "abs");
+    if (i_p < 0 || i_g < 0 || i_abs < 0) { ret 1; }
+    if (!str_equals(nv.data[i_p::usize].dir, "../../proj/../lib-p"))   { ret 1; }
+    if (!str_equals(nv.data[i_p::usize].rel, "../lib-p"))              { ret 1; }
+    if (!str_equals(nv.data[i_g::usize].dir, "../../proj/dep/g"))      { ret 1; }
+    if (!str_equals(nv.data[i_g::usize].rel, "dep/g"))                 { ret 1; }
+    if (!str_equals(nv.data[i_abs::usize].rel, "/abs/lib"))            { ret 1; }
+
+    # the link written for `p` climbs out of the vendor dir and resolves from the
+    # project root, never from wherever the pull was invoked.
+    val res_target: R.Result[str, str] = link_target(?a, "dep", nv.data[i_p::usize].rel);
+    if (R.is_err[str, str](res_target))                                  { ret 1; }
+    if (!str_equals(R.unwrap_ok[str, str](res_target), "../../lib-p"))   { ret 1; }
+
+    # a dep of the path dep resolves against that dep's own directory in both frames.
+    val res_sub: R.Result[toml.Table, str] = toml.parse(?a, "[dep.q]\npath = \"../lib-q\"\n");
+    if (R.is_err[toml.Table, str](res_sub)) { ret 1; }
+    var sub: toml.Table = R.unwrap_ok[toml.Table, str](res_sub);
+    val res_enq2: R.Result[bool, str] = enqueue_manifest(?nv, nv.data[i_p::usize].dir, nv.data[i_p::usize].rel,
+                                                         "../../proj/dep", "dep", ?sub, "p");
+    if (R.is_err[bool, str](res_enq2)) { ret 1; }
+    val i_q: i64 = nv_find(?nv, "q");
+    if (i_q < 0) { ret 1; }
+    if (!str_equals(nv.data[i_q::usize].dir, "../../proj/../lib-p/../lib-q")) { ret 1; }
+    if (!str_equals(nv.data[i_q::usize].rel, "../lib-p/../lib-q"))            { ret 1; }
+    ret 0;
+}
+
+# `mach dep pull <path>` realizes the project it is given, not the one the shell
+# happens to stand in. the path positional used to be accepted and ignored, so a
+# pull aimed at another project reported on the current directory and left the
+# named project's path dep unmaterialized, and the build that sent the user there
+# kept sending them back (#2936)
+test "mach.cli.cmd.dep.run:pull_realizes_the_named_project" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+
+    # a uniquely owned temp path, taken as the root of a two-project tree
+    val res_temp: R.Result[fs.TempFile, str] = fs.temp_create(?a, "mach_test_pull_arg");
+    if (R.is_err[fs.TempFile, str](res_temp)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](res_temp);
+    val root: str = fs.temp_path(?tf);
+    fs.temp_close_and_remove(?tf);
+
+    val proj: str = concat3(?a, root, "/", "proj");
+    val src:  str = concat3(?a, root, "/", "lib-x");
+    if (O.is_some[str](fs.create_dir_all(?a, proj, 0o755))) { ret 1; }
+    if (O.is_some[str](fs.create_dir_all(?a, src,  0o755))) { ret 1; }
+
+    val proj_body: str = "[project]\nid = \"proj\"\n\n[dep.lib-x]\npath = \"../lib-x\"\n";
+    val src_body:  str = "[project]\nid = \"lib-x\"\n";
+    val proj_toml: str = concat3(?a, proj, "/", MANIFEST);
+    val src_toml:  str = concat3(?a, src,  "/", MANIFEST);
+    if (O.is_some[str](fs.write_bytes(proj_toml, proj_body::*u8, str_len(proj_body), 0o644))) {
+        fs.remove_all(?a, root);
+        ret 1;
+    }
+    if (O.is_some[str](fs.write_bytes(src_toml, src_body::*u8, str_len(src_body), 0o644))) {
+        fs.remove_all(?a, root);
+        ret 1;
+    }
+
+    var av: [5]*u8;
+    av[0] = "mach"::*u8;
+    av[1] = "dep"::*u8;
+    av[2] = "pull"::*u8;
+    av[3] = "--quiet"::*u8;
+    av[4] = proj::*u8;
+    var mk: [5]bool;
+    var i: usize = 0;
+    for (i < 5) { mk[i] = false; i = i + 1; }
+
+    val rc: i64 = run(5, ?av[0], ?mk[0]);
+
+    # the link is read through, so this passes only when its target resolves from
+    # the vendor location, not merely when some link was written.
+    val vendored: str = concat3(?a, proj, "/dep/lib-x/", MANIFEST);
+    val linked: bool = fs.exists(vendored);
+    fs.remove_all(?a, root);
+
+    if (rc != 0)  { ret 1; }
+    if (!linked)  { ret 1; }
     ret 0;
 }
 

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -212,7 +212,7 @@ fun help_dep() {
     print.print("manage the project's dependency tree under dir_dep.\n");
     print.print("\n");
     print.print("actions:\n");
-    print.print("  pull                          realise the manifest: clone, re-resolve, repair, lock\n");
+    print.print("  pull [<path>]                 realise the manifest: clone, re-resolve, repair, lock\n");
     print.print("  update <name> | --all         advance branch refs to current remote tips\n");
     print.print("  add <name> --git <url> [--ref R] | --path <dir>   declare a dependency, then pull\n");
     print.print("  remove <name> [--purge]       drop a dependency (--purge deletes its dir)\n");
@@ -224,6 +224,9 @@ fun help_dep() {
     print.print("records each git dep's resolved commit in mach.lock and resolves\n");
     print.print("transitive deps into the flat tree. git is needed only by the network\n");
     print.print("commands; mach build never shells out.\n");
+    print.print("\n");
+    print.print("pull takes a project directory, as mach build does, and defaults to the\n");
+    print.print("current directory. every other action acts on the current directory.\n");
 }
 
 # print the `mach init` detail page

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -516,19 +516,23 @@ fun requirement_index(arr: *manifest.LinkRequirement, count: u32,
 # vendor location that exists but whose manifest failed to open or parse for some
 # other reason, where `parse_toml_file`'s message already names the path and the
 # OS error. Naming the dep either way is what the bare passthrough this replaces
-# never did.
+# never did. The advice carries the project root the build was aimed at, because
+# `mach dep pull` acts on the project it is given and a bare one would realize
+# whatever project the shell happens to stand in (#2936).
 # ---
 # s:       session, for interning the returned message
 # alias:   the dep's `[dep.<alias>]` name
 # dep_dir: the dep's vendor root, checked for existence to pick the diagnosis
+# root:    the project root being built, named in the advice so the command is
+#          runnable from where the build was
 # read_err: `parse_toml_file`'s error (path- and OS-message-qualified already)
 # ret:     the owned, interned diagnostic
-fun diag_dep_manifest_error(s: *session.Session, alias: str, dep_dir: str, read_err: str) str {
+fun diag_dep_manifest_error(s: *session.Session, alias: str, dep_dir: str, root: str, read_err: str) str {
     val fallback: str = "dep manifest unreadable; run `mach dep pull`";
     var res_msg: R.Result[str, str];
     if (!fs.exists(dep_dir)) {
         res_msg = format.sprint(s.build_alloc,
-            "dependency '{}' is not resolved (missing '{}'); run `mach dep pull`", alias, dep_dir);
+            "dependency '{}' is not resolved (missing '{}'); run `mach dep pull {}`", alias, dep_dir, root);
     }
     or {
         res_msg = format.sprint(s.build_alloc, "dep '{}': {}", alias, read_err);
@@ -563,7 +567,7 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     val tr: R.Result[toml.Table, str] = parse_toml_file(s.build_alloc, toml_path);
     str_free(s.build_alloc, toml_path);
     if (R.is_err[toml.Table, str](tr)) {
-        val msg: str = diag_dep_manifest_error(s, alias, dep_dir, R.unwrap_err[toml.Table, str](tr));
+        val msg: str = diag_dep_manifest_error(s, alias, dep_dir, project_root, R.unwrap_err[toml.Table, str](tr));
         str_free(s.build_alloc, dep_dir);
         ret R.err[project.DepEntry, str](msg);
     }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4219,7 +4219,9 @@ test "mach.lang.driver:dep_closure_registers_transitive" {
 # a project declaring a path dep that was never pulled (clean checkout, no dep/,
 # no mach.lock) fails with a diagnostic naming the dep and the fix command, not
 # the bare OS message a raw read failure used to surface with no path or dep
-# attached at all (#2471)
+# attached at all (#2471). the fix command carries the project root the build was
+# aimed at, so running it verbatim realizes the tree this build refused over
+# rather than whichever project the shell stands in (#2936)
 test "mach.lang.driver:dep_unresolved_names_dep_and_fix" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -4248,6 +4250,7 @@ test "mach.lang.driver:dep_unresolved_names_dep_and_fix" {
         if (!ut_str_contains(msg, "'absdep'"))     { bad = 1; }
         if (!ut_str_contains(msg, "not resolved")) { bad = 1; }
         if (!ut_str_contains(msg, "mach dep pull")) { bad = 1; }
+        if (!ut_str_contains(msg, ut_cc3(?alloc, "mach dep pull ", root, ""))) { bad = 1; }
         if (ut_str_contains(msg, "no such file"))  { bad = 1; }
     }
 


### PR DESCRIPTION
Closes #2936

## The defect

`mach dep pull` hardcoded its project root to `"."` and accepted a path positional it then ignored. Aim a pull at a project you are not standing in and it reports on the project you are standing in, materialises nothing for the one you named, and exits 0. The build then refuses and tells the user to run `mach dep pull`, which is the command that just did nothing, so the advice loops.

Reproduced on the base commit with the from-source compiler:

```
$ cd host && mach dep pull ../proj
no dependencies
$ mach build ../proj
error: dependency 'libx' is not resolved (missing '../proj/dep/libx'); run `mach dep pull`
```

The issue's transcript reads `mach.lock up to date` instead of `no dependencies` because the project the shell stood in had its own realised deps. A path dep surfaced it first: a git dep already present in the cwd project makes the wrong pull look like a successful one.

## The fix

`pull` resolves an optional project positional through `util.resolve_project_root`, the same helper `build`, `test`, `run`, `clean` and `doc` use. With no positional the project is the current directory, so a bare `mach dep pull` keeps its meaning and nothing in CI or the docs changes. A positional that is not a project directory is now a hard error instead of a dropped token. `dep pull` still only realises what `mach.lock` names and never moves a pin.

The build's refusal names the root, so what it prints is runnable from where the build was run:

```
error: dependency 'libx' is not resolved (missing 'repro/proj/dep/libx'); run `mach dep pull repro/proj`
```

### The second defect the first one hid

Making the root variable exposed an assumption the hardcoded root had kept true. A path dep's symlink target was computed from the source path as reached from the *working directory*, while the link is read from inside the project, so a pull run from anywhere but the project root wrote a dangling link:

```
$ cd host/sub && mach dep pull ../../proj
linked libx -> ../libx
$ ls proj/dep
libx -> ../../../proj/../libx      # dangles
```

A `DepNode` now carries both frames, `dir` for every filesystem touch and `rel` for the recorded link target, resolved together at the one place a node is built. Git nodes, absolute paths, in-tree vendoring and transitive path deps all go through the same two-frame resolution, and the link a pull writes is now identical whichever directory it was run from.

## Verification

`mach build . && mach test .` with the from-source compiler: **1523 passed, 0 failed**, against a 1521 baseline on the base commit. The delta is exactly the two added tests.

Every guard was mutation-checked, each mutation applied alone and reverted:

| mutation | test that went red |
|---|---|
| pull ignores the positional again | `mach.cli.cmd.dep.run:pull_realizes_the_named_project` |
| link target computed from `dir` again | `mach.cli.cmd.dep.enqueue_manifest:rel_is_root_relative` |
| refusal drops the root again | `mach.lang.driver:dep_unresolved_names_dep_and_fix` |

Checked by hand with the from-source compiler, each pulled from the project root, a sibling, a directory two levels away, and an unrelated directory: relative path dep, absolute path dep, in-tree vendored dep (`path = "dep/<name>"`, still a no-op), transitive path deps, a bogus path, and a directory with no `mach.toml`. In every case the link resolves and the build gets past dep resolution.

## Notes

- `doc/manifest.md` is untouched. The code now matches what it already documents.
- `update`, `add`, `remove` and `list` still act on the current directory only. Their positional is a dep name, so a project path there needs a grammar decision rather than a one-line change, and it is out of scope for this issue. Worth filing.
