### PR TITLE
fix(sema): size the deep secrecy-placement comparison to the type universe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### sema: a wide type graph was reported as a mixed-secrecy one (#3080)
+
+A union whose variants place `^` at exactly the same positions was rejected for mixing
+secret and public storage, and a `::` / `:~` between two such types was rejected for
+changing the qualifier - both on graph size alone:
+
+```
+error: union variants must agree on secrecy: overlapping fields are part secret `^`
+       and part public, which would alias the same storage at two classifications
+```
+
+The deep secrecy-placement comparison walks the two types in LOCKSTEP, so its cycle
+guard records PAIRS of nominals. That set held 128 of them behind a linear rescan, and
+a comparison that entered a 129th answered "these two do not place `^` identically".
+The two siblings this release retired (#3065, #3066) reported the checker's own limit
+when they filled; **this one made a substantive claim about the program instead**, so
+the same fixed bound surfaced as a secrecy defect the author had to go looking for and
+could never find. Graph *width* is what reaches it: two 200-field records compared
+field for field enter 201 pairs, while a chain long enough to fill the set is refused
+first by the layout walk's own depth bound.
+
+The pair set now belongs to the interner beside the `TypeId`-keyed one, borrowed in the
+same stack order and retired by the same epoch, keyed by the two ids packed into one
+word - so its capacity is the allocator's, and its membership test is a hash probe
+rather than the rescan that made the comparison quadratic in entered pairs. It stays
+monotone, which is what it always was despite its comment: the set is both the cycle
+guard and a memo of pairs already settled, and every graph that fit under 128 pairs
+gets the answer it got before.
+
+**This completes the fixed-bound walk family.** All three of the secrecy checker's
+graph walks are now sized to the type universe, and none of them can be exhausted by a
+program's size.
+
+The rule itself is unchanged: a genuine placement difference anywhere in a graph of any
+size is still found and still reported as a secrecy violation, and a cyclic graph still
+terminates. A comparison that genuinely cannot be recorded - now only an allocation
+failure - still fails closed, but says so as a limit of the compiler rather than as a
+`^` in the program.
+
 #### sema: a `val` initialised from a module-qualified path was not constant (#3075)
 
 A module-level `val` whose initialiser reached through a module reference was not a

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -10012,6 +10012,176 @@ test "mach.lang.driver:uni_instance_walk_scales_with_the_type_graph" {
     ret bad;
 }
 
+# a fan-out of `n` distinct records `<p>0` .. `<p>{n-1}`, the last of them carrying
+# `last`, followed by `<p>P` naming every one of them as a field
+#
+# WIDTH where `ut_chain_src` builds DEPTH, because the pair counts a lockstep visited set
+# is about are in the hundreds and the semantic layout walk declines past a nest of
+# `SEMA_LAYOUT_MAX_DEPTH` (64) - a chain long enough to fill the pair set is refused by
+# that bound first, and the comparison never gets there. Every leaf is a distinct nominal
+# the comparison must enter, so comparing `AP` against `BP` enters n + 1 pairs at a nesting
+# depth of two, and `last` is where a placement difference is planted so the walk has to
+# cross the whole width to find it.
+# ---
+# alloc: allocator owning the result and every intermediate
+# p:     the record-name prefix, so two fan-outs can share a module
+# n:     number of leaf records
+# last:  the field list of the LAST leaf
+# ret:   the module fragment, owned by the caller, or none on an allocation failure
+fun ut_fanout_src(alloc: *A.Allocator, p: str, n: u32, last: str) O.Option[str] {
+    var acc: str = "";
+    var i:   u32 = 0;
+    for (i < n) {
+        var body: str = "a: u32; b: u32;";
+        if (i == n - 1) { body = last; }
+        val next: R.Result[str, str] = format.sprint(alloc, "{}rec {}{} {{ {} }}\n", acc, p, i, body);
+        if (i > 0) { A.deallocate[char](alloc, acc::*char, str_len(acc) + 1); }
+        if (R.is_err[str, str](next)) { ret O.none[str](); }
+        acc = R.unwrap_ok[str, str](next);
+        i = i + 1;
+    }
+
+    val open: R.Result[str, str] = format.sprint(alloc, "{}rec {}P {{", acc, p);
+    if (n > 0) { A.deallocate[char](alloc, acc::*char, str_len(acc) + 1); }
+    if (R.is_err[str, str](open)) { ret O.none[str](); }
+    acc = R.unwrap_ok[str, str](open);
+
+    i = 0;
+    for (i < n) {
+        val fld: R.Result[str, str] = format.sprint(alloc, "{} f{}: {}{};", acc, i, p, i);
+        A.deallocate[char](alloc, acc::*char, str_len(acc) + 1);
+        if (R.is_err[str, str](fld)) { ret O.none[str](); }
+        acc = R.unwrap_ok[str, str](fld);
+        i = i + 1;
+    }
+
+    val close: R.Result[str, str] = format.sprint(alloc, "{} }}\n", acc);
+    A.deallocate[char](alloc, acc::*char, str_len(acc) + 1);
+    if (R.is_err[str, str](close)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](close));
+}
+
+# a module of two fan-outs `A` and `B`, their last leaves carrying `a_last` and `b_last`,
+# followed by `tail`
+#
+# The two arms of one deep secrecy-placement comparison: `AP` and `BP` are structurally
+# parallel, so the lockstep walk pairs their leaves one for one and any difference between
+# `a_last` and `b_last` is the only thing it can find - after entering every pair before it.
+# ---
+# alloc:  allocator owning the result and every intermediate
+# n:      number of leaves per fan-out
+# a_last: the field list of `A`'s last leaf
+# b_last: the field list of `B`'s last leaf
+# tail:   the module text appended after both fan-outs
+# ret:    the source text, owned by the caller, or none on an allocation failure
+fun ut_pair_src(alloc: *A.Allocator, n: u32, a_last: str, b_last: str, tail: str) O.Option[str] {
+    val fa: O.Option[str] = ut_fanout_src(alloc, "A", n, a_last);
+    if (O.is_none[str](fa)) { ret O.none[str](); }
+    val sa: str = O.unwrap[str](fa);
+
+    val fb: O.Option[str] = ut_fanout_src(alloc, "B", n, b_last);
+    if (O.is_none[str](fb)) {
+        A.deallocate[char](alloc, sa::*char, str_len(sa) + 1);
+        ret O.none[str]();
+    }
+    val sb: str = O.unwrap[str](fb);
+
+    val whole: R.Result[str, str] = format.sprint(alloc, "{}{}{}", sa, sb, tail);
+    A.deallocate[char](alloc, sa::*char, str_len(sa) + 1);
+    A.deallocate[char](alloc, sb::*char, str_len(sb) + 1);
+    if (R.is_err[str, str](whole)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](whole));
+}
+
+# constant-time (#3080): the deep secrecy-placement comparison is bounded by the ALLOCATOR
+# too - the last of the three fixed-capacity visited sets this walk family carried
+#
+# Its set held 128 (left, right) nominal PAIRS behind a linear rescan, and a comparison
+# that entered a 129th answered "these two types do not place `^` identically". That is a
+# substantive claim about the PROGRAM, so unlike the two siblings this bound did not
+# surface as a "cannot prove" diagnostic about the checker - it surfaced as a secrecy error
+# on a union whose variants agree perfectly, or as a rejected reinterpret, reachable by
+# graph size alone.
+#
+# ARMS 1 AND 2 ARE A PAIR. A comparison that gives up rejects a matching graph and a
+# mismatched one alike, so arm 1 alone is satisfied by a walk that never ran and arm 2 by
+# one that gave up at the bound. Held together they say the walk crossed the whole width,
+# reached the leaf where the placements differ, and judged what was there.
+test "mach.lang.driver:secrecy_pair_walk_scales_with_the_type_graph" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+
+    # comfortably past the 128 pairs the visited set used to hold, so a bound reintroduced
+    # at that size - or at the 128-slot power of two the set now grows through - fails here.
+    val n: u32 = 200;
+
+    # ARM 1 - two `n`-leaf graphs placing `^` at the SAME position, overlaid in a union:
+    # COMPILES. This is the reported bug - before the fix the comparison saturated at the
+    # 129th pair and reported these agreeing variants as a mixed-secrecy union.
+    val same_src: O.Option[str] = ut_pair_src(?alloc, n, "a: ^u32; b: u32;", "a: ^u32; b: u32;",
+                                              "uni V { x: AP; y: BP; }\nfun main() i32 { var v: V; ret 0; }\n");
+    if (O.is_none[str](same_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](same_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 2 - the same two graphs with the `^` SWAPPED to the other field of the last leaf,
+    # a genuine placement difference the walk can only find by entering every pair before
+    # it: still REPORTED, and as the union rule's own violation rather than as the checker
+    # giving up. Lifting the bound must not turn the comparison into a hole in the rule.
+    val diff_src: O.Option[str] = ut_pair_src(?alloc, n, "a: ^u32; b: u32;", "a: u32; b: ^u32;",
+                                              "uni V { x: AP; y: BP; }\nfun main() i32 { var v: V; ret 0; }\n");
+    if (O.is_none[str](diff_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](diff_src);
+        if (ut_vec_diag(src, "union variants must agree on secrecy") != 0) { bad = 1; }
+        if (ut_vec_diag(src, "ran out of room") == 0) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 3 - THE OTHER CALLER, on the same two graphs: a `:~` between two pointers whose
+    # pointees place `^` identically is legal however wide they are, and one between the
+    # mismatched pair is still rejected. The union rule and the reinterpret rule ask the
+    # same comparison, so a bound in it silently rejected correct casts as well.
+    val cast_ok: O.Option[str] = ut_pair_src(?alloc, n, "a: ^u32; b: u32;", "a: ^u32; b: u32;",
+                                             "fun f(p: *AP) *BP { ret p :~ *BP; }\nfun main() i32 { ret 0; }\n");
+    if (O.is_none[str](cast_ok)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](cast_ok);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    val cast_bad: O.Option[str] = ut_pair_src(?alloc, n, "a: ^u32; b: u32;", "a: u32; b: ^u32;",
+                                              "fun f(p: *AP) *BP { ret p :~ *BP; }\nfun main() i32 { ret 0; }\n");
+    if (O.is_none[str](cast_bad)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](cast_bad);
+        if (ut_vec_diag(src, "cannot add or drop the secret qualifier") != 0) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    # ARM 4 - A CYCLE INSIDE A LARGE GRAPH still terminates: the last leaf of each fan-out
+    # points back at its own root, so the walk re-enters a pair it has already recorded.
+    # The cycle guard is the whole reason the pair set exists, and a set REUSED across
+    # comparisons is exactly where a stale mark would break it - a comparison that read the
+    # previous one's marks as its own would cut this graph short and call it equal without
+    # looking, and one that read none of its own would not come back at all.
+    val cyc_src: O.Option[str] = ut_pair_src(?alloc, n, "a: ^u32; b: u32; p: *AP;", "a: ^u32; b: u32; p: *BP;",
+                                             "uni V { x: AP; y: BP; }\nfun main() i32 { var v: V; ret 0; }\n");
+    if (O.is_none[str](cyc_src)) { bad = 1; }
+    or {
+        val src: str = O.unwrap[str](cyc_src);
+        if (!ut_sema_clean(src)) { bad = 1; }
+        A.deallocate[char](?alloc, src::*char, str_len(src) + 1);
+    }
+
+    ret bad;
+}
+
 # block-scoped fin structural rules: control flow cannot cross the fin boundary
 # outward - a `ret` inside a fin body is rejected, as is a `brk` / `cnt` whose
 # target loop encloses the fin; a loop fully inside the fin body keeps `brk` /

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -862,7 +862,15 @@ fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.Typ
     # DEEP (#2165): the reinterpret's `^` placement must match through the field graph, not
     # just the pointer / array spine - else `*P :~ *Q` (P has a `^` field, Q public)
     # reinterprets the secret pointee as public and reads it out.
-    if (!generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), from, to)) {
+    val verdict: generics.SecrecyVerdict = generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), from, to);
+    # a comparison the checker could not finish is rejected too, but named as the
+    # checker's limit: the cast may be perfectly secrecy-safe and nothing here saw it.
+    if (verdict == generics.SECRECY_UNRECORDABLE) {
+        report_note(sc, span, "cast: cannot prove that `::` / `:~` leaves the secret qualifier `^` in place",
+            "the checker ran out of room to record this comparison; this is a limit of the compiler, not a defect in the cast");
+        ret false;
+    }
+    if (verdict == generics.SECRECY_DIFFERS) {
         report_note(sc, span, "cast: `::` and `:~` cannot add or drop the secret qualifier `^`",
             "a public value coerces up to secret with no syntax; `:^` is the only downgrade");
         ret false;

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -572,15 +572,43 @@ fun nominal_overlays(s: *session.Session, tid: type.TypeId) O.Option[bool] {
 
 # a paired cycle guard for the deep secrecy-placement comparison, so two mutually
 # recursive record graphs compared field-for-field terminate (#2165)
+#
+# MONOTONE, not a stack: a pair is recorded on entry and never withdrawn, so the set is
+# both the cycle guard and a memo of the pairs this comparison has already settled. Both
+# readings give the same answer. A pair re-entered while its own frame is still open is
+# assumed equal, the standard coinductive treatment for a lockstep equality walk - a cycle
+# introduces no new placement difference. A pair met again after its frame returned was
+# settled TRUE, because a frame that answered false ends the whole comparison at once, and
+# the answer for a pair depends on nothing but the pair.
+#
+# It held 128 pairs behind a linear rescan, and a comparison that entered a 129th answered
+# "these two types do not place `^` identically" - a substantive claim about the program,
+# reported as a secrecy violation, reachable by graph WIDTH alone (#3080). The set is now
+# borrowed from the interner, so its capacity is the allocator's and its membership test is
+# a hash probe rather than a rescan of everything entered so far.
 # ---
-# a:   the left nominal TypeIds currently on the walk
-# b:   the right nominal TypeIds currently on the walk
-# len: number of pairs on the walk (a graph beyond the bound fails closed)
+# scan:         the borrowed pair set, keyed by the (left, right) nominal pair
+# unrecordable: true once a pair could not be recorded, so the comparison's `false` is
+#               about the checker's room rather than about the program's placement
 rec SecrecyPairScan {
-    a:   [128]type.TypeId;
-    b:   [128]type.TypeId;
-    len: u32;
+    scan:         type.PairScan;
+    unrecordable: bool;
 }
+
+# the outcome of one deep secrecy-placement comparison
+#
+# Three states, not a bool, because the walk's fail-closed exit and a real placement
+# difference demand DIFFERENT diagnostics: one names the program's `^`, the other names the
+# checker's limit. Both reject, so folding them together is safe for the rule and wrong for
+# the reader - that conflation is what made a merely large graph read as a secrecy defect.
+pub def SecrecyVerdict: u8;
+
+# `^` appears at identical positions in both types
+pub val SECRECY_EQUAL:        SecrecyVerdict = 0;
+# the placements differ, or could not be aligned - a fact about the two types
+pub val SECRECY_DIFFERS:      SecrecyVerdict = 1;
+# a pair could not be recorded, so the comparison never completed - a fact about the checker
+pub val SECRECY_UNRECORDABLE: SecrecyVerdict = 2;
 
 # whether types `a` and `b` place the secret qualifier `^` IDENTICALLY through the whole
 # type graph - pointer / array spine AND record / union / generic-instance field graphs
@@ -593,20 +621,32 @@ rec SecrecyPairScan {
 # exactly the same positions in both. A fast path returns true when NEITHER side carries
 # a deep secret (any bit-reinterpret between fully-public types is secrecy-safe, so a
 # public reinterpret / union is never over-rejected); only when a secret is involved does
-# the strict field-for-field walk run - conservatively, failing closed on any structure
-# it cannot align (differing field counts, an unresolvable instance, an over-deep graph),
-# since a reinterpret it cannot prove safe must be rejected. Generic-instance field tables
-# are materialized (`ensure_fields`) so the result is independent of elaboration order.
+# the strict field-for-field walk run - conservatively, reporting SECRECY_DIFFERS for any
+# structure it cannot align (differing field counts, an unresolvable instance, a nest past
+# the layout walk's depth), since a reinterpret it cannot prove safe must be rejected.
+# Generic-instance field tables are materialized (`ensure_fields`) so the result is
+# independent of elaboration order.
 # ---
 # s:   the session
 # a:   the first type
 # b:   the second type
-# ret: true when `a` and `b` carry `^` at identical positions
-pub fun secrecy_structure_equal_deep(s: *session.Session, m: layout.Machine, a: type.TypeId, b: type.TypeId) bool {
-    if (!contains_secret_deep(s, a) && !contains_secret_deep(s, b)) { ret true; }
+# ret: SECRECY_EQUAL when `a` and `b` carry `^` at identical positions, SECRECY_DIFFERS
+#      when they do not, SECRECY_UNRECORDABLE when the comparison could not be completed
+pub fun secrecy_structure_equal_deep(s: *session.Session, m: layout.Machine, a: type.TypeId, b: type.TypeId) SecrecyVerdict {
+    if (!contains_secret_deep(s, a) && !contains_secret_deep(s, b)) { ret SECRECY_EQUAL; }
+
     var scan: SecrecyPairScan;
-    scan.len = 0;
-    ret sse_deep_walk(s, m, a, b, ?scan);
+    scan.unrecordable = false;
+    type.pair_scan_begin(?s.types, ?scan.scan);
+    val equal: bool = sse_deep_walk(s, m, a, b, ?scan);
+    type.pair_scan_end(?s.types, ?scan.scan);
+
+    # an unrecordable pair returns false from its own frame and every frame above it, so
+    # the flag decides the verdict whenever it is set: the `false` it produced carries no
+    # information about placement.
+    if (scan.unrecordable) { ret SECRECY_UNRECORDABLE; }
+    if (equal)             { ret SECRECY_EQUAL; }
+    ret SECRECY_DIFFERS;
 }
 
 # the recursive lockstep worker for `secrecy_structure_equal_deep`
@@ -650,17 +690,18 @@ fun sse_deep_walk(s: *session.Session, m: layout.Machine, a: type.TypeId, b: typ
     val a_nom: bool = ta.kind == type.TYPE_REC || ta.kind == type.TYPE_UNI || ta.kind == type.TYPE_INSTANCE;
     val b_nom: bool = tb.kind == type.TYPE_REC || tb.kind == type.TYPE_UNI || tb.kind == type.TYPE_INSTANCE;
     if (a_nom && b_nom) {
+        val mark: type.VisitMark = type.pair_scan_mark(?s.types, ?scan.scan, sa, sb);
         # a seen pair is assumed equal (coinductive): a cycle introduces no new
         # placement difference, so if the non-cyclic parts match the pair matches.
-        var i: u32 = 0;
-        for (i < scan.len) {
-            if (scan.a[i] == sa && scan.b[i] == sb) { ret true; }
-            i = i + 1;
+        if (mark == type.VISIT_SEEN) { ret true; }
+        # a pair the set could not record leaves the walk unbounded from here, so it FAILS
+        # CLOSED - a comparison that cannot finish must not answer "identical placement".
+        # The flag is what keeps the caller's diagnostic about the checker's room instead
+        # of about the program's `^`.
+        if (mark == type.VISIT_FAILED) {
+            scan.unrecordable = true;
+            ret false;
         }
-        if (scan.len >= 128) { ret false; }
-        scan.a[scan.len] = sa;
-        scan.b[scan.len] = sb;
-        scan.len = scan.len + 1;
 
         if (ta.kind == type.TYPE_INSTANCE) { ensure_fields(s, sa); }
         if (tb.kind == type.TYPE_INSTANCE) { ensure_fields(s, sb); }
@@ -1255,7 +1296,14 @@ fun check_uni_variants(sc: *sema.SemaContext, nom: type.TypeId, args: *type.Type
         val raw: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
         val ty:  type.TypeId = subst_or_self(s, raw, args, arg_len);
         if (type_mentions_gparam(s, ty)) { ret; }
-        if (!secrecy_structure_equal_deep(s, sema.machine_of(sc), first, ty)) {
+        val verdict: SecrecyVerdict = secrecy_structure_equal_deep(s, sema.machine_of(sc), first, ty);
+        # a comparison the checker could not finish joins this walk's OWN fail-closed exit,
+        # which already says the answer is about the checker rather than about the program.
+        if (verdict == SECRECY_UNRECORDABLE) {
+            report_unprovable(sc, scan, span);
+            ret;
+        }
+        if (verdict == SECRECY_DIFFERS) {
             if (sema.uni_report_mark(sc.uni_reports, key)) {
                 sema.report(sc, span, "union variants must agree on secrecy: this instantiation makes overlapping fields part secret `^` and part public, which would alias the same storage at two classifications");
             }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -746,7 +746,14 @@ fun check_uni_secrecy(sc: *context.SemaContext, nom: type.TypeId, fields_start: 
         # aliases the secret bytes under the public `Q` overlay and reads them out. A
         # shallow `is_secret` per variant treats `P` as public and misses it.
         if (!cyclic) {
-            if (!generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), first_ty, ty)) {
+            val verdict: generics.SecrecyVerdict = generics.secrecy_structure_equal_deep(sc.s, context.machine_of(sc), first_ty, ty);
+            # a comparison the checker could not finish is still rejected - this rule guards
+            # a disclosure channel - but named as the checker's limit rather than as a `^`
+            # the author placed, which is what a saturated visited set used to claim (#3080).
+            if (verdict == generics.SECRECY_UNRECORDABLE) {
+                context.report(sc, tn.name, "cannot prove that this union's variants agree on secrecy: the checker ran out of room to record the comparison, so the variants are rejected without having been compared");
+            }
+            if (verdict == generics.SECRECY_DIFFERS) {
                 context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
             }
         }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -640,6 +640,10 @@ pub rec FieldTable {
 #                  guard, one per level of nesting, checked out and returned in stack order
 # visits_len:      sets currently borrowed, which is the current nesting depth
 # visits_cap:      allocated sets in visits
+# pairs:           pool of PAIR-keyed visited sets a lockstep walk borrows, one per level
+#                  of nesting, checked out and returned in stack order
+# pairs_len:       sets currently borrowed, which is the current nesting depth
+# pairs_cap:       allocated sets in pairs
 # gparam:          per-TypeId memo of "this nominal's field graph mentions a generic
 #                  parameter", one GPARAM_* state per TypeId
 # gparam_cap:      allocated slots in gparam
@@ -709,6 +713,10 @@ pub rec TypeInterner {
     visits_len: u32;
     visits_cap: u32;
 
+    pairs:     *PairSet;
+    pairs_len: u32;
+    pairs_cap: u32;
+
     gparam:       *u8;
     gparam_cap:   u32;
     gparam_epoch: u32;
@@ -763,6 +771,10 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
     ti.visits     = nil;
     ti.visits_len = 0;
     ti.visits_cap = 0;
+
+    ti.pairs     = nil;
+    ti.pairs_len = 0;
+    ti.pairs_cap = 0;
 
     ti.gparam       = nil;
     ti.gparam_cap   = 0;
@@ -871,6 +883,14 @@ pub fun dnit(ti: *TypeInterner) {
         }
         A.deallocate[VisitSet](ti.a, ti.visits, ti.visits_cap::usize);
     }
+    if (ti.pairs != nil && ti.pairs_cap > 0) {
+        var pi: u32 = 0;
+        for (pi < ti.pairs_cap) {
+            map.dnit[u64, u32](?ti.pairs[pi].seen);
+            pi = pi + 1;
+        }
+        A.deallocate[PairSet](ti.a, ti.pairs, ti.pairs_cap::usize);
+    }
     if (ti.gparam != nil && ti.gparam_cap > 0) {
         A.deallocate[u8](ti.a, ti.gparam, ti.gparam_cap::usize);
     }
@@ -910,6 +930,10 @@ pub fun dnit(ti: *TypeInterner) {
     ti.visits     = nil;
     ti.visits_len = 0;
     ti.visits_cap = 0;
+
+    ti.pairs     = nil;
+    ti.pairs_len = 0;
+    ti.pairs_cap = 0;
 
     ti.gparam       = nil;
     ti.gparam_cap   = 0;
@@ -1401,6 +1425,148 @@ fun visit_reserve(ti: *TypeInterner, level: u32, tid: TypeId) O.Option[str] {
 
     memory.zero[u32](?set.stamp[set.cap], (new_cap - set.cap)::usize);
     set.cap = new_cap;
+
+    ret O.none[str]();
+}
+
+# one visited set over PAIRS of TypeIds, epoch-stamped the way a VisitSet is
+#
+# The deep secrecy-placement comparison walks two type graphs in LOCKSTEP, so what it has
+# to remember is a PAIR (#2165). A `VisitSet` cannot express one: there is no TypeId that
+# denotes the pair the way `nominal_visit_key` interns a (nominal, args) pair, and minting
+# a synthetic type per pair would grow the type universe with types no program names. The
+# key is therefore the two ids packed into one u64, and the value is the epoch that
+# recorded it - so a borrow retires the previous borrower's entries by advancing the epoch
+# rather than by clearing the table, and a mark stays O(1) whatever the table has held.
+#
+# Stale entries are left in place deliberately. They cost one slot each and keep every
+# borrow free of a clear; the table therefore grows to the number of DISTINCT pairs the
+# session has ever compared at this depth, which is the work actually done rather than a
+# constant chosen in advance.
+# ---
+# seen:  packed (left, right) key -> the epoch of the walk that entered it
+# epoch: the epoch the walk currently holding this set marks with
+rec PairSet {
+    seen:  map.Map[u64, u32];
+    epoch: u32;
+}
+
+# a lockstep walk's borrowed pair set: the cycle guard for a comparison whose state is a
+# pair of positions rather than one (#3080)
+#
+# The third and last of the fixed-capacity visited sets this walk family carried. Its bound
+# was 128 pairs with a LINEAR membership rescan, and the walk answered "these two types do
+# not place `^` identically" when it filled - so a type graph merely wide enough to enter a
+# 129th pair was reported as a secrecy violation of the program, in a message about `^`
+# rather than about the checker. Borrowed from the interner, its capacity is the
+# allocator's and its membership test is a hash probe.
+#
+# Borrowed in STACK order for the same reason `TypeScan` is: this comparison runs INSIDE
+# the generic-union instance walk, which asks a secrecy question per variant pair, and each
+# question is a comparison of its own.
+# ---
+# level: the borrowed set's index in the interner's pool, or SCAN_NONE when the borrow
+#        failed - every mark then reports VISIT_FAILED, taking the walk's fail-closed exit
+pub rec PairScan {
+    level: u32;
+}
+
+# borrow a pair set for one lockstep walk, retiring every mark the previous borrower left
+#
+# Infallible for the same reason `type_scan_begin` is: a pool that cannot be grown binds
+# the scan to SCAN_NONE and the failure surfaces at the first mark.
+# ---
+# ti:   the interner owning the pool
+# scan: the handle to bind to the borrowed set
+pub fun pair_scan_begin(ti: *TypeInterner, scan: *PairScan) {
+    if (O.is_some[str](pairs_reserve(ti))) {
+        scan.level = SCAN_NONE;
+        ret;
+    }
+
+    val level: u32 = ti.pairs_len;
+    ti.pairs_len   = ti.pairs_len + 1;
+
+    # epoch 0 is what a freshly initialized slot holds and what a cleared table reads as,
+    # so the counter wraps to 1 rather than to 0, and clearing first makes the wrap exact.
+    if (ti.pairs[level].epoch == 0xFFFFFFFF) {
+        map.clear[u64, u32](?ti.pairs[level].seen);
+        ti.pairs[level].epoch = 1;
+    }
+    or {
+        ti.pairs[level].epoch = ti.pairs[level].epoch + 1;
+    }
+
+    scan.level = level;
+}
+
+# return `scan`'s set to the pool, freeing it for the next walk at this depth
+# ---
+# ti:   the interner owning the pool
+# scan: the handle to release
+pub fun pair_scan_end(ti: *TypeInterner, scan: *PairScan) {
+    if (scan.level == SCAN_NONE) { ret; }
+    ti.pairs_len = scan.level;
+    scan.level   = SCAN_NONE;
+}
+
+# enter the pair `(a, b)` on `scan`, reporting whether this walk had already reached it
+# ---
+# ti:   the interner owning the pool
+# scan: the open scan
+# a:    the left TypeId of the pair
+# b:    the right TypeId of the pair
+# ret:  VISIT_FRESH, VISIT_SEEN, or VISIT_FAILED
+pub fun pair_scan_mark(ti: *TypeInterner, scan: *PairScan, a: TypeId, b: TypeId) VisitMark {
+    if (scan.level == SCAN_NONE) { ret VISIT_FAILED; }
+
+    val set: *PairSet = ?ti.pairs[scan.level];
+    var key: u64      = (a::u64 << 32) | b::u64;
+
+    val got: R.Result[*u32, str] = map.get[u64, u32](?set.seen, ?key);
+    if (R.is_ok[*u32, str](got)) {
+        val slot: *u32 = R.unwrap_ok[*u32, str](got);
+        if (slot[0] == set.epoch) { ret VISIT_SEEN; }
+        slot[0] = set.epoch;
+        ret VISIT_FRESH;
+    }
+
+    if (R.is_err[bool, str](map.insert[u64, u32](?set.seen, key, set.epoch))) { ret VISIT_FAILED; }
+    ret VISIT_FRESH;
+}
+
+# grow the pair pool so one more set can be borrowed, initializing the new sets empty
+# ---
+# ti:  the interner
+# ret: none once a set is free, or some(error) on allocation failure
+fun pairs_reserve(ti: *TypeInterner) O.Option[str] {
+    if (ti.pairs_len < ti.pairs_cap) { ret O.none[str](); }
+
+    var new_cap: u32 = ti.pairs_cap * 2;
+    if (new_cap == 0) { new_cap = INITIAL_VISIT_DEPTH; }
+
+    if (ti.pairs == nil) {
+        val res_alloc: R.Result[*PairSet, str] = A.allocate[PairSet](ti.a, new_cap::usize);
+        if (R.is_err[*PairSet, str](res_alloc)) {
+            ret O.some[str](R.unwrap_err[*PairSet, str](res_alloc));
+        }
+        ti.pairs = R.unwrap_ok[*PairSet, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*PairSet, str] = A.reallocate[PairSet](ti.a, ti.pairs, ti.pairs_cap::usize, new_cap::usize);
+        if (R.is_err[*PairSet, str](res_realloc)) {
+            ret O.some[str](R.unwrap_err[*PairSet, str](res_realloc));
+        }
+        ti.pairs = R.unwrap_ok[*PairSet, str](res_realloc);
+    }
+
+    var i: u32 = ti.pairs_cap;
+    for (i < new_cap) {
+        ti.pairs[i].seen  = map.init[u64, u32](ti.a, map.hash_u64, map.eq_u64);
+        ti.pairs[i].epoch = 0;
+        i = i + 1;
+    }
+    ti.pairs_cap = new_cap;
 
     ret O.none[str]();
 }


### PR DESCRIPTION
Closes #3080

The third and last fixed-capacity visited set of the walk family #3067 and #3078
retired. `SecrecyPairScan` held 128 (left, right) nominal pairs behind a linear rescan
and answered `false` when it filled, which in this walk means "these two types do not
place `^` identically" - so unlike the two siblings, saturation did not surface as a
diagnostic about the checker. It surfaced as a secrecy error about the program.

## The semantics I found: MONOTONE, not a stack

The rec's comment said "the ... TypeIds currently ON the walk", but `sse_deep_walk`
never pops: `scan.len` only ever increments. The set is therefore a monotone visited
set, and it is simultaneously two things:

* a **cycle guard**, for a pair re-entered while its own frame is still open. Assuming
  such a pair equal is the standard coinductive treatment of a lockstep equality walk -
  the greatest fixpoint - and a cycle introduces no new `^` placement.
* a **memo**, for a pair met again after its frame returned. That pair was settled
  TRUE, necessarily: a frame that answers `false` propagates `false` through every
  caller and ends the whole comparison at once, so a second query can only happen after
  a `true`. And the answer for a pair is a function of the pair alone (plus the machine
  model, fixed for the comparison), so replaying it is exact.

Both readings agree, which is why replacing the array with a hash-keyed set is
behaviour-preserving on every graph that fit under 128 pairs. Only the bound is gone.

## Design chosen: a pair pool on the interner

The issue named two candidates. I took the second - a growable pair structure beside
the `TypeScan` pool - and not the "intern the pair into a single key" route:

* `nominal_visit_key` can intern (nominal, args) because a TYPE_INSTANCE genuinely
  *is* that pair; it is a type the program's own graph contains. There is no type that
  denotes "the pair (A, B)". Manufacturing one (a synthetic TYPE_FUN over the two ids,
  say) would put types in the universe that no program names, grow the `TypeId` space
  and therefore every other walk's stamp array, and make the key's meaning a lie.
* The sides of a pair are not always internable nominals anyway - either may be a
  TYPE_INSTANCE - so the `nominal_visit_key` path would need a second mechanism
  underneath it.

So `TypeInterner` grows a `pairs` pool of `PairSet` next to `visits`, with the same
contract as `TypeScan`: borrowed and returned in **stack order** (this comparison runs
*inside* the generic-union instance walk, which asks a secrecy question per variant
pair), retired by an **epoch** rather than a clear, and marked through the same
three-state `VisitMark`. The key is the two ids packed into one `u64`; the table is the
std hash map, so membership is a probe and the linear rescan that made the walk
quadratic in entered pairs went with the bound.

Stale entries are deliberately left in the table. They cost a slot each and keep every
borrow free of a clear, so the table grows to the number of distinct pairs the session
has actually compared at that depth rather than to a constant chosen in advance.

## The fail-closed exit still exists, and no longer misattributes itself

A pair that cannot be recorded is now only an allocation failure, and it still fails
closed - a comparison that cannot finish must not answer "identical placement". But the
walk now returns a three-state `SecrecyVerdict` (`EQUAL` / `DIFFERS` / `UNRECORDABLE`)
so its callers can tell the two apart:

* `check.check_secrecy_cast` reports "cannot prove that `::` / `:~` leaves the secret
  qualifier `^` in place - the checker ran out of room to record this comparison; this
  is a limit of the compiler, not a defect in the cast".
* `infer.check_uni_secrecy` reports "cannot prove that this union's variants agree on
  secrecy: the checker ran out of room to record the comparison, so the variants are
  rejected without having been compared".
* `generics.check_uni_variants` routes it into its own `report_unprovable`, which
  already says the answer is about the checker.

## Repro, both directions

Width, not depth, is what reaches the bound: a chain long enough to fill the pair set
is refused first by `SEMA_LAYOUT_MAX_DEPTH` (64), a separate and deliberate limit, so
`ut_chain_src` cannot express this case. Two 200-leaf fan-out records enter 201 pairs at
a nesting depth of two.

| case (n = 200 leaves per side, `^` in the last leaf) | before | after |
| --- | --- | --- |
| `uni V { x: AP; y: BP; }`, identical `^` placement | `union variants must agree on secrecy` | clean |
| `p :~ *BP` between the same two, identical placement | `cast: ... cannot add or drop the secret qualifier` | clean |
| same graphs, `^` **swapped** in the last leaf, as a union | `union variants must agree on secrecy` | `union variants must agree on secrecy` |
| same graphs, `^` **swapped**, as `:~` | `cast: ... cannot add or drop` | `cast: ... cannot add or drop` |
| mutually recursive graphs with `^`, compared as a union | clean | clean |

Instrumenting the walk pins the mechanism exactly: at the 200-leaf width the pre-fix
walk stops at `pairs=128 result=0`, and with the bound lifted the same comparison runs
`pairs=201 result=1`. The bound was masking nothing - the mismatched arms were rejected
before and are rejected after, and post-fix they are rejected *because the walk crossed
the whole width and found the difference*, not because it gave up at pair 129.

## Test

`mach.lang.driver:secrecy_pair_walk_scales_with_the_type_graph`, shaped like #3078's
`uni_instance_walk_scales_with_the_type_graph`: five arms over a new `ut_fanout_src` /
`ut_pair_src` generator (width where `ut_chain_src` builds depth, for the layout-depth
reason above).

* **fail before / pass after**: with the four source files restored to `origin/dev` and
  only the test kept, `1542 passed, 1 failed`; with the fix, `1543 passed, 0 failed`.
* **mutation**: making re-entry answer equal unconditionally
  (`mark == VISIT_SEEN || mark == VISIT_FRESH` -> `ret true`) fails this test plus five
  existing secrecy tests, so the mismatch arms are load-bearing. Restored by
  commit-then-`git reset --hard`; marker grep confirms it is gone.

Suite: **1542 -> 1543**, exactly the one test added, 0 failed, through the from-source
`out/linux-x86_64/debug/bin/mach`.
