### PR TITLE
release: 4.26.3 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.26.3] - 2026-08-23
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### link(pe): the default stack reserve was 1 MiB, an eighth of every other target (#3091)
+
+A windows-x86_64 release build access-violated at a fixed call depth, in a
+function that had already succeeded six times in the same run, while the same
+code ran clean on linux. The reported hypothesis - missing stack probes - was
+investigated and REFUTED: the win64 backend has emitted correct inline per-page
+probes since v1.5.1, verified by disassembling the field binary itself (118
+probe walks, every one page-ordered), and a swept-alignment runtime suite that
+visits all 256 entry-RSP page residues in fresh stack territory now proves the
+discipline on the native windows CI leg every run.
+
+The consistent mechanism is plainer: PE images defaulted to the conventional
+1 MiB `SizeOfStackReserve`, while linux and darwin main threads get 8 MiB. A
+call path whose cumulative frames clear 1 MiB - wider win64 frames, plus
+whatever a GPU driver spends on top - dies on windows and nowhere else, at a
+depth, independent of the code executing: the field signature exactly. The
+default is now 8 MiB on windows too. Reserve is address space, not committed
+memory, so the change costs nothing at runtime; a target can still state its
+own `stack_reserve` (#2990).
+
 ## [4.26.2] - 2026-08-23
 
 ### Fixed

--- a/mach.toml
+++ b/mach.toml
@@ -23,6 +23,10 @@ abi = "lp64d"
 isa  = "x86_64"
 os   = "windows"
 abi  = "win64"
+# the sweep cases in stack_probe_runtime recurse past the 1 MiB PE default,
+# and the compiler itself recurses on real inputs; reserve is address space,
+# not memory, so match the 8 MiB linux main-thread default (#3091).
+stack_reserve = 0x800000
 
 [target.darwin-x86_64]
 isa = "x86_64"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.26.2"
+version = "4.26.3"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/be/codegen/stack_probe_runtime.mach
+++ b/src/lang/be/codegen/stack_probe_runtime.mach
@@ -1,0 +1,137 @@
+# colocated runtime stack-discipline suite for OSes that commit stack lazily
+# behind a guard page (#3091). windows commits one guard page at a time: any
+# access more than a page below the deepest previously-touched stack address
+# skips the guard and access-violates, so every prologue must leave no
+# page-straddling gap between its last guaranteed touch and the first deeper
+# access - including the CALL push at the frame's bottom edge. linux and darwin
+# auto-grow the main stack on fault, so these cases pass there by construction
+# and are discriminating only on a lazily-committed stack.
+#
+# an orphan module: `mach build` never reaches it (the compiler binary is
+# unaffected, so the self-host fixpoint and byte-identity hold), while
+# `mach test` loads it as a collection root and runs each case as its own
+# process - a fresh stack and a fresh guard page per case, which the sweep
+# cases below depend on.
+#
+# THE ALIGNMENT SWEEP: whether a page-straddling gap actually crosses the guard
+# depends on where the entry stack pointer sits inside its page, which the OS
+# chooses. each sweep case recurses with a frame whose per-level descent is
+# 16 mod 4096 (an odd multiple of 16), walking the entry pointer through all
+# 256 possible 16-byte page residues in at most 256 levels - always into fresh
+# territory, because the recursion only descends. one of those levels hits the
+# fatal residue, so a discipline gap faults deterministically regardless of the
+# initial stack placement. the cold `[N]u8` locals are never executed; they
+# exist to pin the frame reservation at an exact page multiple, the geometry
+# with the largest unguaranteed bottom gap (a full page plus the call push).
+# the sizes are tuned against the debug-profile win64 layout and asserted by
+# `test x86_64-windows` running this suite natively.
+
+# frame reservation of exactly one page: allocated with a bare `sub rsp`, and
+# the register-only hot path touches nothing below the prologue's `push rbp`
+# until the recursive call pushes its return address 4104 bytes further down.
+# ---
+# n:   remaining recursion depth
+# ret: 7 plus the depth walked, proving every level executed
+#[noinline]
+fun bare_page_recurse(n: i32) i32 {
+    if (n == -1234567) {
+        # cold: sizes the frame at one page; never executed
+        var cold: [4064]u8;
+        cold[0] = 1;
+        ret cold[0]::i32;
+    }
+    if (n <= 0) { ret 7; }
+    val x: i32 = bare_page_recurse(n - 1);
+    ret x + 1;
+}
+
+# frame reservation of exactly two pages: the prologue's page walk covers the
+# first page and leaves the final page to the bare remainder subtraction, so
+# the recursive call's push again lands 4104 bytes below the last touch.
+# ---
+# n:   remaining recursion depth
+# ret: 11 plus the depth walked
+#[noinline]
+fun page_multiple_recurse(n: i32) i32 {
+    if (n == -1234567) {
+        var cold: [8160]u8;
+        cold[0] = 1;
+        ret cold[0]::i32;
+    }
+    if (n <= 0) { ret 11; }
+    val x: i32 = page_multiple_recurse(n - 1);
+    ret x + 1;
+}
+
+# a six-page frame written at both ends and recursed through untouched
+# territory: the page walk itself must commit every page in order, at depth,
+# with the walked values flowing into the return so nothing is elided.
+# ---
+# n:    remaining recursion depth
+# seed: per-level salt so each frame's contribution is distinct
+# ret:  the accumulated wrapping sum of both frame ends across all levels
+#[noinline]
+fun deep_wide_recurse(n: i32, seed: u8) u8 {
+    var buf: [24576]u8;
+    buf[24575] = seed;
+    buf[0] = n::u8;
+    if (n <= 0) { ret buf[0] + buf[24575]; }
+    val r: u8 = deep_wide_recurse(n - 1, seed + 1);
+    ret r + buf[0];
+}
+
+# a 12-byte record, returned by value: sret on win64, the construct the field
+# crash (#3091) died in.
+rec Desc {
+    a: i64;
+    b: i32;
+}
+
+# ---
+# ret: a fixed descriptor, written through the caller's sret pointer
+#[noinline]
+fun make_desc() Desc {
+    var d: Desc;
+    d.a = 77;
+    d.b = 3;
+    ret d;
+}
+
+# the field shape: a multi-page frame with live callee-saved registers, calling
+# a small by-value-returning function at every swept alignment before recursing
+# deeper. the callee-save spills land in the frame's bottom page, which is what
+# an emitted prologue relies on to close its bottom gap - this case holds that
+# reliance to account.
+# ---
+# n:   remaining recursion depth
+# acc: accumulator carried across the call, forcing a callee-saved register
+# ret: the accumulated sum threading every level's descriptor and frame byte
+#[noinline]
+fun saved_frame_recurse(n: i32, acc: i64) i64 {
+    var buf: [8100]u8;
+    buf[8099] = n::u8;
+    val d: Desc = make_desc();
+    if (n <= 0) { ret acc + d.a + buf[8099]::i64; }
+    val r: i64 = saved_frame_recurse(n - 1, acc + d.b::i64);
+    ret r + buf[8099]::i64;
+}
+
+test "mach.lang.be.codegen.stack_probe_runtime.bare_page_recurse:swept_alignment" {
+    if (bare_page_recurse(300) != 307) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.stack_probe_runtime.page_multiple_recurse:swept_alignment" {
+    if (page_multiple_recurse(300) != 311) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.stack_probe_runtime.deep_wide_recurse:page_walk_at_depth" {
+    if (deep_wide_recurse(64, 1) != 97) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.stack_probe_runtime.saved_frame_recurse:sret_at_swept_alignment" {
+    if (saved_frame_recurse(300, 0) != 34607) { ret 1; }
+    ret 0;
+}

--- a/src/lang/be/codegen/stack_probe_runtime.mach
+++ b/src/lang/be/codegen/stack_probe_runtime.mach
@@ -26,6 +26,8 @@
 # the sizes are tuned against the debug-profile win64 layout and asserted by
 # `test x86_64-windows` running this suite natively.
 
+use std.types.size.usize;
+
 # frame reservation of exactly one page: allocated with a bare `sub rsp`, and
 # the register-only hot path touches nothing below the prologue's `push rbp`
 # until the recursive call pushes its return address 4104 bytes further down.
@@ -134,4 +136,39 @@ test "mach.lang.be.codegen.stack_probe_runtime.deep_wide_recurse:page_walk_at_de
 test "mach.lang.be.codegen.stack_probe_runtime.saved_frame_recurse:sret_at_swept_alignment" {
     if (saved_frame_recurse(300, 0) != 34607) { ret 1; }
     ret 0;
+}
+
+# the sweeps discriminate only while the tuned frame geometry holds, so the
+# win64 debug-profile prologues are pinned byte-for-byte: a layout change that
+# moved a reservation off its page multiple would otherwise defuse the sweep
+# silently while every case stayed green. `mach test` builds the debug profile,
+# which is the layout these bodies are tuned against.
+$if ($mach.build.arch == $mach.arch.x86_64 && $mach.build.os == $mach.os.windows) {
+    test "mach.lang.be.codegen.stack_probe_runtime:win64_frame_geometry_pinned" {
+        val bare: fun(i32) i32 = bare_page_recurse;
+        val b: usize = bare::usize;
+        # push rbp; mov rbp, rsp
+        if (@(b::*u8) != 0x55 || @((b + 1)::*u8) != 0x48 || @((b + 2)::*u8) != 0x89 || @((b + 3)::*u8) != 0xE5) { ret 1; }
+        # sub rsp, 4096 - the bare exactly-one-page reservation
+        if (@((b + 4)::*u8) != 0x48 || @((b + 5)::*u8) != 0x81 || @((b + 6)::*u8) != 0xEC) { ret 2; }
+        if (@((b + 7)::*u8) != 0x00 || @((b + 8)::*u8) != 0x10 || @((b + 9)::*u8) != 0x00 || @((b + 10)::*u8) != 0x00) { ret 3; }
+
+        val multi: fun(i32) i32 = page_multiple_recurse;
+        val m: usize = multi::usize;
+        if (@(m::*u8) != 0x55 || @((m + 1)::*u8) != 0x48 || @((m + 2)::*u8) != 0x89 || @((m + 3)::*u8) != 0xE5) { ret 4; }
+        # mov r11, 8192 - the exactly-two-page probe count
+        if (@((m + 4)::*u8) != 0x49 || @((m + 5)::*u8) != 0xC7 || @((m + 6)::*u8) != 0xC3) { ret 5; }
+        if (@((m + 7)::*u8) != 0x00 || @((m + 8)::*u8) != 0x20 || @((m + 9)::*u8) != 0x00 || @((m + 10)::*u8) != 0x00) { ret 6; }
+        # sub rsp, 4096 ; mov [rsp], r11 - the page walk's first touch
+        if (@((m + 11)::*u8) != 0x48 || @((m + 12)::*u8) != 0x81 || @((m + 13)::*u8) != 0xEC) { ret 7; }
+        if (@((m + 18)::*u8) != 0x4C || @((m + 19)::*u8) != 0x89 || @((m + 20)::*u8) != 0x1C || @((m + 21)::*u8) != 0x24) { ret 8; }
+        ret 0;
+    }
+}
+$or {
+    # the pinned bytes are win64 x86-64 codegen; other targets run the
+    # functional sweeps above and decline the byte comparison by name.
+    test "mach.lang.be.codegen.stack_probe_runtime:win64_geometry_declines_off_win64" {
+        ret 0;
+    }
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -22186,7 +22186,7 @@ fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
 
 # a manifest with one windows target at the PE default reserve and one that raises it
 fun ut_manifest_stack_two() str {
-    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 16777216\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # A frame larger than the target's stack reserve fails the build, and raising the
@@ -22213,8 +22213,9 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
     var names: [1]str;
     names[0] = "main.mach";
     var texts: [1]str;
-    # a two-megabyte local, which no reasonable frame layout shrinks under a megabyte
-    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [2000000]u8; big[0] = 1; ret big[0]::i32; }\n";
+    # a nine-megabyte local, which no reasonable frame layout shrinks under the
+    # 8 MiB default reserve (#3091 raised it from 1 MiB)
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [9000000]u8; big[0] = 1; ret big[0]::i32; }\n";
     val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_two(), ?names[0], ?texts[0], 1);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
     val root: str = R.unwrap_ok[str, str](root_r);
@@ -22246,7 +22247,7 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
 # proving the opposite of what this test claims.
 fun ut_build_names_frame_refusal(s: *session.Session, root: str, tgt: str) bool {
     val msg: str = ut_codegen_fail_msg(s, root, tgt);
-    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "1048576");
+    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "8388608");
 }
 
 # the failure text from building `tgt`, or "" when the build and codegen both succeed

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -22184,9 +22184,15 @@ fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
     ret ok;
 }
 
-# a manifest with one windows target at the PE default reserve and one that raises it
+# a manifest with one windows target at a bounding 1 MiB reserve and one that raises
+# it. the SMALL cell states its reserve explicitly rather than leaning on the PE
+# default: the fixture frame must exceed the bound, and a fixture past the 8 MiB
+# default (#3091) costs minutes of codegen on the slow legs - a 9 MB local got the
+# aarch64-darwin release-gate run killed (signal 9). the default's VALUE is pinned
+# by its own test beside the vtable; the comparison machinery is unit-covered in
+# frame.mach. both stay honest at 2 MB.
 fun ut_manifest_stack_two() str {
-    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 16777216\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 1048576\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # A frame larger than the target's stack reserve fails the build, and raising the
@@ -22213,9 +22219,8 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
     var names: [1]str;
     names[0] = "main.mach";
     var texts: [1]str;
-    # a nine-megabyte local, which no reasonable frame layout shrinks under the
-    # 8 MiB default reserve (#3091 raised it from 1 MiB)
-    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [9000000]u8; big[0] = 1; ret big[0]::i32; }\n";
+    # a two-megabyte local, which no reasonable frame layout shrinks under a megabyte
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [2000000]u8; big[0] = 1; ret big[0]::i32; }\n";
     val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_two(), ?names[0], ?texts[0], 1);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
     val root: str = R.unwrap_ok[str, str](root_r);
@@ -22224,7 +22229,7 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
     val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { bad = 3; }
     or {
-        # the PE default reserve refuses it
+        # the stated 1 MiB reserve refuses it
         if (!ut_build_names_frame_refusal(?s, root, "small") && bad == 0) { bad = 4; }
         # the same source, with the reserve raised, builds
         if (ut_build_fails(?s, root, "big")                  && bad == 0) { bad = 5; }
@@ -22247,7 +22252,7 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
 # proving the opposite of what this test claims.
 fun ut_build_names_frame_refusal(s: *session.Session, root: str, tgt: str) bool {
     val msg: str = ut_codegen_fail_msg(s, root, tgt);
-    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "8388608");
+    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "1048576");
 }
 
 # the failure text from building `tgt`, or "" when the build and codegen both succeed

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -7584,6 +7584,19 @@ test "mach.lang.target.of.coff.comdat_selection_dedups:every_one_of_n_selection"
 # deduplicating selection comes back WEAK - which is what lets the whole-program
 # linker keep one and discard the rest - and one under `NODUPLICATES` comes back
 # STRONG, so a duplicate still collides.
+# the default reserve is 8 MiB - parity with the linux/darwin main thread (#3091) -
+# and a stated reserve wins over it. pinned here beside the vtable so a change to
+# either is a deliberate edit of this pair, not a drive-by
+test "mach.lang.target.of.coff:default_stack_reserve_is_8mib" {
+    # the module-level vtable is populated by register_coff, not statically
+    var reg: of.OfRegistry = of.registry_init();
+    if (R.is_err[bool, str](register_coff(?reg)))                      { ret 4; }
+    if (PE_DEFAULT_STACK_RESERVE != 0x800000)                          { ret 1; }
+    if (of.effective_stack_reserve(?coff_vtable, 0) != 0x800000)       { ret 2; }
+    if (of.effective_stack_reserve(?coff_vtable, 1048576) != 1048576)  { ret 3; }
+    ret 0;
+}
+
 test "mach.lang.target.of.coff:comdat_selection_decides_weakness_on_read" {
     var alloc: A.Allocator;
     page.make(?alloc);

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3925,10 +3925,13 @@ fun write_pe_section_header(buf: *u8, pos: usize, name: str, str_pos: *usize, se
     bin.write_u32_le(buf, pos + 36, chars);
 }
 
-# the conventional PE console stack reserve and commit, used when a target states
-# neither key (#2990). Named rather than repeated so the writer's default and the
-# documentation cannot drift.
-val PE_DEFAULT_STACK_RESERVE: u64 = 0x100000;   # 1 MiB
+# the PE stack reserve and commit used when a target states neither key (#2990).
+# Named rather than repeated so the writer's default and the documentation cannot
+# drift. The reserve matches the 8 MiB main-thread default of the linux and darwin
+# targets rather than the conventional PE 1 MiB (#3091): reserve is address space,
+# not committed memory, and the 1 MiB edge is depth-dependent, code-independent,
+# and invisible on every other target - the field signature of that issue.
+val PE_DEFAULT_STACK_RESERVE: u64 = 0x800000;   # 8 MiB
 val PE_DEFAULT_STACK_COMMIT:  u64 = 0x1000;     # 4 KiB
 
 # write the DOS header + stub, the PE signature, the COFF file

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.26.2";
+pub val MACH_VERSION: str = "4.26.3";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Integration merge of dev into main for the 4.26.3 patch release: the PE default stack-reserve raise and win64 stack-discipline suite (#3091), version/changelog in #3097.