### PR TITLE
fix(ct): stop gating on a timing measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### ct: no test gates on a timing measurement (#3070)
+
+`mach.lang.ct.probe` asserted a constant-time verdict against thresholds over
+measured wall-clock time. That failed the 4.26.0 release gate on `x86_64-darwin`
+and passed a re-run of the identical commit. The null control was flat, so the run
+believed it could discriminate, while its means sat at 126k-159k against the
+probe's 12k-38k: a quiet control at 126k ns certifies nothing about noise at 12k
+ns. The thresholds had been calibrated on one linux box and the relative cost of
+these probes is a microarchitecture property.
+
+The gate is gone rather than recalibrated. A better threshold lowers the
+false-failure rate without bounding it, and a required check that can fail
+nondeterministically is worse than no check. The harness stays and is exercised on
+every run at tiny sample counts, asserting only that it executes and produces
+finite, positive, ordered numbers, which is deterministic and still fails if it
+rots. The measurements themselves are taken deliberately by a person, as
+`doc/language/secrecy.md` now says.
+
+The three deterministic restorations from #2944 are untouched, including the
+x86-64 flags probe.
+
+
 ## [4.26.0] - 2026-08-22
 
 ### Added

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -411,29 +411,45 @@ validator independently re-checks the lowered MIR. All three are static. Two
 host-executed measurements sit under them, and each only means anything on the
 machine it runs on, which is why both are unit tests rather than build checks.
 
-**The timing harness runs.** `mach.lang.ct.probe` is a dudect-style harness in the
-tree, measured on every `mach test`, and the claims below are what it establishes.
-It works by refutation, because that is all a timing measurement can do: a clean
-score is consistent with a leak the instrument cannot see, so each mode carries a
-*planted* leak that must be detected and a constant-time reference that must not
-separate the way the planted one does. A mode that has stopped measuring therefore
-fails through its own control instead of reading as a pass.
+**The timing harness is a tool, not a gate.** `mach.lang.ct.probe` is a
+dudect-style harness in the tree. `mach test` runs it at deliberately tiny sample
+counts and asserts only that it still executes and produces finite, positive
+numbers, which is a structural claim about the harness rather than a timing claim
+about the machine. **No threshold over a measured time gates anything**, here or
+anywhere else in the suite.
 
-Every gate is a separation between the two class means, never `|t|`. Welch's
+That is deliberate and it is not a gap. A dudect score is a statistic over
+wall-clock time on hardware nobody controls, so any threshold over it has a
+false-failure rate that belongs to the machine rather than to the code. A required
+check that can fail nondeterministically is worse than no check: it teaches a
+reader to re-run a red constant-time result until it turns green. An earlier form
+of this harness did assert on such thresholds, and failed a release gate on
+`x86_64-darwin` and then passed a re-run of the identical commit (#3070).
+
+**So the claims below are measurements, taken deliberately, not properties this
+suite enforces.** Raising the counts in `mach.lang.ct.probe` and reading the
+printed table is how they are re-taken, on a quiet machine, by a person who then
+reads the numbers. Performance and timing work belongs in
+[mach-bench](https://github.com/briar-systems/mach-bench), which is built for it,
+rather than in a correctness suite that must be deterministic.
+
+What such a measurement can establish is bounded. It works by refutation, because
+that is all a timing measurement can do: a clean score is consistent with a leak
+the instrument cannot see, so each mode carries a *planted* leak that must be
+detected and a constant-time reference that must not separate the way the planted
+one does. Read separations between the two class means, never `|t|` -- Welch's
 statistic divides by the sample variance, and concurrent load inflates the variance
 without moving the means, so `|t|` collapses under load while the leak is plainly
 still there. Measured at load average 27, six consecutive runs of one binary gave
 `|t|` between 7.51 and 11.24 against a threshold of 10 while the mean ratio never
-fell below 3.4. `|t|` is still reported, because it is the right statistic on a
-quiet box, and it is just not the gate.
+fell below 3.4.
 
-A third probe leaks nothing at all and decides whether the run counts. Any
+A third probe leaks nothing at all and says whether a run counts at all. Any
 separation *it* shows is the machine rather than the code, so a run in which it is
-not flat has no discriminating power and **declines** rather than asserting: a
-differential measurement without discriminating power has no verdict in either
-direction, and failing there would be reporting machine load as a compiler
-regression. The consequence to keep in mind is that a permanently noisy runner
-yields a permanently declining harness, which is silence rather than assurance.
+not flat has no discriminating power and its verdict means nothing in either
+direction. Note that a flat null is necessary and not sufficient: it must also be
+sampled at a comparable cost to the probe it is bounding, or a quiet control at one
+magnitude certifies nothing about noise at another.
 
 **The x86-64 inline-asm flags table is measured, not inferred.** The eighteen-row
 classification the `#[oblivious]` asm model rests on, naming which instructions

--- a/src/lang/ct/probe.mach
+++ b/src/lang/ct/probe.mach
@@ -260,34 +260,6 @@ pub fun null_walk(x: u64) u64 {
     ret acc + (x & 0);
 }
 
-# how far a probe must separate past the null control to count as leaking, and how far the
-# null control may separate before the run is judged unable to discriminate at all
-#
-# ONE NUMBER PER MODE, because the two questions have the same answer. A run in which the
-# control that CANNOT leak separates by as much as a leak has to is a run whose sampling
-# produced the signal it was meant to resolve, and nothing measured under it means
-# anything in either direction. That run declines.
-#
-# THE GATES SUBTRACT THE NULL RATHER THAN COMPARING AGAINST 1.0. The control is measured
-# in the same run under the same load, so subtracting it removes whatever the machine did
-# to both, which is the property a fixed threshold on one probe does not have.
-#
-# CALIBRATED INSIDE `mach test`, not standalone. Measured alone this harness looks two
-# orders of magnitude quieter than it is: the environment it has to hold in is a parallel
-# run with a job per core, and thresholds set anywhere else are set against the wrong
-# machine. Over five such runs at debug optimisation, with the rest of the suite and other
-# work on the box:
-#
-#   latency  null 0.017-0.223   leak past null 2.04-3.47   reference past null up to 0.28
-#   address  null 0.003-0.153   leak past null 0.72-1.53   reference past null up to 0.04
-#
-# Every threshold below sits at least twice the worst of that, in whichever direction
-# would trip it.
-val LATENCY_NULL_TOL: f64 = 0.60;
-val LATENCY_LEAK_MARGIN: f64 = 0.60;
-val ADDRESS_NULL_TOL: f64 = 0.30;
-val ADDRESS_LEAK_MARGIN: f64 = 0.30;
-
 # print one measurement
 #
 # EVERY MEASUREMENT IS REPORTED, on the passing path as much as the failing one. A harness
@@ -299,51 +271,85 @@ fun report(name: str, m: *dudect.Measurement) {
                name, m.mean_fix, m.mean_rnd, dudect.separation(m), m.t);
 }
 
-# a latency leak is measurable on this host, and the constant-time reference is not one
-# (#1647)
+# SMOKE COUNTS: enough to run every path, far too few to mean anything
+#
+# The suite's job here is to prove the harness still runs, not to measure the machine.
+# These are deliberately tiny so the check costs milliseconds. A real measurement needs
+# the full counts in `dudect`, and is taken deliberately by a person - see
+# `doc/language/secrecy.md`.
+val SMOKE_INNER:  u64 = 8;
+val SMOKE_ROUNDS: u64 = 64;
+
+# THE HARNESS IS A TOOL, NOT A GATE (#3070)
+#
+# There is no pass/fail threshold over a timing measurement anywhere below, and there must
+# not be one. A dudect-style score is a statistic over wall-clock time on hardware nobody
+# controls, so any threshold over it has a false-failure rate that is a property of the
+# machine rather than of the code. CI must not be able to fail nondeterministically, and
+# a check that can is worse than no check: it teaches a reader to re-run a red
+# constant-time result until it turns green.
+#
+# That is not hypothetical. The earlier form of this file asserted on these thresholds and
+# failed the 4.26.0 release gate on `x86_64-darwin`, then passed a re-run of the identical
+# commit. The null control was flat (0.25 against a 0.60 tolerance) so the run believed it
+# could discriminate, while the control's means sat at 126k-159k against the probe's
+# 12k-38k: a quiet control at 126k ns certifies nothing about noise at 12k ns. The
+# thresholds had been calibrated over five runs on one linux box, and the relative cost of
+# these probes is a microarchitecture property.
+#
+# WHAT IS ASSERTED HERE IS STRUCTURAL, and so is deterministic: that the harness runs, and
+# that every measurement it produces is a finite, positive, ordered number. That fails if
+# the harness rots, if a probe stops executing, or if a measurement comes back NaN or
+# negative - none of which depend on how long anything took.
+#
+# WHAT IS PRINTED IS THE MEASUREMENT, in full, every run. Reading it is a person's job.
+# `doc/language/secrecy.md` states which claims rest on it and that they are measurements
+# a developer takes rather than assertions this suite enforces.
+
+# a measurement is well formed: finite, positive means and a finite, non-negative
+# separation
+#
+# Deliberately not a threshold. This says the instrument produced a number, not that the
+# number is small.
+fun well_formed(m: *dudect.Measurement) bool {
+    if (m.mean_fix != m.mean_fix || m.mean_rnd != m.mean_rnd) { ret false; }
+    if (m.mean_fix <= 0.0 || m.mean_rnd <= 0.0) { ret false; }
+    val s: f64 = dudect.separation(m);
+    if (s != s) { ret false; }
+    ret s >= 0.0;
+}
+
+# the latency harness runs end to end and reports (#1647, #3070)
 #
 # Latency mode covers two of the leakage model's three channels: control-flow trace and
-# variable-latency operands. It cannot see the third, and `an_address_leak_is_measured`
-# below is why that is a separate test rather than a wider threshold here.
-test "mach.lang.ct.probe:a_latency_leak_is_measured" {
+# variable-latency operands. The address mode below is the third, and is a separate test
+# because the batch that resolves one averages the other away.
+test "mach.lang.ct.probe:the_latency_harness_measures_and_reports" {
     var null_m: dudect.Measurement;
     var ct_m:   dudect.Measurement;
     var leak_m: dudect.Measurement;
 
-    dudect.measure_latency(?null_m, null_probe,  0, 0x510E527FADE682D1);
-    dudect.measure_latency(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3);
-    dudect.measure_latency(?leak_m, leaky_probe, 0, 0x452821E638D01377);
+    dudect.measure(?null_m, null_probe,  0, 0x510E527FADE682D1, SMOKE_INNER, SMOKE_ROUNDS);
+    dudect.measure(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3, SMOKE_INNER, SMOKE_ROUNDS);
+    dudect.measure(?leak_m, leaky_probe, 0, 0x452821E638D01377, SMOKE_INNER, SMOKE_ROUNDS);
 
     report("null", ?null_m);
     report("ct",   ?ct_m);
     report("leak", ?leak_m);
 
-    val ns: f64 = dudect.separation(?null_m);
-    val cs: f64 = dudect.separation(?ct_m);
-    val ls: f64 = dudect.separation(?leak_m);
-
-    if (ns > LATENCY_NULL_TOL) {
-        p.println("declined: the latency null control is not flat, so this run cannot discriminate");
-        ret 0;
-    }
-    if (ls - ns < LATENCY_LEAK_MARGIN) {
-        p.println("the planted latency leak was NOT detected, so the harness is not measuring");
-        ret 1;
-    }
-    if (cs - ns >= LATENCY_LEAK_MARGIN) {
-        p.println("the constant-time reference separated the way the planted leak does");
-        ret 2;
-    }
+    if (!well_formed(?null_m)) { ret 1; }
+    if (!well_formed(?ct_m))   { ret 2; }
+    if (!well_formed(?leak_m)) { ret 3; }
     ret 0;
 }
 
-# an address-trace leak is measurable on this host, and the masked scan is not one (#2363)
+# the address harness runs end to end and reports (#2363, #3070)
 #
 # The channel latency mode is blind to, and not by a little: the same `leak_big` measured
 # with latency mode's batch scores flat, because every call in a batch is handed the same
 # input and the single cache miss carrying the signal is averaged away. One call per
 # sample is what sees it, and the cost moves to the sample count.
-test "mach.lang.ct.probe:an_address_leak_is_measured" {
+test "mach.lang.ct.probe:the_address_harness_measures_and_reports" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     if (!setup(?alloc)) {
@@ -355,9 +361,9 @@ test "mach.lang.ct.probe:an_address_leak_is_measured" {
     var leak_m: dudect.Measurement;
     var scan_m: dudect.Measurement;
 
-    dudect.measure_address(?null_m, null_walk, 0, 0x510E527FADE682D1);
-    dudect.measure_address(?leak_m, leak_big,  0, 0x2B7E151628AED2A6);
-    dudect.measure(?scan_m, ct_scan, 0, 0x3C6EF372FE94F82B, 1, dudect.REFERENCE_ROUNDS);
+    dudect.measure(?null_m, null_walk, 0, 0x510E527FADE682D1, 1, SMOKE_ROUNDS);
+    dudect.measure(?leak_m, leak_big,  0, 0x2B7E151628AED2A6, 1, SMOKE_ROUNDS);
+    dudect.measure(?scan_m, ct_scan,   0, 0x3C6EF372FE94F82B, 1, SMOKE_ROUNDS);
 
     teardown(?alloc);
 
@@ -365,23 +371,8 @@ test "mach.lang.ct.probe:an_address_leak_is_measured" {
     report("leak", ?leak_m);
     report("scan", ?scan_m);
 
-    val ns: f64 = dudect.separation(?null_m);
-    val ls: f64 = dudect.separation(?leak_m);
-    val ss: f64 = dudect.separation(?scan_m);
-
-    if (ns > ADDRESS_NULL_TOL) {
-        p.println("declined: the address null control is not flat, so this run cannot discriminate");
-        ret 0;
-    }
-    if (ls - ns < ADDRESS_LEAK_MARGIN) {
-        p.println("the planted address leak was NOT detected. most likely this machine's");
-        p.println("last-level cache is at or above the probe table size: check `lscpu -C`");
-        p.println("and raise `BIG` in mach.lang.ct.probe.");
-        ret 2;
-    }
-    if (ss - ns >= ADDRESS_LEAK_MARGIN) {
-        p.println("the masked scan separated the way the planted address leak does");
-        ret 3;
-    }
+    if (!well_formed(?null_m)) { ret 2; }
+    if (!well_formed(?leak_m)) { ret 3; }
+    if (!well_formed(?scan_m)) { ret 4; }
     ret 0;
 }


### PR DESCRIPTION
Closes #3070.

CI must not be able to fail nondeterministically. `mach.lang.ct.probe` could, and did.

## What happened

`a_latency_leak_is_measured` failed the 4.26.0 release gate on `x86_64-darwin`, then passed a re-run of the identical commit. The compiler was never at fault:

```
null  mean_fix=126895.99  mean_rnd=159253.49  separation=0.2549
ct    mean_fix=38773.00   mean_rnd=12814.00   separation=2.0258   <- reported as a leak
leak  mean_fix=114560.00  mean_rnd=11020.49   separation=9.3952
```

The null was flat (0.2549 against a 0.60 tolerance), so the harness concluded the run could discriminate. But the null's means sat at 126k-159k while the probe's sat at 12k-38k. **A quiet control at 126k ns certifies nothing about noise at 12k ns.** The thresholds were calibrated over five runs on one linux box, and the relative cost of these probes is a microarchitecture property, so the ordering inverted. `aarch64-darwin` passed the same run.

## Why the gate is removed rather than recalibrated

Fixing the cost mismatch would make this rarer. It would not make it impossible, and impossible is the only acceptable standard for a required check. A timing threshold is a statistic over wall-clock time on hardware nobody controls.

The failure mode is worse than the flake itself: a red constant-time result that goes green on a re-run teaches a reader to re-run red security checks.

Two alternatives rejected, both recorded in the issue:

- **Report-only tests that always return 0.** That is exactly the defect #2956 just removed from corpus layer A, a green cell that cannot go red. Not reintroducing it one directory over.
- **Widening the thresholds until darwin stops failing.** Tunes a security-relevant number for CI convenience and blinds the check by the amount it was widened.

## What replaces it

The harness stays and is still exercised every run, at deliberately tiny sample counts, asserting only that it executes and produces finite, positive, ordered numbers. That is a structural claim about the harness rather than a timing claim about the machine, so it is deterministic, and it still fails if a probe rots.

The full measurement table is still printed every run, so the numbers stay readable. Reading them is a person's job.

`doc/language/secrecy.md` is rewritten to say plainly that these claims are measurements taken deliberately, not properties this suite enforces, and points at [mach-bench](https://github.com/briar-systems/mach-bench) as where timing and performance work belongs.

## Scope

**Not a revert of #2944.** Only the two threshold assertions go. The three deterministic restorations stay exactly as they are, including `x64.probe:flags_table_matches_this_cpu`, which executes instructions and reads RFLAGS and is the security surface the `#[oblivious]` model rests on.

## Verification

- `mach test .` **1535 passed, 0 failed** — unchanged count, two tests replaced by two tests.
- **Deterministic across six consecutive full-suite runs** under concurrent load.
- **Cost: 3.5s + ~1.5s -> 16ms + 32ms.**
- **The new assertion still goes red:** forcing a measurement's mean to 0, simulating a dead instrument, fails it with exit 1 at `probe.mach:327`. Reverted, back to 1535/0.
- I also confirmed by grep that **no other test in the suite compares a measured time against a bound** — `src/lang/ct/` held the only ones.
