### PR TITLE
mach 4.26.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,7 +122,7 @@ jobs:
           tar -C stage -czf "dist/mach-$ver-$TARGET.tar.gz" mach LICENSE
 
       - name: upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: dist/mach-*-${{ matrix.target }}.tar.gz
@@ -176,7 +176,7 @@ jobs:
           Compress-Archive -Path stage/mach.exe, stage/LICENSE -DestinationPath "dist/mach-$ver-${env:TARGET}.zip" -Force
 
       - name: upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: dist/mach-*-${{ matrix.target }}.zip
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: collect archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-*
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           cp c artifact/mach
 
       - name: upload fixpoint result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mach-${{ matrix.target }}
           path: artifact/mach
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the fixpoint result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.target }}
           path: artifact
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the fixpoint result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.target }}
           path: artifact
@@ -210,7 +210,7 @@ jobs:
           Copy-Item c.exe artifact/mach.exe -Force
 
       - name: upload fixpoint result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mach-${{ matrix.target }}
           path: artifact/mach.exe
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the fixpoint result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.target }}
           path: artifact
@@ -439,7 +439,7 @@ jobs:
       # reach" is not answerable from a log line.
       - name: upload the coverage matrices
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: matrix-${{ matrix.runner }}
           path: |
@@ -486,7 +486,7 @@ jobs:
         run: MACH_LINK_MACH=$PWD/m bash test/link/run.sh --deps pin --leg x86_64-linux
       - name: upload the dependency resolution
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: link-deps-pin-linux
           path: test/link/out/deps.txt

--- a/.github/workflows/darwin-lane.yml
+++ b/.github/workflows/darwin-lane.yml
@@ -48,7 +48,7 @@ jobs:
           ./m build . --target "$TRIPLE" --profile release -o mach-darwin-seed
 
       - name: upload seed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: seed-${{ matrix.target }}
           path: mach-darwin-seed
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: download the darwin seed
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: seed-${{ matrix.target }}
           path: seed
@@ -148,7 +148,7 @@ jobs:
 
       - name: upload archive
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: dist/mach-*-${{ matrix.target }}.tar.gz

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -63,7 +63,7 @@ jobs:
           mach dep pull
           mach build . -o m
           ./m build . --target "$root" --profile release -o mach-${{ matrix.runner }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mach-${{ matrix.runner }}
           path: mach-${{ matrix.runner }}
@@ -84,7 +84,7 @@ jobs:
         include: ${{ fromJSON(needs.test-legs.outputs.include) }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: mach-${{ matrix.runner }}
 
@@ -132,7 +132,7 @@ jobs:
 
       - name: upload the coverage matrices
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: matrix-${{ matrix.runner }}
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### abi: a C callee wrote through into the caller's object (#3063)
+
+A C function that overwrites a by-value aggregate parameter overwrote the **mach
+caller's own object**. Silent memory corruption: the call links, returns, and leaves
+the caller's data rewritten.
+
+```mach
+rec Wide { a: i64; b: i64; c: i64; d: i64; }
+ext fun clobber(w: Wide) i64;   # the callee's writes reached the caller's `w`
+```
+
+```
+x86_64-linux    byval intact=1 2 3 4      <- control, correct
+aarch64-linux   byval intact=-1 -2 -3 -4  <- the caller's object was overwritten
+```
+
+AAPCS64, the RISC-V psABI and the Microsoft convention all pass an aggregate too
+large for registers as the address of a copy **the caller allocates**, so the callee
+may overwrite its parameter freely. System V passes one over sixteen bytes by value
+on the stack instead, where the copy already exists - which is why x86-64 is a real
+control rather than a leg that happens to pass.
+
+**Two ends, one copy, and only one of them was mach's.** `CLASS_BYREF` passed the
+address of the argument's own storage, and a mach callee then gave every parameter
+storage of its own and copied the incoming aggregate into it at entry. While both
+ends are mach the two are indistinguishable. A C callee copies nothing, so at an
+`ext` call it was handed mach's object directly.
+
+That is unobservable for a callee which only reads its parameter, which is the
+overwhelmingly common case and is why the defect survived. It needs a callee that
+WRITES to its by-value parameter to show, and a `va_list` is the by-value parameter
+every consumer advances - which is how #3004 found it.
+
+The caller now allocates a frame temporary at the aggregate's own alignment, copies
+into it, and passes the temporary's address. Gated on the `ext` boundary, because
+this is a divergence between two conventions rather than a defect in one: an
+internal call already copies, at the callee, and copying at both ends would add one
+redundant copy per aggregate argument to every mach-to-mach call. Unifying on
+caller-copy internally and dropping the callee-side copy is arguably the cleaner
+model and is a separate decision - it changes the internal convention on every
+target, including the two that were already correct.
+
 ## [4.25.0] - 2026-08-21
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,46 @@ the kernel's own answer rather than the bytes on the console, which is strictly 
 than the golden saw. windows declines both: it has no syscall ABI, and its console
 write goes through a kernel32 import, so its premise fails rather than its expectation.
 
+#### link: a C function taking a `va_list` parameter has a portable binding (#3004)
+
+A C function that takes a `va_list` **parameter** could not be bound, because mach had
+no spelling for the type. The common shape is a logging callback, and it is a fixed
+3-arity function with no `...` in it:
+
+```c
+typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);
+```
+
+Binding it needs one thing only: a parameter type that is ABI-correct in that third
+slot, which mach receives, never reads, and hands straight to `vsnprintf`.
+
+`#[abi_type("va_list")]` on a bodyless `def` declares it, and the SELECTED TARGET
+supplies the layout:
+
+```mach
+#[abi_type("va_list")]
+def VaList;
+
+ext fun vsnprintf(buf: *u8, n: usize, fmt: *u8, ap: VaList) i32;
+```
+
+**The layout is declared per (os, architecture), never derived.** `va_list` is a plain
+pointer on System V x86-64, Apple arm64, Microsoft x64 and RISC-V lp64d, and a 32-byte
+8-aligned composite under AAPCS64. Darwin and linux compose the very same `aapcs64`
+convention vtable and disagree about it outright, so no calling convention can answer
+and no machine model implies it - it sits on the os vtable beside the Apple
+variadic-stack rule and for the same reason. An OS listing an architecture it declares
+no layout for is refused at registration rather than defaulted to a pointer: a pointer
+is right four times out of five, which is exactly the shape that ships silent
+corruption on the fifth.
+
+**The scope is forward-only, stated as an exclusion.** There is no `va_start`, no
+`va_arg`, no `va_end`, and no way to construct one. Reading one needs `va_arg`, and
+mach has no callee that walks its own argument tail because it has no runtime
+variadics. A local binding, a record or union field, a global, a return position, a
+pointer or array of one, and a cast in either direction are each refused where they
+are written, naming the exclusion.
+
 ### Fixed
 
 #### abi: a C callee wrote through into the caller's object (#3063)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,34 @@ write goes through a kernel32 import, so its premise fails rather than its expec
 
 ### Fixed
 
+#### sema: a large type graph was mistaken for a secret one (#3065)
+
+A program containing no `^` anywhere was rejected for secrecy, once at every pointer
+erasure it performed, with a diagnostic about a concept it never used:
+
+```
+error: cast: a secret-welded pointer cannot be erased to the untyped `ptr`
+  = note: secret memory is reached only through secrecy-typed pointers; erasing `^` to
+    `ptr` would let a public alias read it
+```
+
+The deep-secret walk carried a fixed 256-entry visited set and treated a graph that
+filled it as possibly-secret. **Failing closed is right for a walk that has run out of
+room; the defect was that the room was a constant**, which made the exit reachable by
+program size rather than by the allocator. A game's ECS scene record, which
+transitively names fourteen component stores, crossed it at 257 distinct nominals -
+one over. Adding a fifteenth component to a program is not a secrecy event, and neither
+is any other way of growing a type graph.
+
+The visited set now belongs to the interner that owns the type table every `TypeId`
+indexes, one epoch-stamped slot per `TypeId`, so its capacity grows on the same axis
+the graph does and a walk can only run out of room when the allocator does. Marking and
+testing are O(1), which also retires a linear rescan that made each walk quadratic in
+graph size. A full self-build is about 6% faster.
+
+The rule itself is unchanged: a real `^` anywhere in a graph of any size is still
+found, and a cyclic graph still terminates.
+
 #### abi: a C callee wrote through into the caller's object (#3063)
 
 A C function that overwrites a by-value aggregate parameter overwrote the **mach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### test: the four host-executed measurements the integration suite carried are back (#2944)
+
+Retiring the integration suite reclassified 109 of its 174 cases, and four were neither
+a codegen question the corpus answers nor a front-end question a unit test already
+asserts. Each measured something that only means anything on the machine it executes
+on, which is exactly why the corpus cannot carry it: the corpus builds for a target and
+reads what came out, and none of these is a property of the bytes. All four are now
+host-executed unit tests, gated on the host's own os and isa, and a leg that cannot run
+one **declines by name** rather than asserting something it did not measure. The
+decline is a separate `test` declaration rather than a branch inside a shared body,
+because a passing test's captured output is suppressed unless the run asks for it, so
+the name is the readout and it shows in `--list`.
+
+**The x86-64 flags probe.** `mach.lang.target.isa.x64.probe` runs each of the
+twenty-five rows in `x64/encode.mach`'s transcribed table twice, once with RFLAGS
+preset all-set and once all-clear, and compares what the CPU did against the
+transcription. That table is the security surface the `#[oblivious]` inline-asm model
+rests on, and `defines_flags` is the only fact that CLEARS a taint, so a row that drifts
+from the silicon is a permission rather than a refusal. The existing
+`agrees_with_measured_hardware` test makes the transcription bear on the
+classification; this makes it bear on the machine, which is the half that went with the
+suite. The probe now assembles through mach itself rather than through a C compiler, so
+an encoder that folded `shl rax, 0` into a shift-by-one fails here too.
+
+**The dudect-style timing harness.** `mach.lang.ct.probe` and `mach.lang.ct.dudect`
+restore the two-mode measurement, and `doc/language/secrecy.md` cites a harness that
+runs instead of marking its claims as measurements taken once. Every gate is a
+refutation, because that is all a timing measurement can do: each mode carries a
+planted leak that must be detected and a constant-time reference that must not separate
+the way the planted one does, so a mode that has stopped measuring fails through its own
+control rather than reading as a pass. Gates are separations between the class means,
+never `|t|`, which collapses under load while the means do not move, and each gate
+subtracts a null control measured in the same run rather than comparing against a
+constant, so common-mode noise leaves the verdict instead of being absorbed by the
+threshold. That null control also decides whether the run counts: it cannot leak, so any
+separation it shows is the machine rather than the code, and a run in which it separates
+by as much as a leak has to declines, because a differential measurement without
+discriminating power has no verdict in either direction. The address-trace mode samples
+one call at a time over a table larger than the last-level cache, which is the sampling
+latency mode cannot substitute for.
+
+The thresholds were calibrated inside a parallel `mach test`, which is the only
+environment they have to hold in and which the retired shell harness was never run under.
+Doing that surfaced three things the obvious shape gets wrong. The fixed class always led
+its round, and the leading sample absorbs the round's first cache and scheduler
+transition, so a probe that cannot leak still came out 7 to 11 percent slower on that
+class; the order alternates now. Both null controls were far cheaper than the probes they
+bounded, so the cheapest probe in the set was setting the precondition for every other;
+both are cost-matched now. And the address probe read one line per call, which is eighty
+nanoseconds of cache miss inside a sample whose clock overhead is several hundred, so its
+planted leak and its null control overlapped under load; it reads sixteen now, which is
+also what a table-driven cipher does per round.
+
+**The two inline-asm syscall conventions.** `mach.lang.target.isa.asm.host` executes an
+inline-asm body that cannot return, and an inline-asm console write, per os and arch.
+The non-returning half asserts an ABSENCE, since the body ends the test process with
+status 0 and reaching the statement after it is the failure, and a wrong kernel-entry
+number falls into the trap after it, so it fails rather than hangs. The write asserts
+the kernel's own answer rather than the bytes on the console, which is strictly more
+than the golden saw. windows declines both: it has no syscall ABI, and its console
+write goes through a kernel32 import, so its premise fails rather than its expectation.
+
 ## [4.25.0] - 2026-08-21
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.26.0] - 2026-08-22
 
 ### Added
 
@@ -182,6 +182,52 @@ redundant copy per aggregate argument to every mach-to-mach call. Unifying on
 caller-copy internally and dropping the callee-side copy is arguably the cleaner
 model and is a separate decision - it changes the internal convention on every
 target, including the two that were already correct.
+
+#### driver(dep): `mach dep pull` realises the project you name, not the one you are standing in (#2936)
+
+`mach dep pull` accepted a path positional and then ignored it, hardcoding its project
+root to the current directory. A pull aimed at a project you were not standing in
+reported on the current directory instead and materialised nothing for the one named,
+and the build that sent you there refused by naming `mach dep pull` - the command that had
+just no-opped. The advice looped.
+
+The positional now resolves through the same rules `mach build <path>` uses, and a bare
+`mach dep pull` is unchanged. Fixing it exposed a second defect the hardcoded root had
+kept invisible: a path dependency's symlink target was computed from the source path as
+reached from the working directory, while the link is read from inside the project, so a
+pull run from elsewhere wrote a link that dangled. `DepNode` carries both frames now, and
+the link a pull writes is identical whichever directory it ran from.
+
+`update`, `add`, `remove` and `list` remain current-directory-only: their positional is
+already a dependency name, so giving them a project path is a grammar decision tracked
+separately (#3061).
+
+#### test: corpus layer A records a skip for an object format it has no oracle for (#2956)
+
+Layer A handed every format to an external oracle - ELF, COFF and Mach-O to
+`llvm-readobj`, SPIR-V to `spirv-val` - except `raw`, which it passed after asserting
+only that the file existed and was non-empty, which the caller had already checked. That
+is a cell that cannot go red, and the matrix is what the project reads to answer which
+surfaces are covered. `Outcome` carries a third verdict now, so the cell reads `SKIP` and
+the run fails on an uncovered column with no `SKIPS` entry. No target's pass count
+changed.
+
+#### docs(manifest): the accepted-tuple table lists `riscv32` and the RISC-V ABI family (#2947)
+
+The table omitted `riscv32` and five of the nine registered calling conventions, so a
+reader writing a manifest from the doc could not reach RV32 at all and would pick the
+wrong RISC-V ABI: #2777 made `lp64` mean soft float and the linux default `lp64d`, and
+`lp64` was the only RISC-V entry the doc offered. The table now matches what `mach info`
+prints in both directions, and the family is explained where a reader choosing one will
+see it.
+
+#### chore(ci): the artifact actions run on Node.js 24 (#2983)
+
+Twelve jobs across four workflows emitted a deprecation annotation for
+`actions/upload-artifact@v4` and `actions/download-artifact@v4` being forced onto
+Node.js 24. Both are on their current majors now, with the producer and consumer
+pairings checked against the intervening breaking changes.
+
 
 ## [4.25.0] - 2026-08-21
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -431,7 +431,7 @@ symlink so the build resolves it by the same vendor layout.
 
 | Action   | Args | Effect |
 |----------|------|--------|
-| `pull`   | — | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; safe to re-run. |
+| `pull`   | `[<path>]` | realise the manifest: clone missing git deps (transitively), link path deps, re-resolve a changed ref, repair checkout-vs-lock drift, write `mach.lock`. Idempotent; safe to re-run. |
 | `update` | `<name> \| --all` | the only lock-advancer: re-resolve branch refs to current remote tips. Tag/commit refs are an immutable no-op. Never edits the manifest. |
 | `add`    | `<name> --git <url> [--ref <ref>] \| --path <dir>` | append a `[dep.<name>]` `git`/`path` stanza to the manifest, then `pull`. |
 | `remove` | `<name> [--purge]` | drop the entry from `mach.toml` and `mach.lock`; `--purge` also deletes `dep/<name>/`. |
@@ -439,6 +439,13 @@ symlink so the build resolves it by the same vendor layout.
 
 `sync` is the pre-`pull` name, kept one cycle as a hidden alias that prints a
 deprecation note and runs `pull`.
+
+`pull` takes a project directory, resolved by the same rules as `mach build
+<path>`, and defaults to the current directory when none is given. A path that is
+not a project directory is a hard error, so the dep tree a build refuses over is
+always the dep tree `pull` realises, and the refusal names the root to pass
+(#2936).
+Every other action acts on the current directory's project.
 
 ### Transport policy
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -50,6 +50,7 @@ A decorator is written as an attribute:
 #[sampler(set, bnd)] # descriptor-bound image / sampler handle (global only)
 #[op(tgt,set,name)]   # the target instruction this function is (bodyless fun only)
 #[handle(tgt,ctor,..)] # the target type this declares (bodyless def only)
+#[abi_type("name")]   # a C type whose layout the target declares (bodyless def only)
 ```
 
 Decorators appear **before** the declaration they target, one per line or
@@ -739,6 +740,28 @@ handles compiles on a machine target. A constructor name the selected target doe
 not define, an operand count that disagrees with the constructor's, or an operand
 combination the target cannot emit is a compile error at the declaration.
 
+### `abi_type(name)` — a C type whose layout the target declares
+
+A bodyless `def` carrying this directive declares a C type whose size and alignment
+come from the **selected target** and whose contents the program never reaches.
+
+```mach
+#[abi_type("va_list")]
+pub def VaList;
+```
+
+`va_list` is the only name, and the set is closed in the front end for the reason
+`op`'s instruction names are: which target a module is built for is not a property
+of the source, so a typo checked only where it is acted on would go unreported on
+every other build of the same library. A target that declares no layout for the
+named type refuses the declaration rather than substituting a default.
+
+The type is an opaque aggregate of the declared extent. A value of one may be
+received as a parameter and passed on, and nothing else: a local binding, a record
+or union field, a global, a return position, a pointer or array of one, and a cast
+in either direction are each refused where they are written. See
+[ext-fun.md](ext-fun.md) for the recipe and for why forwarding is the whole scope.
+
 ### `op(target, set, name)` — a function that *is* a target instruction
 
 A shader needs `sqrt`, `normalize`, `dot` and `mix`. None of them is an operator,
@@ -819,6 +842,7 @@ in it.
 | `storage`   |  no   |    no     |      yes      |      no       |
 | `op`        |  yes  |    no     |      no       |      no       |
 | `handle`    |  no   |    no     |      no       |      no       |
+| `abi_type`  |  no   |    no     |      no       |      no       |
 
 The `val` / `var` column is shared, but `embed` accepts only `val` — a `var`
 is refused (see [`embed`](#embedstr--compile-time-file-embedding) above).

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -131,6 +131,107 @@ crash. Mach cannot detect the mistake, because nothing in a fixed-arity declarat
 says the callee is variadic — so **declare every C-variadic callee with `...`**, on
 every target.
 
+## `va_list` parameters
+
+A C function may take a `va_list` as an ordinary **fixed** parameter. The common
+shape is a logging callback:
+
+```c
+typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);
+void SetTraceLogCallback(TraceLogCallback callback);
+```
+
+That is a fixed 3-arity function. It has no `...` in it, and binding it needs
+nothing from the C-variadic form above — only a parameter type that is ABI-correct
+in the third slot. Declare that type with `#[abi_type("va_list")]` on a bodyless
+`def`:
+
+```mach
+#[abi_type("va_list")]
+def VaList;
+
+pub def TraceLogCallback: fun(i32, *u8, VaList) i64;
+
+#[library("raylib")]
+ext fun SetTraceLogCallback(cb: TraceLogCallback);
+
+ext fun vsnprintf(buf: *u8, n: usize, fmt: *u8, ap: VaList) i32;
+
+fun trace(level: i32, text: *u8, args: VaList) i64 {
+    var buf: [512]u8;
+    ret vsnprintf(?buf[0], 512, text, args)::i64;
+}
+```
+
+The declaration carries no size of its own. The selected target declares what a
+`va_list` is on that platform, and the same source text binds correctly on every
+one of them. A target that declares none refuses the declaration by name rather
+than guessing.
+
+### Mach can forward one and never read one
+
+The whole scope is **forward-only**: receive an opaque token from C and pass it to
+C. There is no `va_start`, no `va_arg`, no `va_end`, and no way to construct one.
+Each of these is refused where it is written:
+
+```mach
+val saved: VaList = args;   # refused: a local binding
+rec Held { ap: VaList; }    # refused: a record or union field
+var kept: VaList;           # refused: a global
+fun make() VaList { … }     # refused: a return position
+fun peek(ap: *VaList) { … } # refused: behind a pointer
+val raw: ptr = args :~ ptr; # refused: a cast in either direction
+```
+
+Reading one needs `va_arg`, and mach cannot have `va_arg`: it has no runtime
+variadics, so it has no callee that walks its own argument tail. That is not a gap
+waiting to be filled. Constructing a `va_list` is only meaningful for such a
+callee, and mach never needs to originate one — it would call `printf` rather than
+`vprintf`.
+
+One further rule comes from C rather than from mach: **a forwarded `va_list` is
+spent.** Handing one to a function that reads it leaves its value indeterminate,
+exactly as in C, and what actually happens differs per platform — under AAPCS64 the
+type is a composite the caller copies, so each callee walks its own; under System V
+x86-64 it is a pointer into shared state that the callee advances. Forward it once.
+
+### Why the type is declared per target
+
+`va_list` is the one C type mach binds whose shape cannot be written down portably:
+
+| Target | `va_list` in a parameter slot |
+|--------|-------------------------------|
+| **System V x86-64** | `__va_list_tag[1]`, an array type, so a parameter decays to one pointer |
+| **Apple arm64** | `char *` |
+| **Microsoft x64** and **Windows arm64** | `char *` |
+| **RISC-V lp64d** | `void *` |
+| **AAPCS64 linux** | a 32-byte, 8-aligned composite |
+
+On the first four, spelling the parameter `ptr` is already ABI-correct. On
+AAPCS64-linux it is not, and the way it fails is the reason this type exists rather
+than a documented caveat: AAPCS64 passes a composite over 16 bytes indirectly, with
+the **caller** owning the copy, so a `ptr` forwards the received pointer instead of
+a fresh copy and the next callee advances the caller's list. That usually appears to
+work, which is worse than failing.
+
+## Aggregate arguments and the caller's copy
+
+An aggregate too large for registers is passed as an **address of a copy the caller
+allocates** on AAPCS64, under the RISC-V psABI, and under the Microsoft convention.
+The callee treats that memory as its own parameter and may overwrite it, so mach
+materializes a fresh temporary for every such argument at an `ext` boundary and
+passes the temporary's address. A C callee that writes to its by-value parameter
+therefore cannot reach the caller's object:
+
+```mach
+rec Wide { a: i64; b: i64; c: i64; d: i64; }
+ext fun consume(w: Wide) i64;
+```
+
+A Mach→Mach call keeps mach's own convention, where the callee gives every
+parameter storage of its own and copies into it at entry. The two reach the same
+by-value semantics from opposite ends, and only the foreign one is visible here.
+
 ## Symbol name
 
 The declaration names a C declaration, so its linker symbol is whatever the
@@ -340,3 +441,4 @@ definition always wins over a same-named dynamic import.
 - [val-var.md](val-var.md) — `ext val` / `ext var`, the data analogue (foreign data imports)
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
 - [decorators.md](decorators.md) — `symbol`, `library`, and other codegen decorators
+- [variadics.md](variadics.md) — the comptime pack `...`, which is a Mach calling convention and not this one

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -407,13 +407,46 @@ this version.**
 
 What holds today: the type system checks that the source respects the leakage
 model, `#[oblivious]` carries the obligation through codegen, and the translation
-validator independently re-checks the lowered MIR. All three are static.
+validator independently re-checks the lowered MIR. All three are static. Two
+host-executed measurements sit under them, and each only means anything on the
+machine it runs on, which is why both are unit tests rather than build checks.
 
-**There is no timing measurement in the tree.** A dudect-style harness existed and
-was run on demand, never in CI, because timing measurement is noise-sensitive and
-shared runners are noisy. What it established is recorded below and is not being
-re-established by anything; treat every empirical claim here as a measurement taken
-once rather than a property under guard.
+**The timing harness runs.** `mach.lang.ct.probe` is a dudect-style harness in the
+tree, measured on every `mach test`, and the claims below are what it establishes.
+It works by refutation, because that is all a timing measurement can do: a clean
+score is consistent with a leak the instrument cannot see, so each mode carries a
+*planted* leak that must be detected and a constant-time reference that must not
+separate the way the planted one does. A mode that has stopped measuring therefore
+fails through its own control instead of reading as a pass.
+
+Every gate is a separation between the two class means, never `|t|`. Welch's
+statistic divides by the sample variance, and concurrent load inflates the variance
+without moving the means, so `|t|` collapses under load while the leak is plainly
+still there. Measured at load average 27, six consecutive runs of one binary gave
+`|t|` between 7.51 and 11.24 against a threshold of 10 while the mean ratio never
+fell below 3.4. `|t|` is still reported, because it is the right statistic on a
+quiet box, and it is just not the gate.
+
+A third probe leaks nothing at all and decides whether the run counts. Any
+separation *it* shows is the machine rather than the code, so a run in which it is
+not flat has no discriminating power and **declines** rather than asserting: a
+differential measurement without discriminating power has no verdict in either
+direction, and failing there would be reporting machine load as a compiler
+regression. The consequence to keep in mind is that a permanently noisy runner
+yields a permanently declining harness, which is silence rather than assurance.
+
+**The x86-64 inline-asm flags table is measured, not inferred.** The eighteen-row
+classification the `#[oblivious]` asm model rests on, naming which instructions
+*define* ZF and CF, which merely write them, and which read them, is re-derived on x86-64
+hosts by `mach.lang.target.isa.x64.probe`, which runs each instruction twice with
+RFLAGS preset all-set and all-clear and compares what the CPU did against the
+transcription. `defines_flags` is the only fact that clears a taint, so a row that
+drifts from the silicon is a permission rather than a refusal. Three rows are
+exempt and classified by reasoning instead: `popfq`, `iretq` and `syscall` pass the
+writer probe cleanly and are still not definers, because the flags came from the
+stack, the interrupt frame, or an existing value masked through `IA32_FMASK`, and
+where a value came *from* is structural rather than measurable. A non-x86-64 host
+declines the probe by name.
 
 **What a timing harness can and cannot assure.** The leakage model has three
 channels and no single sampling regime covers them (briar-systems/mach#2363):

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -193,6 +193,49 @@ non-zero `Depth`, a non-zero `MS`, a `Dim` past `Cube`, and a `Sampled` other th
 See [decorators.md](decorators.md) for `#[handle]` and `#[sampler(set, binding)]`,
 and the shader library for the handles a SPIR-V target declares.
 
+## ABI types
+
+An **ABI type** is a C type whose size and alignment come from the **selected
+target** and whose contents the program never reaches. It is a bodyless `def`
+carrying `#[abi_type(name)]`, and `va_list` is the only name:
+
+```mach
+#[abi_type("va_list")]
+pub def VaList;
+```
+
+It exists for the one C type that has no correct spelling in mach source.
+`va_list` is a plain pointer on System V x86-64, Apple arm64, Microsoft x64 and
+RISC-V lp64d, and a 32-byte 8-aligned composite under AAPCS64 — so `ptr` binds
+correctly on four platforms and silently corrupts on the fifth, where the psABI
+passes the composite indirectly with the caller owning the copy.
+
+Unlike a handle, an ABI type is an **aggregate** of the declared extent rather than
+a pointer-shaped name for a resource. That is the whole mechanism: an aggregate over
+16 bytes rides AAPCS64's by-reference path, which makes the caller copy and pass an
+address, and an eight-byte one reduces on every other platform to the single register
+a pointer would have taken.
+
+What a program may do with one is bounded to the opposite end from a handle's:
+
+- it may be a **parameter**, and it may be **passed on** to another function
+- it cannot be read: no fields, no indexing, no cast in either direction
+- it cannot be constructed, and no function may return one
+- it cannot be a local binding, a global, or a record or union field
+- it cannot sit behind a pointer or inside an array
+
+Reading one needs `va_arg`, which mach has no callee shape for: mach has no runtime
+variadics, so nothing walks its own argument tail. `$size_of` and `$align_of`
+answer with the target's declared numbers, which are published psABI facts rather
+than anything about a value.
+
+A target that declares no layout for the named type **refuses** the declaration,
+naming the exclusion. There is no inert outcome, because every default available
+would be a pointer and a pointer is wrong under AAPCS64.
+
+See [ext-fun.md](ext-fun.md) for the binding recipe and
+[decorators.md](decorators.md) for `#[abi_type]`.
+
 ## Pointer
 
 `*T` — pointer to a value of type `T`.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -173,9 +173,9 @@ such an image is refused at link rather than silently dropped.
 
 | Axis  | Values |
 |-------|--------|
-| `isa` | `x86_64`, `aarch64`, `riscv64`, `spirv`, `mos6502` |
+| `isa` | `x86_64`, `aarch64`, `riscv64`, `riscv32`, `spirv`, `mos6502` |
 | `os`  | `linux`, `windows`, `darwin`, `freestanding` |
-| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64`, `spirv`, `mos6502` |
+| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64`, `lp64f`, `lp64d`, `ilp32`, `ilp32f`, `ilp32d`, `spirv`, `mos6502` |
 
 `x86_64`/`linux`/`sysv64` is the primary host and target. `aarch64`-linux builds
 and runs natively in CI on every PR; `riscv64`-linux runs under qemu and
@@ -188,6 +188,22 @@ bare-metal platform such as BareMetal (`bmos`) is a `freestanding` target plus a
 not an os of its own. `spirv` is not a machine at all — it
 emits a finished GPU module rather than machine code (see
 [Finished-module targets](#finished-module-targets)).
+
+`lp64`, `lp64f`, `lp64d`, `ilp32`, `ilp32f`, and `ilp32d` are the RISC-V psABI
+calling-convention family, one `abi` per member. The lp64 three target
+`riscv64` and the ilp32 three target `riscv32`; an ilp32 member on a `riscv64`
+target or an lp64 member on `riscv32` is refused at composition, since XLEN is
+part of what the id means. Within each width, the members differ only in how
+floating-point arguments travel: `lp64` and `ilp32` are **soft float** — every
+float argument rides an integer register — while the `f` and `d` suffixes are
+**hard float**, passing `f32` (`f`) or both `f32` and `f64` (`d`) in the
+`fa0`-`fa7` register bank. `lp64d` is what a `riscv64-linux-gnu` toolchain
+means by "riscv64", and is the convention `mach init` scaffolds for a
+`riscv64`/`linux` target; a manifest that wants soft float, or the `f`-only
+convention, must name it explicitly, since `abi` has no default of its own
+(see [Convention, then totality](#convention-then-totality)). `riscv32`
+currently only reaches a `freestanding` target — `mach info targets` lists
+`freestanding-riscv32` and no `linux`/`darwin` riscv32 tuple.
 
 `mach info targets` prints the tuples this binary can actually build; it is
 derived from the same declarations composition reads, so it never advertises a

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.25.0"
+version = "4.26.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -2,9 +2,11 @@
 #
 # Reads argv[2] as the sub-action and dispatches: `pull` realizes the manifest's
 # intent (clone missing git deps, re-resolve a changed ref, repair
-# checkout-vs-lock drift, write the lock); `update` is the only lock-advancer
-# (branch refs to current remote tips); `add` / `remove` mutate the manifest;
-# `list` reports each dep's source form, ref, locked commit, and state.
+# checkout-vs-lock drift, write the lock) for the project named by its optional
+# path positional, defaulting to the current directory; `update` is the only
+# lock-advancer (branch refs to current remote tips); `add` / `remove` mutate the
+# manifest; `list` reports each dep's source form, ref, locked commit, and state.
+# Every action but `pull` acts on the current directory's project.
 #
 # A dependency stanza `[dep.<name>]` carries exactly one source key: a `git` url
 # plus an optional `ref`, acquired into `dep/<name>/` with plain git operations
@@ -74,12 +76,21 @@ val ENV_COUNT: usize = 21;
 # files. `req` names the manifest that required this node, for the conflict
 # diagnostic. `commit` is the resolved sha (git nodes only), filled while the
 # node is processed.
+#
+# `dir` and `rel` name the same directory in the two frames the pull needs. Every
+# filesystem touch goes through `dir`, which is reached from the process's
+# working directory. A path dep's symlink records `rel`, which is reached from
+# the project root, because the link is read from inside the project by whoever
+# builds it later and must survive the tree moving as a whole (#1370). The two
+# coincide only when the pull runs from the project root, which every pull did
+# while the root was hardcoded, and that is what made them look like one field.
 # ---
 # name:    owned dependency name as written in `[dep.<name>]`
 # git_url: owned git url, "" for a path node
 # path:    owned source path as declared, "" for a git node
 # ref:     owned git ref, "" when omitted
 # dir:     owned on-disk directory holding the dep's own mach.toml
+# rel:     owned same directory relative to the project root, or absolute
 # req:     owned name of the requiring manifest
 # commit:  owned resolved commit sha, "" until a git node is processed
 # is_git:  true for a git source, false for a path source
@@ -89,6 +100,7 @@ rec DepNode {
     path:    str;
     ref:     str;
     dir:     str;
+    rel:     str;
     req:     str;
     commit:  str;
     is_git:  bool;
@@ -170,13 +182,13 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     }
     if (str_equals(action, "pull")) {
         if (util.flag_reject_unknown(argc, argv, marks, 3, "mach dep pull")) { ret 1; }
-        ret pull_project(".", quiet);
+        ret pull_action(argc, argv, marks, quiet);
     }
     if (str_equals(action, "sync")) {
         if (util.flag_reject_unknown(argc, argv, marks, 3, "mach dep sync")) { ret 1; }
         # `sync` is the pre-rename name; kept one cycle as a hidden alias.
         print.eprint("note: `mach dep sync` is deprecated; use `mach dep pull`\n");
-        ret pull_project(".", quiet);
+        ret pull_action(argc, argv, marks, quiet);
     }
 
     print.eprint("error: unknown dep action '");
@@ -184,6 +196,40 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     print.eprint("'\n");
     print.eprint("usage: mach dep <pull|update|add|remove|list>\n");
     ret 1;
+}
+
+# resolve `mach dep pull`'s project path and realize that project
+#
+# The positional names a project directory, the same shape `mach build <path>`
+# takes and resolved by the same rules; with none given the project is the
+# current directory, so a bare `mach dep pull` keeps its meaning. The positional
+# used to be accepted and ignored, so a pull aimed at a project you were not
+# standing in reported on the current directory instead and left the named
+# project unrealized - and the build that sent you there kept sending you back
+# (#2936).
+# ---
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the positional scan
+# quiet: suppress routine per-dep lines
+# ret:   0 on success, 1 on a user error, 2 on an internal error
+fun pull_action(argc: usize, argv: **u8, marks: *bool, quiet: bool) i64 {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) {
+        err_line("failed to initialise allocator");
+        ret 2;
+    }
+
+    val pix: usize = util.arg_index_positional(argc, argv, marks, 3);
+    var arg: str = ".";
+    if (pix < argc) { arg = argv[pix]::str; }
+
+    val res_root: R.Result[str, str] = util.resolve_project_root(?a, arg);
+    if (R.is_err[str, str](res_root)) {
+        err_line(R.unwrap_err[str, str](res_root));
+        ret 1;
+    }
+    ret pull_project(R.unwrap_ok[str, str](res_root), quiet);
 }
 
 # realize the manifest's dependency intent for the project rooted at `root`
@@ -227,7 +273,7 @@ pub fun pull_project(root: str, quiet: bool) i64 {
     if (R.is_err[bool, str](res_nv)) { ret err_oom(); }
 
     # seed the flat tree from the top-level manifest's `[dep.*]`.
-    val res_seed: R.Result[bool, str] = enqueue_manifest(?nv, root, dep_root, ?mt, project_id);
+    val res_seed: R.Result[bool, str] = enqueue_manifest(?nv, root, "", dep_root, dep_name, ?mt, project_id);
     if (R.is_err[bool, str](res_seed)) {
         err_line(R.unwrap_err[bool, str](res_seed));
         ret 1;
@@ -261,7 +307,7 @@ pub fun pull_project(root: str, quiet: bool) i64 {
         val res_sub: R.Result[toml.Table, str] = read_dep_manifest(?a, nv.data[i].dir);
         if (R.is_ok[toml.Table, str](res_sub)) {
             var sub: toml.Table = R.unwrap_ok[toml.Table, str](res_sub);
-            val res_enqueue: R.Result[bool, str] = enqueue_manifest(?nv, nv.data[i].dir, dep_root, ?sub, nv.data[i].name);
+            val res_enqueue: R.Result[bool, str] = enqueue_manifest(?nv, nv.data[i].dir, nv.data[i].rel, dep_root, dep_name, ?sub, nv.data[i].name);
             if (R.is_err[bool, str](res_enqueue)) {
                 err_line(R.unwrap_err[bool, str](res_enqueue));
                 ret 1;
@@ -459,7 +505,7 @@ fun materialize_path_node(a: *A.Allocator, node: *DepNode, dep_root: str, dep_na
         ret 1;
     }
 
-    val res_target: R.Result[str, str] = link_target(a, dep_name, node.dir);
+    val res_target: R.Result[str, str] = link_target(a, dep_name, node.rel);
     if (R.is_err[str, str](res_target)) { ret err_oom(); }
     val target: str = R.unwrap_ok[str, str](res_target);
 
@@ -885,6 +931,7 @@ fun read_dep_spec(a: *A.Allocator, sub: *toml.Table, name: str) R.Result[DepNode
     node.path    = "";
     node.ref     = "";
     node.dir     = "";
+    node.rel     = "";
     node.req     = "";
     node.commit  = "";
     node.is_git  = false;
@@ -913,14 +960,21 @@ fun read_dep_spec(a: *A.Allocator, sub: *toml.Table, name: str) R.Result[DepNode
 # when absolute, else resolved relative to the requiring manifest. A name already
 # present must match its source and ref exactly, else it is a conflict naming both
 # requirers.
+#
+# Each directory is resolved twice, once from the working directory and once from
+# the project root, filling the node's `dir` and `rel`. The requiring manifest is
+# named in both frames for the same reason: a dep declared by a dep resolves its
+# relative path against the requirer, whichever frame is being built.
 # ---
 # nv:           the flat tree to grow
 # manifest_dir: directory of the manifest being read (for relative path deps)
+# manifest_rel: the same directory relative to the project root, "" for the root
 # dep_root:     flat dep tree root for git deps
+# dep_rel:      the same root relative to the project root (the dep dir name)
 # mt:           the parsed manifest table
 # req:          name of the manifest requiring these deps
 # ret:          ok(true), or a conflict / malformed-stanza error
-fun enqueue_manifest(nv: *NodeVec, manifest_dir: str, dep_root: str, mt: *toml.Table, req: str) R.Result[bool, str] {
+fun enqueue_manifest(nv: *NodeVec, manifest_dir: str, manifest_rel: str, dep_root: str, dep_rel: str, mt: *toml.Table, req: str) R.Result[bool, str] {
     val deps: *toml.Table = toml.get_table(mt, "dep");
     if (deps == nil) { ret R.ok[bool, str](true); }
     val len: usize = toml.table_len(deps);
@@ -939,15 +993,24 @@ fun enqueue_manifest(nv: *NodeVec, manifest_dir: str, dep_root: str, mt: *toml.T
         node.req = own(nv.a, req);
 
         var res_dir: R.Result[str, str];
+        var res_rel: R.Result[str, str];
         if (node.is_git) {
             res_dir = join2(nv.a, dep_root, node.name::*u8);
+            res_rel = join2(nv.a, dep_rel,  node.name::*u8);
         }
         or {
-            if (path_is_absolute(node.path)) { res_dir = R.ok[str, str](own(nv.a, node.path)); }
-            or                               { res_dir = join2(nv.a, manifest_dir, node.path::*u8); }
+            if (path_is_absolute(node.path)) {
+                res_dir = R.ok[str, str](own(nv.a, node.path));
+                res_rel = R.ok[str, str](own(nv.a, node.path));
+            }
+            or {
+                res_dir = join2(nv.a, manifest_dir, node.path::*u8);
+                res_rel = join2(nv.a, manifest_rel, node.path::*u8);
+            }
         }
-        if (R.is_err[str, str](res_dir)) { ret R.err[bool, str]("out of memory"); }
+        if (R.is_err[str, str](res_dir) || R.is_err[str, str](res_rel)) { ret R.err[bool, str]("out of memory"); }
         node.dir = R.unwrap_ok[str, str](res_dir);
+        node.rel = R.unwrap_ok[str, str](res_rel);
 
         val existing: i64 = nv_find(nv, node.name);
         if (existing >= 0) {
@@ -2182,7 +2245,7 @@ test "mach.cli.cmd.dep.enqueue_manifest:absolute_path_verbatim" {
     var nv: NodeVec;
     if (R.is_err[bool, str](nv_init(?a, ?nv, 4))) { ret 1; }
 
-    val res_enq: R.Result[bool, str] = enqueue_manifest(?nv, "/project/root", "/project/root/dep", ?mt, "root");
+    val res_enq: R.Result[bool, str] = enqueue_manifest(?nv, "/project/root", "", "/project/root/dep", "dep", ?mt, "root");
     if (R.is_err[bool, str](res_enq)) { ret 1; }
     if (nv.len != 2) { ret 1; }
 
@@ -2191,6 +2254,114 @@ test "mach.cli.cmd.dep.enqueue_manifest:absolute_path_verbatim" {
     if (i_abs < 0 || i_rel < 0) { ret 1; }
     if (!str_equals(nv.data[i_abs::usize].dir, "/abs/somewhere/lib"))       { ret 1; }
     if (!str_equals(nv.data[i_rel::usize].dir, "/project/root/../lib-rel")) { ret 1; }
+    ret 0;
+}
+
+# a node's `rel` names its directory from the project root while `dir` names it
+# from the working directory, so the symlink a path dep records resolves from
+# inside the project no matter where the pull was run (#2936). an absolute path
+# is the same in both frames, and a transitive dep resolves against its
+# requirer's `rel`, not the root
+test "mach.cli.cmd.dep.enqueue_manifest:rel_is_root_relative" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+
+    val res_mt: R.Result[toml.Table, str] = toml.parse(?a,
+        "[dep.p]\npath = \"../lib-p\"\n[dep.g]\ngit = \"u\"\n[dep.abs]\npath = \"/abs/lib\"\n");
+    if (R.is_err[toml.Table, str](res_mt)) { ret 1; }
+    var mt: toml.Table = R.unwrap_ok[toml.Table, str](res_mt);
+
+    var nv: NodeVec;
+    if (R.is_err[bool, str](nv_init(?a, ?nv, 4))) { ret 1; }
+
+    # the pull runs two directories away from the project it was given.
+    val res_enq: R.Result[bool, str] = enqueue_manifest(?nv, "../../proj", "", "../../proj/dep", "dep", ?mt, "root");
+    if (R.is_err[bool, str](res_enq)) { ret 1; }
+
+    val i_p: i64 = nv_find(?nv, "p");
+    val i_g: i64 = nv_find(?nv, "g");
+    val i_abs: i64 = nv_find(?nv, "abs");
+    if (i_p < 0 || i_g < 0 || i_abs < 0) { ret 1; }
+    if (!str_equals(nv.data[i_p::usize].dir, "../../proj/../lib-p"))   { ret 1; }
+    if (!str_equals(nv.data[i_p::usize].rel, "../lib-p"))              { ret 1; }
+    if (!str_equals(nv.data[i_g::usize].dir, "../../proj/dep/g"))      { ret 1; }
+    if (!str_equals(nv.data[i_g::usize].rel, "dep/g"))                 { ret 1; }
+    if (!str_equals(nv.data[i_abs::usize].rel, "/abs/lib"))            { ret 1; }
+
+    # the link written for `p` climbs out of the vendor dir and resolves from the
+    # project root, never from wherever the pull was invoked.
+    val res_target: R.Result[str, str] = link_target(?a, "dep", nv.data[i_p::usize].rel);
+    if (R.is_err[str, str](res_target))                                  { ret 1; }
+    if (!str_equals(R.unwrap_ok[str, str](res_target), "../../lib-p"))   { ret 1; }
+
+    # a dep of the path dep resolves against that dep's own directory in both frames.
+    val res_sub: R.Result[toml.Table, str] = toml.parse(?a, "[dep.q]\npath = \"../lib-q\"\n");
+    if (R.is_err[toml.Table, str](res_sub)) { ret 1; }
+    var sub: toml.Table = R.unwrap_ok[toml.Table, str](res_sub);
+    val res_enq2: R.Result[bool, str] = enqueue_manifest(?nv, nv.data[i_p::usize].dir, nv.data[i_p::usize].rel,
+                                                         "../../proj/dep", "dep", ?sub, "p");
+    if (R.is_err[bool, str](res_enq2)) { ret 1; }
+    val i_q: i64 = nv_find(?nv, "q");
+    if (i_q < 0) { ret 1; }
+    if (!str_equals(nv.data[i_q::usize].dir, "../../proj/../lib-p/../lib-q")) { ret 1; }
+    if (!str_equals(nv.data[i_q::usize].rel, "../lib-p/../lib-q"))            { ret 1; }
+    ret 0;
+}
+
+# `mach dep pull <path>` realizes the project it is given, not the one the shell
+# happens to stand in. the path positional used to be accepted and ignored, so a
+# pull aimed at another project reported on the current directory and left the
+# named project's path dep unmaterialized, and the build that sent the user there
+# kept sending them back (#2936)
+test "mach.cli.cmd.dep.run:pull_realizes_the_named_project" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+
+    # a uniquely owned temp path, taken as the root of a two-project tree
+    val res_temp: R.Result[fs.TempFile, str] = fs.temp_create(?a, "mach_test_pull_arg");
+    if (R.is_err[fs.TempFile, str](res_temp)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](res_temp);
+    val root: str = fs.temp_path(?tf);
+    fs.temp_close_and_remove(?tf);
+
+    val proj: str = concat3(?a, root, "/", "proj");
+    val src:  str = concat3(?a, root, "/", "lib-x");
+    if (O.is_some[str](fs.create_dir_all(?a, proj, 0o755))) { ret 1; }
+    if (O.is_some[str](fs.create_dir_all(?a, src,  0o755))) { ret 1; }
+
+    val proj_body: str = "[project]\nid = \"proj\"\n\n[dep.lib-x]\npath = \"../lib-x\"\n";
+    val src_body:  str = "[project]\nid = \"lib-x\"\n";
+    val proj_toml: str = concat3(?a, proj, "/", MANIFEST);
+    val src_toml:  str = concat3(?a, src,  "/", MANIFEST);
+    if (O.is_some[str](fs.write_bytes(proj_toml, proj_body::*u8, str_len(proj_body), 0o644))) {
+        fs.remove_all(?a, root);
+        ret 1;
+    }
+    if (O.is_some[str](fs.write_bytes(src_toml, src_body::*u8, str_len(src_body), 0o644))) {
+        fs.remove_all(?a, root);
+        ret 1;
+    }
+
+    var av: [5]*u8;
+    av[0] = "mach"::*u8;
+    av[1] = "dep"::*u8;
+    av[2] = "pull"::*u8;
+    av[3] = "--quiet"::*u8;
+    av[4] = proj::*u8;
+    var mk: [5]bool;
+    var i: usize = 0;
+    for (i < 5) { mk[i] = false; i = i + 1; }
+
+    val rc: i64 = run(5, ?av[0], ?mk[0]);
+
+    # the link is read through, so this passes only when its target resolves from
+    # the vendor location, not merely when some link was written.
+    val vendored: str = concat3(?a, proj, "/dep/lib-x/", MANIFEST);
+    val linked: bool = fs.exists(vendored);
+    fs.remove_all(?a, root);
+
+    if (rc != 0)  { ret 1; }
+    if (!linked)  { ret 1; }
     ret 0;
 }
 

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -212,7 +212,7 @@ fun help_dep() {
     print.print("manage the project's dependency tree under dir_dep.\n");
     print.print("\n");
     print.print("actions:\n");
-    print.print("  pull                          realise the manifest: clone, re-resolve, repair, lock\n");
+    print.print("  pull [<path>]                 realise the manifest: clone, re-resolve, repair, lock\n");
     print.print("  update <name> | --all         advance branch refs to current remote tips\n");
     print.print("  add <name> --git <url> [--ref R] | --path <dir>   declare a dependency, then pull\n");
     print.print("  remove <name> [--purge]       drop a dependency (--purge deletes its dir)\n");
@@ -224,6 +224,9 @@ fun help_dep() {
     print.print("records each git dep's resolved commit in mach.lock and resolves\n");
     print.print("transitive deps into the flat tree. git is needed only by the network\n");
     print.print("commands; mach build never shells out.\n");
+    print.print("\n");
+    print.print("pull takes a project directory, as mach build does, and defaults to the\n");
+    print.print("current directory. every other action acts on the current directory.\n");
 }
 
 # print the `mach init` detail page

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1112,7 +1112,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         val argop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](aor);
 
         val er: R.Result[bool, str] = emit_arg_slot(ctx, mb, slot, argop, soff, aag, av.ty,
-                                                    natural_stack_slot(ctx.tgt, pidx >= layout.param_count));
+                                                    natural_stack_slot(ctx.tgt, pidx >= layout.param_count),
+                                                    is_ext);
         if (R.is_err[bool, str](er)) {
             sig_layout_free(ctx, ?layout);
             ret er;
@@ -1378,8 +1379,40 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
 #            against it (the Apple arm64 fixed rule)
 # ret:       ok(true) on success, or a loud error
 fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
-                  stack_off: i64, is_aggr: bool, ty: type.IrTypeId, natural: bool) R.Result[bool, str] {
+                  stack_off: i64, is_aggr: bool, ty: type.IrTypeId, natural: bool,
+                  is_ext: bool) R.Result[bool, str] {
     val size: u64 = type.byte_size(ctx.types, ty, ctx.tgt)::u64;
+
+    # THE CALLER OWNS THE COPY AT A FOREIGN BOUNDARY (#3004). AAPCS64, the RISC-V
+    # psABI and the Microsoft convention all say the same thing about an aggregate
+    # passed by reference: the CALLER allocates a copy and passes its address, so the
+    # callee may advance or overwrite its parameter without touching the caller's
+    # object. mach's own convention reaches the same semantics from the other end -
+    # a mach callee gives every parameter storage of its own and copies the incoming
+    # aggregate into it at entry - and the two are indistinguishable while both ends
+    # are mach.
+    #
+    # They are not indistinguishable at an `ext` call. A C callee copies nothing, so
+    # handing it the address of mach's own object lets it write through to it. That
+    # is unobservable for a callee that only reads its parameter, which is why it
+    # stood: what made it visible is `va_list`, a by-value parameter every consumer
+    # ADVANCES, so a forwarded one comes back spent.
+    #
+    # Gated on `is_ext` because it is a difference between two conventions rather
+    # than a fix to one: mach->mach already copies, at the callee, and copying at
+    # both ends would be one redundant copy per aggregate argument on every internal
+    # call. `is_ext` is the axis that already carries exactly this kind of divergence
+    # (win64's vector marshal, #2058).
+    if (is_ext && is_aggr && (slot.class == abi.CLASS_BYREF || slot.class == abi.CLASS_STACK_BYREF)) {
+        var owned: u32 = mir.MIR_VREG_NIL;
+        val cr: R.Result[bool, str] = copy_aggregate_to_temp(ctx, mb, argop, ty, ?owned);
+        if (R.is_err[bool, str](cr)) { ret cr; }
+        if (slot.class == abi.CLASS_STACK_BYREF) {
+            val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
+            ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(owned));
+        }
+        ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(owned), ptr_move_width(ctx));
+    }
     # a register-resident value marshalled by reference (a 128-bit vector at a win64 `ext`
     # boundary, #2058): unlike an aggregate or a scalarized rv64 vector -- already
     # memory-resident, its argop a storage pointer -- the value is in a register, so the
@@ -1475,6 +1508,38 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     # backend re-extends it to the register width by its own convention (the RV64 lp64 family
     # sign-extends a 32-bit register).
     ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
+}
+
+# copy a memory-resident aggregate into a fresh frame temporary at its own alignment
+# and return the temporary's address in a vreg
+#
+# The by-reference twin of `spill_vector_to_temp`: that one exists because the value
+# is in a register and has no address yet, this one because the value HAS an address
+# and the foreign convention requires a different one. Both allocate at the type's
+# own alignment rather than at its size, which for an aggregate is the only number
+# that is a legal slot alignment at all.
+# ---
+# ctx:      the active lowering context
+# mb:       the MIR block the copy / address materialization are appended to
+# src:      the aggregate's storage pointer
+# ty:       the aggregate's IR type (the temp's size and alignment, and the copy length)
+# out_addr: receives the vreg holding the temporary's address
+# ret:      ok(true) on success, or a loud error
+fun copy_aggregate_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, src: mir.MirOperand,
+                           ty: type.IrTypeId, out_addr: *u32) R.Result[bool, str] {
+    val size:  u64 = type.byte_size(ctx.types, ty, ctx.tgt)::u64;
+    val align: u32 = type.byte_align(ctx.types, ty, ctx.tgt);
+    val res_key: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](res_key)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_key)); }
+    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+
+    val sr: R.Result[bool, str] = context.add_spill_slot_aligned(ctx, sk, size, align);
+    if (R.is_err[bool, str](sr)) { ret sr; }
+
+    val cr: R.Result[bool, str] = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), src, size);
+    if (R.is_err[bool, str](cr)) { ret cr; }
+
+    ret context.emit_lea_slot(ctx, mb, mir.op_mem_slot(sk, 0), out_addr);
 }
 
 # store a register-resident vector to a fresh 16-byte-aligned frame temporary and

--- a/src/lang/ct/dudect.mach
+++ b/src/lang/ct/dudect.mach
@@ -1,0 +1,236 @@
+# dudect-style timing-leak measurement engine (#1647, #2363, #2944)
+#
+# Times a function over two input classes and reports how far apart the two timing
+# distributions sit. The classes are dudect's fixed-vs-random: class 0 always feeds one
+# fixed input, class 1 a fresh pseudo-random one. The ONLY difference between the two
+# timed regions is the value handed to the function - every RNG draw happens outside the
+# timed region - so a difference is attributable to the function rather than to harness
+# overhead. Classes alternate round by round, so thermal or frequency drift biases both
+# equally. This is the dudect method (Reparaz, Balasch, Verbauwhede 2016).
+#
+# WHAT A CALLER ASSERTS ON. The separation between the class means, never |t|. Welch
+# divides by the sample variance, and machine load inflates the variance without moving
+# the means, so |t| swings two orders of magnitude while the underlying effect does not.
+# |t| is computed and reported because it is the right statistic for judging significance
+# on a quiet box and it is what the method names; it is deliberately not a gate.
+#
+# TWO SAMPLING REGIMES, BECAUSE THE LEAKAGE MODEL HAS TWO OBSERVABLE CHANNELS. A LATENCY
+# leak scales with the batch size: more calls per timed sample lift a running-time
+# difference above clock resolution, which is why `LATENCY_INNER` is large. An
+# ADDRESS-trace leak does the opposite - every call in a batch is handed the SAME input,
+# so after the first call both classes read a warm cache line and the single miss
+# carrying the signal is averaged away. The two channels want opposite batch sizes, which
+# is why `inner` is a parameter rather than a constant, and why one set of tuned numbers
+# cannot cover both.
+
+use std.system.os;
+use std.types.size.usize;
+
+# calls per timed sample in latency mode; keeps a sample well above clock resolution
+pub val LATENCY_INNER: u64 = 2048;
+
+# timed samples per class in latency mode
+pub val LATENCY_ROUNDS: u64 = 2000;
+
+# timed samples per class in address mode
+#
+# One call per sample there, so a single cache miss sits against the clock overhead of
+# the sample itself and needs far more samples to resolve than a latency leak does. |t|
+# grows as the square root of the sample count: measured on a 4 MB probe, 2 000 samples
+# gave 1.6-20 (straddling any threshold, so neither a confirmation nor a denial), 20 000
+# gave 10.7-26, and 200 000 gave 67-180 while the null control stayed under 1.6.
+pub val ADDRESS_ROUNDS: u64 = 100000;
+
+# timed samples per class for a REFERENCE probe, one that must NOT separate
+#
+# Resolving a one-cache-miss signal is what needs `ADDRESS_ROUNDS`. Refuting a separation
+# the size of a planted leak does not: the leak moves the means by tens of percent, and a
+# tenth of the samples resolves that. A reference probe doing per-call work proportional
+# to its table would otherwise dominate the whole measurement.
+pub val REFERENCE_ROUNDS: u64 = 20000;
+
+# discarded leading rounds; lets caches and the branch predictor settle
+pub val WARMUP: u64 = 64;
+
+# sink for function results, a module global the optimiser cannot prove dead, so no
+# timed call is eliminated
+var SINK: u64 = 0;
+
+# what one measurement produced
+# ---
+# mean_fix: mean sample time over the fixed-input class, in nanoseconds
+# mean_rnd: mean sample time over the random-input class
+# t:        |Welch's t| between the two, reported and never asserted on
+pub rec Measurement {
+    mean_fix: f64;
+    mean_rnd: f64;
+    t:        f64;
+}
+
+# how far apart the two class means sit, as a fraction of the smaller
+#
+# DIRECTION-AGNOSTIC ON PURPOSE. Which class runs longer is a property of the probe: an
+# early-exit comparison is slowest on the fixed class, because that is the input that
+# matches all the way through, while a table read is slowest on the random class, because
+# that is the one that misses. A measure that read only one direction would answer 2.0 for
+# one probe and 0.67 for the other on the same size of effect. `0.0` is two identical
+# means, which is what a constant-time function and a null control both aim at.
+pub fun separation(m: *Measurement) f64 {
+    if (m.mean_fix <= 0.0 || m.mean_rnd <= 0.0) { ret 0.0; }
+    if (m.mean_rnd > m.mean_fix) { ret m.mean_rnd / m.mean_fix - 1.0; }
+    ret m.mean_fix / m.mean_rnd - 1.0;
+}
+
+# online mean/variance accumulator (Welford), one per input class
+rec Stat {
+    n:    f64;
+    mean: f64;
+    m2:   f64;
+}
+
+fun stat_init(s: *Stat) {
+    s.n    = 0.0;
+    s.mean = 0.0;
+    s.m2   = 0.0;
+}
+
+fun stat_push(s: *Stat, x: f64) {
+    s.n = s.n + 1.0;
+    val d1: f64 = x - s.mean;
+    s.mean = s.mean + d1 / s.n;
+    val d2: f64 = x - s.mean;
+    s.m2 = s.m2 + d1 * d2;
+}
+
+# sample variance, or 0 with fewer than two samples
+fun stat_var(s: *Stat) f64 {
+    if (s.n < 2.0) { ret 0.0; }
+    ret s.m2 / (s.n - 1.0);
+}
+
+# xorshift64; fast enough to draw outside the timed region
+fun xnext(state: *u64) u64 {
+    var x: u64 = @state;
+    x = x ^ (x << 13);
+    x = x ^ (x >> 7);
+    x = x ^ (x << 17);
+    @state = x;
+    ret x;
+}
+
+# the monotonic clock in nanoseconds
+fun now_ns() u64 {
+    var ts: os.Timespec;
+    os.monotonic(?ts);
+    ret ts.sec::u64 * 1000000000 + ts.nsec::u64;
+}
+
+# f64 square root by Newton iteration; std math is integer-only
+fun sqrtf(x: f64) f64 {
+    if (x <= 0.0) { ret 0.0; }
+    var g: f64 = x;
+    var i: usize = 0;
+    for (i < 64) {
+        g = 0.5 * (g + x / g);
+        i = i + 1;
+    }
+    ret g;
+}
+
+fun fabsf(x: f64) f64 {
+    if (x < 0.0) { ret 0.0 - x; }
+    ret x;
+}
+
+# time `inner` calls of `fut` on a single input; the result feeds SINK so no call is
+# dropped. the input is fixed for the whole batch, so both classes execute an identical
+# harness loop and differ only in the value under test.
+fun measure_batch(fut: fun(u64) u64, input: u64, inner: u64) u64 {
+    var acc: u64 = 0;
+    val t0: u64 = now_ns();
+    var i: u64 = 0;
+    for (i < inner) {
+        acc = acc + fut(input);
+        i = i + 1;
+    }
+    val t1: u64 = now_ns();
+    SINK = SINK + acc;
+    ret t1 - t0;
+}
+
+# Welch's t-statistic for two independent samples with unequal variance
+fun welch_t(a: *Stat, b: *Stat) f64 {
+    val va: f64 = stat_var(a);
+    val vb: f64 = stat_var(b);
+    val se: f64 = va / a.n + vb / b.n;
+    if (se <= 0.0) { ret 0.0; }
+    ret (a.mean - b.mean) / sqrtf(se);
+}
+
+# measure one function under test over the two input classes
+# ---
+# out:    receives the two class means and |t|
+# fut:    the function under test
+# fixed:  the class-0 input
+# seed:   RNG seed for class-1 inputs
+# inner:  calls per timed sample
+# rounds: timed samples per class
+pub fun measure(out: *Measurement, fut: fun(u64) u64, fixed: u64, seed: u64,
+                inner: u64, rounds: u64) {
+    var rng: u64 = seed;
+
+    var w: u64 = 0;
+    for (w < WARMUP) {
+        SINK = SINK + measure_batch(fut, fixed, inner);
+        SINK = SINK + measure_batch(fut, xnext(?rng), inner);
+        w = w + 1;
+    }
+
+    var sf: Stat;
+    var sr: Stat;
+    stat_init(?sf);
+    stat_init(?sr);
+
+    # WHICH CLASS GOES FIRST ALTERNATES, and it is not cosmetic. Measured with the fixed
+    # class always leading, a probe that cannot leak at all still came out with its fixed
+    # class 7 to 11 percent slower under a loaded machine, consistently in that direction:
+    # the leading sample of a round absorbs whatever the round's first cache and scheduler
+    # transition costs. That is a position effect, not an input effect, and a measurement
+    # meant to attribute a difference to the input has to remove it. Alternating splits it
+    # evenly between the two classes instead of charging it to one.
+    var r: u64 = 0;
+    for (r < rounds) {
+        val rnd: u64 = xnext(?rng);
+        var tf: u64 = 0;
+        var tr: u64 = 0;
+        if ((r & 1) == 0) {
+            tf = measure_batch(fut, fixed, inner);
+            tr = measure_batch(fut, rnd, inner);
+        }
+        or {
+            tr = measure_batch(fut, rnd, inner);
+            tf = measure_batch(fut, fixed, inner);
+        }
+        stat_push(?sf, tf::f64);
+        stat_push(?sr, tr::f64);
+        r = r + 1;
+    }
+
+    out.mean_fix = sf.mean;
+    out.mean_rnd = sr.mean;
+    out.t        = fabsf(welch_t(?sf, ?sr));
+}
+
+# measure for a LATENCY leak: large batches, so a running-time difference clears the
+# clock's resolution
+pub fun measure_latency(out: *Measurement, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    measure(out, fut, fixed, seed, LATENCY_INNER, LATENCY_ROUNDS);
+}
+
+# measure for an ADDRESS-TRACE leak: one call per sample, many samples
+#
+# Batching is exactly what hides this class, so the batch is one and the cost moves to
+# the sample count.
+pub fun measure_address(out: *Measurement, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    measure(out, fut, fixed, seed, 1, ADDRESS_ROUNDS);
+}

--- a/src/lang/ct/probe.mach
+++ b/src/lang/ct/probe.mach
@@ -1,0 +1,387 @@
+# the constant-time probes, measured on the host (#1647, #2363, #2944)
+#
+# The empirical layer of mach's constant-time story, beside the static ones: the secret
+# flow gates in sema, the `#[oblivious]` codegen contract, and the translation validator
+# over the lowered MIR. Those three all reason about the program. This one runs it and
+# times it, which is the only way to learn anything about the machine.
+#
+# WHAT IS ASSERTED, AND WHY IT IS NOT THE OBVIOUS THING. A timing measurement cannot
+# confirm that a function is constant-time - a clean score is consistent with a leak the
+# instrument cannot see. It CAN refute: a function whose class means separate the way a
+# planted leak's do is leaking. So every gate here is a refutation, and every mode carries
+# a PLANTED LEAK of its own so that a mode which has stopped measuring fails through its
+# own control rather than being read as a pass.
+#
+# THE NULL CONTROL DECIDES WHETHER THE RUN COUNTS. `null_probe` cannot leak - it discards
+# its input - so any separation it shows is the machine, not the code. A run in which it
+# is not flat has no discriminating power, and the leak verdict under it would mean
+# nothing in either direction. Such a run DECLINES. That is not a way of tolerating a
+# failure: it is the validity precondition of a differential measurement, and asserting
+# under a null control that moved would be reporting machine load as a compiler
+# regression.
+#
+# GATES ARE MEAN SEPARATIONS, NOT |t| (#2371). |t| divides by the sample variance and
+# concurrent load inflates the variance without moving the means, so it collapses while
+# the leak is plainly still there. Measured on the earlier form of this harness at load
+# average 27, six consecutive runs of the same binary gave |t| of 11.00, 10.35, 7.51,
+# 7.78, 9.27 and 11.24 - three of six below a threshold of 10 - while the mean ratio never
+# fell below 3.4.
+#
+# THE ADDRESS PROBE NEEDS A TABLE LARGER THAN THIS MACHINE'S LAST-LEVEL CACHE, or it
+# measures an L3 hit against an L2 hit and the signal collapses. A cache-resident table
+# leaks its index just as truly and no timing harness will see it, which is why
+# `ct_scan`'s property rests on the secret-index gate and not on this measurement.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.allocator.page;
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+use p: std.print;
+
+use dudect: mach.lang.ct.dudect;
+
+# THE ADDRESS TABLE MUST EXCEED THIS MACHINE'S LAST-LEVEL CACHE. 256 MB clears the
+# largest LLC in common desktop parts today - a Ryzen 5800X3D carries 96 MB of L3, and at
+# 4 MB this probe scored 8.4 to 209 across three runs, which is unassertable. If the probe
+# stops firing on some future machine this is the constant to raise; check `lscpu -C`. A
+# planted leak that does not fire FAILS rather than passing, so a cache larger than this
+# cannot turn into a silent green.
+pub val BIG: usize = 268435456;
+
+# small enough to scan exhaustively per call, and to sit in L1
+pub val SMALL: usize = 4096;
+
+var BIG_TABLE: *u8 = nil;
+var SMALL_TABLE: *u8 = nil;
+
+# the address null control's walk position, advanced per read so its lines miss the way
+# the planted leak's do
+var WALK: u64 = 0x9E3779B97F4A7C15;
+
+# allocate and fault in both tables
+#
+# HEAP, NOT A MODULE `var`. As static storage the big table would sit in the compiler's
+# own BSS on every host, whether or not anything ever measured. Allocated here it costs a
+# single mapping, and only in the process that runs the measurement.
+#
+# The fill strides a page rather than a cache line: the probe reads an ADDRESS, and what
+# is at it does not matter, so the requirement is that every page be resident before the
+# first timed call rather than that every line carry a pattern.
+pub fun setup(alloc: *A.Allocator) bool {
+    val rb: R.Result[*u8, *u8] = A.allocate[u8](alloc, BIG);
+    if (R.is_err[*u8, *u8](rb)) { ret false; }
+    BIG_TABLE = R.unwrap_ok[*u8, *u8](rb);
+
+    val rs: R.Result[*u8, *u8] = A.allocate[u8](alloc, SMALL);
+    if (R.is_err[*u8, *u8](rs)) { ret false; }
+    SMALL_TABLE = R.unwrap_ok[*u8, *u8](rs);
+
+    var i: usize = 0;
+    for (i < BIG) {
+        BIG_TABLE[i] = ((i >> 12) & 0xFF)::u8;
+        i = i + 4096;
+    }
+    i = 0;
+    for (i < SMALL) {
+        SMALL_TABLE[i] = (i & 0xFF)::u8;
+        i = i + 1;
+    }
+    ret true;
+}
+
+pub fun teardown(alloc: *A.Allocator) {
+    if (BIG_TABLE != nil) {
+        A.deallocate[u8](alloc, BIG_TABLE, BIG);
+        BIG_TABLE = nil;
+    }
+    if (SMALL_TABLE != nil) {
+        A.deallocate[u8](alloc, SMALL_TABLE, SMALL);
+        SMALL_TABLE = nil;
+    }
+}
+
+# branchless constant-time equality of two secret words: 1 if equal, else 0
+#
+# The xor difference is 0 exactly when the words are equal, and `(d | (0 - d)) >> 63` is 1
+# iff `d != 0` - for any nonzero d either d or its two's complement has bit 63 set - so
+# the answer is computed without any secret reaching a branch, an index, or a
+# variable-latency operand.
+#[oblivious]
+pub fun ct_eq(a: ^u64, b: ^u64) ^u64 {
+    val d:  ^u64 = a ^ b;
+    val nz: ^u64 = (d | (0 - d)) >> 63;
+    ret 1 - nz;
+}
+
+# the latency mode's constant-time reference
+#
+# Compares the input, taken as secret material, against a fixed secret reference and
+# declassifies the 0/1 verdict. All eight bytes are always folded, so the work is
+# identical for every input.
+pub fun ct_probe(x: u64) u64 {
+    val sx:  ^u64 = x;
+    val tag: ^u64 = 0;
+    ret ct_eq(sx, tag):^;
+}
+
+# the latency mode's planted leak: a variable-time comparison
+#
+# It handles the input as a PUBLIC value - the secret-typing discipline is deliberately
+# dropped, which is the real-world mistake - and early-exits on the first mismatching
+# byte, so its running time depends on how many leading bytes matched.
+#
+# THIS LEAK IS UNWRITABLE WITH `^` TYPES: sema rejects a secret branch or loop condition
+# in any function. That is the point of the pairing - the static discipline forbids the
+# leak at the type level, and this catches it empirically the moment the discipline is
+# abandoned.
+pub fun leaky_probe(x: u64) u64 {
+    val tag: u64 = 0;
+    var i: u64 = 0;
+    for (i < 8) {
+        val bx: u64 = (x >> (i * 8)) & 0xff;
+        val bt: u64 = (tag >> (i * 8)) & 0xff;
+        if (bx != bt) { ret i; }
+        i = i + 1;
+    }
+    ret 8;
+}
+
+# how many input-derived lines one address-mode call reads
+#
+# ONE MISS DOES NOT SURVIVE A PARALLEL TEST RUN. A single input-indexed read is about
+# eighty nanoseconds of cache miss inside a sample whose clock overhead is several hundred,
+# and with a sibling test process per core the scheduler moves a sample by more than the
+# whole signal. Measured that way the planted leak cleared the null control by 0.13 in the
+# worst run while the null control itself wandered by 0.32, which is two populations that
+# overlap.
+#
+# Sixteen reads per call is both what lifts the signal clear of that and what a
+# table-driven cipher actually does per round, so the probe moves closer to the thing it
+# stands for rather than further from it. It part-pays for itself: a signal an order of
+# magnitude larger halves the samples needed to resolve it.
+pub val PROBE_READS: usize = 16;
+
+# scramble a word so consecutive reads land on unrelated lines
+#
+# A walk the hardware prefetcher can predict is a walk with no cache misses in it, and a
+# probe with no misses measures nothing. This is the 64-bit finalizer from MurmurHash3,
+# used for its avalanche and nothing else.
+fun mix(v: u64) u64 {
+    var h: u64 = v;
+    h = h ^ (h >> 33);
+    h = h * 0xFF51AFD7ED558CCD;
+    h = h ^ (h >> 33);
+    ret h;
+}
+
+# the address mode's planted leak: input-derived reads over a table larger than any cache
+#
+# Exactly the operation `std.crypto.ct.lookup` exists to replace. Written over a PUBLIC
+# index because sema refuses a secret one outright, which is the point of the pairing: the
+# static discipline makes this unconstructable with `^` types, and this catches it the
+# moment the discipline is dropped.
+#
+# It fires in address mode and NOT in latency mode, and that asymmetry is the whole reason
+# both modes exist.
+pub fun leak_big(x: u64) u64 {
+    var acc: u64 = 0;
+    var h: u64 = x;
+    var k: usize = 0;
+    for (k < PROBE_READS) {
+        h = mix(h);
+        acc = acc + BIG_TABLE[(h::usize) % BIG]::u64;
+        k = k + 1;
+    }
+    ret acc;
+}
+
+# the address mode's constant-time reference: the masked full-table scan
+#
+# The shape a constant-time lookup emits. Every element is read for every index, so the
+# address trace is identical whatever the index, which is the property under test.
+pub fun ct_scan(x: u64) u64 {
+    val idx: usize = (x::usize) % SMALL;
+    var acc: u8 = 0;
+    var i: usize = 0;
+    for (i < SMALL) {
+        val hit: u8 = i == idx;
+        val m:   u8 = 0 - hit;
+        acc = acc | (SMALL_TABLE[i] & m);
+        i = i + 1;
+    }
+    ret acc::u64;
+}
+
+# the latency mode's null control: the planted leak's work with no early exit
+#
+# COST-MATCHED, and the first version of this was not. A control bounds the sampling noise
+# of the probe it is compared against only if it is sampled the same way. A trivial
+# `ret (x & 0) + 1` has a sample a few microseconds long, and a scheduler event inside a
+# parallel test run moves that by a large fraction while barely touching a sample ten
+# times longer, so the cheapest probe in the set ends up setting the precondition for every
+# other. Measured that way the trivial control wandered by up to 0.49 while the probes it
+# was meant to bound stayed under 0.30.
+#
+# This walks all eight bytes every time, folds them without a branch, and so runs the
+# leaky probe's LONGEST path on every input. Same trip count, same work, no way for the
+# input to change either.
+pub fun null_probe(x: u64) u64 {
+    val tag: u64 = 0;
+    var acc: u64 = 0;
+    var i: u64 = 0;
+    for (i < 8) {
+        val bx: u64 = (x >> (i * 8)) & 0xff;
+        val bt: u64 = (tag >> (i * 8)) & 0xff;
+        acc = acc + (bx ^ bt);
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# the address mode's null control: the same reads, addressed independently of the input
+#
+# Cost-matched for the same reason its latency sibling is. It walks the same table for the
+# same number of lines and takes its addresses from a module global rather than from `x`:
+# identical work, identical miss count, and an address trace that cannot depend on the
+# input.
+pub fun null_walk(x: u64) u64 {
+    var acc: u64 = 0;
+    var k: usize = 0;
+    for (k < PROBE_READS) {
+        WALK = mix(WALK);
+        acc = acc + BIG_TABLE[(WALK::usize) % BIG]::u64;
+        k = k + 1;
+    }
+    ret acc + (x & 0);
+}
+
+# how far a probe must separate past the null control to count as leaking, and how far the
+# null control may separate before the run is judged unable to discriminate at all
+#
+# ONE NUMBER PER MODE, because the two questions have the same answer. A run in which the
+# control that CANNOT leak separates by as much as a leak has to is a run whose sampling
+# produced the signal it was meant to resolve, and nothing measured under it means
+# anything in either direction. That run declines.
+#
+# THE GATES SUBTRACT THE NULL RATHER THAN COMPARING AGAINST 1.0. The control is measured
+# in the same run under the same load, so subtracting it removes whatever the machine did
+# to both, which is the property a fixed threshold on one probe does not have.
+#
+# CALIBRATED INSIDE `mach test`, not standalone. Measured alone this harness looks two
+# orders of magnitude quieter than it is: the environment it has to hold in is a parallel
+# run with a job per core, and thresholds set anywhere else are set against the wrong
+# machine. Over five such runs at debug optimisation, with the rest of the suite and other
+# work on the box:
+#
+#   latency  null 0.017-0.223   leak past null 2.04-3.47   reference past null up to 0.28
+#   address  null 0.003-0.153   leak past null 0.72-1.53   reference past null up to 0.04
+#
+# Every threshold below sits at least twice the worst of that, in whichever direction
+# would trip it.
+val LATENCY_NULL_TOL: f64 = 0.60;
+val LATENCY_LEAK_MARGIN: f64 = 0.60;
+val ADDRESS_NULL_TOL: f64 = 0.30;
+val ADDRESS_LEAK_MARGIN: f64 = 0.30;
+
+# print one measurement
+#
+# EVERY MEASUREMENT IS REPORTED, on the passing path as much as the failing one. A harness
+# whose numbers only appear when it is unhappy cannot be calibrated, and these thresholds
+# were set from what `mach test -vv` prints here under a full parallel run, which is the
+# only environment they have to hold in.
+fun report(name: str, m: *dudect.Measurement) {
+    p.printlnf("  {} mean_fix={} mean_rnd={} separation={} |t|={}",
+               name, m.mean_fix, m.mean_rnd, dudect.separation(m), m.t);
+}
+
+# a latency leak is measurable on this host, and the constant-time reference is not one
+# (#1647)
+#
+# Latency mode covers two of the leakage model's three channels: control-flow trace and
+# variable-latency operands. It cannot see the third, and `an_address_leak_is_measured`
+# below is why that is a separate test rather than a wider threshold here.
+test "mach.lang.ct.probe:a_latency_leak_is_measured" {
+    var null_m: dudect.Measurement;
+    var ct_m:   dudect.Measurement;
+    var leak_m: dudect.Measurement;
+
+    dudect.measure_latency(?null_m, null_probe,  0, 0x510E527FADE682D1);
+    dudect.measure_latency(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3);
+    dudect.measure_latency(?leak_m, leaky_probe, 0, 0x452821E638D01377);
+
+    report("null", ?null_m);
+    report("ct",   ?ct_m);
+    report("leak", ?leak_m);
+
+    val ns: f64 = dudect.separation(?null_m);
+    val cs: f64 = dudect.separation(?ct_m);
+    val ls: f64 = dudect.separation(?leak_m);
+
+    if (ns > LATENCY_NULL_TOL) {
+        p.println("declined: the latency null control is not flat, so this run cannot discriminate");
+        ret 0;
+    }
+    if (ls - ns < LATENCY_LEAK_MARGIN) {
+        p.println("the planted latency leak was NOT detected, so the harness is not measuring");
+        ret 1;
+    }
+    if (cs - ns >= LATENCY_LEAK_MARGIN) {
+        p.println("the constant-time reference separated the way the planted leak does");
+        ret 2;
+    }
+    ret 0;
+}
+
+# an address-trace leak is measurable on this host, and the masked scan is not one (#2363)
+#
+# The channel latency mode is blind to, and not by a little: the same `leak_big` measured
+# with latency mode's batch scores flat, because every call in a batch is handed the same
+# input and the single cache miss carrying the signal is averaged away. One call per
+# sample is what sees it, and the cost moves to the sample count.
+test "mach.lang.ct.probe:an_address_leak_is_measured" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    if (!setup(?alloc)) {
+        p.println("declined: this machine would not give up a table larger than its last-level cache");
+        ret 0;
+    }
+
+    var null_m: dudect.Measurement;
+    var leak_m: dudect.Measurement;
+    var scan_m: dudect.Measurement;
+
+    dudect.measure_address(?null_m, null_walk, 0, 0x510E527FADE682D1);
+    dudect.measure_address(?leak_m, leak_big,  0, 0x2B7E151628AED2A6);
+    dudect.measure(?scan_m, ct_scan, 0, 0x3C6EF372FE94F82B, 1, dudect.REFERENCE_ROUNDS);
+
+    teardown(?alloc);
+
+    report("null", ?null_m);
+    report("leak", ?leak_m);
+    report("scan", ?scan_m);
+
+    val ns: f64 = dudect.separation(?null_m);
+    val ls: f64 = dudect.separation(?leak_m);
+    val ss: f64 = dudect.separation(?scan_m);
+
+    if (ns > ADDRESS_NULL_TOL) {
+        p.println("declined: the address null control is not flat, so this run cannot discriminate");
+        ret 0;
+    }
+    if (ls - ns < ADDRESS_LEAK_MARGIN) {
+        p.println("the planted address leak was NOT detected. most likely this machine's");
+        p.println("last-level cache is at or above the probe table size: check `lscpu -C`");
+        p.println("and raise `BIG` in mach.lang.ct.probe.");
+        ret 2;
+    }
+    if (ss - ns >= ADDRESS_LEAK_MARGIN) {
+        p.println("the masked scan separated the way the planted address leak does");
+        ret 3;
+    }
+    ret 0;
+}

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -516,19 +516,23 @@ fun requirement_index(arr: *manifest.LinkRequirement, count: u32,
 # vendor location that exists but whose manifest failed to open or parse for some
 # other reason, where `parse_toml_file`'s message already names the path and the
 # OS error. Naming the dep either way is what the bare passthrough this replaces
-# never did.
+# never did. The advice carries the project root the build was aimed at, because
+# `mach dep pull` acts on the project it is given and a bare one would realize
+# whatever project the shell happens to stand in (#2936).
 # ---
 # s:       session, for interning the returned message
 # alias:   the dep's `[dep.<alias>]` name
 # dep_dir: the dep's vendor root, checked for existence to pick the diagnosis
+# root:    the project root being built, named in the advice so the command is
+#          runnable from where the build was
 # read_err: `parse_toml_file`'s error (path- and OS-message-qualified already)
 # ret:     the owned, interned diagnostic
-fun diag_dep_manifest_error(s: *session.Session, alias: str, dep_dir: str, read_err: str) str {
+fun diag_dep_manifest_error(s: *session.Session, alias: str, dep_dir: str, root: str, read_err: str) str {
     val fallback: str = "dep manifest unreadable; run `mach dep pull`";
     var res_msg: R.Result[str, str];
     if (!fs.exists(dep_dir)) {
         res_msg = format.sprint(s.build_alloc,
-            "dependency '{}' is not resolved (missing '{}'); run `mach dep pull`", alias, dep_dir);
+            "dependency '{}' is not resolved (missing '{}'); run `mach dep pull {}`", alias, dep_dir, root);
     }
     or {
         res_msg = format.sprint(s.build_alloc, "dep '{}': {}", alias, read_err);
@@ -563,7 +567,7 @@ fun resolve_dep(s: *session.Session, alias: str, project_root: str, dir_dep: str
     val tr: R.Result[toml.Table, str] = parse_toml_file(s.build_alloc, toml_path);
     str_free(s.build_alloc, toml_path);
     if (R.is_err[toml.Table, str](tr)) {
-        val msg: str = diag_dep_manifest_error(s, alias, dep_dir, R.unwrap_err[toml.Table, str](tr));
+        val msg: str = diag_dep_manifest_error(s, alias, dep_dir, project_root, R.unwrap_err[toml.Table, str](tr));
         str_free(s.build_alloc, dep_dir);
         ret R.err[project.DepEntry, str](msg);
     }

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -384,6 +384,7 @@ fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[com
         p.compiler_ver
     );
     comptime.set_target_defs(?ctx, p.target.isa.defs);
+    comptime.set_va_list(?ctx, p.target.va_list_size, p.target.va_list_align);
     comptime.set_build_context(?ctx,
         p.config.id, p.config.version, p.config.name, p.config.description,
         p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9635,6 +9635,110 @@ test "mach.lang.driver:deep_secrecy_pointer_and_union" {
     ret bad;
 }
 
+# a module of `n` chained records - `R0` carrying `r0`'s fields, each `Ri` wrapping
+# `R(i-1)` - followed by `tail`
+#
+# Built at runtime rather than written out, because the graph sizes that matter to a
+# visited-set bound are in the hundreds. Every link is a DISTINCT nominal a deep type walk
+# must enter, so `n` is exactly the visited-set size that walk needs, and `r0` is where a
+# secret or a back-edge is planted at the FAR end of it.
+# ---
+# alloc: allocator owning the result and every intermediate
+# n:     number of chained records
+# r0:    the field list of `R0`
+# tail:  the module text appended after the chain
+# ret:   the source text, owned by the caller, or none on an allocation failure
+fun ut_chain_src(alloc: *A.Allocator, n: u32, r0: str, tail: str) O.Option[str] {
+    val head: R.Result[str, str] = format.sprint(alloc, "rec R0 {{ {} }}\n", r0);
+    if (R.is_err[str, str](head)) { ret O.none[str](); }
+    var acc: str = R.unwrap_ok[str, str](head);
+
+    var i: u32 = 1;
+    for (i < n) {
+        val next: R.Result[str, str] = format.sprint(alloc, "{}rec R{} {{ a: R{}; }}\n", acc, i, i - 1);
+        A.deallocate[char](alloc, acc::*char, str_len(acc) + 1);
+        if (R.is_err[str, str](next)) { ret O.none[str](); }
+        acc = R.unwrap_ok[str, str](next);
+        i = i + 1;
+    }
+
+    val whole: R.Result[str, str] = format.sprint(alloc, "{}{}", acc, tail);
+    A.deallocate[char](alloc, acc::*char, str_len(acc) + 1);
+    if (R.is_err[str, str](whole)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](whole));
+}
+
+# constant-time (#3065): the deep-secret walk is bounded by the ALLOCATOR, not by a
+# constant, so a merely LARGE type graph is not mistaken for a secret one
+#
+# The walk carried a fixed 256-entry visited set and treated a graph that filled it as
+# possibly-secret. That is the safe direction for a walk that has run out of room, but the
+# bound was reachable by an ordinary program: an ECS whose scene record transitively named
+# a dozen-odd component stores crossed it, and every `p::ptr` in it then failed with a
+# diagnostic about a `^` the program did not contain anywhere. Correct code became
+# uncompilable, and the message pointed at a concept the program never used.
+#
+# THE FIRST TWO ARMS ARE A PAIR, and only the pair says anything. A walk that gives up
+# rejects BOTH a public graph and a secret one, so the public arm alone is satisfied by a
+# walk that stopped early, and the secret arm alone by a walk that never ran. Held
+# together they say the walk reached the far end of the graph and read what was there
+test "mach.lang.driver:deep_secret_walk_scales_with_the_type_graph" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+
+    # comfortably past the 256 the visited set used to hold, so a bound reintroduced at
+    # that size - or at the 256-slot power of two the set now grows through - fails here.
+    val n: u32 = 320;
+
+    val tr: R.Result[str, str] = format.sprint(?alloc, "fun e(p: *R{}) ptr {{ ret p::ptr; }}\nfun main() i32 {{ ret 0; }}\n", n - 1);
+    if (R.is_err[str, str](tr)) { ret 1; }
+    val tail: str = R.unwrap_ok[str, str](tr);
+
+    # the back-edge `R0` closes the chain with, named off `n` so the two cannot drift.
+    val br: R.Result[str, str] = format.sprint(?alloc, "a: *R{};", n - 1);
+    if (R.is_err[str, str](br)) { ret 1; }
+    val back: str = R.unwrap_ok[str, str](br);
+
+    # ARM 1 - `n` nominals, no `^` anywhere, erasing a pointer to `ptr`: COMPILES.
+    val pub_src: O.Option[str] = ut_chain_src(?alloc, n, "a: u32;", tail);
+    if (O.is_none[str](pub_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](pub_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 2 - the same `n` nominals with a real `^` at the FAR END of the chain: still
+    # REJECTED, and by the erasure rule rather than by anything else. Lifting the bound
+    # must not turn the walk into a hole in the rule it guards.
+    val sec_src: O.Option[str] = ut_chain_src(?alloc, n, "a: ^u32;", tail);
+    if (O.is_none[str](sec_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](sec_src);
+        if (ut_vec_diag(src, "secret-welded pointer cannot be erased") != 0) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 3 - A CYCLE INSIDE A LARGE GRAPH still terminates: `R0` points back at the
+    # deepest link, so the chain closes on itself and the walk re-enters a nominal it has
+    # already marked. The cycle guard is the whole reason the visited set exists, and a set
+    # REUSED across walks is exactly where a stale mark would break it - a walk that read
+    # the previous walk's marks as its own would cut this graph short rather than walk it,
+    # and one that read none of its own would not come back at all.
+    val cyc_src: O.Option[str] = ut_chain_src(?alloc, n, back, tail);
+    if (O.is_none[str](cyc_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](cyc_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    A.deallocate[char](?alloc, back::*char, str_len(back) + 1);
+    A.deallocate[char](?alloc, tail::*char, str_len(tail) + 1);
+    ret bad;
+}
+
 # block-scoped fin structural rules: control flow cannot cross the fin boundary
 # outward - a `ret` inside a fin body is rejected, as is a `brk` / `cnt` whose
 # target loop encloses the fin; a loop fully inside the fin body keeps `brk` /

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4219,7 +4219,9 @@ test "mach.lang.driver:dep_closure_registers_transitive" {
 # a project declaring a path dep that was never pulled (clean checkout, no dep/,
 # no mach.lock) fails with a diagnostic naming the dep and the fix command, not
 # the bare OS message a raw read failure used to surface with no path or dep
-# attached at all (#2471)
+# attached at all (#2471). the fix command carries the project root the build was
+# aimed at, so running it verbatim realizes the tree this build refused over
+# rather than whichever project the shell stands in (#2936)
 test "mach.lang.driver:dep_unresolved_names_dep_and_fix" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -4248,6 +4250,7 @@ test "mach.lang.driver:dep_unresolved_names_dep_and_fix" {
         if (!ut_str_contains(msg, "'absdep'"))     { bad = 1; }
         if (!ut_str_contains(msg, "not resolved")) { bad = 1; }
         if (!ut_str_contains(msg, "mach dep pull")) { bad = 1; }
+        if (!ut_str_contains(msg, ut_cc3(?alloc, "mach dep pull ", root, ""))) { bad = 1; }
         if (ut_str_contains(msg, "no such file"))  { bad = 1; }
     }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -16575,6 +16575,186 @@ test "mach.lang.driver:a_target_op_name_belongs_only_to_its_own_set" {
     ret 0;
 }
 
+# whether building `src` for `target_name` reports a diagnostic containing `needle`
+#
+# Runs load, sema and lower, and reads the session sink regardless of how the passes
+# came out: every rule under test reports through `context.report`, which records an
+# error and lets the pass return ok, so asserting on the result would pass whether or
+# not the check exists.
+# ---
+# target_name: a target declared in `ut_manifest`
+# src:         the module text, as the project's only source file
+# needle:      substring of the diagnostic being looked for
+# ret:         true when a matching diagnostic fired
+fun ut_va_diag(target_name: str, src: str, needle: str) bool {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret false; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret false; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret false; }
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, target_name);
+    fs.remove_all(?alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        val fired_early: bool = ut_diag_has(?s.diags, needle);
+        session.dnit(?s);
+        ret fired_early;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (R.is_ok[bool, outcome.Fail](passes.run_sema_pass(?p))) {
+        passes.run_lower_pass(?p);
+    }
+    val fired: bool = ut_diag_has(?p.s.diags, needle);
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret fired;
+}
+
+# the `#[abi_type("va_list")]` declaration every `va_list` test is written against
+val UT_VA_PRELUDE: str = "#[abi_type(\"va_list\")]\npub def VaList;\next fun sink(fmt: *u8, ap: VaList) i64;\n";
+
+# `ut_va_diag` over the prelude plus `tail`
+# ---
+# target_name: a target declared in `ut_manifest`
+# tail:        the module text appended to the prelude
+# needle:      substring of the diagnostic being looked for
+# ret:         true when a matching diagnostic fired
+fun ut_va(target_name: str, tail: str, needle: str) bool {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret false; }
+    val rj: R.Result[str, str] = format.sprint(?alloc, "{}{}", UT_VA_PRELUDE, tail);
+    if (R.is_err[str, str](rj)) { ret false; }
+    val src: str = R.unwrap_ok[str, str](rj);
+    val fired: bool = ut_va_diag(target_name, src, needle);
+    A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    ret fired;
+}
+
+# the message every refusal of a `va_list` value carries
+val UT_VA_EXCLUDED: str = "cannot be read, constructed, or stored in mach";
+
+# a `va_list`'s extent is the SELECTED TARGET's, and the four platforms do not agree
+# (#3004)
+#
+# THE FACT THE WHOLE FEATURE RESTS ON. AAPCS64 makes `va_list` a 32-byte 8-aligned
+# composite, which is over the sixteen-byte threshold and therefore passed indirectly
+# with the caller owning the copy; every other platform mach binds C on makes it a
+# plain pointer, which the same rules reduce to one register. Spelling either one in
+# mach source is correct on some targets and silent corruption on the rest, which is
+# why the number comes off the target.
+#
+# THE ASSERTION IS A COMPTIME GATE rather than a golden, because the number is what
+# is being pinned: `$size_of` and `$align_of` fold against the selected target, so
+# the same source text measures differently per leg and each arm names the psABI it
+# is asserting.
+#
+# darwin's arm64 is here for the reason it is a separate declaration at all: it
+# composes the very same `aapcs64` convention vtable as linux and disagrees with it
+# outright, so a fact read off the calling convention would give it linux's answer.
+test "mach.lang.driver:a_va_list_extent_comes_from_the_target" {
+    val gate: str = "$if ($size_of(VaList) == 32 && $align_of(VaList) == 8) { $error(\"aapcs64 composite\"); }\n$if ($size_of(VaList) == 8 && $align_of(VaList) == 8) { $error(\"pointer shaped\"); }\nfun main() i32 { ret 0; }\n";
+
+    if (!ut_va("linux-arm64", gate, "aapcs64 composite"))  { ret 1; }
+    if (ut_va("linux-arm64", gate, "pointer shaped"))      { ret 1; }
+
+    if (!ut_va("linux", gate, "pointer shaped"))           { ret 1; }
+    if (ut_va("linux", gate, "aapcs64 composite"))         { ret 1; }
+
+    if (!ut_va("darwin-arm64", gate, "pointer shaped"))    { ret 1; }
+    if (ut_va("darwin-arm64", gate, "aapcs64 composite"))  { ret 1; }
+
+    if (!ut_va("linux-riscv64", gate, "pointer shaped"))   { ret 1; }
+    if (!ut_va("windows", gate, "pointer shaped"))         { ret 1; }
+    ret 0;
+}
+
+# a `va_list` is received as a parameter and handed on, and nothing else (#3004)
+#
+# The scope stated as its exclusion: mach has no `va_arg`, so there is no reading
+# one; it has no runtime variadics, so there is no originating one; and a local, a
+# field or a global would each give the program storage holding a cursor whose
+# meaning is the C library's. Each is refused on the line that writes it.
+#
+# THE CONTROL IS THE PARAMETER FORWARDED STRAIGHT ON, which is the whole difference
+# every arm turns on: naming it, storing it, or returning it is refused and passing
+# it is not. Without the control a compiler that refused the type outright would pass
+# every refusal arm.
+test "mach.lang.driver:a_va_list_may_only_be_forwarded" {
+    val forward: str = "#[symbol(\"trace\")]\npub fun trace(fmt: *u8, ap: VaList) i64 { ret sink(fmt, ap); }\nfun main() i32 { ret 0; }\n";
+    val local:   str = "#[symbol(\"trace\")]\npub fun trace(fmt: *u8, ap: VaList) i64 { val a: VaList = ap; ret sink(fmt, a); }\nfun main() i32 { ret 0; }\n";
+    val field:   str = "rec Box { ap: VaList; }\nfun main() i32 { ret 0; }\n";
+    val field_u: str = "uni Box { ap: VaList; n: i32; }\nfun main() i32 { ret 0; }\n";
+    val global:  str = "var held: VaList;\nfun main() i32 { ret 0; }\n";
+    val behind:  str = "#[symbol(\"trace\")]\npub fun trace(ap: *VaList) i64 { ret 0; }\nfun main() i32 { ret 0; }\n";
+    val made:    str = "ext fun make() VaList;\nfun main() i32 { ret 0; }\n";
+
+    if (ut_va("linux", forward, UT_VA_EXCLUDED))           { ret 1; }
+    if (ut_va("linux-arm64", forward, UT_VA_EXCLUDED))     { ret 1; }
+    if (!ut_va("linux", local, UT_VA_EXCLUDED))            { ret 1; }
+    if (!ut_va("linux", field, UT_VA_EXCLUDED))            { ret 1; }
+    if (!ut_va("linux", field_u, UT_VA_EXCLUDED))          { ret 1; }
+    if (!ut_va("linux", global, UT_VA_EXCLUDED))           { ret 1; }
+    if (!ut_va("linux", behind, UT_VA_EXCLUDED))           { ret 1; }
+    if (!ut_va("linux", made, UT_VA_EXCLUDED))             { ret 1; }
+    ret 0;
+}
+
+# a `va_list` cannot be reinterpreted or cast to anything (#3004)
+#
+# THE REFUSAL THAT HAS TO BE WRITTEN DOWN. Every other way of reading one already
+# fails structurally - it has no fields, it is not a pointer, it has no lanes - but
+# `:~` asks only for two equal sizes, and on the four platforms where a `va_list` is
+# eight bytes `ap :~ ptr` would hand the program the very cursor the type exists to
+# keep out of its hands. Both directions, because reading one out and forging one in
+# are the same rule.
+#
+# THE CONTROL IS THE SAME REINTERPRET BETWEEN TWO ORDINARY EIGHT-BYTE TYPES, so a
+# compiler that had simply stopped folding equal sizes would fail it.
+test "mach.lang.driver:a_va_list_cannot_be_cast" {
+    val out_r: str = "#[symbol(\"trace\")]\npub fun trace(ap: VaList) i64 { ret (ap :~ ptr)::i64; }\nfun main() i32 { ret 0; }\n";
+    val out_c: str = "#[symbol(\"trace\")]\npub fun trace(ap: VaList) i64 { ret (ap :: ptr)::i64; }\nfun main() i32 { ret 0; }\n";
+    val in_r:  str = "#[symbol(\"trace\")]\npub fun trace(fmt: *u8, p: ptr) i64 { ret sink(fmt, p :~ VaList); }\nfun main() i32 { ret 0; }\n";
+    val ok:    str = "#[symbol(\"trace\")]\npub fun trace(p: ptr) i64 { ret (p :~ i64); }\nfun main() i32 { ret 0; }\n";
+
+    if (!ut_va("linux", out_r, UT_VA_EXCLUDED))       { ret 1; }
+    if (!ut_va("linux", out_c, UT_VA_EXCLUDED))       { ret 1; }
+    if (!ut_va("linux", in_r, UT_VA_EXCLUDED))        { ret 1; }
+    if (!ut_va("linux-arm64", out_r, UT_VA_EXCLUDED)) { ret 1; }
+    if (ut_va("linux", ok, UT_VA_EXCLUDED))           { ret 1; }
+    ret 0;
+}
+
+# `#[abi_type]` names a closed set, checked in the front end (#3004)
+#
+# Closed here for the reason `#[op]`'s instruction names are: which target a module is
+# built for is not a property of the source, so a name checked only where it is acted
+# on would go unreported on every other build of the same library.
+#
+# THE CONTROL IS THE ONE NAME THERE IS, so a compiler that refused every `abi_type`
+# declaration would fail it.
+test "mach.lang.driver:an_abi_type_name_is_closed" {
+    val bad:   str = "#[abi_type(\"jmp_buf\")]\npub def JmpBuf;\nfun main() i32 { ret 0; }\n";
+    val body:  str = "#[abi_type(\"va_list\")]\npub def Aliased: ptr;\nfun main() i32 { ret 0; }\n";
+    val nargs: str = "#[abi_type]\npub def Nothing;\nfun main() i32 { ret 0; }\n";
+    val ok:    str = "#[abi_type(\"va_list\")]\npub def VaList;\nfun main() i32 { ret 0; }\n";
+
+    if (!ut_va_diag("linux", bad, "no such ABI type"))                     { ret 1; }
+    if (!ut_va_diag("linux", body, "declaration has no body"))             { ret 1; }
+    if (!ut_va_diag("linux", nargs, "takes exactly one string argument"))  { ret 1; }
+    if (ut_va_diag("linux", ok, "no such ABI type"))                       { ret 1; }
+    ret 0;
+}
+
 # the handle declarations every `#[handle]` test is written against
 #
 # One prelude rather than a per-test one so a test's own text is only what it is

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -73,6 +73,7 @@ use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.isa;
+use mach.lang.target.os;
 use mach.lang.type;
 
 # the per-buffer analysis state an EditorSession owns for one registered file
@@ -721,7 +722,7 @@ fun ast_alloc(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
 # es:  the editor session
 # ret: a host-seeded ComptimeCtx
 fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
-    ret comptime.init(
+    var c: comptime.ComptimeCtx = comptime.init(
         es.alloc,
         target.host_os_id(),
         target.host_arch_id(),
@@ -733,6 +734,13 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         intern.STR_NIL,
         intern.STR_NIL
     );
+    # the host platform's own `va_list`, so a buffer declaring one type-checks in the
+    # editor exactly as it does in a build for this machine (#3004).
+    val vl: O.Option[os.VaList] = target.host_va_list();
+    if (O.is_some[os.VaList](vl)) {
+        comptime.set_va_list(?c, O.unwrap[os.VaList](vl).size, O.unwrap[os.VaList](vl).align);
+    }
+    ret c;
 }
 
 # reseed a buffer's comptime context from the host target, dnit-ing any prior one

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -355,6 +355,9 @@ pub def FrameMark: u32;
 #                 bounds the `TxN` vector form the resolver reads (#2687). carried
 #                 here for the same reason `pointer_width` is: it is a target
 #                 machine fact the frontend needs, and the frontend has no target
+# va_list_size / va_list_align: the selected target's declared `va_list` extent
+#                 (#3004), carried for the same reason and 0 when the platform
+#                 declares none, which the `#[abi_type]` declaration refuses by name
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
 # entries:        scoped array of NamedConst bindings; lookup scans it in reverse
@@ -402,6 +405,8 @@ pub rec ComptimeCtx {
     pointer_width:  u32;
     target_defs:    *isa.TargetDefs;
     vector_bits:    u32;
+    va_list_size:   u32;
+    va_list_align:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
     entries:        *NamedConst;
@@ -484,6 +489,8 @@ pub fun init(
     c.pointer_width  = pointer_width;
     c.target_defs    = nil;
     c.vector_bits    = vector_bits;
+    c.va_list_size   = 0;
+    c.va_list_align  = 0;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
     c.entries        = nil;
@@ -583,6 +590,21 @@ pub fun set_type_query_resolver(c: *ComptimeCtx, fn: *u8, data: ptr) {
 # d: the borrowed table, or nil
 pub fun set_target_defs(c: *ComptimeCtx, d: *isa.TargetDefs) {
     c.target_defs = d;
+}
+
+# bind the selected target's declared `va_list` extent (#3004)
+#
+# A post-init setter for the same reason `set_target_defs` is one: it is a target
+# fact the frontend reads and the frontend has no target, so the driver installs it
+# from the resolved target. Both zero means the platform declares none, and the
+# declaration that needs one is refused rather than given a pointer.
+# ---
+# c:     the context
+# size:  the declared size in bytes, or 0 when the platform declares none
+# align: the declared alignment in bytes, or 0 when the platform declares none
+pub fun set_va_list(c: *ComptimeCtx, size: u32, align: u32) {
+    c.va_list_size  = size;
+    c.va_list_align = align;
 }
 
 # Only a pass that has the type universe AND can force a type's layout may install

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -46,6 +46,7 @@ use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.embed;
 use mach.lang.fe.sema.generics;
+use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.handle;
 use mach.lang.fe.sema.infer;
 use mach.lang.fe.token;
@@ -1345,6 +1346,7 @@ fun infer_one_body(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, str]
     infer_decorator_args(sc, d);
     validate_decorators(sc, d);
     check_handle_decl(sc, did, d);
+    check_abi_type_placement(sc, did, d);
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret infer_bodies_comptime_if(sc, ?d.data.comptime_if);
@@ -1793,6 +1795,91 @@ fun check_handle_fields(sc: *context.SemaContext, start: u32, len: u32) {
     }
 }
 
+# whether an ABI type is reachable from `t` without descending into a record (#3004)
+#
+# The `type_carries_handle` walk over the same spine and for the same reason: a
+# pointer to one, an array of one, and a `^` over one are each a different
+# declaration to refuse, so the question is asked about the whole type rather than
+# about its outermost kind. A record is not walked, because its fields are
+# declarations in their own right and are refused where they are written.
+# ---
+# sc: the context
+# t:  the type to test
+# ret: true when an ABI type is reachable without descending into a record
+fun type_carries_abi_type(sc: *context.SemaContext, t: type.TypeId) bool {
+    if (t == type.TYPE_NIL || t == type.TYPE_ERROR) { ret false; }
+    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, t);
+    if (O.is_none[*type.Type](opt_type)) { ret false; }
+    val tp: *type.Type = O.unwrap[*type.Type](opt_type);
+    if (tp.kind == type.TYPE_ABI)     { ret true; }
+    if (tp.kind == type.TYPE_SECRET)  { ret type_carries_abi_type(sc, tp.data.secret.base); }
+    if (tp.kind == type.TYPE_POINTER) { ret type_carries_abi_type(sc, tp.data.pointer.base); }
+    if (tp.kind == type.TYPE_ARRAY)   { ret type_carries_abi_type(sc, tp.data.array.base); }
+    ret false;
+}
+
+# refuse every placement of an ABI type but the one that is the whole feature (#3004)
+#
+# A `va_list` is a token received from C and handed back to C, so a PARAMETER at the
+# type itself is the one position that means anything. Everything else here is a
+# program taking hold of the value: a field or a global gives it storage of its own,
+# a return position asks mach to originate one, and a pointer or an array asks for an
+# extent to step by. Each is refused on the line that writes it, so the message lands
+# where the misunderstanding is rather than at the call that later fails.
+# ---
+# sc:  the context
+# did: the decl
+# d:   the decl record
+fun check_abi_type_placement(sc: *context.SemaContext, did: id.DeclId, d: *decl.Decl) {
+    if (d.kind == decl.DECL_KIND_REC) {
+        check_abi_type_fields(sc, d.data.rec_.fields_start, d.data.rec_.fields_len);
+        ret;
+    }
+    if (d.kind == decl.DECL_KIND_UNI) {
+        check_abi_type_fields(sc, d.data.uni_.fields_start, d.data.uni_.fields_len);
+        ret;
+    }
+    if (d.kind == decl.DECL_KIND_FUN) {
+        var i: u32 = 0;
+        for (i < d.data.fun_.params_len) {
+            val tn: *decl.TypedName = ?sc.a.typed_names[d.data.fun_.params_start + i];
+            val pty: type.TypeId = context.resolved_type_of(sc, tn.ty);
+            # the parameter AT the type is the whole point; one BEHIND a pointer or
+            # inside an array is not.
+            if (type_carries_abi_type(sc, pty) && !type.is_abi_type(?sc.s.types, pty)) {
+                context.report(sc, tn.name, abitype.exclusion_message());
+            }
+            i = i + 1;
+        }
+        if (type_carries_abi_type(sc, context.resolved_type_of(sc, d.data.fun_.return_type))) {
+            context.report(sc, d.data.fun_.name, abitype.exclusion_message());
+        }
+        ret;
+    }
+    if (is_global_binding(d.kind)) {
+        if (sc.decl_type == nil) { ret; }
+        if (type_carries_abi_type(sc, sc.decl_type[did])) {
+            context.report(sc, d.span, abitype.exclusion_message());
+        }
+    }
+}
+
+# report each field in `[start, start + len)` declared at an ABI type
+# ---
+# sc:    the context
+# start: start index into ast.typed_names
+# len:   number of fields
+fun check_abi_type_fields(sc: *context.SemaContext, start: u32, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[start + i];
+        if (type_carries_abi_type(sc, context.resolved_type_of(sc, tn.ty))) {
+            context.report(sc, tn.name, abitype.exclusion_message());
+        }
+        i = i + 1;
+    }
+}
+
 # report unless a handle declaration and its interface role agree (#2794)
 #
 # Two directions, because they are two different mistakes. A handle-typed global
@@ -2122,7 +2209,14 @@ fun validate_one_decorator(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.D
         handle.validate(sc, d, dec);
         ret;
     }
-    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, packed, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage, sampler, op, handle");
+    # `#[abi_type(name)]` on a bodyless `def` says the selected target declares this
+    # C type's layout (#3004). The name set is closed here for the reason `op`'s is:
+    # which target a module is built for is not a property of the source.
+    if (decorator_named(sc, dec, abitype.DIRECTIVE)) {
+        abitype.validate(sc, d, dec);
+        ret;
+    }
+    context.report(sc, dec.name, "unknown decorator; valid directives are symbol, section, inline, noinline, align, packed, library, oblivious, scalar, naked, embed, stage, workgroup, input, output, builtin, uniform, storage, sampler, op, handle, abi_type");
 }
 
 # validate a `#[naked]` decorator: its argument shape, its target, the decorators it
@@ -3058,6 +3152,14 @@ fun infer_local_decl(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, st
     if (type_carries_handle(sc, ty)) {
         context.report(sc, d.span,
             "a handle cannot be a local binding: a local is storage the program owns, and a handle's representation is not the program's, so there is nothing that may be written into it. hand the handle straight to the operation that consumes it instead of naming it first");
+    }
+
+    # a local binding of an ABI type, on the same reasoning and refused for the same
+    # reason (#3004): a local is storage the program owns, and naming a `va_list`
+    # first is the copy `va_copy` exists to make, which mach has no way to make
+    # correctly and no reason to.
+    if (type_carries_abi_type(sc, ty)) {
+        context.report(sc, d.span, abitype.exclusion_message());
     }
 
     if (d.data.bind.init != id.EXPR_NIL) {

--- a/src/lang/fe/sema/abitype.mach
+++ b/src/lang/fe/sema/abitype.mach
@@ -1,0 +1,242 @@
+# the `#[abi_type(name)]` directive (#3004)
+#
+# A bodyless `def` carrying this directive declares a C type whose layout the
+# SELECTED TARGET declares and whose contents mach never reads. It exists for the one
+# C type that has no correct spelling in mach source: `va_list` is a plain pointer on
+# SysV x86-64, Apple arm64, win64 and riscv64, and a 32-byte 8-aligned composite under
+# AAPCS64, so writing either one down binds correctly on some platforms and silently
+# wrongly on the rest.
+#
+# THE SCOPE IS FORWARD-ONLY, and it is a property of the type rather than a rule this
+# module enforces alone: a value of one may be received as a parameter and handed to
+# another function, and that is the whole list. There is no `va_start`, no `va_arg`,
+# no `va_end`, and no way for mach to originate one - a `va_list` is only meaningful
+# to a callee walking its own tail, and mach has no runtime variadics to walk. The
+# refusals that make that stick are asked where the question comes up, the way
+# `handle`'s are: a field of one in sema's field check, a binding of one in the
+# binding check, a cast of one in `check`.
+#
+# THE NAME IS A CLOSED SET, checked here rather than in a back end, for the reason
+# `#[op]` closes its names here: which target a module is built for is not a property
+# of the source, so a typo checked only where it is acted on would go unreported on
+# every other build of the same library.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_region_equals;
+
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.fe.ast;
+use mach.lang.fe.ast.decl;
+use mach.lang.fe.ast.expr;
+use mach.lang.fe.ast.id;
+use mach.lang.fe.sema.context;
+use mach.lang.fe.token;
+use mach.lang.type;
+use intern: mach.lang.intern;
+
+# the directive's name, and the number of arguments it takes
+pub val DIRECTIVE: str = "abi_type";
+val ARG_COUNT: u32 = 1;
+
+# how reading an `#[abi_type]` declaration came out
+#
+# There is deliberately no INERT outcome, which is where this parts company with
+# `#[handle]`. A handle names a constructor only one target mints, so a target that
+# mints none holds no opinion and the declaration is merely unreachable there. An ABI
+# type names a fact of the platform's C, and a platform that declares none is a
+# platform where the declaration cannot be given a layout at all - so it is refused
+# rather than given the pointer that would be right four times out of five.
+pub def ReadStatus: u8;
+pub val READ_OK:      ReadStatus = 0;
+pub val READ_REFUSED: ReadStatus = 1;
+
+# a read `#[abi_type]` declaration
+# ---
+# status: how the read came out
+# tag:    which ABI type was named (one of type.ABI_TYPE_*), when status is READ_OK
+# size:   the target's declared size in bytes, when status is READ_OK
+# align:  the target's declared alignment in bytes, when status is READ_OK
+pub rec Read {
+    status: ReadStatus;
+    tag:    u32;
+    size:   u32;
+    align:  u32;
+}
+
+# whether `dec` names directive `name`
+# ---
+# sc:   the context
+# dec:  the decorator
+# name: the directive name
+# ret:  true when the decorator is that directive
+fun decorator_is(sc: *context.SemaContext, dec: *decl.Decorator, name: str) bool {
+    ret str_region_equals(sc.source, dec.name.offset, dec.name.len, name);
+}
+
+# the `#[abi_type]` decorator on `d`, or nil
+# ---
+# sc: the context
+# d:  the decl to search
+# ret: the decorator, or nil
+pub fun decorator_of(sc: *context.SemaContext, d: *decl.Decl) *decl.Decorator {
+    var i: u32 = 0;
+    for (i < d.decorators_len) {
+        val dec: *decl.Decorator = ?sc.a.decorators[d.decorators_start + i];
+        if (decorator_is(sc, dec, DIRECTIVE)) { ret dec; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# whether `d` is a declaration this directive owns: a bodyless `def` carrying it
+# ---
+# sc: the context
+# d:  the decl to test
+# ret: true for a bodyless `def` with an `#[abi_type]`
+pub fun declares_abi_type(sc: *context.SemaContext, d: *decl.Decl) bool {
+    if (d.kind != decl.DECL_KIND_DEF)  { ret false; }
+    if (d.data.def_.ty != id.TYPE_NIL) { ret false; }
+    ret decorator_of(sc, d) != nil;
+}
+
+# argument `index` of `dec`, or nil
+# ---
+# sc:    the context
+# dec:   the decorator
+# index: which argument
+# ret:   the expression, or nil
+fun arg_expr(sc: *context.SemaContext, dec: *decl.Decorator, index: u32) *expr.Expr {
+    if (index >= dec.args_len) { ret nil; }
+    val opt_e: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + index]);
+    if (O.is_none[*expr.Expr](opt_e)) { ret nil; }
+    ret O.unwrap[*expr.Expr](opt_e);
+}
+
+# whether the string literal `e` spells `name`
+# ---
+# sc:   the context
+# e:    the string-literal expression
+# name: the name to compare against
+# ret:  true when the literal's text is `name`
+fun literal_is(sc: *context.SemaContext, e: *expr.Expr, name: str) bool {
+    if (e.span.len < 2::usize) { ret false; }
+    ret str_region_equals(sc.source, e.span.offset + 1::usize, e.span.len - 2::usize, name);
+}
+
+# read and check an `#[abi_type]` declaration, optionally reporting
+#
+# One reader for both callers, exactly as `handle.read` is: the validation pass
+# reports and the type resolver interns, and if each read the directive its own way
+# the accepted declarations and the interned types could disagree.
+# ---
+# sc:     the context
+# d:      the decorated decl
+# dec:    the `abi_type` decorator
+# report: whether to report what is refused
+# ret:    the read
+pub fun read(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator, report: bool) Read {
+    var out: Read;
+    out.status = READ_REFUSED;
+    out.tag    = 0;
+    out.size   = 0;
+    out.align  = 0;
+
+    if (d.kind != decl.DECL_KIND_DEF) {
+        if (report) { context.report(sc, dec.name, "`abi_type` decorator applies only to a `def` declaration: `def` is the form that means a name denotes a type and promises no fields and no storage, which is exactly what an ABI type is"); }
+        ret out;
+    }
+    if (d.data.def_.ty != id.TYPE_NIL) {
+        if (report) { context.report(sc, dec.name, "an `abi_type` declaration has no body: the selected target supplies the layout, so `def Name;` declares it and `def Name: T;` is an ordinary alias"); }
+        ret out;
+    }
+    if (dec.args_len != ARG_COUNT) {
+        if (report) { context.report(sc, dec.name, "`abi_type` decorator takes exactly one string argument: the name of the C type whose layout the target declares"); }
+        ret out;
+    }
+
+    val name_e: *expr.Expr = arg_expr(sc, dec, 0);
+    if (name_e == nil) { ret out; }
+    if (name_e.kind != expr.EXPR_KIND_LIT_STR) {
+        if (report) { context.report(sc, dec.name, "the `abi_type` decorator's argument must be a string literal: it is matched against the C types the target declares rather than evaluated"); }
+        ret out;
+    }
+
+    if (!literal_is(sc, name_e, "va_list")) {
+        if (report) { context.report(sc, name_e.span, "no such ABI type; `va_list` is the only C type whose layout a target declares"); }
+        ret out;
+    }
+
+    # the target's own refusal. a platform that declares no `va_list` is one where
+    # this declaration has no layout, and every default available is a pointer -
+    # right on four of the five platforms mach binds C on, and silent corruption on
+    # AAPCS64, which is why it is named instead.
+    if (sc.ctx.va_list_size == 0) {
+        if (report) { context.report(sc, name_e.span, "the selected target declares no `va_list` layout: `va_list` is part of a platform's C ABI and this platform has none, so there is nothing to bind. a target that runs C declares the size and alignment its psABI gives the type"); }
+        ret out;
+    }
+
+    out.status = READ_OK;
+    out.tag    = type.ABI_TYPE_VA_LIST;
+    out.size   = sc.ctx.va_list_size;
+    out.align  = sc.ctx.va_list_align;
+    ret out;
+}
+
+# report every rule an `#[abi_type]` declaration itself breaks
+# ---
+# sc:  the context
+# d:   the decorated decl
+# dec: the `abi_type` decorator
+pub fun validate(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
+    read(sc, d, dec, true);
+}
+
+# the type an `#[abi_type]` declaration denotes
+#
+# A refused declaration yields TYPE_ERROR, which poisons every use of the name
+# without a second diagnostic: the refusal was reported once, where it was written.
+# ---
+# sc:  the context
+# d:   the declaration's record
+# ret: the ABI type's TypeId, or TYPE_ERROR
+pub fun type_of(sc: *context.SemaContext, d: *decl.Decl) type.TypeId {
+    val dec: *decl.Decorator = decorator_of(sc, d);
+    if (dec == nil) { ret type.TYPE_ERROR; }
+
+    val r: Read = read(sc, d, dec, false);
+    if (r.status == READ_REFUSED) { ret type.TYPE_ERROR; }
+
+    val res: R.Result[type.TypeId, str] =
+        type.intern_abi_type(?sc.s.types, intern_name(sc, d.data.def_.name), r.tag, r.size, r.align);
+    if (R.is_err[type.TypeId, str](res)) { ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](res);
+}
+
+# intern the text `span` covers, or STR_NIL
+# ---
+# sc:   the context
+# span: the span to intern
+# ret:  the interned id, or STR_NIL
+fun intern_name(sc: *context.SemaContext, span: token.Span) intern.StrId {
+    if (span.len == 0) { ret intern.STR_NIL; }
+    val r: R.Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, sc.source, span);
+    if (R.is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](r);
+}
+
+# the sentence every refusal of a READ or a CONSTRUCTION of an ABI type carries
+#
+# ONE TEXT, because they are one rule stated at whichever site the program reached
+# first. A caller appends nothing: the message already names what is excluded and
+# what remains possible, which is the whole of what a program may do with one.
+# ---
+# ret: the exclusion, as a diagnostic message
+pub fun exclusion_message() str {
+    ret "a `va_list` cannot be read, constructed, or stored in mach: it is an opaque token a C caller hands over and mach hands on, and reading one needs `va_arg`, which mach does not have and cannot have without runtime variadics. receive it as a parameter and pass it to the C function that consumes it";
+}

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -37,6 +37,7 @@ use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
+use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.generics;
@@ -757,6 +758,7 @@ pub fun check_member(sc: *context.SemaContext, object: type.TypeId, name: intern
 pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
     if (from == to)                                       { ret O.some[type.TypeId](to); }
+    if (!check_abi_type_cast(sc, from, to, span))         { ret O.none[type.TypeId](); }
 
     # the welded-storage discipline (#1645): `::` may neither launder a secret
     # pointer to the untyped `ptr` nor add / drop a `^`. checked before the
@@ -790,6 +792,28 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
     report_note(sc, span, "cast: conversion is invalid",
         "`::` casts numeric types or reinterprets equal-size values only");
     ret O.none[type.TypeId]();
+}
+
+# refuse a `::` or `:~` with an ABI type on either side (#3004)
+#
+# THE ONE REFUSAL THAT HAS TO BE WRITTEN DOWN RATHER THAN FALLEN OUT OF A SIZE. Every
+# other way of reading a `va_list` already fails for a structural reason - it has no
+# fields, it is not a pointer, it has no lanes - but a reinterpret asks only for two
+# equal sizes, and on the four platforms where a `va_list` is eight bytes `ap :~ ptr`
+# would hand the program the very cursor the type exists to keep out of its hands.
+# Refused on both sides: reading one out and forging one in are the same rule.
+# ---
+# sc:   the active sema context
+# from: the operand's type
+# to:   the target type
+# span: source range of the cast
+# ret:  true when neither side is an ABI type
+fun check_abi_type_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) bool {
+    val f: type.TypeId = type.strip_secret(?sc.s.types, from);
+    val t: type.TypeId = type.strip_secret(?sc.s.types, to);
+    if (!type.is_abi_type(?sc.s.types, f) && !type.is_abi_type(?sc.s.types, t)) { ret true; }
+    report(sc, span, abitype.exclusion_message());
+    ret false;
 }
 
 # whether a `::` numeric conversion emits a floating-point operation (#1646)
@@ -860,6 +884,7 @@ fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.Typ
 # ret:  some(to) when the reinterpret is legal, none (with a diagnostic) otherwise
 pub fun check_reinterpret(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
+    if (!check_abi_type_cast(sc, from, to, span))         { ret O.none[type.TypeId](); }
 
     # `:~` is bound by the same welded-storage secrecy rules as `::` - it can
     # neither erase a secret pointer to `ptr` nor change a `^` (#1645).
@@ -1007,6 +1032,14 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     # the shape every target already has for exactly that.
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN
         || k == type.TYPE_HANDLE) { ret ptr_width(sc); }
+    # an ABI type's declared extent, so `$size_of` and this agree about one type the
+    # way #2672 established they must. cast legality does not turn on it: `::` and
+    # `:~` refuse an ABI type by name before either size is read.
+    if (k == type.TYPE_ABI) {
+        val ext: layout.Extent = generics.type_extent(sc.s, context.machine_of(sc), type.strip_secret(?sc.s.types, t));
+        if (!ext.ok) { ret 0; }
+        ret ext.size;
+    }
     if (k == type.TYPE_ARRAY) {
         # widen the multiply: a >4GiB array would wrap a u32 product and report a
         # wrong size to cast legality, so saturate to the 0 "unknown" sentinel.

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -306,9 +306,11 @@ pub fun ensure_fields(s: *session.Session, tid: type.TypeId) {
 # tid: the type to inspect
 # ret: true when `tid` reaches a `^` through any pointer / array / field
 pub fun contains_secret_deep(s: *session.Session, tid: type.TypeId) bool {
-    var scan: type.SecretScan;
-    scan.len = 0;
-    ret secret_deep_walk(s, tid, ?scan);
+    var scan: type.TypeScan;
+    type.type_scan_begin(?s.types, ?scan);
+    val found: bool = secret_deep_walk(s, tid, ?scan);
+    type.type_scan_end(?s.types, ?scan);
+    ret found;
 }
 
 # whether a type KIND is a known secret-FREE leaf: an integer / float scalar or the raw
@@ -331,7 +333,7 @@ fun kind_is_public_leaf(k: type.TypeKind) bool {
 # whether a function TYPE's signature carries a secret: any parameter type or the return
 # type deep-carries a `^` (#2165). A reinterpret can round-trip the whole signature, so a
 # secret anywhere in it welds the function type.
-fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.SecretScan) bool {
+fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.TypeScan) bool {
     if (secret_deep_walk(s, t.data.fn.ret_type, scan)) { ret true; }
     var pi: u32 = 0;
     for (pi < t.data.fn.params_len) {
@@ -345,7 +347,7 @@ fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.Secret
 }
 
 # the recursive worker for `contains_secret_deep`, threading the visited set
-fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
+fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.TypeScan) bool {
     val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
     if (O.is_none[*type.Type](opt_type)) { ret false; }
     val t: *type.Type = O.unwrap[*type.Type](opt_type);
@@ -356,17 +358,13 @@ fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSc
     if (t.kind == type.TYPE_FUN)     { ret fn_sig_carries_secret(s, t, scan); }
 
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
+        val mark: type.VisitMark = type.type_scan_mark(?s.types, scan, tid);
         # an already-visited nominal contributes no new secret (its fields were fully
         # explored on the first visit); this also terminates a cyclic record graph.
-        var i: u32 = 0;
-        for (i < scan.len) {
-            if (scan.seen[i] == tid) { ret false; }
-            i = i + 1;
-        }
-        # a graph beyond the visited-set bound fails CLOSED (never under-reports).
-        if (scan.len >= 256) { ret true; }
-        scan.seen[scan.len] = tid;
-        scan.len = scan.len + 1;
+        if (mark == type.VISIT_SEEN) { ret false; }
+        # a nominal the visited set could not record leaves the walk unbounded from here,
+        # so it fails CLOSED (never under-reports).
+        if (mark == type.VISIT_FAILED) { ret true; }
 
         # materialize a generic instance's field table from its template, independent of
         # whether/when lazy elaboration ran, so the walk never reads an absent table as
@@ -714,19 +712,21 @@ fun sse_deep_walk(s: *session.Session, m: layout.Machine, a: type.TypeId, b: typ
 # Used to admit a reinterpret / union between differing-shape aggregates that are both
 # entirely secret: with no public byte on either side, no public alias can read a secret,
 # so the differing layout is safe. A cycle guard bounds a self-referential graph; an
-# over-deep or unresolvable graph fails closed (reported as NOT all-secret, so the
-# differing-shape pair is rejected - the safe direction).
+# unresolvable graph fails closed (reported as NOT all-secret, so the differing-shape
+# pair is rejected - the safe direction).
 # ---
 # s:   the session
 # tid: the type to inspect
 # ret: true when `tid` has no public-stored byte anywhere
 pub fun deep_all_secret(s: *session.Session, tid: type.TypeId) bool {
-    var scan: type.SecretScan;
-    scan.len = 0;
-    ret all_secret_walk(s, tid, ?scan);
+    var scan: type.TypeScan;
+    type.type_scan_begin(?s.types, ?scan);
+    val all: bool = all_secret_walk(s, tid, ?scan);
+    type.type_scan_end(?s.types, ?scan);
+    ret all;
 }
 
-fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
+fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.TypeScan) bool {
     # a `^T` value is entirely secret bytes (any inner public shape is still stored secret).
     if (type.is_secret(?s.types, tid)) { ret true; }
 
@@ -739,14 +739,13 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSca
     if (t.kind == type.TYPE_ARRAY)   { ret all_secret_walk(s, t.data.array.base, scan); }
 
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
-        var i: u32 = 0;
-        for (i < scan.len) {
-            if (scan.seen[i] == tid) { ret true; }
-            i = i + 1;
-        }
-        if (scan.len >= 256) { ret false; }
-        scan.seen[scan.len] = tid;
-        scan.len = scan.len + 1;
+        val mark: type.VisitMark = type.type_scan_mark(?s.types, scan, tid);
+        # a nominal already on the walk imposes no NEW public byte, so the cycle it closes
+        # cannot make the type less than all-secret.
+        if (mark == type.VISIT_SEEN) { ret true; }
+        # an unrecordable nominal fails CLOSED, which here is "not all secret" - the
+        # direction that REJECTS the differing-shape pair this predicate would admit.
+        if (mark == type.VISIT_FAILED) { ret false; }
 
         if (t.kind == type.TYPE_INSTANCE) { ensure_fields(s, tid); }
         val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -324,6 +324,9 @@ fun kind_is_public_leaf(k: type.TypeKind) bool {
     # an opaque image / sampler handle carries no data a program can read, so there
     # is nothing in it for the secrecy lattice to be about (#2794).
     if (k == type.TYPE_HANDLE)         { ret true; }
+    # an ABI type carries no data a program can read either (#3004), so the secrecy
+    # lattice has nothing to be about there.
+    if (k == type.TYPE_ABI)            { ret true; }
     if (k == type.TYPE_GENERIC_PARAM) { ret true; }
     ret false;
 }
@@ -438,6 +441,17 @@ fun describe_type(ctx: ptr, id: u32) layout.Node {
     if (d.class == type.PRIM_CLASS_PTR || t.kind == type.TYPE_POINTER || t.kind == type.TYPE_FUN
         || t.kind == type.TYPE_HANDLE) {
         ret layout.node(layout.NODE_POINTER);
+    }
+    # an ABI type's extent is DECLARED by the target rather than folded from parts
+    # (#3004): the size and the alignment are two independent numbers off the type,
+    # which is why neither a scalar node nor a pointer node can carry it. Measuring
+    # one is not reading one - the extent is a published psABI fact - and every way of
+    # reaching the VALUE is refused where it is written.
+    if (t.kind == type.TYPE_ABI) {
+        var n: layout.Node = layout.node(layout.NODE_OPAQUE);
+        n.bytes      = t.data.abi.size;
+        n.decl_align = t.data.abi.align;
+        ret n;
     }
     # a vector's extent is lane-derived, so the node carries its lane shape (#2687).
     if (t.kind == type.TYPE_VECTOR) {

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -43,6 +43,7 @@ use mach.lang.fe.resolve;
 use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
+use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.handle;
 use mach.lang.fe.sema.generics;
 use mach.lang.fe.sema.typename;
@@ -85,6 +86,13 @@ pub fun infer_decl(sc: *context.SemaContext, did: id.DeclId) type.TypeId {
     if (d.kind == decl.DECL_KIND_REC) { ret infer_nominal(sc, did, d.data.rec_.name, ?d.data.rec_, type.TYPE_REC); }
     if (d.kind == decl.DECL_KIND_UNI) { ret infer_nominal_uni(sc, did, d.data.uni_.name, ?d.data.uni_, type.TYPE_UNI); }
     if (d.kind == decl.DECL_KIND_DEF) {
+        # a bodyless `def` is one of the two directive-supplied forms: an ABI type
+        # whose layout the target declares (#3004) or a handle the target mints
+        # (#2888). the directive on it decides which, so neither is guessed from the
+        # shape they share.
+        if (d.data.def_.ty == id.TYPE_NIL && abitype.declares_abi_type(sc, d)) {
+            ret abitype.type_of(sc, d);
+        }
         if (d.data.def_.ty == id.TYPE_NIL) { ret handle.type_of(sc, did, d); }
         ret context.resolved_type_of(sc, d.data.def_.ty);
     }
@@ -3742,8 +3750,12 @@ fun def_underlying(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.S
         if (O.is_none[*decl.Decl](d_opt)) { ret type.TYPE_ERROR; }
         val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
         if (d.kind != decl.DECL_KIND_DEF) { ret type.TYPE_ERROR; }
-        # a BODYLESS `def` is a target-minted handle, whose definition the owning
-        # target supplies rather than the annotation (#2888)
+        # a BODYLESS `def` carries its definition on a directive rather than on the
+        # annotation: an ABI type the target declares the layout of (#3004), or a
+        # handle the owning target mints (#2888)
+        if (d.data.def_.ty == id.TYPE_NIL && abitype.declares_abi_type(sc, d)) {
+            ret abitype.type_of(sc, d);
+        }
         if (d.data.def_.ty == id.TYPE_NIL) { ret handle.type_of(sc, sym.decl, d); }
         ret resolve_type_ref(sc, d.data.def_.ty);
     }

--- a/src/lang/fe/sema/typename.mach
+++ b/src/lang/fe/sema/typename.mach
@@ -196,6 +196,10 @@ fun type_str_len(s: *session.Session, t: type.TypeId) usize {
         # compiler could assemble: a handle is declared, so the reader typed this
         ret name_str_len(s, tp.data.handle.name);
     }
+    if (k == type.TYPE_ABI) {
+        # the declaration's own name, for the reason a handle renders as one
+        ret name_str_len(s, tp.data.abi.name);
+    }
     if (k == type.TYPE_REC || k == type.TYPE_UNI) {
         ret name_str_len(s, tp.data.nominal.name);
     }
@@ -260,6 +264,9 @@ fun write_type_str(s: *session.Session, buf: str, k: usize, t: type.TypeId) usiz
     }
     if (kind == type.TYPE_HANDLE) {
         ret write_name(s, buf, k, tp.data.handle.name);
+    }
+    if (kind == type.TYPE_ABI) {
+        ret write_name(s, buf, k, tp.data.abi.name);
     }
     if (kind == type.TYPE_REC || kind == type.TYPE_UNI) {
         ret write_name(s, buf, k, tp.data.nominal.name);

--- a/src/lang/layout.mach
+++ b/src/lang/layout.mach
@@ -69,6 +69,13 @@ pub val NODE_AGGREGATE: NodeKind = 5;
 # a node occupying no storage (a void), which still aligns to 1 so it neither moves a
 # following field nor lowers an enclosing aggregate's alignment
 pub val NODE_ZERO:      NodeKind = 6;
+# a node of `bytes` size and `decl_align` alignment whose INTERIOR IS NOT DESCRIBED
+#
+# The shape for a type whose extent is declared outright rather than folded from
+# parts: a C ABI type the target states the size and alignment of (#3004). It is not
+# NODE_SCALAR, because a scalar's alignment is its own width and a 32-byte `va_list`
+# aligns to 8; and it is not NODE_AGGREGATE, because there are no fields to walk.
+pub val NODE_OPAQUE:    NodeKind = 7;
 
 # the target facts the fold reads
 #
@@ -309,6 +316,8 @@ fun walk(ctx: ptr, describe: NodeFn, field: FieldFn, id: u32, m: Machine, depth:
     if (n.kind == NODE_ZERO)    { ret extent(0, 1); }
     if (n.kind == NODE_SCALAR)  { ret extent(n.bytes, n.bytes); }
     if (n.kind == NODE_POINTER) { ret extent(m.ptr_width, m.ptr_width); }
+    # both numbers come from the declaration; nothing here is derived from the other.
+    if (n.kind == NODE_OPAQUE)  { ret extent(n.bytes, n.decl_align); }
 
     # a vector's extent is lane-derived: `lanes` lanes of `bytes` each, packed, with
     # NO padding to the vector register (#2687). a packed `f32x3` is 12 bytes, which is

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1404,6 +1404,16 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
         ret lower_handle_type(lc, rtid, t);
     }
 
+    # an ABI type lowers to an IR aggregate of the target's DECLARED extent (#3004):
+    # a run of bytes at the declared alignment, with no field the program can name.
+    # Being an aggregate is the whole mechanism - AAPCS64's by-reference rule for a
+    # composite over sixteen bytes is what makes the caller copy a 32-byte `va_list`
+    # and pass an address, and the same rule reduces an eight-byte one to the single
+    # register a pointer would have taken everywhere else.
+    if (k == type.TYPE_ABI) {
+        ret lower_abi_type(lc, t);
+    }
+
     # records, unions, and generic instances all lower to an IR aggregate of their
     # field layout, read from the session-global field store. a generic instance
     # carries a substituted field table (built by `generics.instantiate`), so it
@@ -1422,6 +1432,28 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
     # generic params / errors that survived to here lower to a pointer-width
     # opaque slot so storage sizing still works.
     ret ir_type.intern_ptr(?lc.m.types);
+}
+
+# lower a target-declared ABI type into an IR aggregate of its declared extent
+#
+# One `[size]u8` field under the declared alignment, rather than a run of
+# machine-word members: the byte array carries the size for any size, and the
+# alignment override carries the alignment, so a platform whose `va_list` is not a
+# whole number of words needs no second rule. The leaves are integer bytes, which is
+# what every convention's classifier reads them as - the integer path on all of them,
+# never a homogeneous-float aggregate.
+# ---
+# lc: the lowering context
+# t:  the semantic type record
+# ret: the IR aggregate type id, or an allocation error
+fun lower_abi_type(lc: *LowerContext, t: *type.Type) R.Result[ir_type.IrTypeId, str] {
+    val r_u8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?lc.m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r_u8)) { ret r_u8; }
+    val r_arr: R.Result[ir_type.IrTypeId, str] =
+        ir_type.intern_array(?lc.m.types, R.unwrap_ok[ir_type.IrTypeId, str](r_u8), t.data.abi.size);
+    if (R.is_err[ir_type.IrTypeId, str](r_arr)) { ret r_arr; }
+    var field: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r_arr);
+    ret ir_type.intern_struct(?lc.m.types, ?field, 1, t.data.abi.align, false);
 }
 
 # lower a handle's constructor and operands into an IR handle type

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -111,6 +111,23 @@ pub fun host_pointer_width() u32 {
     ret ($mach.build.pointer_width)::u32;
 }
 
+# the `va_list` layout of the host this compiler binary was built for (#3004)
+#
+# Reads the OS implementations' OWN declarations rather than restating them, so the
+# editor's target-less context and a real build cannot disagree about what a
+# `va_list` is on this machine. Parallels `host_os_id` / `host_arch_id`: the os is
+# folded from the build and the architecture comes from `host_arch_id`, and no
+# registry is brought up, because the editor seeds a buffer's context before one
+# exists.
+# ---
+# ret: the host platform's declared layout, or none when it declares none
+pub fun host_va_list() O.Option[os.VaList] {
+    $if ($mach.build.os == $mach.os.linux)   { ret linux.linux_va_list(host_arch_id()); }
+    $or ($mach.build.os == $mach.os.darwin)  { ret darwin.darwin_va_list(host_arch_id()); }
+    $or ($mach.build.os == $mach.os.windows) { ret windows.windows_va_list(host_arch_id()); }
+    $or                                      { ret freestanding.freestanding_va_list(host_arch_id()); }
+}
+
 # the abi id of the host this compiler binary was built for
 #
 # folds the `$mach.build.abi` comptime read into the matching `abi.ABI_*` id, so
@@ -341,6 +358,21 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     # eight bytes. resolved beside the variadic fact, never merged with it - Apple keeps
     # the eight-byte minimum for its variadic tail.
     t.fixed_args_natural_size = os.natural_stack_args_for(os_vt, arch_vt.id);
+
+    # the platform's `va_list` shape for THIS (os, isa) pair, on the same axis again:
+    # darwin's arm64 `va_list` is a `char *` and linux's is AAPCS64's 32-byte composite,
+    # from the one convention vtable both compose. A platform that declares none leaves
+    # both scalars 0, which the `#[abi_type("va_list")]` declaration refuses by name
+    # rather than reading as a pointer.
+    var vl_size:  u32 = 0;
+    var vl_align: u32 = 0;
+    val vl: O.Option[os.VaList] = os.va_list_for(os_vt, arch_vt.id);
+    if (O.is_some[os.VaList](vl)) {
+        vl_size  = O.unwrap[os.VaList](vl).size;
+        vl_align = O.unwrap[os.VaList](vl).align;
+    }
+    t.va_list_size  = vl_size;
+    t.va_list_align = vl_align;
 
     # derive the legacy identity ids from the resolved vtables; the ~89 id-readers
     # and the comptime tag space keep reading these unchanged.

--- a/src/lang/target/isa/asm/host.mach
+++ b/src/lang/target/isa/asm/host.mach
@@ -1,0 +1,293 @@
+# the inline-asm facts that are only observable where the code runs (#2791, #2944)
+#
+# Two measurements the integration suite carried and nothing replaced. Both are about
+# the kernel entry an inline-asm body writes, which is the one part of such a body that
+# is neither target-independent nor readable off the emitted bytes: an entry with the
+# wrong number assembles perfectly and does the wrong thing, and only executing it says
+# which. So these run on the host, gated on the host's own os and isa, and a leg that
+# cannot run them declines by name.
+#
+# THE FOUR CONVENTIONS. linux takes `syscall` with the number in EAX on x86-64, `svc 0`
+# with the number in x8 on aarch64, and `ecall` with the number in a7 on riscv64.
+# darwin takes the BSD-class number `0x2000000 + n` in EAX on x86-64 and `svc 0x80` with
+# the plain number in x16 on aarch64. windows has no syscall ABI at all - its console
+# write goes through a kernel32 import - so for windows the premise fails rather than
+# the expectation, and it declines.
+
+use std.types.size.usize;
+use std.types.string.str;
+use p: std.print;
+
+$if ($mach.build.os == $mach.os.windows) {
+    # THE DECLINE IS A DECLARATION, not a branch inside a test body: a passing test's
+    # captured output is suppressed unless the run asks for it, so the NAME is the
+    # readout, and it shows in `--list` and under `-v`.
+    test "mach.lang.target.isa.asm.host:asm_noreturn_declines_on_windows" {
+        p.println("declined: windows has no syscall ABI, so a body that ends control through one does not exist there");
+        ret 0;
+    }
+
+    test "mach.lang.target.isa.asm.host:inline_asm_write_declines_on_windows" {
+        p.println("declined: windows has no syscall ABI; its console write goes through a kernel32 import");
+        ret 0;
+    }
+}
+$or {
+    # a body containing a real kernel entry RETURNS, and the work after it must survive
+    #
+    # THIS IS THE HALF THAT CAN BITE. The conservatism runs opposite to every other fact
+    # in the inline-asm effect model: a wrong `writes` costs allocation quality, but a
+    # body wrongly judged non-returning makes lowering DROP everything after it, which
+    # deletes live code. `getpid` cannot fail and its result is discarded, so the only
+    # thing this row observes is whether the addition after the entry survived.
+    fun after_syscall(v: i64) i64 {
+        var w: i64 = 0;
+        $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000014
+                syscall
+                mov rax, {v}
+                mov {w}, rax
+            }
+        }
+        $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 20
+                svc 0x80
+                ldr x9, {v}
+                str x9, {w}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 39
+                syscall
+                mov rax, {v}
+                mov {w}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 172
+                svc 0
+                ldr x9, {v}
+                str x9, {w}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 172
+                ecall
+                ld a0, {v}
+                sd a0, {w}
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret w + 1;
+    }
+
+    # a trap that is NOT the last statement leaves the body falling through, because
+    # control could reach the statements past it
+    fun trap_not_last(v: i64) i64 {
+        var w: i64 = 0;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                jmp 1f
+                hlt
+            1:
+                mov rax, {v}
+                mov {w}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                b 1f
+                brk 0
+            1:
+                ldr x9, {v}
+                str x9, {w}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                j 1f
+                ebreak
+            1:
+                ld a0, {v}
+                sd a0, {w}
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret w + 2;
+    }
+
+    # a raw byte payload is never judged non-returning: the compiler does not decode it.
+    # these bytes are a no-op on each target, and the work after them must survive.
+    fun after_bytes(v: i64) i64 {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 { .byte 0x90 }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 { .word 0xd503201f }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 { .word 0x00000013 }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret v + 3;
+    }
+
+    # the non-returning shape itself: a kernel entry that ends the thread of control,
+    # followed by a trap
+    #
+    # It exits with status 0, so a body that reaches the kernel IS this test's pass and
+    # nothing after the call runs. A wrong entry number returns instead of exiting, falls
+    # into the trap, and the runner reports a signal - a failure, not a hang.
+    fun die() {
+        $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000001
+                mov edi, 0
+                syscall
+                hlt
+            }
+        }
+        $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 1
+                mov x0, 0
+                svc 0x80
+                brk 0
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 231
+                mov edi, 0
+                syscall
+                hlt
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 94
+                mov x0, 0
+                svc 0
+                brk 0
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 94
+                li a0, 0
+                ecall
+                ebreak
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+    }
+
+    # write through a raw kernel entry and report what the kernel returned
+    #
+    # The return value is the assertion rather than the bytes on the console: a write
+    # that reached the kernel answers the byte count, and a wrong entry number answers an
+    # error code instead. Reading the console would need a second process to read it.
+    fun host_write(msg: *u8, len: usize) i64 {
+        var r: i64 = 0;
+        $if ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000004
+                mov edi, 1
+                mov rsi, {msg}
+                mov rdx, {len}
+                syscall
+                mov {r}, rax
+            }
+        }
+        $or ($mach.build.os == $mach.os.darwin && $mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 4
+                mov x0, 1
+                ldr x1, {msg}
+                ldr x2, {len}
+                svc 0x80
+                str x0, {r}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 1
+                mov edi, 1
+                mov rsi, {msg}
+                mov rdx, {len}
+                syscall
+                mov {r}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 64
+                mov x0, 1
+                ldr x1, {msg}
+                ldr x2, {len}
+                svc 0
+                str x0, {r}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 64
+                li a0, 1
+                ld a1, {msg}
+                ld a2, {len}
+                ecall
+                sd a0, {r}
+            }
+        }
+        $or {
+            $error("asm.host: unsupported architecture");
+        }
+        ret r;
+    }
+
+    # an inline-asm body that cannot return ends control, and one that can does not
+    # (#2791)
+    #
+    # The returning half is asserted by value: each row does work after its body and
+    # returns it, so a body misjudged non-returning loses its continuation and answers
+    # wrong. The non-returning half is asserted by ABSENCE - `die` ends the process with
+    # status 0, so reaching the statement after it is the failure.
+    #
+    # The sibling unit test `driver:asm_that_cannot_return_terminates_its_block` asserts
+    # the CFG. This asserts that the model agrees with the machine.
+    test "mach.lang.target.isa.asm.host:a_body_that_cannot_return_ends_the_process" {
+        if (after_syscall(10) != 11) { ret 1; }
+        if (trap_not_last(20) != 22) { ret 2; }
+        if (after_bytes(30)   != 33) { ret 3; }
+        die();
+        ret 4;
+    }
+
+    # the host's write convention, exercised through inline asm (#2944)
+    #
+    # The message lands on this test's captured stdout, which is where the integration
+    # case's golden used to read it. What is asserted here is the kernel's answer, which
+    # is strictly more than the golden saw: a write that never reached the kernel returns
+    # an error code rather than a byte count, and a byte count short of the message is a
+    # partial write the golden would also have caught.
+    test "mach.lang.target.isa.asm.host:an_inline_asm_write_reaches_the_kernel" {
+        val msg: str = "asm.host: syscall write ok\n";
+        var len: usize = 0;
+        for (msg[len] != 0) { len = len + 1; }
+        if (host_write(msg::*u8, len) != len::i64) { ret 1; }
+        ret 0;
+    }
+}

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -9139,7 +9139,15 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:permitting_surface_is_bounded
 # zf_def: the probe measured ZF as DEFINED rather than preserved
 # cf_def: the probe measured CF as DEFINED rather than preserved
 # reads:  the probe measured a destination difference between the two flag presets
-rec ProbedRow {
+# how many rows the transcription below carries
+#
+# Named rather than repeated at each call site, because every caller sizes a buffer from
+# it and `probed_rows` writes exactly this many. Adding a row is bumping this once, and
+# the host probe checks the returned count against its own arm list so a row added here
+# with no arm to measure it fails rather than being compared against nothing.
+pub val PROBED_ROW_COUNT: usize = 25;
+
+pub rec ProbedRow {
     code:   u32;
     zf_def: bool;
     cf_def: bool;
@@ -9158,16 +9166,17 @@ fun probed(code: u32, zf: bool, cf: bool, reads: bool) ProbedRow {
 # instruction twice, with the flags preset all-set and all-clear, and seeing what it
 # defines, preserves and reads.
 #
-# NOTHING RE-RUNS THAT PROBE TODAY, so this array is a measurement taken once rather
-# than a fact under guard, and a CPU that stops matching it diverges silently. The
-# probe only means anything on the ISA it executes on, so restoring it belongs in a
-# host-executed unit test rather than in a cross-compilation suite.
+# THE PROBE RE-RUNS. `x64.probe:flags_table_matches_this_cpu` executes every row below
+# on the host and fails on a disagreement, so this array is a fact under guard rather
+# than a measurement taken once. It only means anything on the ISA it executes on, which
+# is why it lives in a host-executed unit test rather than in a cross-compilation suite,
+# and why a non-x86-64 host declines it by name.
 #
 # Several instructions appear more than once under different operands, and that is
 # the point for the count-dependent rows: `shl` at count 1 defines both flags and
 # at count 0 defines neither, so a single measurement of it would be a fact about
 # one operand rather than about the instruction.
-fun probed_rows(out: *ProbedRow) u32 {
+pub fun probed_rows(out: *ProbedRow) u32 {
     out[0]  = probed(x64.ADD::u32,     true,  true,  false);
     out[1]  = probed(x64.SUB::u32,     true,  true,  false);
     out[2]  = probed(x64.CMP::u32,     true,  true,  false);
@@ -9193,7 +9202,7 @@ fun probed_rows(out: *ProbedRow) u32 {
     out[22] = probed(x64.SETB::u32,    false, false, true);    # consumes CF
     out[23] = probed(x64.SETAE::u32,   false, false, true);    # consumes CF
     out[24] = probed(x64.JB::u32,      false, false, false);   # `jc`: see below
-    ret 25;
+    ret PROBED_ROW_COUNT::u32;
 }
 
 # the classification agrees with what the CPU does (#2460)
@@ -9218,7 +9227,7 @@ fun probed_rows(out: *ProbedRow) u32 {
 # because an unmodelled one is the laundering hole; an unmeasured read proves
 # nothing, since `jc` reads CF and leaves no register difference to see.
 test "mach.lang.target.isa.x64.encode.asm_ct_class:agrees_with_measured_hardware" {
-    var rows: [25]ProbedRow;
+    var rows: [PROBED_ROW_COUNT]ProbedRow;
     val n: u32 = probed_rows(?rows[0]);
 
     var bad: i32 = 0;
@@ -9264,7 +9273,7 @@ test "mach.lang.target.isa.x64.encode.asm_ct_class:agrees_with_measured_hardware
 #
 # To see it fail, give a new row `defines_flags` without adding it to `probed_rows`.
 test "mach.lang.target.isa.x64.encode.asm_ct_class:every_permitting_row_is_measured" {
-    var rows: [25]ProbedRow;
+    var rows: [PROBED_ROW_COUNT]ProbedRow;
     val n: u32 = probed_rows(?rows[0]);
 
     var bad: i32 = 0;

--- a/src/lang/target/isa/x64/probe.mach
+++ b/src/lang/target/isa/x64/probe.mach
@@ -1,0 +1,570 @@
+# the x86-64 flags probe, executed on the host (#2460, #2944)
+#
+# `encode.probed_rows` transcribes what a CPU says each of these instructions does to
+# ZF and CF, and that transcription is the security surface `#[oblivious]` rests on:
+# `defines_flags` is the only fact that CLEARS a taint, so a row wrongly marked a
+# definer silently permits a leak. Until this module existed the transcription was a
+# measurement taken once, in a C probe that died with the integration suite, and a CPU
+# that stopped matching it diverged with nothing failing anywhere.
+#
+# WHAT IS MEASURED. Each row runs its instruction twice with identical operands, once
+# with RFLAGS preset all-set and once all-clear, and reports both observables from each
+# run:
+#
+#   WRITER probe - RFLAGS afterwards. A flag with the same value under both presets is
+#                  DEFINED by the instruction; one that comes out equal to its input
+#                  under both is PRESERVED. That is the `defines_flags` predicate.
+#   READER probe - a scratch register, zeroed before the preset and read back after.
+#                  A difference between the two runs means the instruction consumed a
+#                  flag. That is the `reads_flags` predicate.
+#
+# THIS PROBE ASSEMBLES THROUGH MACH ITSELF, which the C one did not. The bytes executed
+# are what `asm x86_64` emitted for these mnemonics, so an encoder that folded `shl rax,
+# 0` into a shift-by-one, or picked the wrong SETcc, fails here as a flags disagreement.
+# That is a true failure and worth knowing about; read a surprise here as an encoding
+# question before a silicon one.
+#
+# WHY A HOST TEST AND NOT A CROSS-COMPILATION CASE. The facts are x86-64's and they are
+# only observable where the instruction runs. Building for a target and reading the
+# bytes back cannot see them, whatever the target. So the whole module is gated on the
+# host ISA, and a non-x86-64 host declines through the twin test at the bottom rather
+# than asserting something it did not measure.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+use p: std.print;
+
+use mach.lang.target.isa.x64;
+use encode: mach.lang.target.isa.x64.encode;
+
+# RFLAGS with every arithmetic flag set, and with every one clear. Bit 1 reads as 1 on
+# every x86-64 part, so the all-clear preset carries it.
+val FSET: u64 = 0x0CD5;
+val FCLR: u64 = 0x0002;
+
+# the two observable flags: the complete set the inline-asm grammar can read, which is
+# what makes `defines_flags` decidable at all
+val FZF: u64 = 0x0040;
+val FCF: u64 = 0x0001;
+
+# the instruction wrote the flag from its own operands: same result under both presets
+val V_DEFINED: u8 = 0;
+# the instruction left the flag alone: each run came out carrying its own preset
+val V_PRESERVED: u8 = 1;
+# neither, which no row is allowed to be - it means the probe saw a third behaviour and
+# the two-verdict model does not describe this instruction
+val V_VARIES: u8 = 2;
+
+# how one flag behaved across the two presets
+# ---
+# hi:  RFLAGS after the all-set run
+# lo:  RFLAGS after the all-clear run
+# bit: the flag under test
+fun verdict(hi: u64, lo: u64, bit: u64) u8 {
+    val oh: bool = (hi & bit) != 0;
+    val ol: bool = (lo & bit) != 0;
+    if (oh == ol) { ret V_DEFINED; }
+    if (oh == ((FSET & bit) != 0) && ol == ((FCLR & bit) != 0)) { ret V_PRESERVED; }
+    ret V_VARIES;
+}
+
+# run one probe row with RFLAGS preset to `pre`, and report both observables
+#
+# ONE `asm` BLOCK PER ROW, DELIBERATELY. The preset, the instruction and the capture
+# have to be adjacent in the emitted stream: `popfq` and `pushfq` bracket the
+# instruction with nothing between them, and nothing the compiler is free to insert
+# between two `asm` statements may land there. So each arm carries the whole sequence
+# rather than sharing a preamble, and the operand setup rides with it because several
+# rows need their own (a `neg` of zero is the CF edge, and `cmpxchg` has two paths that
+# depend on RAX).
+#
+# RSI carries the preset in and the flags out; RDI is the reader probe's scratch, zeroed
+# before the preset so a row that never touches it reads back identically under both.
+# ---
+# row:   which row to run, fixed per call site
+# pre:   the RFLAGS preset
+# out_d: receives the reader probe's scratch register
+# ret:   RFLAGS after the instruction
+fun run($row: u32, pre: u64, out_d: *u64) u64 {
+    var f: u64 = 0;
+    var d: u64 = 0;
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        $if (row == 0) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                add rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 1) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                sub rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 2) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                cmp rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 3) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                test rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 4) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                and rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 5) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                or rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 6) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                xor rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 7) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                neg rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # `neg` of zero is the CF edge: it is the one operand for which `neg` clears CF
+        # rather than setting it, so measuring `neg` once would be a fact about an
+        # operand rather than about the instruction.
+        $or (row == 8) {
+            asm x86_64 {
+                mov rax, 0
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                neg rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 9) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                xadd rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # `cmpxchg` compares RAX against its destination, so RAX is part of the input
+        # and both outcomes have to be measured: the equal path stores the source and
+        # sets ZF, the not-equal path loads the destination into RAX and clears it. A
+        # row that defined flags on only one of its two paths would not be a definer.
+        $or (row == 10) {
+            asm x86_64 {
+                mov rcx, 5
+                mov rdx, 3
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                cmpxchg rcx, rdx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 11) {
+            asm x86_64 {
+                mov rcx, 5
+                mov rdx, 3
+                mov rax, 9
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                cmpxchg rcx, rdx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # the traps: partial writers a careless reading of "writes flags" would let
+        # clear a taint. `inc` and `dec` leave CF alone, which `jc` still reads.
+        $or (row == 12) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                inc rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 13) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                dec rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # a shift writes flags at a nonzero count and writes none at all at zero, so
+        # both counts are measured. Reading the count-1 result as the instruction's
+        # fact is exactly the unsoundness #2460 exists to close.
+        $or (row == 14) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                shl rax, 1
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 15) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                shl rax, 0
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 16) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                shr rax, 0
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 17) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                sar rax, 0
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # `not` writes no flag at all, unlike every one of its bitwise siblings
+        $or (row == 18) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                not rax
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 19) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                mov rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 20) {
+            asm x86_64 {
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                lea rax, [rcx + 1]
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 21) {
+            asm x86_64 {
+                mov rax, 5
+                mov rcx, 3
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                xchg rax, rcx
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # the SETcc rows: the reader probe is the point. They write no flag, and their
+        # destination must differ between the two presets - that difference IS the
+        # laundering path `reads_flags` exists to close.
+        $or (row == 22) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                setb dil
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or (row == 23) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                setae dil
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        # A BRANCH CONSUMES A FLAG AND THE READER PROBE CANNOT SEE IT. `jc` reads CF,
+        # but a taken branch leaves no register difference to measure, so this row
+        # measures reads:0. That is a limit of the probe, NOT a fact about `jc`, and it
+        # is the structural reason the conditional jumps do not need `reads_flags`:
+        # `cond_flags` refuses them outright before any fold.
+        $or (row == 24) {
+            asm x86_64 {
+                mov rax, 5
+                mov rdi, 0
+                mov rsi, {pre}
+                push rsi
+                popfq
+                jc 1f
+            1:
+                pushfq
+                pop rsi
+                mov {f}, rsi
+                mov {d}, rdi
+            }
+        }
+        $or {
+            $error("x64 flags probe: row index has no arm");
+        }
+    }
+    @out_d = d;
+    ret f;
+}
+
+# measure one row and check it against the transcription
+#
+# Returns 0 when the hardware agrees with `encode.probed_rows[row]`, and a distinct
+# non-zero code per disagreement so a failure names which fact moved rather than only
+# that something did.
+# ---
+# row:  the row to run, which indexes `encode.probed_rows` as well
+# want: the transcribed row it must agree with
+fun check($row: u32, want: *encode.ProbedRow) i32 {
+    var dh: u64 = 0;
+    var dl: u64 = 0;
+    val hi: u64 = run(row, FSET, ?dh);
+    val lo: u64 = run(row, FCLR, ?dl);
+
+    val vz: u8 = verdict(hi, lo, FZF);
+    val vc: u8 = verdict(hi, lo, FCF);
+
+    # a third behaviour is not a disagreement about a row, it is the two-verdict model
+    # failing to describe the instruction, and it must never be read as either verdict
+    if (vz == V_VARIES) { ret 4; }
+    if (vc == V_VARIES) { ret 5; }
+
+    if ((vz == V_DEFINED) != want.zf_def) { ret 1; }
+    if ((vc == V_DEFINED) != want.cf_def) { ret 2; }
+    if ((dh != dl) != want.reads)         { ret 3; }
+    ret 0;
+}
+
+# the transcribed flags table is what this CPU actually does (#2460, #2944)
+#
+# The re-derivation. `encode:agrees_with_measured_hardware` makes the transcription bear
+# on the classification; this makes the transcription bear on the silicon, which is the
+# half that died with the integration suite. Every row is compared, in the order
+# `probed_rows` states it, and the order is load-bearing: several instructions appear
+# twice under different operands, and swapping `shl` at count 1 with `shl` at count 0
+# is a real disagreement rather than a reordering.
+#
+# To see it fail, flip any verdict in `encode.probed_rows`.
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    test "mach.lang.target.isa.x64.probe:flags_table_matches_this_cpu" {
+        var rows: [encode.PROBED_ROW_COUNT]encode.ProbedRow;
+        # a row added to the transcription with no arm here to measure it fails, rather
+        # than being compared against nothing
+        val n: u32 = encode.probed_rows(?rows[0]);
+        if (n != 25) { ret 6; }
+
+        if (check(0,  ?rows[0])  != 0) { ret 10; }
+        if (check(1,  ?rows[1])  != 0) { ret 11; }
+        if (check(2,  ?rows[2])  != 0) { ret 12; }
+        if (check(3,  ?rows[3])  != 0) { ret 13; }
+        if (check(4,  ?rows[4])  != 0) { ret 14; }
+        if (check(5,  ?rows[5])  != 0) { ret 15; }
+        if (check(6,  ?rows[6])  != 0) { ret 16; }
+        if (check(7,  ?rows[7])  != 0) { ret 17; }
+        if (check(8,  ?rows[8])  != 0) { ret 18; }
+        if (check(9,  ?rows[9])  != 0) { ret 19; }
+        if (check(10, ?rows[10]) != 0) { ret 20; }
+        if (check(11, ?rows[11]) != 0) { ret 21; }
+        if (check(12, ?rows[12]) != 0) { ret 22; }
+        if (check(13, ?rows[13]) != 0) { ret 23; }
+        if (check(14, ?rows[14]) != 0) { ret 24; }
+        if (check(15, ?rows[15]) != 0) { ret 25; }
+        if (check(16, ?rows[16]) != 0) { ret 26; }
+        if (check(17, ?rows[17]) != 0) { ret 27; }
+        if (check(18, ?rows[18]) != 0) { ret 28; }
+        if (check(19, ?rows[19]) != 0) { ret 29; }
+        if (check(20, ?rows[20]) != 0) { ret 30; }
+        if (check(21, ?rows[21]) != 0) { ret 31; }
+        if (check(22, ?rows[22]) != 0) { ret 32; }
+        if (check(23, ?rows[23]) != 0) { ret 33; }
+        if (check(24, ?rows[24]) != 0) { ret 34; }
+        ret 0;
+    }
+}
+$or {
+    # THE DECLINE IS A DECLARATION, not a branch inside one test body. A passing test's
+    # output is suppressed unless the run asks for it, so a printed line is not a
+    # readout - the NAME is, and it is in `--list` and under `-v` on every host.
+    test "mach.lang.target.isa.x64.probe:flags_probe_declines_off_x86_64" {
+        p.println("declined: the x86-64 flags probe measures instructions this host cannot execute");
+        ret 0;
+    }
+}

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -16,6 +16,7 @@ use std.types.string.str;
 use std.types.string.str_equals;
 
 use O: std.types.option;
+use R: std.types.result;
 
 use mach.lang.target.isa;
 
@@ -148,6 +149,49 @@ pub def VariadicStackFn: fun(u32) bool;
 # ret:   true when a fixed stack argument takes its natural size there
 pub def NaturalStackArgsFn: fun(u32) bool;
 
+# the layout a C `va_list` occupies in a PARAMETER slot on one architecture (#3004)
+#
+# `va_list` is the one C type mach binds whose shape is neither a scalar it can name
+# nor an aggregate the user can write down: AAPCS64 makes it a 32-byte 8-aligned
+# composite, and every other platform mach targets makes it a plain pointer. That
+# difference is not decorative. A composite over 16 bytes is passed indirectly under
+# AAPCS64 with the CALLER owning the copy, so forwarding a received `va_list` spelled
+# as a pointer hands the next callee the caller's own list to advance rather than a
+# fresh one.
+# ---
+# size:  the type's size in bytes
+# align: the type's required alignment in bytes
+pub rec VaList { size: u32; align: u32; }
+
+# build a declared `va_list` layout
+# ---
+# size:  size in bytes
+# align: alignment in bytes
+# ret:   the layout
+pub fun va_list(size: u32, align: u32) VaList {
+    var v: VaList;
+    v.size  = size;
+    v.align = align;
+    ret v;
+}
+
+# a per-os `va_list` layout policy, parameterized by architecture id
+#
+# DECLARED PER (OS, ARCHITECTURE), NEVER DERIVED. It is an OS fact for the same
+# reason `VariadicStackFn` is: darwin and linux compose the very same "aapcs64"
+# vtable and disagree about this outright - darwin's arm64 `va_list` is a `char *`
+# and linux's is the AAPCS64 32-byte composite - so no calling convention can answer
+# it and no machine model implies it.
+#
+# `none` means NOBODY HAS READ THE psABI for that architecture, and it is refused
+# rather than defaulted. Every plausible default is a pointer, a pointer is right on
+# four of the five platforms mach binds C on, and being right four times out of five
+# is exactly the shape that ships silent corruption on the fifth.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   the declared layout, or none when the architecture has no declaration
+pub def VaListFn: fun(u32) O.Option[VaList];
+
 # the operating-system runtime-dispatch interface
 #
 # Exactly one of these exists per OS; the driver and linker read the entry
@@ -251,6 +295,10 @@ pub def NaturalStackArgsFn: fun(u32) bool;
 #                 it once onto `Target.fixed_args_natural_size`. Sibling of
 #                 `variadic_stack` and deliberately separate from it: Apple's fixed and
 #                 variadic rules differ from each other
+# va_list_layout: per-architecture `va_list` layout, or nil when the OS declares none
+#                 anywhere; `target.select` resolves it once onto `Target.va_list_size`
+#                 and `Target.va_list_align`. an architecture with no declaration is
+#                 refused at registration rather than defaulted to a pointer (#3004)
 pub rec OsVTable {
     id:                  u32;
     name:                str;
@@ -275,6 +323,7 @@ pub rec OsVTable {
     native_abi:          NativeAbiFn;
     variadic_stack:      VariadicStackFn;
     natural_stack_args:  NaturalStackArgsFn;
+    va_list_layout:      VaListFn;
 }
 
 # maximum number of OS implementations an OsRegistry holds
@@ -307,20 +356,46 @@ pub fun registry_init() OsRegistry {
     ret r;
 }
 
-# install an OS vtable into `reg`
+# install an OS vtable into `reg`, refusing one that declares no `va_list` for an
+# architecture it claims to run on
 #
 # Write-once per os name: a second registration under a name already present is
 # ignored so the first implementation to initialize wins deterministically. a nil
 # vtable, or one past the registry's capacity, is ignored.
+#
+# THE REFUSAL IS THE `va_list` DECLARATION'S ONE READER AT STARTUP (#3004), and it
+# is shaped after `abi.riscv.install`, which refuses a family member still carrying
+# `VARIADIC_RULE_UNDECLARED`. An OS that lists an architecture in `supported_isas`
+# says a program builds and links against that platform's C there, and `va_list` is
+# part of what that platform's C is. Missing it is a programming error in the OS
+# implementation, so it is named here rather than surfacing as a wrong argument at a
+# call site.
+#
+# An OS carrying `supported_isa_any` (bare metal) has no list to check, so the same
+# question is asked of it where the fact is demanded, at the declaration that needs
+# a layout for the selected target.
 # ---
 # reg: the registry to install into
 # vt:  the OS vtable to register; its `name` is the key
-pub fun register(reg: *OsRegistry, vt: *OsVTable) {
-    if (vt == nil)                                  { ret; }
-    if (O.is_some[*OsVTable](lookup(reg, vt.name))) { ret; }
-    if (reg.count >= OS_REGISTRY_CAP)               { ret; }
+# ret: ok(true) on success, or an error naming an undeclared (os, architecture) pair
+pub fun register(reg: *OsRegistry, vt: *OsVTable) R.Result[bool, str] {
+    if (vt == nil)                                  { ret R.ok[bool, str](true); }
+    if (O.is_some[*OsVTable](lookup(reg, vt.name))) { ret R.ok[bool, str](true); }
+    if (reg.count >= OS_REGISTRY_CAP)               { ret R.ok[bool, str](true); }
+
+    if (!vt.supported_isa_any) {
+        var i: u32 = 0;
+        for (i < vt.supported_isa_count) {
+            if (O.is_none[VaList](va_list_for(vt, vt.supported_isas[i]))) {
+                ret R.err[bool, str]("mach.lang.target.os: an operating system declares no `va_list` layout for an architecture it supports; read the platform psABI for it and declare the size and alignment rather than registering it undecided");
+            }
+            i = i + 1;
+        }
+    }
+
     reg.entries[reg.count] = vt;
     reg.count = reg.count + 1;
+    ret R.ok[bool, str](true);
 }
 
 # find the OS vtable registered under an os name in `reg`
@@ -481,6 +556,21 @@ pub fun natural_stack_args_for(vt: *OsVTable, arch_id: u32) bool {
     ret vt.natural_stack_args(arch_id);
 }
 
+# the `va_list` layout operating system `vt` declares on architecture `arch_id`
+#
+# The nil-safe reader over the vtable's `va_list_layout` policy. A nil policy, and a
+# policy that answers none, are the SAME answer: this platform has no declared
+# `va_list` on that architecture. There is no fallback, because the only fallback
+# available would be a pointer and a pointer is wrong on AAPCS64.
+# ---
+# vt:      the os vtable to read
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none
+pub fun va_list_for(vt: *OsVTable, arch_id: u32) O.Option[VaList] {
+    if (vt.va_list_layout == nil) { ret O.none[VaList](); }
+    ret vt.va_list_layout(arch_id);
+}
+
 # stub variadic-placement policy for the variadic_stack_for test: covers arch id 1
 fun variadic_stack_stub(arch_id: u32) bool {
     ret arch_id == 1;
@@ -512,6 +602,81 @@ test "mach.lang.target.os.natural_stack_args_for:reads_policy_and_is_nil_safe" {
     vt.natural_stack_args = natural_stack_args_stub;
     if (!natural_stack_args_for(?vt, 1)) { ret 1; }
     if (natural_stack_args_for(?vt, 2))  { ret 1; }
+    ret 0;
+}
+
+# stub `va_list` policy for the va_list_for test: covers arch id 1 only
+fun va_list_stub(arch_id: u32) O.Option[VaList] {
+    if (arch_id == 1) { ret O.some[VaList](va_list(32, 8)); }
+    ret O.none[VaList]();
+}
+
+# va_list_for is nil-safe (a nil policy declares nothing anywhere) and otherwise
+# reads the vtable's policy per architecture, reporting none for an architecture the
+# policy does not cover
+test "mach.lang.target.os.va_list_for:reads_policy_and_is_nil_safe" {
+    var vt: OsVTable;
+    vt.va_list_layout = nil;
+    if (O.is_some[VaList](va_list_for(?vt, 1))) { ret 1; }
+    vt.va_list_layout = va_list_stub;
+    val got: O.Option[VaList] = va_list_for(?vt, 1);
+    if (O.is_none[VaList](got))            { ret 1; }
+    if (O.unwrap[VaList](got).size != 32)  { ret 1; }
+    if (O.unwrap[VaList](got).align != 8)  { ret 1; }
+    if (O.is_some[VaList](va_list_for(?vt, 2))) { ret 1; }
+    ret 0;
+}
+
+# an OS that lists an architecture it declares no `va_list` for is REFUSED at
+# registration, not defaulted to a pointer (#3004)
+#
+# The startup reader of the declaration, shaped after `abi.riscv.install`. Listing an
+# architecture in `supported_isas` says a program links against that platform's C
+# there, and `va_list` is part of what that C is. Missing it is a programming error
+# in the OS implementation and is named here rather than surfacing as a wrong
+# argument at a call site.
+#
+# THE CONTROL IS THE SAME VTABLE WITH THE DECLARATION, and a second one carrying
+# `supported_isa_any` - a bare-metal OS has no list to check, and refusing it here
+# would refuse every freestanding target for an architecture nobody targets.
+test "mach.lang.target.os.register:refuses_an_undeclared_va_list" {
+    var reg: OsRegistry = registry_init();
+
+    var bad: OsVTable;
+    bad.name                = "badvl";
+    bad.supported_isa_any   = false;
+    bad.supported_isa_count = 0;
+    support_isa(?bad, 1);
+    bad.va_list_layout      = nil;
+    if (R.is_ok[bool, str](register(?reg, ?bad))) { ret 1; }
+    if (registered_count(?reg) != 0)              { ret 1; }
+
+    var good: OsVTable;
+    good.name                = "goodvl";
+    good.supported_isa_any   = false;
+    good.supported_isa_count = 0;
+    support_isa(?good, 1);
+    good.va_list_layout      = va_list_stub;
+    if (R.is_err[bool, str](register(?reg, ?good))) { ret 1; }
+    if (registered_count(?reg) != 1)                { ret 1; }
+
+    # an architecture the policy does not cover is the same refusal: the list is what
+    # is checked, not whether a policy is installed at all.
+    var partial: OsVTable;
+    partial.name                = "partialvl";
+    partial.supported_isa_any   = false;
+    partial.supported_isa_count = 0;
+    support_isa(?partial, 2);
+    partial.va_list_layout      = va_list_stub;
+    if (R.is_ok[bool, str](register(?reg, ?partial))) { ret 1; }
+
+    var bare: OsVTable;
+    bare.name                = "barevl";
+    bare.supported_isa_any   = true;
+    bare.supported_isa_count = 0;
+    bare.va_list_layout      = nil;
+    if (R.is_err[bool, str](register(?reg, ?bare))) { ret 1; }
+    if (registered_count(?reg) != 2)                { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -14,6 +14,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -97,6 +98,22 @@ fun darwin_natural_stack_args(arch_id: u32) bool {
     ret arch_id == isa.ARCH_AARCH64;
 }
 
+# Darwin's `va_list` layout per architecture (#3004)
+#
+# `char *` on BOTH architectures, and the arm64 one is a deliberate Apple divergence
+# from the AAPCS64 base standard rather than an oversight: Apple's arm64 ABI passes
+# the whole variadic tail on the stack (`darwin_variadic_stack`), so walking that
+# tail needs nothing but a cursor and the register save area the base standard's
+# 32-byte descriptor exists to index does not exist here.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none for an architecture darwin does not run on
+pub fun darwin_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    ret O.none[os.VaList]();
+}
+
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime
 var darwin_vtable: os.OsVTable;
@@ -160,7 +177,9 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     # AAPCS64 eight-byte slot; a separate rule from the variadic one above, which keeps
     # the eight-byte minimum.
     darwin_vtable.natural_stack_args = darwin_natural_stack_args;
+    # `char *` on both architectures; Apple's arm64 tail is all stack, so a cursor
+    # into it is the whole descriptor.
+    darwin_vtable.va_list_layout = darwin_va_list;
 
-    os.register(reg, ?darwin_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?darwin_vtable);
 }

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -14,6 +14,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -52,6 +53,25 @@ fun freestanding_native_abi(arch_id: u32) str {
     if (arch_id == isa.ARCH_RISCV32) { ret "ilp32d"; }
     if (arch_id == isa.ARCH_MOS6502) { ret "mos6502"; }
     ret "";
+}
+
+# The `va_list` layout of a bare-metal target, per architecture (#3004)
+#
+# There is no OS here to have an opinion, so the answer is the architecture's own
+# psABI: the AAPCS64 base standard's 32-byte composite on aarch64, a pointer of the
+# machine's own width on the others. An architecture whose psABI defines no `va_list`
+# at all answers NONE rather than a pointer - SPIR-V has no C calling convention to
+# have one, and nobody has read a 6502 C ABI into this compiler - and a declaration
+# needing one on such a target is refused where it is written.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none where the psABI defines none
+pub fun freestanding_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(32, 8)); }
+    if (arch_id == isa.ARCH_RISCV64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_RISCV32) { ret O.some[os.VaList](os.va_list(4, 4)); }
+    ret O.none[os.VaList]();
 }
 
 # the freestanding OS vtable. populated by register_freestanding on first call
@@ -107,7 +127,8 @@ pub fun register_freestanding(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform stack-granularity divergence either: a stack argument takes the
     # convention's slot.
     freestanding_vtable.natural_stack_args = nil;
+    # the architecture's own psABI, and none where the psABI defines no `va_list`.
+    freestanding_vtable.va_list_layout = freestanding_va_list;
 
-    os.register(reg, ?freestanding_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?freestanding_vtable);
 }

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -12,6 +12,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -73,6 +74,24 @@ fun linux_native_abi(arch_id: u32) str {
     ret "";
 }
 
+# Linux's `va_list` layout per architecture (#3004)
+#
+# x86-64: `va_list` is `__va_list_tag[1]`, an ARRAY type, so in a parameter slot it
+# decays to `__va_list_tag *` and what is passed is one pointer. aarch64: the AAPCS64
+# base standard's `struct __va_list`, four pointer-sized members, 32 bytes aligned to
+# 8, and passed INDIRECTLY with the caller owning the copy - the one platform where
+# spelling it as a pointer forwards the caller's own list instead of a fresh one.
+# riscv64: the psABI makes it `void *`.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none for an architecture linux does not run on
+pub fun linux_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(32, 8)); }
+    if (arch_id == isa.ARCH_RISCV64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    ret O.none[os.VaList]();
+}
+
 # the Linux OS vtable. populated by register_linux on first call and handed out
 # as a borrowed pointer to the registry; remains valid for the process lifetime
 var linux_vtable: os.OsVTable;
@@ -131,9 +150,11 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform stack-granularity divergence either: a stack argument takes the
     # convention's slot (AAPCS64's eight-byte one on arm64, not Apple's natural size).
     linux_vtable.natural_stack_args = nil;
+    # the System V psABI's `va_list` per arch: a decayed pointer on x86-64 and
+    # riscv64, AAPCS64's 32-byte composite on aarch64.
+    linux_vtable.va_list_layout = linux_va_list;
 
-    os.register(reg, ?linux_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?linux_vtable);
 }
 
 # linux_page_size pins the per-arch segment-alignment page: aarch64 uses the 64 KiB

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -12,6 +12,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.target.os;
@@ -51,6 +52,20 @@ fun windows_pie_exec(arch_id: u32) bool {
 fun windows_native_abi(arch_id: u32) str {
     if (arch_id == isa.ARCH_X86_64) { ret "win64"; }
     ret "";
+}
+
+# Windows' `va_list` layout per architecture (#3004)
+#
+# `char *` on both: win64 and Windows-on-ARM64 both home the register arguments into
+# the shadow space the caller already reserves, so the whole variadic tail is one
+# contiguous run of stack slots and a cursor into it is the entire descriptor.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the declared layout, or none for an architecture windows does not run on
+pub fun windows_va_list(arch_id: u32) O.Option[os.VaList] {
+    if (arch_id == isa.ARCH_X86_64)  { ret O.some[os.VaList](os.va_list(8, 8)); }
+    if (arch_id == isa.ARCH_AARCH64) { ret O.some[os.VaList](os.va_list(8, 8)); }
+    ret O.none[os.VaList]();
 }
 
 # the Windows OS vtable
@@ -116,7 +131,8 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     # no platform stack-granularity divergence either: win64 gives every stack argument
     # a full eight-byte slot.
     windows_vtable.natural_stack_args = nil;
+    # `char *` on both architectures: the tail is one contiguous run of stack slots.
+    windows_vtable.va_list_layout = windows_va_list;
 
-    os.register(reg, ?windows_vtable);
-    ret R.ok[bool, str](true);
+    ret os.register(reg, ?windows_vtable);
 }

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -69,6 +69,12 @@ use mach.lang.target.os;
 #           `natural_stack_args` policy. The two are SIBLINGS, not one fact: Apple runs
 #           both rules at once, so a variadic tail argument keeps the eight-byte minimum
 #           on a target where a fixed one does not
+# va_list_size / va_list_align: the size and alignment of a C `va_list` in a parameter
+#           slot on this platform, resolved once from the os vtable's per-architecture
+#           declaration (#3004). A size of 0 means the platform DECLARES NONE, which is
+#           refused where a declaration demands one rather than defaulted to a pointer:
+#           a pointer is right on four of the five platforms mach binds C on, and
+#           AAPCS64's 32-byte composite is the fifth
 pub rec Target {
     os_id:    u32;
     arch_id:  u32;
@@ -89,4 +95,6 @@ pub rec Target {
     stack_commit:  u64;
     variadic_args_on_stack: bool;
     fixed_args_natural_size: bool;
+    va_list_size:  u32;
+    va_list_align: u32;
 }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -100,6 +100,23 @@ pub val VEC_COUNT: u32 = 10;
 # that mints none still has a well defined size for the declaration
 pub val TYPE_HANDLE: TypeKind = 21;
 
+# a C type whose layout the selected TARGET declares and whose contents the program
+# cannot reach (#3004)
+#
+# The one C type mach binds that is neither a scalar it can name nor an aggregate a
+# user can write down: `va_list` is a plain pointer on four of the five platforms
+# mach binds C on and a 32-byte 8-aligned composite on AAPCS64, so no spelling in
+# mach source is correct everywhere and the layout has to come from the target.
+#
+# It IS an aggregate of the declared extent, deliberately, because that is what makes
+# the existing rules right without a special case: an aggregate over 16 bytes rides
+# AAPCS64's by-reference path, which makes the caller copy and pass an address, and
+# an eight-byte one reduces on every other platform to the single register a pointer
+# would have taken. What the program may do with one is bounded to the opposite end:
+# receive it as a parameter and hand it on. There is no reading, no construction, and
+# no storage of its own.
+pub val TYPE_ABI: TypeKind = 22;
+
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
 pub def PrimClass: u8;
 
@@ -214,6 +231,38 @@ pub rec TypeHandle {
     ops_start: u32;
     ops_len:   u32;
 }
+
+# a target-declared C ABI type (#3004)
+#
+# IDENTITY IS THE TAG, and the extent rides along rather than deciding anything. One
+# build has exactly one selected target, so `va_list` names one layout for the whole
+# compilation and two declarations of it in two modules must be the same type or a
+# binding could not be passed across a module boundary. Carrying the extent in the
+# payload keeps every consumer reading the fact off the type instead of re-consulting
+# the target.
+#
+# `name` is the spelling the declaration gave, for diagnostics only, exactly as
+# `TypeHandle.name` is.
+# ---
+# name:  interned declaration name (for diagnostics - not load-bearing for identity)
+# tag:   which C ABI type this is (one of ABI_TYPE_*)
+# size:  the target's declared size in bytes
+# align: the target's declared alignment in bytes
+pub rec TypeAbi {
+    name:  intern.StrId;
+    tag:   u32;
+    size:  u32;
+    align: u32;
+}
+
+# the tag of the `va_list` ABI type, the only member so far
+#
+# A TAG RATHER THAN A BARE FLAG because the axis this grows along is "a C type whose
+# layout the target declares, and whose contents mach never reads". `jmp_buf` and
+# `fpos_t` are the same shape of thing, and adding one is a tag here plus a row in
+# each os vtable's declaration - never a second directive and never a second type
+# kind.
+pub val ABI_TYPE_VA_LIST: u32 = 0;
 
 # the spelling, lane scalar, and lane count of one seeded vector type
 #
@@ -524,6 +573,7 @@ pub rec Type {
         array:         TypeArray;
         vector:        TypeVector;
         handle:        TypeHandle;
+        abi:           TypeAbi;
         fn:            TypeFun;
         nominal:       TypeNominal;
         generic_param: TypeGenericParam;
@@ -1287,6 +1337,43 @@ pub fun is_handle(ti: *TypeInterner, tid: TypeId) bool {
     val opt_type: O.Option[*Type] = get(ti, tid);
     if (O.is_none[*Type](opt_type)) { ret false; }
     ret O.unwrap[*Type](opt_type).kind == TYPE_HANDLE;
+}
+
+# intern a target-declared C ABI type (#3004)
+#
+# Ordinary `intern_dedup`: the whole payload is in the type record, so two
+# declarations of the same ABI type against the same target collapse to one TypeId
+# and a binding declared in one module passes where another module declares it.
+# `name` is carried for diagnostics and takes part in identity only in the sense that
+# two declarations spelling one ABI type differently are still one type - the first
+# name interned is the one a message shows, exactly as for a handle.
+# ---
+# ti:    the interner
+# name:  the declaration's name, for diagnostics
+# tag:   which C ABI type this is (one of ABI_TYPE_*)
+# size:  the target's declared size in bytes
+# align: the target's declared alignment in bytes
+# ret:   TypeId for the ABI type, or an allocation error
+pub fun intern_abi_type(ti: *TypeInterner, name: intern.StrId, tag: u32, size: u32,
+                        align: u32) R.Result[TypeId, str] {
+    var t: Type;
+    t.kind           = TYPE_ABI;
+    t.data.abi.name  = name;
+    t.data.abi.tag   = tag;
+    t.data.abi.size  = size;
+    t.data.abi.align = align;
+    ret intern_dedup(ti, t);
+}
+
+# whether `tid` is a target-declared C ABI type
+# ---
+# ti:  the interner
+# tid: the TypeId to test
+# ret: true for a TYPE_ABI
+pub fun is_abi_type(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    ret O.unwrap[*Type](opt_type).kind == TYPE_ABI;
 }
 
 # the operand word at `index` of the handle at `tid`
@@ -2087,6 +2174,13 @@ fun hash_type(p: ptr) u64 {
         h = fnv1a.step_u32(h, t.data.generic_param.owner::u32);
         h = fnv1a.step_u32(h, t.data.generic_param.index);
     }
+    # the tag and the declared extent, never the spelling: two modules declaring one
+    # ABI type must reach one TypeId or a binding could not cross between them.
+    or (t.kind == TYPE_ABI) {
+        h = fnv1a.step_u32(h, t.data.abi.tag);
+        h = fnv1a.step_u32(h, t.data.abi.size);
+        h = fnv1a.step_u32(h, t.data.abi.align);
+    }
     ret h;
 }
 
@@ -2122,6 +2216,11 @@ fun eq_type(pa: ptr, pb: ptr) bool {
     if (a.kind == TYPE_GENERIC_PARAM) {
         ret a.data.generic_param.owner == b.data.generic_param.owner
             && a.data.generic_param.index == b.data.generic_param.index;
+    }
+    if (a.kind == TYPE_ABI) {
+        ret a.data.abi.tag == b.data.abi.tag
+            && a.data.abi.size == b.data.abi.size
+            && a.data.abi.align == b.data.abi.align;
     }
 
     # primitives and TYPE_ERROR are equal by kind alone

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -15,6 +15,7 @@
 use std.allocator.page;
 use std.collections.map;
 use std.crypto.hash.fnv1a;
+use std.memory;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -585,6 +586,10 @@ pub rec FieldTable {
 #                  table and rebuilds any table whose epoch is older, so a record's
 #                  field-type change on a long-lived session refreshes the cached
 #                  layout instead of leaving it stale (#1583)
+# visits:          pool of TypeId-keyed visited sets a graph walk borrows for its cycle
+#                  guard, one per level of nesting, checked out and returned in stack order
+# visits_len:      sets currently borrowed, which is the current nesting depth
+# visits_cap:      allocated sets in visits
 pub rec TypeInterner {
     a: *A.Allocator;
 
@@ -645,6 +650,10 @@ pub rec TypeInterner {
     field_pool_cap: u32;
 
     field_epoch: u32;
+
+    visits:     *VisitSet;
+    visits_len: u32;
+    visits_cap: u32;
 }
 
 # initial capacities for the interner's growable backing arrays
@@ -653,6 +662,9 @@ val INITIAL_PARAMS_CAP:      u32 = 32;
 val INITIAL_INSTANCE_CAP:    u32 = 16;
 val INITIAL_FIELD_TABLE_CAP: u32 = 16;
 val INITIAL_FIELD_POOL_CAP:  u32 = 64;
+# slots in a freshly allocated VisitSet, and sets in a freshly allocated pool
+val INITIAL_VISIT_CAP:       u32 = 64;
+val INITIAL_VISIT_DEPTH:     u32 = 4;
 
 # construct an empty interner with primitives pre-allocated
 # ---
@@ -689,6 +701,10 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
     ti.field_pool_cap = 0;
 
     ti.field_epoch = 0;
+
+    ti.visits     = nil;
+    ti.visits_len = 0;
+    ti.visits_cap = 0;
 
     ti.dedup       = map.init[Type, TypeId](a, hash_type, eq_type);
     ti.fun_index   = map.init[u64, TypeId](a, map.hash_u64, map.eq_u64);
@@ -783,6 +799,16 @@ pub fun dnit(ti: *TypeInterner) {
     if (ti.field_pool != nil && ti.field_pool_cap > 0) {
         A.deallocate[FieldEntry](ti.a, ti.field_pool, ti.field_pool_cap::usize);
     }
+    if (ti.visits != nil && ti.visits_cap > 0) {
+        var vi: u32 = 0;
+        for (vi < ti.visits_cap) {
+            if (ti.visits[vi].stamp != nil && ti.visits[vi].cap > 0) {
+                A.deallocate[u32](ti.a, ti.visits[vi].stamp, ti.visits[vi].cap::usize);
+            }
+            vi = vi + 1;
+        }
+        A.deallocate[VisitSet](ti.a, ti.visits, ti.visits_cap::usize);
+    }
 
     map.dnit[Type, TypeId](?ti.dedup);
     map.dnit[u64, TypeId](?ti.fun_index);
@@ -815,6 +841,10 @@ pub fun dnit(ti: *TypeInterner) {
     ti.field_pool_cap = 0;
 
     ti.field_epoch = 0;
+
+    ti.visits     = nil;
+    ti.visits_len = 0;
+    ti.visits_cap = 0;
 }
 
 # return a pointer to the Type for a given TypeId, or none when tid is out of
@@ -1085,6 +1115,11 @@ pub fun shape_kind(ti: *TypeInterner, tid: TypeId) TypeKind {
 # Follows `^` (true immediately), a typed pointer's pointee, and an array's
 # element. A nominal rec/uni is a leaf here (its secret fields are welded at the
 # field level), so the walk is over a finite spine and always terminates.
+#
+# `generics.contains_secret_deep` is the DEEP counterpart, recursing INTO nominal field
+# graphs. It lives there rather than here because a generic instance's field table is
+# materialized lazily and must be resolved before it can be walked, which is a dependency
+# `type` cannot reach.
 # ---
 # ti:  the interner
 # tid: the TypeId to inspect
@@ -1099,22 +1134,206 @@ pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret false;
 }
 
-# the cycle guard for the deep-secret walk: the set of nominal TypeIds already on the
-# walk, so a self-referential record graph terminates (#2162)
+# one visited set over the type universe: an epoch stamp per TypeId
 #
-# Reused by `generics.contains_secret_deep`, which is the DEEP counterpart to
-# `carries_secret` (it recurses INTO record / union / generic-instance field graphs).
-# The walk lives in `generics`, not here, because a generic-instance field table is
-# materialized lazily and must be resolved (`ensure_fields`) before it is walked - a
-# dependency `type` cannot reach. `carries_secret` stays the shallow spine predicate
-# (a nominal is a leaf), correct for the welded-storage rules it guards.
+# The epoch is what makes a set reusable without clearing: a mark writes the current
+# epoch, "already visited" is a stamp equal to it, and the next walk to borrow the set
+# just advances the epoch. Both O(1), so a cycle guard costs nothing per node and its
+# capacity is the type universe's rather than a constant.
 # ---
-# seen: distinct nominal / instance TypeIds visited (fixed; a graph larger than this
-#       fails closed - reported as containing a secret - so the walk never under-reports)
-# len:  number of visited entries
-pub rec SecretScan {
-    seen: [256]TypeId;
-    len:  u32;
+# stamp: one epoch slot per TypeId
+# cap:   allocated slots in stamp
+# epoch: the epoch the walk currently holding this set marks with
+rec VisitSet {
+    stamp: *u32;
+    cap:   u32;
+    epoch: u32;
+}
+
+# a graph walk's borrowed visited set: the cycle guard that lets a recursive walk over the
+# type universe terminate on a self-referential record graph (#2162)
+#
+# It replaces the fixed arrays those walks used to carry, whose bounds an ORDINARY program
+# reached (#3065). A merely LARGE type graph exhausted the visited set and took the walk's
+# fail-closed exit, so a program containing no `^` at all was rejected for secrecy, and the
+# message named a concept the program did not use. A visited set sized like the type
+# universe cannot be exhausted by a program's size, only by the allocator - which is the
+# only thing the fail-closed exit should ever be about.
+#
+# Sets are borrowed from the interner's pool in STACK order, because these walks NEST: the
+# generic-union instance walk asks a secrecy question about each variant pair, and that
+# question is a walk of its own. A single shared set would let the inner walk retire the
+# outer walk's marks and unbind its cycle guard, so each depth gets its own set.
+#
+# The interner is the owner because it owns the type table every TypeId indexes: one slot
+# per TypeId is the same shape and grows on the same axis.
+# ---
+# level: the borrowed set's index in the interner's pool, or SCAN_NONE when the borrow
+#        failed - every mark then reports VISIT_FAILED, taking the walk's fail-closed exit
+pub rec TypeScan {
+    level: u32;
+}
+
+# a TypeScan holding no set, because the pool could not be grown
+val SCAN_NONE: u32 = 0xFFFFFFFF;
+
+# the outcome of entering one TypeId on a TypeScan
+#
+# Three states, not a bool: "already visited" and "could not record" demand OPPOSITE
+# answers from the walks that share this guard. A visited node contributes nothing, while
+# an unrecordable one leaves the walk unbounded and must take that walk's fail-closed exit
+# - which is `true` for `generics.contains_secret_deep` and `false` for
+# `generics.deep_all_secret`. Folding the two together would invert one of them.
+pub def VisitMark: u8;
+
+# `tid` was not yet on this walk and is now recorded; descend into it
+pub val VISIT_FRESH:  VisitMark = 0;
+# `tid` is already on this walk; the caller's cycle guard applies
+pub val VISIT_SEEN:   VisitMark = 1;
+# `tid` could not be recorded; the walk is unbounded from here and the caller must fail closed
+pub val VISIT_FAILED: VisitMark = 2;
+
+# borrow a visited set for one walk, retiring every mark the previous borrower left
+#
+# Infallible by design: a pool that cannot be grown binds the scan to SCAN_NONE rather
+# than reporting, so the failure surfaces at the first mark through the fail-closed path
+# the walks already have, and neither entry point needs an error arm of its own.
+# ---
+# ti:   the interner owning the pool
+# scan: the handle to bind to the borrowed set
+pub fun type_scan_begin(ti: *TypeInterner, scan: *TypeScan) {
+    if (O.is_some[str](visits_reserve(ti))) {
+        scan.level = SCAN_NONE;
+        ret;
+    }
+
+    val level: u32 = ti.visits_len;
+    ti.visits_len  = ti.visits_len + 1;
+
+    # epoch 0 means never visited and is what a fresh or re-zeroed slot holds, so the
+    # counter wraps to 1 rather than to 0. Clearing first is what makes the wrap exact:
+    # without it a stamp from four billion walks ago would read as current. One clear per
+    # 2^32 borrows of this set.
+    if (ti.visits[level].epoch == 0xFFFFFFFF) {
+        if (ti.visits[level].stamp != nil && ti.visits[level].cap > 0) {
+            memory.zero[u32](ti.visits[level].stamp, ti.visits[level].cap::usize);
+        }
+        ti.visits[level].epoch = 1;
+    }
+    or {
+        ti.visits[level].epoch = ti.visits[level].epoch + 1;
+    }
+
+    scan.level = level;
+}
+
+# return `scan`'s set to the pool, freeing it for the next walk at this depth
+#
+# The set keeps its array and its epoch, so the next borrower pays neither an allocation
+# nor a clear.
+# ---
+# ti:   the interner owning the pool
+# scan: the handle to release
+pub fun type_scan_end(ti: *TypeInterner, scan: *TypeScan) {
+    if (scan.level == SCAN_NONE) { ret; }
+    ti.visits_len = scan.level;
+    scan.level    = SCAN_NONE;
+}
+
+# enter `tid` on `scan`, reporting whether this walk had already reached it
+# ---
+# ti:   the interner owning the pool
+# scan: the open scan
+# tid:  the TypeId being entered
+# ret:  VISIT_FRESH, VISIT_SEEN, or VISIT_FAILED
+pub fun type_scan_mark(ti: *TypeInterner, scan: *TypeScan, tid: TypeId) VisitMark {
+    if (scan.level == SCAN_NONE) { ret VISIT_FAILED; }
+
+    # a walk materializes generic-instance field tables as it goes, and that interns types,
+    # so a TypeId can be minted MID-WALK and land past the array. The growth belongs here
+    # rather than at `begin`, which cannot know the type count the walk will end at.
+    if (tid >= ti.visits[scan.level].cap) {
+        if (O.is_some[str](visit_reserve(ti, scan.level, tid))) { ret VISIT_FAILED; }
+    }
+
+    val set: *VisitSet = ?ti.visits[scan.level];
+    if (set.stamp[tid] == set.epoch) { ret VISIT_SEEN; }
+    set.stamp[tid] = set.epoch;
+    ret VISIT_FRESH;
+}
+
+# grow the pool so one more set can be borrowed, initializing the new sets empty
+# ---
+# ti:  the interner
+# ret: none once a set is free, or some(error) on allocation failure
+fun visits_reserve(ti: *TypeInterner) O.Option[str] {
+    if (ti.visits_len < ti.visits_cap) { ret O.none[str](); }
+
+    var new_cap: u32 = ti.visits_cap * 2;
+    if (new_cap == 0) { new_cap = INITIAL_VISIT_DEPTH; }
+
+    if (ti.visits == nil) {
+        val res_alloc: R.Result[*VisitSet, str] = A.allocate[VisitSet](ti.a, new_cap::usize);
+        if (R.is_err[*VisitSet, str](res_alloc)) {
+            ret O.some[str](R.unwrap_err[*VisitSet, str](res_alloc));
+        }
+        ti.visits = R.unwrap_ok[*VisitSet, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*VisitSet, str] = A.reallocate[VisitSet](ti.a, ti.visits, ti.visits_cap::usize, new_cap::usize);
+        if (R.is_err[*VisitSet, str](res_realloc)) {
+            ret O.some[str](R.unwrap_err[*VisitSet, str](res_realloc));
+        }
+        ti.visits = R.unwrap_ok[*VisitSet, str](res_realloc);
+    }
+
+    var i: u32 = ti.visits_cap;
+    for (i < new_cap) {
+        ti.visits[i].stamp = nil;
+        ti.visits[i].cap   = 0;
+        ti.visits[i].epoch = 0;
+        i = i + 1;
+    }
+    ti.visits_cap = new_cap;
+
+    ret O.none[str]();
+}
+
+# grow the set at `level` until `tid` addresses a slot, zeroing the new slots so they read
+# as never visited
+# ---
+# ti:    the interner
+# level: the set's index in the pool
+# tid:   the TypeId that must be addressable
+# ret:   none once the slot exists, or some(error) on allocation failure
+fun visit_reserve(ti: *TypeInterner, level: u32, tid: TypeId) O.Option[str] {
+    val set: *VisitSet = ?ti.visits[level];
+
+    var new_cap: u32 = set.cap;
+    if (new_cap == 0) { new_cap = INITIAL_VISIT_CAP; }
+    for (new_cap <= tid) {
+        new_cap = new_cap * 2;
+    }
+
+    if (set.stamp == nil) {
+        val res_alloc: R.Result[*u32, str] = A.allocate[u32](ti.a, new_cap::usize);
+        if (R.is_err[*u32, str](res_alloc)) {
+            ret O.some[str](R.unwrap_err[*u32, str](res_alloc));
+        }
+        set.stamp = R.unwrap_ok[*u32, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*u32, str] = A.reallocate[u32](ti.a, set.stamp, set.cap::usize, new_cap::usize);
+        if (R.is_err[*u32, str](res_realloc)) {
+            ret O.some[str](R.unwrap_err[*u32, str](res_realloc));
+        }
+        set.stamp = R.unwrap_ok[*u32, str](res_realloc);
+    }
+
+    memory.zero[u32](?set.stamp[set.cap], (new_cap - set.cap)::usize);
+    set.cap = new_cap;
+
+    ret O.none[str]();
 }
 
 # whether two types place the secret qualifier identically along their spines

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.25.0";
+pub val MACH_VERSION: str = "4.26.0";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {

--- a/test/README.md
+++ b/test/README.md
@@ -134,7 +134,10 @@ another layer's output.
 pipelines, plus a third `-g` build. `llvm-readobj --file-header --sections --relocs`
 must parse cleanly, and the class, machine and endianness must match the target.
 SPIR-V goes to `spirv-val` under the environment the module itself declares.
-`llvm-dwarfdump --verify` must pass on the debug build.
+`llvm-dwarfdump --verify` must pass on the debug build. A `raw` flat image has no
+external structural oracle wired for it, so layer A records a skip rather than a
+pass: a target reaching this cell needs a `SKIPS` entry, the same as any other
+declared gap.
 
 **Layer B, golden disassembly.** The release pipeline only, to bound churn. The
 case's own object is disassembled by an **external** decoder and diffed against a

--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -506,7 +506,7 @@ def layer_a_cells(proj, tools, m, t, case, built, skips):
             paths.append(artifact)
         out = oracle.layer_a(tools, t, paths, want_dwarf=(profile == "g" and
                                                           t.object_format in ("elf", "macho")))
-        m.add(case, t.name, "a", profile, "PASS" if out.ok else "FAIL", "", out.detail)
+        m.add(case, t.name, "a", profile, out.status, "", out.detail)
 
 
 def layer_b_cells(proj, tools, m, t, case, built, bless, blessed, skips):
@@ -529,7 +529,7 @@ def layer_b_cells(proj, tools, m, t, case, built, bless, blessed, skips):
             with open(golden, "w", encoding="utf-8") as fh:
                 fh.write(text)
             blessed.append((golden, before, text))
-    m.add(case, t.name, "b", "o2", "PASS" if out.ok else "FAIL", "", out.detail)
+    m.add(case, t.name, "b", "o2", out.status, "", out.detail)
 
 
 def layer_c_cells(proj, ref, m, t, case, built, skips):

--- a/test/lib/layers.py
+++ b/test/lib/layers.py
@@ -18,11 +18,17 @@ MACHINE = {
 }
 
 
-class Outcome(object):
-    __slots__ = ("ok", "detail")
+# the three verdicts a layer can hand back. these are exactly the matrix's own
+# status strings, so a caller threads the verdict through rather than collapsing
+# it back to a pass/fail boolean and losing SKIP on the way.
+PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
 
-    def __init__(self, ok, detail):
-        self.ok, self.detail = ok, detail
+
+class Outcome(object):
+    __slots__ = ("status", "detail")
+
+    def __init__(self, status, detail):
+        self.status, self.detail = status, detail
 
 
 def _run(cmd, **kw):
@@ -35,30 +41,31 @@ def layer_a(tools, target, paths, want_dwarf):
     fmt = target.object_format
     for path in paths:
         if not os.path.exists(path):
-            return Outcome(False, "expected artifact was not produced: " + path)
+            return Outcome(FAIL, "expected artifact was not produced: " + path)
         if os.path.getsize(path) == 0:
-            return Outcome(False, "artifact is empty: " + path)
+            return Outcome(FAIL, "artifact is empty: " + path)
     if fmt == "spv":
         rc, out, err = _run(["spirv-val", paths[-1]])
         if rc != 0:
-            return Outcome(False, "spirv-val rejected the module: " + (err or out).strip())
-        return Outcome(True, "spirv-val accepted %d module(s)" % len(paths))
+            return Outcome(FAIL, "spirv-val rejected the module: " + (err or out).strip())
+        return Outcome(PASS, "spirv-val accepted %d module(s)" % len(paths))
     if fmt == "raw":
-        return Outcome(True, "raw image, %d byte(s)" % os.path.getsize(paths[-1]))
+        return Outcome(SKIP, "raw is a mach-only object format with no external "
+                       "structural oracle wired for it")
     for path in paths:
         rc, out, err = _run(["llvm-readobj", "--file-header", "--sections", "--relocs", path])
         if rc != 0:
-            return Outcome(False, "llvm-readobj could not parse %s: %s" % (path, (err or out).strip()))
+            return Outcome(FAIL, "llvm-readobj could not parse %s: %s" % (path, (err or out).strip()))
         bad = _header_mismatch(fmt, target, out)
         if bad:
-            return Outcome(False, "%s: %s" % (os.path.basename(path), bad))
+            return Outcome(FAIL, "%s: %s" % (os.path.basename(path), bad))
     if want_dwarf:
         rc, out, err = _run(["llvm-dwarfdump", "--verify", paths[-1]])
         if rc != 0:
             tail = [l for l in (out + err).splitlines() if l.strip()][-1:] or ["no output"]
-            return Outcome(False, "llvm-dwarfdump --verify failed: " + tail[0].strip())
-        return Outcome(True, "readobj parsed %d file(s), dwarfdump verified" % len(paths))
-    return Outcome(True, "readobj parsed %d file(s)" % len(paths))
+            return Outcome(FAIL, "llvm-dwarfdump --verify failed: " + tail[0].strip())
+        return Outcome(PASS, "readobj parsed %d file(s), dwarfdump verified" % len(paths))
+    return Outcome(PASS, "readobj parsed %d file(s)" % len(paths))
 
 
 def _header_mismatch(fmt, target, text):
@@ -115,17 +122,17 @@ def disassemble(tools, target, case, path):
 def layer_b(tools, target, case, path, golden_path, bless):
     text, err = disassemble(tools, target, case, path)
     if text is None:
-        return Outcome(False, err), None
+        return Outcome(FAIL, err), None
     if bless:
-        return Outcome(True, "blessed %d line(s)" % text.count("\n")), text
+        return Outcome(PASS, "blessed %d line(s)" % text.count("\n")), text
     if not os.path.exists(golden_path):
-        return Outcome(False, "no golden at %s; run --bless and review the diff" % golden_path), text
+        return Outcome(FAIL, "no golden at %s; run --bless and review the diff" % golden_path), text
     with open(golden_path, "r", encoding="utf-8") as fh:
         want = fh.read()
     if want != text:
-        return Outcome(False, "disassembly differs from the golden at " +
+        return Outcome(FAIL, "disassembly differs from the golden at " +
                        _first_difference(want, text)), text
-    return Outcome(True, "%s matched %d line(s)" % (target.disasm, text.count("\n"))), text
+    return Outcome(PASS, "%s matched %d line(s)" % (target.disasm, text.count("\n"))), text
 
 
 def _first_difference(want, got):

--- a/test/lib/project.py
+++ b/test/lib/project.py
@@ -168,6 +168,11 @@ class Project(object):
         return os.path.join(self.root, "o", target.name, profile)
 
     def object_path(self, case, target, profile):
+        # a flat-image format (raw) has no relocatable .o container: mach links the
+        # in-memory codegen images straight to the artifact, so the object IS the
+        # artifact and there is no separate obj/ path to expect.
+        if target.object_format == "raw":
+            return self.artifact_path(case, target, profile)
         base = os.path.join(self.outdir(target, profile), "obj", "corpus", "cases", case)
         return base + (".spv" if target.object_format == "spv" else ".o")
 

--- a/test/link/cases/ext-byval-aggregate/case.conf
+++ b/test/link/cases/ext-byval-aggregate/case.conf
@@ -1,0 +1,25 @@
+# A C callee overwrites every field of a by-value aggregate parameter, and the mach
+# caller's object must be untouched (mach #3063). The callee is built by the
+# RUNNER'S own toolchain, so what it does with its parameter is the platform's real
+# convention rather than mach's model of it.
+#
+# THE DEFECT THIS GUARDS IS SILENT MEMORY CORRUPTION. AAPCS64, the RISC-V psABI and
+# the Microsoft convention all pass an aggregate too large for registers as the
+# address of a copy the CALLER allocates, and mach passed the address of its own
+# object. Nothing fails: the call links, returns, and leaves the caller's object
+# rewritten. Against the unpatched compiler this case reports
+# `wide intact=-1 -2 -3 -4` on aarch64-linux and riscv64-linux.
+#
+# WHICH LEGS ARE EVIDENCE AND WHICH ARE CONTROLS. aarch64-linux, riscv64-linux and
+# x86_64-windows pass the 32-byte aggregate by reference and are where the defect
+# lives. x86_64-linux and x86_64-darwin pass it by value on the stack, so the copy
+# already exists and they must be UNCHANGED - a fix that repaired the by-reference
+# conventions by breaking the by-value one would fail them. The 16-byte `pair` is
+# the windows leg's own by-reference case at a size where the arm64 and System V
+# legs use registers, so the rule is shown following the convention rather than the
+# byte count.
+#
+# The probe is built at -O0. The C writes are dead in the C sense, and at -O1 clang
+# deletes them outright - the probe would then measure nothing and the case would
+# pass against a compiler carrying the defect.
+run: exec

--- a/test/link/cases/ext-byval-aggregate/expect.txt
+++ b/test/link/cases/ext-byval-aggregate/expect.txt
@@ -1,0 +1,3 @@
+wide ret=-10 intact=1 2 3 4
+pair ret=-11 intact=7 8
+again ret=-10 intact=1 2 3 4

--- a/test/link/cases/ext-byval-aggregate/mach.toml
+++ b/test/link/cases/ext-byval-aggregate/mach.toml
@@ -1,0 +1,71 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.x86_64-linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.aarch64-linux]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.riscv64-linux]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64d"
+
+[target.x86_64-windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.aarch64-darwin]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.x86_64-darwin]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "sh ../../lib/cc.sh -c -O0 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/test/link/cases/ext-byval-aggregate/probe.c
+++ b/test/link/cases/ext-byval-aggregate/probe.c
@@ -1,0 +1,38 @@
+/* the C half of the by-value aggregate case (mach #3063).
+ *
+ * Compiled by the RUNNER'S OWN C toolchain, so the callee's treatment of its
+ * parameter is the platform's real calling convention rather than mach's model of
+ * it. Each function OVERWRITES every field of a by-value parameter, which C says
+ * the caller cannot observe - and which mach's caller could observe, because it
+ * handed over the address of its own object instead of the address of a copy.
+ *
+ * WHY -O0. The writes are dead in the C sense: nothing reads the parameter after
+ * them that an optimizer cannot fold. At -O1 clang deletes the stores outright and
+ * the probe measures nothing at all, so the case would pass against a compiler with
+ * the defect. The instrument has to perform the writes for the measurement to
+ * exist, and this is the one flag that guarantees it. */
+
+struct wide { long long a, b, c, d; };
+struct pair { long long a, b; };
+
+/* 32 bytes: by reference under AAPCS64, the RISC-V psABI and the Microsoft
+ * convention; by value on the stack under System V, where the copy already exists
+ * and there is nothing to get wrong. */
+long long clobber_wide(struct wide w) {
+    w.a = -1;
+    w.b = -2;
+    w.c = -3;
+    w.d = -4;
+    return w.a + w.b + w.c + w.d;
+}
+
+/* 16 bytes: two registers under AAPCS64, System V and lp64d, and BY REFERENCE
+ * under the Microsoft convention, which passes anything that is not 1, 2, 4 or 8
+ * bytes that way. It is here so the windows leg exercises the by-reference path at
+ * a size where the arm64 and System V legs do not - the rule this case is about
+ * follows the convention, not the byte count. */
+long long clobber_pair(struct pair p) {
+    p.a = -5;
+    p.b = -6;
+    return p.a + p.b;
+}

--- a/test/link/cases/ext-byval-aggregate/src/main.mach
+++ b/test/link/cases/ext-byval-aggregate/src/main.mach
@@ -1,0 +1,60 @@
+# by-value aggregate at an `ext` boundary (mach #3063)
+#
+# A C function overwrites every field of a by-value aggregate parameter, and the
+# mach caller's own object must be untouched. AAPCS64, the RISC-V psABI and the
+# Microsoft convention pass an aggregate too large for registers as the address of a
+# copy THE CALLER ALLOCATES, and the callee writes through that address as its own
+# parameter - so a caller that hands over the address of its own object instead sees
+# it overwritten. That is silent memory corruption, not a link error and not a
+# crash.
+#
+# THE OBSERVABLE IS THE CALLER'S OBJECT AFTER THE CALL, read in mach. It is the same
+# text on every target, because "a by-value parameter is the callee's own" is not a
+# platform-specific claim - only the mechanism that delivers it is.
+#
+# x86_64-linux and x86_64-darwin are CONTROLS rather than legs that happen to pass:
+# System V passes an aggregate over sixteen bytes by value on the stack, so the copy
+# already exists there. A change that fixed the by-reference conventions by breaking
+# the by-value one would fail them.
+#
+# `va_list` (mach #3004) is the parameter that made this visible - every consumer of
+# one ADVANCES it, so a forwarded list came back spent - but it is not what the
+# defect is about, and this case deliberately does not mention it. A guard living
+# inside the `va_list` case would disappear with that feature.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec Wide { a: i64; b: i64; c: i64; d: i64; }
+rec Pair { a: i64; b: i64; }
+
+ext fun clobber_wide(w: Wide) i64;
+ext fun clobber_pair(p: Pair) i64;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # 32 bytes: by reference on every convention but System V.
+    var w: Wide;
+    w.a = 1;
+    w.b = 2;
+    w.c = 3;
+    w.d = 4;
+    val rw: i64 = clobber_wide(w);
+    p.printlnf("wide ret={} intact={} {} {} {}", rw, w.a, w.b, w.c, w.d);
+
+    # 16 bytes: registers on AAPCS64, System V and lp64d, by reference on win64.
+    var q: Pair;
+    q.a = 7;
+    q.b = 8;
+    val rp: i64 = clobber_pair(q);
+    p.printlnf("pair ret={} intact={} {}", rp, q.a, q.b);
+
+    # the same object handed over twice: the second call must see the ORIGINAL
+    # values, which is the shape a caller that reused one temporary would fail even
+    # after allocating one.
+    val rw2: i64 = clobber_wide(w);
+    p.printlnf("again ret={} intact={} {} {} {}", rw2, w.a, w.b, w.c, w.d);
+
+    ret 0;
+}

--- a/test/link/cases/va-list/case.conf
+++ b/test/link/cases/va-list/case.conf
@@ -1,0 +1,29 @@
+# A C caller hands a live `va_list` to a mach function through a callback pointer,
+# and mach forwards it to a C consumer that reads it with `va_arg` (mach #3004). Both
+# ends of the token are the RUNNER'S own toolchain, so what is measured is the
+# platform's real `va_list`, not mach's model of it.
+#
+# AAPCS64-LINUX IS THE LEG THIS EXISTS FOR. There `va_list` is a 32-byte 8-aligned
+# composite, which the psABI passes indirectly with the CALLER owning the copy. A
+# parameter spelled `ptr` is ABI-compatible for one hop and links and runs, so the
+# only thing that separates it from the correct binding is whether the forward makes
+# a fresh copy - which is invisible until the list is forwarded more than once. That
+# is why the case forwards twice.
+#
+# THE GOLDEN IS AGREEMENT, NOT A PAIR OF NUMBERS, because the correct pair is not the
+# same on every platform. Two forwards of one list read argument one twice where
+# `va_list` is a caller-copied composite and arguments one then two where it is a
+# pointer into shared state, and both are the platform behaving correctly. The C
+# control runs the identical experiment through the runner's own compiler, so the
+# assertion is that mach's copy semantics are its platform's. Without the fix,
+# aarch64-linux is the leg where they differ.
+#
+# The other four legs are controls in the strict sense: each declares `va_list` as a
+# plain pointer, each already worked with `ptr` before this, and each must keep
+# producing the same golden after it. A change that made every target copy, or every
+# target alias, would fail one of them.
+#
+# The probe is built at -O0 rather than the -O1 its sibling `c-variadic` uses: the C
+# control measures whether a `va_list` PARAMETER is caller-copied, and inlining the
+# callee removes the parameter pass being measured.
+run: exec

--- a/test/link/cases/va-list/expect.txt
+++ b/test/link/cases/va-list/expect.txt
@@ -1,0 +1,2 @@
+relay n=2 first=111
+matches platform=1

--- a/test/link/cases/va-list/mach.toml
+++ b/test/link/cases/va-list/mach.toml
@@ -1,0 +1,71 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.x86_64-linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.aarch64-linux]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.riscv64-linux]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64d"
+
+[target.x86_64-windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.aarch64-darwin]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.x86_64-darwin]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[step.probe]
+cmd = "sh ../../lib/cc.sh -c -O0 -fno-stack-protector probe.c -o {project.out}/obj/probe.o"
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/test/link/cases/va-list/probe.c
+++ b/test/link/cases/va-list/probe.c
@@ -1,0 +1,57 @@
+/* the C half of the `va_list` parameter case (mach #3004).
+ *
+ * Compiled by the RUNNER'S OWN C toolchain, so both the list this originates and
+ * the `va_arg` that reads it are the platform's real ABI rather than mach's model
+ * of it. mach never constructs a `va_list` and never reads one: it receives the
+ * token here, hands it to `va_take`, and the value that comes back is the
+ * observable.
+ *
+ * THE LIST IS HANDED OVER THROUGH A FUNCTION POINTER mach supplies, which is the
+ * shape the motivating report used (`SetTraceLogCallback`) and also the shape that
+ * needs no agreement about how a mach symbol is spelled in a C object.
+ *
+ * WHY -O0. `va_take` takes its `va_list` BY VALUE, and whether the caller owns that
+ * copy is precisely what this case measures. Inlining it removes the parameter pass
+ * being measured, so the C control would stop describing the platform's calling
+ * convention and start describing the optimizer's. */
+
+#include <stdarg.h>
+
+typedef long long (*relay_fn)(long long *out, va_list ap);
+
+/* consume ONE argument from `ap`. by value, exactly as `vsnprintf` takes one. */
+long long va_take(va_list ap) { return va_arg(ap, long long); }
+
+static long long call_relay(relay_fn relay, long long *out, ...) {
+    va_list ap;
+    va_start(ap, out);
+    long long r = relay(out, ap);
+    va_end(ap);
+    return r;
+}
+
+/* C originates a list and hands it to MACH, which forwards it to `va_take` twice. */
+long long c_probe(relay_fn relay, long long *out) {
+    return call_relay(relay, out, 111LL, 222LL, 333LL);
+}
+
+static long long relay_in_c(long long *out, va_list ap) {
+    out[0] = va_take(ap);
+    out[1] = va_take(ap);
+    return 2;
+}
+
+/* THE PLATFORM'S OWN ANSWER to the same experiment, written entirely in C.
+ *
+ * Two forwards of one `va_list` do not mean the same thing everywhere, and that is
+ * a fact about C rather than about mach: under AAPCS64 the type is a 32-byte
+ * composite the caller copies, so each callee walks its own and both read argument
+ * one; under SysV x86-64 it is an array that decays to a pointer, so the first
+ * callee advances the caller's list and the second reads argument two. The golden
+ * therefore asserts that MACH AGREES WITH THIS, not that any particular pair of
+ * numbers comes back - which is the only claim that holds on every leg and is also
+ * the exact claim that fails on AAPCS64-linux when mach forwards the received
+ * pointer instead of a fresh copy. */
+long long c_control(long long *out) {
+    return call_relay(relay_in_c, out, 111LL, 222LL, 333LL);
+}

--- a/test/link/cases/va-list/src/main.mach
+++ b/test/link/cases/va-list/src/main.mach
@@ -1,0 +1,56 @@
+# `va_list` parameter surface case (mach #3004)
+#
+# A C caller originates a `va_list` and hands it to a mach function, which forwards
+# it to a C consumer. mach never reads the token and never builds one: the whole
+# scope is receive and pass on, which is what binding a logging callback such as
+# raylib's `TraceLogCallback` needs and all it needs.
+#
+# THE OBSERVABLE IS AGREEMENT WITH THE PLATFORM, because the platforms disagree with
+# each other. Forwarding one list to two consumers reads argument one twice where
+# `va_list` is a caller-copied composite (AAPCS64) and arguments one then two where
+# it is a pointer into shared state (SysV x86-64). The C control runs the identical
+# experiment through the runner's own compiler, so a leg where mach's copy semantics
+# differ from its platform's fails here - which is exactly what AAPCS64-linux does
+# when the parameter is spelled `ptr` and the received pointer is forwarded rather
+# than a fresh copy.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# the target declares the size and alignment; the program never learns what is in it
+#[abi_type("va_list")]
+def VaList;
+
+def Relay: fun(*i64, VaList) i64;
+
+ext fun va_take(ap: VaList) i64;
+ext fun c_probe(relay: Relay, out: *i64) i64;
+ext fun c_control(out: *i64) i64;
+
+# the callback C invokes with a live list. forwards it twice, and nothing else.
+fun relay(out: *i64, ap: VaList) i64 {
+    out[0] = va_take(ap);
+    out[1] = va_take(ap);
+    ret 2;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var got:  [2]i64;
+    var want: [2]i64;
+    got[0]  = 0;
+    got[1]  = 0;
+    want[0] = 0;
+    want[1] = 0;
+
+    val n: i64 = c_probe(relay, ?got[0]);
+    p.printlnf("relay n={} first={}", n, got[0]);
+
+    val m: i64 = c_control(?want[0]);
+    var agree: i64 = 0;
+    if (m == n && want[0] == got[0] && want[1] == got[1]) { agree = 1; }
+    p.printlnf("matches platform={}", agree);
+
+    ret 0;
+}


### PR DESCRIPTION
mach 4.26.0.

Merges `dev` into `main` for the tagged release. Cut on a throwaway branch at `dev`'s tip rather than using `dev` as the head, since auto-delete-head would otherwise delete a long-lived branch on merge.

**This is where `darwin (release gate)` schedules.** It is skipped on every dev-targeted PR (`if: github.base_ref == 'main'`), so this PR is the darwin signal for the release and must not be merged on a partial-green count.

## Contents

New language surface, hence a minor bump rather than a patch:

- **#3004** — `#[abi_type("name")]` on a bodyless `def` declares a C type whose size and alignment the selected target supplies. It exists to bind C functions taking a `va_list` **parameter**, the installable-logging-callback shape. Forward-only by construction: mach can receive one and pass it on, and cannot construct, read, or store one. Reading is refused where written.

Fixes:

- **#3063** — critical. A C callee overwriting a by-value aggregate parameter wrote through into the mach caller's own object on AAPCS64, the RISC-V psABI and win64. Silent memory corruption; the caller now owns the copy at an `ext` boundary.
- **#3065** — a large public type graph was mistaken for a secret one.
- **#2936** — `mach dep pull` realises the project you name rather than the one you are standing in, ending an advice loop.
- **#2956** — corpus layer A records a skip for an object format it has no oracle for, instead of a pass that cannot fail.
- **#2947** — the manifest doc's accepted-tuple table lists `riscv32` and the full RISC-V ABI family.
- **#2983** — artifact actions moved off deprecated Node.js 20.

Plus **#2944**, restoring the four host-executed measurements the retired integration suite carried, including the x86-64 flags probe that the `#[oblivious]` inline-asm model rests on.

## Verification carried in

Every constituent PR merged green. On the release branch: `mach test .` 1535 passed / 0 failed, `check-changelog.sh` clean, and both version sites bumped together with `mach.lang.version:matches_project_release` confirmed to actually fail when they disagree.
