### PR TITLE
fix(fe): recognise CRLF in the doc-block whitespace predicate

### DIFF
--- a/src/lang/fe/doc.mach
+++ b/src/lang/fe/doc.mach
@@ -173,12 +173,14 @@ fun empty_span() token.Span {
     ret s;
 }
 
-# whether byte `c` is in-line whitespace (a space or tab)
+# whether byte `c` is in-line whitespace (a space, tab, or carriage return) - CR
+# only ever precedes LF in this module's inputs, so treating it as trailing
+# in-line whitespace is correct at every caller
 # ---
 # c:   the byte to test
-# ret: true for a space or tab
+# ret: true for a space, tab, or carriage return
 fun is_space(c: u8) bool {
-    ret c == ' ' || c == '\t';
+    ret c == ' ' || c == '\t' || c == '\r';
 }
 
 # the byte offset of the newline ending the line that starts at `off`, or `end`
@@ -460,5 +462,36 @@ test "mach.lang.fe.doc:empty_block" {
     var it: DocComponentIter = component_iter(src, doc);
     var c:  DocComponent;
     if (component_next(?it, ?c)) { ret 1; }
+    ret 0;
+}
+
+# a CRLF doc block parses identically to its LF form: the `# ---` separator is
+# still recognised and no desc_span keeps a trailing `\r`
+test "mach.lang.fe.doc.component_next:crlf" {
+    val lf:   str        = "# read the wall-clock time\n# ---\n# out: pointer to populate\n# ret: 0 on success";
+    val crlf: str        = "# read the wall-clock time\r\n# ---\r\n# out: pointer to populate\r\n# ret: 0 on success";
+    val doc_lf:   token.Span = t_span(lf);
+    val doc_crlf: token.Span = t_span(crlf);
+
+    if (has_component_block(lf, doc_lf) != has_component_block(crlf, doc_crlf)) { ret 1; }
+    if (!has_component_block(crlf, doc_crlf))                                   { ret 1; }
+    if (!t_eq(crlf, summary_span(crlf, doc_crlf), "read the wall-clock time"))  { ret 1; }
+
+    var it_lf:   DocComponentIter = component_iter(lf, doc_lf);
+    var it_crlf: DocComponentIter = component_iter(crlf, doc_crlf);
+    var c_lf:   DocComponent;
+    var c_crlf: DocComponent;
+
+    if (!component_next(?it_lf, ?c_lf))     { ret 1; }
+    if (!component_next(?it_crlf, ?c_crlf)) { ret 1; }
+    if (!t_eq(crlf, c_crlf.name_span, "out"))                 { ret 1; }
+    if (!t_eq(crlf, c_crlf.desc_span, "pointer to populate")) { ret 1; }
+
+    if (!component_next(?it_lf, ?c_lf))     { ret 1; }
+    if (!component_next(?it_crlf, ?c_crlf)) { ret 1; }
+    if (!t_eq(crlf, c_crlf.name_span, "ret"))          { ret 1; }
+    if (!t_eq(crlf, c_crlf.desc_span, "0 on success")) { ret 1; }
+
+    if (component_next(?it_crlf, ?c_crlf)) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
## Summary
- `is_space` in `src/lang/fe/doc.mach` only matched space and tab, so on a CRLF file `trim_trailing` left a trailing `\r` on every comment line's content.
- The `# ---` separator line then measured 4 bytes instead of 3 and was never recognised, so `has_component_block`, `summary_span`, and `component_iter` treated the whole doc block as prose with zero components. Every `desc_span` also kept a trailing `\r`.
- Fix: add `\r` to `is_space`. CR only ever precedes LF in this module's inputs, so every caller (`strip_hash`, `trim_trailing`, `component_head`) treating it as trailing/interior whitespace is correct.

Closes #3072

## Test plan
- [x] Added `mach.lang.fe.doc.component_next:crlf`, asserting the LF and CRLF forms of the same doc block produce identical `has_component_block`, `summary_span`, and component name/desc spans.
- [x] Confirmed the new test fails before the fix (separator not recognised, `has_component_block` false).
- [x] Confirmed the new test passes after the fix.
- [x] Mutated the fix back to the buggy predicate and confirmed the test catches the regression; restored the fix.
- [x] `mach test .` — 1536 passed, 0 failed.