### PR TITLE
fix(ct): size the smoke batches above the coarsest clock resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### ct: the probe smoke tests asserted positivity a microsecond clock cannot promise (#3092)
+
+The smoke tests #3070 kept in place of the removed timing gate asserted strictly
+positive mean latencies. On `x86_64-darwin` the monotonic clock ticks in
+microseconds, and the smoke batches ran far below one tick, so an all-zero class
+mean was a truthful reading of the instrument - and failed the 4.26.2 release gate
+on scheduling luck, the exact failure mode #3070 exists to forbid. The latency
+smoke now batches `dudect.LATENCY_INNER` calls per sample, the tool's own "well
+above clock resolution" constant, which makes positivity deterministic on every
+supported clock. The address smoke times single calls by design and cannot batch,
+so its check now asserts exactly what the instrument promises at any resolution:
+finite, non-negative, ordered numbers.
+
 #### dist: install.ps1 failed on Windows PowerShell 5.1 (#3086)
 
 The windows install one-liner (`irm https://machlang.org/install.ps1 | iex`) died

--- a/src/lang/ct/probe.mach
+++ b/src/lang/ct/probe.mach
@@ -274,10 +274,19 @@ fun report(name: str, m: *dudect.Measurement) {
 # SMOKE COUNTS: enough to run every path, far too few to mean anything
 #
 # The suite's job here is to prove the harness still runs, not to measure the machine.
-# These are deliberately tiny so the check costs milliseconds. A real measurement needs
-# the full counts in `dudect`, and is taken deliberately by a person - see
-# `doc/language/secrecy.md`.
-val SMOKE_INNER:  u64 = 8;
+# The round count is deliberately tiny so the check costs milliseconds. A real
+# measurement needs the full counts in `dudect`, and is taken deliberately by a person -
+# see `doc/language/secrecy.md`.
+#
+# The BATCH size is not negotiable the same way (#3092): the latency smoke asserts
+# strictly positive means, and that is only deterministic while every timed batch spans
+# at least one tick of the coarsest monotonic clock a leg runs on - darwin's ticks in
+# MICROSECONDS. A `SMOKE_INNER = 8` batch of the null probe ran in tens of nanoseconds,
+# read 0 whenever no tick boundary fell inside it, and failed the 4.26.2 release gate on
+# an all-zero class mean that was a truthful reading of a sub-resolution batch. So the
+# smoke run times `dudect.LATENCY_INNER` calls per batch, the tool's own "well above
+# clock resolution" constant: 2048 calls of even the cheapest probe span several
+# microseconds, so every batch reads at least one tick everywhere, deterministically.
 val SMOKE_ROUNDS: u64 = 64;
 
 # THE HARNESS IS A TOOL, NOT A GATE (#3070)
@@ -306,14 +315,32 @@ val SMOKE_ROUNDS: u64 = 64;
 # `doc/language/secrecy.md` states which claims rest on it and that they are measurements
 # a developer takes rather than assertions this suite enforces.
 
-# a measurement is well formed: finite, positive means and a finite, non-negative
-# separation
+# a latency measurement is well formed: finite, positive means and a finite,
+# non-negative separation
 #
 # Deliberately not a threshold. This says the instrument produced a number, not that the
-# number is small.
+# number is small. Strict positivity is legitimate here ONLY because the latency smoke
+# batches `dudect.LATENCY_INNER` calls per sample, which spans the coarsest supported
+# clock tick by construction (#3092).
 fun well_formed(m: *dudect.Measurement) bool {
     if (m.mean_fix != m.mean_fix || m.mean_rnd != m.mean_rnd) { ret false; }
     if (m.mean_fix <= 0.0 || m.mean_rnd <= 0.0) { ret false; }
+    val s: f64 = dudect.separation(m);
+    if (s != s) { ret false; }
+    ret s >= 0.0;
+}
+
+# an address-mode measurement is well formed: finite, NON-NEGATIVE means and a finite,
+# non-negative separation
+#
+# Address mode times ONE call per sample - batching is what blinds latency mode to the
+# address channel - and a single sub-microsecond call against darwin's microsecond
+# monotonic clock legitimately reads 0. Zero means are a truthful reading there, so
+# strict positivity would reintroduce the scheduling-luck failure #3070 removed (#3092).
+# Harness-rot coverage stays with the latency smoke, which drives the same measure loop.
+fun well_formed_sub_resolution(m: *dudect.Measurement) bool {
+    if (m.mean_fix != m.mean_fix || m.mean_rnd != m.mean_rnd) { ret false; }
+    if (m.mean_fix < 0.0 || m.mean_rnd < 0.0) { ret false; }
     val s: f64 = dudect.separation(m);
     if (s != s) { ret false; }
     ret s >= 0.0;
@@ -329,9 +356,9 @@ test "mach.lang.ct.probe:the_latency_harness_measures_and_reports" {
     var ct_m:   dudect.Measurement;
     var leak_m: dudect.Measurement;
 
-    dudect.measure(?null_m, null_probe,  0, 0x510E527FADE682D1, SMOKE_INNER, SMOKE_ROUNDS);
-    dudect.measure(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3, SMOKE_INNER, SMOKE_ROUNDS);
-    dudect.measure(?leak_m, leaky_probe, 0, 0x452821E638D01377, SMOKE_INNER, SMOKE_ROUNDS);
+    dudect.measure(?null_m, null_probe,  0, 0x510E527FADE682D1, dudect.LATENCY_INNER, SMOKE_ROUNDS);
+    dudect.measure(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3, dudect.LATENCY_INNER, SMOKE_ROUNDS);
+    dudect.measure(?leak_m, leaky_probe, 0, 0x452821E638D01377, dudect.LATENCY_INNER, SMOKE_ROUNDS);
 
     report("null", ?null_m);
     report("ct",   ?ct_m);
@@ -371,8 +398,8 @@ test "mach.lang.ct.probe:the_address_harness_measures_and_reports" {
     report("leak", ?leak_m);
     report("scan", ?scan_m);
 
-    if (!well_formed(?null_m)) { ret 2; }
-    if (!well_formed(?leak_m)) { ret 3; }
-    if (!well_formed(?scan_m)) { ret 4; }
+    if (!well_formed_sub_resolution(?null_m)) { ret 2; }
+    if (!well_formed_sub_resolution(?leak_m)) { ret 3; }
+    if (!well_formed_sub_resolution(?scan_m)) { ret 4; }
     ret 0;
 }


### PR DESCRIPTION
The 4.26.2 release gate (#3090) failed on `mach.lang.ct.probe:the_latency_harness_measures_and_reports` on x86_64-darwin. Root cause: the smoke test timed `SMOKE_INNER = 8` calls per batch against darwin's microsecond-resolution monotonic clock — a null-probe batch spans tens of nanoseconds, reads 0 unless a tick boundary lands inside it (~3% per batch), and an all-64-zero class (~14% per run) is a truthful measurement that failed the strict-positivity assertion. The two earlier green darwin runs on the same source were the other side of those odds.

Fix per #3092: the latency smoke batches `dudect.LATENCY_INNER` (2048) calls — the tool's own 'well above clock resolution' constant — so every batch spans several microseconds and reads at least one tick on every supported clock, deterministically; strict positivity stays. The address smoke times single calls by design (batching blinds the address channel), where zero is legitimate at microsecond resolution, so its well-formedness drops strict positivity and asserts finite, non-negative, ordered numbers. Harness-rot coverage remains with the latency smoke, which drives the same measure loop.

Verified: full suite 1543/0 locally through the from-source compiler. Darwin verification happens on the release gate re-run of #3090, which this unblocks — the failure mechanism is closed by construction (batch time >> tick), not by threshold tuning.

Closes #3092