### PR TITLE
fix(sema): fold a module-qualified path in a module-level val initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### sema: a `val` initialised from a module-qualified path was not constant (#3075)
+
+A module-level `val` whose initialiser reached through a module reference was not a
+comptime constant, so it could not be used where one is required:
+
+```mach
+use pkg.inner.sizes;
+
+val CAP: usize = sizes.SLOTS;
+
+rec C { slots: [CAP]u8; }   # error: array length is not a comptime constant
+```
+
+The same constant spelled inline (`[sizes.SLOTS]u8`) folded, and so did a `val`
+initialised from the same constant imported as a bare symbol - which is what made the
+defect read as an array-length problem rather than what it was.
+
+**The divergence was one pass earlier than the diagnostic.** The load walk builds each
+module's comptime environment, folding every module-level `val` initialiser in source
+order and binding the ones that fold; an initialiser that does not fold is deliberately
+skipped, and the requirement is enforced at the use site. It installed no
+module-member resolver, so *every* module-qualified path in an initialiser failed with
+"only comptime-evaluable after name resolution" and the name was never bound. Sema then
+answered the qualified path directly, through the resolver it does install, but
+answered the NAME out of an environment the value had never reached.
+
+The load walk owns the import graph, so it can answer such a path itself, and now does:
+`use` records the local name a module-binding path introduces, and the walk installs a
+resolver that reads the member out of the origin module's export list. Resolution is
+structural - an identifier naming a module reference - because no resolve result exists
+that early, and the export list *is* the visibility guard, since a private `val` is not
+in it. A path that still does not name an exported constant answers nothing and folds
+to the same skip as before, so nothing that used to load stops loading.
+
+The same resolver now covers a declaration-scope `$if` gate at load and in the union
+walk, which had the identical hole.
+
 #### sema: `val` was immutable by documentation only (#3074)
 
 Assigning to a `val` was accepted everywhere. A module-level one compiled clean and

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -447,6 +447,9 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     m.pub_consts        = nil;
     m.pub_const_count   = 0;
     m.pub_const_cap     = 0;
+    m.mod_refs          = nil;
+    m.mod_ref_count     = 0;
+    m.mod_ref_cap       = 0;
     m.deps              = nil;
     m.dep_count         = 0;
     m.dep_cap           = 0;
@@ -948,7 +951,7 @@ fun walk_comptime_if_for_load(p: *project.Project, mid: session.ModuleId, ci: *d
 fun comptime_branch_active_load(p: *project.Project, mid: session.ModuleId, br: *decl.ComptimeBranch, source: str, emit_diag: bool) R.Result[bool, str] {
     if (br.cond == id.EXPR_NIL) { ret R.ok[bool, str](true); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val r: R.Result[comptime.CTValue, str] = comptime.eval(?m.ctx, m.a, source, br.cond, ?p.s.interner);
+    val r: R.Result[comptime.CTValue, str] = eval_for_load(p, mid, source, br.cond, float.FLOAT_W_NONE);
     val e_opt: O.Option[*expr.Expr] = ast.get_expr(m.a, br.cond);
     if (O.is_none[*expr.Expr](e_opt)) { ret R.err[bool, str]("comptime branch cond ExprId out of range"); }
     val cond_span: token.Span = O.unwrap[*expr.Expr](e_opt).span;
@@ -1118,11 +1121,56 @@ fun walk_use_for_load(p: *project.Project, mid: session.ModuleId, du: *decl.Decl
     # const merge it no longer needs.
     if (propagate_target_gate(p, mid, dep_mid)) { ret R.ok[bool, str](true); }
 
+    # a path ending AT a module binds a module reference, never a bare const: its
+    # members are reached qualified, and recording the binding is what lets the
+    # load walk fold `alias.CONST` in a later initializer (#3075)
+    if (ut.binds_module) {
+        val name_r: R.Result[intern.StrId, str] = use_bound_name(p, source, du, ut);
+        if (R.is_err[intern.StrId, str](name_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](name_r)); }
+        ret record_mod_ref(p, mid, R.unwrap_ok[intern.StrId, str](name_r), dep_mid);
+    }
+
     if (du.alias.len > 0) {
         ret R.ok[bool, str](true);
     }
 
     ret merge_pub_consts(p, mid, dep_mid, ut.leaf);
+}
+
+# the local name a `use` decl binds: its alias when it spells one, else the
+# path's leaf segment
+fun use_bound_name(p: *project.Project, source: str, du: *decl.DeclUse, ut: UseTarget) R.Result[intern.StrId, str] {
+    if (du.alias.len == 0) { ret R.ok[intern.StrId, str](ut.leaf); }
+    ret intern.intern_span(?p.s.interner, source, du.alias);
+}
+
+# bind `name` to module `dep_mid` in module `mid`'s module-reference table,
+# growing it as needed
+fun record_mod_ref(p: *project.Project, mid: session.ModuleId, name: intern.StrId, dep_mid: session.ModuleId) R.Result[bool, str] {
+    val m: *project.ModuleEntry = ?p.modules[mid::u32];
+    # first binding of a name wins, matching the lookup: a union walk can reach the
+    # same `use` under two targets, and a name bound twice to different modules is
+    # the resolver's duplicate-import error to report
+    if (O.is_some[session.ModuleId](mod_ref_lookup(m, name))) { ret R.ok[bool, str](true); }
+    if (m.mod_refs == nil) {
+        val r: R.Result[*project.ModRef, str] = A.allocate[project.ModRef](p.alloc, INITIAL_DEP_CAP::usize);
+        if (R.is_err[*project.ModRef, str](r)) { ret R.err[bool, str](R.unwrap_err[*project.ModRef, str](r)); }
+        m.mod_refs    = R.unwrap_ok[*project.ModRef, str](r);
+        m.mod_ref_cap = INITIAL_DEP_CAP;
+    }
+    or (m.mod_ref_count == m.mod_ref_cap) {
+        val new_cap: u32 = m.mod_ref_cap * 2;
+        val r: R.Result[*project.ModRef, str] = A.reallocate[project.ModRef](p.alloc, m.mod_refs, m.mod_ref_cap::usize, new_cap::usize);
+        if (R.is_err[*project.ModRef, str](r)) { ret R.err[bool, str](R.unwrap_err[*project.ModRef, str](r)); }
+        m.mod_refs    = R.unwrap_ok[*project.ModRef, str](r);
+        m.mod_ref_cap = new_cap;
+    }
+    var mr: project.ModRef;
+    mr.name   = name;
+    mr.module = dep_mid;
+    m.mod_refs[m.mod_ref_count] = mr;
+    m.mod_ref_count = m.mod_ref_count + 1;
+    ret R.ok[bool, str](true);
 }
 
 # handle one `fwd` re-export during the load walk. a `fwd
@@ -1163,13 +1211,19 @@ fun walk_fwd_for_load(p: *project.Project, mid: session.ModuleId, df: *decl.Decl
 # the resolution of a `use` path into the module to load plus
 # the leaf name an unaliased import binds
 # ---
-# module_fqn: FQN of the module file the path resolves to (longest prefix
-#             of the path naming a real `.mach` file)
-# leaf:       the name an unaliased `use` binds - the trailing symbol
-#             segment when the path ends at a symbol, else the module leaf
+# module_fqn:   FQN of the module file the path resolves to (longest prefix
+#               of the path naming a real `.mach` file)
+# leaf:         the name an unaliased `use` binds - the trailing symbol
+#               segment when the path ends at a symbol, else the module leaf
+# binds_module: whether the path ends AT the module rather than at a symbol inside
+#               it, so the bound name denotes a module and its members are reached
+#               qualified. declared here rather than derived from `module_fqn ==
+#               path`, which is true of the bare-project-id form under a different
+#               spelling
 pub rec UseTarget {
-    module_fqn: intern.StrId;
-    leaf:       intern.StrId;
+    module_fqn:   intern.StrId;
+    leaf:         intern.StrId;
+    binds_module: bool;
 }
 
 # whether the dotted path covers exactly one segment (no `.` separator) - the
@@ -1241,8 +1295,9 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
             val fqn_r: R.Result[intern.StrId, str] = compose_module_fqn(p, O.unwrap[str](id_opt), O.unwrap[str](mod_opt));
             if (R.is_err[intern.StrId, str](fqn_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](fqn_r)); }
             var ut: UseTarget;
-            ut.module_fqn = R.unwrap_ok[intern.StrId, str](fqn_r);
-            ut.leaf       = leaf;
+            ut.module_fqn   = R.unwrap_ok[intern.StrId, str](fqn_r);
+            ut.leaf         = leaf;
+            ut.binds_module = true;
             ret R.ok[UseTarget, str](ut);
         }
     }
@@ -1250,8 +1305,9 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
     # the full path is itself a module file: bind it as a module, leaf is its own name.
     if (fqn_names_file(p, full_id)) {
         var ut: UseTarget;
-        ut.module_fqn = full_id;
-        ut.leaf       = leaf;
+        ut.module_fqn   = full_id;
+        ut.leaf         = leaf;
+        ut.binds_module = true;
         ret R.ok[UseTarget, str](ut);
     }
 
@@ -1270,8 +1326,9 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
         val pid: intern.StrId = R.unwrap_ok[intern.StrId, str](pid_r);
         if (fqn_names_file(p, pid)) {
             var ut: UseTarget;
-            ut.module_fqn = pid;
-            ut.leaf       = leaf;
+            ut.module_fqn   = pid;
+            ut.leaf         = leaf;
+            ut.binds_module = false;
             ret R.ok[UseTarget, str](ut);
         }
         seg_end = dot - 1;
@@ -1410,15 +1467,118 @@ fun record_dep(p: *project.Project, mid: session.ModuleId, dep_mid: session.Modu
 fun merge_pub_consts(p: *project.Project, mid: session.ModuleId, dep_mid: session.ModuleId, leaf: intern.StrId) R.Result[bool, str] {
     val m:   *project.ModuleEntry = ?p.modules[mid::u32];
     val dep: *project.ModuleEntry = ?p.modules[dep_mid::u32];
+    val v: O.Option[comptime.CTValue] = pub_const_lookup(dep, leaf);
+    if (O.is_none[comptime.CTValue](v)) { ret R.ok[bool, str](true); }
+    ret comptime.bind(?m.ctx, leaf, O.unwrap[comptime.CTValue](v));
+}
+
+# the value module `dep` exports under `name`, or none when it exports no such
+# comptime constant. the export list holds exactly the module's `pub` comptime
+# vals, so a miss here IS the visibility guard: a private `val` is not in it
+fun pub_const_lookup(dep: *project.ModuleEntry, name: intern.StrId) O.Option[comptime.CTValue] {
     var i: u32 = 0;
     for (i < dep.pub_const_count) {
         val pc: *project.PubConst = ?dep.pub_consts[i];
-        if (pc.name == leaf) {
-            ret comptime.bind(?m.ctx, pc.name, pc.value);
-        }
+        if (pc.name == name) { ret O.some[comptime.CTValue](pc.value); }
         i = i + 1;
     }
-    ret R.ok[bool, str](true);
+    ret O.none[comptime.CTValue]();
+}
+
+# the module a local name denotes in module `m`, or none when the name binds no
+# module reference
+fun mod_ref_lookup(m: *project.ModuleEntry, name: intern.StrId) O.Option[session.ModuleId] {
+    var i: u32 = 0;
+    for (i < m.mod_ref_count) {
+        val mr: *project.ModRef = ?m.mod_refs[i];
+        if (mr.name == name) { ret O.some[session.ModuleId](mr.module); }
+        i = i + 1;
+    }
+    ret O.none[session.ModuleId]();
+}
+
+# what the load walk's member resolver needs to answer a module-qualified path:
+# the project (re-indexed on every call, since loading a module reallocates the
+# entry array) and the module whose expression is being folded
+rec LoadMemberCtx {
+    p:   *project.Project;
+    mid: session.ModuleId;
+}
+
+# the module-qualified member resolver (a comptime.ModuleMemberFn) the load walk
+# installs around its own folds, so `sizes.SLOTS` folds at load exactly as the
+# bare `SLOTS` an unaliased import binds already does (#3075).
+#
+# Without it a module-level `val` whose initializer reached through a module
+# reference never folded, so it was never bound into the module's ComptimeCtx and
+# every later use of the NAME - an array length, a `$if` gate - reported the name
+# as not a comptime constant, while the same qualified path spelled inline folded
+# fine against the resolver sema installs. The load walk owns the import graph, so
+# it can answer the path here from the alias-to-module map `use` records and the
+# dep's own export list, with no dependency on name resolution.
+#
+# Resolution is structural (an IDENT object naming a module reference) because no
+# resolve result exists yet. Anything else - a member of a value, an unknown name,
+# a member the dep does not export - is none, which the evaluator turns into its
+# ordinary "not a module-level constant" refusal; the caller folding an initializer
+# skips the val exactly as it did before, so nothing that used to load stops.
+# ---
+# data: the *LoadMemberCtx, erased to a ptr by the installer
+# eid:  the MEMBER expression id, valid in this module's ast
+# ret:  some(value) when the path names an exported module-level constant, else none
+fun resolve_module_member_const_load(data: ptr, eid: id.ExprId) R.Result[O.Option[comptime.CTValue], str] {
+    val lc: *LoadMemberCtx = data::*LoadMemberCtx;
+    if (lc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val m: *project.ModuleEntry = ?lc.p.modules[lc.mid::u32];
+    if (m.a == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(m.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val node: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    if (node.kind != expr.EXPR_KIND_MEMBER) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+
+    val o_opt: O.Option[*expr.Expr] = ast.get_expr(m.a, node.data.member.object);
+    if (O.is_none[*expr.Expr](o_opt)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val obj: *expr.Expr = O.unwrap[*expr.Expr](o_opt);
+    if (obj.kind != expr.EXPR_KIND_IDENT) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+
+    val src_opt: O.Option[*src.SourceFile] = src.get(?lc.p.s.sources, m.file_id);
+    if (O.is_none[*src.SourceFile](src_opt)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val source: str = O.unwrap[*src.SourceFile](src_opt).text;
+
+    val obj_r: R.Result[intern.StrId, str] = intern.intern_span(?lc.p.s.interner, source, obj.span);
+    if (R.is_err[intern.StrId, str](obj_r)) { ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[intern.StrId, str](obj_r)); }
+    val dep_opt: O.Option[session.ModuleId] = mod_ref_lookup(m, R.unwrap_ok[intern.StrId, str](obj_r));
+    if (O.is_none[session.ModuleId](dep_opt)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+
+    val name_r: R.Result[intern.StrId, str] = intern.intern_span(?lc.p.s.interner, source, node.data.member.name);
+    if (R.is_err[intern.StrId, str](name_r)) { ret R.err[O.Option[comptime.CTValue], str](R.unwrap_err[intern.StrId, str](name_r)); }
+
+    val dep: *project.ModuleEntry = ?lc.p.modules[(O.unwrap[session.ModuleId](dep_opt))::u32];
+    ret R.ok[O.Option[comptime.CTValue], str](pub_const_lookup(dep, R.unwrap_ok[intern.StrId, str](name_r)));
+}
+
+# fold one of module `mid`'s own comptime expressions with the load walk's member
+# resolver installed for the duration. the window is the call, not the pass: the
+# resolver context lives on this frame, so the borrowed ctx never keeps a pointer
+# into a frame that has returned
+pub fun eval_for_load(
+    p:      *project.Project,
+    mid:    session.ModuleId,
+    source: str,
+    e:      id.ExprId,
+    fw:     float.FloatWidth
+) R.Result[comptime.CTValue, str] {
+    val m: *project.ModuleEntry = ?p.modules[mid::u32];
+    var lc: LoadMemberCtx;
+    lc.p   = p;
+    lc.mid = mid;
+    val lcp: *LoadMemberCtx = ?lc;
+    comptime.set_member_resolver(?m.ctx, resolve_module_member_const_load::*u8, lcp::ptr);
+    val r: R.Result[comptime.CTValue, str] =
+        comptime.eval_at_float_width(?m.ctx, m.a, source, e, ?p.s.interner, fw);
+    comptime.set_member_resolver(?m.ctx, nil, nil);
+    ret r;
 }
 
 # fold a module-level `val` initializer and, when it is comptime, bind it into the
@@ -1453,7 +1613,7 @@ fun register_val_for_load(p: *project.Project, mid: session.ModuleId, d: *decl.D
     # with it only sometimes (#2918).
     val fw: float.FloatWidth = comptime.declared_float_width(m.a, source, d.data.bind.ty);
     val r_val: R.Result[comptime.CTValue, str] =
-        comptime.eval_at_float_width(?m.ctx, m.a, source, d.data.bind.init, ?p.s.interner, fw);
+        eval_for_load(p, mid, source, d.data.bind.init, fw);
     if (R.is_err[comptime.CTValue, str](r_val)) { ret R.ok[bool, str](true); }
     val v: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](r_val);
 

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -214,6 +214,20 @@ pub rec PubConst {
     value: comptime.CTValue;
 }
 
+# one local name a `use` binds to a MODULE rather than to a symbol - the left half
+# of a module-qualified path (`sizes.SLOTS`, `sz.CAP`)
+#
+# The load walk owns the import graph, so it is the only pass that can answer such
+# a path before name resolution runs; it needs the alias-to-module map to do it
+# (#3075). A path ending at a symbol binds no entry here.
+# ---
+# name:   interned local name the import binds (the `use` alias, else the path leaf)
+# module: the module that name denotes
+pub rec ModRef {
+    name:   intern.StrId;
+    module: session.ModuleId;
+}
+
 # one loaded module
 # ---
 # fqn:            interned fully-qualified module path (e.g. "std.types.bool")
@@ -222,6 +236,7 @@ pub rec PubConst {
 # ctx:            comptime context populated during DFS load: target params,
 #                 imports' pub consts, and this-module's pub comptime vals
 # pub_consts:     snapshot of comptime vals declared `pub` in this module
+# mod_refs:       local names this module's `use` decls bind to modules (#3075)
 # deps:           ModuleIds this module directly depends on (active uses only)
 # resolve_result: borrowed pointer to this module's ResolveResult, owned by the
 #                 session query DB as the Q_RESOLVE handle (keyed by stable_id) and
@@ -255,6 +270,9 @@ pub rec ModuleEntry {
     pub_consts:        *PubConst;
     pub_const_count:   u32;
     pub_const_cap:     u32;
+    mod_refs:          *ModRef;
+    mod_ref_count:     u32;
+    mod_ref_cap:       u32;
     deps:              *session.ModuleId;
     dep_count:         u32;
     dep_cap:           u32;
@@ -491,6 +509,9 @@ pub fun dnit_project(p: *Project) {
         # and frees it (and reuses it across rebuilds). do NOT free it here.
         if (m.pub_consts != nil && m.pub_const_cap > 0) {
             A.deallocate[PubConst](p.alloc, m.pub_consts, m.pub_const_cap::usize);
+        }
+        if (m.mod_refs != nil && m.mod_ref_cap > 0) {
+            A.deallocate[ModRef](p.alloc, m.mod_refs, m.mod_ref_cap::usize);
         }
         if (m.deps != nil && m.dep_cap > 0) {
             A.deallocate[session.ModuleId](p.alloc, m.deps, m.dep_cap::usize);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7817,6 +7817,41 @@ test "mach.lang.driver:generic_instance_as_value_cross_module" {
     ret bad;
 }
 
+# a module-level `val` whose initializer reaches through a module reference is a
+# comptime constant, exactly as one initialized from an imported symbol is (#3075)
+#
+# The load walk builds each module's comptime environment and owns the import
+# graph, so it is the pass that can answer `lib.SLOTS` - but it had no member
+# resolver, so such an initializer folded nowhere and the name was never bound.
+# Every later use then reported the NAME as non-constant while the same path
+# spelled inline folded fine against sema's resolver, which is what made the bug
+# read as an array-length defect rather than a hole in the load-time environment.
+test "mach.lang.driver:qualified_module_const_folds_into_val" {
+    var bad: i32 = 0;
+    val lib: str = "pub val KINDS: u64 = 2;\npub val ACTIONS: u64 = 11;\npub val SLOTS: u64 = KINDS * ACTIONS;\n";
+
+    # the reported shape: through a val, then read as an array length
+    if (!ut_sema_clean2("use uniontest.lib;\nval CAP: u64 = lib.SLOTS;\nrec C { slots: [CAP]u8; }\nfun main() i64 { ret 0; }\n", lib)) { bad = 1; }
+
+    # under an alias, and with arithmetic over the qualified path
+    if (!ut_sema_clean2("use a: uniontest.lib;\nval CAP: u64 = a.SLOTS * 2;\nrec C { slots: [CAP]u8; }\nfun main() i64 { ret 0; }\n", lib)) { bad = 1; }
+
+    # chained through a second val and read in a `$if` gate: the value has to be
+    # right, not merely present
+    if (!ut_sema_clean2("use uniontest.lib;\nval CAP: u64 = lib.SLOTS;\nval MORE: u64 = CAP + 1;\nfun main() i64 { $if (MORE != 23) { $error(\"WRONG\"); } ret 0; }\n", lib)) { bad = 1; }
+
+    # the gate above is live rather than skipped: a wrong expectation must fire, or
+    # a fold that quietly stopped answering would pass the clean arms
+    if (ut_vec_diag2("use uniontest.lib;\nval CAP: u64 = lib.SLOTS;\nfun main() i64 { $if (CAP != 99) { $error(\"FIRED\"); } ret 0; }\n", lib, "FIRED") != 0) { bad = 1; }
+
+    # what the origin does not export is still not a constant here: the load-time
+    # answer reads the module's export list, not its private declarations
+    if (ut_vec_diag2("use uniontest.lib;\nval CAP: u64 = lib.HIDDEN;\nrec C { slots: [CAP]u8; }\nfun main() i64 { ret 0; }\n",
+        "val HIDDEN: u64 = 4;\n", "exported by") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # the address of a `#[packed]` field is refused, and the predicate is a CHAIN WALK
 # (#2715)
 #
@@ -11248,18 +11283,21 @@ test "mach.lang.driver:qualified_const_ignores_leaf_import_shadow" {
 }
 
 # a same-module global initialiser that references ANOTHER same-module global
-# folds, even when that other global's own initialiser needed a cross-module
-# resolution to fold (#2486)
+# folds, even when that other global's own initialiser only became constant at
+# LOWERING (#2486)
 #
-# `A`'s initialiser needs the module-qualified member resolver, which exists only
-# once lowering starts (load-time registration runs before name resolution, so it
-# cannot fold `A` and never binds it). Before the fix nothing rebound `A`'s
-# lowering-time fold back into the comptime table, so `B`'s bare `A` reference never
-# found it - the identical shape one scope closer than `a.BASE` was rejected.
-# Checking the folded VALUE (not merely a clean lower) is the point: `0x1000 + 0x48 +
-# 8 = 0x1050` proves the chain folded through both hops, and `p()`'s own read of `B`
-# proves a same-module `val` whose initialiser needed the fix reads back correctly
-# too - the same comptime table backs both.
+# `a.BASE` is measured from a layout, which no pass before lowering holds, so the
+# load walk cannot fold it and `A` binds only once lowering reaches it. Before the
+# fix nothing rebound `A`'s lowering-time fold back into the comptime table, so
+# `B`'s bare `A` reference never found it. Checking the folded VALUE (not merely a
+# clean lower) is the point: `16 + 0x48 + 8 = 0x60` proves the chain folded through
+# both hops, and `p()`'s own read of `B` proves a same-module `val` whose
+# initialiser needed the fix reads back correctly too - the same comptime table
+# backs both.
+#
+# The lever is a LAYOUT measurement rather than the module-qualified path this
+# fixture used to carry: since #3075 the load walk answers a qualified path itself,
+# so that spelling folds one pass earlier and no longer reaches lowering unbound.
 test "mach.lang.driver:same_module_global_folds_through_cross_module_base" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -11271,7 +11309,7 @@ test "mach.lang.driver:same_module_global_folds_through_cross_module_base" {
     names[0] = "main.mach"; names[1] = "a.mach";
     var texts: [2]str;
     texts[0] = "use uniontest.a;\nval A: u64 = a.BASE + 0x48;\nval B: u64 = A + 8;\npub fun p() u64 { ret B; }\nfun main() i32 { ret 0; }\n";
-    texts[1] = "pub val BASE: u64 = 0x1000;\n";
+    texts[1] = "pub rec P { x: u64; y: u64; }\npub val BASE: u64 = $size_of(P);\n";
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
@@ -11282,7 +11320,7 @@ test "mach.lang.driver:same_module_global_folds_through_cross_module_base" {
     val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
     if (m == nil) { bad = 1; }
     or {
-        if (ut_const_uses(m, 0x1050) != 1) { bad = 1; }  # B folded through A folded through a.BASE
+        if (ut_const_uses(m, 0x60) != 1) { bad = 1; }  # B folded through A folded through a.BASE
     }
 
     project.dnit_project(?p);
@@ -11299,6 +11337,11 @@ test "mach.lang.driver:same_module_global_folds_through_cross_module_base" {
 # `B`'s initialiser gets the SAME diagnostic every other non-constant initialiser
 # gets - not a new, special-cased message - because from the evaluator's
 # perspective `A` genuinely is not yet a comptime constant when `B` is folded.
+#
+# It bites only when `A` reaches lowering unbound, so the fixture makes `A` a
+# LAYOUT measurement: a global the load walk can fold is bound before lowering
+# starts and a forward reference to it has always folded, whichever order the two
+# are written in.
 test "mach.lang.driver:same_module_forward_reference_is_refused" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -11310,7 +11353,7 @@ test "mach.lang.driver:same_module_forward_reference_is_refused" {
     names[0] = "main.mach"; names[1] = "a.mach";
     var texts: [2]str;
     texts[0] = "use uniontest.a;\nval B: u64 = A + 8;\nval A: u64 = a.BASE + 0x48;\nfun main() i32 { ret 0; }\n";
-    texts[1] = "pub val BASE: u64 = 0x1000;\n";
+    texts[1] = "pub rec P { x: u64; y: u64; }\npub val BASE: u64 = $size_of(P);\n";
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -33,6 +33,7 @@ use sysos: std.system.os;
 
 use mach.lang.diagnostic;
 use mach.lang.embed;
+use mach.lang.float;
 use mach.lang.fe.ast;
 use mach.lang.fe.comptime;
 use mach.lang.fe.ast.decl;
@@ -490,9 +491,8 @@ fun comptime_branch_active(p: *project.Project, mid: session.ModuleId, source: s
                            br: *decl.ComptimeBranch) R.Result[bool, str] {
     if (br.cond == id.EXPR_NIL) { ret R.ok[bool, str](true); }
     if (str_len(source) == 0) { ret R.ok[bool, str](false); }
-    val m: *project.ModuleEntry = ?p.modules[mid::u32];
     val ev: R.Result[comptime.CTValue, str] =
-        comptime.eval(?m.ctx, m.a, source, br.cond, ?p.s.interner);
+        load.eval_for_load(p, mid, source, br.cond, float.FLOAT_W_NONE);
     if (R.is_err[comptime.CTValue, str](ev)) {
         ret R.err[bool, str](R.unwrap_err[comptime.CTValue, str](ev));
     }


### PR DESCRIPTION
A module-level `val` whose initialiser reaches through a module reference was not a
comptime constant, so `[CAP]u8` was rejected as a non-constant array length - while
`[sizes.SLOTS]u8` spelled inline folded fine, and so did a `val` initialised from the
same constant imported as a bare symbol.

## The divergence

It is one pass earlier than the diagnostic, and it is not in the array-length path.

- `src/lang/fe/sema/infer.mach:3854` - the array length asks `comptime.eval`, which
  answers the NAME `CAP` from the module's `ComptimeCtx`.
- `src/lang/driver/load.mach:1424` (`register_val_for_load`) - the load walk builds
  that ctx, folding every module-level `val` initialiser in source order and binding
  the ones that fold. It installed no `ModuleMemberFn`, so every module-qualified path
  in an initialiser failed with `COMPTIME_MEMBER_NO_RESOLVER_MSG` and the val was
  skipped - deliberate behaviour for a non-foldable initialiser, and the reason the
  failure was silent.
- `src/lang/fe/sema.mach:144` - sema installs `resolve_module_member_const` for type
  resolution, which is why the same path spelled inline answers. It answers the path,
  never the name that was supposed to hold its value.

## The fix

The load walk owns the import graph, so it can answer such a path itself.

- `use` records the local name a module-binding path introduces (`ModRef` on
  `ModuleEntry`); `UseTarget` now declares `binds_module` rather than leaving it to be
  derived from the path spelling.
- The walk installs a resolver for the duration of each of its own folds, which reads
  the member out of the origin module's **export list** - so the export list is the
  visibility guard, and a private `val` is not in it.
- Resolution is structural (an identifier naming a module reference) because no
  resolve result exists that early.
- A path that still does not name an exported constant answers nothing, folding to the
  same skip as before, so nothing that used to load stops loading.
- The same resolver now covers a declaration-scope `$if` gate at load and in the union
  walk, which had the identical hole.

## Verification

Fail-before / pass-after on the new
`mach.lang.driver:qualified_module_const_folds_into_val`, plus a mutation of the
resolver (return the origin's first export instead of the named one) which the test
catches on value, not merely on "it compiled".

Adjacent shapes probed on a two-module scratch project, all folding to the right
values: aliased module reference, arithmetic over the qualified path, a chain through
a second `val`, two different module references in one expression, a qualified read of
a constant that is itself a chain in its own module, `$if` gates, and `$size_of` of the
records sized by each. A non-exported member is still refused.

Two #2486 fixtures used a module-qualified path as their way to make a global fold
only at lowering. That lever is gone, so both are re-levered on a layout measurement,
which is still lowering-only. Their rules are unchanged.

`mach test`: 1541 passed, 0 failed.

Closes #3075
