### PR TITLE
test(driver): bound the reserve-refusal fixture with a stated reserve

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -22184,9 +22184,15 @@ fun ut_pe_stack_of(p: *project.Project, res: *u64, com: *u64) bool {
     ret ok;
 }
 
-# a manifest with one windows target at the PE default reserve and one that raises it
+# a manifest with one windows target at a bounding 1 MiB reserve and one that raises
+# it. the SMALL cell states its reserve explicitly rather than leaning on the PE
+# default: the fixture frame must exceed the bound, and a fixture past the 8 MiB
+# default (#3091) costs minutes of codegen on the slow legs - a 9 MB local got the
+# aarch64-darwin release-gate run killed (signal 9). the default's VALUE is pinned
+# by its own test beside the vtable; the comparison machinery is unit-covered in
+# frame.mach. both stay honest at 2 MB.
 fun ut_manifest_stack_two() str {
-    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 16777216\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    ret "[project]\nid = \"stk\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.small]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 1048576\n\n[target.big]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\nstack_reserve = 8388608\n\n[target.lin]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.stk]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/stk\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # A frame larger than the target's stack reserve fails the build, and raising the
@@ -22213,9 +22219,8 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
     var names: [1]str;
     names[0] = "main.mach";
     var texts: [1]str;
-    # a nine-megabyte local, which no reasonable frame layout shrinks under the
-    # 8 MiB default reserve (#3091 raised it from 1 MiB)
-    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [9000000]u8; big[0] = 1; ret big[0]::i32; }\n";
+    # a two-megabyte local, which no reasonable frame layout shrinks under a megabyte
+    texts[0] = "#[symbol(\"mainCRTStartup\")]\nfun main() i32 { var big: [2000000]u8; big[0] = 1; ret big[0]::i32; }\n";
     val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_manifest_stack_two(), ?names[0], ?texts[0], 1);
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 2; }
     val root: str = R.unwrap_ok[str, str](root_r);
@@ -22224,7 +22229,7 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
     val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
     if (R.is_err[bool, str](rr)) { bad = 3; }
     or {
-        # the PE default reserve refuses it
+        # the stated 1 MiB reserve refuses it
         if (!ut_build_names_frame_refusal(?s, root, "small") && bad == 0) { bad = 4; }
         # the same source, with the reserve raised, builds
         if (ut_build_fails(?s, root, "big")                  && bad == 0) { bad = 5; }
@@ -22247,7 +22252,7 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
 # proving the opposite of what this test claims.
 fun ut_build_names_frame_refusal(s: *session.Session, root: str, tgt: str) bool {
     val msg: str = ut_codegen_fail_msg(s, root, tgt);
-    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "8388608");
+    ret str_contains(msg, "stack reserve cannot hold") && str_contains(msg, "1048576");
 }
 
 # the failure text from building `tgt`, or "" when the build and codegen both succeed

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -7584,6 +7584,19 @@ test "mach.lang.target.of.coff.comdat_selection_dedups:every_one_of_n_selection"
 # deduplicating selection comes back WEAK - which is what lets the whole-program
 # linker keep one and discard the rest - and one under `NODUPLICATES` comes back
 # STRONG, so a duplicate still collides.
+# the default reserve is 8 MiB - parity with the linux/darwin main thread (#3091) -
+# and a stated reserve wins over it. pinned here beside the vtable so a change to
+# either is a deliberate edit of this pair, not a drive-by
+test "mach.lang.target.of.coff:default_stack_reserve_is_8mib" {
+    # the module-level vtable is populated by register_coff, not statically
+    var reg: of.OfRegistry = of.registry_init();
+    if (R.is_err[bool, str](register_coff(?reg)))                      { ret 4; }
+    if (PE_DEFAULT_STACK_RESERVE != 0x800000)                          { ret 1; }
+    if (of.effective_stack_reserve(?coff_vtable, 0) != 0x800000)       { ret 2; }
+    if (of.effective_stack_reserve(?coff_vtable, 1048576) != 1048576)  { ret 3; }
+    ret 0;
+}
+
 test "mach.lang.target.of.coff:comdat_selection_decides_weakness_on_read" {
     var alloc: A.Allocator;
     page.make(?alloc);


### PR DESCRIPTION
The 4.26.3 release gate (#3098) failed on aarch64-darwin: signal 9 on `a_frame_larger_than_the_stack_reserve_is_refused`. My release-prep edit had grown its fixture to a 9 MB local to exceed the new 8 MiB default (#3091/#3095), and codegen cost scales with local size — driver tests went 17s to 40s on linux and past the resource limit on the slow darwin arm leg.

Fix: the test's small cell states an explicit 1 MiB reserve, restoring the original cheap 2 MB fixture (the frame-vs-reserve comparison it exercises is unchanged, and is unit-covered in frame.mach); the 8 MiB default VALUE is pinned by a new zero-codegen test beside the coff vtable (`default_stack_reserve_is_8mib`, which also asserts a stated reserve wins). Full suite 1549/0, back to 9.7s from 40s.