### PR TITLE
fix(sema): probe literal coercion before committing expr types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### sema: a parenthesised `c1 - c2 * x` as a right operand lost the subtraction (#3073)
+
+An `f32` binary operation whose right operand was a parenthesised
+`floatlit - floatlit * expr` computed the wrong value, silently:
+
+```mach
+fun bad(a: f32, b: f32) f32 { ret a * (3.0 - 2.0 * b); }
+
+# bad(2.0, 0.5) should be 4.0
+#   opt = 2  ->  6.0      (the `- 2.0 * b` term is gone)
+#   opt = 0  ->  garbage
+```
+
+Literal coercion is offered as a *try*: `unify_literals` first offers the whole
+`2.0 * b` subtree the `f64` its untyped `3.0` sibling defaulted to, and falls back
+to coercing `3.0` toward `f32` when that declines. But the descent committed each
+literal **as it was visited**, so `2.0` was retyped `f64` before `b` declined the
+attempt, and the decline left the stale slot behind. Every surrounding node then
+settled correctly at `f32`, so lowering emitted a `mul f64 (f64, f32)` feeding an
+`f32` subtraction - mixed operand widths the backend read as garbage at `-O0` and
+the release fold collapsed into dropping the `- 2.0 * b` term at `-O2`.
+
+The trigger needed exactly that asymmetry. Spelled as the **left** operand (or a
+call argument, a `ret` value, an annotated `val`), the statement-level
+expected-type coercion re-walked the subtree toward `f32` afterward and repaired
+the stale slot by accident; as the right operand of a binary op, the repair walk
+declined at the non-literal left sibling before ever reaching it. The same shape
+in `i32` carried the same stale `2: i64` and returned the right value only because
+integer truncation of a small constant is lossless.
+
+Coercion is now two-phase: a probe pass decides the whole subtree's outcome
+without writing a single `expr_type` slot, and only a whole-tree success runs the
+committing pass. A declined offer - whatever it managed to coerce along the way -
+now leaves the tree exactly as it found it. A regression test asserts the
+guarantee at the IR level: every lowered arithmetic instruction's operands carry
+exactly the instruction's own type.
+
 ## [4.26.0] - 2026-08-22
 
 ### Added

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1441,6 +1441,28 @@ test "mach.lang.driver:coerced_char_literal_lowers_at_context_width" {
     ret bad;
 }
 
+# a literal subtree offered a type it cannot wholly take must stay untouched (#3073)
+#
+# `a * (3.0 - 2.0 * b)`: the inner subtraction's literal unification first offers
+# the whole `2.0 * b` subtree the f64 default of its untyped `3.0` sibling.
+# coercion committed `2.0: f64` before `b` declined the attempt, and the stale
+# slot survived every later (correct) settlement of the surrounding nodes, so
+# lowering emitted a `mul f64 (f64, f32)` feeding an f32 subtraction - garbage at
+# -O0, a dropped `- 2.0 * b` term at -O2. spelled as the LEFT operand, the
+# statement-level expected-type coercion happened to re-walk the subtree toward
+# f32 and repaired the slot, which is why only the right-operand spelling
+# miscompiled. the guard asserts what the probe-then-commit coercion guarantees:
+# a lowered arithmetic instruction's operands carry exactly its own type.
+test "mach.lang.driver:literal_subtree_partial_coercion_leaves_no_stale_type" {
+    var bad: i32 = 0;
+    if (ut_arith_operand_mismatches("fun f(a: f32, b: f32) f32 { ret a * (3.0 - 2.0 * b); }\nfun main() i32 { ret 0; }\n") != 0) { bad = 1; }
+    # one level deeper: the corrupted subtree is itself a right operand
+    if (ut_arith_operand_mismatches("fun f(a: f32, b: f32) f32 { ret a * (1.0 + (3.0 - 2.0 * b)); }\nfun main() i32 { ret 0; }\n") != 0) { bad = 1; }
+    # the integer shape had the same stale `2: i64` and survived by truncation luck
+    if (ut_arith_operand_mismatches("fun f(a: i32, b: i32) i32 { ret a * (3 - 2 * b); }\nfun main() i32 { ret 0; }\n") != 0) { bad = 1; }
+    ret bad;
+}
+
 # a vector op reaching instruction selection always resolves to DEFINED behavior
 # -- never an ICE, never a silent miscompile. driving real vector ops (a pointer
 # lane-wise add and a full-arity literal) through the HOST backend on each CI
@@ -7232,6 +7254,77 @@ fun ut_lower_errs(text: str) i32 {
 
 # whether `text` reaches the end of lowering with no error on the sink
 fun ut_lower_clean(text: str) bool { ret ut_lower_errs(text) == 0; }
+
+# the number of arithmetic instructions in `text`'s lowered IR whose operand types
+# disagree with the instruction's own type
+#
+# The add/sub/mul/div family is same-type in and out by construction, so any
+# disagreement is a stale expr_type slot that leaked through lowering (#3073).
+# Returns -1 when the harness cannot build/lower, and -2 when lowering succeeded
+# but produced no arithmetic instruction at all, so a fixture rewrite that stops
+# exercising the operators cannot pass vacuously.
+# ---
+# text: the single-module source to compile
+# ret:  the mismatch count, -1 on a harness failure, -2 on a vacuous fixture
+fun ut_arith_operand_mismatches(text: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret -1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = text;
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var out: i32 = -1;
+    val sem: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](sem) && ut_count_errors(?s.diags) == 0) {
+        val low: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_ok[bool, outcome.Fail](low) && ut_count_errors(?s.diags) == 0) {
+            var arith:      u32 = 0;
+            var mismatched: u32 = 0;
+            var ti: u32 = 0;
+            for (ti < p.topo_len) {
+                val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+                if (m != nil) {
+                    var fi: u32 = 0;
+                    for (fi < m.function_len) {
+                        val fn: *ir.Function = ?m.functions[fi];
+                        var ii: u32 = 0;
+                        for (ii < fn.instr_len) {
+                            val ins: *instruction.Instruction = ?fn.instrs[ii];
+                            if (ins.kind == instruction.OP_ADD || ins.kind == instruction.OP_SUB
+                             || ins.kind == instruction.OP_MUL || ins.kind == instruction.OP_DIV_S
+                             || ins.kind == instruction.OP_DIV_U) {
+                                arith = arith + 1;
+                                var oi: u32 = 0;
+                                for (oi < ins.operand_count) {
+                                    if (ins.operands[oi].ty != ins.ty) { mismatched = mismatched + 1; }
+                                    oi = oi + 1;
+                                }
+                            }
+                            ii = ii + 1;
+                        }
+                        fi = fi + 1;
+                    }
+                }
+                ti = ti + 1;
+            }
+            out = mismatched::i32;
+            if (arith == 0) { out = -2; }
+        }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret out;
+}
 
 # whether `text` is rejected with at least one sema error
 fun ut_sema_rejects(text: str) bool { ret ut_sema_errs(text) > 0; }

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -194,8 +194,18 @@ pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.Ty
     # leaves, a folded comptime path, and the `- ~` / arithmetic nodes whose every
     # leaf is one of those. An identifier reference declines (NOT_APPLICABLE), so a
     # value COMPUTED from a secret never reaches this retype however it is spelled.
+    # TWO-PHASE: probe without writing, commit only on a whole-tree COERCED (#3073).
+    # coercion is a try: a decline must leave every expr_type slot untouched. the
+    # recursive descent decides per NODE, so a subtree could coerce its first
+    # literal and then decline on a later operand - `3.0 - 2.0 * b` toward f64
+    # committed `2.0: f64` before `b` declined the whole attempt, and the stale
+    # slot survived into lowering as a mixed-width operand. probing first makes
+    # the outcome known before the first write.
     val pub_to: type.TypeId = type.strip_secret(?sc.s.types, to);
-    val r: CoerceResult = coerce_to(sc, eid, pub_to, false);
+    var r: CoerceResult = coerce_to(sc, eid, pub_to, false, true);
+    if (r.kind == COERCE_COERCED) {
+        r = coerce_to(sc, eid, pub_to, false, false);
+    }
     if (pub_to != to && r.kind == COERCE_OUT_OF_RANGE) {
         # a secret destination: an out-of-range result names the secret type the
         # user actually wrote, while keeping the integer base's bounds.
@@ -212,13 +222,17 @@ pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.Ty
 # expression, so a leaf integer literal is range-checked against the signed
 # negative domain of `to`.
 # ---
+# `probe` suppresses every expr_type write (see try_coerce_literal): the probe
+# pass computes the outcome, the commit pass repeats it with the writes on.
+# ---
 # sc:      the active sema context
 # eid:     the expression to coerce
 # to:      the destination TypeId
 # negated: true when the literal sits under an odd number of unary `-`
+# probe:   true to decide without writing expr_type
 # ret:     COERCED when the possibly nested literal takes `to`, OUT_OF_RANGE when
 #          an integer literal overflows an integer `to`, else NOT_APPLICABLE
-fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) CoerceResult {
+fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     if (eid == id.EXPR_NIL) { ret not_applicable(); }
 
     val opt_e: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
@@ -226,14 +240,14 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
     val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
 
     if (e.kind == expr.EXPR_KIND_LIT_INT) {
-        ret coerce_int_literal(sc, eid, e.data.lit_int, to, negated, true);
+        ret coerce_int_literal(sc, eid, e.data.lit_int, to, negated, true, probe);
     }
     if (e.kind == expr.EXPR_KIND_LIT_CHAR) {
-        ret coerce_int_literal(sc, eid, e.data.lit_char::u64, to, negated, true);
+        ret coerce_int_literal(sc, eid, e.data.lit_char::u64, to, negated, true, probe);
     }
     if (e.kind == expr.EXPR_KIND_LIT_FLOAT) {
         if (to != type.TYPE_F32 && to != type.TYPE_F64) { ret not_applicable(); }
-        ret commit(sc, eid, to);
+        ret commit(sc, eid, to, probe);
     }
     if (e.kind == expr.EXPR_KIND_LIT_NIL) {
         # nil is the null address; it takes any pointer-like type - a raw `ptr`,
@@ -241,19 +255,19 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
         # the null address is a valid null callback). `fn == nil` / `fn != nil`
         # stay related as comparisons in infer_binary, independent of this.
         if (!type.is_pointer_like(?sc.s.types, to)) { ret not_applicable(); }
-        ret commit(sc, eid, to);
+        ret commit(sc, eid, to, probe);
     }
     if (e.kind == expr.EXPR_KIND_COMPTIME_IDENT || e.kind == expr.EXPR_KIND_MEMBER) {
-        ret coerce_comptime_int_path(sc, eid, to, negated);
+        ret coerce_comptime_int_path(sc, eid, to, negated, probe);
     }
     if (e.kind == expr.EXPR_KIND_CALL) {
-        ret coerce_layout_intrinsic(sc, eid, to, negated);
+        ret coerce_layout_intrinsic(sc, eid, to, negated, probe);
     }
     if (e.kind == expr.EXPR_KIND_UNARY) {
-        ret coerce_unary(sc, eid, ?e.data.unary, to, negated);
+        ret coerce_unary(sc, eid, ?e.data.unary, to, negated, probe);
     }
     if (e.kind == expr.EXPR_KIND_BINARY) {
-        ret coerce_binary(sc, eid, ?e.data.binary, to);
+        ret coerce_binary(sc, eid, ?e.data.binary, to, probe);
     }
 
     ret not_applicable();
@@ -276,12 +290,12 @@ fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated
 # to:      the destination TypeId
 # negated: true when the literal sits under an odd number of unary `-`
 # ret:     COERCED, OUT_OF_RANGE, or NOT_APPLICABLE per the destination
-fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: type.TypeId, negated: bool, literal: bool) CoerceResult {
+fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: type.TypeId, negated: bool, literal: bool, probe: bool) CoerceResult {
     val opt_bounds: O.Option[IntBounds] = int_bounds_of(sc, to);
     if (O.is_none[IntBounds](opt_bounds)) { ret not_applicable(); }
     val bounds: IntBounds = O.unwrap[IntBounds](opt_bounds);
     if (!fits_bounds(v, negated, bounds)) { ret out_of_range(to, v, negated, bounds, literal); }
-    ret commit(sc, eid, to);
+    ret commit(sc, eid, to, probe);
 }
 
 # coerce a comptime path that folds to an integer to a destination integer type
@@ -300,14 +314,14 @@ fun coerce_int_literal(sc: *context.SemaContext, eid: id.ExprId, v: u64, to: typ
 # negated: true when the path sits under an odd number of unary `-`
 # ret:     COERCED when the folded integer fits `to`, OUT_OF_RANGE when it
 #          overflows an integer `to`, else NOT_APPLICABLE
-fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) CoerceResult {
+fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     if (!comptime.is_comptime_path(sc.a, eid)) { ret not_applicable(); }
 
     val res_eval: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
     if (R.is_err[comptime.CTValue, str](res_eval)) { ret not_applicable(); }
     val ctval: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](res_eval);
 
-    ret coerce_ct_int(sc, eid, ctval, to, negated);
+    ret coerce_ct_int(sc, eid, ctval, to, negated, probe);
 }
 
 # range-check an already-folded comptime integer against `to` and commit
@@ -324,7 +338,7 @@ fun coerce_comptime_int_path(sc: *context.SemaContext, eid: id.ExprId, to: type.
 # to:      the destination TypeId
 # negated: true when the expression sits under an odd number of unary `-`
 # ret:     COERCED, OUT_OF_RANGE, or NOT_APPLICABLE per the destination
-fun coerce_ct_int(sc: *context.SemaContext, eid: id.ExprId, ctval: comptime.CTValue, to: type.TypeId, negated: bool) CoerceResult {
+fun coerce_ct_int(sc: *context.SemaContext, eid: id.ExprId, ctval: comptime.CTValue, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     if (ctval.kind != comptime.CT_KIND_INT) { ret not_applicable(); }
 
     val raw: i64 = ctval.data.i;
@@ -338,7 +352,7 @@ fun coerce_ct_int(sc: *context.SemaContext, eid: id.ExprId, ctval: comptime.CTVa
     var negated_total: bool = negated;
     if (value_negated) { negated_total = !negated; }
 
-    ret coerce_int_literal(sc, eid, mag, to, negated_total, false);
+    ret coerce_int_literal(sc, eid, mag, to, negated_total, false, probe);
 }
 
 # coerce a layout intrinsic (`$size_of` / `$align_of` / `$length_of`) to a
@@ -368,7 +382,7 @@ fun coerce_ct_int(sc: *context.SemaContext, eid: id.ExprId, ctval: comptime.CTVa
 # negated: true when the call sits under an odd number of unary `-`
 # ret:     COERCED when the measured constant fits `to`, OUT_OF_RANGE when it
 #          overflows an integer `to`, else NOT_APPLICABLE
-fun coerce_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool) CoerceResult {
+fun coerce_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     # every other call is a runtime value and coerces to nothing
     if (!comptime.is_layout_intrinsic_call(sc.a, sc.source, eid)) { ret not_applicable(); }
 
@@ -389,7 +403,7 @@ fun coerce_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, to: type.T
     if (R.is_ok[comptime.CTValue, str](res_eval)) {
         val ctval: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](res_eval);
         if (ctval.kind == comptime.CT_KIND_INT) {
-            ret coerce_ct_int(sc, eid, ctval, to, negated);
+            ret coerce_ct_int(sc, eid, ctval, to, negated, probe);
         }
     }
 
@@ -403,7 +417,7 @@ fun coerce_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, to: type.T
     # Declining instead would leave them `u64`, which is exactly the defect: on an
     # ilp32 target `$size_of(T) * count` against a `usize` count is the mismatch
     # that stopped mach-std compiling at all (#2934).
-    ret commit(sc, eid, to);
+    ret commit(sc, eid, to, probe);
 }
 
 # coerce a unary `-`/`~` node by coercing its operand to `to`
@@ -420,15 +434,15 @@ fun coerce_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, to: type.T
 # negated: true when this node sits under an odd number of unary `-`
 # ret:     COERCED when the operand coerces, else the operand's own outcome
 #          (OUT_OF_RANGE carries the offending literal up unchanged)
-fun coerce_unary(sc: *context.SemaContext, eid: id.ExprId, u: *expr.ExprUnary, to: type.TypeId, negated: bool) CoerceResult {
+fun coerce_unary(sc: *context.SemaContext, eid: id.ExprId, u: *expr.ExprUnary, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     if (u.op != expr.UN_NEG && u.op != expr.UN_BIT_NOT) { ret not_applicable(); }
 
     var operand_negated: bool = negated;
     if (u.op == expr.UN_NEG) { operand_negated = !negated; }
 
-    val r: CoerceResult = coerce_to(sc, u.operand, to, operand_negated);
+    val r: CoerceResult = coerce_to(sc, u.operand, to, operand_negated, probe);
     if (r.kind != COERCE_COERCED) { ret r; }
-    ret commit(sc, eid, to);
+    ret commit(sc, eid, to, probe);
 }
 
 # coerce a binary arithmetic/bitwise node by coercing both operands to `to`
@@ -445,14 +459,14 @@ fun coerce_unary(sc: *context.SemaContext, eid: id.ExprId, u: *expr.ExprUnary, t
 # to:  the destination TypeId
 # ret: COERCED when both operands coerce; otherwise the first non-coercing
 #      operand's outcome (an OUT_OF_RANGE operand carries its literal up unchanged)
-fun coerce_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, to: type.TypeId) CoerceResult {
+fun coerce_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, to: type.TypeId, probe: bool) CoerceResult {
     if (!is_value_preserving_binop(b.op)) { ret not_applicable(); }
 
-    val lhs: CoerceResult = coerce_to(sc, b.lhs, to, false);
+    val lhs: CoerceResult = coerce_to(sc, b.lhs, to, false, probe);
     if (lhs.kind != COERCE_COERCED) { ret lhs; }
-    val rhs: CoerceResult = coerce_to(sc, b.rhs, to, false);
+    val rhs: CoerceResult = coerce_to(sc, b.rhs, to, false, probe);
     if (rhs.kind != COERCE_COERCED) { ret rhs; }
-    ret commit(sc, eid, to);
+    ret commit(sc, eid, to, probe);
 }
 
 # whether a binary operator yields its operand type
@@ -531,8 +545,8 @@ fun fits_bounds(v: u64, negated: bool, bounds: IntBounds) bool {
 # eid: the expression whose type slot to update
 # to:  the coerced TypeId
 # ret: a COERCED CoerceResult carrying `to`
-fun commit(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) CoerceResult {
-    if (sc.expr_type != nil && eid::usize < sc.a.expr_len) {
+fun commit(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, probe: bool) CoerceResult {
+    if (!probe && sc.expr_type != nil && eid::usize < sc.a.expr_len) {
         sc.expr_type[eid] = to;
     }
     ret applicable(to);


### PR DESCRIPTION
## Summary

Fixes the silent `f32` miscompile where a parenthesised `floatlit - floatlit * expr` as the **right operand** of any binary op lost its `- c2 * x` term at `-O2` and produced garbage at `-O0`.

## Root cause (sema, not lowering or codegen)

`try_coerce_literal` is offered as a *try*, but its recursive descent committed each literal's `expr_type` slot **as it was visited**. In `a * (3.0 - 2.0 * b)`:

1. `infer_binary` on the inner subtraction sees `lt = f64` (the untyped `3.0` default) vs `rt = f32` and calls `unify_literals`, which first offers the whole `2.0 * b` subtree the LHS type `f64`.
2. `coerce_binary` coerces `2.0 -> f64` and **commits it**, then `b` (an ident) declines, so the offer returns NOT_APPLICABLE — leaving `expr_type[2.0] = f64` behind.
3. The fallback coerces `3.0 -> f32`; every surrounding node settles at `f32`, no diagnostic.
4. Lowering reads the stale slot and emits mixed-width IR (at `-O0`, pre-pass):

```
%8 = mul f64 f2: f64, %p1: f32   ; 2.0 materialized f64, f32 param as an f64 operand
%9 = sub f32 f3: f32, %8: f64    ; f32 sub consuming a "f64" value
```

The backend reads the mixed widths as garbage at `-O0`; the release folds collapse the ill-typed subtraction into its LHS (`a * 3.0`) at `-O2`.

## Why the trigger matrix has exactly that shape

- **Right operand of any binop / `var` init of a compound expr / nested deeper** — WRONG: the later statement-level expected-type coercion (`check_coercible`) walks lhs-first and declines at the non-literal left sibling (`a`), so the stale slot is never repaired.
- **Left operand / call argument / alone in ret / annotated `val`** — CORRECT: the expected-type walk reaches the subtree, re-coerces toward `f32`, and repairs the stale slot by accident before lowering.
- **`(c - 2.0*b)`** — CORRECT: `lt == rt` at the subtraction, `unify_literals` never fires.
- **`(3.0 - c*b)`, `(3.0 - b*2.0)`, `(3.0 - b/2.0)`** — CORRECT: the offered subtree's *left* operand is non-literal, and `coerce_binary` declines lhs-first before committing anything.
- **i32 same shape** — the IR had the *same* stale `mul i64 2: i64, %p1: i32`, and returned the right value only because truncating a small integer constant is lossless. This PR fixes that latent form too.

## Fix

Two-phase coercion, contained in `fe/sema/coerce.mach`: a `probe` flag threads through the recursive `coerce_to` descent and gates the single `expr_type` write point (`commit`). `try_coerce_literal` probes first (no writes), and only a whole-tree COERCED repeats the walk with writes on. A declined offer now leaves the tree untouched, which is the contract both callers (`unify_literals`, `check_coercible`) already assumed.

## Verification

- Full 15-case trigger matrix from the issue scripted and run at `opt = 0` and `opt = 2`: all six WRONG cases now correct, all CORRECT cases unchanged, output deterministic across runs. IR inspected clean (all-`f32` / all-`i32`).
- Regression test `mach.lang.driver:literal_subtree_partial_coercion_leaves_no_stale_type`: lowers the right-operand, nested, and integer shapes and asserts every arithmetic instruction's operands carry exactly the instruction's own type (with a vacuity guard). Mutation-checked: reverting to the direct (non-probing) call fails the test.
- `mach test .`: 1536 passed, 0 failed. Full `mach build .` self-build clean.

Closes #3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MfQ6dUDKvvsGE9f9KBSEn