### PR TITLE
feat(target): declare the C `va_list` layout per target and bind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,46 @@ the kernel's own answer rather than the bytes on the console, which is strictly 
 than the golden saw. windows declines both: it has no syscall ABI, and its console
 write goes through a kernel32 import, so its premise fails rather than its expectation.
 
+#### link: a C function taking a `va_list` parameter has a portable binding (#3004)
+
+A C function that takes a `va_list` **parameter** could not be bound, because mach had
+no spelling for the type. The common shape is a logging callback, and it is a fixed
+3-arity function with no `...` in it:
+
+```c
+typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);
+```
+
+Binding it needs one thing only: a parameter type that is ABI-correct in that third
+slot, which mach receives, never reads, and hands straight to `vsnprintf`.
+
+`#[abi_type("va_list")]` on a bodyless `def` declares it, and the SELECTED TARGET
+supplies the layout:
+
+```mach
+#[abi_type("va_list")]
+def VaList;
+
+ext fun vsnprintf(buf: *u8, n: usize, fmt: *u8, ap: VaList) i32;
+```
+
+**The layout is declared per (os, architecture), never derived.** `va_list` is a plain
+pointer on System V x86-64, Apple arm64, Microsoft x64 and RISC-V lp64d, and a 32-byte
+8-aligned composite under AAPCS64. Darwin and linux compose the very same `aapcs64`
+convention vtable and disagree about it outright, so no calling convention can answer
+and no machine model implies it - it sits on the os vtable beside the Apple
+variadic-stack rule and for the same reason. An OS listing an architecture it declares
+no layout for is refused at registration rather than defaulted to a pointer: a pointer
+is right four times out of five, which is exactly the shape that ships silent
+corruption on the fifth.
+
+**The scope is forward-only, stated as an exclusion.** There is no `va_start`, no
+`va_arg`, no `va_end`, and no way to construct one. Reading one needs `va_arg`, and
+mach has no callee that walks its own argument tail because it has no runtime
+variadics. A local binding, a record or union field, a global, a return position, a
+pointer or array of one, and a cast in either direction are each refused where they
+are written, naming the exclusion.
+
 ### Fixed
 
 #### abi: a C callee wrote through into the caller's object (#3063)

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -50,6 +50,7 @@ A decorator is written as an attribute:
 #[sampler(set, bnd)] # descriptor-bound image / sampler handle (global only)
 #[op(tgt,set,name)]   # the target instruction this function is (bodyless fun only)
 #[handle(tgt,ctor,..)] # the target type this declares (bodyless def only)
+#[abi_type("name")]   # a C type whose layout the target declares (bodyless def only)
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -739,6 +740,28 @@ handles compiles on a machine target. A constructor name the selected target doe
 not define, an operand count that disagrees with the constructor's, or an operand
 combination the target cannot emit is a compile error at the declaration.
 
+### `abi_type(name)` — a C type whose layout the target declares
+
+A bodyless `def` carrying this directive declares a C type whose size and alignment
+come from the **selected target** and whose contents the program never reaches.
+
+```mach
+#[abi_type("va_list")]
+pub def VaList;
+```
+
+`va_list` is the only name, and the set is closed in the front end for the reason
+`op`'s instruction names are: which target a module is built for is not a property
+of the source, so a typo checked only where it is acted on would go unreported on
+every other build of the same library. A target that declares no layout for the
+named type refuses the declaration rather than substituting a default.
+
+The type is an opaque aggregate of the declared extent. A value of one may be
+received as a parameter and passed on, and nothing else: a local binding, a record
+or union field, a global, a return position, a pointer or array of one, and a cast
+in either direction are each refused where they are written. See
+[ext-fun.md](ext-fun.md) for the recipe and for why forwarding is the whole scope.
+
 ### `op(target, set, name)` — a function that *is* a target instruction
 
 A shader needs `sqrt`, `normalize`, `dot` and `mix`. None of them is an operator,
@@ -819,6 +842,7 @@ in it.
 | `storage`   |  no   |    no     |      yes      |      no       |
 | `op`        |  yes  |    no     |      no       |      no       |
 | `handle`    |  no   |    no     |      no       |      no       |
+| `abi_type`  |  no   |    no     |      no       |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -131,6 +131,107 @@ crash. Mach cannot detect the mistake, because nothing in a fixed-arity declarat
 says the callee is variadic — so **declare every C-variadic callee with `...`**, on
 every target.
 
+## `va_list` parameters
+
+A C function may take a `va_list` as an ordinary **fixed** parameter. The common
+shape is a logging callback:
+
+```c
+typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);
+void SetTraceLogCallback(TraceLogCallback callback);
+```
+
+That is a fixed 3-arity function. It has no `...` in it, and binding it needs
+nothing from the C-variadic form above — only a parameter type that is ABI-correct
+in the third slot. Declare that type with `#[abi_type("va_list")]` on a bodyless
+`def`:
+
+```mach
+#[abi_type("va_list")]
+def VaList;
+
+pub def TraceLogCallback: fun(i32, *u8, VaList) i64;
+
+#[library("raylib")]
+ext fun SetTraceLogCallback(cb: TraceLogCallback);
+
+ext fun vsnprintf(buf: *u8, n: usize, fmt: *u8, ap: VaList) i32;
+
+fun trace(level: i32, text: *u8, args: VaList) i64 {
+    var buf: [512]u8;
+    ret vsnprintf(?buf[0], 512, text, args)::i64;
+}
+```
+
+The declaration carries no size of its own. The selected target declares what a
+`va_list` is on that platform, and the same source text binds correctly on every
+one of them. A target that declares none refuses the declaration by name rather
+than guessing.
+
+### Mach can forward one and never read one
+
+The whole scope is **forward-only**: receive an opaque token from C and pass it to
+C. There is no `va_start`, no `va_arg`, no `va_end`, and no way to construct one.
+Each of these is refused where it is written:
+
+```mach
+val saved: VaList = args;   # refused: a local binding
+rec Held { ap: VaList; }    # refused: a record or union field
+var kept: VaList;           # refused: a global
+fun make() VaList { … }     # refused: a return position
+fun peek(ap: *VaList) { … } # refused: behind a pointer
+val raw: ptr = args :~ ptr; # refused: a cast in either direction
+```
+
+Reading one needs `va_arg`, and mach cannot have `va_arg`: it has no runtime
+variadics, so it has no callee that walks its own argument tail. That is not a gap
+waiting to be filled. Constructing a `va_list` is only meaningful for such a
+callee, and mach never needs to originate one — it would call `printf` rather than
+`vprintf`.
+
+One further rule comes from C rather than from mach: **a forwarded `va_list` is
+spent.** Handing one to a function that reads it leaves its value indeterminate,
+exactly as in C, and what actually happens differs per platform — under AAPCS64 the
+type is a composite the caller copies, so each callee walks its own; under System V
+x86-64 it is a pointer into shared state that the callee advances. Forward it once.
+
+### Why the type is declared per target
+
+`va_list` is the one C type mach binds whose shape cannot be written down portably:
+
+| Target | `va_list` in a parameter slot |
+|--------|-------------------------------|
+| **System V x86-64** | `__va_list_tag[1]`, an array type, so a parameter decays to one pointer |
+| **Apple arm64** | `char *` |
+| **Microsoft x64** and **Windows arm64** | `char *` |
+| **RISC-V lp64d** | `void *` |
+| **AAPCS64 linux** | a 32-byte, 8-aligned composite |
+
+On the first four, spelling the parameter `ptr` is already ABI-correct. On
+AAPCS64-linux it is not, and the way it fails is the reason this type exists rather
+than a documented caveat: AAPCS64 passes a composite over 16 bytes indirectly, with
+the **caller** owning the copy, so a `ptr` forwards the received pointer instead of
+a fresh copy and the next callee advances the caller's list. That usually appears to
+work, which is worse than failing.
+
+## Aggregate arguments and the caller's copy
+
+An aggregate too large for registers is passed as an **address of a copy the caller
+allocates** on AAPCS64, under the RISC-V psABI, and under the Microsoft convention.
+The callee treats that memory as its own parameter and may overwrite it, so mach
+materializes a fresh temporary for every such argument at an `ext` boundary and
+passes the temporary's address. A C callee that writes to its by-value parameter
+therefore cannot reach the caller's object:
+
+```mach
+rec Wide { a: i64; b: i64; c: i64; d: i64; }
+ext fun consume(w: Wide) i64;
+```
+
+A Mach→Mach call keeps mach's own convention, where the callee gives every
+parameter storage of its own and copies into it at entry. The two reach the same
+by-value semantics from opposite ends, and only the foreign one is visible here.
+
 ## Symbol name
 
 The declaration names a C declaration, so its linker symbol is whatever the
@@ -340,3 +441,4 @@ definition always wins over a same-named dynamic import.
 - [val-var.md](val-var.md) — `ext val` / `ext var`, the data analogue (foreign data imports)
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
 - [decorators.md](decorators.md) — `symbol`, `library`, and other codegen decorators
+- [variadics.md](variadics.md) — the comptime pack `...`, which is a Mach calling convention and not this one

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -193,6 +193,49 @@ non-zero `Depth`, a non-zero `MS`, a `Dim` past `Cube`, and a `Sampled` other th
 See [decorators.md](decorators.md) for `#[handle]` and `#[sampler(set, binding)]`,
 and the shader library for the handles a SPIR-V target declares.
 
+## ABI types
+
+An **ABI type** is a C type whose size and alignment come from the **selected
+target** and whose contents the program never reaches. It is a bodyless `def`
+carrying `#[abi_type(name)]`, and `va_list` is the only name:
+
+```mach
+#[abi_type("va_list")]
+pub def VaList;
+```
+
+It exists for the one C type that has no correct spelling in mach source.
+`va_list` is a plain pointer on System V x86-64, Apple arm64, Microsoft x64 and
+RISC-V lp64d, and a 32-byte 8-aligned composite under AAPCS64 — so `ptr` binds
+correctly on four platforms and silently corrupts on the fifth, where the psABI
+passes the composite indirectly with the caller owning the copy.
+
+Unlike a handle, an ABI type is an **aggregate** of the declared extent rather than
+a pointer-shaped name for a resource. That is the whole mechanism: an aggregate over
+16 bytes rides AAPCS64's by-reference path, which makes the caller copy and pass an
+address, and an eight-byte one reduces on every other platform to the single register
+a pointer would have taken.
+
+What a program may do with one is bounded to the opposite end from a handle's:
+
+- it may be a **parameter**, and it may be **passed on** to another function
+- it cannot be read: no fields, no indexing, no cast in either direction
+- it cannot be constructed, and no function may return one
+- it cannot be a local binding, a global, or a record or union field
+- it cannot sit behind a pointer or inside an array
+
+Reading one needs `va_arg`, which mach has no callee shape for: mach has no runtime
+variadics, so nothing walks its own argument tail. `$size_of` and `$align_of`
+answer with the target's declared numbers, which are published psABI facts rather
+than anything about a value.
+
+A target that declares no layout for the named type **refuses** the declaration,
+naming the exclusion. There is no inert outcome, because every default available
+would be a pointer and a pointer is wrong under AAPCS64.
+
+See [ext-fun.md](ext-fun.md) for the binding recipe and
+[decorators.md](decorators.md) for `#[abi_type]`.
+
 ## Pointer
 
 `*T` — pointer to a value of type `T`.

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -384,6 +384,7 @@ fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[com
         p.compiler_ver
     );
     comptime.set_target_defs(?ctx, p.target.isa.defs);
+    comptime.set_va_list(?ctx, p.target.va_list_size, p.target.va_list_align);
     comptime.set_build_context(?ctx,
         p.config.id, p.config.version, p.config.name, p.config.description,
         p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -16575,6 +16575,186 @@ test "mach.lang.driver:a_target_op_name_belongs_only_to_its_own_set" {
     ret 0;
 }
 
+# whether building `src` for `target_name` reports a diagnostic containing `needle`
+#
+# Runs load, sema and lower, and reads the session sink regardless of how the passes
+# came out: every rule under test reports through `context.report`, which records an
+# error and lets the pass return ok, so asserting on the result would pass whether or
+# not the check exists.
+# ---
+# target_name: a target declared in `ut_manifest`
+# src:         the module text, as the project's only source file
+# needle:      substring of the diagnostic being looked for
+# ret:         true when a matching diagnostic fired
+fun ut_va_diag(target_name: str, src: str, needle: str) bool {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret false; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret false; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret false; }
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, target_name);
+    fs.remove_all(?alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        val fired_early: bool = ut_diag_has(?s.diags, needle);
+        session.dnit(?s);
+        ret fired_early;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (R.is_ok[bool, outcome.Fail](passes.run_sema_pass(?p))) {
+        passes.run_lower_pass(?p);
+    }
+    val fired: bool = ut_diag_has(?p.s.diags, needle);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret fired;
+}
+
+# the `#[abi_type("va_list")]` declaration every `va_list` test is written against
+val UT_VA_PRELUDE: str = "#[abi_type(\"va_list\")]\npub def VaList;\next fun sink(fmt: *u8, ap: VaList) i64;\n";
+
+# `ut_va_diag` over the prelude plus `tail`
+# ---
+# target_name: a target declared in `ut_manifest`
+# tail:        the module text appended to the prelude
+# needle:      substring of the diagnostic being looked for
+# ret:         true when a matching diagnostic fired
+fun ut_va(target_name: str, tail: str, needle: str) bool {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret false; }
+    val rj: R.Result[str, str] = format.sprint(?alloc, "{}{}", UT_VA_PRELUDE, tail);
+    if (R.is_err[str, str](rj)) { ret false; }
+    val src: str = R.unwrap_ok[str, str](rj);
+    val fired: bool = ut_va_diag(target_name, src, needle);
+    A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    ret fired;
+}
+
+# the message every refusal of a `va_list` value carries
+val UT_VA_EXCLUDED: str = "cannot be read, constructed, or stored in mach";
+
+# a `va_list`'s extent is the SELECTED TARGET's, and the four platforms do not agree
+# (#3004)
+#
+# THE FACT THE WHOLE FEATURE RESTS ON. AAPCS64 makes `va_list` a 32-byte 8-aligned
+# composite, which is over the sixteen-byte threshold and therefore passed indirectly
+# with the caller owning the copy; every other platform mach binds C on makes it a
+# plain pointer, which the same rules reduce to one register. Spelling either one in
+# mach source is correct on some targets and silent corruption on the rest, which is
+# why the number comes off the target.
+#
+# THE ASSERTION IS A COMPTIME GATE rather than a golden, because the number is what
+# is being pinned: `$size_of` and `$align_of` fold against the selected target, so
+# the same source text measures differently per leg and each arm names the psABI it
+# is asserting.
+#
+# darwin's arm64 is here for the reason it is a separate declaration at all: it
+# composes the very same `aapcs64` convention vtable as linux and disagrees with it
+# outright, so a fact read off the calling convention would give it linux's answer.
+test "mach.lang.driver:a_va_list_extent_comes_from_the_target" {
+    val gate: str = "$if ($size_of(VaList) == 32 && $align_of(VaList) == 8) { $error(\"aapcs64 composite\"); }\n$if ($size_of(VaList) == 8 && $align_of(VaList) == 8) { $error(\"pointer shaped\"); }\nfun main() i32 { ret 0; }\n";
+
+    if (!ut_va("linux-arm64", gate, "aapcs64 composite"))  { ret 1; }
+    if (ut_va("linux-arm64", gate, "pointer shaped"))      { ret 1; }
+
+    if (!ut_va("linux", gate, "pointer shaped"))           { ret 1; }
+    if (ut_va("linux", gate, "aapcs64 composite"))         { ret 1; }
+
+    if (!ut_va("darwin-arm64", gate, "pointer shaped"))    { ret 1; }
+    if (ut_va("darwin-arm64", gate, "aapcs64 composite"))  { ret 1; }
+
+    if (!ut_va("linux-riscv64", gate, "pointer shaped"))   { ret 1; }
+    if (!ut_va("windows", gate, "pointer shaped"))         { ret 1; }
+    ret 0;
+}
+
+# a `va_list` is received as a parameter and handed on, and nothing else (#3004)
+#
+# The scope stated as its exclusion: mach has no `va_arg`, so there is no reading
+# one; it has no runtime variadics, so there is no originating one; and a local, a
+# field or a global would each give the program storage holding a cursor whose
+# meaning is the C library's. Each is refused on the line that writes it.
+#
+# THE CONTROL IS THE PARAMETER FORWARDED STRAIGHT ON, which is the whole difference
+# every arm turns on: naming it, storing it, or returning it is refused and passing
+# it is not. Without the control a compiler that refused the type outright would pass
+# every refusal arm.
+test "mach.lang.driver:a_va_list_may_only_be_forwarded" {
+    val forward: str = "#[symbol(\"trace\")]\npub fun trace(fmt: *u8, ap: VaList) i64 { ret sink(fmt, ap); }\nfun main() i32 { ret 0; }\n";
+    val local:   str = "#[symbol(\"trace\")]\npub fun trace(fmt: *u8, ap: VaList) i64 { val a: VaList = ap; ret sink(fmt, a); }\nfun main() i32 { ret 0; }\n";
+    val field:   str = "rec Box { ap: VaList; }\nfun main() i32 { ret 0; }\n";
+    val field_u: str = "uni Box { ap: VaList; n: i32; }\nfun main() i32 { ret 0; }\n";
+    val global:  str = "var held: VaList;\nfun main() i32 { ret 0; }\n";
+    val behind:  str = "#[symbol(\"trace\")]\npub fun trace(ap: *VaList) i64 { ret 0; }\nfun main() i32 { ret 0; }\n";
+    val made:    str = "ext fun make() VaList;\nfun main() i32 { ret 0; }\n";
+
+    if (ut_va("linux", forward, UT_VA_EXCLUDED))           { ret 1; }
+    if (ut_va("linux-arm64", forward, UT_VA_EXCLUDED))     { ret 1; }
+    if (!ut_va("linux", local, UT_VA_EXCLUDED))            { ret 1; }
+    if (!ut_va("linux", field, UT_VA_EXCLUDED))            { ret 1; }
+    if (!ut_va("linux", field_u, UT_VA_EXCLUDED))          { ret 1; }
+    if (!ut_va("linux", global, UT_VA_EXCLUDED))           { ret 1; }
+    if (!ut_va("linux", behind, UT_VA_EXCLUDED))           { ret 1; }
+    if (!ut_va("linux", made, UT_VA_EXCLUDED))             { ret 1; }
+    ret 0;
+}
+
+# a `va_list` cannot be reinterpreted or cast to anything (#3004)
+#
+# THE REFUSAL THAT HAS TO BE WRITTEN DOWN. Every other way of reading one already
+# fails structurally - it has no fields, it is not a pointer, it has no lanes - but
+# `:~` asks only for two equal sizes, and on the four platforms where a `va_list` is
+# eight bytes `ap :~ ptr` would hand the program the very cursor the type exists to
+# keep out of its hands. Both directions, because reading one out and forging one in
+# are the same rule.
+#
+# THE CONTROL IS THE SAME REINTERPRET BETWEEN TWO ORDINARY EIGHT-BYTE TYPES, so a
+# compiler that had simply stopped folding equal sizes would fail it.
+test "mach.lang.driver:a_va_list_cannot_be_cast" {
+    val out_r: str = "#[symbol(\"trace\")]\npub fun trace(ap: VaList) i64 { ret (ap :~ ptr)::i64; }\nfun main() i32 { ret 0; }\n";
+    val out_c: str = "#[symbol(\"trace\")]\npub fun trace(ap: VaList) i64 { ret (ap :: ptr)::i64; }\nfun main() i32 { ret 0; }\n";
+    val in_r:  str = "#[symbol(\"trace\")]\npub fun trace(fmt: *u8, p: ptr) i64 { ret sink(fmt, p :~ VaList); }\nfun main() i32 { ret 0; }\n";
+    val ok:    str = "#[symbol(\"trace\")]\npub fun trace(p: ptr) i64 { ret (p :~ i64); }\nfun main() i32 { ret 0; }\n";
+
+    if (!ut_va("linux", out_r, UT_VA_EXCLUDED))       { ret 1; }
+    if (!ut_va("linux", out_c, UT_VA_EXCLUDED))       { ret 1; }
+    if (!ut_va("linux", in_r, UT_VA_EXCLUDED))        { ret 1; }
+    if (!ut_va("linux-arm64", out_r, UT_VA_EXCLUDED)) { ret 1; }
+    if (ut_va("linux", ok, UT_VA_EXCLUDED))           { ret 1; }
+    ret 0;
+}
+
+# `#[abi_type]` names a closed set, checked in the front end (#3004)
+#
+# Closed here for the reason `#[op]`'s instruction names are: which target a module is
+# built for is not a property of the source, so a name checked only where it is acted
+# on would go unreported on every other build of the same library.
+#
+# THE CONTROL IS THE ONE NAME THERE IS, so a compiler that refused every `abi_type`
+# declaration would fail it.
+test "mach.lang.driver:an_abi_type_name_is_closed" {
+    val bad:   str = "#[abi_type(\"jmp_buf\")]\npub def JmpBuf;\nfun main() i32 { ret 0; }\n";
+    val body:  str = "#[abi_type(\"va_list\")]\npub def Aliased: ptr;\nfun main() i32 { ret 0; }\n";
+    val nargs: str = "#[abi_type]\npub def Nothing;\nfun main() i32 { ret 0; }\n";
+    val ok:    str = "#[abi_type(\"va_list\")]\npub def VaList;\nfun main() i32 { ret 0; }\n";
+
+    if (!ut_va_diag("linux", bad, "no such ABI type"))                     { ret 1; }
+    if (!ut_va_diag("linux", body, "declaration has no body"))             { ret 1; }
+    if (!ut_va_diag("linux", nargs, "takes exactly one string argument"))  { ret 1; }
+    if (ut_va_diag("linux", ok, "no such ABI type"))                       { ret 1; }
+    ret 0;
+}
+
 # the handle declarations every `#[handle]` test is written against
 #
 # One prelude rather than a per-test one so a test's own text is only what it is

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -73,6 +73,7 @@ use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.isa;
+use mach.lang.target.os;
 use mach.lang.type;
 
 # the per-buffer analysis state an EditorSession owns for one registered file
@@ -721,7 +722,7 @@ fun ast_alloc(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
 # es:  the editor session
 # ret: a host-seeded ComptimeCtx
 fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
-    ret comptime.init(
+    var c: comptime.ComptimeCtx = comptime.init(
         es.alloc,
         target.host_os_id(),
         target.host_arch_id(),
@@ -733,6 +734,13 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         intern.STR_NIL,
         intern.STR_NIL
     );
+    # the host platform's own `va_list`, so a buffer declaring one type-checks in the
+    # editor exactly as it does in a build for this machine (#3004).
+    val vl: O.Option[os.VaList] = target.host_va_list();
+    if (O.is_some[os.VaList](vl)) {
+        comptime.set_va_list(?c, O.unwrap[os.VaList](vl).size, O.unwrap[os.VaList](vl).align);
+    }
+    ret c;
 }
 
 # reseed a buffer's comptime context from the host target, dnit-ing any prior one

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -355,6 +355,9 @@ pub def FrameMark: u32;
 #                 bounds the `TxN` vector form the resolver reads (#2687). carried
 #                 here for the same reason `pointer_width` is: it is a target
 #                 machine fact the frontend needs, and the frontend has no target
+# va_list_size / va_list_align: the selected target's declared `va_list` extent
+#                 (#3004), carried for the same reason and 0 when the platform
+#                 declares none, which the `#[abi_type]` declaration refuses by name
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
 # entries:        scoped array of NamedConst bindings; lookup scans it in reverse
@@ -402,6 +405,8 @@ pub rec ComptimeCtx {
     pointer_width:  u32;
     target_defs:    *isa.TargetDefs;
     vector_bits:    u32;
+    va_list_size:   u32;
+    va_list_align:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
     entries:        *NamedConst;
@@ -484,6 +489,8 @@ pub fun init(
     c.pointer_width  = pointer_width;
     c.target_defs    = nil;
     c.vector_bits    = vector_bits;
+    c.va_list_size   = 0;
+    c.va_list_align  = 0;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
     c.entries        = nil;
@@ -583,6 +590,21 @@ pub fun set_type_query_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 # d: the borrowed table, or nil
 pub fun set_target_defs(c: *ComptimeCtx, d: *isa.TargetDefs) {
     c.target_defs = d;
+}
+
+# bind the selected target's declared `va_list` extent (#3004)
+#
+# A post-init setter for the same reason `set_target_defs` is one: it is a target
+# fact the frontend reads and the frontend has no target, so the driver installs it
+# from the resolved target. Both zero means the platform declares none, and the
+# declaration that needs one is refused rather than given a pointer.
+# ---
+# c:     the context
+# size:  the declared size in bytes, or 0 when the platform declares none
+# align: the declared alignment in bytes, or 0 when the platform declares none
+pub fun set_va_list(c: *ComptimeCtx, size: u32, align: u32) {
+    c.va_list_size  = size;
+    c.va_list_align = align;
 }
 
 # Only a pass that has the type universe AND can force a type's layout may install

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -46,6 +46,7 @@ use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.embed;
 use mach.lang.fe.sema.generics;
+use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.handle;
 use mach.lang.fe.sema.infer;
 use mach.lang.fe.token;
@@ -1345,6 +1346,7 @@ fun infer_one_body(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, str]
     infer_decorator_args(sc, d);
     validate_decorators(sc, d);
     check_handle_decl(sc, did, d);
+    check_abi_type_placement(sc, did, d);
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret infer_bodies_comptime_if(sc, ?d.data.comptime_if);
@@ -1793,6 +1795,91 @@ fun check_handle_fields(sc: *context.SemaContext, start: u32, len: u32) {
     }
 }
 
+# whether an ABI type is reachable from `t` without descending into a record (#3004)
+#
+# The `type_carries_handle` walk over the same spine and for the same reason: a
+# pointer to one, an array of one, and a `^` over one are each a different
+# declaration to refuse, so the question is asked about the whole type rather than
+# about its outermost kind. A record is not walked, because its fields are
+# declarations in their own right and are refused where they are written.
+# ---
+# sc: the context
+# t:  the type to test
+# ret: true when an ABI type is reachable without descending into a record
+fun type_carries_abi_type(sc: *context.SemaContext, t: type.TypeId) bool {
+    if (t == type.TYPE_NIL || t == type.TYPE_ERROR) { ret false; }
+    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, t);
+    if (O.is_none[*type.Type](opt_type)) { ret false; }
+    val tp: *type.Type = O.unwrap[*type.Type](opt_type);
+    if (tp.kind == type.TYPE_ABI)     { ret true; }
+    if (tp.kind == type.TYPE_SECRET)  { ret type_carries_abi_type(sc, tp.data.secret.base); }
+    if (tp.kind == type.TYPE_POINTER) { ret type_carries_abi_type(sc, tp.data.pointer.base); }
+    if (tp.kind == type.TYPE_ARRAY)   { ret type_carries_abi_type(sc, tp.data.array.base); }
+    ret false;
+}
+
+# refuse every placement of an ABI type but the one that is the whole feature (#3004)
+#
+# A `va_list` is a token received from C and handed back to C, so a PARAMETER at the
+# type itself is the one position that means anything. Everything else here is a
+# program taking hold of the value: a field or a global gives it storage of its own,
+# a return position asks mach to originate one, and a pointer or an array asks for an
+# extent to step by. Each is refused on the line that writes it, so the message lands
+# where the misunderstanding is rather than at the call that later fails.
+# ---
+# sc:  the context
+# did: the decl
+# d:   the decl record
+fun check_abi_type_placement(sc: *context.SemaContext, did: id.DeclId, d: *decl.Decl) {
+    if (d.kind == decl.DECL_KIND_REC) {
+        check_abi_type_fields(sc, d.data.rec_.fields_start, d.data.rec_.fields_len);
+        ret;
+    }
+    if (d.kind == decl.DECL_KIND_UNI) {
+        check_abi_type_fields(sc, d.data.uni_.fields_start, d.data.uni_.fields_len);
+        ret;
+    }
+    if (d.kind == decl.DECL_KIND_FUN) {
+        var i: u32 = 0;
+        for (i < d.data.fun_.params_len) {
+            val tn: *decl.TypedName = ?sc.a.typed_names[d.data.fun_.params_start + i];
+            val pty: type.TypeId = context.resolved_type_of(sc, tn.ty);
+            # the parameter AT the type is the whole point; one BEHIND a pointer or
+            # inside an array is not.
+            if (type_carries_abi_type(sc, pty) && !type.is_abi_type(?sc.s.types, pty)) {
+                context.report(sc, tn.name, abitype.exclusion_message());
+            }
+            i = i + 1;
+        }
+        if (type_carries_abi_type(sc, context.resolved_type_of(sc, d.data.fun_.return_type))) {
+            context.report(sc, d.data.fun_.name, abitype.exclusion_message());
+        }
+        ret;
+    }
+    if (is_global_binding(d.kind)) {
+        if (sc.decl_type == nil) { ret; }
+        if (type_carries_abi_type(sc, sc.decl_type[did])) {
+            context.report(sc, d.span, abitype.exclusion_message());
+        }
+    }
+}
+
+# report each field in `[start, start + len)` declared at an ABI type
+# ---
+# sc:    the context
+# start: start index into ast.typed_names
+# len:   number of fields
+fun check_abi_type_fields(sc: *context.SemaContext, start: u32, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[start + i];
+        if (type_carries_abi_type(sc, context.resolved_type_of(sc, tn.ty))) {
+            context.report(sc, tn.name, abitype.exclusion_message());
+        }
+        i = i + 1;
+    }
+}
+
 # report unless a handle declaration and its interface role agree (#2794)
 #
 # Two directions, because they are two different mistakes. A handle-typed global
@@ -2122,7 +2209,14 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         handle.validate(sc, d, dec);
         ret;
     }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, packed, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage, sampler, op, handle");
+    # `#[abi_type(name)]` on a bodyless `def` says the selected target declares this
+    # C type's layout (#3004). The name set is closed here for the reason `op`'s is:
+    # which target a module is built for is not a property of the source.
+    if (decorator_named(sc, dec, abitype.DIRECTIVE)) {
+        abitype.validate(sc, d, dec);
+        ret;
+    }
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, packed, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage, sampler, op, handle, abi_type");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it
@@ -3058,6 +3152,14 @@ fun infer_local_decl(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, st
     if (type_carries_handle(sc, ty)) {
         context.report(sc, d.span,
             "a handle cannot be a local binding: a local is storage the program owns, and a handle's representation is not the program's, so there is nothing that may be written into it. hand the handle straight to the operation that consumes it instead of naming it first");
+    }
+
+    # a local binding of an ABI type, on the same reasoning and refused for the same
+    # reason (#3004): a local is storage the program owns, and naming a `va_list`
+    # first is the copy `va_copy` exists to make, which mach has no way to make
+    # correctly and no reason to.
+    if (type_carries_abi_type(sc, ty)) {
+        context.report(sc, d.span, abitype.exclusion_message());
     }
 
     if (d.data.bind.init != id.EXPR_NIL) {

--- a/src/lang/fe/sema/abitype.mach
+++ b/src/lang/fe/sema/abitype.mach
@@ -1,0 +1,242 @@
+# the `#[abi_type(name)]` directive (#3004)
+#
+# A bodyless `def` carrying this directive declares a C type whose layout the
+# SELECTED TARGET declares and whose contents mach never reads. It exists for the one
+# C type that has no correct spelling in mach source: `va_list` is a plain pointer on
+# SysV x86-64, Apple arm64, win64 and riscv64, and a 32-byte 8-aligned composite under
+# AAPCS64, so writing either one down binds correctly on some platforms and silently
+# wrongly on the rest.
+#
+# THE SCOPE IS FORWARD-ONLY, and it is a property of the type rather than a rule this
+# module enforces alone: a value of one may be received as a parameter and handed to
+# another function, and that is the whole list. There is no `va_start`, no `va_arg`,
+# no `va_end`, and no way for mach to originate one - a `va_list` is only meaningful
+# to a callee walking its own tail, and mach has no runtime variadics to walk. The
+# refusals that make that stick are asked where the question comes up, the way
+# `handle`'s are: a field of one in sema's field check, a binding of one in the
+# binding check, a cast of one in `check`.
+#
+# THE NAME IS A CLOSED SET, checked here rather than in a back end, for the reason
+# `#[op]` closes its names here: which target a module is built for is not a property
+# of the source, so a typo checked only where it is acted on would go unreported on
+# every other build of the same library.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_region_equals;
+
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.fe.ast;
+use mach.lang.fe.ast.decl;
+use mach.lang.fe.ast.expr;
+use mach.lang.fe.ast.id;
+use mach.lang.fe.sema.context;
+use mach.lang.fe.token;
+use mach.lang.type;
+use intern: mach.lang.intern;
+
+# the directive's name, and the number of arguments it takes
+pub val DIRECTIVE: str = "abi_type";
+val ARG_COUNT: u32 = 1;
+
+# how reading an `#[abi_type]` declaration came out
+#
+# There is deliberately no INERT outcome, which is where this parts company with
+# `#[handle]`. A handle names a constructor only one target mints, so a target that
+# mints none holds no opinion and the declaration is merely unreachable there. An ABI
+# type names a fact of the platform's C, and a platform that declares none is a
+# platform where the declaration cannot be given a layout at all - so it is refused
+# rather than given the pointer that would be right four times out of five.
+pub def ReadStatus: u8;
+pub val READ_OK:      ReadStatus = 0;
+pub val READ_REFUSED: ReadStatus = 1;
+
+# a read `#[abi_type]` declaration
+# ---
+# status: how the read came out
+# tag:    which ABI type was named (one of type.ABI_TYPE_*), when status is READ_OK
+# size:   the target's declared size in bytes, when status is READ_OK
+# align:  the target's declared alignment in bytes, when status is READ_OK
+pub rec Read {
+    status: ReadStatus;
+    tag:    u32;
+    size:   u32;
+    align:  u32;
+}
+
+# whether `dec` names directive `name`
+# ---
+# sc:   the context
+# dec:  the decorator
+# name: the directive name
+# ret:  true when the decorator is that directive
+fun decorator_is(sc: *context.SemaContext, dec: *decl.Decorator, name: str) bool {
+    ret str_region_equals(sc.source, dec.name.offset, dec.name.len, name);
+}
+
+# the `#[abi_type]` decorator on `d`, or nil
+# ---
+# sc: the context
+# d:  the decl to search
+# ret: the decorator, or nil
+pub fun decorator_of(sc: *context.SemaContext, d: *decl.Decl) *decl.Decorator {
+    var i: u32 = 0;
+    for (i < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + i];
+        if (decorator_is(sc, dec, DIRECTIVE)) { ret dec; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# whether `d` is a declaration this directive owns: a bodyless `def` carrying it
+# ---
+# sc: the context
+# d:  the decl to test
+# ret: true for a bodyless `def` with an `#[abi_type]`
+pub fun declares_abi_type(sc: *context.SemaContext, d: *decl.Decl) bool {
+    if (d.kind != decl.DECL_KIND_DEF)  { ret false; }
+    if (d.data.def_.ty != id.TYPE_NIL) { ret false; }
+    ret decorator_of(sc, d) != nil;
+}
+
+# argument `index` of `dec`, or nil
+# ---
+# sc:    the context
+# dec:   the decorator
+# index: which argument
+# ret:   the expression, or nil
+fun arg_expr(sc: *context.SemaContext, dec: *decl.Decorator, index: u32) *expr.Expr {
+    if (index >= dec.args_len) { ret nil; }
+    val opt_e: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + index]);
+    if (O.is_none[*expr.Expr](opt_e)) { ret nil; }
+    ret O.unwrap[*expr.Expr](opt_e);
+}
+
+# whether the string literal `e` spells `name`
+# ---
+# sc:   the context
+# e:    the string-literal expression
+# name: the name to compare against
+# ret:  true when the literal's text is `name`
+fun literal_is(sc: *context.SemaContext, e: *expr.Expr, name: str) bool {
+    if (e.span.len < 2::usize) { ret false; }
+    ret str_region_equals(sc.source, e.span.offset + 1::usize, e.span.len - 2::usize, name);
+}
+
+# read and check an `#[abi_type]` declaration, optionally reporting
+#
+# One reader for both callers, exactly as `handle.read` is: the validation pass
+# reports and the type resolver interns, and if each read the directive its own way
+# the accepted declarations and the interned types could disagree.
+# ---
+# sc:     the context
+# d:      the decorated decl
+# dec:    the `abi_type` decorator
+# report: whether to report what is refused
+# ret:    the read
+pub fun read(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator, report: bool) Read {
+    var out: Read;
+    out.status = READ_REFUSED;
+    out.tag    = 0;
+    out.size   = 0;
+    out.align  = 0;
+
+    if (d.kind != decl.DECL_KIND_DEF) {
+        if (report) { context.report(sc, dec.name, "`abi_type` decorator applies only to a `def` declaration: `def` is the form that means a name denotes a type and promises no fields and no storage, which is exactly what an ABI type is"); }
+        ret out;
+    }
+    if (d.data.def_.ty != id.TYPE_NIL) {
+        if (report) { context.report(sc, dec.name, "an `abi_type` declaration has no body: the selected target supplies the layout, so `def Name;` declares it and `def Name: T;` is an ordinary alias"); }
+        ret out;
+    }
+    if (dec.args_len != ARG_COUNT) {
+        if (report) { context.report(sc, dec.name, "`abi_type` decorator takes exactly one string argument: the name of the C type whose layout the target declares"); }
+        ret out;
+    }
+
+    val name_e: *expr.Expr = arg_expr(sc, dec, 0);
+    if (name_e == nil) { ret out; }
+    if (name_e.kind != expr.EXPR_KIND_LIT_STR) {
+        if (report) { context.report(sc, dec.name, "the `abi_type` decorator's argument must be a string literal: it is matched against the C types the target declares rather than evaluated"); }
+        ret out;
+    }
+
+    if (!literal_is(sc, name_e, "va_list")) {
+        if (report) { context.report(sc, name_e.span, "no such ABI type; `va_list` is the only C type whose layout a target declares"); }
+        ret out;
+    }
+
+    # the target's own refusal. a platform that declares no `va_list` is one where
+    # this declaration has no layout, and every default available is a pointer -
+    # right on four of the five platforms mach binds C on, and silent corruption on
+    # AAPCS64, which is why it is named instead.
+    if (sc.ctx.va_list_size == 0) {
+        if (report) { context.report(sc, name_e.span, "the selected target declares no `va_list` layout: `va_list` is part of a platform's C ABI and this platform has none, so there is nothing to bind. a target that runs C declares the size and alignment its psABI gives the type"); }
+        ret out;
+    }
+
+    out.status = READ_OK;
+    out.tag    = type.ABI_TYPE_VA_LIST;
+    out.size   = sc.ctx.va_list_size;
+    out.align  = sc.ctx.va_list_align;
+    ret out;
+}
+
+# report every rule an `#[abi_type]` declaration itself breaks
+# ---
+# sc:  the context
+# d:   the decorated decl
+# dec: the `abi_type` decorator
+pub fun validate(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    read(sc, d, dec, true);
+}
+
+# the type an `#[abi_type]` declaration denotes
+#
+# A refused declaration yields TYPE_ERROR, which poisons every use of the name
+# without a second diagnostic: the refusal was reported once, where it was written.
+# ---
+# sc:  the context
+# d:   the declaration's record
+# ret: the ABI type's TypeId, or TYPE_ERROR
+pub fun type_of(sc: *context.SemaContext, d: *decl.Decl) type.TypeId {
+    val dec: *decl.Decorator = decorator_of(sc, d);
+    if (dec == nil) { ret type.TYPE_ERROR; }
+
+    val r: Read = read(sc, d, dec, false);
+    if (r.status == READ_REFUSED) { ret type.TYPE_ERROR; }
+
+    val res: R.Result[type.TypeId, str] =
+        type.intern_abi_type(?sc.s.types, intern_name(sc, d.data.def_.name), r.tag, r.size, r.align);
+    if (R.is_err[type.TypeId, str](res)) { ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](res);
+}
+
+# intern the text `span` covers, or STR_NIL
+# ---
+# sc:   the context
+# span: the span to intern
+# ret:  the interned id, or STR_NIL
+fun intern_name(sc: *context.SemaContext, span: token.Span) intern.StrId {
+    if (span.len == 0) { ret intern.STR_NIL; }
+    val r: R.Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, span);
+    if (R.is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](r);
+}
+
+# the sentence every refusal of a READ or a CONSTRUCTION of an ABI type carries
+#
+# ONE TEXT, because they are one rule stated at whichever site the program reached
+# first. A caller appends nothing: the message already names what is excluded and
+# what remains possible, which is the whole of what a program may do with one.
+# ---
+# ret: the exclusion, as a diagnostic message
+pub fun exclusion_message() str {
+    ret "a `va_list` cannot be read, constructed, or stored in mach: it is an opaque token a C caller hands over and mach hands on, and reading one needs `va_arg`, which mach does not have and cannot have without runtime variadics. receive it as a parameter and pass it to the C function that consumes it";
+}

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -37,6 +37,7 @@ use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
+use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.generics;
@@ -757,6 +758,7 @@ pub fun check_member(sc: *context.SemaContext, object: type.TypeId, name: intern
 pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
     if (from == to)                                       { ret O.some[type.TypeId](to); }
+    if (!check_abi_type_cast(sc, from, to, span))         { ret O.none[type.TypeId](); }
 
     # the welded-storage discipline (#1645): `::` may neither launder a secret
     # pointer to the untyped `ptr` nor add / drop a `^`. checked before the
@@ -790,6 +792,28 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
     report_note(sc, span, "cast: conversion is invalid",
         "`::` casts numeric types or reinterprets equal-size values only");
     ret O.none[type.TypeId]();
+}
+
+# refuse a `::` or `:~` with an ABI type on either side (#3004)
+#
+# THE ONE REFUSAL THAT HAS TO BE WRITTEN DOWN RATHER THAN FALLEN OUT OF A SIZE. Every
+# other way of reading a `va_list` already fails for a structural reason - it has no
+# fields, it is not a pointer, it has no lanes - but a reinterpret asks only for two
+# equal sizes, and on the four platforms where a `va_list` is eight bytes `ap :~ ptr`
+# would hand the program the very cursor the type exists to keep out of its hands.
+# Refused on both sides: reading one out and forging one in are the same rule.
+# ---
+# sc:   the active sema context
+# from: the operand's type
+# to:   the target type
+# span: source range of the cast
+# ret:  true when neither side is an ABI type
+fun check_abi_type_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) bool {
+    val f: type.TypeId = type.strip_secret(?sc.s.types, from);
+    val t: type.TypeId = type.strip_secret(?sc.s.types, to);
+    if (!type.is_abi_type(?sc.s.types, f) && !type.is_abi_type(?sc.s.types, t)) { ret true; }
+    report(sc, span, abitype.exclusion_message());
+    ret false;
 }
 
 # whether a `::` numeric conversion emits a floating-point operation (#1646)
@@ -860,6 +884,7 @@ fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.Typ
 # ret:  some(to) when the reinterpret is legal, none (with a diagnostic) otherwise
 pub fun check_reinterpret(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
+    if (!check_abi_type_cast(sc, from, to, span))         { ret O.none[type.TypeId](); }
 
     # `:~` is bound by the same welded-storage secrecy rules as `::` - it can
     # neither erase a secret pointer to `ptr` nor change a `^` (#1645).
@@ -1007,6 +1032,14 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     # the shape every target already has for exactly that.
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN
         || k == type.TYPE_HANDLE) { ret ptr_width(sc); }
+    # an ABI type's declared extent, so `$size_of` and this agree about one type the
+    # way #2672 established they must. cast legality does not turn on it: `::` and
+    # `:~` refuse an ABI type by name before either size is read.
+    if (k == type.TYPE_ABI) {
+        val ext: layout.Extent = generics.type_extent(sc.s, context.machine_of(sc), type.strip_secret(?sc.s.types, t));
+        if (!ext.ok) { ret 0; }
+        ret ext.size;
+    }
     if (k == type.TYPE_ARRAY) {
         # widen the multiply: a >4GiB array would wrap a u32 product and report a
         # wrong size to cast legality, so saturate to the 0 "unknown" sentinel.

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -324,6 +324,9 @@ fun kind_is_public_leaf(k: type.TypeKind) bool {
     # an opaque image / sampler handle carries no data a program can read, so there
     # is nothing in it for the secrecy lattice to be about (#2794).
     if (k == type.TYPE_HANDLE)         { ret true; }
+    # an ABI type carries no data a program can read either (#3004), so the secrecy
+    # lattice has nothing to be about there.
+    if (k == type.TYPE_ABI)            { ret true; }
     if (k == type.TYPE_GENERIC_PARAM) { ret true; }
     ret false;
 }
@@ -438,6 +441,17 @@ fun describe_type(ctx: ptr, id: u32) layout.Node {
     if (d.class == type.PRIM_CLASS_PTR || t.kind == type.TYPE_POINTER || t.kind == type.TYPE_FUN
         || t.kind == type.TYPE_HANDLE) {
         ret layout.node(layout.NODE_POINTER);
+    }
+    # an ABI type's extent is DECLARED by the target rather than folded from parts
+    # (#3004): the size and the alignment are two independent numbers off the type,
+    # which is why neither a scalar node nor a pointer node can carry it. Measuring
+    # one is not reading one - the extent is a published psABI fact - and every way of
+    # reaching the VALUE is refused where it is written.
+    if (t.kind == type.TYPE_ABI) {
+        var n: layout.Node = layout.node(layout.NODE_OPAQUE);
+        n.bytes      = t.data.abi.size;
+        n.decl_align = t.data.abi.align;
+        ret n;
     }
     # a vector's extent is lane-derived, so the node carries its lane shape (#2687).
     if (t.kind == type.TYPE_VECTOR) {

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -43,6 +43,7 @@ use mach.lang.fe.resolve;
 use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
+use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.handle;
 use mach.lang.fe.sema.generics;
 use mach.lang.fe.sema.typename;
@@ -85,6 +86,13 @@ pub fun infer_decl(sc: *context.SemaContext, did: id.DeclId) type.TypeId {
     if (d.kind == decl.DECL_KIND_REC) { ret infer_nominal(sc, did, d.data.rec_.name, ?d.data.rec_, type.TYPE_REC); }
     if (d.kind == decl.DECL_KIND_UNI) { ret infer_nominal_uni(sc, did, d.data.uni_.name, ?d.data.uni_, type.TYPE_UNI); }
     if (d.kind == decl.DECL_KIND_DEF) {
+        # a bodyless `def` is one of the two directive-supplied forms: an ABI type
+        # whose layout the target declares (#3004) or a handle the target mints
+        # (#2888). the directive on it decides which, so neither is guessed from the
+        # shape they share.
+        if (d.data.def_.ty == id.TYPE_NIL && abitype.declares_abi_type(sc, d)) {
+            ret abitype.type_of(sc, d);
+        }
         if (d.data.def_.ty == id.TYPE_NIL) { ret handle.type_of(sc, did, d); }
         ret context.resolved_type_of(sc, d.data.def_.ty);
     }
@@ -3742,8 +3750,12 @@ fun def_underlying(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.S
         if (O.is_none[*decl.Decl](d_opt)) { ret type.TYPE_ERROR; }
         val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
         if (d.kind != decl.DECL_KIND_DEF) { ret type.TYPE_ERROR; }
-        # a BODYLESS `def` is a target-minted handle, whose definition the owning
-        # target supplies rather than the annotation (#2888)
+        # a BODYLESS `def` carries its definition on a directive rather than on the
+        # annotation: an ABI type the target declares the layout of (#3004), or a
+        # handle the owning target mints (#2888)
+        if (d.data.def_.ty == id.TYPE_NIL && abitype.declares_abi_type(sc, d)) {
+            ret abitype.type_of(sc, d);
+        }
         if (d.data.def_.ty == id.TYPE_NIL) { ret handle.type_of(sc, sym.decl, d); }
         ret resolve_type_ref(sc, d.data.def_.ty);
     }

--- a/src/lang/fe/sema/typename.mach
+++ b/src/lang/fe/sema/typename.mach
@@ -196,6 +196,10 @@ fun type_str_len(s: *session.Session, t: type.TypeId) usize {
         # compiler could assemble: a handle is declared, so the reader typed this
         ret name_str_len(s, tp.data.handle.name);
     }
+    if (k == type.TYPE_ABI) {
+        # the declaration's own name, for the reason a handle renders as one
+        ret name_str_len(s, tp.data.abi.name);
+    }
     if (k == type.TYPE_REC || k == type.TYPE_UNI) {
         ret name_str_len(s, tp.data.nominal.name);
     }
@@ -260,6 +264,9 @@ fun write_type_str(s: *session.Session, buf: str, k: usize, t: type.TypeId) usiz
     }
     if (kind == type.TYPE_HANDLE) {
         ret write_name(s, buf, k, tp.data.handle.name);
+    }
+    if (kind == type.TYPE_ABI) {
+        ret write_name(s, buf, k, tp.data.abi.name);
     }
     if (kind == type.TYPE_REC || kind == type.TYPE_UNI) {
         ret write_name(s, buf, k, tp.data.nominal.name);

--- a/src/lang/layout.mach
+++ b/src/lang/layout.mach
@@ -69,6 +69,13 @@ pub val NODE_AGGREGATE: NodeKind = 5;
 # a node occupying no storage (a void), which still aligns to 1 so it neither moves a
 # following field nor lowers an enclosing aggregate's alignment
 pub val NODE_ZERO:      NodeKind = 6;
+# a node of `bytes` size and `decl_align` alignment whose INTERIOR IS NOT DESCRIBED
+#
+# The shape for a type whose extent is declared outright rather than folded from
+# parts: a C ABI type the target states the size and alignment of (#3004). It is not
+# NODE_SCALAR, because a scalar's alignment is its own width and a 32-byte `va_list`
+# aligns to 8; and it is not NODE_AGGREGATE, because there are no fields to walk.
+pub val NODE_OPAQUE:    NodeKind = 7;
 
 # the target facts the fold reads
 #
@@ -309,6 +316,8 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, m: Machine, depth:
     if (n.kind == NODE_ZERO)    { ret extent(0, 1); }
     if (n.kind == NODE_SCALAR)  { ret extent(n.bytes, n.bytes); }
     if (n.kind == NODE_POINTER) { ret extent(m.ptr_width, m.ptr_width); }
+    # both numbers come from the declaration; nothing here is derived from the other.
+    if (n.kind == NODE_OPAQUE)  { ret extent(n.bytes, n.decl_align); }
 
     # a vector's extent is lane-derived: `lanes` lanes of `bytes` each, packed, with
     # NO padding to the vector register (#2687). a packed `f32x3` is 12 bytes, which is

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1404,6 +1404,16 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
         ret lower_handle_type(lc, rtid, t);
     }
 
+    # an ABI type lowers to an IR aggregate of the target's DECLARED extent (#3004):
+    # a run of bytes at the declared alignment, with no field the program can name.
+    # Being an aggregate is the whole mechanism - AAPCS64's by-reference rule for a
+    # composite over sixteen bytes is what makes the caller copy a 32-byte `va_list`
+    # and pass an address, and the same rule reduces an eight-byte one to the single
+    # register a pointer would have taken everywhere else.
+    if (k == type.TYPE_ABI) {
+        ret lower_abi_type(lc, t);
+    }
+
     # records, unions, and generic instances all lower to an IR aggregate of their
     # field layout, read from the session-global field store. a generic instance
     # carries a substituted field table (built by `generics.instantiate`), so it
@@ -1422,6 +1432,28 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
     # generic params / errors that survived to here lower to a pointer-width
     # opaque slot so storage sizing still works.
     ret ir_type.intern_ptr(?lc.m.types);
+}
+
+# lower a target-declared ABI type into an IR aggregate of its declared extent
+#
+# One `[size]u8` field under the declared alignment, rather than a run of
+# machine-word members: the byte array carries the size for any size, and the
+# alignment override carries the alignment, so a platform whose `va_list` is not a
+# whole number of words needs no second rule. The leaves are integer bytes, which is
+# what every convention's classifier reads them as - the integer path on all of them,
+# never a homogeneous-float aggregate.
+# ---
+# lc: the lowering context
+# t:  the semantic type record
+# ret: the IR aggregate type id, or an allocation error
+fun lower_abi_type(lc: *LowerContext, t: *type.Type) R.Result[ir_type.IrTypeId, str] {
+    val r_u8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?lc.m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r_u8)) { ret r_u8; }
+    val r_arr: R.Result[ir_type.IrTypeId, str] =
+        ir_type.intern_array(?lc.m.types, R.unwrap_ok[ir_type.IrTypeId, str](r_u8), t.data.abi.size);
+    if (R.is_err[ir_type.IrTypeId, str](r_arr)) { ret r_arr; }
+    var field: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r_arr);
+    ret ir_type.intern_struct(?lc.m.types, ?field, 1, t.data.abi.align, false);
 }
 
 # lower a handle's constructor and operands into an IR handle type

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -111,6 +111,23 @@ pub fun host_pointer_width() u32 {
     ret ($mach.build.pointer_width)::u32;
 }
 
+# the `va_list` layout of the host this compiler binary was built for (#3004)
+#
+# Reads the OS implementations' OWN declarations rather than restating them, so the
+# editor's target-less context and a real build cannot disagree about what a
+# `va_list` is on this machine. Parallels `host_os_id` / `host_arch_id`: the os is
+# folded from the build and the architecture comes from `host_arch_id`, and no
+# registry is brought up, because the editor seeds a buffer's context before one
+# exists.
+# ---
+# ret: the host platform's declared layout, or none when it declares none
+pub fun host_va_list() O.Option[os.VaList] {
+    $if ($mach.build.os == $mach.os.linux)   { ret linux.linux_va_list(host_arch_id()); }
+    $or ($mach.build.os == $mach.os.darwin)  { ret darwin.darwin_va_list(host_arch_id()); }
+    $or ($mach.build.os == $mach.os.windows) { ret windows.windows_va_list(host_arch_id()); }
+    $or                                      { ret freestanding.freestanding_va_list(host_arch_id()); }
+}
+
 # the abi id of the host this compiler binary was built for
 #
 # folds the `$mach.build.abi` comptime read into the matching `abi.ABI_*` id, so
@@ -341,6 +358,21 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     # eight bytes. resolved beside the variadic fact, never merged with it - Apple keeps
     # the eight-byte minimum for its variadic tail.
     t.fixed_args_natural_size = os.natural_stack_args_for(os_vt, arch_vt.id);
+
+    # the platform's `va_list` shape for THIS (os, isa) pair, on the same axis again:
+    # darwin's arm64 `va_list` is a `char *` and linux's is AAPCS64's 32-byte composite,
+    # from the one convention vtable both compose. A platform that declares none leaves
+    # both scalars 0, which the `#[abi_type("va_list")]` declaration refuses by name
+    # rather than reading as a pointer.
+    var vl_size:  u32 = 0;
+    var vl_align: u32 = 0;
+    val vl: O.Option[os.VaList] = os.va_list_for(os_vt, arch_vt.id);
+    if (O.is_some[os.VaList](vl)) {
+        vl_size  = O.unwrap[os.VaList](vl).size;
+        vl_align = O.unwrap[os.VaList](vl).align;
+    }
+    t.va_list_size  = vl_size;
+    t.va_list_align = vl_align;
 
     # derive the legacy identity ids from the resolved vtables; the ~89 id-readers
     # and the comptime tag space keep reading these unchanged.

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -16,6 +16,7 @@ use std.types.string.str;
 use std.types.string.str_equals;
 
 use O: std.types.option;
+use R: std.types.result;
 
 use mach.lang.target.isa;
 
@@ -148,6 +149,49 @@ pub def VariadicStackFn: fun(u32) bool;
 # ret:   true when a fixed stack argument takes its natural size there
 pub def NaturalStackArgsFn: fun(u32) bool;
 
+# the layout a C `va_list` occupies in a PARAMETER slot on one architecture (#3004)
+#
+# `va_list` is the one C type mach binds whose shape is neither a scalar it can name
+# nor an aggregate the user can write down: AAPCS64 makes it a 32-byte 8-aligned
+# composite, and every other platform mach targets makes it a plain pointer. That
+# difference is not decorative. A composite over 16 bytes is passed indirectly under
+# AAPCS64 with the CALLER owning the copy, so forwarding a received `va_list` spelled
+# as a pointer hands the next callee the caller's own list to advance rather than a
+# fresh one.
+# ---
+# size:  the type's size in bytes
+# align: the type's required alignment in bytes
+pub rec VaList { size: u32; align: u32; }
+
+# build a declared `va_list` layout
+# ---
+# size:  size in bytes
+# align: alignment in bytes
+# ret:   the layout
+pub fun va_list(size: u32, align: u32) VaList {
+    var v: VaList;
+    v.size  = size;
+    v.align = align;
+    ret v;
+}
+
+# a per-os `va_list` layout policy, parameterized by architecture id
+#
+# DECLARED PER (OS, ARCHITECTURE), NEVER DERIVED. It is an OS fact for the same
+# reason `VariadicStackFn` is: darwin and linux compose the very same "aapcs64"
+# vtable and disagree about this outright - darwin's arm64 `va_list` is a `char *`
+# and linux's is the AAPCS64 32-byte composite - so no calling convention can answer
+# it and no machine model implies it.
+#
+# `none` means NOBODY HAS READ THE psABI for that architecture, and it is refused
+# rather than defaulted. Every plausible default is a pointer, a pointer is right on
+# four of the five platforms mach binds C on, and being right four times out of five
+# is exactly the shape that ships silent corruption on the fifth.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   the declared layout, or none when the architecture has no declaration
+pub def VaListFn: fun(u32) O.Option[VaList];
+
 # the operating-system runtime-dispatch interface
 #
 # Exactly one of these exists per OS; the driver and linker read the entry
@@ -251,6 +295,10 @@ pub def NaturalStackArgsFn: fun(u32) bool;
 #                 it once onto `Target.fixed_args_natural_size`. Sibling of
 #                 `variadic_stack` and deliberately separate from it: Apple's fixed and
 #                 variadic rules differ from each other
+# va_list_layout: per-architecture `va_list` layout, or nil when the OS declares none
+#                 anywhere; `target.select` resolves it once onto `Target.va_list_size`
+#                 and `Target.va_list_align`. an architecture with no declaration is
+#                 refused at registration rather than defaulted to a pointer (#3004)
 pub rec OsVTable {
     id:                  u32;
     name:                str;
@@ -275,6 +323,7 @@ pub rec OsVTable {
     native_abi:          NativeAbiFn;
     variadic_stack:      VariadicStackFn;
     natural_stack_args:  NaturalStackArgsFn;
+    va_list_layout:      VaListFn;
 }
 
 # maximum number of OS implementations an OsRegistry holds
@@ -307,20 +356,46 @@ pub fun registry_init() OsRegistry {
     ret r;
 }
 
-# install an OS vtable into `reg`
+# install an OS vtable into `reg`, refusing one that declares no `va_list` for an
+# architecture it claims to run on
 #
 # Write-once per os name: a second registration under a name already present is
 # ignored so the first implementation to initialize wins deterministically. a nil
 # vtable, or one past the registry's capacity, is ignored.
+#
+# THE REFUSAL IS THE `va_list` DECLARATION'S ONE READER AT STARTUP (#3004), and it
+# is shaped after `abi.riscv.install`, which refuses a family member still carrying
+# `VARIADIC_RULE_UNDECLARED`. An OS that lists an architecture in `supported_isas`
+# says a program builds and links against that platform's C there, and `va_list` is
+# part of what that platform's C is. Missing it is a programming error in the OS
+# implementation, so it is named here rather than surfacing as a wrong argument at a
+# call site.
+#
+# An OS carrying `supported_isa_any` (bare metal) has no list to check, so the same
+# question is asked of it where the fact is demanded, at the declaration that needs
+# a layout for the selected target.
 # ---
 # reg: the registry to install into
 # vt:  the OS vtable to register; its `name` is the key
-pub fun register(reg: *OsRegistry, vt: *OsVTable) {
-    if (vt == nil)                                  { ret; }
-    if (O.is_some[*OsVTable](lookup(reg, vt.name))) { ret; }
-    if (reg.count >= OS_REGISTRY_CAP)               { ret; }
+# ret: ok(true) on success, or an error naming an undeclared (os, architecture) pair
+pub fun register(reg: *OsRegistry, vt: *OsVTable) R.Result[bool, str] {
+    if (vt == nil)                                  { ret R.ok[bool, str](true); }
+    if (O.is_some[*OsVTable](lookup(reg, vt.name))) { ret R.ok[bool, str](true); }
+    if (reg.count >= OS_REGISTRY_CAP)               { ret R.ok[bool, str](true); }
+
+    if (!vt.supported_isa_any) {
+        var i: u32 = 0;
+        for (i < vt.supported_isa_count) {
+            if (O.is_none[VaList](va_list_for(vt, vt.supported_isas[i]))) {
+                ret R.err[bool, str]("mach.lang.target.os: an operating system declares no `va_list` layout for an architecture it supports; read the platform psABI for it and declare the size and alignment rather than registering it undecided");
+            }
+            i = i + 1;
+        }
+    }
+
     reg.entries[reg.count] = vt;
     reg.count = reg.count + 1;
+    ret R.ok[bool, str](true);
 }
 
 # find the OS vtable registered under an os name in `reg`
@@ -481,6 +556,21 @@ pub fun natural_stack_args_for(vt: *OsVTable, arch_id: u32) bool {
     ret vt.natural_stack_args(arch_id);
 }
 
+# the `va_list` layout operating system `vt` declares on architecture `arch_id`
+#
+# The nil-safe reader over the vtable's `va_list_layout` policy. A nil policy, and a
+# policy that answers none, are the SAME answer: this platform has no declared
+# `va_list` on that architecture. There is no fallback, because the only fallback
+# available would be a pointer and a pointer is wrong on AAPCS64.
+# ---
+# vt:      the os vtable to read
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none
+pub fun va_list_for(vt: *OsVTable, arch_id: u32) O.Option[VaList] {
+    if (vt.va_list_layout == nil) { ret O.none[VaList](); }
+    ret vt.va_list_layout(arch_id);
+}
+
 # stub variadic-placement policy for the variadic_stack_for test: covers arch id 1
 fun variadic_stack_stub(arch_id: u32) bool {
     ret arch_id == 1;
@@ -512,6 +602,81 @@ test "mach.lang.target.os.natural_stack_args_for:reads_policy_and_is_nil_safe" {
     vt.natural_stack_args = natural_stack_args_stub;
     if (!natural_stack_args_for(?vt, 1)) { ret 1; }
     if (natural_stack_args_for(?vt, 2))  { ret 1; }
+    ret 0;
+}
+
+# stub `va_list` policy for the va_list_for test: covers arch id 1 only
+fun va_list_stub(arch_id: u32) O.Option[VaList] {
+    if (arch_id == 1) { ret O.some[VaList](va_list(32, 8)); }
+    ret O.none[VaList]();
+}
+
+# va_list_for is nil-safe (a nil policy declares nothing anywhere) and otherwise
+# reads the vtable's policy per architecture, reporting none for an architecture the
+# policy does not cover
+test "mach.lang.target.os.va_list_for:reads_policy_and_is_nil_safe" {
+    var vt: OsVTable;
+    vt.va_list_layout = nil;
+    if (O.is_some[VaList](va_list_for(?vt, 1))) { ret 1; }
+    vt.va_list_layout = va_list_stub;
+    val got: O.Option[VaList] = va_list_for(?vt, 1);
+    if (O.is_none[VaList](got))            { ret 1; }
+    if (O.unwrap[VaList](got).size != 32)  { ret 1; }
+    if (O.unwrap[VaList](got).align != 8)  { ret 1; }
+    if (O.is_some[VaList](va_list_for(?vt, 2))) { ret 1; }
+    ret 0;
+}
+
+# an OS that lists an architecture it declares no `va_list` for is REFUSED at
+# registration, not defaulted to a pointer (#3004)
+#
+# The startup reader of the declaration, shaped after `abi.riscv.install`. Listing an
+# architecture in `supported_isas` says a program links against that platform's C
+# there, and `va_list` is part of what that C is. Missing it is a programming error
+# in the OS implementation and is named here rather than surfacing as a wrong
+# argument at a call site.
+#
+# THE CONTROL IS THE SAME VTABLE WITH THE DECLARATION, and a second one carrying
+# `supported_isa_any` - a bare-metal OS has no list to check, and refusing it here
+# would refuse every freestanding target for an architecture nobody targets.
+test "mach.lang.target.os.register:refuses_an_undeclared_va_list" {
+    var reg: OsRegistry = registry_init();
+
+    var bad: OsVTable;
+    bad.name                = "badvl";
+    bad.supported_isa_any   = false;
+    bad.supported_isa_count = 0;
+    support_isa(?bad, 1);
+    bad.va_list_layout      = nil;
+    if (R.is_ok[bool, str](register(?reg, ?bad))) { ret 1; }
+    if (registered_count(?reg) != 0)              { ret 1; }
+
+    var good: OsVTable;
+    good.name                = "goodvl";
+    good.supported_isa_any   = false;
+    good.supported_isa_count = 0;
+    support_isa(?good, 1);
+    good.va_list_layout      = va_list_stub;
+    if (R.is_err[bool, str](register(?reg, ?good))) { ret 1; }
+    if (registered_count(?reg) != 1)                { ret 1; }
+
+    # an architecture the policy does not cover is the same refusal: the list is what
+    # is checked, not whether a policy is installed at all.
+    var partial: OsVTable;
+    partial.name                = "partialvl";
+    partial.supported_isa_any   = false;
+    partial.supported_isa_count = 0;
+    support_isa(?partial, 2);
+    partial.va_list_layout      = va_list_stub;
+    if (R.is_ok[bool, str](register(?reg, ?partial))) { ret 1; }
+
+    var bare: OsVTable;
+    bare.name                = "barevl";
+    bare.supported_isa_any   = true;
+    bare.supported_isa_count = 0;
+    bare.va_list_layout      = nil;
+    if (R.is_err[bool, str](register(?reg, ?bare))) { ret 1; }
+    if (registered_count(?reg) != 2)                { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -14,6 +14,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -97,6 +98,22 @@ fun darwin_natural_stack_args(arch_id: u32) bool {
     ret arch_id == isa.ARCH_AARCH64;
 }
 
+# Darwin's `va_list` layout per architecture (#3004)
+#
+# `char *` on BOTH architectures, and the arm64 one is a deliberate Apple divergence
+# from the AAPCS64 base standard rather than an oversight: Apple's arm64 ABI passes
+# the whole variadic tail on the stack (`darwin_variadic_stack`), so walking that
+# tail needs nothing but a cursor and the register save area the base standard's
+# 32-byte descriptor exists to index does not exist here.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none for an architecture darwin does not run on
+pub fun darwin_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    ret O.none[os.VaList]();
+}
+
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime
 var darwin_vtable: os.OsVTable;
@@ -160,7 +177,9 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     # AAPCS64 eight-byte slot; a separate rule from the variadic one above, which keeps
     # the eight-byte minimum.
     darwin_vtable.natural_stack_args = darwin_natural_stack_args;
+    # `char *` on both architectures; Apple's arm64 tail is all stack, so a cursor
+    # into it is the whole descriptor.
+    darwin_vtable.va_list_layout = darwin_va_list;
 
-    os.register(reg, ?darwin_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?darwin_vtable);
 }

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -14,6 +14,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -52,6 +53,25 @@ fun freestanding_native_abi(arch_id: u32) str {
     if (arch_id == isa.ARCH_RISCV32) { ret "ilp32d"; }
     if (arch_id == isa.ARCH_MOS6502) { ret "mos6502"; }
     ret "";
+}
+
+# The `va_list` layout of a bare-metal target, per architecture (#3004)
+#
+# There is no OS here to have an opinion, so the answer is the architecture's own
+# psABI: the AAPCS64 base standard's 32-byte composite on aarch64, a pointer of the
+# machine's own width on the others. An architecture whose psABI defines no `va_list`
+# at all answers NONE rather than a pointer - SPIR-V has no C calling convention to
+# have one, and nobody has read a 6502 C ABI into this compiler - and a declaration
+# needing one on such a target is refused where it is written.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none where the psABI defines none
+pub fun freestanding_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(32, 8)); }
+    if (arch_id == isa.ARCH_RISCV64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_RISCV32) { ret O.some[os.VaList](os.va_list(4, 4)); }
+    ret O.none[os.VaList]();
 }
 
 # the freestanding OS vtable. populated by register_freestanding on first call
@@ -107,7 +127,8 @@ pub fun register_freestanding(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform stack-granularity divergence either: a stack argument takes the
     # convention's slot.
     freestanding_vtable.natural_stack_args = nil;
+    # the architecture's own psABI, and none where the psABI defines no `va_list`.
+    freestanding_vtable.va_list_layout = freestanding_va_list;
 
-    os.register(reg, ?freestanding_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?freestanding_vtable);
 }

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -12,6 +12,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -73,6 +74,24 @@ fun linux_native_abi(arch_id: u32) str {
     ret "";
 }
 
+# Linux's `va_list` layout per architecture (#3004)
+#
+# x86-64: `va_list` is `__va_list_tag[1]`, an ARRAY type, so in a parameter slot it
+# decays to `__va_list_tag *` and what is passed is one pointer. aarch64: the AAPCS64
+# base standard's `struct __va_list`, four pointer-sized members, 32 bytes aligned to
+# 8, and passed INDIRECTLY with the caller owning the copy - the one platform where
+# spelling it as a pointer forwards the caller's own list instead of a fresh one.
+# riscv64: the psABI makes it `void *`.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none for an architecture linux does not run on
+pub fun linux_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(32, 8)); }
+    if (arch_id == isa.ARCH_RISCV64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    ret O.none[os.VaList]();
+}
+
 # the Linux OS vtable. populated by register_linux on first call and handed out
 # as a borrowed pointer to the registry; remains valid for the process lifetime
 var linux_vtable: os.OsVTable;
@@ -131,9 +150,11 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform stack-granularity divergence either: a stack argument takes the
     # convention's slot (AAPCS64's eight-byte one on arm64, not Apple's natural size).
     linux_vtable.natural_stack_args = nil;
+    # the System V psABI's `va_list` per arch: a decayed pointer on x86-64 and
+    # riscv64, AAPCS64's 32-byte composite on aarch64.
+    linux_vtable.va_list_layout = linux_va_list;
 
-    os.register(reg, ?linux_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?linux_vtable);
 }
 
 # linux_page_size pins the per-arch segment-alignment page: aarch64 uses the 64 KiB

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -12,6 +12,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -51,6 +52,20 @@ fun windows_pie_exec(arch_id: u32) bool {
 fun windows_native_abi(arch_id: u32) str {
     if (arch_id == isa.ARCH_X86_64) { ret "win64"; }
     ret "";
+}
+
+# Windows' `va_list` layout per architecture (#3004)
+#
+# `char *` on both: win64 and Windows-on-ARM64 both home the register arguments into
+# the shadow space the caller already reserves, so the whole variadic tail is one
+# contiguous run of stack slots and a cursor into it is the entire descriptor.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none for an architecture windows does not run on
+pub fun windows_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    ret O.none[os.VaList]();
 }
 
 # the Windows OS vtable
@@ -116,7 +131,8 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform stack-granularity divergence either: win64 gives every stack argument
     # a full eight-byte slot.
     windows_vtable.natural_stack_args = nil;
+    # `char *` on both architectures: the tail is one contiguous run of stack slots.
+    windows_vtable.va_list_layout = windows_va_list;
 
-    os.register(reg, ?windows_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?windows_vtable);
 }

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -69,6 +69,12 @@ use mach.lang.target.os;
 #           `natural_stack_args` policy. The two are SIBLINGS, not one fact: Apple runs
 #           both rules at once, so a variadic tail argument keeps the eight-byte minimum
 #           on a target where a fixed one does not
+# va_list_size / va_list_align: the size and alignment of a C `va_list` in a parameter
+#           slot on this platform, resolved once from the os vtable's per-architecture
+#           declaration (#3004). A size of 0 means the platform DECLARES NONE, which is
+#           refused where a declaration demands one rather than defaulted to a pointer:
+#           a pointer is right on four of the five platforms mach binds C on, and
+#           AAPCS64's 32-byte composite is the fifth
 pub rec Target {
     os_id:    u32;
     arch_id:  u32;
@@ -89,4 +95,6 @@ pub rec Target {
     stack_commit:  u64;
     variadic_args_on_stack: bool;
     fixed_args_natural_size: bool;
+    va_list_size:  u32;
+    va_list_align: u32;
 }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -100,6 +100,23 @@ pub val VEC_COUNT: u32 = 10;
 # that mints none still has a well defined size for the declaration
 pub val TYPE_HANDLE: TypeKind = 21;
 
+# a C type whose layout the selected TARGET declares and whose contents the program
+# cannot reach (#3004)
+#
+# The one C type mach binds that is neither a scalar it can name nor an aggregate a
+# user can write down: `va_list` is a plain pointer on four of the five platforms
+# mach binds C on and a 32-byte 8-aligned composite on AAPCS64, so no spelling in
+# mach source is correct everywhere and the layout has to come from the target.
+#
+# It IS an aggregate of the declared extent, deliberately, because that is what makes
+# the existing rules right without a special case: an aggregate over 16 bytes rides
+# AAPCS64's by-reference path, which makes the caller copy and pass an address, and
+# an eight-byte one reduces on every other platform to the single register a pointer
+# would have taken. What the program may do with one is bounded to the opposite end:
+# receive it as a parameter and hand it on. There is no reading, no construction, and
+# no storage of its own.
+pub val TYPE_ABI: TypeKind = 22;
+
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
 pub def PrimClass: u8;
 
@@ -214,6 +231,38 @@ pub rec TypeHandle {
     ops_start: u32;
     ops_len:   u32;
 }
+
+# a target-declared C ABI type (#3004)
+#
+# IDENTITY IS THE TAG, and the extent rides along rather than deciding anything. One
+# build has exactly one selected target, so `va_list` names one layout for the whole
+# compilation and two declarations of it in two modules must be the same type or a
+# binding could not be passed across a module boundary. Carrying the extent in the
+# payload keeps every consumer reading the fact off the type instead of re-consulting
+# the target.
+#
+# `name` is the spelling the declaration gave, for diagnostics only, exactly as
+# `TypeHandle.name` is.
+# ---
+# name:  interned declaration name (for diagnostics - not load-bearing for identity)
+# tag:   which C ABI type this is (one of ABI_TYPE_*)
+# size:  the target's declared size in bytes
+# align: the target's declared alignment in bytes
+pub rec TypeAbi {
+    name:  intern.StrId;
+    tag:   u32;
+    size:  u32;
+    align: u32;
+}
+
+# the tag of the `va_list` ABI type, the only member so far
+#
+# A TAG RATHER THAN A BARE FLAG because the axis this grows along is "a C type whose
+# layout the target declares, and whose contents mach never reads". `jmp_buf` and
+# `fpos_t` are the same shape of thing, and adding one is a tag here plus a row in
+# each os vtable's declaration - never a second directive and never a second type
+# kind.
+pub val ABI_TYPE_VA_LIST: u32 = 0;
 
 # the spelling, lane scalar, and lane count of one seeded vector type
 #
@@ -524,6 +573,7 @@ pub rec Type {
         array:         TypeArray;
         vector:        TypeVector;
         handle:        TypeHandle;
+        abi:           TypeAbi;
         fn:            TypeFun;
         nominal:       TypeNominal;
         generic_param: TypeGenericParam;
@@ -1287,6 +1337,43 @@ pub fun is_handle(ti: *TypeInterner, tid: TypeId) bool {
     val opt_type: O.Option[*Type] = get(ti, tid);
     if (O.is_none[*Type](opt_type)) { ret false; }
     ret O.unwrap[*Type](opt_type).kind == TYPE_HANDLE;
+}
+
+# intern a target-declared C ABI type (#3004)
+#
+# Ordinary `intern_dedup`: the whole payload is in the type record, so two
+# declarations of the same ABI type against the same target collapse to one TypeId
+# and a binding declared in one module passes where another module declares it.
+# `name` is carried for diagnostics and takes part in identity only in the sense that
+# two declarations spelling one ABI type differently are still one type - the first
+# name interned is the one a message shows, exactly as for a handle.
+# ---
+# ti:    the interner
+# name:  the declaration's name, for diagnostics
+# tag:   which C ABI type this is (one of ABI_TYPE_*)
+# size:  the target's declared size in bytes
+# align: the target's declared alignment in bytes
+# ret:   TypeId for the ABI type, or an allocation error
+pub fun intern_abi_type(ti: *TypeInterner, name: intern.StrId, tag: u32, size: u32,
+                        align: u32) R.Result[TypeId, str] {
+    var t: Type;
+    t.kind           = TYPE_ABI;
+    t.data.abi.name  = name;
+    t.data.abi.tag   = tag;
+    t.data.abi.size  = size;
+    t.data.abi.align = align;
+    ret intern_dedup(ti, t);
+}
+
+# whether `tid` is a target-declared C ABI type
+# ---
+# ti:  the interner
+# tid: the TypeId to test
+# ret: true for a TYPE_ABI
+pub fun is_abi_type(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    ret O.unwrap[*Type](opt_type).kind == TYPE_ABI;
 }
 
 # the operand word at `index` of the handle at `tid`
@@ -2087,6 +2174,13 @@ fun hash_type(p: ptr) u64 {
         h = fnv1a.step_u32(h, t.data.generic_param.owner::u32);
         h = fnv1a.step_u32(h, t.data.generic_param.index);
     }
+    # the tag and the declared extent, never the spelling: two modules declaring one
+    # ABI type must reach one TypeId or a binding could not cross between them.
+    or (t.kind == TYPE_ABI) {
+        h = fnv1a.step_u32(h, t.data.abi.tag);
+        h = fnv1a.step_u32(h, t.data.abi.size);
+        h = fnv1a.step_u32(h, t.data.abi.align);
+    }
     ret h;
 }
 
@@ -2122,6 +2216,11 @@ fun eq_type(pa: ptr, pb: ptr) bool {
     if (a.kind == TYPE_GENERIC_PARAM) {
         ret a.data.generic_param.owner == b.data.generic_param.owner
             && a.data.generic_param.index == b.data.generic_param.index;
+    }
+    if (a.kind == TYPE_ABI) {
+        ret a.data.abi.tag == b.data.abi.tag
+            && a.data.abi.size == b.data.abi.size
+            && a.data.abi.align == b.data.abi.align;
     }
 
     # primitives and TYPE_ERROR are equal by kind alone

--- a/test/link/cases/va-list/case.conf
+++ b/test/link/cases/va-list/case.conf
@@ -1,0 +1,29 @@
+# A C caller hands a live `va_list` to a mach function through a callback pointer,
+# and mach forwards it to a C consumer that reads it with `va_arg` (mach #3004). Both
+# ends of the token are the RUNNER'S own toolchain, so what is measured is the
+# platform's real `va_list`, not mach's model of it.
+#
+# AAPCS64-LINUX IS THE LEG THIS EXISTS FOR. There `va_list` is a 32-byte 8-aligned
+# composite, which the psABI passes indirectly with the CALLER owning the copy. A
+# parameter spelled `ptr` is ABI-compatible for one hop and links and runs, so the
+# only thing that separates it from the correct binding is whether the forward makes
+# a fresh copy - which is invisible until the list is forwarded more than once. That
+# is why the case forwards twice.
+#
+# THE GOLDEN IS AGREEMENT, NOT A PAIR OF NUMBERS, because the correct pair is not the
+# same on every platform. Two forwards of one list read argument one twice where
+# `va_list` is a caller-copied composite and arguments one then two where it is a
+# pointer into shared state, and both are the platform behaving correctly. The C
+# control runs the identical experiment through the runner's own compiler, so the
+# assertion is that mach's copy semantics are its platform's. Without the fix,
+# aarch64-linux is the leg where they differ.
+#
+# The other four legs are controls in the strict sense: each declares `va_list` as a
+# plain pointer, each already worked with `ptr` before this, and each must keep
+# producing the same golden after it. A change that made every target copy, or every
+# target alias, would fail one of them.
+#
+# The probe is built at -O0 rather than the -O1 its sibling `c-variadic` uses: the C
+# control measures whether a `va_list` PARAMETER is caller-copied, and inlining the
+# callee removes the parameter pass being measured.
+run: exec

--- a/test/link/cases/va-list/expect.txt
+++ b/test/link/cases/va-list/expect.txt
@@ -1,0 +1,2 @@
+relay n=2 first=111
+matches platform=1

--- a/test/link/cases/va-list/mach.toml
+++ b/test/link/cases/va-list/mach.toml
@@ -1,0 +1,71 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.x86_64-linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.aarch64-linux]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.riscv64-linux]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64d"
+
+[target.x86_64-windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.aarch64-darwin]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.x86_64-darwin]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "sh ../../lib/cc.sh -c -O0 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/test/link/cases/va-list/probe.c
+++ b/test/link/cases/va-list/probe.c
@@ -1,0 +1,57 @@
+/* the C half of the `va_list` parameter case (mach #3004).
+ *
+ * Compiled by the RUNNER'S OWN C toolchain, so both the list this originates and
+ * the `va_arg` that reads it are the platform's real ABI rather than mach's model
+ * of it. mach never constructs a `va_list` and never reads one: it receives the
+ * token here, hands it to `va_take`, and the value that comes back is the
+ * observable.
+ *
+ * THE LIST IS HANDED OVER THROUGH A FUNCTION POINTER mach supplies, which is the
+ * shape the motivating report used (`SetTraceLogCallback`) and also the shape that
+ * needs no agreement about how a mach symbol is spelled in a C object.
+ *
+ * WHY -O0. `va_take` takes its `va_list` BY VALUE, and whether the caller owns that
+ * copy is precisely what this case measures. Inlining it removes the parameter pass
+ * being measured, so the C control would stop describing the platform's calling
+ * convention and start describing the optimizer's. */
+
+#include <stdarg.h>
+
+typedef long long (*relay_fn)(long long *out, va_list ap);
+
+/* consume ONE argument from `ap`. by value, exactly as `vsnprintf` takes one. */
+long long va_take(va_list ap) { return va_arg(ap, long long); }
+
+static long long call_relay(relay_fn relay, long long *out, ...) {
+    va_list ap;
+    va_start(ap, out);
+    long long r = relay(out, ap);
+    va_end(ap);
+    return r;
+}
+
+/* C originates a list and hands it to MACH, which forwards it to `va_take` twice. */
+long long c_probe(relay_fn relay, long long *out) {
+    return call_relay(relay, out, 111LL, 222LL, 333LL);
+}
+
+static long long relay_in_c(long long *out, va_list ap) {
+    out[0] = va_take(ap);
+    out[1] = va_take(ap);
+    return 2;
+}
+
+/* THE PLATFORM'S OWN ANSWER to the same experiment, written entirely in C.
+ *
+ * Two forwards of one `va_list` do not mean the same thing everywhere, and that is
+ * a fact about C rather than about mach: under AAPCS64 the type is a 32-byte
+ * composite the caller copies, so each callee walks its own and both read argument
+ * one; under SysV x86-64 it is an array that decays to a pointer, so the first
+ * callee advances the caller's list and the second reads argument two. The golden
+ * therefore asserts that MACH AGREES WITH THIS, not that any particular pair of
+ * numbers comes back - which is the only claim that holds on every leg and is also
+ * the exact claim that fails on AAPCS64-linux when mach forwards the received
+ * pointer instead of a fresh copy. */
+long long c_control(long long *out) {
+    return call_relay(relay_in_c, out, 111LL, 222LL, 333LL);
+}

--- a/test/link/cases/va-list/src/main.mach
+++ b/test/link/cases/va-list/src/main.mach
@@ -1,0 +1,56 @@
+# `va_list` parameter surface case (mach #3004)
+#
+# A C caller originates a `va_list` and hands it to a mach function, which forwards
+# it to a C consumer. mach never reads the token and never builds one: the whole
+# scope is receive and pass on, which is what binding a logging callback such as
+# raylib's `TraceLogCallback` needs and all it needs.
+#
+# THE OBSERVABLE IS AGREEMENT WITH THE PLATFORM, because the platforms disagree with
+# each other. Forwarding one list to two consumers reads argument one twice where
+# `va_list` is a caller-copied composite (AAPCS64) and arguments one then two where
+# it is a pointer into shared state (SysV x86-64). The C control runs the identical
+# experiment through the runner's own compiler, so a leg where mach's copy semantics
+# differ from its platform's fails here - which is exactly what AAPCS64-linux does
+# when the parameter is spelled `ptr` and the received pointer is forwarded rather
+# than a fresh copy.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# the target declares the size and alignment; the program never learns what is in it
+#[abi_type("va_list")]
+def VaList;
+
+def Relay: fun(*i64, VaList) i64;
+
+ext fun va_take(ap: VaList) i64;
+ext fun c_probe(relay: Relay, out: *i64) i64;
+ext fun c_control(out: *i64) i64;
+
+# the callback C invokes with a live list. forwards it twice, and nothing else.
+fun relay(out: *i64, ap: VaList) i64 {
+    out[0] = va_take(ap);
+    out[1] = va_take(ap);
+    ret 2;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var got:  [2]i64;
+    var want: [2]i64;
+    got[0]  = 0;
+    got[1]  = 0;
+    want[0] = 0;
+    want[1] = 0;
+
+    val n: i64 = c_probe(relay, ?got[0]);
+    p.printlnf("relay n={} first={}", n, got[0]);
+
+    val m: i64 = c_control(?want[0]);
+    var agree: i64 = 0;
+    if (m == n && want[0] == got[0] && want[1] == got[1]) { agree = 1; }
+    p.printlnf("matches platform={}", agree);
+
+    ret 0;
+}


### PR DESCRIPTION
Closes #3004

## The spelling

`#[abi_type("va_list")]` on a bodyless `def`, which needs no mach-std change.

```mach
#[abi_type("va_list")]
def VaList;

pub def TraceLogCallback: fun(i32, *u8, VaList) i64;

#[library("raylib")]
ext fun SetTraceLogCallback(cb: TraceLogCallback);
```

Chosen over `$va_list` because it is what the codebase already does for a
target-supplied type. `#[handle(target, constructor, operands...)]` (#2888) is
exactly this shape: a bodyless `def` whose representation is not the program's,
declared by a directive and filled in by the target. There is no `$`-sigil type
form to extend - `$if`, `$each` and `$error` are comptime *statements* - so a
`$va_list` would be a new grammar for one type. A `std.ffi.VaList` would need the
layout to come from mach-std, which is a separate repo with its own pin, and a
cross-repo change would block this.

The name is an argument rather than a bare `#[va_list]` because that is the axis
this grows along: a second C type whose layout the target declares (`jmp_buf`,
`fpos_t`) is a tag in `type.mach`, a row in each os vtable, and a name in the
closed set - never a second directive and never a second type kind. The set is
closed in the front end for the reason `#[op]`'s instruction names are: which
target a module is built for is not a property of the source.

## The declared fact

`OsVTable.va_list_layout`, a per-architecture policy, sibling of `variadic_stack`
and there for the same reason. Darwin and linux compose the very same `aapcs64`
convention vtable and disagree about `va_list` outright (`char *` vs the 32-byte
composite), so no calling convention can answer it and no machine model implies it.
`target.select` resolves it once onto `Target.va_list_size` / `va_list_align`.

| Target | declared |
|---|---|
| linux x86_64 / riscv64 | (8, 8) |
| **linux aarch64** | **(32, 8)** |
| darwin x86_64 / aarch64 | (8, 8) |
| windows x86_64 / aarch64 | (8, 8) |
| freestanding x86_64 / riscv64 | (8, 8), aarch64 (32, 8), riscv32 (4, 4) |

`os.register` now returns a `Result` and **refuses** an OS that lists an
architecture in `supported_isas` with no declaration, shaped after
`abi/riscv.mach`'s `install`. A `supported_isa_any` OS has no list to check, so the
same question is asked of it at the declaration that demands a layout.

The type is `TYPE_ABI`, an opaque aggregate of the declared extent, which lowers to
an IR struct of `[size]u8` at the declared alignment - so AAPCS64's over-16-bytes
by-reference rule and every other convention's register rule apply with no special
case.

## The part the issue did not predict, now split out

The issue's fix says a `va_list` parameter "rides the EXISTING aggregate-by-reference
path, which already makes the caller copy and pass an address". It did not. That
turned out to be a pre-existing ABI defect affecting **every** by-reference aggregate
at a foreign boundary, independent of `va_list`, and it is now **#3063**, fixed and
merged separately in #3064.

This branch no longer carries it. `src/lang/be/codegen/mir/abi.mach` is byte-identical
to `dev` here, and the va_list case still passes on aarch64-linux with the fix
arriving from `dev` (`965ed4d2`) rather than from this branch - which is also
independent confirmation that the split preserved the behaviour.

## Constant blocks extended

Re-checked against `dev` at `9a79f3b6`, reading the blocks rather than trusting the
earlier look: `TYPE_HANDLE = 21` is still the TypeKind high-water mark and
`NODE_ZERO = 6` still the last NodeKind, and both blocks are dense with **no
duplicate values** (TypeKind 0-22, NodeKind 0-7).

- `src/lang/type.mach`: `TYPE_ABI: TypeKind = 22` (after `TYPE_HANDLE = 21`)
- `src/lang/layout.mach`: `NODE_OPAQUE: NodeKind = 7` (after `NODE_ZERO = 6`)
- `src/lang/type.mach`: `ABI_TYPE_VA_LIST: u32 = 0`, a new block of its own

## Exclusions

Reading, constructing or storing one is refused where it is written, each naming
the exclusion: local binding, record or union field, global, return position,
behind a pointer or inside an array, and `::` / `:~` in either direction. The cast
refusal is the one that had to be written down - `:~` asks only for two equal
sizes, and on the four eight-byte platforms `ap :~ ptr` would hand the program the
cursor.

`$size_of` / `$align_of` answer with the declared numbers, and sema's fold and
lowering's fold agree (the #2672 rule).

## Verification

Rebased onto `dev` at `9a79f3b6` and every number re-measured against that tree, not
carried over from the pre-split branch.

- `mach build . && mach test .`: **1534 passed, 0 failed**. `dev` at `9a79f3b6`
  measures **1528**, built and run here rather than assumed, so the delta is exactly
  the six tests this adds: 2 in `src/lang/target/os.mach` (`va_list_for` nil-safety,
  the registration refusal) and 4 in `src/lang/driver/tests.mach` (per-target extent,
  forward-only exclusions, no casts, closed name set).
- `test/link/run.sh`: 147 pass / 0 fail (143 on `dev` plus this case's four cells).
- `test/run.sh` (codegen corpus): 1416 pass / 0 fail. No golden churn - a corpus case
  makes no `ext` call.
- Three-generation fixpoint: seed-built A, A-built B, B-built C all byte-identical.
- Cross-target: the case builds for all five targets. Executed locally on
  x86_64-linux natively, and on aarch64-linux under qemu. The local riscv64 run used
  a stub sysroot (these probes include only `<stdarg.h>`, which clang supplies
  itself), so treat riscv64 as **CI-verified** rather than locally verified.
- `bash .github/scripts/check-changelog.sh CHANGELOG.md` exits 0: one
  `## [Unreleased]`, one `### Added`, one `### Fixed`. The `#### link: …` entry is
  appended under `dev`'s existing `### Added`; `git diff origin/dev -- CHANGELOG.md`
  has zero deletions, so nothing of #3060's or #3063's was lost.

### Every new guard shown going red

Each mutation was applied alone against this branch and fails exactly its own test:

| mutation | fails |
|---|---|
| linux aarch64 `va_list` (32,8) → (8,8) | `a_va_list_extent_comes_from_the_target` |
| placement + local-binding refusals disabled | `a_va_list_may_only_be_forwarded` |
| cast / reinterpret refusal disabled | `a_va_list_cannot_be_cast` |
| `os.register` va_list check disabled | `register:refuses_an_undeclared_va_list` |
| `abi_type` name set opened | `an_abi_type_name_is_closed` |

The acceptance criterion's "AAPCS64-linux is the leg that fails without the fix" is
carried by #3064, whose own case reports `wide intact=-1 -2 -3 -4` on aarch64-linux
and riscv64-linux with its one branch disabled, and leaves x86_64-linux unchanged.

## The link case

`test/link/cases/va-list/`. C originates a `va_list`, hands it to a mach function
through a callback pointer (the `SetTraceLogCallback` shape, and no agreement needed
about how a mach symbol is spelled in a C object), and mach forwards it to a C
consumer that reads it with `va_arg`.

The case tests `va_list` and nothing else: the by-value aggregate half that lived
here before the split moved to #3064's own
`test/link/cases/ext-byval-aggregate/`, so neither case depends on the other.

**The golden is agreement with the platform, not a pair of numbers,** because the
correct pair differs per platform: two forwards of one list read argument one twice
where `va_list` is a caller-copied composite and arguments one then two where it is
a pointer into shared state, and both are the platform behaving correctly. The case
runs the identical experiment through the runner's own compiler as its control, so
what is asserted is that mach's copy semantics are its platform's.

**Substitution, called out:** the consumer is a `va_arg` reader in `probe.c` rather
than `vsnprintf`. Reaching `vsnprintf` means linking libc on all five legs, which
the sibling `c-variadic` case deliberately avoids (mach-std makes raw syscalls) - it
would be glibc, libSystem and msvcrt entries in the manifest for no extra
observable. The probe is built at `-O0` rather than `-O1`: the C control measures
whether a `va_list` *parameter* is caller-copied, and inlining removes the parameter
pass being measured.

## Not done

Nothing from the acceptance list. The two local gaps are environment, not scope:
aarch64-linux and the darwin / windows legs have no runner on this host, so the
arm64 evidence is qemu plus disassembly rather than native silicon, and CI's
`ubuntu-24.04-arm` leg is what settles it.

### CI, this branch

Every check green. The link case executed on all four legs the pr lane runs, both
profiles each:

| leg | engine | result |
|---|---|---|
| x86_64-linux | native | PASS debug + release |
| **aarch64-linux** | **native arm silicon** | **PASS debug + release** |
| riscv64-linux | qemu | PASS debug + release |
| x86_64-windows | native | PASS debug + release |

The aarch64-linux row is the acceptance criterion's leg, settled on real hardware
rather than the local qemu run. The two darwin legs run on the release gate
(`test-main.yml`), the same cadence its sibling `c-variadic` has.
