### PR TITLE
fix(sema): size the generic-union instance walk to the type universe

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -9739,6 +9739,96 @@ test "mach.lang.driver:deep_secret_walk_scales_with_the_type_graph" {
     ret bad;
 }
 
+# constant-time (#3066): the generic-union INSTANCE walk is bounded by the ALLOCATOR too,
+# and it stays affordable once nothing cuts it short
+#
+# This walk carried its own fixed 256-entry visited set, and unlike the deep-secret walk's
+# it REPORTED when the set filled - so a module that named a `^` anywhere and reached more
+# than 256 nominals got one "cannot prove ... too large" per annotation past the bound: a
+# wall of diagnostics about the checker rather than about the program.
+#
+# Lifting the bound alone would have made that WORSE, because the bound was also the only
+# thing capping the walk's cost. Each nominal it enters asks whether that nominal's field
+# graph mentions a generic parameter, and that question used to re-walk the whole graph
+# behind a visited set with a LINEAR membership test - cubic in graph size, per annotation.
+# So the arms below assert the answers and the harness's own runtime asserts the cost: at
+# this `n` the pre-fix walk spent seconds inside sema, which is why the case could not have
+# been an ordinary test before.
+#
+# ARMS 1 AND 2 ARE A PAIR. A walk that gives up reports on a clean graph and a violating
+# one alike, so arm 1 alone is satisfied by a walk that never ran and arm 2 by one that
+# gave up. Held together they say the walk reached the far end of the graph, read what was
+# there, and judged it.
+test "mach.lang.driver:uni_instance_walk_scales_with_the_type_graph" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+
+    # comfortably past the 256 the visited set used to hold, so a bound reintroduced at
+    # that size - or at the 256-slot power of two the set now grows through - fails here.
+    val n: u32 = 320;
+
+    # `U` rides in the TAIL because `ut_chain_src` appends that text whole; a module's
+    # declarations are order-independent, so `R0` naming it above still resolves.
+    val tr: R.Result[str, str] = format.sprint(?alloc, "uni U[T] {{ a: T; b: u32; }}\nfun e(p: *R{}) u32 {{ ret 0; }}\nfun main() i32 {{ ret 0; }}\n", n - 1);
+    if (R.is_err[str, str](tr)) { ret 1; }
+    val tail: str = R.unwrap_ok[str, str](tr);
+
+    # the back-edge `R0` closes the chain with, named off `n` so the two cannot drift.
+    val br: R.Result[str, str] = format.sprint(?alloc, "a: ^u32; b: *R{};", n - 1);
+    if (R.is_err[str, str](br)) { ret 1; }
+    val back: str = R.unwrap_ok[str, str](br);
+
+    # ARM 1 - `n` nominals and a real `^` at the far end of them, with every generic union
+    # the graph reaches agreeing on secrecy: COMPILES. This is the reported bug.
+    val plain_src: O.Option[str] = ut_chain_src(?alloc, n, "a: ^u32;", tail);
+    if (O.is_none[str](plain_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](plain_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 2 - a genuinely mixed generic union at the FAR END of the same graph: still
+    # REPORTED, and as the rule's own violation rather than as the checker giving up.
+    # Lifting the bound must not turn the walk into a hole in the rule it guards.
+    val mixed_src: O.Option[str] = ut_chain_src(?alloc, n, "a: ^u32; u: U[^u32];", tail);
+    if (O.is_none[str](mixed_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](mixed_src);
+        if (ut_vec_diag(src, "union variants must agree on secrecy") != 0) { bad = 1; }
+        if (ut_vec_diag(src, "too large") == 0) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 3 - the same union at a PUBLIC argument, equally deep: COMPILES. Arm 2 must be
+    # about the argument the union was given, not about how far in it sits.
+    val ok_src: O.Option[str] = ut_chain_src(?alloc, n, "a: ^u32; u: U[u32];", tail);
+    if (O.is_none[str](ok_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](ok_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 4 - A CYCLE INSIDE A LARGE GRAPH still terminates: `R0` points back at the
+    # deepest link. The cycle guard is the whole reason the visited set exists, and a set
+    # REUSED across walks is where a stale mark would break it - the union walk NESTS
+    # around the deep-secret walk it asks each variant pair about, so a shared set would
+    # let the inner walk retire the outer walk's marks and unbind this cycle.
+    val cyc_src: O.Option[str] = ut_chain_src(?alloc, n, back, tail);
+    if (O.is_none[str](cyc_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](cyc_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    A.deallocate[char](?alloc, back::*char, str_len(back) + 1);
+    A.deallocate[char](?alloc, tail::*char, str_len(tail) + 1);
+    ret bad;
+}
+
 # block-scoped fin structural rules: control flow cannot cross the fin boundary
 # outward - a `ret` inside a fin body is rejected, as is a `brk` / `cnt` whose
 # target loop encloses the fin; a loop fully inside the fin body keeps `brk` /

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -37,18 +37,31 @@ use mach.lang.session;
 use mach.lang.source;
 use mach.lang.type;
 
-# the set of nominal TypeIds entered during a single generic-parameter search
+# one generic-parameter search over the field graph
 #
-# A recursive nominal (`rec Node { next: *Node; }`) would otherwise recurse
-# forever; recording each entered nominal lets a re-entry break its own cycle.
+# A recursive nominal (`rec Node { next: *Node; }`) would otherwise recurse forever;
+# recording each entered nominal in `scan` lets a re-entry break its own cycle. The set is
+# borrowed from the interner rather than grown per search, so membership is O(1) instead of
+# a rescan of everything entered so far - the rescan is what made a search quadratic in
+# graph size, and this search runs at every nominal the union-instance walk enters (#3066).
 # ---
-# visited: dynamic array of entered nominal TypeIds
-# len:     number of ids stored
-# cap:     allocated slots
-rec GParamScan {
-    visited: *type.TypeId;
-    len:     u32;
-    cap:     u32;
+# scan:     the borrowed cycle guard, open for the life of the search
+# resolved: false once the search reached a nominal whose field table was unavailable, so
+#           its answer describes the checker's timing and may not be memoized
+rec GParamWalk {
+    scan:     type.TypeScan;
+    resolved: bool;
+}
+
+# open a generic-parameter search, borrowing its cycle guard
+fun gparam_walk_begin(s: *session.Session, w: *GParamWalk) {
+    type.type_scan_begin(?s.types, ?w.scan);
+    w.resolved = true;
+}
+
+# close a generic-parameter search, returning its cycle guard
+fun gparam_walk_end(s: *session.Session, w: *GParamWalk) {
+    type.type_scan_end(?s.types, ?w.scan);
 }
 
 # instantiate a generic declaration with concrete type arguments, producing an
@@ -780,23 +793,28 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.TypeScan)
     ret false;
 }
 
-# the number of distinct (nominal, arguments) pairs one walk enters before failing closed
-val UNI_SCAN_CAP: u32 = 256;
-
 # the (nominal, argument-list) pairs entered during one instance union-secrecy walk
 #
 # Keyed by the interned TYPE_INSTANCE the pair denotes, so the same nominal reached
 # under two different argument lists is examined twice (`rec P[T] { a: U[T]; b: U[u32]; }`)
 # while a recursive generic (`rec Node[T] { next: *Node[T]; }`) terminates on its second
-# entry. A graph past the bound fails CLOSED - it reports rather than returning "no
-# violation", which padding the graph would otherwise exploit.
+# entry. Since the key is an interned TypeId, the visited set is the interner's own, whose
+# capacity is the type universe's.
+#
+# It used to be a fixed 256 keys, and a graph past that reported (#3066) - so an ordinary
+# module naming a `^` anywhere and reaching more than 256 nominals got a wall of
+# diagnostics about the checker rather than about the program, and the message said as
+# much. Failing closed is right for a walk out of room; the defect was that the room was a
+# constant. The only exhaustion left is the allocator's.
+#
+# This walk NESTS around the deep-secret walk - `check_uni_variants` asks a secrecy
+# question per variant pair, and each is a walk of its own - which is why the interner
+# hands out one set per level rather than sharing one.
 # ---
-# seen:                the (nominal, args) keys already entered
-# len:                 number of entries
+# scan:                the borrowed visited set, keyed by `nominal_visit_key`
 # unprovable_reported: true once this walk's fail-closed exit has been reported
 rec UniInstScan {
-    seen:                [UNI_SCAN_CAP]type.TypeId;
-    len:                 u32;
+    scan:                type.TypeScan;
     unprovable_reported: bool;
 }
 
@@ -823,13 +841,11 @@ pub fun module_reaches_secret(s: *session.Session, resolved: *type.TypeId, len: 
 
     # ONE visited set across every annotation, not one per annotation: a nominal explored
     # and found secret-free stays secret-free whichever root reached it, so sharing turns
-    # the scan from (annotations x graph) into (distinct types). It grows rather than
-    # capping, because a capped scan would answer "possibly secret" for any large module
+    # the scan from (annotations x graph) into (distinct types). Its capacity is the type
+    # universe's, because a capped scan would answer "possibly secret" for any large module
     # and switch the whole rule on for it - paying far more than the scan saved.
-    var scan: GParamScan;
-    scan.visited = nil;
-    scan.len     = 0;
-    scan.cap     = 0;
+    var scan: type.TypeScan;
+    type.type_scan_begin(?s.types, ?scan);
 
     var found: bool = false;
     var i:     u32  = 0;
@@ -841,19 +857,17 @@ pub fun module_reaches_secret(s: *session.Session, resolved: *type.TypeId, len: 
         i = i + 1;
     }
 
-    if (scan.visited != nil && scan.cap > 0) {
-        A.deallocate[type.TypeId](s.alloc, scan.visited, scan.cap::usize);
-    }
+    type.type_scan_end(?s.types, ?scan);
     ret found;
 }
 
-# the recursive worker for `module_reaches_secret`, threading one growable visited set
+# the recursive worker for `module_reaches_secret`, threading one borrowed visited set
 #
 # The same structural discipline as `secret_deep_walk` - pointer, array, function
 # SIGNATURE, and every field of every aggregate - and the same fail-closed default over
 # the kind space, so an unresolvable table or an unrecognized kind answers "possibly
 # secret" and switches the rule on rather than off.
-fun secret_reach_walk(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bool {
+fun secret_reach_walk(s: *session.Session, tid: type.TypeId, scan: *type.TypeScan) bool {
     if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret false; }
 
     val opt_t: O.Option[*type.Type] = type.get(?s.types, tid);
@@ -890,8 +904,9 @@ fun secret_reach_walk(s: *session.Session, tid: type.TypeId, scan: *GParamScan) 
     # layout the program may never need - the scan runs on every module, including the
     # overwhelming majority that reach no secret at all and pay only this walk.
     if (k == type.TYPE_INSTANCE) {
-        if (scan_contains(scan, tid)) { ret false; }
-        if (!scan_push(s, scan, tid)) { ret true; }
+        val mark: type.VisitMark = type.type_scan_mark(?s.types, scan, tid);
+        if (mark == type.VISIT_SEEN)   { ret false; }
+        if (mark == type.VISIT_FAILED) { ret true; }
 
         val origin:     session.ModuleId = t.data.instance.target_origin;
         val decl_id:    id.DeclId        = t.data.instance.target_decl;
@@ -911,8 +926,9 @@ fun secret_reach_walk(s: *session.Session, tid: type.TypeId, scan: *GParamScan) 
     }
 
     if (k == type.TYPE_REC || k == type.TYPE_UNI) {
-        if (scan_contains(scan, tid)) { ret false; }
-        if (!scan_push(s, scan, tid)) { ret true; }
+        val mark: type.VisitMark = type.type_scan_mark(?s.types, scan, tid);
+        if (mark == type.VISIT_SEEN)   { ret false; }
+        if (mark == type.VISIT_FAILED) { ret true; }
 
         val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);
         if (O.is_none[*type.FieldTable](opt_tab)) { ret true; }
@@ -983,9 +999,10 @@ pub fun check_type_uni_secrecy(sc: *sema.SemaContext, tid: type.TypeId, args: *t
     if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret; }
 
     var scan: UniInstScan;
-    scan.len                 = 0;
     scan.unprovable_reported = false;
+    type.type_scan_begin(?sc.s.types, ?scan.scan);
     uni_inst_walk(sc, tid, args, arg_len, ?scan, span);
+    type.type_scan_end(?sc.s.types, ?scan.scan);
 }
 
 # the recursive worker: descend `tid` carrying `args`, checking every union nominal
@@ -1159,19 +1176,16 @@ fun uni_inst_walk_nominal(sc: *sema.SemaContext, nom: type.TypeId, args: *type.T
     }
 
     val key: type.TypeId = nominal_visit_key(s, nom, a, n);
-    var i: u32 = 0;
-    for (i < scan.len) {
-        if (scan.seen[i] == key) { ret; }
-        i = i + 1;
-    }
-    # a graph past the bound FAILS CLOSED: it reports rather than answering "no
-    # violation", which padding the graph past the bound would otherwise exploit.
-    if (scan.len >= UNI_SCAN_CAP) {
+    val mark: type.VisitMark = type.type_scan_mark(?s.types, ?scan.scan, key);
+    # this pair was already entered; its own frame checked and descended it.
+    if (mark == type.VISIT_SEEN) { ret; }
+    # a pair the visited set could not record leaves the walk unbounded from here, so it
+    # FAILS CLOSED: it reports rather than answering "no violation", which padding the
+    # graph would otherwise exploit.
+    if (mark == type.VISIT_FAILED) {
         report_unprovable(sc, scan, span);
         ret;
     }
-    scan.seen[scan.len] = key;
-    scan.len = scan.len + 1;
 
     if (generic && nom_kind == type.TYPE_UNI) {
         check_uni_variants(sc, nom, a, n, key, scan, span);
@@ -1283,15 +1297,10 @@ fun subst_or_self(s: *session.Session, tid: type.TypeId, args: *type.TypeId, arg
 
 # whether `tid` is, or structurally contains, a generic parameter (owning the cycle guard)
 fun type_mentions_gparam(s: *session.Session, tid: type.TypeId) bool {
-    var scan: GParamScan;
-    scan.visited = nil;
-    scan.len     = 0;
-    scan.cap     = 0;
-
-    val mentioned: bool = mentions_gparam(s, tid, ?scan);
-    if (scan.visited != nil && scan.cap > 0) {
-        A.deallocate[type.TypeId](s.alloc, scan.visited, scan.cap::usize);
-    }
+    var w: GParamWalk;
+    gparam_walk_begin(s, ?w);
+    val mentioned: bool = mentions_gparam(s, tid, ?w);
+    gparam_walk_end(s, ?w);
     ret mentioned;
 }
 
@@ -1587,47 +1596,69 @@ fun substitute_aggregate(s: *session.Session, t: *type.Type, args: *type.TypeId,
 # a nominal is part of an unspecialized generic body and must be substituted per
 # instance; a fully concrete one need not be. A fresh cycle-guard scan bounds the
 # search against recursive nominals.
+#
+# MEMOIZED on the interner per field epoch, because the answer is a property of `tid`'s
+# field graph rather than of whoever asked: the union-instance walk asks it at every
+# nominal it enters, and every annotation in the module opens a walk of its own, so
+# recomputing it turned one graph traversal into (annotations x graph) of them (#3066).
 # ---
 # s:   the shared session (type universe, allocator)
 # tid: the nominal TypeId to inspect
 # ret: true when any field mentions a generic parameter
 fun nominal_has_gparam(s: *session.Session, tid: type.TypeId) bool {
-    var scan: GParamScan;
-    scan.visited = nil;
-    scan.len     = 0;
-    scan.cap     = 0;
+    val memo: type.GParamMemo = type.gparam_memo_get(?s.types, tid);
+    if (memo == type.GPARAM_YES) { ret true; }
+    if (memo == type.GPARAM_NO)  { ret false; }
 
-    val mentioned: bool = nominal_fields_mention(s, tid, ?scan);
-    if (scan.visited != nil && scan.cap > 0) {
-        A.deallocate[type.TypeId](s.alloc, scan.visited, scan.cap::usize);
-    }
+    var w: GParamWalk;
+    gparam_walk_begin(s, ?w);
+    val mentioned: bool = nominal_fields_mention(s, tid, ?w);
+    val resolved:  bool = w.resolved;
+    gparam_walk_end(s, ?w);
+
+    # ONLY the search's ROOT may be memoized. A nominal met partway through carries the
+    # cycle guard's assumption - a re-entry answers "no" so the recursion terminates - and
+    # that answer is about this search, not about the nominal: `rec A { b: *B; t: T; }` with
+    # `rec B { a: *A; }` decides B "no" while B asked on its own decides "yes". The root
+    # holds because a false root means the whole reachable graph was walked and no
+    # parameter was found in any of it.
+    if (resolved) { type.gparam_memo_set(?s.types, tid, mentioned); }
     ret mentioned;
 }
 
 # whether any field of nominal `tid` mentions a generic parameter
 #
-# Guards against recursive nominals via `scan`: a TypeId already on the search
-# stack yields false here (its own frame examines every field), so a cycle cannot
-# recurse forever. An allocation failure recording the visit degrades to true,
-# forcing a harmless substitution attempt rather than risking a missed one.
+# Guards against recursive nominals via `w.scan`: a TypeId already entered yields false
+# here (the frame that entered it examines every field), so a cycle cannot recurse forever.
+# A visit the guard cannot record degrades to true, forcing a harmless substitution attempt
+# rather than risking a missed one.
 # ---
-# s:    the shared session (type universe, allocator)
-# tid:  the nominal TypeId whose fields are scanned
-# scan: the in-progress cycle guard
-# ret:  true when a field mentions a generic parameter
-fun nominal_fields_mention(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bool {
-    if (scan_contains(scan, tid)) { ret false; }
-    if (!scan_push(s, scan, tid)) { ret true; }
+# s:   the shared session (type universe, allocator)
+# tid: the nominal TypeId whose fields are scanned
+# w:   the in-progress search
+# ret: true when a field mentions a generic parameter
+fun nominal_fields_mention(s: *session.Session, tid: type.TypeId, w: *GParamWalk) bool {
+    val mark: type.VisitMark = type.type_scan_mark(?s.types, ?w.scan, tid);
+    if (mark == type.VISIT_SEEN)   { ret false; }
+    if (mark == type.VISIT_FAILED) {
+        w.resolved = false;
+        ret true;
+    }
 
     val opt_table: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);
-    if (O.is_none[*type.FieldTable](opt_table)) { ret false; }
+    if (O.is_none[*type.FieldTable](opt_table)) {
+        # an absent table is not evidence of anything about `tid`; saying so keeps the
+        # answer out of the memo, where it would outlive the table's arrival.
+        w.resolved = false;
+        ret false;
+    }
     val fields_len: u32 = O.unwrap[*type.FieldTable](opt_table).fields_len;
 
     var i: u32 = 0;
     for (i < fields_len) {
         val opt_entry: O.Option[*type.FieldEntry] = type.field_at(?s.types, tid, i);
         if (O.is_some[*type.FieldEntry](opt_entry)) {
-            if (mentions_gparam(s, O.unwrap[*type.FieldEntry](opt_entry).ty, scan)) { ret true; }
+            if (mentions_gparam(s, O.unwrap[*type.FieldEntry](opt_entry).ty, w)) { ret true; }
         }
         i = i + 1;
     }
@@ -1641,11 +1672,11 @@ fun nominal_fields_mention(s: *session.Session, tid: type.TypeId, scan: *GParamS
 # guard so two-plus levels of nested anonymous aggregate are reached without
 # unbounded recursion on a recursive nominal.
 # ---
-# s:    the shared session (type universe, allocator)
-# tid:  the TypeId to inspect
-# scan: the in-progress cycle guard
-# ret:  true when `tid` mentions a generic parameter
-fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bool {
+# s:   the shared session (type universe, allocator)
+# tid: the TypeId to inspect
+# w:   the in-progress search
+# ret: true when `tid` mentions a generic parameter
+fun mentions_gparam(s: *session.Session, tid: type.TypeId, w: *GParamWalk) bool {
     if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret false; }
 
     val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
@@ -1653,11 +1684,11 @@ fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bo
     val t: *type.Type = O.unwrap[*type.Type](opt_type);
 
     if (t.kind == type.TYPE_GENERIC_PARAM) { ret true; }
-    if (t.kind == type.TYPE_POINTER)       { ret mentions_gparam(s, t.data.pointer.base, scan); }
-    if (t.kind == type.TYPE_SECRET)        { ret mentions_gparam(s, t.data.secret.base, scan); }
-    if (t.kind == type.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base, scan); }
+    if (t.kind == type.TYPE_POINTER)       { ret mentions_gparam(s, t.data.pointer.base, w); }
+    if (t.kind == type.TYPE_SECRET)        { ret mentions_gparam(s, t.data.secret.base, w); }
+    if (t.kind == type.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base, w); }
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
-        ret nominal_fields_mention(s, tid, scan);
+        ret nominal_fields_mention(s, tid, w);
     }
 
     # a SIGNATURE is a position like any other: `rec Box[T] { f: fun(*U[T]) u32; }`
@@ -1668,11 +1699,11 @@ fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bo
         val ret_ty:       type.TypeId = t.data.fn.ret_type;
         val params_start: u32         = t.data.fn.params_start;
         val params_len:   u32         = t.data.fn.params_len;
-        if (mentions_gparam(s, ret_ty, scan)) { ret true; }
+        if (mentions_gparam(s, ret_ty, w)) { ret true; }
         var i: u32 = 0;
         for (i < params_len) {
             val p_opt: O.Option[type.TypeId] = type.get_param(?s.types, params_start + i);
-            if (O.is_some[type.TypeId](p_opt) && mentions_gparam(s, O.unwrap[type.TypeId](p_opt), scan)) { ret true; }
+            if (O.is_some[type.TypeId](p_opt) && mentions_gparam(s, O.unwrap[type.TypeId](p_opt), w)) { ret true; }
             i = i + 1;
         }
         ret false;
@@ -1685,56 +1716,12 @@ fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bo
         for (i < args_len) {
             val opt_arg: O.Option[type.TypeId] = type.get_param(?s.types, args_start + i);
             if (O.is_some[type.TypeId](opt_arg)) {
-                if (mentions_gparam(s, O.unwrap[type.TypeId](opt_arg), scan)) { ret true; }
+                if (mentions_gparam(s, O.unwrap[type.TypeId](opt_arg), w)) { ret true; }
             }
             i = i + 1;
         }
     }
     ret false;
-}
-
-# whether nominal TypeId `tid` is already recorded in `scan`
-# ---
-# scan: the cycle guard to search
-# tid:  the TypeId to look for
-# ret:  true when `tid` is present
-fun scan_contains(scan: *GParamScan, tid: type.TypeId) bool {
-    var i: u32 = 0;
-    for (i < scan.len) {
-        if (scan.visited[i] == tid) { ret true; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-# record nominal TypeId `tid` in `scan`, growing the backing array as needed
-# ---
-# s:    the shared session (allocator)
-# scan: the cycle guard to extend
-# tid:  the TypeId to record
-# ret:  true on success, false only on an allocation failure
-fun scan_push(s: *session.Session, scan: *GParamScan, tid: type.TypeId) bool {
-    if (scan.len == scan.cap) {
-        var new_cap: u32 = scan.cap * 2;
-        if (new_cap == 0) { new_cap = 8; }
-
-        if (scan.visited == nil) {
-            val res_alloc: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](s.alloc, new_cap::usize);
-            if (R.is_err[*type.TypeId, str](res_alloc)) { ret false; }
-            scan.visited = R.unwrap_ok[*type.TypeId, str](res_alloc);
-        }
-        or {
-            val res_realloc: R.Result[*type.TypeId, str] = A.reallocate[type.TypeId](s.alloc, scan.visited, scan.cap::usize, new_cap::usize);
-            if (R.is_err[*type.TypeId, str](res_realloc)) { ret false; }
-            scan.visited = R.unwrap_ok[*type.TypeId, str](res_realloc);
-        }
-
-        scan.cap = new_cap;
-    }
-
-    scan.visited[scan.len] = tid;
-    scan.len = scan.len + 1;
-    ret true;
 }
 
 # intern the identifier text of a name `span` taken from module `ga`'s source

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -640,6 +640,10 @@ pub rec FieldTable {
 #                  guard, one per level of nesting, checked out and returned in stack order
 # visits_len:      sets currently borrowed, which is the current nesting depth
 # visits_cap:      allocated sets in visits
+# gparam:          per-TypeId memo of "this nominal's field graph mentions a generic
+#                  parameter", one GPARAM_* state per TypeId
+# gparam_cap:      allocated slots in gparam
+# gparam_epoch:    the field epoch the memo's contents describe; a bump retires them
 pub rec TypeInterner {
     a: *A.Allocator;
 
@@ -704,6 +708,10 @@ pub rec TypeInterner {
     visits:     *VisitSet;
     visits_len: u32;
     visits_cap: u32;
+
+    gparam:       *u8;
+    gparam_cap:   u32;
+    gparam_epoch: u32;
 }
 
 # initial capacities for the interner's growable backing arrays
@@ -755,6 +763,10 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
     ti.visits     = nil;
     ti.visits_len = 0;
     ti.visits_cap = 0;
+
+    ti.gparam       = nil;
+    ti.gparam_cap   = 0;
+    ti.gparam_epoch = 0;
 
     ti.dedup       = map.init[Type, TypeId](a, hash_type, eq_type);
     ti.fun_index   = map.init[u64, TypeId](a, map.hash_u64, map.eq_u64);
@@ -859,6 +871,9 @@ pub fun dnit(ti: *TypeInterner) {
         }
         A.deallocate[VisitSet](ti.a, ti.visits, ti.visits_cap::usize);
     }
+    if (ti.gparam != nil && ti.gparam_cap > 0) {
+        A.deallocate[u8](ti.a, ti.gparam, ti.gparam_cap::usize);
+    }
 
     map.dnit[Type, TypeId](?ti.dedup);
     map.dnit[u64, TypeId](?ti.fun_index);
@@ -895,6 +910,10 @@ pub fun dnit(ti: *TypeInterner) {
     ti.visits     = nil;
     ti.visits_len = 0;
     ti.visits_cap = 0;
+
+    ti.gparam       = nil;
+    ti.gparam_cap   = 0;
+    ti.gparam_epoch = 0;
 }
 
 # return a pointer to the Type for a given TypeId, or none when tid is out of
@@ -1382,6 +1401,98 @@ fun visit_reserve(ti: *TypeInterner, level: u32, tid: TypeId) O.Option[str] {
 
     memory.zero[u32](?set.stamp[set.cap], (new_cap - set.cap)::usize);
     set.cap = new_cap;
+
+    ret O.none[str]();
+}
+
+# the memo states for "this nominal's field graph mentions a generic parameter"
+#
+# The property is a function of the field tables alone, so it belongs to the interner that
+# owns them and is answered once per nominal per field epoch rather than recomputed by
+# every walk that asks. Deciding it costs a walk of the whole reachable field graph, and
+# the generic-union instance walk asks it at EVERY nominal it enters, which is what made
+# that walk cubic in graph size (#3066).
+pub def GParamMemo: u8;
+
+# not yet decided at this field epoch
+pub val GPARAM_UNKNOWN: GParamMemo = 0;
+# decided: the field graph mentions no generic parameter
+pub val GPARAM_NO:      GParamMemo = 1;
+# decided: the field graph mentions a generic parameter
+pub val GPARAM_YES:     GParamMemo = 2;
+
+# read the memoized answer for `tid`, or GPARAM_UNKNOWN when there is none
+#
+# A field epoch newer than the memo's retires every entry, because a rebuilt field table
+# can change the answer for any nominal that reaches it (#1583).
+# ---
+# ti:  the interner owning the memo
+# tid: the nominal being asked about
+# ret: GPARAM_UNKNOWN, GPARAM_NO, or GPARAM_YES
+pub fun gparam_memo_get(ti: *TypeInterner, tid: TypeId) GParamMemo {
+    if (ti.gparam_epoch != ti.field_epoch) {
+        if (ti.gparam != nil && ti.gparam_cap > 0) {
+            memory.zero[u8](ti.gparam, ti.gparam_cap::usize);
+        }
+        ti.gparam_epoch = ti.field_epoch;
+    }
+    if (ti.gparam == nil || tid >= ti.gparam_cap) { ret GPARAM_UNKNOWN; }
+    ret ti.gparam[tid];
+}
+
+# record the decided answer for `tid`
+#
+# Only a walk that resolved every field table it reached may record one: an answer read
+# off an absent table is about the checker's timing rather than about the type, and
+# freezing it would outlive the table's arrival. An allocation failure growing the memo
+# simply drops the entry, which costs a recomputation and nothing else.
+# ---
+# ti:       the interner owning the memo
+# tid:      the nominal being recorded
+# mentions: the decided answer
+pub fun gparam_memo_set(ti: *TypeInterner, tid: TypeId, mentions: bool) {
+    if (ti.gparam_epoch != ti.field_epoch) {
+        if (ti.gparam != nil && ti.gparam_cap > 0) {
+            memory.zero[u8](ti.gparam, ti.gparam_cap::usize);
+        }
+        ti.gparam_epoch = ti.field_epoch;
+    }
+    if (tid >= ti.gparam_cap) {
+        if (O.is_some[str](gparam_reserve(ti, tid))) { ret; }
+    }
+    if (mentions) { ti.gparam[tid] = GPARAM_YES; }
+    or           { ti.gparam[tid] = GPARAM_NO; }
+}
+
+# grow the memo until `tid` addresses a slot, zeroing the new slots to GPARAM_UNKNOWN
+# ---
+# ti:  the interner
+# tid: the TypeId that must be addressable
+# ret: none once the slot exists, or some(error) on allocation failure
+fun gparam_reserve(ti: *TypeInterner, tid: TypeId) O.Option[str] {
+    var new_cap: u32 = ti.gparam_cap;
+    if (new_cap == 0) { new_cap = INITIAL_VISIT_CAP; }
+    for (new_cap <= tid) {
+        new_cap = new_cap * 2;
+    }
+
+    if (ti.gparam == nil) {
+        val res_alloc: R.Result[*u8, str] = A.allocate[u8](ti.a, new_cap::usize);
+        if (R.is_err[*u8, str](res_alloc)) {
+            ret O.some[str](R.unwrap_err[*u8, str](res_alloc));
+        }
+        ti.gparam = R.unwrap_ok[*u8, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*u8, str] = A.reallocate[u8](ti.a, ti.gparam, ti.gparam_cap::usize, new_cap::usize);
+        if (R.is_err[*u8, str](res_realloc)) {
+            ret O.some[str](R.unwrap_err[*u8, str](res_realloc));
+        }
+        ti.gparam = R.unwrap_ok[*u8, str](res_realloc);
+    }
+
+    memory.zero[u8](?ti.gparam[ti.gparam_cap], (new_cap - ti.gparam_cap)::usize);
+    ti.gparam_cap = new_cap;
 
     ret O.none[str]();
 }


### PR DESCRIPTION
Closes #3066

Both halves of the issue are fixed: the bound, and the cost the bound was hiding.

## 1. The bound

`UniInstScan` held `[256]type.TypeId` with a linear membership scan, and its fail-closed exit **reports**. Reproduced exactly as filed — a chain of `n` records with one `^` at the far end:

| n | `cannot prove ... too large` diagnostics (before) |
|---|---|
| 260 | 5 |
| 300 | 45 |
| 400 | 145 |
| 400, cyclic | 403 |

The first diagnostic lands on `rec R257`, i.e. the first annotation whose walk enters a 257th nominal. The set is now a `type.TypeScan` borrowed from the interner's pool — the mechanism #3065 built — so the two walks are symmetric and the only exhaustion left is the allocator's. The key was already an interned `TypeId` (`nominal_visit_key`), so the substitution is mechanical, and the pool's stack discipline covers the fact that this walk nests around the deep-secret walk (`check_uni_variants` → `secrecy_structure_equal_deep` → `contains_secret_deep`).

## 2. The cost

Measured cubic before, as filed. `nominal_has_gparam` re-walked the whole reachable field graph at **every** nominal the union walk entered, behind a `GParamScan` whose membership test was a linear rescan, and every annotation opened a walk of its own.

Two changes, both from the issue's own list:

- the generic-parameter search borrows a `TypeScan` too, so membership is O(1) rather than a rescan;
- "does this nominal's field graph mention a generic parameter" is memoized on `TypeInterner` per field epoch, since it is a property of the nominal rather than of the walk that asked.

**Only the search's root is memoized.** A nominal met partway through carries the cycle guard's assumption — a re-entry answers "no" so the recursion terminates — and that answer is about the search, not about the nominal: `rec A { b: *B; t: T; }` with `rec B { a: *A; }` decides B "no" inside A's search while B asked on its own decides "yes". A search that reached an unavailable field table does not record either, since that answer is about the checker's timing and would outlive the table's arrival.

Sema phase time, same fixtures, debug compiler:

| fixture | before | after |
|---|---|---|
| n=100 | 34ms | 3ms |
| n=200 | 282ms | 11ms |
| n=300 | 1.0s | 26ms |
| n=400 | 2.4s | **46ms** |
| n=400 cyclic | 13.0s | **77ms** |
| n=800 | — | 185ms |

Growth is now ~4x per doubling (quadratic overall for the module, from summing the memoized searches over roots) rather than ~8x. The acceptance bar — n=400 well under a second — is met by 20x.

The outer factor the issue raised third (whether every annotation needs a walk of its own) is **not** changed here, deliberately: sharing one `UniInstScan` across annotations is sound for the visited set, since the key already encodes the substitution and `uni_report_mark` already dedups violations by key module-wide, but it would change *which annotation's span* a diagnostic is anchored at. That is a behaviour change that wants its own decision, and with the two changes above it is no longer the bottleneck.

## Acceptance

All four arms verified end to end, at n=400, before and after:

| case | before | after |
|---|---|---|
| large graph, `^` at far end, unions agree | 145 `too large` | clean |
| same + cycle | 403 `too large` | clean |
| `U[u32]` deep inside | 146 `too large` | clean |
| `U[^u32]` deep inside | 146 `too large` + 1 violation | 0 `too large` + 1 violation |

So lifting the bound did not become a hole in the rule.

## Test

`mach.lang.driver:uni_instance_walk_scales_with_the_type_graph`, four arms at n=320, reusing the `ut_chain_src` generator #3065 added.

- fail-before (this test against `origin/dev`'s `generics.mach` + `type.mach`): **FAIL, 15.4s**
- pass-after: **ok, 421ms**
- `mach test`, HEAD compiler, debug: **1536 passed, 0 failed** (was 1535; +1 new test)

## Adjacent, not fixed here

`SecrecyPairScan` (`generics.mach`) is a third fixed bound of the same family: 128 nominal **pairs**, linear rescan, and `sse_deep_walk` returns `false` when it fills — which surfaces as a false *"union variants must agree on secrecy"* / *"secret-welded pointer cannot be erased"*, again reachable by graph size alone. It is keyed by a pair, so `TypeScan` is not a drop-in and it wants its own issue rather than scope creep here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MfQ6dUDKvvsGE9f9KBSEn
