### PR TITLE
fix(dist): make install.ps1 run on windows powershell 5.1

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -6,6 +6,12 @@
 
 $ErrorActionPreference = 'Stop'
 
+# windows powershell 5.1 can start with a SecurityProtocol set that excludes
+# TLS 1.2, and github refuses anything older; or it in rather than overwrite
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
+
 $base = if ($env:MACH_BASE_URL) { $env:MACH_BASE_URL } else { 'https://github.com/briar-systems/mach/releases' }
 $target = 'x86_64-windows'
 
@@ -17,16 +23,20 @@ if (-not [System.Environment]::Is64BitOperatingSystem) {
 if ($env:MACH_VERSION) {
     $tag = if ($env:MACH_VERSION.StartsWith('v')) { $env:MACH_VERSION } else { "v$($env:MACH_VERSION)" }
 } else {
-    $handler = New-Object System.Net.Http.HttpClientHandler
-    $handler.AllowAutoRedirect = $false
-    $client = New-Object System.Net.Http.HttpClient($handler)
+    # HttpWebRequest lives in System.dll, loaded in every powershell; the
+    # HttpClient it replaces needed System.Net.Http, absent by default on
+    # windows powershell 5.1 (#3086). a redirect status is not an error to
+    # GetResponse, so the Location header comes back without an exception.
+    $req = [System.Net.WebRequest]::CreateHttp("$base/latest")
+    $req.Method = 'HEAD'
+    $req.AllowAutoRedirect = $false
+    $resp = $req.GetResponse()
     try {
-        $req = New-Object System.Net.Http.HttpRequestMessage([System.Net.Http.HttpMethod]::Head, "$base/latest")
-        $resp = $client.SendAsync($req).GetAwaiter().GetResult()
-        if (-not $resp.Headers.Location) { throw 'install.ps1: could not resolve the latest release tag' }
-        $tag = ($resp.Headers.Location.ToString() -split '/tag/')[-1]
+        $loc = $resp.Headers['Location']
+        if (-not $loc) { throw 'install.ps1: could not resolve the latest release tag' }
+        $tag = ($loc -split '/tag/')[-1]
     } finally {
-        $client.Dispose()
+        $resp.Close()
     }
 }
 $version = $tag.TrimStart('v')
@@ -40,8 +50,10 @@ $art = @'
 '@
 # the banner is the only colored output: mach magenta (0xff00ff) on a real console
 $e = [char]27
-$mag   = if ([Console]::IsOutputRedirected) { '' } else { "${e}[38;2;255;0;255m" }
-$reset = if ([Console]::IsOutputRedirected) { '' } else { "${e}[0m" }
+# 5.1's console leaves VT processing off, so the escapes would print literally
+$vt    = -not [Console]::IsOutputRedirected -and $Host.UI.SupportsVirtualTerminal
+$mag   = if ($vt) { "${e}[38;2;255;0;255m" } else { '' }
+$reset = if ($vt) { "${e}[0m" } else { '' }
 Write-Host ''
 Write-Host "$mag$art$reset"
 Write-Host "  mach $version ($target)`n"
@@ -63,7 +75,12 @@ $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "mach-install-$([System.IO.Pa
 New-Item -ItemType Directory -Path $tmp | Out-Null
 try {
     Write-Host "`ndownloading $archive..."
-    Invoke-WebRequest -Uri "$base/download/$tag/$archive" -OutFile (Join-Path $tmp $archive)
+    # the progress bar makes 5.1's download an order of magnitude slower; the
+    # scriptblock keeps the preference change out of the caller's session
+    & {
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -UseBasicParsing -Uri "$base/download/$tag/$archive" -OutFile (Join-Path $tmp $archive)
+    }
 
     Write-Host "extracting $archive..."
     Expand-Archive -Path (Join-Path $tmp $archive) -DestinationPath $tmp -Force


### PR DESCRIPTION
Hotfix to `main` because machlang.org serves `dist/install.ps1` raw from `main` — a dev-only fix would not reach users until the next release. Will be back-merged to dev.

The site's `irm https://machlang.org/install.ps1 | iex` lands in Windows PowerShell 5.1 on a stock box, where `System.Net.Http` is not loaded and the latest-tag `HttpClient` probe dies with `Cannot find type [System.Net.Http.HttpClientHandler]`. The tag probe now uses `HttpWebRequest` (System.dll, always loaded); TLS 1.2 is or'd in on 5.1; the banner color gates on `SupportsVirtualTerminal`; the download suppresses the progress bar in a child scope and passes `-UseBasicParsing`. PowerShell 7 behavior is unchanged by construction (guards are version- or capability-gated; `HttpWebRequest` and `-UseBasicParsing` remain supported there).

Verified the redirect endpoint contract (`HEAD /releases/latest` → `Location: …/tag/v4.26.1`) with curl; no pwsh available on this box, so the 5.1-specific paths are argued by construction in the diff comments.

Closes #3086