### PR TITLE
fix(abi): make the caller own the copy of a by-reference aggregate at an ext call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### abi: a C callee wrote through into the caller's object (#3063)
+
+A C function that overwrites a by-value aggregate parameter overwrote the **mach
+caller's own object**. Silent memory corruption: the call links, returns, and leaves
+the caller's data rewritten.
+
+```mach
+rec Wide { a: i64; b: i64; c: i64; d: i64; }
+ext fun clobber(w: Wide) i64;   # the callee's writes reached the caller's `w`
+```
+
+```
+x86_64-linux    byval intact=1 2 3 4      <- control, correct
+aarch64-linux   byval intact=-1 -2 -3 -4  <- the caller's object was overwritten
+```
+
+AAPCS64, the RISC-V psABI and the Microsoft convention all pass an aggregate too
+large for registers as the address of a copy **the caller allocates**, so the callee
+may overwrite its parameter freely. System V passes one over sixteen bytes by value
+on the stack instead, where the copy already exists - which is why x86-64 is a real
+control rather than a leg that happens to pass.
+
+**Two ends, one copy, and only one of them was mach's.** `CLASS_BYREF` passed the
+address of the argument's own storage, and a mach callee then gave every parameter
+storage of its own and copied the incoming aggregate into it at entry. While both
+ends are mach the two are indistinguishable. A C callee copies nothing, so at an
+`ext` call it was handed mach's object directly.
+
+That is unobservable for a callee which only reads its parameter, which is the
+overwhelmingly common case and is why the defect survived. It needs a callee that
+WRITES to its by-value parameter to show, and a `va_list` is the by-value parameter
+every consumer advances - which is how #3004 found it.
+
+The caller now allocates a frame temporary at the aggregate's own alignment, copies
+into it, and passes the temporary's address. Gated on the `ext` boundary, because
+this is a divergence between two conventions rather than a defect in one: an
+internal call already copies, at the callee, and copying at both ends would add one
+redundant copy per aggregate argument to every mach-to-mach call. Unifying on
+caller-copy internally and dropping the callee-side copy is arguably the cleaner
+model and is a separate decision - it changes the internal convention on every
+target, including the two that were already correct.
+
 ## [4.25.0] - 2026-08-21
 
 

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1112,7 +1112,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         val argop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](aor);
 
         val er: R.Result[bool, str] = emit_arg_slot(ctx, mb, slot, argop, soff, aag, av.ty,
-                                                    natural_stack_slot(ctx.tgt, pidx >= layout.param_count));
+                                                    natural_stack_slot(ctx.tgt, pidx >= layout.param_count),
+                                                    is_ext);
         if (R.is_err[bool, str](er)) {
             sig_layout_free(ctx, ?layout);
             ret er;
@@ -1378,8 +1379,40 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
 #            against it (the Apple arm64 fixed rule)
 # ret:       ok(true) on success, or a loud error
 fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
-                  stack_off: i64, is_aggr: bool, ty: type.IrTypeId, natural: bool) R.Result[bool, str] {
+                  stack_off: i64, is_aggr: bool, ty: type.IrTypeId, natural: bool,
+                  is_ext: bool) R.Result[bool, str] {
     val size: u64 = type.byte_size(ctx.types, ty, ctx.tgt)::u64;
+
+    # THE CALLER OWNS THE COPY AT A FOREIGN BOUNDARY (#3004). AAPCS64, the RISC-V
+    # psABI and the Microsoft convention all say the same thing about an aggregate
+    # passed by reference: the CALLER allocates a copy and passes its address, so the
+    # callee may advance or overwrite its parameter without touching the caller's
+    # object. mach's own convention reaches the same semantics from the other end -
+    # a mach callee gives every parameter storage of its own and copies the incoming
+    # aggregate into it at entry - and the two are indistinguishable while both ends
+    # are mach.
+    #
+    # They are not indistinguishable at an `ext` call. A C callee copies nothing, so
+    # handing it the address of mach's own object lets it write through to it. That
+    # is unobservable for a callee that only reads its parameter, which is why it
+    # stood: what made it visible is `va_list`, a by-value parameter every consumer
+    # ADVANCES, so a forwarded one comes back spent.
+    #
+    # Gated on `is_ext` because it is a difference between two conventions rather
+    # than a fix to one: mach->mach already copies, at the callee, and copying at
+    # both ends would be one redundant copy per aggregate argument on every internal
+    # call. `is_ext` is the axis that already carries exactly this kind of divergence
+    # (win64's vector marshal, #2058).
+    if (is_ext && is_aggr && (slot.class == abi.CLASS_BYREF || slot.class == abi.CLASS_STACK_BYREF)) {
+        var owned: u32 = mir.MIR_VREG_NIL;
+        val cr: R.Result[bool, str] = copy_aggregate_to_temp(ctx, mb, argop, ty, ?owned);
+        if (R.is_err[bool, str](cr)) { ret cr; }
+        if (slot.class == abi.CLASS_STACK_BYREF) {
+            val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
+            ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(owned));
+        }
+        ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(owned), ptr_move_width(ctx));
+    }
     # a register-resident value marshalled by reference (a 128-bit vector at a win64 `ext`
     # boundary, #2058): unlike an aggregate or a scalarized rv64 vector -- already
     # memory-resident, its argop a storage pointer -- the value is in a register, so the
@@ -1475,6 +1508,38 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     # backend re-extends it to the register width by its own convention (the RV64 lp64 family
     # sign-extends a 32-bit register).
     ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
+}
+
+# copy a memory-resident aggregate into a fresh frame temporary at its own alignment
+# and return the temporary's address in a vreg
+#
+# The by-reference twin of `spill_vector_to_temp`: that one exists because the value
+# is in a register and has no address yet, this one because the value HAS an address
+# and the foreign convention requires a different one. Both allocate at the type's
+# own alignment rather than at its size, which for an aggregate is the only number
+# that is a legal slot alignment at all.
+# ---
+# ctx:      the active lowering context
+# mb:       the MIR block the copy / address materialization are appended to
+# src:      the aggregate's storage pointer
+# ty:       the aggregate's IR type (the temp's size and alignment, and the copy length)
+# out_addr: receives the vreg holding the temporary's address
+# ret:      ok(true) on success, or a loud error
+fun copy_aggregate_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, src: mir.MirOperand,
+                           ty: type.IrTypeId, out_addr: *u32) R.Result[bool, str] {
+    val size:  u64 = type.byte_size(ctx.types, ty, ctx.tgt)::u64;
+    val align: u32 = type.byte_align(ctx.types, ty, ctx.tgt);
+    val res_key: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](res_key)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_key)); }
+    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+
+    val sr: R.Result[bool, str] = context.add_spill_slot_aligned(ctx, sk, size, align);
+    if (R.is_err[bool, str](sr)) { ret sr; }
+
+    val cr: R.Result[bool, str] = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), src, size);
+    if (R.is_err[bool, str](cr)) { ret cr; }
+
+    ret context.emit_lea_slot(ctx, mb, mir.op_mem_slot(sk, 0), out_addr);
 }
 
 # store a register-resident vector to a fresh 16-byte-aligned frame temporary and

--- a/test/link/cases/ext-byval-aggregate/case.conf
+++ b/test/link/cases/ext-byval-aggregate/case.conf
@@ -1,0 +1,25 @@
+# A C callee overwrites every field of a by-value aggregate parameter, and the mach
+# caller's object must be untouched (mach #3063). The callee is built by the
+# RUNNER'S own toolchain, so what it does with its parameter is the platform's real
+# convention rather than mach's model of it.
+#
+# THE DEFECT THIS GUARDS IS SILENT MEMORY CORRUPTION. AAPCS64, the RISC-V psABI and
+# the Microsoft convention all pass an aggregate too large for registers as the
+# address of a copy the CALLER allocates, and mach passed the address of its own
+# object. Nothing fails: the call links, returns, and leaves the caller's object
+# rewritten. Against the unpatched compiler this case reports
+# `wide intact=-1 -2 -3 -4` on aarch64-linux and riscv64-linux.
+#
+# WHICH LEGS ARE EVIDENCE AND WHICH ARE CONTROLS. aarch64-linux, riscv64-linux and
+# x86_64-windows pass the 32-byte aggregate by reference and are where the defect
+# lives. x86_64-linux and x86_64-darwin pass it by value on the stack, so the copy
+# already exists and they must be UNCHANGED - a fix that repaired the by-reference
+# conventions by breaking the by-value one would fail them. The 16-byte `pair` is
+# the windows leg's own by-reference case at a size where the arm64 and System V
+# legs use registers, so the rule is shown following the convention rather than the
+# byte count.
+#
+# The probe is built at -O0. The C writes are dead in the C sense, and at -O1 clang
+# deletes them outright - the probe would then measure nothing and the case would
+# pass against a compiler carrying the defect.
+run: exec

--- a/test/link/cases/ext-byval-aggregate/expect.txt
+++ b/test/link/cases/ext-byval-aggregate/expect.txt
@@ -1,0 +1,3 @@
+wide ret=-10 intact=1 2 3 4
+pair ret=-11 intact=7 8
+again ret=-10 intact=1 2 3 4

--- a/test/link/cases/ext-byval-aggregate/mach.toml
+++ b/test/link/cases/ext-byval-aggregate/mach.toml
@@ -1,0 +1,71 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.x86_64-linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.aarch64-linux]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.riscv64-linux]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64d"
+
+[target.x86_64-windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.aarch64-darwin]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.x86_64-darwin]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "sh ../../lib/cc.sh -c -O0 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/test/link/cases/ext-byval-aggregate/probe.c
+++ b/test/link/cases/ext-byval-aggregate/probe.c
@@ -1,0 +1,38 @@
+/* the C half of the by-value aggregate case (mach #3063).
+ *
+ * Compiled by the RUNNER'S OWN C toolchain, so the callee's treatment of its
+ * parameter is the platform's real calling convention rather than mach's model of
+ * it. Each function OVERWRITES every field of a by-value parameter, which C says
+ * the caller cannot observe - and which mach's caller could observe, because it
+ * handed over the address of its own object instead of the address of a copy.
+ *
+ * WHY -O0. The writes are dead in the C sense: nothing reads the parameter after
+ * them that an optimizer cannot fold. At -O1 clang deletes the stores outright and
+ * the probe measures nothing at all, so the case would pass against a compiler with
+ * the defect. The instrument has to perform the writes for the measurement to
+ * exist, and this is the one flag that guarantees it. */
+
+struct wide { long long a, b, c, d; };
+struct pair { long long a, b; };
+
+/* 32 bytes: by reference under AAPCS64, the RISC-V psABI and the Microsoft
+ * convention; by value on the stack under System V, where the copy already exists
+ * and there is nothing to get wrong. */
+long long clobber_wide(struct wide w) {
+    w.a = -1;
+    w.b = -2;
+    w.c = -3;
+    w.d = -4;
+    return w.a + w.b + w.c + w.d;
+}
+
+/* 16 bytes: two registers under AAPCS64, System V and lp64d, and BY REFERENCE
+ * under the Microsoft convention, which passes anything that is not 1, 2, 4 or 8
+ * bytes that way. It is here so the windows leg exercises the by-reference path at
+ * a size where the arm64 and System V legs do not - the rule this case is about
+ * follows the convention, not the byte count. */
+long long clobber_pair(struct pair p) {
+    p.a = -5;
+    p.b = -6;
+    return p.a + p.b;
+}

--- a/test/link/cases/ext-byval-aggregate/src/main.mach
+++ b/test/link/cases/ext-byval-aggregate/src/main.mach
@@ -1,0 +1,60 @@
+# by-value aggregate at an `ext` boundary (mach #3063)
+#
+# A C function overwrites every field of a by-value aggregate parameter, and the
+# mach caller's own object must be untouched. AAPCS64, the RISC-V psABI and the
+# Microsoft convention pass an aggregate too large for registers as the address of a
+# copy THE CALLER ALLOCATES, and the callee writes through that address as its own
+# parameter - so a caller that hands over the address of its own object instead sees
+# it overwritten. That is silent memory corruption, not a link error and not a
+# crash.
+#
+# THE OBSERVABLE IS THE CALLER'S OBJECT AFTER THE CALL, read in mach. It is the same
+# text on every target, because "a by-value parameter is the callee's own" is not a
+# platform-specific claim - only the mechanism that delivers it is.
+#
+# x86_64-linux and x86_64-darwin are CONTROLS rather than legs that happen to pass:
+# System V passes an aggregate over sixteen bytes by value on the stack, so the copy
+# already exists there. A change that fixed the by-reference conventions by breaking
+# the by-value one would fail them.
+#
+# `va_list` (mach #3004) is the parameter that made this visible - every consumer of
+# one ADVANCES it, so a forwarded list came back spent - but it is not what the
+# defect is about, and this case deliberately does not mention it. A guard living
+# inside the `va_list` case would disappear with that feature.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec Wide { a: i64; b: i64; c: i64; d: i64; }
+rec Pair { a: i64; b: i64; }
+
+ext fun clobber_wide(w: Wide) i64;
+ext fun clobber_pair(p: Pair) i64;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # 32 bytes: by reference on every convention but System V.
+    var w: Wide;
+    w.a = 1;
+    w.b = 2;
+    w.c = 3;
+    w.d = 4;
+    val rw: i64 = clobber_wide(w);
+    p.printlnf("wide ret={} intact={} {} {} {}", rw, w.a, w.b, w.c, w.d);
+
+    # 16 bytes: registers on AAPCS64, System V and lp64d, by reference on win64.
+    var q: Pair;
+    q.a = 7;
+    q.b = 8;
+    val rp: i64 = clobber_pair(q);
+    p.printlnf("pair ret={} intact={} {}", rp, q.a, q.b);
+
+    # the same object handed over twice: the second call must see the ORIGINAL
+    # values, which is the shape a caller that reused one temporary would fail even
+    # after allocating one.
+    val rw2: i64 = clobber_wide(w);
+    p.printlnf("again ret={} intact={} {} {} {}", rw2, w.a, w.b, w.c, w.d);
+
+    ret 0;
+}


### PR DESCRIPTION
Closes #3063

Split out of #3062, where the defect was found. The commit is the same one, rebased
onto current `dev`, plus a standalone regression case and the changelog entry.

## The fix

The caller allocates a frame temporary at the aggregate's own alignment, copies into
it, and passes the temporary's address. `copy_aggregate_to_temp` is the by-reference
twin of the existing `spill_vector_to_temp`: that one exists because the value is in
a register and has no address yet, this one because the value **has** an address and
the foreign convention requires a different one.

Gated on `is_ext`, exactly as the issue specifies. The rejected alternative -
unifying internal calls on caller-copy and dropping the callee-side copy - is left
alone; the note explaining why lives in the comment at the branch, not only here.

Both by-reference classes are covered, `CLASS_BYREF` and `CLASS_STACK_BYREF` (the
win64 exhausted-slot case, where the copy's address goes to the stack rather than to
a register).

## The regression case

`test/link/cases/ext-byval-aggregate/`, standalone and not mentioning `va_list` -
a guard living inside the `va_list` case would disappear with that feature.

- **`Wide`, 32 bytes** - by reference under AAPCS64, the RISC-V psABI and the
  Microsoft convention; by value on the stack under System V.
- **`Pair`, 16 bytes** - two registers under AAPCS64, System V and lp64d, and **by
  reference under the Microsoft convention**, which passes anything that is not 1,
  2, 4 or 8 bytes that way. It is the windows leg's own by-reference case at a size
  where the other legs use registers, so the rule is shown following the convention
  rather than the byte count.
- **The same object handed over twice**, which a caller that allocated one temporary
  and reused it would still fail.

The probe is built at `-O0`. The C writes are dead in the C sense, and at `-O1`
clang deletes the stores outright - the probe would then measure nothing and the
case would pass against a compiler carrying the defect. That is written down in
`case.conf` and in `probe.c`, because it is the one flag the measurement depends on.

## Acceptance

> A C callee that overwrites a by-value aggregate parameter leaves the mach caller's
> object untouched on aarch64-linux, riscv64-linux and x86_64-windows.

Executed locally on aarch64-linux and riscv64-linux under qemu, both reporting
`wide ret=-10 intact=1 2 3 4`. x86_64-windows has no runner on this host and is
settled by CI below.

> x86_64-linux and the darwin legs are unchanged, and shown unchanged rather than
> assumed.

x86_64-linux is in the mutation table below: it reports the same three lines with
the fix and without it, which is the shape a control has to have. The darwin legs
run on the release gate.

> An internal mach-to-mach call gains no second copy.

The codegen corpus is 1416 pass / 0 fail with **zero golden churn**, and a corpus
case makes no `ext` call - every call in it is internal. A second copy on an
internal call would move the disassembly of every aggregate-passing case on
aarch64-linux and riscv64-linux.

> A link case executes the repro on every leg whose runner has a C toolchain, and is
> shown reporting the clobbered values against the unpatched compiler.

Below.

## The guard shown going red

The one branch this PR adds was disabled (`if (false && …)`) and the case re-run on
each leg:

| leg | with the fix | with it disabled |
|---|---|---|
| x86_64-linux | `wide intact=1 2 3 4` | `wide intact=1 2 3 4` (**control, unchanged**) |
| aarch64-linux | `wide intact=1 2 3 4` | `wide intact=-1 -2 -3 -4` |
| riscv64-linux | `wide intact=1 2 3 4` | `wide intact=-1 -2 -3 -4` |

`pair` is unaffected on all three, since 16 bytes rides registers on each - the
windows leg is where that line carries its signal.

## Verification

- `mach build . && mach test .`: **1528 passed, 0 failed**. `dev` at `1b95ce14`
  measures **1528** too, so the delta is exactly zero: this branch adds no unit test.
  That is deliberate - the guard is the link case, because the defect is only
  observable against a foreign toolchain and mach's own objects can be
  self-consistently wrong about a calling convention. (Measured by building `dev`
  itself, not inferred from the diff.)
- `test/link/run.sh`: 143 pass / 0 fail (139 on `dev` plus this case's four cells).
- `test/run.sh` (codegen corpus): 1416 pass / 0 fail, no golden churn.
- From-source `out/linux-x86_64/debug/bin/mach` throughout, never the 4.25.0 seed.

## Follow-on

#3062 (`va_list`, #3004) currently carries this commit. Once this merges I will
rebase it, drop the commit, and move the by-value pieces out of its case so the two
do not overlap.

### CI, this branch

Every check green. The case executed on all four legs the pr lane runs, both
profiles each:

| leg | engine | by-reference there? | result |
|---|---|---|---|
| x86_64-linux | native | no, System V stacks it | PASS (control) |
| **aarch64-linux** | **native arm silicon** | yes | **PASS** |
| **riscv64-linux** | qemu | yes | **PASS** |
| **x86_64-windows** | native | yes, and `Pair` too | **PASS** |

That is all three legs the acceptance criterion names, plus the control. The
windows leg is the one I could not run locally, and it is also the only leg where
the 16-byte `Pair` line carries signal.


## Merged `dev` in for the changelog heading

`#3060` added a `## [Unreleased]` heading while this was being split, so this branch
merged `origin/dev` (`1b95ce14`) and folded its own `### Fixed` under that single
heading rather than adding a second one - which is the case
`.github/scripts/check-changelog.sh` exists to fail. `#### abi: ...` is unchanged;
`### Fixed` and `#3060`'s `### Added` do not clash, so the per-kind rule holds too.
`changelog headings` is green above, and every number in this PR was re-measured
against the merged tree rather than carried over.
