### PR TITLE
docs(language): writing through a pointer to a val's storage is UB

### DIFF
--- a/doc/language/val-var.md
+++ b/doc/language/val-var.md
@@ -34,6 +34,12 @@ A pointer is the exception that proves the rule — `val p: *T` binds the **addr
 immutably, not the storage it addresses, so `@p = x`, `p.field = x` and `p[i] = x`
 write the pointee and are legal.
 
+The check ends where the address escapes. `?NAME` on a `val` yields a plain `*T` —
+there is deliberately no read-only pointer type — and writing through any pointer
+that reaches a `val`'s storage is **undefined behaviour**: a module-level `val`
+lives in read-only data, so the store typically faults, while a local one may
+silently appear to work. The compiler does not diagnose it.
+
 ## Scope
 
 `val` and `var` work at module top level and inside function bodies.


### PR DESCRIPTION
Records the owner ruling on the open question flagged in #3077: there will be no read-only pointer type or other pointer decorators. `?NAME` on a `val` yields a plain `*T`, and a write through any pointer reaching a `val`'s storage is undefined behaviour — now stated in `doc/language/val-var.md` so the current state is a documented contract rather than a trap.