### PR TITLE
chore: release 4.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.26.2] - 2026-08-23
+
+### Fixed
+
+#### dist: install.ps1 failed on Windows PowerShell 5.1 (#3086)
+
+The windows install one-liner (`irm https://machlang.org/install.ps1 | iex`) died
+with `Cannot find type [System.Net.Http.HttpClientHandler]` on the shell it is
+most likely pasted into: the latest-tag probe built a `System.Net.Http.HttpClient`,
+and that assembly is not loaded by default on Windows PowerShell 5.1, so the
+installer only ever worked in PowerShell 7. The probe now uses `HttpWebRequest`,
+which every PowerShell loads.
+
+Three more 5.1 gaps closed in the same pass: TLS 1.2 is or'd into the protocol set
+(github refuses older, and 5.1 can start without it), the banner color gates on
+`SupportsVirtualTerminal` (5.1's console would print the escapes literally), and
+the download passes `-UseBasicParsing` and suppresses the progress bar in a child
+scope. Shipped as a hotfix to `main` (#3087), since machlang.org serves the script
+from `main` raw; this release records it.
+
 ## [4.26.1] - 2026-08-23
 
 ### Fixed

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.26.1"
+version = "4.26.2"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.26.1";
+pub val MACH_VERSION: str = "4.26.2";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Version bump and changelog for the 4.26.2 patch release: records the install.ps1 Windows PowerShell 5.1 hotfix (#3086, shipped to main as #3087). No compiler change.