### PR TITLE
fix(sema): size the deep-secret walk's visited set to the type universe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,34 @@ write goes through a kernel32 import, so its premise fails rather than its expec
 
 ### Fixed
 
+#### sema: a large type graph was mistaken for a secret one (#3065)
+
+A program containing no `^` anywhere was rejected for secrecy, once at every pointer
+erasure it performed, with a diagnostic about a concept it never used:
+
+```
+error: cast: a secret-welded pointer cannot be erased to the untyped `ptr`
+  = note: secret memory is reached only through secrecy-typed pointers; erasing `^` to
+    `ptr` would let a public alias read it
+```
+
+The deep-secret walk carried a fixed 256-entry visited set and treated a graph that
+filled it as possibly-secret. **Failing closed is right for a walk that has run out of
+room; the defect was that the room was a constant**, which made the exit reachable by
+program size rather than by the allocator. A game's ECS scene record, which
+transitively names fourteen component stores, crossed it at 257 distinct nominals -
+one over. Adding a fifteenth component to a program is not a secrecy event, and neither
+is any other way of growing a type graph.
+
+The visited set now belongs to the interner that owns the type table every `TypeId`
+indexes, one epoch-stamped slot per `TypeId`, so its capacity grows on the same axis
+the graph does and a walk can only run out of room when the allocator does. Marking and
+testing are O(1), which also retires a linear rescan that made each walk quadratic in
+graph size. A full self-build is about 6% faster.
+
+The rule itself is unchanged: a real `^` anywhere in a graph of any size is still
+found, and a cyclic graph still terminates.
+
 #### abi: a C callee wrote through into the caller's object (#3063)
 
 A C function that overwrites a by-value aggregate parameter overwrote the **mach

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9635,6 +9635,110 @@ test "mach.lang.driver:deep_secrecy_pointer_and_union" {
     ret bad;
 }
 
+# a module of `n` chained records - `R0` carrying `r0`'s fields, each `Ri` wrapping
+# `R(i-1)` - followed by `tail`
+#
+# Built at runtime rather than written out, because the graph sizes that matter to a
+# visited-set bound are in the hundreds. Every link is a DISTINCT nominal a deep type walk
+# must enter, so `n` is exactly the visited-set size that walk needs, and `r0` is where a
+# secret or a back-edge is planted at the FAR end of it.
+# ---
+# alloc: allocator owning the result and every intermediate
+# n:     number of chained records
+# r0:    the field list of `R0`
+# tail:  the module text appended after the chain
+# ret:   the source text, owned by the caller, or none on an allocation failure
+fun ut_chain_src(alloc: *A.Allocator, n: u32, r0: str, tail: str) O.Option[str] {
+    val head: R.Result[str, str] = format.sprint(alloc, "rec R0 {{ {} }}\n", r0);
+    if (R.is_err[str, str](head)) { ret O.none[str](); }
+    var acc: str = R.unwrap_ok[str, str](head);
+
+    var i: u32 = 1;
+    for (i < n) {
+        val next: R.Result[str, str] = format.sprint(alloc, "{}rec R{} {{ a: R{}; }}\n", acc, i, i - 1);
+        A.deallocate[char](alloc, acc::*char, str_len(acc) + 1);
+        if (R.is_err[str, str](next)) { ret O.none[str](); }
+        acc = R.unwrap_ok[str, str](next);
+        i = i + 1;
+    }
+
+    val whole: R.Result[str, str] = format.sprint(alloc, "{}{}", acc, tail);
+    A.deallocate[char](alloc, acc::*char, str_len(acc) + 1);
+    if (R.is_err[str, str](whole)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](whole));
+}
+
+# constant-time (#3065): the deep-secret walk is bounded by the ALLOCATOR, not by a
+# constant, so a merely LARGE type graph is not mistaken for a secret one
+#
+# The walk carried a fixed 256-entry visited set and treated a graph that filled it as
+# possibly-secret. That is the safe direction for a walk that has run out of room, but the
+# bound was reachable by an ordinary program: an ECS whose scene record transitively named
+# a dozen-odd component stores crossed it, and every `p::ptr` in it then failed with a
+# diagnostic about a `^` the program did not contain anywhere. Correct code became
+# uncompilable, and the message pointed at a concept the program never used.
+#
+# THE FIRST TWO ARMS ARE A PAIR, and only the pair says anything. A walk that gives up
+# rejects BOTH a public graph and a secret one, so the public arm alone is satisfied by a
+# walk that stopped early, and the secret arm alone by a walk that never ran. Held
+# together they say the walk reached the far end of the graph and read what was there
+test "mach.lang.driver:deep_secret_walk_scales_with_the_type_graph" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+
+    # comfortably past the 256 the visited set used to hold, so a bound reintroduced at
+    # that size - or at the 256-slot power of two the set now grows through - fails here.
+    val n: u32 = 320;
+
+    val tr: R.Result[str, str] = format.sprint(?alloc, "fun e(p: *R{}) ptr {{ ret p::ptr; }}\nfun main() i32 {{ ret 0; }}\n", n - 1);
+    if (R.is_err[str, str](tr)) { ret 1; }
+    val tail: str = R.unwrap_ok[str, str](tr);
+
+    # the back-edge `R0` closes the chain with, named off `n` so the two cannot drift.
+    val br: R.Result[str, str] = format.sprint(?alloc, "a: *R{};", n - 1);
+    if (R.is_err[str, str](br)) { ret 1; }
+    val back: str = R.unwrap_ok[str, str](br);
+
+    # ARM 1 - `n` nominals, no `^` anywhere, erasing a pointer to `ptr`: COMPILES.
+    val pub_src: O.Option[str] = ut_chain_src(?alloc, n, "a: u32;", tail);
+    if (O.is_none[str](pub_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](pub_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 2 - the same `n` nominals with a real `^` at the FAR END of the chain: still
+    # REJECTED, and by the erasure rule rather than by anything else. Lifting the bound
+    # must not turn the walk into a hole in the rule it guards.
+    val sec_src: O.Option[str] = ut_chain_src(?alloc, n, "a: ^u32;", tail);
+    if (O.is_none[str](sec_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](sec_src);
+        if (ut_vec_diag(src, "secret-welded pointer cannot be erased") != 0) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 3 - A CYCLE INSIDE A LARGE GRAPH still terminates: `R0` points back at the
+    # deepest link, so the chain closes on itself and the walk re-enters a nominal it has
+    # already marked. The cycle guard is the whole reason the visited set exists, and a set
+    # REUSED across walks is exactly where a stale mark would break it - a walk that read
+    # the previous walk's marks as its own would cut this graph short rather than walk it,
+    # and one that read none of its own would not come back at all.
+    val cyc_src: O.Option[str] = ut_chain_src(?alloc, n, back, tail);
+    if (O.is_none[str](cyc_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](cyc_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    A.deallocate[char](?alloc, back::*char, str_len(back) + 1);
+    A.deallocate[char](?alloc, tail::*char, str_len(tail) + 1);
+    ret bad;
+}
+
 # block-scoped fin structural rules: control flow cannot cross the fin boundary
 # outward - a `ret` inside a fin body is rejected, as is a `brk` / `cnt` whose
 # target loop encloses the fin; a loop fully inside the fin body keeps `brk` /

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -306,9 +306,11 @@ pub fun ensure_fields(s: *session.Session, tid: type.TypeId) {
 # tid: the type to inspect
 # ret: true when `tid` reaches a `^` through any pointer / array / field
 pub fun contains_secret_deep(s: *session.Session, tid: type.TypeId) bool {
-    var scan: type.SecretScan;
-    scan.len = 0;
-    ret secret_deep_walk(s, tid, ?scan);
+    var scan: type.TypeScan;
+    type.type_scan_begin(?s.types, ?scan);
+    val found: bool = secret_deep_walk(s, tid, ?scan);
+    type.type_scan_end(?s.types, ?scan);
+    ret found;
 }
 
 # whether a type KIND is a known secret-FREE leaf: an integer / float scalar or the raw
@@ -331,7 +333,7 @@ fun kind_is_public_leaf(k: type.TypeKind) bool {
 # whether a function TYPE's signature carries a secret: any parameter type or the return
 # type deep-carries a `^` (#2165). A reinterpret can round-trip the whole signature, so a
 # secret anywhere in it welds the function type.
-fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.SecretScan) bool {
+fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.TypeScan) bool {
     if (secret_deep_walk(s, t.data.fn.ret_type, scan)) { ret true; }
     var pi: u32 = 0;
     for (pi < t.data.fn.params_len) {
@@ -345,7 +347,7 @@ fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.Secret
 }
 
 # the recursive worker for `contains_secret_deep`, threading the visited set
-fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
+fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.TypeScan) bool {
     val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
     if (O.is_none[*type.Type](opt_type)) { ret false; }
     val t: *type.Type = O.unwrap[*type.Type](opt_type);
@@ -356,17 +358,13 @@ fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSc
     if (t.kind == type.TYPE_FUN)     { ret fn_sig_carries_secret(s, t, scan); }
 
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
+        val mark: type.VisitMark = type.type_scan_mark(?s.types, scan, tid);
         # an already-visited nominal contributes no new secret (its fields were fully
         # explored on the first visit); this also terminates a cyclic record graph.
-        var i: u32 = 0;
-        for (i < scan.len) {
-            if (scan.seen[i] == tid) { ret false; }
-            i = i + 1;
-        }
-        # a graph beyond the visited-set bound fails CLOSED (never under-reports).
-        if (scan.len >= 256) { ret true; }
-        scan.seen[scan.len] = tid;
-        scan.len = scan.len + 1;
+        if (mark == type.VISIT_SEEN) { ret false; }
+        # a nominal the visited set could not record leaves the walk unbounded from here,
+        # so it fails CLOSED (never under-reports).
+        if (mark == type.VISIT_FAILED) { ret true; }
 
         # materialize a generic instance's field table from its template, independent of
         # whether/when lazy elaboration ran, so the walk never reads an absent table as
@@ -714,19 +712,21 @@ fun sse_deep_walk(s: *session.Session, m: layout.Machine, a: type.TypeId, b: typ
 # Used to admit a reinterpret / union between differing-shape aggregates that are both
 # entirely secret: with no public byte on either side, no public alias can read a secret,
 # so the differing layout is safe. A cycle guard bounds a self-referential graph; an
-# over-deep or unresolvable graph fails closed (reported as NOT all-secret, so the
-# differing-shape pair is rejected - the safe direction).
+# unresolvable graph fails closed (reported as NOT all-secret, so the differing-shape
+# pair is rejected - the safe direction).
 # ---
 # s:   the session
 # tid: the type to inspect
 # ret: true when `tid` has no public-stored byte anywhere
 pub fun deep_all_secret(s: *session.Session, tid: type.TypeId) bool {
-    var scan: type.SecretScan;
-    scan.len = 0;
-    ret all_secret_walk(s, tid, ?scan);
+    var scan: type.TypeScan;
+    type.type_scan_begin(?s.types, ?scan);
+    val all: bool = all_secret_walk(s, tid, ?scan);
+    type.type_scan_end(?s.types, ?scan);
+    ret all;
 }
 
-fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
+fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.TypeScan) bool {
     # a `^T` value is entirely secret bytes (any inner public shape is still stored secret).
     if (type.is_secret(?s.types, tid)) { ret true; }
 
@@ -739,14 +739,13 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSca
     if (t.kind == type.TYPE_ARRAY)   { ret all_secret_walk(s, t.data.array.base, scan); }
 
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
-        var i: u32 = 0;
-        for (i < scan.len) {
-            if (scan.seen[i] == tid) { ret true; }
-            i = i + 1;
-        }
-        if (scan.len >= 256) { ret false; }
-        scan.seen[scan.len] = tid;
-        scan.len = scan.len + 1;
+        val mark: type.VisitMark = type.type_scan_mark(?s.types, scan, tid);
+        # a nominal already on the walk imposes no NEW public byte, so the cycle it closes
+        # cannot make the type less than all-secret.
+        if (mark == type.VISIT_SEEN) { ret true; }
+        # an unrecordable nominal fails CLOSED, which here is "not all secret" - the
+        # direction that REJECTS the differing-shape pair this predicate would admit.
+        if (mark == type.VISIT_FAILED) { ret false; }
 
         if (t.kind == type.TYPE_INSTANCE) { ensure_fields(s, tid); }
         val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -15,6 +15,7 @@
 use std.allocator.page;
 use std.collections.map;
 use std.crypto.hash.fnv1a;
+use std.memory;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -585,6 +586,10 @@ pub rec FieldTable {
 #                  table and rebuilds any table whose epoch is older, so a record's
 #                  field-type change on a long-lived session refreshes the cached
 #                  layout instead of leaving it stale (#1583)
+# visits:          pool of TypeId-keyed visited sets a graph walk borrows for its cycle
+#                  guard, one per level of nesting, checked out and returned in stack order
+# visits_len:      sets currently borrowed, which is the current nesting depth
+# visits_cap:      allocated sets in visits
 pub rec TypeInterner {
     a: *A.Allocator;
 
@@ -645,6 +650,10 @@ pub rec TypeInterner {
     field_pool_cap: u32;
 
     field_epoch: u32;
+
+    visits:     *VisitSet;
+    visits_len: u32;
+    visits_cap: u32;
 }
 
 # initial capacities for the interner's growable backing arrays
@@ -653,6 +662,9 @@ val INITIAL_PARAMS_CAP:      u32 = 32;
 val INITIAL_INSTANCE_CAP:    u32 = 16;
 val INITIAL_FIELD_TABLE_CAP: u32 = 16;
 val INITIAL_FIELD_POOL_CAP:  u32 = 64;
+# slots in a freshly allocated VisitSet, and sets in a freshly allocated pool
+val INITIAL_VISIT_CAP:       u32 = 64;
+val INITIAL_VISIT_DEPTH:     u32 = 4;
 
 # construct an empty interner with primitives pre-allocated
 # ---
@@ -689,6 +701,10 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
     ti.field_pool_cap = 0;
 
     ti.field_epoch = 0;
+
+    ti.visits     = nil;
+    ti.visits_len = 0;
+    ti.visits_cap = 0;
 
     ti.dedup       = map.init[Type, TypeId](a, hash_type, eq_type);
     ti.fun_index   = map.init[u64, TypeId](a, map.hash_u64, map.eq_u64);
@@ -783,6 +799,16 @@ pub fun dnit(ti: *TypeInterner) {
     if (ti.field_pool != nil && ti.field_pool_cap > 0) {
         A.deallocate[FieldEntry](ti.a, ti.field_pool, ti.field_pool_cap::usize);
     }
+    if (ti.visits != nil && ti.visits_cap > 0) {
+        var vi: u32 = 0;
+        for (vi < ti.visits_cap) {
+            if (ti.visits[vi].stamp != nil && ti.visits[vi].cap > 0) {
+                A.deallocate[u32](ti.a, ti.visits[vi].stamp, ti.visits[vi].cap::usize);
+            }
+            vi = vi + 1;
+        }
+        A.deallocate[VisitSet](ti.a, ti.visits, ti.visits_cap::usize);
+    }
 
     map.dnit[Type, TypeId](?ti.dedup);
     map.dnit[u64, TypeId](?ti.fun_index);
@@ -815,6 +841,10 @@ pub fun dnit(ti: *TypeInterner) {
     ti.field_pool_cap = 0;
 
     ti.field_epoch = 0;
+
+    ti.visits     = nil;
+    ti.visits_len = 0;
+    ti.visits_cap = 0;
 }
 
 # return a pointer to the Type for a given TypeId, or none when tid is out of
@@ -1085,6 +1115,11 @@ pub fun shape_kind(ti: *TypeInterner, tid: TypeId) TypeKind {
 # Follows `^` (true immediately), a typed pointer's pointee, and an array's
 # element. A nominal rec/uni is a leaf here (its secret fields are welded at the
 # field level), so the walk is over a finite spine and always terminates.
+#
+# `generics.contains_secret_deep` is the DEEP counterpart, recursing INTO nominal field
+# graphs. It lives there rather than here because a generic instance's field table is
+# materialized lazily and must be resolved before it can be walked, which is a dependency
+# `type` cannot reach.
 # ---
 # ti:  the interner
 # tid: the TypeId to inspect
@@ -1099,22 +1134,206 @@ pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret false;
 }
 
-# the cycle guard for the deep-secret walk: the set of nominal TypeIds already on the
-# walk, so a self-referential record graph terminates (#2162)
+# one visited set over the type universe: an epoch stamp per TypeId
 #
-# Reused by `generics.contains_secret_deep`, which is the DEEP counterpart to
-# `carries_secret` (it recurses INTO record / union / generic-instance field graphs).
-# The walk lives in `generics`, not here, because a generic-instance field table is
-# materialized lazily and must be resolved (`ensure_fields`) before it is walked - a
-# dependency `type` cannot reach. `carries_secret` stays the shallow spine predicate
-# (a nominal is a leaf), correct for the welded-storage rules it guards.
+# The epoch is what makes a set reusable without clearing: a mark writes the current
+# epoch, "already visited" is a stamp equal to it, and the next walk to borrow the set
+# just advances the epoch. Both O(1), so a cycle guard costs nothing per node and its
+# capacity is the type universe's rather than a constant.
 # ---
-# seen: distinct nominal / instance TypeIds visited (fixed; a graph larger than this
-#       fails closed - reported as containing a secret - so the walk never under-reports)
-# len:  number of visited entries
-pub rec SecretScan {
-    seen: [256]TypeId;
-    len:  u32;
+# stamp: one epoch slot per TypeId
+# cap:   allocated slots in stamp
+# epoch: the epoch the walk currently holding this set marks with
+rec VisitSet {
+    stamp: *u32;
+    cap:   u32;
+    epoch: u32;
+}
+
+# a graph walk's borrowed visited set: the cycle guard that lets a recursive walk over the
+# type universe terminate on a self-referential record graph (#2162)
+#
+# It replaces the fixed arrays those walks used to carry, whose bounds an ORDINARY program
+# reached (#3065). A merely LARGE type graph exhausted the visited set and took the walk's
+# fail-closed exit, so a program containing no `^` at all was rejected for secrecy, and the
+# message named a concept the program did not use. A visited set sized like the type
+# universe cannot be exhausted by a program's size, only by the allocator - which is the
+# only thing the fail-closed exit should ever be about.
+#
+# Sets are borrowed from the interner's pool in STACK order, because these walks NEST: the
+# generic-union instance walk asks a secrecy question about each variant pair, and that
+# question is a walk of its own. A single shared set would let the inner walk retire the
+# outer walk's marks and unbind its cycle guard, so each depth gets its own set.
+#
+# The interner is the owner because it owns the type table every TypeId indexes: one slot
+# per TypeId is the same shape and grows on the same axis.
+# ---
+# level: the borrowed set's index in the interner's pool, or SCAN_NONE when the borrow
+#        failed - every mark then reports VISIT_FAILED, taking the walk's fail-closed exit
+pub rec TypeScan {
+    level: u32;
+}
+
+# a TypeScan holding no set, because the pool could not be grown
+val SCAN_NONE: u32 = 0xFFFFFFFF;
+
+# the outcome of entering one TypeId on a TypeScan
+#
+# Three states, not a bool: "already visited" and "could not record" demand OPPOSITE
+# answers from the walks that share this guard. A visited node contributes nothing, while
+# an unrecordable one leaves the walk unbounded and must take that walk's fail-closed exit
+# - which is `true` for `generics.contains_secret_deep` and `false` for
+# `generics.deep_all_secret`. Folding the two together would invert one of them.
+pub def VisitMark: u8;
+
+# `tid` was not yet on this walk and is now recorded; descend into it
+pub val VISIT_FRESH:  VisitMark = 0;
+# `tid` is already on this walk; the caller's cycle guard applies
+pub val VISIT_SEEN:   VisitMark = 1;
+# `tid` could not be recorded; the walk is unbounded from here and the caller must fail closed
+pub val VISIT_FAILED: VisitMark = 2;
+
+# borrow a visited set for one walk, retiring every mark the previous borrower left
+#
+# Infallible by design: a pool that cannot be grown binds the scan to SCAN_NONE rather
+# than reporting, so the failure surfaces at the first mark through the fail-closed path
+# the walks already have, and neither entry point needs an error arm of its own.
+# ---
+# ti:   the interner owning the pool
+# scan: the handle to bind to the borrowed set
+pub fun type_scan_begin(ti: *TypeInterner, scan: *TypeScan) {
+    if (O.is_some[str](visits_reserve(ti))) {
+        scan.level = SCAN_NONE;
+        ret;
+    }
+
+    val level: u32 = ti.visits_len;
+    ti.visits_len  = ti.visits_len + 1;
+
+    # epoch 0 means never visited and is what a fresh or re-zeroed slot holds, so the
+    # counter wraps to 1 rather than to 0. Clearing first is what makes the wrap exact:
+    # without it a stamp from four billion walks ago would read as current. One clear per
+    # 2^32 borrows of this set.
+    if (ti.visits[level].epoch == 0xFFFFFFFF) {
+        if (ti.visits[level].stamp != nil && ti.visits[level].cap > 0) {
+            memory.zero[u32](ti.visits[level].stamp, ti.visits[level].cap::usize);
+        }
+        ti.visits[level].epoch = 1;
+    }
+    or {
+        ti.visits[level].epoch = ti.visits[level].epoch + 1;
+    }
+
+    scan.level = level;
+}
+
+# return `scan`'s set to the pool, freeing it for the next walk at this depth
+#
+# The set keeps its array and its epoch, so the next borrower pays neither an allocation
+# nor a clear.
+# ---
+# ti:   the interner owning the pool
+# scan: the handle to release
+pub fun type_scan_end(ti: *TypeInterner, scan: *TypeScan) {
+    if (scan.level == SCAN_NONE) { ret; }
+    ti.visits_len = scan.level;
+    scan.level    = SCAN_NONE;
+}
+
+# enter `tid` on `scan`, reporting whether this walk had already reached it
+# ---
+# ti:   the interner owning the pool
+# scan: the open scan
+# tid:  the TypeId being entered
+# ret:  VISIT_FRESH, VISIT_SEEN, or VISIT_FAILED
+pub fun type_scan_mark(ti: *TypeInterner, scan: *TypeScan, tid: TypeId) VisitMark {
+    if (scan.level == SCAN_NONE) { ret VISIT_FAILED; }
+
+    # a walk materializes generic-instance field tables as it goes, and that interns types,
+    # so a TypeId can be minted MID-WALK and land past the array. The growth belongs here
+    # rather than at `begin`, which cannot know the type count the walk will end at.
+    if (tid >= ti.visits[scan.level].cap) {
+        if (O.is_some[str](visit_reserve(ti, scan.level, tid))) { ret VISIT_FAILED; }
+    }
+
+    val set: *VisitSet = ?ti.visits[scan.level];
+    if (set.stamp[tid] == set.epoch) { ret VISIT_SEEN; }
+    set.stamp[tid] = set.epoch;
+    ret VISIT_FRESH;
+}
+
+# grow the pool so one more set can be borrowed, initializing the new sets empty
+# ---
+# ti:  the interner
+# ret: none once a set is free, or some(error) on allocation failure
+fun visits_reserve(ti: *TypeInterner) O.Option[str] {
+    if (ti.visits_len < ti.visits_cap) { ret O.none[str](); }
+
+    var new_cap: u32 = ti.visits_cap * 2;
+    if (new_cap == 0) { new_cap = INITIAL_VISIT_DEPTH; }
+
+    if (ti.visits == nil) {
+        val res_alloc: R.Result[*VisitSet, str] = A.allocate[VisitSet](ti.a, new_cap::usize);
+        if (R.is_err[*VisitSet, str](res_alloc)) {
+            ret O.some[str](R.unwrap_err[*VisitSet, str](res_alloc));
+        }
+        ti.visits = R.unwrap_ok[*VisitSet, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*VisitSet, str] = A.reallocate[VisitSet](ti.a, ti.visits, ti.visits_cap::usize, new_cap::usize);
+        if (R.is_err[*VisitSet, str](res_realloc)) {
+            ret O.some[str](R.unwrap_err[*VisitSet, str](res_realloc));
+        }
+        ti.visits = R.unwrap_ok[*VisitSet, str](res_realloc);
+    }
+
+    var i: u32 = ti.visits_cap;
+    for (i < new_cap) {
+        ti.visits[i].stamp = nil;
+        ti.visits[i].cap   = 0;
+        ti.visits[i].epoch = 0;
+        i = i + 1;
+    }
+    ti.visits_cap = new_cap;
+
+    ret O.none[str]();
+}
+
+# grow the set at `level` until `tid` addresses a slot, zeroing the new slots so they read
+# as never visited
+# ---
+# ti:    the interner
+# level: the set's index in the pool
+# tid:   the TypeId that must be addressable
+# ret:   none once the slot exists, or some(error) on allocation failure
+fun visit_reserve(ti: *TypeInterner, level: u32, tid: TypeId) O.Option[str] {
+    val set: *VisitSet = ?ti.visits[level];
+
+    var new_cap: u32 = set.cap;
+    if (new_cap == 0) { new_cap = INITIAL_VISIT_CAP; }
+    for (new_cap <= tid) {
+        new_cap = new_cap * 2;
+    }
+
+    if (set.stamp == nil) {
+        val res_alloc: R.Result[*u32, str] = A.allocate[u32](ti.a, new_cap::usize);
+        if (R.is_err[*u32, str](res_alloc)) {
+            ret O.some[str](R.unwrap_err[*u32, str](res_alloc));
+        }
+        set.stamp = R.unwrap_ok[*u32, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*u32, str] = A.reallocate[u32](ti.a, set.stamp, set.cap::usize, new_cap::usize);
+        if (R.is_err[*u32, str](res_realloc)) {
+            ret O.some[str](R.unwrap_err[*u32, str](res_realloc));
+        }
+        set.stamp = R.unwrap_ok[*u32, str](res_realloc);
+    }
+
+    memory.zero[u32](?set.stamp[set.cap], (new_cap - set.cap)::usize);
+    set.cap = new_cap;
+
+    ret O.none[str]();
 }
 
 # whether two types place the secret qualifier identically along their spines


### PR DESCRIPTION
Closes #3065

The deep-secret walk carried a fixed 256-entry `SecretScan`, and a merely large nominal graph filled it and took the fail-closed exit, so an ordinary `::ptr` erasure was rejected as secret-welded on a program containing no `^` anywhere.

Failing closed is right for a walk that has run out of room. The defect was that the room was a **constant**, which made the exit reachable by program size rather than by the allocator. Raising the constant only moves the cliff, so it is not the fix.

## The change

The visited set now belongs to `TypeInterner`, which already owns the type table every `TypeId` indexes, so its capacity grows on the same axis a type graph does.

- **One epoch stamp per `TypeId`.** A mark writes the current epoch, "already visited" is a stamp equal to it, and opening a walk advances the epoch. Both O(1), and nothing is cleared between walks. That also retires the linear rescan of `seen`, which made each walk quadratic in graph size.
- **The epoch wraps exactly.** At `u32` it zeroes the array and restarts at 1, so no stamp from four billion walks ago can read as current. One clear per 2^32 borrows.
- **Growth happens at the mark, not at the open.** Materializing a generic instance's field table interns types, so a `TypeId` can be minted mid-walk and land past the array; `type_scan_begin` cannot know the count the walk will end at.
- **Sets are borrowed from a pool in stack order, because these walks nest.** `check_uni_variants` calls `secrecy_structure_equal_deep`, which opens deep-secret scans of its own, so a single shared set would let the inner walk retire the outer walk's marks and unbind its cycle guard. Each depth gets its own set. This is the one place I departed from a single shared array: the second member of this contract already exists in the same file, and a single array is a contract that member breaks. Borrowing is infallible — a pool that cannot be grown binds the scan to no set, and the failure surfaces at the first mark through the fail-closed path the walks already have, so neither entry point needs an error arm.
- **A mark reports one of three outcomes, not a bool.** "Seen" and "could not record" need opposite answers from the two walks that share the guard: fail-closed is `true` for `contains_secret_deep` and `false` for `deep_all_secret`. Folding them together would silently invert one.

The only remaining fail-closed exit is an allocation failure, which is what it should always have been about. The rule itself is unchanged.

## Verification

**The real program.** [ludus](https://github.com/briar-systems/ludus) at `5d34d1a` fails on `dev` with nine errors and builds clean here, in a throwaway worktree, unmodified:

| | result |
|---|---|
| `dev` compiler | 9 errors, first at `src/core/scenes/experiment.mach:82` |
| this branch | exit 0, `out/linux-x86_64/debug/bin/ludus` produced |

Instrumenting the walk measures its peak at **257** distinct nominals entered on one walk, against the old bound of 256 — exactly one over, which is why raising the constant would have been a fix with a shelf life.

**Self-host.** Builds and reaches the byte-identical fixpoint (`fe857173…`, stage1 and stage2 agree). `mach test .` is 1529 passed, 0 failed.

**Compile time**, ten alternating full release self-builds of the same tree with each compiler:

| | median | min |
|---|---|---|
| `dev` | 17.65s | 16.61s |
| this branch | 16.60s | 15.63s |

About 6% faster, faster in 8 of the 10 pairs. That is the removed rescan.

## Tests

`mach.lang.driver:deep_secret_walk_scales_with_the_type_graph` builds a 320-record chain at runtime and asserts three arms. It fails on `dev` and passes here.

The first two arms are **a pair, and only the pair says anything**: a walk that gives up rejects both a public graph and a secret one, so the public arm alone is satisfied by a walk that stopped early and the secret arm alone by a walk that never ran.

1. 320 nominals, no `^`, erasing a pointer to `ptr` — compiles.
2. The same 320 nominals with a real `^` at the **far end** of the chain — still rejected, by the erasure rule specifically. This is the arm that keeps the fix from becoming a hole in the rule it guards.
3. A cycle inside a large graph still terminates. This is where a reused set would break: a walk that read the previous walk's marks as its own would cut the graph short instead of walking it.

Nothing in the existing suite asserted the old 256 behaviour, so there was nothing to update deliberately.

## Found, not fixed

Two sibling bounds of the same shape, neither of which affects ludus (both are gated behind the program actually containing a `^`):

- **#3066** — `UniInstScan`'s `UNI_SCAN_CAP = 256` is reachable the same way and, unlike the deep-secret walk, its fail-closed exit **reports**, so a module naming a `^` with a graph past 256 gets a wall of `cannot prove … type graph is too large`. It is filed separately rather than folded in here because lifting its bound alone makes things *worse*: that walk is O(annotations × graph²) and the bound is currently what caps it. Measured on a cyclic 400-record chain with one `^`, sema takes 17.6s *with* the bound cutting every walk short. The mechanism added here drops straight in once the cost work is done — `UniInstScan` is keyed by an interned `TypeId`, and the stack discipline already covers its nesting around the deep-secret walk.
- `SecrecyPairScan`'s 128-entry bound in `sse_deep_walk` is keyed by nominal **pairs**, so a `TypeId`-keyed set does not apply to it. It fails closed by rejecting a reinterpret rather than by reporting, and reaching it needs two large aligned graphs with a secret in them, so it is much further out. Noted here rather than filed.
