### PR TITLE
fix(sema): refuse a store into a `val`'s storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: `val` was immutable by documentation only (#3074)
+
+Assigning to a `val` was accepted everywhere. A module-level one compiled clean and
+faulted at runtime, because codegen had placed it in read-only data and nothing along
+the way objected:
+
+```mach
+val i: i32 = 0;
+#[symbol("main")]
+fun entry(argc: i64, argv: **u8) i64 {
+    i = 2;          # no diagnostic; SIGBUS / SIGSEGV when the binary runs
+    ret 0;
+}
+```
+
+A **block-local** `val` was the worse half of the same hole: its storage is an ordinary
+frame slot, so the write succeeded and the binding silently held a second value, with
+no runtime symptom to notice. There was no immutability check in the assignment path at
+all — the language's central distinction between `val` and `var` was enforced by
+nothing.
+
+Sema now refuses a store whose destination is a `val`'s own storage, wherever it lands
+and however it is spelled: the binding itself, a field or element inside it
+(`g.a = v`, `arr[i] = v`), a module-qualified reference (`lib.K = v`), and a `val`
+imported from another module, whose mutability is read from the declaration its origin
+module owns. The diagnostic names the binding and the rule.
+
+Writing **through** a pointer a `val` holds stays legal and is not a special case:
+`val p: *T` binds the address immutably, not the storage it addresses, so `@p`, the
+`p.field` auto-deref and `p[i]` write the pointee and end the walk. Function parameters
+are unaffected — they are mutable bindings, not `val`s.
+
 ## [4.26.0] - 2026-08-22
 
 ### Added

--- a/doc/language/val-var.md
+++ b/doc/language/val-var.md
@@ -21,7 +21,18 @@ var counter: i64 = 0;
 var buf:     [256]u8;               # default-initialized to zero
 
 counter = counter + 1;              # var is reassignable
+n = 43;                             # ERROR — `n` is a val
 ```
+
+## Immutability
+
+Assigning to a `val` is a compile-time error, at module scope and inside a function
+alike. So is writing a field or an element of one (`v.field = x`, `v[i] = x`): the
+store lands in the same storage the binding names.
+
+A pointer is the exception that proves the rule — `val p: *T` binds the **address**
+immutably, not the storage it addresses, so `@p = x`, `p.field = x` and `p[i] = x`
+write the pointee and are legal.
 
 ## Scope
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7384,6 +7384,61 @@ fun ut_sema_rejects_with(text: str, needle: str) bool {
     ret hit;
 }
 
+# a store into a `val`'s own storage is refused, however it is spelled (#3074)
+#
+# Nothing enforced `val`'s immutability at all. The reported program - a module-level
+# `val` written from a function body - compiled clean and the store faulted at
+# runtime, in read-only data, with no diagnostic from either end; a block-local `val`
+# did not even fault, it was silently reassigned. Both are the same rule, so both are
+# asserted here, and the aggregate spellings with them: a field or an element writes
+# the same storage the binding names, and a check that read only the outermost
+# expression would catch `g = v` and pass `g.a = v`.
+#
+# Message-precise, not merely "some error": a shape assertion would still pass with
+# the gate removed as long as any unrelated diagnostic remained.
+test "mach.lang.driver:val_assignment_refused" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects_with("val i: i32 = 0;\nfun main() i32 { i = 2; ret 0; }\n",
+        "cannot assign to `i`: a `val` is immutable"))    { bad = 1; }
+    if (!ut_sema_rejects_with("fun main() i32 { val x: i32 = 0; x = 2; ret x; }\n",
+        "cannot assign to `x`: a `val` is immutable"))    { bad = 1; }
+    if (!ut_sema_rejects_with("rec P { a: i32; }\nval g: P = P{ a: 1 };\nfun main() i32 { g.a = 9; ret 0; }\n",
+        "cannot assign into `g`: a `val` is immutable"))  { bad = 1; }
+    if (!ut_sema_rejects_with("val arr: [2]i32 = [2]i32{1, 2};\nfun main() i32 { arr[1] = 9; ret 0; }\n",
+        "cannot assign into `arr`: a `val` is immutable")) { bad = 1; }
+    if (!ut_sema_rejects_with("rec P { a: i32; }\nfun main() i32 { val r: P = P{ a: 1 }; r.a = 9; ret 0; }\n",
+        "cannot assign into `r`: a `val` is immutable"))  { bad = 1; }
+    ret bad;
+}
+
+# the gate keys on the destination's BINDING, not on the shape of the store (#3074)
+#
+# Every mutable spelling stays legal, and so does every store through a pointer a
+# `val` holds: `val p: *T` binds the ADDRESS immutably, not the storage it addresses,
+# so `@p`, the `p.field` auto-deref and `p[i]` all write the pointee and are none of
+# the gate's business. A gate that walked through a pointer object would reject these,
+# which is why they are asserted beside the refusals rather than left implied.
+test "mach.lang.driver:mutable_and_indirect_assignment_stays_clean" {
+    val src: str = "rec P { a: i32; }\nvar gv: i32 = 0;\nvar gr: P = P{ a: 1 };\nvar ga: [2]i32 = [2]i32{1, 2};\nval kv: i32 = 7;\nfun f(n: i32) i32 { n = 1; ret n; }\nfun main() i32 { gv = kv; gr.a = 2; ga[1] = 3; var lv: i32 = 0; lv = gv; val p: *i32 = ?gv; @p = 4; val pr: *P = ?gr; pr.a = 5; val pa: *i32 = ?ga[0]; pa[1] = 6; ret 0; }\n";
+    if (!ut_sema_clean(src)) { ret 1; }
+    ret 0;
+}
+
+# an imported `val` is immutable in the importing module too (#3074)
+#
+# A cross-module reference resolves to SYM_IMPORTED, whose kind says nothing about
+# mutability - that lives in the declaration the origin module owns - so the gate
+# reads the origin AST. A single-file fixture never enters that path, and an
+# imported `var` proves the origin lookup discriminates rather than refusing every
+# import.
+test "mach.lang.driver:imported_val_assignment_refused" {
+    var bad: i32 = 0;
+    if (ut_vec_diag2("use uniontest.lib;\nfun main() i32 { lib.K = 1; ret 0; }\n", "pub val K: i32 = 7;\n",
+        "cannot assign to `K`: a `val` is immutable") != 0) { bad = 1; }
+    if (!ut_sema_clean2("use uniontest.lib;\nfun main() i32 { lib.M = 1; ret 0; }\n", "pub var M: i32 = 7;\n")) { bad = 1; }
+    ret bad;
+}
+
 # secret flow typing: a clean program exercising the join, the implicit
 # public->secret up-coerce, the `:^` strip, secret record fields, storing public
 # through `*^T`, and an all-secret union, all without a sema error (#1645)

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1919,9 +1919,147 @@ fun infer_assign(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span
     val rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    check_assign_mutable(sc, b.lhs, span);
     check_readonly_storage(sc, b.lhs, span);
     check.check_coercible(sc, lt, b.rhs, rt, span);
     ret lt;
+}
+
+# report an assignment whose destination is the storage of an immutable `val` (#3074)
+#
+# `val` is immutable by declaration, and nothing enforced it: a local `val` was
+# silently reassigned, and a module-level one - which codegen places in read-only
+# data - compiled clean and faulted at runtime with no diagnostic at all. The rule
+# is one rule for every binding, local and module-level alike: the storage a `val`
+# names is written by its initializer and never again.
+#
+# A CHAIN WALK, like `check_readonly_storage`: `x = v`, `x.field = v`, `x.arr[i] = v`
+# and `lib.x.field = v` all store into the binding's own storage, and only the first
+# spelling is a bare identifier. The walk stops at a POINTER object, because the two
+# auto-derefs (`p.field`, `p[i]`) and an explicit `@p` write the POINTEE, not the
+# binding: a `val p: *T` binds the address immutably, not the storage it addresses.
+# ---
+# sc:   sema context
+# eid:  the assignment's destination expression
+# span: the operator span for the diagnostic
+fun check_assign_mutable(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) {
+    val so: O.Option[*resolve.Symbol] = immutable_binding_for_target(sc, eid);
+    if (O.is_none[*resolve.Symbol](so)) { ret; }
+    val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
+
+    # the destination is the binding itself, or a field / element inside it
+    val direct: bool = symbol_at_expr_is(sc, eid, sym);
+    var prefix: str = "cannot assign into `";
+    if (direct) { prefix = "cannot assign to `"; }
+
+    report_immutable_assign(sc, span, prefix, sym.name);
+}
+
+# the immutable `val` binding a store into `eid` would write, or none
+#
+# Asked at every link of the destination chain, since a module-qualified reference
+# (`lib.x`) resolves at a MEMBER rather than at the base identifier.
+# ---
+# sc:  sema context
+# eid: the destination expression, or one of its objects
+# ret: some(*Symbol) when the store lands in a `val`'s storage, none otherwise
+fun immutable_binding_for_target(sc: *context.SemaContext, eid: id.ExprId) O.Option[*resolve.Symbol] {
+    if (eid == id.EXPR_NIL) { ret O.none[*resolve.Symbol](); }
+
+    val so: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
+    if (O.is_some[*resolve.Symbol](so)) {
+        val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
+        if (symbol_is_val_binding(sc, sym))                              { ret O.some[*resolve.Symbol](sym); }
+        if (sym.kind == resolve.SYM_VAR || sym.kind == resolve.SYM_PARAM) { ret O.none[*resolve.Symbol](); }
+    }
+
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret O.none[*resolve.Symbol](); }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) { ret binding_through_object(sc, e.data.member.object); }
+    if (e.kind == expr.EXPR_KIND_INDEX)  { ret binding_through_object(sc, e.data.index.object); }
+
+    # a deref, a cast, a call result: the store does not land in a named binding's
+    # own storage, so no `val` is written
+    ret O.none[*resolve.Symbol]();
+}
+
+# continue the walk into a projection's object, unless the projection auto-derefs
+# ---
+# sc:  sema context
+# obj: the object a MEMBER or INDEX projects from
+# ret: some(*Symbol) when the store lands in a `val`'s storage, none otherwise
+fun binding_through_object(sc: *context.SemaContext, obj: id.ExprId) O.Option[*resolve.Symbol] {
+    if (is_pointer_like(sc, type.strip_secret(?sc.s.types, target_expr_type(sc, obj)))) {
+        ret O.none[*resolve.Symbol]();
+    }
+    ret immutable_binding_for_target(sc, obj);
+}
+
+# whether `sym` is a binding declared `val`
+#
+# An imported binding carries its mutability in the declaration the origin module
+# owns, so it is read from that module's AST rather than from the local symbol kind
+# (which is only ever SYM_IMPORTED).
+# ---
+# sc:  sema context
+# sym: the symbol to classify
+# ret: true when a store into it writes immutable storage
+fun symbol_is_val_binding(sc: *context.SemaContext, sym: *resolve.Symbol) bool {
+    if (sym.kind == resolve.SYM_VAL)      { ret true; }
+    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    if (sym.decl == id.DECL_NIL)          { ret false; }
+
+    val a: *ast.Ast = symbol_ast(sc, sym);
+    if (a == nil) { ret false; }
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (O.is_none[*decl.Decl](d_opt)) { ret false; }
+    ret O.unwrap[*decl.Decl](d_opt).kind == decl.DECL_KIND_VAL;
+}
+
+# whether `eid` itself resolves to `sym`, distinguishing `x = v` from `x.f = v`
+# ---
+# sc:  sema context
+# eid: the destination expression
+# sym: the immutable binding the walk found
+# ret: true when the destination names the binding directly
+fun symbol_at_expr_is(sc: *context.SemaContext, eid: id.ExprId, sym: *resolve.Symbol) bool {
+    val so: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
+    if (O.is_none[*resolve.Symbol](so)) { ret false; }
+    ret O.unwrap[*resolve.Symbol](so) == sym;
+}
+
+# the inferred type of `eid`, TYPE_ERROR for a nil or out-of-range id
+# ---
+# sc:  sema context
+# eid: the expression to read the type of
+# ret: the inferred type, or TYPE_ERROR
+fun target_expr_type(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
+    if (sc.expr_type == nil)                             { ret type.TYPE_ERROR; }
+    if (eid == id.EXPR_NIL || eid >= sc.a.expr_len::u32) { ret type.TYPE_ERROR; }
+    ret sc.expr_type[eid];
+}
+
+# emit the immutable-assignment diagnostic, naming the binding
+#
+# The note carries the rule rather than the spelling: the mistake is not a typo, it
+# is a binding declared to hold one value being asked to hold another.
+# ---
+# sc:     sema context
+# span:   the operator span
+# prefix: message text up to the opening backtick
+# name:   interned identifier of the `val`
+fun report_immutable_assign(sc: *context.SemaContext, span: token.Span, prefix: str, name: intern.StrId) {
+    val note: str = "a `val` binds its value once, at its declaration; declare it `var` if it must be assigned. a module-level `val` is emitted in read-only storage, so the store would fault at runtime";
+    val res: R.Result[str, str] = format.sprint(sc.s.alloc, "{}{}`: a `val` is immutable", prefix, typename.name_str(sc.s, name));
+    if (R.is_err[str, str](res)) {
+        context.report_note(sc, span, "cannot assign to a `val`: a `val` is immutable", note);
+        ret;
+    }
+    val msg: str = R.unwrap_ok[str, str](res);
+    context.report_note(sc, span, msg, note);
+    A.deallocate[char](sc.s.alloc, msg, str_len(msg) + 1);
 }
 
 # report an assignment whose destination lives in a `#[storage(..., "readonly")]`


### PR DESCRIPTION
Closes #3074

## What was wrong

Nothing enforced `val`'s immutability. The reported program compiled clean and the
binary faulted at runtime:

```mach
val i: i32 = 0;
#[symbol("main")]
fun entry(argc: i64, argv: **u8) i64 {
    i = 2;          # no diagnostic; SIGSEGV on linux, SIGBUS on darwin
    ret 0;
}
```

The store lands in read-only data, which is why it faults. The **block-local** case is
the worse half of the same hole and was not in the report: a local `val`'s storage is an
ordinary frame slot, so `val x: i32 = 0; x = 2;` succeeded silently, with no runtime
symptom at all.

There was no mutability check in the assignment path — `infer_assign` carried a
`#[storage(..., "readonly")]` check and a coercion check and nothing else. Every
spelling was unguarded: local and module-level, direct and through a field or element,
same-module and imported.

## The fix

`src/lang/fe/sema/infer.mach` — `infer_assign` now walks the destination chain to the
binding the store lands in and refuses it when that binding is a `val`. The walk mirrors
`check_readonly_storage`, which exists for the same reason: `x = v`, `x.field = v`,
`x.arr[i] = v` and `lib.x.field = v` all write the binding's own storage, and only the
first is a bare identifier. An imported binding's mutability lives in the declaration its
origin module owns, so it is read from that module's AST rather than from the local
`SYM_IMPORTED` kind.

The walk **stops at a pointer object**. `val p: *T` binds the address immutably, not the
storage it addresses, so `@p = v`, the `p.field` auto-deref and `p[i] = v` write the
pointee and are none of the gate's business. Function parameters are mutable bindings and
are untouched.

```
error: cannot assign to `i`: a `val` is immutable
 --> src/bin/main.mach:6:5
  |
6 |     i = 2;
  |     ^^^^^
  |
  = note: a `val` binds its value once, at its declaration; declare it `var` if it must
    be assigned. a module-level `val` is emitted in read-only storage, so the store would
    fault at runtime
```

A field or element target reads `cannot assign into `arr`: a `val` is immutable`, naming
the binding the store reaches rather than the projection.

## Verification

- The issue's exact repro now errors at compile time; before the fix it built clean and
  exited 139.
- Three tests in `src/lang/driver/tests.mach`, message-precise (a "some error" assertion
  would survive the gate's removal): the refusals (module-level, local, record field,
  array element, local aggregate field), the clean cases (every mutable spelling, a
  parameter, and all three stores through a `val`-held pointer), and the cross-module
  pair (imported `val` refused, imported `var` clean).
- `mach test`: 1538 passed, 0 failed.
- The whole compiler and mach-std build clean under the new rule — no existing source
  assigns to a `val`.
- Mutation checks, both restored: dropping the `check_assign_mutable` call fails both
  refusal tests; dropping the pointer stop fails the clean test.

## Not fixed here

`?v` on a `val` yields a plain `*T`, so a write through that pointer is still accepted
and still faults for a module-level `val`. Closing that needs a pointer-to-immutable in
the type system, which is a language change rather than a missing check.
