### PR TITLE
test: restore the four host-executed measurements the integration suite carried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### test: the four host-executed measurements the integration suite carried are back (#2944)
+
+Retiring the integration suite reclassified 109 of its 174 cases, and four were neither
+a codegen question the corpus answers nor a front-end question a unit test already
+asserts. Each measured something that only means anything on the machine it executes
+on, which is exactly why the corpus cannot carry it: the corpus builds for a target and
+reads what came out, and none of these is a property of the bytes. All four are now
+host-executed unit tests, gated on the host's own os and isa, and a leg that cannot run
+one **declines by name** rather than asserting something it did not measure. The
+decline is a separate `test` declaration rather than a branch inside a shared body,
+because a passing test's captured output is suppressed unless the run asks for it, so
+the name is the readout and it shows in `--list`.
+
+**The x86-64 flags probe.** `mach.lang.target.isa.x64.probe` runs each of the
+twenty-five rows in `x64/encode.mach`'s transcribed table twice, once with RFLAGS
+preset all-set and once all-clear, and compares what the CPU did against the
+transcription. That table is the security surface the `#[oblivious]` inline-asm model
+rests on, and `defines_flags` is the only fact that CLEARS a taint, so a row that drifts
+from the silicon is a permission rather than a refusal. The existing
+`agrees_with_measured_hardware` test makes the transcription bear on the
+classification; this makes it bear on the machine, which is the half that went with the
+suite. The probe now assembles through mach itself rather than through a C compiler, so
+an encoder that folded `shl rax, 0` into a shift-by-one fails here too.
+
+**The dudect-style timing harness.** `mach.lang.ct.probe` and `mach.lang.ct.dudect`
+restore the two-mode measurement, and `doc/language/secrecy.md` cites a harness that
+runs instead of marking its claims as measurements taken once. Every gate is a
+refutation, because that is all a timing measurement can do: each mode carries a
+planted leak that must be detected and a constant-time reference that must not separate
+the way the planted one does, so a mode that has stopped measuring fails through its own
+control rather than reading as a pass. Gates are separations between the class means,
+never `|t|`, which collapses under load while the means do not move, and each gate
+subtracts a null control measured in the same run rather than comparing against a
+constant, so common-mode noise leaves the verdict instead of being absorbed by the
+threshold. That null control also decides whether the run counts: it cannot leak, so any
+separation it shows is the machine rather than the code, and a run in which it separates
+by as much as a leak has to declines, because a differential measurement without
+discriminating power has no verdict in either direction. The address-trace mode samples
+one call at a time over a table larger than the last-level cache, which is the sampling
+latency mode cannot substitute for.
+
+The thresholds were calibrated inside a parallel `mach test`, which is the only
+environment they have to hold in and which the retired shell harness was never run under.
+Doing that surfaced three things the obvious shape gets wrong. The fixed class always led
+its round, and the leading sample absorbs the round's first cache and scheduler
+transition, so a probe that cannot leak still came out 7 to 11 percent slower on that
+class; the order alternates now. Both null controls were far cheaper than the probes they
+bounded, so the cheapest probe in the set was setting the precondition for every other;
+both are cost-matched now. And the address probe read one line per call, which is eighty
+nanoseconds of cache miss inside a sample whose clock overhead is several hundred, so its
+planted leak and its null control overlapped under load; it reads sixteen now, which is
+also what a table-driven cipher does per round.
+
+**The two inline-asm syscall conventions.** `mach.lang.target.isa.asm.host` executes an
+inline-asm body that cannot return, and an inline-asm console write, per os and arch.
+The non-returning half asserts an ABSENCE, since the body ends the test process with
+status 0 and reaching the statement after it is the failure, and a wrong kernel-entry
+number falls into the trap after it, so it fails rather than hangs. The write asserts
+the kernel's own answer rather than the bytes on the console, which is strictly more
+than the golden saw. windows declines both: it has no syscall ABI, and its console
+write goes through a kernel32 import, so its premise fails rather than its expectation.
+
 ## [4.25.0] - 2026-08-21
 
 

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -407,13 +407,46 @@ this version.**
 
 What holds today: the type system checks that the source respects the leakage
 model, `#[oblivious]` carries the obligation through codegen, and the translation
-validator independently re-checks the lowered MIR. All three are static.
+validator independently re-checks the lowered MIR. All three are static. Two
+host-executed measurements sit under them, and each only means anything on the
+machine it runs on, which is why both are unit tests rather than build checks.
 
-**There is no timing measurement in the tree.** A dudect-style harness existed and
-was run on demand, never in CI, because timing measurement is noise-sensitive and
-shared runners are noisy. What it established is recorded below and is not being
-re-established by anything; treat every empirical claim here as a measurement taken
-once rather than a property under guard.
+**The timing harness runs.** `mach.lang.ct.probe` is a dudect-style harness in the
+tree, measured on every `mach test`, and the claims below are what it establishes.
+It works by refutation, because that is all a timing measurement can do: a clean
+score is consistent with a leak the instrument cannot see, so each mode carries a
+*planted* leak that must be detected and a constant-time reference that must not
+separate the way the planted one does. A mode that has stopped measuring therefore
+fails through its own control instead of reading as a pass.
+
+Every gate is a separation between the two class means, never `|t|`. Welch's
+statistic divides by the sample variance, and concurrent load inflates the variance
+without moving the means, so `|t|` collapses under load while the leak is plainly
+still there. Measured at load average 27, six consecutive runs of one binary gave
+`|t|` between 7.51 and 11.24 against a threshold of 10 while the mean ratio never
+fell below 3.4. `|t|` is still reported, because it is the right statistic on a
+quiet box, and it is just not the gate.
+
+A third probe leaks nothing at all and decides whether the run counts. Any
+separation *it* shows is the machine rather than the code, so a run in which it is
+not flat has no discriminating power and **declines** rather than asserting: a
+differential measurement without discriminating power has no verdict in either
+direction, and failing there would be reporting machine load as a compiler
+regression. The consequence to keep in mind is that a permanently noisy runner
+yields a permanently declining harness, which is silence rather than assurance.
+
+**The x86-64 inline-asm flags table is measured, not inferred.** The eighteen-row
+classification the `#[oblivious]` asm model rests on, naming which instructions
+*define* ZF and CF, which merely write them, and which read them, is re-derived on x86-64
+hosts by `mach.lang.target.isa.x64.probe`, which runs each instruction twice with
+RFLAGS preset all-set and all-clear and compares what the CPU did against the
+transcription. `defines_flags` is the only fact that clears a taint, so a row that
+drifts from the silicon is a permission rather than a refusal. Three rows are
+exempt and classified by reasoning instead: `popfq`, `iretq` and `syscall` pass the
+writer probe cleanly and are still not definers, because the flags came from the
+stack, the interrupt frame, or an existing value masked through `IA32_FMASK`, and
+where a value came *from* is structural rather than measurable. A non-x86-64 host
+declines the probe by name.
 
 **What a timing harness can and cannot assure.** The leakage model has three
 channels and no single sampling regime covers them (briar-systems/mach#2363):

--- a/src/lang/ct/dudect.mach
+++ b/src/lang/ct/dudect.mach
@@ -1,0 +1,236 @@
+# dudect-style timing-leak measurement engine (#1647, #2363, #2944)
+#
+# Times a function over two input classes and reports how far apart the two timing
+# distributions sit. The classes are dudect's fixed-vs-random: class 0 always feeds one
+# fixed input, class 1 a fresh pseudo-random one. The ONLY difference between the two
+# timed regions is the value handed to the function - every RNG draw happens outside the
+# timed region - so a difference is attributable to the function rather than to harness
+# overhead. Classes alternate round by round, so thermal or frequency drift biases both
+# equally. This is the dudect method (Reparaz, Balasch, Verbauwhede 2016).
+#
+# WHAT A CALLER ASSERTS ON. The separation between the class means, never |t|. Welch
+# divides by the sample variance, and machine load inflates the variance without moving
+# the means, so |t| swings two orders of magnitude while the underlying effect does not.
+# |t| is computed and reported because it is the right statistic for judging significance
+# on a quiet box and it is what the method names; it is deliberately not a gate.
+#
+# TWO SAMPLING REGIMES, BECAUSE THE LEAKAGE MODEL HAS TWO OBSERVABLE CHANNELS. A LATENCY
+# leak scales with the batch size: more calls per timed sample lift a running-time
+# difference above clock resolution, which is why `LATENCY_INNER` is large. An
+# ADDRESS-trace leak does the opposite - every call in a batch is handed the SAME input,
+# so after the first call both classes read a warm cache line and the single miss
+# carrying the signal is averaged away. The two channels want opposite batch sizes, which
+# is why `inner` is a parameter rather than a constant, and why one set of tuned numbers
+# cannot cover both.
+
+use std.system.os;
+use std.types.size.usize;
+
+# calls per timed sample in latency mode; keeps a sample well above clock resolution
+pub val LATENCY_INNER: u64 = 2048;
+
+# timed samples per class in latency mode
+pub val LATENCY_ROUNDS: u64 = 2000;
+
+# timed samples per class in address mode
+#
+# One call per sample there, so a single cache miss sits against the clock overhead of
+# the sample itself and needs far more samples to resolve than a latency leak does. |t|
+# grows as the square root of the sample count: measured on a 4 MB probe, 2 000 samples
+# gave 1.6-20 (straddling any threshold, so neither a confirmation nor a denial), 20 000
+# gave 10.7-26, and 200 000 gave 67-180 while the null control stayed under 1.6.
+pub val ADDRESS_ROUNDS: u64 = 100000;
+
+# timed samples per class for a REFERENCE probe, one that must NOT separate
+#
+# Resolving a one-cache-miss signal is what needs `ADDRESS_ROUNDS`. Refuting a separation
+# the size of a planted leak does not: the leak moves the means by tens of percent, and a
+# tenth of the samples resolves that. A reference probe doing per-call work proportional
+# to its table would otherwise dominate the whole measurement.
+pub val REFERENCE_ROUNDS: u64 = 20000;
+
+# discarded leading rounds; lets caches and the branch predictor settle
+pub val WARMUP: u64 = 64;
+
+# sink for function results, a module global the optimiser cannot prove dead, so no
+# timed call is eliminated
+var SINK: u64 = 0;
+
+# what one measurement produced
+# ---
+# mean_fix: mean sample time over the fixed-input class, in nanoseconds
+# mean_rnd: mean sample time over the random-input class
+# t:        |Welch's t| between the two, reported and never asserted on
+pub rec Measurement {
+    mean_fix: f64;
+    mean_rnd: f64;
+    t:        f64;
+}
+
+# how far apart the two class means sit, as a fraction of the smaller
+#
+# DIRECTION-AGNOSTIC ON PURPOSE. Which class runs longer is a property of the probe: an
+# early-exit comparison is slowest on the fixed class, because that is the input that
+# matches all the way through, while a table read is slowest on the random class, because
+# that is the one that misses. A measure that read only one direction would answer 2.0 for
+# one probe and 0.67 for the other on the same size of effect. `0.0` is two identical
+# means, which is what a constant-time function and a null control both aim at.
+pub fun separation(m: *Measurement) f64 {
+    if (m.mean_fix <= 0.0 || m.mean_rnd <= 0.0) { ret 0.0; }
+    if (m.mean_rnd > m.mean_fix) { ret m.mean_rnd / m.mean_fix - 1.0; }
+    ret m.mean_fix / m.mean_rnd - 1.0;
+}
+
+# online mean/variance accumulator (Welford), one per input class
+rec Stat {
+    n:    f64;
+    mean: f64;
+    m2:   f64;
+}
+
+fun stat_init(s: *Stat) {
+    s.n    = 0.0;
+    s.mean = 0.0;
+    s.m2   = 0.0;
+}
+
+fun stat_push(s: *Stat, x: f64) {
+    s.n = s.n + 1.0;
+    val d1: f64 = x - s.mean;
+    s.mean = s.mean + d1 / s.n;
+    val d2: f64 = x - s.mean;
+    s.m2 = s.m2 + d1 * d2;
+}
+
+# sample variance, or 0 with fewer than two samples
+fun stat_var(s: *Stat) f64 {
+    if (s.n < 2.0) { ret 0.0; }
+    ret s.m2 / (s.n - 1.0);
+}
+
+# xorshift64; fast enough to draw outside the timed region
+fun xnext(state: *u64) u64 {
+    var x: u64 = @state;
+    x = x ^ (x << 13);
+    x = x ^ (x >> 7);
+    x = x ^ (x << 17);
+    @state = x;
+    ret x;
+}
+
+# the monotonic clock in nanoseconds
+fun now_ns() u64 {
+    var ts: os.Timespec;
+    os.monotonic(?ts);
+    ret ts.sec::u64 * 1000000000 + ts.nsec::u64;
+}
+
+# f64 square root by Newton iteration; std math is integer-only
+fun sqrtf(x: f64) f64 {
+    if (x <= 0.0) { ret 0.0; }
+    var g: f64 = x;
+    var i: usize = 0;
+    for (i < 64) {
+        g = 0.5 * (g + x / g);
+        i = i + 1;
+    }
+    ret g;
+}
+
+fun fabsf(x: f64) f64 {
+    if (x < 0.0) { ret 0.0 - x; }
+    ret x;
+}
+
+# time `inner` calls of `fut` on a single input; the result feeds SINK so no call is
+# dropped. the input is fixed for the whole batch, so both classes execute an identical
+# harness loop and differ only in the value under test.
+fun measure_batch(fut: fun(u64) u64, input: u64, inner: u64) u64 {
+    var acc: u64 = 0;
+    val t0: u64 = now_ns();
+    var i: u64 = 0;
+    for (i < inner) {
+        acc = acc + fut(input);
+        i = i + 1;
+    }
+    val t1: u64 = now_ns();
+    SINK = SINK + acc;
+    ret t1 - t0;
+}
+
+# Welch's t-statistic for two independent samples with unequal variance
+fun welch_t(a: *Stat, b: *Stat) f64 {
+    val va: f64 = stat_var(a);
+    val vb: f64 = stat_var(b);
+    val se: f64 = va / a.n + vb / b.n;
+    if (se <= 0.0) { ret 0.0; }
+    ret (a.mean - b.mean) / sqrtf(se);
+}
+
+# measure one function under test over the two input classes
+# ---
+# out:    receives the two class means and |t|
+# fut:    the function under test
+# fixed:  the class-0 input
+# seed:   RNG seed for class-1 inputs
+# inner:  calls per timed sample
+# rounds: timed samples per class
+pub fun measure(out: *Measurement, fut: fun(u64) u64, fixed: u64, seed: u64,
+                inner: u64, rounds: u64) {
+    var rng: u64 = seed;
+
+    var w: u64 = 0;
+    for (w < WARMUP) {
+        SINK = SINK + measure_batch(fut, fixed, inner);
+        SINK = SINK + measure_batch(fut, xnext(?rng), inner);
+        w = w + 1;
+    }
+
+    var sf: Stat;
+    var sr: Stat;
+    stat_init(?sf);
+    stat_init(?sr);
+
+    # WHICH CLASS GOES FIRST ALTERNATES, and it is not cosmetic. Measured with the fixed
+    # class always leading, a probe that cannot leak at all still came out with its fixed
+    # class 7 to 11 percent slower under a loaded machine, consistently in that direction:
+    # the leading sample of a round absorbs whatever the round's first cache and scheduler
+    # transition costs. That is a position effect, not an input effect, and a measurement
+    # meant to attribute a difference to the input has to remove it. Alternating splits it
+    # evenly between the two classes instead of charging it to one.
+    var r: u64 = 0;
+    for (r < rounds) {
+        val rnd: u64 = xnext(?rng);
+        var tf: u64 = 0;
+        var tr: u64 = 0;
+        if ((r & 1) == 0) {
+            tf = measure_batch(fut, fixed, inner);
+            tr = measure_batch(fut, rnd, inner);
+        }
+        or {
+            tr = measure_batch(fut, rnd, inner);
+            tf = measure_batch(fut, fixed, inner);
+        }
+        stat_push(?sf, tf::f64);
+        stat_push(?sr, tr::f64);
+        r = r + 1;
+    }
+
+    out.mean_fix = sf.mean;
+    out.mean_rnd = sr.mean;
+    out.t        = fabsf(welch_t(?sf, ?sr));
+}
+
+# measure for a LATENCY leak: large batches, so a running-time difference clears the
+# clock's resolution
+pub fun measure_latency(out: *Measurement, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    measure(out, fut, fixed, seed, LATENCY_INNER, LATENCY_ROUNDS);
+}
+
+# measure for an ADDRESS-TRACE leak: one call per sample, many samples
+#
+# Batching is exactly what hides this class, so the batch is one and the cost moves to
+# the sample count.
+pub fun measure_address(out: *Measurement, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    measure(out, fut, fixed, seed, 1, ADDRESS_ROUNDS);
+}

--- a/src/lang/ct/probe.mach
+++ b/src/lang/ct/probe.mach
@@ -1,0 +1,387 @@
+# the constant-time probes, measured on the host (#1647, #2363, #2944)
+#
+# The empirical layer of mach's constant-time story, beside the static ones: the secret
+# flow gates in sema, the `#[oblivious]` codegen contract, and the translation validator
+# over the lowered MIR. Those three all reason about the program. This one runs it and
+# times it, which is the only way to learn anything about the machine.
+#
+# WHAT IS ASSERTED, AND WHY IT IS NOT THE OBVIOUS THING. A timing measurement cannot
+# confirm that a function is constant-time - a clean score is consistent with a leak the
+# instrument cannot see. It CAN refute: a function whose class means separate the way a
+# planted leak's do is leaking. So every gate here is a refutation, and every mode carries
+# a PLANTED LEAK of its own so that a mode which has stopped measuring fails through its
+# own control rather than being read as a pass.
+#
+# THE NULL CONTROL DECIDES WHETHER THE RUN COUNTS. `null_probe` cannot leak - it discards
+# its input - so any separation it shows is the machine, not the code. A run in which it
+# is not flat has no discriminating power, and the leak verdict under it would mean
+# nothing in either direction. Such a run DECLINES. That is not a way of tolerating a
+# failure: it is the validity precondition of a differential measurement, and asserting
+# under a null control that moved would be reporting machine load as a compiler
+# regression.
+#
+# GATES ARE MEAN SEPARATIONS, NOT |t| (#2371). |t| divides by the sample variance and
+# concurrent load inflates the variance without moving the means, so it collapses while
+# the leak is plainly still there. Measured on the earlier form of this harness at load
+# average 27, six consecutive runs of the same binary gave |t| of 11.00, 10.35, 7.51,
+# 7.78, 9.27 and 11.24 - three of six below a threshold of 10 - while the mean ratio never
+# fell below 3.4.
+#
+# THE ADDRESS PROBE NEEDS A TABLE LARGER THAN THIS MACHINE'S LAST-LEVEL CACHE, or it
+# measures an L3 hit against an L2 hit and the signal collapses. A cache-resident table
+# leaks its index just as truly and no timing harness will see it, which is why
+# `ct_scan`'s property rests on the secret-index gate and not on this measurement.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.allocator.page;
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+use p: std.print;
+
+use dudect: mach.lang.ct.dudect;
+
+# THE ADDRESS TABLE MUST EXCEED THIS MACHINE'S LAST-LEVEL CACHE. 256 MB clears the
+# largest LLC in common desktop parts today - a Ryzen 5800X3D carries 96 MB of L3, and at
+# 4 MB this probe scored 8.4 to 209 across three runs, which is unassertable. If the probe
+# stops firing on some future machine this is the constant to raise; check `lscpu -C`. A
+# planted leak that does not fire FAILS rather than passing, so a cache larger than this
+# cannot turn into a silent green.
+pub val BIG: usize = 268435456;
+
+# small enough to scan exhaustively per call, and to sit in L1
+pub val SMALL: usize = 4096;
+
+var BIG_TABLE: *u8 = nil;
+var SMALL_TABLE: *u8 = nil;
+
+# the address null control's walk position, advanced per read so its lines miss the way
+# the planted leak's do
+var WALK: u64 = 0x9E3779B97F4A7C15;
+
+# allocate and fault in both tables
+#
+# HEAP, NOT A MODULE `var`. As static storage the big table would sit in the compiler's
+# own BSS on every host, whether or not anything ever measured. Allocated here it costs a
+# single mapping, and only in the process that runs the measurement.
+#
+# The fill strides a page rather than a cache line: the probe reads an ADDRESS, and what
+# is at it does not matter, so the requirement is that every page be resident before the
+# first timed call rather than that every line carry a pattern.
+pub fun setup(alloc: *A.Allocator) bool {
+    val rb: R.Result[*u8, *u8] = A.allocate[u8](alloc, BIG);
+    if (R.is_err[*u8, *u8](rb)) { ret false; }
+    BIG_TABLE = R.unwrap_ok[*u8, *u8](rb);
+
+    val rs: R.Result[*u8, *u8] = A.allocate[u8](alloc, SMALL);
+    if (R.is_err[*u8, *u8](rs)) { ret false; }
+    SMALL_TABLE = R.unwrap_ok[*u8, *u8](rs);
+
+    var i: usize = 0;
+    for (i < BIG) {
+        BIG_TABLE[i] = ((i >> 12) & 0xFF)::u8;
+        i = i + 4096;
+    }
+    i = 0;
+    for (i < SMALL) {
+        SMALL_TABLE[i] = (i & 0xFF)::u8;
+        i = i + 1;
+    }
+    ret true;
+}
+
+pub fun teardown(alloc: *A.Allocator) {
+    if (BIG_TABLE != nil) {
+        A.deallocate[u8](alloc, BIG_TABLE, BIG);
+        BIG_TABLE = nil;
+    }
+    if (SMALL_TABLE != nil) {
+        A.deallocate[u8](alloc, SMALL_TABLE, SMALL);
+        SMALL_TABLE = nil;
+    }
+}
+
+# branchless constant-time equality of two secret words: 1 if equal, else 0
+#
+# The xor difference is 0 exactly when the words are equal, and `(d | (0 - d)) >> 63` is 1
+# iff `d != 0` - for any nonzero d either d or its two's complement has bit 63 set - so
+# the answer is computed without any secret reaching a branch, an index, or a
+# variable-latency operand.
+#[oblivious]
+pub fun ct_eq(a: ^u64, b: ^u64) ^u64 {
+    val d:  ^u64 = a ^ b;
+    val nz: ^u64 = (d | (0 - d)) >> 63;
+    ret 1 - nz;
+}
+
+# the latency mode's constant-time reference
+#
+# Compares the input, taken as secret material, against a fixed secret reference and
+# declassifies the 0/1 verdict. All eight bytes are always folded, so the work is
+# identical for every input.
+pub fun ct_probe(x: u64) u64 {
+    val sx:  ^u64 = x;
+    val tag: ^u64 = 0;
+    ret ct_eq(sx, tag):^;
+}
+
+# the latency mode's planted leak: a variable-time comparison
+#
+# It handles the input as a PUBLIC value - the secret-typing discipline is deliberately
+# dropped, which is the real-world mistake - and early-exits on the first mismatching
+# byte, so its running time depends on how many leading bytes matched.
+#
+# THIS LEAK IS UNWRITABLE WITH `^` TYPES: sema rejects a secret branch or loop condition
+# in any function. That is the point of the pairing - the static discipline forbids the
+# leak at the type level, and this catches it empirically the moment the discipline is
+# abandoned.
+pub fun leaky_probe(x: u64) u64 {
+    val tag: u64 = 0;
+    var i: u64 = 0;
+    for (i < 8) {
+        val bx: u64 = (x >> (i * 8)) & 0xff;
+        val bt: u64 = (tag >> (i * 8)) & 0xff;
+        if (bx != bt) { ret i; }
+        i = i + 1;
+    }
+    ret 8;
+}
+
+# how many input-derived lines one address-mode call reads
+#
+# ONE MISS DOES NOT SURVIVE A PARALLEL TEST RUN. A single input-indexed read is about
+# eighty nanoseconds of cache miss inside a sample whose clock overhead is several hundred,
+# and with a sibling test process per core the scheduler moves a sample by more than the
+# whole signal. Measured that way the planted leak cleared the null control by 0.13 in the
+# worst run while the null control itself wandered by 0.32, which is two populations that
+# overlap.
+#
+# Sixteen reads per call is both what lifts the signal clear of that and what a
+# table-driven cipher actually does per round, so the probe moves closer to the thing it
+# stands for rather than further from it. It part-pays for itself: a signal an order of
+# magnitude larger halves the samples needed to resolve it.
+pub val PROBE_READS: usize = 16;
+
+# scramble a word so consecutive reads land on unrelated lines
+#
+# A walk the hardware prefetcher can predict is a walk with no cache misses in it, and a
+# probe with no misses measures nothing. This is the 64-bit finalizer from MurmurHash3,
+# used for its avalanche and nothing else.
+fun mix(v: u64) u64 {
+    var h: u64 = v;
+    h = h ^ (h >> 33);
+    h = h * 0xFF51AFD7ED558CCD;
+    h = h ^ (h >> 33);
+    ret h;
+}
+
+# the address mode's planted leak: input-derived reads over a table larger than any cache
+#
+# Exactly the operation `std.crypto.ct.lookup` exists to replace. Written over a PUBLIC
+# index because sema refuses a secret one outright, which is the point of the pairing: the
+# static discipline makes this unconstructable with `^` types, and this catches it the
+# moment the discipline is dropped.
+#
+# It fires in address mode and NOT in latency mode, and that asymmetry is the whole reason
+# both modes exist.
+pub fun leak_big(x: u64) u64 {
+    var acc: u64 = 0;
+    var h: u64 = x;
+    var k: usize = 0;
+    for (k < PROBE_READS) {
+        h = mix(h);
+        acc = acc + BIG_TABLE[(h::usize) % BIG]::u64;
+        k = k + 1;
+    }
+    ret acc;
+}
+
+# the address mode's constant-time reference: the masked full-table scan
+#
+# The shape a constant-time lookup emits. Every element is read for every index, so the
+# address trace is identical whatever the index, which is the property under test.
+pub fun ct_scan(x: u64) u64 {
+    val idx: usize = (x::usize) % SMALL;
+    var acc: u8 = 0;
+    var i: usize = 0;
+    for (i < SMALL) {
+        val hit: u8 = i == idx;
+        val m:   u8 = 0 - hit;
+        acc = acc | (SMALL_TABLE[i] & m);
+        i = i + 1;
+    }
+    ret acc::u64;
+}
+
+# the latency mode's null control: the planted leak's work with no early exit
+#
+# COST-MATCHED, and the first version of this was not. A control bounds the sampling noise
+# of the probe it is compared against only if it is sampled the same way. A trivial
+# `ret (x & 0) + 1` has a sample a few microseconds long, and a scheduler event inside a
+# parallel test run moves that by a large fraction while barely touching a sample ten
+# times longer, so the cheapest probe in the set ends up setting the precondition for every
+# other. Measured that way the trivial control wandered by up to 0.49 while the probes it
+# was meant to bound stayed under 0.30.
+#
+# This walks all eight bytes every time, folds them without a branch, and so runs the
+# leaky probe's LONGEST path on every input. Same trip count, same work, no way for the
+# input to change either.
+pub fun null_probe(x: u64) u64 {
+    val tag: u64 = 0;
+    var acc: u64 = 0;
+    var i: u64 = 0;
+    for (i < 8) {
+        val bx: u64 = (x >> (i * 8)) & 0xff;
+        val bt: u64 = (tag >> (i * 8)) & 0xff;
+        acc = acc + (bx ^ bt);
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# the address mode's null control: the same reads, addressed independently of the input
+#
+# Cost-matched for the same reason its latency sibling is. It walks the same table for the
+# same number of lines and takes its addresses from a module global rather than from `x`:
+# identical work, identical miss count, and an address trace that cannot depend on the
+# input.
+pub fun null_walk(x: u64) u64 {
+    var acc: u64 = 0;
+    var k: usize = 0;
+    for (k < PROBE_READS) {
+        WALK = mix(WALK);
+        acc = acc + BIG_TABLE[(WALK::usize) % BIG]::u64;
+        k = k + 1;
+    }
+    ret acc + (x & 0);
+}
+
+# how far a probe must separate past the null control to count as leaking, and how far the
+# null control may separate before the run is judged unable to discriminate at all
+#
+# ONE NUMBER PER MODE, because the two questions have the same answer. A run in which the
+# control that CANNOT leak separates by as much as a leak has to is a run whose sampling
+# produced the signal it was meant to resolve, and nothing measured under it means
+# anything in either direction. That run declines.
+#
+# THE GATES SUBTRACT THE NULL RATHER THAN COMPARING AGAINST 1.0. The control is measured
+# in the same run under the same load, so subtracting it removes whatever the machine did
+# to both, which is the property a fixed threshold on one probe does not have.
+#
+# CALIBRATED INSIDE `mach test`, not standalone. Measured alone this harness looks two
+# orders of magnitude quieter than it is: the environment it has to hold in is a parallel
+# run with a job per core, and thresholds set anywhere else are set against the wrong
+# machine. Over five such runs at debug optimisation, with the rest of the suite and other
+# work on the box:
+#
+#   latency  null 0.017-0.223   leak past null 2.04-3.47   reference past null up to 0.28
+#   address  null 0.003-0.153   leak past null 0.72-1.53   reference past null up to 0.04
+#
+# Every threshold below sits at least twice the worst of that, in whichever direction
+# would trip it.
+val LATENCY_NULL_TOL: f64 = 0.60;
+val LATENCY_LEAK_MARGIN: f64 = 0.60;
+val ADDRESS_NULL_TOL: f64 = 0.30;
+val ADDRESS_LEAK_MARGIN: f64 = 0.30;
+
+# print one measurement
+#
+# EVERY MEASUREMENT IS REPORTED, on the passing path as much as the failing one. A harness
+# whose numbers only appear when it is unhappy cannot be calibrated, and these thresholds
+# were set from what `mach test -vv` prints here under a full parallel run, which is the
+# only environment they have to hold in.
+fun report(name: str, m: *dudect.Measurement) {
+    p.printlnf("  {} mean_fix={} mean_rnd={} separation={} |t|={}",
+               name, m.mean_fix, m.mean_rnd, dudect.separation(m), m.t);
+}
+
+# a latency leak is measurable on this host, and the constant-time reference is not one
+# (#1647)
+#
+# Latency mode covers two of the leakage model's three channels: control-flow trace and
+# variable-latency operands. It cannot see the third, and `an_address_leak_is_measured`
+# below is why that is a separate test rather than a wider threshold here.
+test "mach.lang.ct.probe:a_latency_leak_is_measured" {
+    var null_m: dudect.Measurement;
+    var ct_m:   dudect.Measurement;
+    var leak_m: dudect.Measurement;
+
+    dudect.measure_latency(?null_m, null_probe,  0, 0x510E527FADE682D1);
+    dudect.measure_latency(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3);
+    dudect.measure_latency(?leak_m, leaky_probe, 0, 0x452821E638D01377);
+
+    report("null", ?null_m);
+    report("ct",   ?ct_m);
+    report("leak", ?leak_m);
+
+    val ns: f64 = dudect.separation(?null_m);
+    val cs: f64 = dudect.separation(?ct_m);
+    val ls: f64 = dudect.separation(?leak_m);
+
+    if (ns > LATENCY_NULL_TOL) {
+        p.println("declined: the latency null control is not flat, so this run cannot discriminate");
+        ret 0;
+    }
+    if (ls - ns < LATENCY_LEAK_MARGIN) {
+        p.println("the planted latency leak was NOT detected, so the harness is not measuring");
+        ret 1;
+    }
+    if (cs - ns >= LATENCY_LEAK_MARGIN) {
+        p.println("the constant-time reference separated the way the planted leak does");
+        ret 2;
+    }
+    ret 0;
+}
+
+# an address-trace leak is measurable on this host, and the masked scan is not one (#2363)
+#
+# The channel latency mode is blind to, and not by a little: the same `leak_big` measured
+# with latency mode's batch scores flat, because every call in a batch is handed the same
+# input and the single cache miss carrying the signal is averaged away. One call per
+# sample is what sees it, and the cost moves to the sample count.
+test "mach.lang.ct.probe:an_address_leak_is_measured" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    if (!setup(?alloc)) {
+        p.println("declined: this machine would not give up a table larger than its last-level cache");
+        ret 0;
+    }
+
+    var null_m: dudect.Measurement;
+    var leak_m: dudect.Measurement;
+    var scan_m: dudect.Measurement;
+
+    dudect.measure_address(?null_m, null_walk, 0, 0x510E527FADE682D1);
+    dudect.measure_address(?leak_m, leak_big,  0, 0x2B7E151628AED2A6);
+    dudect.measure(?scan_m, ct_scan, 0, 0x3C6EF372FE94F82B, 1, dudect.REFERENCE_ROUNDS);
+
+    teardown(?alloc);
+
+    report("null", ?null_m);
+    report("leak", ?leak_m);
+    report("scan", ?scan_m);
+
+    val ns: f64 = dudect.separation(?null_m);
+    val ls: f64 = dudect.separation(?leak_m);
+    val ss: f64 = dudect.separation(?scan_m);
+
+    if (ns > ADDRESS_NULL_TOL) {
+        p.println("declined: the address null control is not flat, so this run cannot discriminate");
+        ret 0;
+    }
+    if (ls - ns < ADDRESS_LEAK_MARGIN) {
+        p.println("the planted address leak was NOT detected. most likely this machine's");
+        p.println("last-level cache is at or above the probe table size: check `lscpu -C`");
+        p.println("and raise `BIG` in mach.lang.ct.probe.");
+        ret 2;
+    }
+    if (ss - ns >= ADDRESS_LEAK_MARGIN) {
+        p.println("the masked scan separated the way the planted address leak does");
+        ret 3;
+    }
+    ret 0;
+}

--- a/src/lang/target/isa/asm/host.mach
+++ b/src/lang/target/isa/asm/host.mach
@@ -1,0 +1,293 @@
+# the inline-asm facts that are only observable where the code runs (#2791, #2944)
+#
+# Two measurements the integration suite carried and nothing replaced. Both are about
+# the kernel entry an inline-asm body writes, which is the one part of such a body that
+# is neither target-independent nor readable off the emitted bytes: an entry with the
+# wrong number assembles perfectly and does the wrong thing, and only executing it says
+# which. So these run on the host, gated on the host's own os and isa, and a leg that
+# cannot run them declines by name.
+#
+# THE FOUR CONVENTIONS. linux takes `syscall` with the number in EAX on x86-64, `svc 0`
+# with the number in x8 on aarch64, and `ecall` with the number in a7 on riscv64.
+# darwin takes the BSD-class number `0x2000000 + n` in EAX on x86-64 and `svc 0x80` with
+# the plain number in x16 on aarch64. windows has no syscall ABI at all - its console
+# write goes through a kernel32 import - so for windows the premise fails rather than
+# the expectation, and it declines.
+
+use std.types.size.usize;
+use std.types.string.str;
+use p: std.print;
+
+$if ($mach.build.os == $mach.os.windows) {
+    # THE DECLINE IS A DECLARATION, not a branch inside a test body: a passing test's
+    # captured output is suppressed unless the run asks for it, so the NAME is the
+    # readout, and it shows in `--list` and under `-v`.
+    test "mach.lang.target.isa.asm.host:asm_noreturn_declines_on_windows" {
+        p.println("declined: windows has no syscall ABI, so a body that ends control through one does not exist there");
+        ret 0;
+    }
+
+    test "mach.lang.target.isa.asm.host:inline_asm_write_declines_on_windows" {
+        p.println("declined: windows has no syscall ABI; its console write goes through a kernel32 import");
+        ret 0;
+    }
+}
+$or {
+    # a body containing a real kernel entry RETURNS, and the work after it must survive
+    #
+    # THIS IS THE HALF THAT CAN BITE. The conservatism runs opposite to every other fact
+    # in the inline-asm effect model: a wrong `writes` costs allocation quality, but a
+    # body wrongly judged non-returning makes lowering DROP everything after it, which
+    # deletes live code. `getpid` cannot fail and its result is discarded, so the only
+    # thing this row observes is whether the addition after the entry survived.
+    fun after_syscall(v: i64) i64 {
+        var w: i64 = 0;
+        $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000014
+                syscall
+                mov rax, {v}
+                mov {w}, rax
+            }
+        }
+        $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 20
+                svc 0x80
+                ldr x9, {v}
+                str x9, {w}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 39
+                syscall
+                mov rax, {v}
+                mov {w}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 172
+                svc 0
+                ldr x9, {v}
+                str x9, {w}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 172
+                ecall
+                ld a0, {v}
+                sd a0, {w}
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret w + 1;
+    }
+
+    # a trap that is NOT the last statement leaves the body falling through, because
+    # control could reach the statements past it
+    fun trap_not_last(v: i64) i64 {
+        var w: i64 = 0;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                jmp 1f
+                hlt
+            1:
+                mov rax, {v}
+                mov {w}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                b 1f
+                brk 0
+            1:
+                ldr x9, {v}
+                str x9, {w}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                j 1f
+                ebreak
+            1:
+                ld a0, {v}
+                sd a0, {w}
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret w + 2;
+    }
+
+    # a raw byte payload is never judged non-returning: the compiler does not decode it.
+    # these bytes are a no-op on each target, and the work after them must survive.
+    fun after_bytes(v: i64) i64 {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 { .byte 0x90 }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 { .word 0xd503201f }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 { .word 0x00000013 }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret v + 3;
+    }
+
+    # the non-returning shape itself: a kernel entry that ends the thread of control,
+    # followed by a trap
+    #
+    # It exits with status 0, so a body that reaches the kernel IS this test's pass and
+    # nothing after the call runs. A wrong entry number returns instead of exiting, falls
+    # into the trap, and the runner reports a signal - a failure, not a hang.
+    fun die() {
+        $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000001
+                mov edi, 0
+                syscall
+                hlt
+            }
+        }
+        $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 1
+                mov x0, 0
+                svc 0x80
+                brk 0
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 231
+                mov edi, 0
+                syscall
+                hlt
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 94
+                mov x0, 0
+                svc 0
+                brk 0
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 94
+                li a0, 0
+                ecall
+                ebreak
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+    }
+
+    # write through a raw kernel entry and report what the kernel returned
+    #
+    # The return value is the assertion rather than the bytes on the console: a write
+    # that reached the kernel answers the byte count, and a wrong entry number answers an
+    # error code instead. Reading the console would need a second process to read it.
+    fun host_write(msg: *u8, len: usize) i64 {
+        var r: i64 = 0;
+        $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000004
+                mov edi, 1
+                mov rsi, {msg}
+                mov rdx, {len}
+                syscall
+                mov {r}, rax
+            }
+        }
+        $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 4
+                mov x0, 1
+                ldr x1, {msg}
+                ldr x2, {len}
+                svc 0x80
+                str x0, {r}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 1
+                mov edi, 1
+                mov rsi, {msg}
+                mov rdx, {len}
+                syscall
+                mov {r}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 64
+                mov x0, 1
+                ldr x1, {msg}
+                ldr x2, {len}
+                svc 0
+                str x0, {r}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 64
+                li a0, 1
+                ld a1, {msg}
+                ld a2, {len}
+                ecall
+                sd a0, {r}
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret r;
+    }
+
+    # an inline-asm body that cannot return ends control, and one that can does not
+    # (#2791)
+    #
+    # The returning half is asserted by value: each row does work after its body and
+    # returns it, so a body misjudged non-returning loses its continuation and answers
+    # wrong. The non-returning half is asserted by ABSENCE - `die` ends the process with
+    # status 0, so reaching the statement after it is the failure.
+    #
+    # The sibling unit test `driver:asm_that_cannot_return_terminates_its_block` asserts
+    # the CFG. This asserts that the model agrees with the machine.
+    test "mach.lang.target.isa.asm.host:a_body_that_cannot_return_ends_the_process" {
+        if (after_syscall(10) != 11) { ret 1; }
+        if (trap_not_last(20) != 22) { ret 2; }
+        if (after_bytes(30)   != 33) { ret 3; }
+        die();
+        ret 4;
+    }
+
+    # the host's write convention, exercised through inline asm (#2944)
+    #
+    # The message lands on this test's captured stdout, which is where the integration
+    # case's golden used to read it. What is asserted here is the kernel's answer, which
+    # is strictly more than the golden saw: a write that never reached the kernel returns
+    # an error code rather than a byte count, and a byte count short of the message is a
+    # partial write the golden would also have caught.
+    test "mach.lang.target.isa.asm.host:an_inline_asm_write_reaches_the_kernel" {
+        val msg: str = "asm.host: syscall write ok\n";
+        var len: usize = 0;
+        for (msg[len] != 0) { len = len + 1; }
+        if (host_write(msg::*u8, len) != len::i64) { ret 1; }
+        ret 0;
+    }
+}

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -9139,7 +9139,15 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:permitting_surface_is_bounded
 # zf_def: the probe measured ZF as DEFINED rather than preserved
 # cf_def: the probe measured CF as DEFINED rather than preserved
 # reads:  the probe measured a destination difference between the two flag presets
-rec ProbedRow {
+# how many rows the transcription below carries
+#
+# Named rather than repeated at each call site, because every caller sizes a buffer from
+# it and `probed_rows` writes exactly this many. Adding a row is bumping this once, and
+# the host probe checks the returned count against its own arm list so a row added here
+# with no arm to measure it fails rather than being compared against nothing.
+pub val PROBED_ROW_COUNT: usize = 25;
+
+pub rec ProbedRow {
     code:   u32;
     zf_def: bool;
     cf_def: bool;
@@ -9158,16 +9166,17 @@ fun probed(code: u32, zf: bool, cf: bool, reads: bool) ProbedRow {
 # instruction twice, with the flags preset all-set and all-clear, and seeing what it
 # defines, preserves and reads.
 #
-# NOTHING RE-RUNS THAT PROBE TODAY, so this array is a measurement taken once rather
-# than a fact under guard, and a CPU that stops matching it diverges silently. The
-# probe only means anything on the ISA it executes on, so restoring it belongs in a
-# host-executed unit test rather than in a cross-compilation suite.
+# THE PROBE RE-RUNS. `x64.probe:flags_table_matches_this_cpu` executes every row below
+# on the host and fails on a disagreement, so this array is a fact under guard rather
+# than a measurement taken once. It only means anything on the ISA it executes on, which
+# is why it lives in a host-executed unit test rather than in a cross-compilation suite,
+# and why a non-x86-64 host declines it by name.
 #
 # Several instructions appear more than once under different operands, and that is
 # the point for the count-dependent rows: `shl` at count 1 defines both flags and
 # at count 0 defines neither, so a single measurement of it would be a fact about
 # one operand rather than about the instruction.
-fun probed_rows(out: *ProbedRow) u32 {
+pub fun probed_rows(out: *ProbedRow) u32 {
     out[0]  = probed(x64.ADD::u32,     true,  true,  false);
     out[1]  = probed(x64.SUB::u32,     true,  true,  false);
     out[2]  = probed(x64.CMP::u32,     true,  true,  false);
@@ -9193,7 +9202,7 @@ fun probed_rows(out: *ProbedRow) u32 {
     out[22] = probed(x64.SETB::u32,    false, false, true);    # consumes CF
     out[23] = probed(x64.SETAE::u32,   false, false, true);    # consumes CF
     out[24] = probed(x64.JB::u32,      false, false, false);   # `jc`: see below
-    ret 25;
+    ret PROBED_ROW_COUNT::u32;
 }
 
 # the classification agrees with what the CPU does (#2460)
@@ -9218,7 +9227,7 @@ fun probed_rows(out: *ProbedRow) u32 {
 # because an unmodelled one is the laundering hole; an unmeasured read proves
 # nothing, since `jc` reads CF and leaves no register difference to see.
 test "mach.lang.target.isa.x64.encode.asm_ct_class:agrees_with_measured_hardware" {
-    var rows: [25]ProbedRow;
+    var rows: [PROBED_ROW_COUNT]ProbedRow;
     val n: u32 = probed_rows(?rows[0]);
 
     var bad: i32 = 0;
@@ -9264,7 +9273,7 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:agrees_with_measured_hardware
 #
 # To see it fail, give a new row `defines_flags` without adding it to `probed_rows`.
 test "mach.lang.target.isa.x64.encode.asm_ct_class:every_permitting_row_is_measured" {
-    var rows: [25]ProbedRow;
+    var rows: [PROBED_ROW_COUNT]ProbedRow;
     val n: u32 = probed_rows(?rows[0]);
 
     var bad: i32 = 0;

--- a/src/lang/target/isa/x64/probe.mach
+++ b/src/lang/target/isa/x64/probe.mach
@@ -1,0 +1,570 @@
+# the x86-64 flags probe, executed on the host (#2460, #2944)
+#
+# `encode.probed_rows` transcribes what a CPU says each of these instructions does to
+# ZF and CF, and that transcription is the security surface `#[oblivious]` rests on:
+# `defines_flags` is the only fact that CLEARS a taint, so a row wrongly marked a
+# definer silently permits a leak. Until this module existed the transcription was a
+# measurement taken once, in a C probe that died with the integration suite, and a CPU
+# that stopped matching it diverged with nothing failing anywhere.
+#
+# WHAT IS MEASURED. Each row runs its instruction twice with identical operands, once
+# with RFLAGS preset all-set and once all-clear, and reports both observables from each
+# run:
+#
+#   WRITER probe - RFLAGS afterwards. A flag with the same value under both presets is
+#                  DEFINED by the instruction; one that comes out equal to its input
+#                  under both is PRESERVED. That is the `defines_flags` predicate.
+#   READER probe - a scratch register, zeroed before the preset and read back after.
+#                  A difference between the two runs means the instruction consumed a
+#                  flag. That is the `reads_flags` predicate.
+#
+# THIS PROBE ASSEMBLES THROUGH MACH ITSELF, which the C one did not. The bytes executed
+# are what `asm x86_64` emitted for these mnemonics, so an encoder that folded `shl rax,
+# 0` into a shift-by-one, or picked the wrong SETcc, fails here as a flags disagreement.
+# That is a true failure and worth knowing about; read a surprise here as an encoding
+# question before a silicon one.
+#
+# WHY A HOST TEST AND NOT A CROSS-COMPILATION CASE. The facts are x86-64's and they are
+# only observable where the instruction runs. Building for a target and reading the
+# bytes back cannot see them, whatever the target. So the whole module is gated on the
+# host ISA, and a non-x86-64 host declines through the twin test at the bottom rather
+# than asserting something it did not measure.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+use p: std.print;
+
+use mach.lang.target.isa.x64;
+use encode: mach.lang.target.isa.x64.encode;
+
+# RFLAGS with every arithmetic flag set, and with every one clear. Bit 1 reads as 1 on
+# every x86-64 part, so the all-clear preset carries it.
+val FSET: u64 = 0x0CD5;
+val FCLR: u64 = 0x0002;
+
+# the two observable flags: the complete set the inline-asm grammar can read, which is
+# what makes `defines_flags` decidable at all
+val FZF: u64 = 0x0040;
+val FCF: u64 = 0x0001;
+
+# the instruction wrote the flag from its own operands: same result under both presets
+val V_DEFINED: u8 = 0;
+# the instruction left the flag alone: each run came out carrying its own preset
+val V_PRESERVED: u8 = 1;
+# neither, which no row is allowed to be - it means the probe saw a third behaviour and
+# the two-verdict model does not describe this instruction
+val V_VARIES: u8 = 2;
+
+# how one flag behaved across the two presets
+# ---
+# hi:  RFLAGS after the all-set run
+# lo:  RFLAGS after the all-clear run
+# bit: the flag under test
+fun verdict(hi: u64, lo: u64, bit: u64) u8 {
+    val oh: bool = (hi & bit) != 0;
+    val ol: bool = (lo & bit) != 0;
+    if (oh == ol) { ret V_DEFINED; }
+    if (oh == ((FSET & bit) != 0) && ol == ((FCLR & bit) != 0)) { ret V_PRESERVED; }
+    ret V_VARIES;
+}
+
+# run one probe row with RFLAGS preset to `pre`, and report both observables
+#
+# ONE `asm` BLOCK PER ROW, DELIBERATELY. The preset, the instruction and the capture
+# have to be adjacent in the emitted stream: `popfq` and `pushfq` bracket the
+# instruction with nothing between them, and nothing the compiler is free to insert
+# between two `asm` statements may land there. So each arm carries the whole sequence
+# rather than sharing a preamble, and the operand setup rides with it because several
+# rows need their own (a `neg` of zero is the CF edge, and `cmpxchg` has two paths that
+# depend on RAX).
+#
+# RSI carries the preset in and the flags out; RDI is the reader probe's scratch, zeroed
+# before the preset so a row that never touches it reads back identically under both.
+# ---
+# row:   which row to run, fixed per call site
+# pre:   the RFLAGS preset
+# out_d: receives the reader probe's scratch register
+# ret:   RFLAGS after the instruction
+fun run($row: u32, pre: u64, out_d: *u64) u64 {
+    var f: u64 = 0;
+    var d: u64 = 0;
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        $if (row == 0) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                add rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 1) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                sub rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 2) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                cmp rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 3) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                test rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 4) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                and rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 5) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                or rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 6) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                xor rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 7) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                neg rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # `neg` of zero is the CF edge: it is the one operand for which `neg` clears CF
+        # rather than setting it, so measuring `neg` once would be a fact about an
+        # operand rather than about the instruction.
+        $or (row == 8) {
+            asm x86_64 {
+                mov rax, 0
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                neg rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 9) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                xadd rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # `cmpxchg` compares RAX against its destination, so RAX is part of the input
+        # and both outcomes have to be measured: the equal path stores the source and
+        # sets ZF, the not-equal path loads the destination into RAX and clears it. A
+        # row that defined flags on only one of its two paths would not be a definer.
+        $or (row == 10) {
+            asm x86_64 {
+                mov rcx, 5
+                mov rdx, 3
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                cmpxchg rcx, rdx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 11) {
+            asm x86_64 {
+                mov rcx, 5
+                mov rdx, 3
+                mov rax, 9
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                cmpxchg rcx, rdx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # the traps: partial writers a careless reading of "writes flags" would let
+        # clear a taint. `inc` and `dec` leave CF alone, which `jc` still reads.
+        $or (row == 12) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                inc rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 13) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                dec rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # a shift writes flags at a nonzero count and writes none at all at zero, so
+        # both counts are measured. Reading the count-1 result as the instruction's
+        # fact is exactly the unsoundness #2460 exists to close.
+        $or (row == 14) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                shl rax, 1
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 15) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                shl rax, 0
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 16) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                shr rax, 0
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 17) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                sar rax, 0
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # `not` writes no flag at all, unlike every one of its bitwise siblings
+        $or (row == 18) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                not rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 19) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                mov rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 20) {
+            asm x86_64 {
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                lea rax, [rcx + 1]
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 21) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                xchg rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # the SETcc rows: the reader probe is the point. They write no flag, and their
+        # destination must differ between the two presets - that difference IS the
+        # laundering path `reads_flags` exists to close.
+        $or (row == 22) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                setb dil
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 23) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                setae dil
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # A BRANCH CONSUMES A FLAG AND THE READER PROBE CANNOT SEE IT. `jc` reads CF,
+        # but a taken branch leaves no register difference to measure, so this row
+        # measures reads:0. That is a limit of the probe, NOT a fact about `jc`, and it
+        # is the structural reason the conditional jumps do not need `reads_flags`:
+        # `cond_flags` refuses them outright before any fold.
+        $or (row == 24) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                jc 1f
+            1:
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or {
+            $error("x64 flags probe: row index has no arm");
+        }
+    }
+    @out_d = d;
+    ret f;
+}
+
+# measure one row and check it against the transcription
+#
+# Returns 0 when the hardware agrees with `encode.probed_rows[row]`, and a distinct
+# non-zero code per disagreement so a failure names which fact moved rather than only
+# that something did.
+# ---
+# row:  the row to run, which indexes `encode.probed_rows` as well
+# want: the transcribed row it must agree with
+fun check($row: u32, want: *encode.ProbedRow) i32 {
+    var dh: u64 = 0;
+    var dl: u64 = 0;
+    val hi: u64 = run(row, FSET, ?dh);
+    val lo: u64 = run(row, FCLR, ?dl);
+
+    val vz: u8 = verdict(hi, lo, FZF);
+    val vc: u8 = verdict(hi, lo, FCF);
+
+    # a third behaviour is not a disagreement about a row, it is the two-verdict model
+    # failing to describe the instruction, and it must never be read as either verdict
+    if (vz == V_VARIES) { ret 4; }
+    if (vc == V_VARIES) { ret 5; }
+
+    if ((vz == V_DEFINED) != want.zf_def) { ret 1; }
+    if ((vc == V_DEFINED) != want.cf_def) { ret 2; }
+    if ((dh != dl) != want.reads)         { ret 3; }
+    ret 0;
+}
+
+# the transcribed flags table is what this CPU actually does (#2460, #2944)
+#
+# The re-derivation. `encode:agrees_with_measured_hardware` makes the transcription bear
+# on the classification; this makes the transcription bear on the silicon, which is the
+# half that died with the integration suite. Every row is compared, in the order
+# `probed_rows` states it, and the order is load-bearing: several instructions appear
+# twice under different operands, and swapping `shl` at count 1 with `shl` at count 0
+# is a real disagreement rather than a reordering.
+#
+# To see it fail, flip any verdict in `encode.probed_rows`.
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    test "mach.lang.target.isa.x64.probe:flags_table_matches_this_cpu" {
+        var rows: [encode.PROBED_ROW_COUNT]encode.ProbedRow;
+        # a row added to the transcription with no arm here to measure it fails, rather
+        # than being compared against nothing
+        val n: u32 = encode.probed_rows(?rows[0]);
+        if (n != 25) { ret 6; }
+
+        if (check(0,  ?rows[0])  != 0) { ret 10; }
+        if (check(1,  ?rows[1])  != 0) { ret 11; }
+        if (check(2,  ?rows[2])  != 0) { ret 12; }
+        if (check(3,  ?rows[3])  != 0) { ret 13; }
+        if (check(4,  ?rows[4])  != 0) { ret 14; }
+        if (check(5,  ?rows[5])  != 0) { ret 15; }
+        if (check(6,  ?rows[6])  != 0) { ret 16; }
+        if (check(7,  ?rows[7])  != 0) { ret 17; }
+        if (check(8,  ?rows[8])  != 0) { ret 18; }
+        if (check(9,  ?rows[9])  != 0) { ret 19; }
+        if (check(10, ?rows[10]) != 0) { ret 20; }
+        if (check(11, ?rows[11]) != 0) { ret 21; }
+        if (check(12, ?rows[12]) != 0) { ret 22; }
+        if (check(13, ?rows[13]) != 0) { ret 23; }
+        if (check(14, ?rows[14]) != 0) { ret 24; }
+        if (check(15, ?rows[15]) != 0) { ret 25; }
+        if (check(16, ?rows[16]) != 0) { ret 26; }
+        if (check(17, ?rows[17]) != 0) { ret 27; }
+        if (check(18, ?rows[18]) != 0) { ret 28; }
+        if (check(19, ?rows[19]) != 0) { ret 29; }
+        if (check(20, ?rows[20]) != 0) { ret 30; }
+        if (check(21, ?rows[21]) != 0) { ret 31; }
+        if (check(22, ?rows[22]) != 0) { ret 32; }
+        if (check(23, ?rows[23]) != 0) { ret 33; }
+        if (check(24, ?rows[24]) != 0) { ret 34; }
+        ret 0;
+    }
+}
+$or {
+    # THE DECLINE IS A DECLARATION, not a branch inside one test body. A passing test's
+    # output is suppressed unless the run asks for it, so a printed line is not a
+    # readout - the NAME is, and it is in `--list` and under `-v` on every host.
+    test "mach.lang.target.isa.x64.probe:flags_probe_declines_off_x86_64" {
+        p.println("declined: the x86-64 flags probe measures instructions this host cannot execute");
+        ret 0;
+    }
+}


### PR DESCRIPTION
Closes #2944

Four measurements died with the integration suite and nothing replaced them. Each only
means anything on the machine it executes on, which is why the corpus cannot carry them:
the corpus builds for a target and reads what came out, and none of these is a property
of the bytes. All four are back as host-executed unit tests, gated on `$mach.build.arch`
and `$mach.build.os`.

Nothing is restored as an integration case. The int/ freeze holds, and a host-executed
unit test observes all four better than a cross-compilation suite did.

## The decline is a declaration, not a branch

A passing test's captured output is suppressed unless the run asks for it, so a printed
line is not a readout. The gate therefore selects between two `test` DECLARATIONS and the
name carries the decline, which shows in `--list` and under `-v` on every leg. The
printed reason rides underneath for `-vv` and for a failure expansion.

```
=== linux-x86_64 ===        mach.lang.target.isa.x64.probe:flags_table_matches_this_cpu
=== linux-arm64 ===         mach.lang.target.isa.x64.probe:flags_probe_declines_off_x86_64
=== windows-x86_64 ===      mach.lang.target.isa.asm.host:asm_noreturn_declines_on_windows
                            mach.lang.target.isa.asm.host:inline_asm_write_declines_on_windows
```

The collected count is 1526 on every target, because exactly one arm of each gate is
collected.

## The x86-64 flags probe

`mach.lang.target.isa.x64.probe` runs each of the twenty-five rows in
`encode.probed_rows` twice, once with RFLAGS preset all-set and once all-clear, reads
back RFLAGS and a scratch destination register, and compares the verdicts against the
transcription. `encode:agrees_with_measured_hardware` makes the transcription bear on the
classification, and this makes it bear on the machine, which is the half that went with the
suite.

The probe assembles through mach rather than through a C compiler, which is more than the
old one had: the bytes executed are what `asm x86_64` emitted for those mnemonics, so an
encoder that folded `shl rax, 0` into a shift-by-one fails here as a flags disagreement.
Read a surprise here as an encoding question before a silicon one.

Each row is a complete `asm` block rather than a shared preamble around one varying line,
because `popfq` and `pushfq` have to bracket the instruction with nothing between them,
and nothing the compiler is free to insert between two `asm` statements may land there.

`ProbedRow` and `probed_rows` become `pub`, and the row count becomes one named constant
every caller sizes its buffer from. It was a 25 repeated at three call sites, where a
twenty-sixth row would have been written past the end of all three arrays before any
count check ran.

## The dudect-style timing harness

`mach.lang.ct.dudect` is the engine and `mach.lang.ct.probe` the probes and the two
tests. `doc/language/secrecy.md` now cites a harness that runs instead of marking its
empirical claims as measurements taken once.

Every gate is a refutation, because that is all a timing measurement can do: a clean
score is consistent with a leak the instrument cannot see. Each mode therefore carries a
planted leak that must be detected and a constant-time reference that must not separate
the way the planted one does, so a mode that has stopped measuring fails through its own
control rather than reading as a pass.

Gates are separations between the two class means, never `|t|`. Welch divides by the
sample variance and concurrent load inflates the variance without moving the means. One
of the mutation runs makes the point directly: with the address leak removed, the
non-leaking probe still scored `|t| = 16.1` while its separation was `0.0089`.

Each gate subtracts a null control measured in the same run, so common-mode noise leaves
the verdict rather than being absorbed by the threshold. That control also decides
whether the run counts: it cannot leak, so any separation it shows is the machine rather
than the code, and a run in which it separates by as much as a leak has to DECLINES. That
is the validity precondition of a differential measurement, not a way of tolerating a
failure: asserting under a null control that moved would report machine load as a
compiler regression. The consequence worth stating is that a permanently noisy runner
yields a permanently declining harness, which is silence rather than assurance.

The address table is heap-allocated rather than a module `var`. As static storage 256 MB
would sit in the compiler's own BSS on every host, for a measurement most builds never
take.

### Three things the obvious shape gets wrong

All three were found by calibrating **inside a parallel `mach test`**, which is the only
environment the thresholds have to hold in and which the retired shell harness was never
run under. Measured standalone this harness looks two orders of magnitude quieter than it
is, and every threshold set that way is set against the wrong machine.

- **The fixed class always led its round.** The leading sample absorbs whatever the
  round's first cache and scheduler transition costs, so a probe that cannot leak at all
  came out 7 to 11 percent slower on that class, consistently in that direction. That is
  a position effect, not an input effect. The order alternates now.
- **Both null controls were far cheaper than the probes they bounded.** A control bounds
  a probe's sampling noise only if it is sampled the same way, so the cheapest probe in
  the set was setting the precondition for every other one: the trivial control wandered
  by up to 0.49 while the probes it was meant to bound stayed under 0.30. Both are
  cost-matched now.
- **The address probe read one line per call.** That is eighty nanoseconds of cache miss
  inside a sample whose clock overhead is several hundred, and under a parallel run its
  planted leak cleared the null by 0.13 in the worst case while the null itself wandered
  by 0.32, which is two populations that overlap. It reads sixteen now, which is also what a
  table-driven cipher does per round, so the probe moved closer to the thing it stands
  for. The signal is an order of magnitude larger and needs half the samples.

### Noise floor

Five full parallel `mach test` runs (a job per core on a sixteen-core box, with other
work on the machine), at debug optimisation, after all three fixes:

| | observed range | threshold | headroom |
|---|---|---|---|
| latency null separation | 0.017 – 0.223 | declines past **0.60** | 2.7x |
| latency leak, past null | 2.04 – 3.47 | must clear **0.60** | 3.4x |
| latency reference, past null | up to 0.28 | must stay under **0.60** | 2.2x |
| address null separation | 0.003 – 0.153 | declines past **0.30** | 2.0x |
| address leak, past null | 0.72 – 1.53 | must clear **0.30** | 2.4x |
| address reference, past null | up to 0.04 | must stay under **0.30** | 7.5x |

One number per mode, because the two questions have the same answer: a run in which the
control that cannot leak separates by as much as a leak has to is a run whose sampling
produced the signal it was meant to resolve.

Six consecutive full-suite runs at these thresholds were green. Cost is 0.6s and 1.5s of
CPU for the two tests, and no measurable suite wall time: the suite runs 13.0–15.6s
without them and 13.1–15.4s with them, because the critical path is elsewhere.

## The two inline-asm syscall conventions

`mach.lang.target.isa.asm.host` executes both shapes per os and arch.

The returning rows assert by value, so a body wrongly judged non-returning loses its
continuation and answers wrong. The non-returning row asserts an ABSENCE: `die` ends the
test process with status 0, so reaching the statement after it is the failure. A wrong
entry number returns instead of exiting and falls into the trap after it, so it fails
rather than hangs.

`after_syscall` now contains a real kernel entry. It was named for one and had none, and
`syscall` is the mnemonic most likely to be misjudged non-returning, which is the risk
the row exists to cover.

The write asserts the kernel's own answer rather than the bytes on the console, which is
strictly more than the golden saw: a write that never reached the kernel returns an error
code, and a count short of the message is a partial write. The message still lands on the
test's captured stdout.

windows declines both. It has no syscall ABI, and its console write goes through a
kernel32 import, so its premise fails rather than its expectation.

## Verification

`mach build . && mach test .` with the from-source compiler
(`out/linux-x86_64/debug/bin/mach`), not the seed on PATH:

```
1521 passed, 0 failed   (base 7e06bfcb)
1526 passed, 0 failed   (this branch)
```

`+5`, accounted exactly: `x64.probe` 1, `asm.host` 2, `ct.probe` 2. Green on six
consecutive runs, and green under the release-profile compiler as well.

### Every guard was mutated and observed to fire

Each row was run against the final thresholds.

| mutation | result |
|---|---|
| flip `inc`'s CF verdict in `probed_rows` | `exit 22`, naming row 12 |
| gate the flags probe on aarch64 | declines, by the other name |
| wrong `exit_group` number in `die` | `signal 11` from the trap, not a hang |
| `hlt` after it replaced by `nop`, so `die` falls through | `exit 4`, the absence-assertion |
| wrong `write` number | `exit 1`, the kernel's error code |
| gate `asm.host` on linux, so linux takes the windows arm | both decline, by name |
| `leaky_probe` loses its early exit | `exit 1`, planted latency leak not detected |
| `leak_big` addressed independently of its input | `exit 2`, planted address leak not detected |
| `ct_probe` made to leak | `exit 2`, reference separated like the leak |
| `ct_scan` made a direct index | `exit 3`, same |
| `null_probe` made input-dependent | latency mode declines |
| `null_walk` made input-dependent | address mode declines |

The `inc` mutation is worth singling out: `agrees_with_measured_hardware` passes it,
because a measurement can refute `defines_flags` and never confirm it. Only executing the
probe catches that direction.

### What ran where

This host is linux x86_64. CI covers more than I first assumed, and the corrected picture
is:

- **linux x86_64**: all five tests, natively, here and on `test x86_64-linux`. Green.
- **linux aarch64**: `mach test` runs natively on `ubuntu-24.04-arm`, so the `asm.host`
  linux-aarch64 syscall arms, the flags-probe decline, and both timing tests **executed**
  there. Green.
- **windows x86_64**: `mach test` runs natively on `windows-latest`, so the two windows
  declining tests, the flags probe under a win64 frame (`push` / `popfq` with `{name}`
  bindings), and both timing tests against `QueryPerformanceCounter` **executed** there.
  Green.
- **linux riscv64**: no CI lane runs `mach test` for it, so the riscv64 arms were
  cross-built and **executed under qemu-user locally**: the write reached the kernel and
  `die` exited 0 without reaching the statement after it.
- **darwin x86_64 and aarch64**: **assembled only**. `mach test --target <t>` compiles
  every test block for all six targets, so the darwin arms are known to encode, and their
  syscall numbers are #2942's, unchanged. Nothing executed them, here or in CI: there is
  no darwin lane. This is the one gap.

No lane runs `mach test` under qemu, so the timing harness is never asked to measure an
emulated cache.

## Not done

Nothing in the issue's scope was left out. Two things a reviewer should decide on rather
than discover:

- The timing harness now runs in CI, which the retired `ct.sh` deliberately avoided
  because shared runners are noisy. The null-control decline is what makes that
  defensible, and it means a noisy lane produces silence rather than a verdict. It passed
  first time on all three `mach test` lanes, including a two-core windows runner reading
  `QueryPerformanceCounter`, but the signal to watch over the next weeks is how often
  those lanes DECLINE rather than whether they flake.
- The `## [Unreleased]` heading is new on this branch. A parallel branch adding its own
  will trip `check-changelog.sh` on whichever merges second, which is the check working.


