### PR TITLE
fix(ct): remove every assertion over a timing measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-#### ct: the probe smoke tests asserted positivity a microsecond clock cannot promise (#3092)
+#### ct: no assertion over a timing measurement remains, of any kind (#3092)
 
-The smoke tests #3070 kept in place of the removed timing gate asserted strictly
-positive mean latencies. On `x86_64-darwin` the monotonic clock ticks in
-microseconds, and the smoke batches ran far below one tick, so an all-zero class
-mean was a truthful reading of the instrument - and failed the 4.26.2 release gate
-on scheduling luck, the exact failure mode #3070 exists to forbid. The latency
-smoke now batches `dudect.LATENCY_INNER` calls per sample, the tool's own "well
-above clock resolution" constant, which makes positivity deterministic on every
-supported clock. The address smoke times single calls by design and cannot batch,
-so its check now asserts exactly what the instrument promises at any resolution:
-finite, non-negative, ordered numbers.
+The smoke tests #3070 kept in place of the removed timing gate still asserted
+that measured means were finite, positive, ordered numbers - billed as structural
+and deterministic. Positivity was neither: `x86_64-darwin`'s monotonic clock
+ticks in microseconds, the smoke batches ran below one tick, and an all-zero
+class mean was a truthful reading of the instrument that failed the 4.26.2
+release gate on scheduling luck - the exact failure mode #3070 exists to forbid.
+
+The assertions are gone entirely, not recalibrated: the smoke tests now run the
+harness and print its table, and can only fail if the harness itself crashes.
+They remain the documented entry point for taking a real measurement (raise the
+counts, read the table), per `doc/language/secrecy.md`.
 
 #### dist: install.ps1 failed on Windows PowerShell 5.1 (#3086)
 

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -413,10 +413,11 @@ machine it runs on, which is why both are unit tests rather than build checks.
 
 **The timing harness is a tool, not a gate.** `mach.lang.ct.probe` is a
 dudect-style harness in the tree. `mach test` runs it at deliberately tiny sample
-counts and asserts only that it still executes and produces finite, positive
-numbers, which is a structural claim about the harness rather than a timing claim
-about the machine. **No threshold over a measured time gates anything**, here or
-anywhere else in the suite.
+counts and prints its table; it asserts **nothing about the numbers** - not a
+threshold, not positivity - because even "a mean is positive" proved to be a
+property of the host's clock resolution rather than of the harness (#3092). The
+run can only fail if the harness itself crashes. **No property of a measured time
+gates anything**, here or anywhere else in the suite.
 
 That is deliberate and it is not a gap. A dudect score is a statistic over
 wall-clock time on hardware nobody controls, so any threshold over it has a

--- a/src/lang/ct/probe.mach
+++ b/src/lang/ct/probe.mach
@@ -273,20 +273,11 @@ fun report(name: str, m: *dudect.Measurement) {
 
 # SMOKE COUNTS: enough to run every path, far too few to mean anything
 #
-# The suite's job here is to prove the harness still runs, not to measure the machine.
-# The round count is deliberately tiny so the check costs milliseconds. A real
-# measurement needs the full counts in `dudect`, and is taken deliberately by a person -
-# see `doc/language/secrecy.md`.
-#
-# The BATCH size is not negotiable the same way (#3092): the latency smoke asserts
-# strictly positive means, and that is only deterministic while every timed batch spans
-# at least one tick of the coarsest monotonic clock a leg runs on - darwin's ticks in
-# MICROSECONDS. A `SMOKE_INNER = 8` batch of the null probe ran in tens of nanoseconds,
-# read 0 whenever no tick boundary fell inside it, and failed the 4.26.2 release gate on
-# an all-zero class mean that was a truthful reading of a sub-resolution batch. So the
-# smoke run times `dudect.LATENCY_INNER` calls per batch, the tool's own "well above
-# clock resolution" constant: 2048 calls of even the cheapest probe span several
-# microseconds, so every batch reads at least one tick everywhere, deterministically.
+# The suite's job here is to run the harness and print its table, not to measure the
+# machine or judge the numbers. These are deliberately tiny so the run costs
+# milliseconds. A real measurement needs the full counts in `dudect`, and is taken
+# deliberately by a person - see `doc/language/secrecy.md`.
+val SMOKE_INNER:  u64 = 8;
 val SMOKE_ROUNDS: u64 = 64;
 
 # THE HARNESS IS A TOOL, NOT A GATE (#3070)
@@ -306,45 +297,17 @@ val SMOKE_ROUNDS: u64 = 64;
 # thresholds had been calibrated over five runs on one linux box, and the relative cost of
 # these probes is a microarchitecture property.
 #
-# WHAT IS ASSERTED HERE IS STRUCTURAL, and so is deterministic: that the harness runs, and
-# that every measurement it produces is a finite, positive, ordered number. That fails if
-# the harness rots, if a probe stops executing, or if a measurement comes back NaN or
-# negative - none of which depend on how long anything took.
+# NOTHING IS ASSERTED OVER A MEASUREMENT - not a threshold, not well-formedness, not
+# positivity (#3092). Even "a mean is strictly positive" turned out to be a property of
+# the clock rather than of the harness: darwin's monotonic clock ticks in microseconds,
+# a smoke batch runs below one tick, and an all-zero class mean is a truthful reading
+# that failed the 4.26.2 release gate on scheduling luck. These tests run the harness
+# and print the table; the only way they go red is the harness itself crashing, which
+# is a defect on any machine and does not depend on how long anything took.
 #
 # WHAT IS PRINTED IS THE MEASUREMENT, in full, every run. Reading it is a person's job.
 # `doc/language/secrecy.md` states which claims rest on it and that they are measurements
 # a developer takes rather than assertions this suite enforces.
-
-# a latency measurement is well formed: finite, positive means and a finite,
-# non-negative separation
-#
-# Deliberately not a threshold. This says the instrument produced a number, not that the
-# number is small. Strict positivity is legitimate here ONLY because the latency smoke
-# batches `dudect.LATENCY_INNER` calls per sample, which spans the coarsest supported
-# clock tick by construction (#3092).
-fun well_formed(m: *dudect.Measurement) bool {
-    if (m.mean_fix != m.mean_fix || m.mean_rnd != m.mean_rnd) { ret false; }
-    if (m.mean_fix <= 0.0 || m.mean_rnd <= 0.0) { ret false; }
-    val s: f64 = dudect.separation(m);
-    if (s != s) { ret false; }
-    ret s >= 0.0;
-}
-
-# an address-mode measurement is well formed: finite, NON-NEGATIVE means and a finite,
-# non-negative separation
-#
-# Address mode times ONE call per sample - batching is what blinds latency mode to the
-# address channel - and a single sub-microsecond call against darwin's microsecond
-# monotonic clock legitimately reads 0. Zero means are a truthful reading there, so
-# strict positivity would reintroduce the scheduling-luck failure #3070 removed (#3092).
-# Harness-rot coverage stays with the latency smoke, which drives the same measure loop.
-fun well_formed_sub_resolution(m: *dudect.Measurement) bool {
-    if (m.mean_fix != m.mean_fix || m.mean_rnd != m.mean_rnd) { ret false; }
-    if (m.mean_fix < 0.0 || m.mean_rnd < 0.0) { ret false; }
-    val s: f64 = dudect.separation(m);
-    if (s != s) { ret false; }
-    ret s >= 0.0;
-}
 
 # the latency harness runs end to end and reports (#1647, #3070)
 #
@@ -356,17 +319,14 @@ test "mach.lang.ct.probe:the_latency_harness_measures_and_reports" {
     var ct_m:   dudect.Measurement;
     var leak_m: dudect.Measurement;
 
-    dudect.measure(?null_m, null_probe,  0, 0x510E527FADE682D1, dudect.LATENCY_INNER, SMOKE_ROUNDS);
-    dudect.measure(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3, dudect.LATENCY_INNER, SMOKE_ROUNDS);
-    dudect.measure(?leak_m, leaky_probe, 0, 0x452821E638D01377, dudect.LATENCY_INNER, SMOKE_ROUNDS);
+    dudect.measure(?null_m, null_probe,  0, 0x510E527FADE682D1, SMOKE_INNER, SMOKE_ROUNDS);
+    dudect.measure(?ct_m,   ct_probe,    0, 0x243F6A8885A308D3, SMOKE_INNER, SMOKE_ROUNDS);
+    dudect.measure(?leak_m, leaky_probe, 0, 0x452821E638D01377, SMOKE_INNER, SMOKE_ROUNDS);
 
     report("null", ?null_m);
     report("ct",   ?ct_m);
     report("leak", ?leak_m);
 
-    if (!well_formed(?null_m)) { ret 1; }
-    if (!well_formed(?ct_m))   { ret 2; }
-    if (!well_formed(?leak_m)) { ret 3; }
     ret 0;
 }
 
@@ -398,8 +358,5 @@ test "mach.lang.ct.probe:the_address_harness_measures_and_reports" {
     report("leak", ?leak_m);
     report("scan", ?scan_m);
 
-    if (!well_formed_sub_resolution(?null_m)) { ret 2; }
-    if (!well_formed_sub_resolution(?leak_m)) { ret 3; }
-    if (!well_formed_sub_resolution(?scan_m)) { ret 4; }
     ret 0;
 }


### PR DESCRIPTION
Owner ruling on #3092: remove it. Supersedes the batch-resize approach merged in #3093 — no property of a measurement is asserted at all now, not positivity, not well-formedness. The smoke tests run the harness and print the table (staying the documented tool entry point per doc/language/secrecy.md), and can only fail if the harness itself crashes, which is deterministic on any machine. secrecy.md and the 4.26.2 changelog entry updated to match. Full suite 1543/0 locally.

Closes #3092