### PR TITLE
of(coff): build .xdata from declared frame-unwind records, not prologue byte-matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,24 @@ frames, and each callee-save offset - on a per-function record that rides the
 object image through codegen re-homing and the link merge to the PE writer,
 which builds `UNWIND_INFO` from the record. The byte-matcher is deleted: a
 record-less function (frame-omitting leaf, `#[naked]`, foreign code covered by
-its own `.pdata`) contributes no unwind data, never a pattern-matched guess. A
-structural test cross-checks every emitted prologue shape's `.xdata` against
-the prologue's own bytes, and a windows-gated runtime suite has
-`RtlVirtualUnwind` itself recover a probed frame's caller exactly.
+its own `.pdata`) contributes no unwind data, never a pattern-matched guess.
+
+The records also survive the disk object round-trip, which is not a corner: the
+test dispatcher always links from written `.o` files and warm incremental links
+do the same, so an in-memory-only record would silently vanish from exactly
+those binaries. The COFF emitter serializes the records into a mach-private
+`.mach.frames` section - name-keyed by function symbol, so the weak COMDAT
+split cannot skew them - and the parser restores and strips it. Getting there
+also surfaced that every object parser filled the caller's image field by
+field, leaving fields it predates as heap garbage; a parsed object's garbage
+`frame_count` summed to a terabyte-scale allocation that linux overcommit
+absorbed and windows commit charging refused. Parsers now zero the whole image
+at entry, closing that field-drop class for good.
+
+A structural test cross-checks every emitted prologue shape's `.xdata` against
+the prologue's own bytes, a round-trip unit test pins the `.o` seam (weak
+function included), and a windows-gated runtime suite has `RtlVirtualUnwind`
+itself recover a probed frame's caller exactly.
 
 ## [4.26.3] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### of(coff): probed prologues fell out of the unwind-info pattern, understating large-frame .xdata (#3096)
+
+Found during the #3091 investigation: the PE writer synthesized each function's
+`.pdata`/`.xdata` by pattern-matching prologue bytes, and it only knew the
+small-frame shape `push rbp; mov rbp, rsp; sub rsp, imm`. A probed prologue -
+any frame over one page, emitted as the `mov r11, total` page-walk - fell out
+of the pattern after the push, so every such function's unwind record carried
+a bare `UWOP_PUSH_NONVOL RBP`: no allocation, no save codes. Anything that
+unwinds through such a frame - SEH dispatch, `RtlVirtualUnwind`-based stack
+walks, debuggers without full symbols, profilers - recovered an RSP short by
+the whole frame and read wrong non-volatile values. The #3091 field binary had
+123 such frames. Realigned frames (an over-aligned local's `and rsp, -N`)
+fared worse: no record at all.
+
+The fix is the declared-over-derived shape the target axes already use: the
+prologue's facts are known at emission, so the x64 encoder now records them -
+the push, ONE allocation of the total (the probe walk is an implementation
+detail of how RSP moved), the frame-pointer establishment for realigned
+frames, and each callee-save offset - on a per-function record that rides the
+object image through codegen re-homing and the link merge to the PE writer,
+which builds `UNWIND_INFO` from the record. The byte-matcher is deleted: a
+record-less function (frame-omitting leaf, `#[naked]`, foreign code covered by
+its own `.pdata`) contributes no unwind data, never a pattern-matched guess. A
+structural test cross-checks every emitted prologue shape's `.xdata` against
+the prologue's own bytes, and a windows-gated runtime suite has
+`RtlVirtualUnwind` itself recover a probed frame's caller exactly.
+
 ## [4.26.3] - 2026-08-23
 
 ### Fixed

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -450,6 +450,13 @@ fun pack_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_symbols));
     }
 
+    val res_frames: R.Result[bool, str] = pack_frames(?image, enc, text_sec, placements, placement_count);
+    if (R.is_err[bool, str](res_frames)) {
+        if (placements != nil) { A.deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
+        obj.dnit(?image);
+        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_frames));
+    }
+
     # relocations are recorded by target name and bound to symbol indices only
     # after pack_globals, because a global's aggregate initializer may point at a
     # global that pass has not packed yet. binding also declares any target no
@@ -651,6 +658,35 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
         if (R.is_err[u32, str](res_sym)) {
             ret R.err[bool, str](R.unwrap_err[u32, str](res_sym));
         }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# carry every declared frame-unwind record onto the image, re-homed to its final
+# section and offset exactly as its function's symbol mark is (#3096)
+#
+# The encoder keyed each record by the function's `.text`-blob entry offset, the
+# same key the entry `SymbolMark` carries, so `site_placed` resolves both to the
+# same (section, offset) and the record stays beside the code it describes - a
+# `#[section("...")]` function's record moves with it.
+# ---
+# image:           object image the records are appended to
+# enc:             encoder output supplying the frame records
+# text_sec:        index of the `.text` section a non-sectioned function stays in
+# placements:      the sectioned-function ranges, in increasing text offset
+# placement_count: number of placements
+# ret:             true on success, or an allocation error
+fun pack_frames(image: *of.ObjectImage, enc: *encode.EncoderOutput, text_sec: u32,
+                placements: *SectionPlacement, placement_count: u32) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < enc.frame_count) {
+        val site: PlacedSite = site_placed(placements, placement_count, text_sec, enc.frames[i].offset);
+        var fr: of.FrameUnwind = enc.frames[i];
+        fr.section = site.sec;
+        fr.offset  = site.off;
+        val res_fr: R.Result[bool, str] = obj.add_frame(image, ?fr);
+        if (R.is_err[bool, str](res_fr)) { ret res_fr; }
         i = i + 1;
     }
     ret R.ok[bool, str](true);

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -83,6 +83,8 @@ pub rec EncoderOutput {
     inline_pc_count: u32;
     consts:       *ConstEntry;
     const_count:  u32;
+    frames:       *of.FrameUnwind;
+    frame_count:  u32;
 }
 
 # one retained PC<->source mapping: a `.text` byte offset and the source location of
@@ -1083,6 +1085,11 @@ pub rec EncodeState {
     consts:      *ConstEntry;
     const_count: u32;
     const_cap:   u32;
+    # per-function frame-unwind records (#3096): one opened per emitted prologue,
+    # its steps appended as the prologue instructions are emitted
+    frames:      *of.FrameUnwind;
+    frame_count: u32;
+    frame_cap:   u32;
     last_inline_site: u32;
     next_block_id:  u32;
     has_next_block: bool;
@@ -1272,6 +1279,8 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirM
     out.varloc_count = st.varloc_count;
     out.consts       = st.consts;
     out.const_count  = st.const_count;
+    out.frames       = st.frames;
+    out.frame_count  = st.frame_count;
 
     # the text, symbol, relocation, line-row, varloc, and constant-pool arrays are
     # transferred to the output; only the driver-internal fixup and block-offset
@@ -1341,6 +1350,77 @@ pub fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u3
     st.syms[st.sym_count].offset = offset;
     st.syms[st.sym_count].flags  = flags;
     st.sym_count = st.sym_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# open a frame-unwind record for the function whose prologue is about to be
+# emitted (#3096), growing the frame array on demand
+#
+# The record is keyed by the function's `.text` offset - the same key its entry
+# `SymbolMark` carries - so the object builder can re-home it beside the symbol.
+# Steps are appended through `push_frame_step` while the prologue is emitted.
+# ---
+# st:     the encode state whose frame array receives the record
+# offset: byte offset of the function entry within `.text`
+# ret:    ok(true) on success, or an allocation error
+pub fun push_frame(st: *EncodeState, offset: u32) R.Result[bool, str] {
+    if (st.frame_count >= st.frame_cap) {
+        val res_grow: R.Result[bool, str] = grow_frames(st);
+        if (R.is_err[bool, str](res_grow)) { ret res_grow; }
+    }
+    st.frames[st.frame_count].section    = 0;
+    st.frames[st.frame_count].offset     = offset;
+    st.frames[st.frame_count].step_count = 0;
+    st.frame_count = st.frame_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# append one prologue step to the frame-unwind record `push_frame` opened last
+#
+# The step capacity is sized to the widest prologue any ISA emits, so exhausting
+# it is an encoder defect and fails the encode loudly rather than shipping an
+# understated record - the silent-understatement failure mode is the one #3096
+# exists to remove.
+# ---
+# st:      the encode state whose open frame record receives the step
+# kind:    one of of.FRAME_STEP_*
+# reg:     ISA register number (unused for FRAME_STEP_ALLOC)
+# end_off: function-relative byte offset just past the step's instruction(s)
+# value:   the step's byte quantity (alloc size / save offset / frame bias)
+# ret:     ok(true) on success, or an error when no record is open or it is full
+pub fun push_frame_step(st: *EncodeState, kind: u8, reg: u8, end_off: u32, value: u64) R.Result[bool, str] {
+    if (st.frame_count == 0) {
+        ret R.err[bool, str]("encode: frame step recorded with no open frame record");
+    }
+    val fr: *of.FrameUnwind = ?st.frames[st.frame_count - 1];
+    if (fr.step_count >= of.FRAME_STEP_CAP) {
+        ret R.err[bool, str]("encode: frame record step capacity exceeded");
+    }
+    fr.steps[fr.step_count].kind    = kind;
+    fr.steps[fr.step_count].reg     = reg;
+    fr.steps[fr.step_count].end_off = end_off;
+    fr.steps[fr.step_count].value   = value;
+    fr.step_count = fr.step_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# grow the frame-record array, allocating it on first use
+# ---
+# st:  the state whose frame array is grown
+# ret: ok(true) once the array has room, or an allocation error
+fun grow_frames(st: *EncodeState) R.Result[bool, str] {
+    if (st.frames == nil) {
+        val res_alloc: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](st.alloc, DRIVER_INIT_CAP::usize);
+        if (R.is_err[*of.FrameUnwind, str](res_alloc)) { ret R.err[bool, str](R.unwrap_err[*of.FrameUnwind, str](res_alloc)); }
+        st.frames    = R.unwrap_ok[*of.FrameUnwind, str](res_alloc);
+        st.frame_cap = DRIVER_INIT_CAP;
+        ret R.ok[bool, str](true);
+    }
+    val new_cap: u32 = st.frame_cap * 2;
+    val res_realloc: R.Result[*of.FrameUnwind, str] = A.reallocate[of.FrameUnwind](st.alloc, st.frames, st.frame_cap::usize, new_cap::usize);
+    if (R.is_err[*of.FrameUnwind, str](res_realloc)) { ret R.err[bool, str](R.unwrap_err[*of.FrameUnwind, str](res_realloc)); }
+    st.frames    = R.unwrap_ok[*of.FrameUnwind, str](res_realloc);
+    st.frame_cap = new_cap;
     ret R.ok[bool, str](true);
 }
 
@@ -1925,6 +2005,9 @@ pub fun state_blank(st: *EncodeState, alloc: *A.Allocator, model: *isa.MachineMo
     st.consts      = nil;
     st.const_count = 0;
     st.const_cap   = 0;
+    st.frames      = nil;
+    st.frame_count = 0;
+    st.frame_cap   = 0;
     st.last_inline_site = 0;
     st.next_block_id  = 0;
     st.has_next_block = false;
@@ -1975,6 +2058,12 @@ fun state_dnit(st: *EncodeState) {
     st.consts      = nil;
     st.const_count = 0;
     st.const_cap   = 0;
+    if (st.frames != nil && st.frame_cap > 0) {
+        A.deallocate[of.FrameUnwind](st.alloc, st.frames, st.frame_cap::usize);
+    }
+    st.frames      = nil;
+    st.frame_count = 0;
+    st.frame_cap   = 0;
     scratch_release(st);
 }
 
@@ -2190,6 +2279,14 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[bool, str]
     for (ri < st.reloc_count) {
         if (st.relocs[ri].offset >= pos) { st.relocs[ri].offset = st.relocs[ri].offset + nbytes; }
         ri = ri + 1;
+    }
+    # a frame record's steps are function-relative and a gap never opens inside a
+    # prologue (relaxation patches branches, and no prologue holds one), so only
+    # the function-start offset shifts.
+    var fri: u32 = 0;
+    for (fri < st.frame_count) {
+        if (st.frames[fri].offset >= pos) { st.frames[fri].offset = st.frames[fri].offset + nbytes; }
+        fri = fri + 1;
     }
     var wi: u32 = 0;
     for (wi < st.row_count) {

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -2628,6 +2628,29 @@ fun free_load_segments(alloc: *A.Allocator, segs: *of.LoadSegment, count: u32) {
 # seg_count:  number of load segments
 # func_count: out - number of function ranges produced
 # ret:        the function-range array (freed by the caller), or an error string
+# whether frame record `a` sorts after `b` in (section, offset) order
+fun frame_key_after(a: *of.FrameUnwind, b: *of.FrameUnwind) bool {
+    if (a.section != b.section) { ret a.section > b.section; }
+    ret a.offset > b.offset;
+}
+
+# binary-search the sorted frame index for the record at (section, offset),
+# returning its index into `out_img.frames` or 0xFFFFFFFF when no function
+# declared one there
+fun frame_find(out_img: *of.ObjectImage, fidx: *u32, section: u32, offset: u32) u32 {
+    if (fidx == nil || out_img.frame_count == 0) { ret 0xFFFFFFFF; }
+    var lo: u32 = 0;
+    var hi: u32 = out_img.frame_count;
+    for (lo < hi) {
+        val mid: u32 = lo + (hi - lo) / 2;
+        val fr: *of.FrameUnwind = ?out_img.frames[fidx[mid]];
+        if (fr.section == section && fr.offset == offset) { ret fidx[mid]; }
+        if (fr.section < section || (fr.section == section && fr.offset < offset)) { lo = mid + 1; }
+        or                                                                         { hi = mid; }
+    }
+    ret 0xFFFFFFFF;
+}
+
 fun build_exec_functions(alloc: *A.Allocator, out_img: *of.ObjectImage,
                          segs: *of.LoadSegment, seg_count: u32,
                          func_count: *u32) R.Result[*of.ExecFunction, str] {
@@ -2640,6 +2663,33 @@ fun build_exec_functions(alloc: *A.Allocator, out_img: *of.ObjectImage,
     }
     var funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](ar);
     var n: u32 = 0;
+
+    # sorted (by section, then offset) index over the merged image's declared
+    # frame-unwind records, so each function symbol's record joins by binary search
+    # rather than a quadratic scan. the records arrive in module emission order,
+    # which is already nearly sorted, so the insertion sort is effectively linear.
+    var fidx: *u32 = nil;
+    if (out_img.frame_count > 0) {
+        val fr: R.Result[*u32, str] = A.allocate[u32](alloc, out_img.frame_count::usize);
+        if (R.is_err[*u32, str](fr)) {
+            A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
+            ret R.err[*of.ExecFunction, str](R.unwrap_err[*u32, str](fr));
+        }
+        fidx = R.unwrap_ok[*u32, str](fr);
+        var k: u32 = 0;
+        for (k < out_img.frame_count) { fidx[k] = k; k = k + 1; }
+        k = 1;
+        for (k < out_img.frame_count) {
+            val cur: u32 = fidx[k];
+            var j: i32 = k::i32 - 1;
+            for (j >= 0 && frame_key_after(?out_img.frames[fidx[j::u32]], ?out_img.frames[cur])) {
+                fidx[(j + 1)::u32] = fidx[j::u32];
+                j = j - 1;
+            }
+            fidx[(j + 1)::u32] = cur;
+            k = k + 1;
+        }
+    }
 
     var si: u32 = 0;
     for (si < out_img.symbol_count) {
@@ -2655,9 +2705,23 @@ fun build_exec_functions(alloc: *A.Allocator, out_img: *of.ObjectImage,
         funcs[n].seg_index = seg;
         funcs[n].seg_offset = sym.offset;
         funcs[n].size = 0;
+        # attach the function's declared frame-unwind record, when one exists: the
+        # record was rebased to the same merged (section, offset) as the symbol.
+        funcs[n].step_count = 0;
+        val fmatch: u32 = frame_find(out_img, fidx, sym.section, sym.offset);
+        if (fmatch != 0xFFFFFFFF) {
+            funcs[n].step_count = out_img.frames[fmatch].step_count;
+            var sc: u32 = 0;
+            for (sc < out_img.frames[fmatch].step_count) {
+                funcs[n].steps[sc] = out_img.frames[fmatch].steps[sc];
+                sc = sc + 1;
+            }
+        }
         n = n + 1;
         si = si + 1;
     }
+
+    if (fidx != nil) { A.deallocate[u32](alloc, fidx, out_img.frame_count::usize); }
 
     if (n == 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
@@ -4863,6 +4927,59 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             sy = sy + 1;
         }
         m = m + 1;
+    }
+
+    # carry every declared frame-unwind record onto the output image, rebased to
+    # its merged section exactly as its function's symbol was (#3096). records are
+    # bulk-allocated rather than appended one by one: a record is an order of
+    # magnitude wider than a symbol, so the grow-by-one realloc pattern would copy
+    # quadratically. a parsed foreign image carries no records, so this walks only
+    # the codegen images' declarations.
+    var frame_total: u32 = 0;
+    m = 0;
+    for (m < module_count) { frame_total = frame_total + modules[m].frame_count; m = m + 1; }
+    if (frame_total > 0) {
+        val fa: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](out_img.alloc, frame_total::usize);
+        if (R.is_err[*of.FrameUnwind, str](fa)) { ret R.err[bool, str](R.unwrap_err[*of.FrameUnwind, str](fa)); }
+        var out_frames: *of.FrameUnwind = R.unwrap_ok[*of.FrameUnwind, str](fa);
+        var fn: u32 = 0;
+        m = 0;
+        for (m < module_count) {
+            var fi: u32 = 0;
+            for (fi < modules[m].frame_count) {
+                val ifr: *of.FrameUnwind = ?modules[m].frames[fi];
+                if (ifr.section >= modules[m].section_count) { fi = fi + 1; cnt; }
+                val flat: u32 = sec_base[m] + ifr.section;
+                if (atom_offset_dead(atoms, flat, ifr.offset)) { fi = fi + 1; cnt; }
+                val ki: u32 = placements[flat].merged_index;
+                val out_ix: u32 = merged_to_out[ki];
+                if (out_ix == 0xFFFFFFFF) { fi = fi + 1; cnt; }
+
+                out_frames[fn] = @ifr;
+                out_frames[fn].section = out_ix;
+                out_frames[fn].offset  = placements[flat].offset
+                    + atom_live_offset(atoms, flat, ifr.offset);
+                fn = fn + 1;
+                fi = fi + 1;
+            }
+            m = m + 1;
+        }
+        if (fn == 0) {
+            A.deallocate[of.FrameUnwind](out_img.alloc, out_frames, frame_total::usize);
+        }
+        or {
+            if (fn < frame_total) {
+                val fs: R.Result[*of.FrameUnwind, str] =
+                    A.reallocate[of.FrameUnwind](out_img.alloc, out_frames, frame_total::usize, fn::usize);
+                if (R.is_err[*of.FrameUnwind, str](fs)) {
+                    A.deallocate[of.FrameUnwind](out_img.alloc, out_frames, frame_total::usize);
+                    ret R.err[bool, str](R.unwrap_err[*of.FrameUnwind, str](fs));
+                }
+                out_frames = R.unwrap_ok[*of.FrameUnwind, str](fs);
+            }
+            out_img.frames      = out_frames;
+            out_img.frame_count = fn;
+        }
     }
 
     ret R.ok[bool, str](true);

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -52,6 +52,8 @@ pub fun init(a: *A.Allocator, interner: *intern.Interner, name: intern.StrId) R.
     o.symbol_count  = 0;
     o.relocations   = nil;
     o.reloc_count   = 0;
+    o.frames        = nil;
+    o.frame_count   = 0;
     o.imports       = nil;
     o.import_count  = 0;
     # 0 is "this arch defines no machine flags", which is the truth for every arch
@@ -94,6 +96,12 @@ pub fun dnit(o: *of.ObjectImage) {
         A.deallocate[of.Relocation](o.alloc, o.relocations, o.reloc_count::usize);
         o.relocations = nil;
         o.reloc_count = 0;
+    }
+
+    if (o.frames != nil) {
+        A.deallocate[of.FrameUnwind](o.alloc, o.frames, o.frame_count::usize);
+        o.frames      = nil;
+        o.frame_count = 0;
     }
 
     if (o.imports != nil) {
@@ -143,6 +151,23 @@ pub fun add_symbol(o: *of.ObjectImage, sym: of.Symbol) R.Result[u32, str] {
     o.symbols[ix]  = sym;
     o.symbol_count = o.symbol_count + 1;
     ret R.ok[u32, str](ix);
+}
+
+# append a frame-unwind record, growing the image's frame array by one slot (#3096)
+# ---
+# o:   the image to append to
+# fr:  the frame-unwind record to copy in
+# ret: true on success, or an allocation error
+pub fun add_frame(o: *of.ObjectImage, fr: *of.FrameUnwind) R.Result[bool, str] {
+    val res_grow: R.Result[*of.FrameUnwind, str] = array_grow_one[of.FrameUnwind](o.alloc, o.frames, o.frame_count);
+    if (R.is_err[*of.FrameUnwind, str](res_grow)) {
+        ret R.err[bool, str](R.unwrap_err[*of.FrameUnwind, str](res_grow));
+    }
+    o.frames = R.unwrap_ok[*of.FrameUnwind, str](res_grow);
+
+    o.frames[o.frame_count] = @fr;
+    o.frame_count = o.frame_count + 1;
+    ret R.ok[bool, str](true);
 }
 
 # append a relocation, growing the image's relocation array by one slot
@@ -452,6 +477,17 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
         # copy preserves position-for-position, so nothing about it is remapped.
         memory.copy[of.Relocation](img.relocations, src.relocations, src.reloc_count::usize);
         img.reloc_count = src.reloc_count;
+    }
+
+    if (src.frame_count > 0) {
+        # a frame-unwind record holds section index, offset and register numbers -
+        # no interned id - so it copies verbatim, but into dst_alloc-owned storage
+        # for the lifetime reason the note above gives (#3096).
+        val rf: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](dst_alloc, src.frame_count::usize);
+        if (R.is_err[*of.FrameUnwind, str](rf)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.FrameUnwind, str](rf)); }
+        img.frames = R.unwrap_ok[*of.FrameUnwind, str](rf);
+        memory.copy[of.FrameUnwind](img.frames, src.frames, src.frame_count::usize);
+        img.frame_count = src.frame_count;
     }
 
     ret R.ok[of.ObjectImage, str](img);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -22276,3 +22276,283 @@ fun ut_codegen_fail_msg(s: *session.Session, root: str, tgt: str) str {
 fun ut_build_fails(s: *session.Session, root: str, tgt: str) bool {
     ret str_len(ut_codegen_fail_msg(s, root, tgt)) != 0;
 }
+
+# a manifest with one windows-x86_64 target, for the #3096 unwind-info fixture
+fun ut_w64uw_manifest() str {
+    ret "[project]\nid = \"w64uw\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.win]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.w64uw]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/w64uw\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+}
+
+# the #3096 fixture: one function per emitted allocation shape - an imm8 `sub rsp`
+# (frame <= 128 bytes), an imm32 `sub rsp` (sub-page frame), and the probed
+# page-walk (frame > one page) - plus the entry that keeps them all live
+fun ut_w64uw_src() str {
+    ret "fun probe_small(x: i64) i64 {\n    var buf: [64]u8;\n    buf[0] = x::u8;\n    buf[63] = (x >> 8)::u8;\n    ret buf[0]::i64 + buf[63]::i64;\n}\n\nfun probe_mid(x: i64) i64 {\n    var buf: [4000]u8;\n    buf[0] = x::u8;\n    buf[3999] = (x >> 8)::u8;\n    ret buf[0]::i64 + buf[3999]::i64;\n}\n\nfun probe_big(x: i64) i64 {\n    var buf: [12000]u8;\n    buf[0] = x::u8;\n    buf[11999] = (x >> 8)::u8;\n    ret probe_small(buf[0]::i64) + buf[11999]::i64;\n}\n\n#[symbol(\"mainCRTStartup\")]\nfun start() i32 {\n    ret (probe_big(7) + probe_mid(9))::i32;\n}\n";
+}
+
+# build the #3096 fixture for windows-x86_64 and link it into a PE image, read back
+# as bytes (COFF has no in-memory capture path, so the link goes through a temp file
+# exactly as in ut_pe_stack_of)
+# ---
+# alloc: allocator owning the returned bytes
+# out:   out - the PE image bytes
+# ret:   true when the build and the link both succeeded
+fun ut_w64uw_image(alloc: *A.Allocator, out: *Vector[u8]) bool {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret false; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = ut_w64uw_src();
+    val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_w64uw_manifest(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret false; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var ok: bool = false;
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_ok[bool, str](rr)) {
+        val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, "win");
+        if (R.is_ok[project.Project, outcome.Fail](pr)) {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            if (ut_run_codegen_ok(?p) == 0) { ok = ut_w64uw_link(?p, out); }
+            project.dnit_project(?p);
+        }
+    }
+    fs.remove_all(alloc, root);
+    session.dnit(?s);
+    ret ok;
+}
+
+# link the built fixture through the shipping `linker.link_images` into a temp PE
+# file and read the bytes back
+fun ut_w64uw_link(p: *project.Project, out: *Vector[u8]) bool {
+    val alloc: *A.Allocator = p.alloc;
+    if (p.emit_len == 0) { ret false; }
+
+    val ir: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, p.emit_len::usize);
+    if (R.is_err[*of.ObjectImage, str](ir)) { ret false; }
+    val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](ir);
+    var missing: bool = false;
+    var i: u32 = 0;
+    for (i < p.emit_len) {
+        val m: *project.ModuleEntry = ?p.modules[(p.topo[i])::u32];
+        if (m.object_image == nil) { missing = true; }
+        or                         { images[i] = @m.object_image; }
+        i = i + 1;
+    }
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "w64uw_pe");
+    if (R.is_err[fs.TempFile, str](tf_r)) {
+        A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+        ret false;
+    }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+
+    var linked: bool = false;
+    if (!missing) {
+        val lr: R.Result[bool, str] = linker.link_images(p.s, ?p.target, images,
+            p.emit_len, nil::*of.DynLib, 0, fs.temp_path(?tf)::*u8, "w64uw"::*u8,
+            linker.LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
+        linked = R.is_ok[bool, str](lr);
+    }
+    A.deallocate[of.ObjectImage](alloc, images, p.emit_len::usize);
+    if (!linked) { fs.temp_close_and_remove(?tf); ret false; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, fs.temp_path(?tf));
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret false; }
+    @out = R.unwrap_ok[Vector[u8], str](rb);
+    ret true;
+}
+
+# one PE section's placement, for the in-tree reader below
+rec UtPeSec {
+    rva:   u32;
+    vsize: u32;
+    raw:   u32;
+}
+
+# find the PE section named `name` (7 chars or fewer) in the image's section table
+fun ut_pe_find_sec(img: *Vector[u8], name: str, sec: *UtPeSec) bool {
+    if (img.len < 0x40) { ret false; }
+    val b: *u8 = img.data;
+    val pe_off: usize = ut_le32(b, 0x3C)::usize;
+    val nsec: u64 = ut_le16(b, pe_off + 4 + 2);
+    val optsz: u64 = ut_le16(b, pe_off + 4 + 16);
+    var sh: usize = pe_off + 4 + 20 + optsz::usize;
+    val nlen: usize = str_len(name);
+    if (nlen > 7) { ret false; }
+    val np: *u8 = name::*u8;
+    var i: u64 = 0;
+    for (i < nsec) {
+        if (sh + 40 > img.len) { ret false; }
+        var matches: bool = true;
+        var k: usize = 0;
+        for (k < nlen) {
+            if (b[sh + k] != np[k]) { matches = false; }
+            k = k + 1;
+        }
+        if (matches && b[sh + nlen] == 0) {
+            sec.vsize = ut_le32(b, sh + 8)::u32;
+            sec.rva   = ut_le32(b, sh + 12)::u32;
+            sec.raw   = ut_le32(b, sh + 20)::u32;
+            ret true;
+        }
+        sh = sh + 40;
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the file offset of `rva` inside `sec`, or -1 when it lies outside it
+fun ut_pe_sec_off(sec: *UtPeSec, rva: u32) i64 {
+    if (rva < sec.rva) { ret -1; }
+    ret sec.raw::i64 + (rva - sec.rva)::i64;
+}
+
+# EVERY function's `.xdata` declares its full prologue, checked against the
+# prologue bytes themselves (#3096)
+#
+# WHY THIS TEST EXISTS. The PE writer used to synthesize unwind info by
+# pattern-matching prologue bytes, and only knew the small-frame shape
+# `push rbp; mov rbp, rsp; sub rsp, imm`: a probed prologue (any frame over one
+# page - the `mov r11, total` page-walk) fell out of the pattern after the push,
+# so the function's RUNTIME_FUNCTION understated the frame to a bare
+# UWOP_PUSH_NONVOL and anything unwinding through it (SEH dispatch,
+# RtlVirtualUnwind, a profiler) computed a wrong RSP. The encoder now DECLARES
+# each prologue's unwind facts and the writer consumes the record.
+#
+# WHAT MAKES IT UNFAKEABLE. The expected allocation is read from the emitted
+# prologue itself - the `sub rsp, imm` immediate or the probe walk's
+# `mov r11, total` - and the `.xdata` alloc code must equal it EXACTLY, so the
+# assertion is a cross-check of two independent paths (the bytes the encoder
+# emitted vs the record it declared), not a golden constant that drifts with
+# frame layout. Every prologue shape the x64 backend can emit must parse: an
+# unknown shape fails the test rather than being skipped, which is what keeps a
+# future prologue change from silently escaping the check - the role the deleted
+# byte-matcher could only fake, since it was itself the thing under suspicion.
+test "mach.lang.driver:w64_xdata_declares_every_prologue_shape" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    var img: Vector[u8];
+    if (!ut_w64uw_image(?alloc, ?img)) { ret 2; }
+
+    var text_sec: UtPeSec;
+    var pdata_sec: UtPeSec;
+    var xdata_sec: UtPeSec;
+    if (!ut_pe_find_sec(?img, ".text", ?text_sec))   { ret 3; }
+    if (!ut_pe_find_sec(?img, ".pdata", ?pdata_sec)) { ret 4; }
+    if (!ut_pe_find_sec(?img, ".xdata", ?xdata_sec)) { ret 5; }
+
+    val b: *u8 = img.data;
+    val n: u32 = pdata_sec.vsize / 12;
+    # the entry plus the three probe shapes, at least.
+    if (n < 4) { ret 6; }
+
+    var saw_imm8: u32 = 0;
+    var saw_imm32: u32 = 0;
+    var saw_probed: u32 = 0;
+
+    var i: u32 = 0;
+    for (i < n) {
+        val row: usize = pdata_sec.raw::usize + i::usize * 12;
+        val begin: u32 = ut_le32(b, row)::u32;
+        val fin: u32 = ut_le32(b, row + 4)::u32;
+        val uw_rva: u32 = ut_le32(b, row + 8)::u32;
+        if (begin == 0 || fin <= begin) { ret 7; }
+
+        val fo_s: i64 = ut_pe_sec_off(?text_sec, begin);
+        if (fo_s < 0) { ret 8; }
+        val fo: usize = fo_s::usize;
+
+        # ground truth from the prologue bytes: push rbp; mov rbp, rsp; then the
+        # allocation in one of the three emitted forms.
+        if (b[fo] != 0x55)                                                { ret 9; }
+        if (b[fo + 1] != 0x48 || b[fo + 2] != 0x89 || b[fo + 3] != 0xE5)  { ret 10; }
+        var total: u64 = 0;
+        var alloc_end: u32 = 0;
+        if (b[fo + 4] == 0x48 && b[fo + 5] == 0x83 && b[fo + 6] == 0xEC) {
+            total = b[fo + 7]::u64;
+            alloc_end = 8;
+            saw_imm8 = saw_imm8 + 1;
+        }
+        or (b[fo + 4] == 0x48 && b[fo + 5] == 0x81 && b[fo + 6] == 0xEC) {
+            total = ut_le32(b, fo + 7);
+            alloc_end = 11;
+            saw_imm32 = saw_imm32 + 1;
+        }
+        or (b[fo + 4] == 0x49 && b[fo + 5] == 0xC7 && b[fo + 6] == 0xC3) {
+            total = ut_le32(b, fo + 7);
+            # the walk ends at its `sub rsp, r11` (4C 29 DC); find it.
+            var k: u32 = 11;
+            for (k < 64 && alloc_end == 0) {
+                if (b[fo + k::usize] == 0x4C && b[fo + k::usize + 1] == 0x29 && b[fo + k::usize + 2] == 0xDC) {
+                    alloc_end = k + 3;
+                }
+                k = k + 1;
+            }
+            if (alloc_end == 0) { ret 11; }
+            saw_probed = saw_probed + 1;
+        }
+        or { ret 12; }  # a prologue shape this test does not know - teach it, don't skip it
+
+        # the declared record, from .xdata.
+        val xo_s: i64 = ut_pe_sec_off(?xdata_sec, uw_rva);
+        if (xo_s < 0) { ret 13; }
+        val xo: usize = xo_s::usize;
+        if (b[xo] != 0x01)  { ret 14; }  # version 1, no flags
+        val psz: u32 = b[xo + 1]::u32;
+        val cnt: u32 = b[xo + 2]::u32;
+        if (b[xo + 3] != 0) { ret 15; }  # fixed-RSP frames declare no frame register
+        if (psz < alloc_end) { ret 16; }
+
+        var push_rbp_ok: bool = false;
+        var alloc_codes: u32 = 0;
+        var alloc_size: u64 = 0;
+        var alloc_at: u32 = 0;
+        var j: u32 = 0;
+        for (j < cnt) {
+            val slot: usize = xo + 4 + j::usize * 2;
+            val eo: u32 = b[slot]::u32;
+            val op: u8 = b[slot + 1] & 0x0F;
+            val info: u8 = b[slot + 1] >> 4;
+            if (eo > psz) { ret 17; }
+            if (op == 0) {
+                if (info == 5 && eo == 1) { push_rbp_ok = true; }
+            }
+            or (op == 2) {
+                alloc_codes = alloc_codes + 1;
+                alloc_size = (info::u64 + 1) * 8;
+                alloc_at = eo;
+            }
+            or (op == 1) {
+                alloc_codes = alloc_codes + 1;
+                if (info == 0) { alloc_size = ut_le16(b, xo + 4 + (j::usize + 1) * 2) * 8; j = j + 1; }
+                or             { alloc_size = ut_le32(b, xo + 4 + (j::usize + 1) * 2);     j = j + 2; }
+                alloc_at = eo;
+            }
+            or (op == 4 || op == 8) { j = j + 1; }  # SAVE_NONVOL / SAVE_XMM128: one operand slot
+            or (op == 5 || op == 9) { j = j + 2; }  # the far forms: two operand slots
+            or (op == 3) { }                        # SET_FPREG carries no operand slot
+            or { ret 18; }                          # an unwind code this test does not know
+            j = j + 1;
+        }
+
+        if (!push_rbp_ok)          { ret 19; }
+        # THE HEART OF #3096: exactly one allocation code, of exactly the total the
+        # prologue's own bytes moved RSP by, ending where the allocation ended.
+        if (alloc_codes != 1)      { ret 20; }
+        if (alloc_size != total)   { ret 21; }
+        if (alloc_at != alloc_end) { ret 22; }
+
+        i = i + 1;
+    }
+
+    # all three allocation shapes were present and checked.
+    if (saw_imm8 == 0 || saw_imm32 == 0 || saw_probed == 0) { ret 23; }
+
+    vector.dnit[u8](?img);
+    ret 0;
+}

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2484,13 +2484,32 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
 # record are addressed from it and belong to the caller, and after a mask only one of the
 # two pointers can still be a fixed distance from the caller's stack.
 # ---
-# st: encoder state whose byte sink the prologue bytes are appended to
-# f:  the laid-out function whose frame facts drive the reservation
-fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction) {
+# EVERY PROLOGUE FACT IS DECLARED AS IT IS EMITTED (#3096). Each step below records
+# itself onto the function's `of.FrameUnwind` record through `enc.push_frame_step`,
+# so the object writer that needs unwind data (the PE `.xdata` producer) consumes
+# declared facts instead of re-deriving them from prologue bytes. A fixed-RSP frame
+# records RSP-based facts: the allocation total (the probe walk is one ALLOC step -
+# how RSP got there is an implementation detail) and each save's offset from the
+# final RSP. A REALIGNED frame records only the push and the frame-pointer
+# establishment (FRAME_STEP_SET_FP): after `and rsp, -N` the save slots sit at a
+# masked address with no fixed distance from either RBP or the declared allocation,
+# so no RSP- or FP-relative save offset exists to declare; an unwinder recovers
+# RSP, RBP and the return address through the frame pointer, and the callee-saved
+# VALUES in such a frame stay undeclarable until the prologue saves them before the
+# mask.
+# ---
+# st:      encoder state whose byte sink the prologue bytes are appended to
+# f:       the laid-out function whose frame facts drive the reservation
+# fn_base: `.text` offset of the function entry, for function-relative step offsets
+# ret:     ok(true) on success, or a frame-record recording error
+fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32) R.Result[bool, str] {
     val frame_size: u32     = f.frame.size;
     val callee_mask: u32    = f.callee_mask;
     val callee_mask_fp: u32 = f.callee_mask_fp;
     val outgoing_size: u32  = f.frame.outgoing_size;
+
+    val rf: R.Result[bool, str] = enc.push_frame(st, fn_base);
+    if (R.is_err[bool, str](rf)) { ret rf; }
 
     var push_rbp: isa.Inst = isa.inst_blank();
     push_rbp.opcode = x64.PUSH;
@@ -2498,6 +2517,9 @@ fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction) {
     push_rbp.size   = 8;
     push_rbp.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?push_rbp);
+    val rs_push: R.Result[bool, str] = enc.push_frame_step(st, of.FRAME_STEP_PUSH, x64.RBP::u8,
+                                                           st.buf.len::u32 - fn_base, 0);
+    if (R.is_err[bool, str](rs_push)) { ret rs_push; }
 
     var mov_rbp: isa.Inst = isa.inst_blank();
     mov_rbp.opcode = x64.MOV;
@@ -2507,7 +2529,15 @@ fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction) {
     mov_rbp.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?mov_rbp);
 
-    if (f.frame.realign != 0) {
+    val realigned: bool = f.frame.realign != 0;
+    if (realigned) {
+        # RBP == RSP here, so the frame pointer is established zero bytes above the
+        # stack pointer; from the end of this instruction on, only RBP locates the
+        # frame (the mask below moves RSP by a runtime-dependent amount).
+        val rs_fp: R.Result[bool, str] = enc.push_frame_step(st, of.FRAME_STEP_SET_FP, x64.RBP::u8,
+                                                             st.buf.len::u32 - fn_base, 0);
+        if (R.is_err[bool, str](rs_fp)) { ret rs_fp; }
+
         var and_rsp: isa.Inst = isa.inst_blank();
         and_rsp.opcode = x64.AND;
         and_rsp.dst    = isa.make_reg(x64.RSP, 8);
@@ -2535,6 +2565,15 @@ fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction) {
             sub_rsp.flags  = x64.FLAG_REX_W;
             emit_inst(st, ?sub_rsp);
         }
+        # one allocation step for the whole reservation, probe walk or bare
+        # subtraction alike: the unwind fact is how far RSP moved, and its end
+        # offset is past the last instruction that moved it. skipped for a
+        # realigned frame, where FRAME_STEP_SET_FP above supersedes RSP tracking.
+        if (!realigned) {
+            val rs_alloc: R.Result[bool, str] = enc.push_frame_step(st, of.FRAME_STEP_ALLOC, 0,
+                                                                    st.buf.len::u32 - fn_base, total::u64);
+            if (R.is_err[bool, str](rs_alloc)) { ret rs_alloc; }
+        }
     }
 
     val sbase: i32 = slot_base_reg(f);
@@ -2547,6 +2586,14 @@ fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction) {
     for (i < ln) {
         if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
             emit_frame_store(st, list[i], sbase, (sbias - coff::i64)::i32);
+            # the save lands at [rbp - coff] with RSP fixed `total` below RBP, so
+            # its declared frame-base offset is `total - coff`.
+            if (!realigned) {
+                val rs_save: R.Result[bool, str] = enc.push_frame_step(st, of.FRAME_STEP_SAVE, list[i]::u8,
+                                                                       st.buf.len::u32 - fn_base,
+                                                                       (total::i64 - coff::i64)::u64);
+                if (R.is_err[bool, str](rs_save)) { ret rs_save; }
+            }
             coff = coff + 8;
         }
         i = i + 1;
@@ -2560,10 +2607,17 @@ fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction) {
     for (x < 16) {
         if ((callee_mask_fp & (1::u32 << x::u32)) != 0) {
             emit_xmm_store(st, x, sbase, (sbias - xoff::i64)::i32);
+            if (!realigned) {
+                val rs_xsave: R.Result[bool, str] = enc.push_frame_step(st, of.FRAME_STEP_SAVE_VEC, x::u8,
+                                                                        st.buf.len::u32 - fn_base,
+                                                                        (total::i64 - xoff::i64)::u64);
+                if (R.is_err[bool, str](rs_xsave)) { ret rs_xsave; }
+            }
             xoff = xoff + 16;
         }
         x = x + 1;
     }
+    ret R.ok[bool, str](true);
 }
 
 # encode the standard x86-64 function epilogue into the `.text`
@@ -2812,7 +2866,10 @@ fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[bool, st
         if (R.is_err[bool, str](rh)) { ret rh; }
     }
 
-    if (!naked) { emit_prologue(st, f); }
+    if (!naked) {
+        val rpl: R.Result[bool, str] = emit_prologue(st, f, fn_base);
+        if (R.is_err[bool, str](rpl)) { ret rpl; }
+    }
     val rp: R.Result[bool, str] = check_accounted(st, PROLOGUE_REGION);
     if (R.is_err[bool, str](rp)) { ret rp; }
 

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -313,6 +313,72 @@ pub rec Symbol {
     align:    u32;
 }
 
+# one prologue fact in a function's frame-unwind record, declared by the encoder
+# at the moment it emits the instruction (#3096)
+#
+# The kinds are the operations an unwinder must reverse, not the instructions that
+# performed them: a probed page-walk that lowers RSP across six instructions is ONE
+# `FRAME_STEP_ALLOC` of the total, because "how RSP got there" is an implementation
+# detail and "how far RSP moved" is the unwind fact. Offsets in `value` are measured
+# from the frame base - the stack pointer at the end of the prologue - which is the
+# base the consuming format's save codes are defined on (win64 `.xdata` without a
+# frame register).
+# ---
+# FRAME_STEP_PUSH:     `reg` was pushed (RSP moved down one slot holding it)
+# FRAME_STEP_ALLOC:    RSP moved down `value` bytes, however that was emitted
+# FRAME_STEP_SET_FP:   `reg` became the frame pointer, `value` bytes above RSP; from
+#                      here on RSP may move unpredictably (realignment) and only
+#                      `reg` locates the frame
+# FRAME_STEP_SAVE:     `reg` was stored at [frame base + `value`]
+# FRAME_STEP_SAVE_VEC: 128-bit vector `reg` was stored at [frame base + `value`]
+pub val FRAME_STEP_PUSH:     u8 = 1;
+pub val FRAME_STEP_ALLOC:    u8 = 2;
+pub val FRAME_STEP_SET_FP:   u8 = 3;
+pub val FRAME_STEP_SAVE:     u8 = 4;
+pub val FRAME_STEP_SAVE_VEC: u8 = 5;
+
+# capacity of a frame-unwind record's step array. the widest x86-64 prologue is one
+# push, one frame-pointer establishment or allocation (never both recorded plus a
+# second alloc), seven GP callee saves and ten XMM callee saves - nineteen steps -
+# so 24 leaves headroom without making the record a heap allocation
+pub val FRAME_STEP_CAP: u32 = 24;
+
+# one recorded prologue step
+# ---
+# kind:    one of FRAME_STEP_*
+# reg:     ISA register number (the x86-64 encoding numbers, which are also the
+#          win64 unwind-code numbers); meaningless for FRAME_STEP_ALLOC
+# end_off: byte offset just past the step's instruction (for FRAME_STEP_ALLOC, past
+#          the last instruction that moved RSP), relative to the function entry
+# value:   the step's byte quantity (alloc size / save offset / frame-pointer bias)
+pub rec FrameStep {
+    kind:    u8;
+    reg:     u8;
+    end_off: u32;
+    value:   u64;
+}
+
+# one function's declared frame-unwind record: the prologue facts an unwind-info
+# producer needs, recorded by the encoder that emitted the prologue (#3096)
+#
+# This is the declared-over-derived shape the target axes use: the backend KNOWS the
+# prologue it just emitted, so the object writer consumes this record instead of
+# re-deriving the facts by pattern-matching prologue bytes - a derivation that
+# silently understated every prologue shape it did not recognize (the probed
+# page-walk, the realigned frame). A function with no record (a frame-omitting
+# leaf, `#[naked]`, or any foreign function) gets NO synthesized unwind data.
+# ---
+# section:    defining section index within the owning image
+# offset:     function entry offset within that section
+# step_count: number of recorded steps, in emission order
+# steps:      the prologue steps
+pub rec FrameUnwind {
+    section:    u32;
+    offset:     u32;
+    step_count: u32;
+    steps:      [FRAME_STEP_CAP]FrameStep;
+}
+
 # one relocation in an object image
 #
 # `kind` is an abstract relocation kind (a closed `RK_*` enum owned here); the
@@ -360,6 +426,8 @@ pub rec Relocation {
 # symbol_count:  number of symbols
 # relocations:   array of relocations
 # reloc_count:   number of relocations
+# frames:        array of declared per-function frame-unwind records
+# frame_count:   number of frame-unwind records
 pub rec ObjectImage {
     alloc:    *A.Allocator;
     interner: *intern.Interner;
@@ -373,6 +441,12 @@ pub rec ObjectImage {
 
     relocations: *Relocation;
     reloc_count: u32;
+
+    # per-function frame-unwind records the encoder declared (#3096). empty for a
+    # parsed foreign image - its unwind data, if any, arrives as sections the
+    # format writer passes through instead
+    frames:      *FrameUnwind;
+    frame_count: u32;
 
     # imports this image DECLARES rather than defines, from an archive member that
     # is an import record instead of an object (#2525). empty for every ordinary
@@ -676,10 +750,15 @@ pub rec LoadSegment {
 # seg_index:  index into the executable writer's `LoadSegment` array
 # seg_offset: byte offset of the function start within that segment
 # size:       byte length of the function body
+# step_count: number of declared frame-unwind steps, or 0 when the function
+#             carries no record (frame-omitting leaf, `#[naked]`, foreign)
+# steps:      the function's declared prologue steps (#3096)
 pub rec ExecFunction {
     seg_index:  u32;
     seg_offset: u32;
     size:       u32;
+    step_count: u32;
+    steps:      [FRAME_STEP_CAP]FrameStep;
 }
 
 # one function symbol destined for an executable's symbol table (ELF `.symtab`,

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -1034,6 +1034,111 @@ fun free_weak_comdat_image(alloc: *A.Allocator, out: *of.ObjectImage, comdat: *b
 # img:     the object image to serialize
 # path:    null-terminated output file path
 # ret:     ok(true) on success, or an error string
+# the mach-private object section that carries the image's declared frame-unwind
+# records (`of.FrameUnwind`, #3096) across the disk round-trip
+#
+# WHY THE OBJECT MUST CARRY THEM. The build engine's test dispatcher always links
+# from written `.o` files, and the incremental cache feeds warm links the same
+# way, so "the linker consumes in-memory codegen images" is not a path every link
+# takes. A record that lives only in memory silently vanishes on those links and
+# every affected function loses its unwind data - the exact silent-divergence
+# class #3096 removes. The records ride the object the way `machine_flags` and
+# the riscv `attributes` body do: written by this emitter, restored by
+# `coff_parse_object`, invisible to everything else (the parser strips the
+# section after decoding it, so no linked image carries it).
+#
+# Records are keyed by FUNCTION SYMBOL NAME, not by (section, offset) or symbol
+# index: the emit re-partitions sections at weak boundaries (#2125) and the COFF
+# symbol table interleaves section and aux records, so both of those keys would
+# couple this blob to serializer layout that legitimately shifts. A name resolves
+# through the parsed symbol table to wherever the function landed. Function
+# symbol names are unique within a builder-assembled image (`obj.symbol_index`'s
+# contract), which is the only kind of image that carries records.
+#
+# layout (little-endian): u32 version, u32 record count, then per record
+# u32 name_len, u32 step_count, name bytes (padded to 4), and step_count
+# 16-byte steps (u8 kind, u8 reg, u16 zero, u32 end_off, u64 value).
+val MACH_FRAMES_SECTION_NAME: str = ".mach.frames";
+val MACH_FRAMES_VERSION: u32 = 1;
+
+# the function symbol a frame record describes, or SYMBOL_NONE when no defined
+# function symbol sits at the record's (section, offset)
+fun frames_record_symbol(img: *of.ObjectImage, fr: *of.FrameUnwind) u32 {
+    var i: u32 = 0;
+    for (i < img.symbol_count) {
+        val sym: *of.Symbol = ?img.symbols[i];
+        if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0
+            && sym.section == fr.section && sym.offset == fr.offset) {
+            ret i;
+        }
+        i = i + 1;
+    }
+    ret of.SYMBOL_NONE;
+}
+
+# encode the image's frame-unwind records into a `.mach.frames` section body;
+# a record whose function symbol cannot be found fails the emit loudly (it would
+# otherwise vanish silently on every disk-linked build)
+fun encode_frames_section(alloc: *A.Allocator, img: *of.ObjectImage,
+                          out_bytes: **u8, out_len: *u32) R.Result[bool, str] {
+    @out_bytes = nil;
+    @out_len = 0;
+    if (img.frame_count == 0) { ret R.ok[bool, str](true); }
+
+    var total: usize = 8;
+    var i: u32 = 0;
+    for (i < img.frame_count) {
+        val fr: *of.FrameUnwind = ?img.frames[i];
+        if (fr.step_count > of.FRAME_STEP_CAP) {
+            ret R.err[bool, str]("coff: frame record step count exceeds capacity");
+        }
+        val si: u32 = frames_record_symbol(img, fr);
+        if (si == of.SYMBOL_NONE) {
+            ret R.err[bool, str]("coff: frame record has no defined function symbol");
+        }
+        val nm: str = bin.resolve_name(img.interner, img.symbols[si].name);
+        if (nm == nil) {
+            ret R.err[bool, str]("coff: frame record symbol name did not resolve");
+        }
+        total = total + 8 + bin.align_up(str_len(nm), 4) + fr.step_count::usize * 16;
+        i = i + 1;
+    }
+
+    val rb: R.Result[*u8, str] = A.zallocate[u8](alloc, total);
+    if (R.is_err[*u8, str](rb)) { ret R.err[bool, str]("coff: frame section alloc failed"); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    bin.write_u32_le(buf, 0, MACH_FRAMES_VERSION);
+    bin.write_u32_le(buf, 4, img.frame_count);
+    var pos: usize = 8;
+    i = 0;
+    for (i < img.frame_count) {
+        val fr: *of.FrameUnwind = ?img.frames[i];
+        val si: u32 = frames_record_symbol(img, fr);
+        val nm: str = bin.resolve_name(img.interner, img.symbols[si].name);
+        val nlen: usize = str_len(nm);
+        bin.write_u32_le(buf, pos, nlen::u32);
+        bin.write_u32_le(buf, pos + 4, fr.step_count);
+        pos = pos + 8;
+        memory.raw_copy((buf::usize + pos)::ptr, nm::ptr, nlen);
+        pos = pos + bin.align_up(nlen, 4);
+        var k: u32 = 0;
+        for (k < fr.step_count) {
+            buf[pos] = fr.steps[k].kind;
+            buf[pos + 1] = fr.steps[k].reg;
+            bin.write_u16_le(buf, pos + 2, 0);
+            bin.write_u32_le(buf, pos + 4, fr.steps[k].end_off);
+            bin.write_u64_le(buf, pos + 8, fr.steps[k].value);
+            pos = pos + 16;
+            k = k + 1;
+        }
+        i = i + 1;
+    }
+
+    @out_bytes = buf;
+    @out_len = total::u32;
+    ret R.ok[bool, str](true);
+}
+
 fun coff_emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R.Result[bool, str] {
     if (tgt_isa == nil || img == nil || path == nil) {
         ret R.err[bool, str]("coff: nil writer argument");
@@ -1054,8 +1159,65 @@ fun coff_emit_object(tgt_isa: *isa.IsaVTable, img: *of.ObjectImage, path: *u8) R
         ret R.err[bool, str](R.unwrap_err[bool, str](br));
     }
 
-    val sr: R.Result[bool, str] = coff_serialize_image(?derived, comdat, path);
-    free_weak_comdat_image(alloc, ?derived, comdat);
+    # append the mach-private frame-record section (#3096) so the records survive
+    # the disk round-trip every dispatcher and warm incremental link takes. added
+    # after the weak split so it never participates in COMDAT planning; its bytes
+    # are owned here and freed after serialization (the derived image's own
+    # section bytes alias the source image and are never freed).
+    var fr_bytes: *u8 = nil;
+    var fr_len: u32 = 0;
+    var comdat2: *bool = comdat;
+    val fe: R.Result[bool, str] = encode_frames_section(alloc, img, ?fr_bytes, ?fr_len);
+    if (R.is_err[bool, str](fe)) {
+        free_weak_comdat_image(alloc, ?derived, comdat);
+        ret R.err[bool, str](R.unwrap_err[bool, str](fe));
+    }
+    if (fr_len > 0) {
+        val fnr: R.Result[intern.StrId, str] = intern.intern(img.interner, MACH_FRAMES_SECTION_NAME);
+        if (R.is_err[intern.StrId, str](fnr)) {
+            A.deallocate[u8](alloc, fr_bytes, fr_len::usize);
+            free_weak_comdat_image(alloc, ?derived, comdat);
+            ret R.err[bool, str](R.unwrap_err[intern.StrId, str](fnr));
+        }
+        val n0: u32 = derived.section_count;
+        # grow the comdat flag array first: each grow's failure path must free every
+        # array at the exact size it currently has, and free_weak_comdat_image frees
+        # both by `section_count`, so the count only moves once both grows landed.
+        if (comdat != nil) {
+            val gc: R.Result[*bool, str] = A.reallocate[bool](alloc, comdat, n0::usize, (n0 + 1)::usize);
+            if (R.is_err[*bool, str](gc)) {
+                A.deallocate[u8](alloc, fr_bytes, fr_len::usize);
+                # a failed reallocate leaves the original block live (the pattern
+                # build_exec_functions frees by), so the ordinary teardown applies.
+                free_weak_comdat_image(alloc, ?derived, comdat);
+                ret R.err[bool, str]("coff: frame comdat append failed");
+            }
+            comdat2 = R.unwrap_ok[*bool, str](gc);
+            comdat2[n0] = false;
+        }
+        val gs: R.Result[*of.Section, str] =
+            A.reallocate[of.Section](alloc, derived.sections, n0::usize, (n0 + 1)::usize);
+        if (R.is_err[*of.Section, str](gs)) {
+            A.deallocate[u8](alloc, fr_bytes, fr_len::usize);
+            if (comdat2 != nil) { A.deallocate[bool](alloc, comdat2, (n0 + 1)::usize); }
+            # section_count is still n0 and the failed reallocate left the original
+            # section array live, so the ordinary teardown frees it exactly.
+            free_weak_comdat_image(alloc, ?derived, nil::*bool);
+            ret R.err[bool, str]("coff: frame section append failed");
+        }
+        derived.sections = R.unwrap_ok[*of.Section, str](gs);
+        derived.sections[n0].name  = R.unwrap_ok[intern.StrId, str](fnr);
+        derived.sections[n0].kind  = of.SK_DEBUG;
+        derived.sections[n0].bytes = fr_bytes;
+        derived.sections[n0].len   = fr_len;
+        derived.sections[n0].align = 4;
+        derived.sections[n0].flags = 0;
+        derived.section_count = n0 + 1;
+    }
+
+    val sr: R.Result[bool, str] = coff_serialize_image(?derived, comdat2, path);
+    if (fr_bytes != nil) { A.deallocate[u8](alloc, fr_bytes, fr_len::usize); }
+    free_weak_comdat_image(alloc, ?derived, comdat2);
     ret sr;
 }
 
@@ -1903,6 +2065,13 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
     if (buf == nil || out == nil || buf_size < 4) {
         ret R.err[bool, str]("coff: object too small");
     }
+    # start from a fully zeroed image before any field is set: the caller's slot is
+    # arbitrary heap or arena memory, and a field this parser does not know about -
+    # one added to `of.ObjectImage` after it was written - would otherwise carry
+    # garbage into every consumer that sums or walks it (#3096 shipped a garbage
+    # `frame_count` exactly this way; same field-drop class as #2813/#2828).
+    var blank: of.ObjectImage;
+    @out = blank;
     # /bigobj (#2147) replaces the classic header's first two fields (Machine,
     # NumberOfSections) with a fixed Sig1/Sig2 pair: Sig1 is always
     # IMAGE_FILE_MACHINE_UNKNOWN, a machine type no real object ever carries, and
@@ -2248,6 +2417,132 @@ fun coff_parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_
 
     A.deallocate[i32](alloc, rec_map, (num_records + 1)::usize);
     if (R.is_err[bool, str](inf)) { ret R.err[bool, str](R.unwrap_err[bool, str](inf)); }
+
+    # restore the declared frame-unwind records a mach-emitted object carries in
+    # its `.mach.frames` section (#3096), then strip the section (its slot stays,
+    # zero-length, so section ordinals and relocation indices are undisturbed and
+    # no linked image inherits the metadata).
+    val dfr: R.Result[bool, str] = decode_frames_section(alloc, itn, out);
+    if (R.is_err[bool, str](dfr)) { ret R.err[bool, str](R.unwrap_err[bool, str](dfr)); }
+    ret R.ok[bool, str](true);
+}
+
+# decode a parsed image's `.mach.frames` section into `out.frames` and strip it
+#
+# The inverse of `encode_frames_section`: each record's function-symbol name
+# resolves through the parsed symbol table to the (section, offset) the function
+# landed at - however the emit re-partitioned sections (#2125). A malformed blob
+# or an unresolvable name fails the parse loudly: the alternative is a function
+# silently shipping without unwind data, the #3096 failure class. Absent section
+# (every foreign object, every pre-#3096 mach object) is a clean no-op.
+fun decode_frames_section(alloc: *A.Allocator, itn: *intern.Interner,
+                          out: *of.ObjectImage) R.Result[bool, str] {
+    val fname_r: R.Result[intern.StrId, str] = intern.intern(itn, MACH_FRAMES_SECTION_NAME);
+    if (R.is_err[intern.StrId, str](fname_r)) {
+        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](fname_r));
+    }
+    val fname: intern.StrId = R.unwrap_ok[intern.StrId, str](fname_r);
+
+    var fs_i: u32 = 0xFFFFFFFF;
+    var si: u32 = 0;
+    for (si < out.section_count) {
+        if (out.sections[si].name == fname) { fs_i = si; brk; }
+        si = si + 1;
+    }
+    if (fs_i == 0xFFFFFFFF) { ret R.ok[bool, str](true); }
+
+    val sec: *of.Section = ?out.sections[fs_i];
+    val blob: *u8 = sec.bytes;
+    val blen: usize = sec.len::usize;
+    if (blob == nil || blen < 8) { ret R.err[bool, str]("coff: malformed .mach.frames section"); }
+    if (bin.read_u32_le(blob, 0) != MACH_FRAMES_VERSION) {
+        ret R.err[bool, str]("coff: unsupported .mach.frames version");
+    }
+    val count: u32 = bin.read_u32_le(blob, 4);
+    # each record is at least 8 bytes of header, so an absurd count is malformed.
+    if (count::usize > blen / 8) { ret R.err[bool, str]("coff: malformed .mach.frames count"); }
+
+    var frames: *of.FrameUnwind = nil;
+    if (count > 0) {
+        val fa: R.Result[*of.FrameUnwind, str] = A.zallocate[of.FrameUnwind](alloc, count::usize);
+        if (R.is_err[*of.FrameUnwind, str](fa)) { ret R.err[bool, str]("coff: frame record alloc failed"); }
+        frames = R.unwrap_ok[*of.FrameUnwind, str](fa);
+    }
+
+    var pos: usize = 8;
+    var i: u32 = 0;
+    for (i < count) {
+        if (pos + 8 > blen) {
+            A.deallocate[of.FrameUnwind](alloc, frames, count::usize);
+            ret R.err[bool, str]("coff: truncated .mach.frames record");
+        }
+        val nlen: usize = bin.read_u32_le(blob, pos)::usize;
+        val step_count: u32 = bin.read_u32_le(blob, pos + 4);
+        pos = pos + 8;
+        val npad: usize = bin.align_up(nlen, 4);
+        if (step_count > of.FRAME_STEP_CAP || nlen == 0
+            || pos + npad + step_count::usize * 16 > blen) {
+            A.deallocate[of.FrameUnwind](alloc, frames, count::usize);
+            ret R.err[bool, str]("coff: malformed .mach.frames record");
+        }
+
+        # the name bytes are not NUL-terminated in the blob; intern via a bounded copy.
+        val nb: R.Result[*u8, str] = A.allocate[u8](alloc, nlen + 1);
+        if (R.is_err[*u8, str](nb)) {
+            A.deallocate[of.FrameUnwind](alloc, frames, count::usize);
+            ret R.err[bool, str]("coff: frame name alloc failed");
+        }
+        val nbuf: *u8 = R.unwrap_ok[*u8, str](nb);
+        memory.raw_copy(nbuf::ptr, (blob::usize + pos)::ptr, nlen);
+        nbuf[nlen] = 0;
+        val nir: R.Result[intern.StrId, str] = intern.intern(itn, nbuf::str);
+        A.deallocate[u8](alloc, nbuf, nlen + 1);
+        if (R.is_err[intern.StrId, str](nir)) {
+            A.deallocate[of.FrameUnwind](alloc, frames, count::usize);
+            ret R.err[bool, str](R.unwrap_err[intern.StrId, str](nir));
+        }
+        val nid: intern.StrId = R.unwrap_ok[intern.StrId, str](nir);
+        pos = pos + npad;
+
+        var sym: u32 = 0xFFFFFFFF;
+        var sy: u32 = 0;
+        for (sy < out.symbol_count) {
+            if (out.symbols[sy].name == nid
+                && (out.symbols[sy].flags & of.SYM_OBJ_FLAG_FUNCTION) != 0
+                && out.symbols[sy].section != of.SECTION_EXTERNAL
+                && out.symbols[sy].section < out.section_count) {
+                sym = sy;
+                brk;
+            }
+            sy = sy + 1;
+        }
+        if (sym == 0xFFFFFFFF) {
+            A.deallocate[of.FrameUnwind](alloc, frames, count::usize);
+            ret R.err[bool, str]("coff: .mach.frames record names no defined function symbol");
+        }
+
+        frames[i].section    = out.symbols[sym].section;
+        frames[i].offset     = out.symbols[sym].offset;
+        frames[i].step_count = step_count;
+        var k: u32 = 0;
+        for (k < step_count) {
+            frames[i].steps[k].kind    = blob[pos];
+            frames[i].steps[k].reg     = blob[pos + 1];
+            frames[i].steps[k].end_off = bin.read_u32_le(blob, pos + 4);
+            frames[i].steps[k].value   = bin.read_u64_le(blob, pos + 8);
+            pos = pos + 16;
+            k = k + 1;
+        }
+        i = i + 1;
+    }
+
+    out.frames = frames;
+    out.frame_count = count;
+
+    # strip the metadata: the slot stays for ordinal stability, its content goes.
+    A.deallocate[u8](alloc, sec.bytes, sec.len::usize);
+    sec.bytes = nil;
+    sec.len = 0;
     ret R.ok[bool, str](true);
 }
 
@@ -4421,6 +4716,130 @@ test "mach.lang.target.of.coff:emit_parse_round_trip" {
 # so the in-memory image and its re-parsed object are link-equivalent (#1865)
 # `.pdata` round-trips as writer-owned exception metadata rather than ordinary
 # read-only data, preserving the distinction the executable writer needs
+# a declared frame-unwind record survives the object round-trip (#3096): the
+# emit serializes `.mach.frames` name-keyed by function symbol, the parse
+# restores each record at wherever its function landed - including a WEAK
+# function the emit moved into its own COMDAT section (#2125) - and the
+# metadata section itself is stripped to zero length. this is the seam the test
+# dispatcher and every warm incremental link cross: a record that does not
+# round-trip here ships binaries whose functions silently lost their unwind data
+test "mach.lang.target.of.coff:frame_record_round_trip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+    var isa_vt: isa.IsaVTable = t_isa(isa.ARCH_X86_64);
+
+    var text_bytes: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text_bytes[k] = 0x90; k = k + 1; }
+
+    var secs: [1]of.Section;
+    secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
+    secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
+
+    # a plain function and a defined WEAK one: the weak body is re-homed into a
+    # COMDAT carrier section at emit, so its record must resolve through the
+    # symbol, never through the pre-split (section, offset).
+    var syms: [2]of.Symbol;
+    syms[0].name = t_intern(?i, "deep"); syms[0].section = 0; syms[0].offset = 0;
+    syms[0].size = 8; syms[0].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_FUNCTION;
+    syms[1].name = t_intern(?i, "wfn"); syms[1].section = 0; syms[1].offset = 8;
+    syms[1].size = 8;
+    syms[1].flags = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+
+    var frames: [2]of.FrameUnwind;
+    frames[0].section = 0; frames[0].offset = 0; frames[0].step_count = 2;
+    frames[0].steps[0].kind = of.FRAME_STEP_PUSH;  frames[0].steps[0].reg = 5; frames[0].steps[0].end_off = 1;    frames[0].steps[0].value = 0;
+    frames[0].steps[1].kind = of.FRAME_STEP_ALLOC; frames[0].steps[1].reg = 0; frames[0].steps[1].end_off = 0x2D; frames[0].steps[1].value = 0x6040;
+    frames[1].section = 0; frames[1].offset = 8; frames[1].step_count = 2;
+    frames[1].steps[0].kind = of.FRAME_STEP_PUSH; frames[1].steps[0].reg = 5; frames[1].steps[0].end_off = 1; frames[1].steps[0].value = 0;
+    frames[1].steps[1].kind = of.FRAME_STEP_SAVE; frames[1].steps[1].reg = 3; frames[1].steps[1].end_off = 8; frames[1].steps[1].value = 0x18;
+
+    var img: of.ObjectImage;
+    img.alloc = ?alloc;
+    img.interner = ?i;
+    img.name = t_intern(?i, "frt");
+    img.sections = ?secs[0]; img.section_count = 1;
+    img.symbols = ?syms[0]; img.symbol_count = 2;
+    img.frames = ?frames[0]; img.frame_count = 2;
+
+    val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_frt");
+    if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
+    var tf: fs.TempFile = R.unwrap_ok[fs.TempFile, str](tf_r);
+    val tpath: str = fs.temp_path(?tf);
+
+    val em: R.Result[bool, str] = coff_emit_object(?isa_vt, ?img, tpath::*u8);
+    if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 2; }
+
+    val rb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    fs.temp_close_and_remove(?tf);
+    if (R.is_err[Vector[u8], str](rb)) { ret 3; }
+    val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+
+    var out: of.ObjectImage;
+    val pr: R.Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
+    if (R.is_err[bool, str](pr)) { ret 4; }
+
+    if (out.frame_count != 2) { ret 5; }
+
+    # each record must sit exactly at its function symbol's parsed location.
+    val deep_id: intern.StrId = t_intern(?i, "deep");
+    val wfn_id: intern.StrId = t_intern(?i, "wfn");
+    var seen_deep: bool = false;
+    var seen_wfn: bool = false;
+    var fi: u32 = 0;
+    for (fi < out.frame_count) {
+        val fr: *of.FrameUnwind = ?out.frames[fi];
+        var sy: u32 = 0;
+        for (sy < out.symbol_count) {
+            val sym: *of.Symbol = ?out.symbols[sy];
+            if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) == 0) { sy = sy + 1; cnt; }
+            if (sym.section != fr.section || sym.offset != fr.offset) { sy = sy + 1; cnt; }
+            if (sym.name == deep_id) {
+                if (fr.step_count != 2)                          { ret 6; }
+                if (fr.steps[1].kind != of.FRAME_STEP_ALLOC)     { ret 7; }
+                if (fr.steps[1].value != 0x6040)                 { ret 8; }
+                if (fr.steps[1].end_off != 0x2D)                 { ret 9; }
+                seen_deep = true;
+            }
+            if (sym.name == wfn_id) {
+                if (fr.step_count != 2)                      { ret 10; }
+                if (fr.steps[1].kind != of.FRAME_STEP_SAVE)  { ret 11; }
+                if (fr.steps[1].reg != 3)                    { ret 12; }
+                if (fr.steps[1].value != 0x18)               { ret 13; }
+                seen_wfn = true;
+            }
+            sy = sy + 1;
+        }
+        fi = fi + 1;
+    }
+    if (!seen_deep || !seen_wfn) { ret 14; }
+
+    # the weak record really crossed the split: it does not sit in the same parsed
+    # section as the plain one (the carrier is its own COMDAT section).
+    var deep_sec: u32 = 0xFFFFFFFF;
+    var wfn_sec: u32 = 0xFFFFFFFF;
+    var sy2: u32 = 0;
+    for (sy2 < out.symbol_count) {
+        if (out.symbols[sy2].name == deep_id) { deep_sec = out.symbols[sy2].section; }
+        if (out.symbols[sy2].name == wfn_id)  { wfn_sec = out.symbols[sy2].section; }
+        sy2 = sy2 + 1;
+    }
+    if (deep_sec == wfn_sec) { ret 15; }
+
+    # the metadata section was stripped: whatever slot it holds is empty.
+    val frames_id: intern.StrId = t_intern(?i, MACH_FRAMES_SECTION_NAME);
+    var si: u32 = 0;
+    for (si < out.section_count) {
+        if (out.sections[si].name == frames_id) {
+            if (out.sections[si].len != 0 || out.sections[si].bytes != nil) { ret 16; }
+        }
+        si = si + 1;
+    }
+
+    ret 0;
+}
+
 test "mach.lang.target.of.coff:exception_section_round_trip" {
     var alloc: A.Allocator;
     page.make(?alloc);

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2633,33 +2633,35 @@ fun push_save_xmm128(uw: *FunctionUnwind, end_off: u8, reg: u8, save_off: usize)
                          (save_off & 0xFFFF)::u16, ((save_off >> 16) & 0xFFFF)::u16, 2);
 }
 
-# whether a vector register number is callee-saved under the
-# win64 ABI (XMM6-XMM15)
-fun is_win64_nonvol_xmm(reg: u8) bool {
-    ret reg >= 6 && reg <= 15;
-}
-
-# whether a register number is callee-saved under the win64
-# ABI (RBX, RBP, RSI, RDI, R12-R15)
-fun is_win64_nonvol_reg(reg: u8) bool {
-    if (reg == 3 || reg == 5 || reg == 6 || reg == 7) { ret true; }  # RBX/RBP/RSI/RDI
-    if (reg >= 12 && reg <= 15) { ret true; }  # R12-R15
-    ret false;
-}
-
-# decode one emitted function's canonical prologue
-# (push rbp; mov rbp,rsp; sub rsp,N; nonvolatile saves) into x64 unwind codes;
-# false when the bytes are not the recognized fixed-frame shape
+# build one emitted function's x64 unwind codes from its DECLARED frame-unwind
+# record (`of.ExecFunction.steps`), the facts the encoder recorded as it emitted
+# the prologue; false when the function carries no record or the record does not
+# encode
 #
-# A frame-omitting function (`mir.MirFrame.omit`, #1940) has no `push rbp` to
-# find, so it falls out here and contributes no RUNTIME_FUNCTION. That is what
-# the win64 ABI requires rather than a gap in coverage: a function that
-# allocates no stack, saves no nonvolatile register and calls nothing is a leaf,
-# and leaf functions carry no unwind data. `.pdata` has always been sparse - a
-# `#[naked]` entry point reaches this same exit, and there the absence is the
-# author's contract rather than a derived fact - and the elision only widens the
-# set that legitimately takes it.
-fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count: u32,
+# THE RECORD IS THE ONLY SOURCE (#3096). This writer used to re-derive the facts by
+# pattern-matching prologue bytes, and every shape the pattern did not recognize -
+# the probed page-walk a >1-page frame gets on windows, the realigned frame -
+# silently understated its unwind data to a bare PUSH, which is exactly the record
+# an unwinder trusts most and checks least. Declared facts cannot fall out of a
+# pattern, and a shape the backend adds tomorrow ships its unwind data by
+# construction or fails the build in the encoder, never silently here.
+#
+# A record-less function contributes no RUNTIME_FUNCTION. For mach's own code that
+# is a frame-omitting leaf or a `#[naked]` body (`mir.MirFrame.omit`, #1940), and
+# the win64 ABI wants exactly that: a function that allocates no stack, saves no
+# nonvolatile register and calls nothing carries no unwind data. A foreign
+# function is also record-less - its unwind data, when it has any, arrives through
+# its object's own `.pdata`/`.xdata` (#2535), which `collect_function_unwind`
+# already treats as authoritative.
+#
+# The frame model mirrors what the prologue guarantees. A fixed-RSP frame (no
+# FRAME_STEP_SET_FP) declares no frame register: RSP holds still for the whole
+# body, so RSP-based save offsets stay valid and `mov rbp, rsp` needs no code at
+# all - RBP is restored by its UWOP_PUSH_NONVOL. A probed allocation is one
+# UWOP_ALLOC_SMALL/LARGE of the declared total; how RSP walked there is not an
+# unwind fact. A realigned frame declares UWOP_SET_FPREG instead, so the unwinder
+# recovers RSP through the frame register that the mask could not move.
+fun build_function_unwind(uw: *FunctionUnwind, seg_count: u32,
                           funcs: *of.ExecFunction, idx: u32) bool {
     uw.seg_index = funcs[idx].seg_index;
     uw.seg_offset = funcs[idx].seg_offset;
@@ -2673,151 +2675,61 @@ fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count:
     uw.xdata_size = 0;
 
     if (uw.seg_index >= seg_count || uw.size == 0) { ret false; }
-    val seg: *of.LoadSegment = ?segs[uw.seg_index];
-    if (seg.bytes == nil)                   { ret false; }
-    if (uw.seg_offset::usize >= seg.filesz) { ret false; }
-    val lim_all: usize = seg.filesz - uw.seg_offset::usize;
-    var lim: usize = uw.size::usize;
-    if (lim > lim_all) { lim = lim_all; }
-    if (lim < 4)       { ret false; }
+    if (funcs[idx].step_count == 0)                { ret false; }
+    if (funcs[idx].step_count > of.FRAME_STEP_CAP) { ret false; }
 
-    val base: usize = uw.seg_offset::usize;
-    var pos: usize = 0;
+    var prolog_end: u32 = 0;
+    var i: u32 = 0;
+    for (i < funcs[idx].step_count) {
+        val stp: *of.FrameStep = ?funcs[idx].steps[i];
+        # a prologue offset is a u8 in UNWIND_INFO, and every step lies inside the
+        # function it describes.
+        if (stp.end_off == 0 || stp.end_off > 255)   { ret false; }
+        if (stp.end_off::u32 > funcs[idx].size)      { ret false; }
+        if (stp.end_off > prolog_end)                { prolog_end = stp.end_off; }
+        val end8: u8 = stp.end_off::u8;
 
-    if (seg.bytes[base] != 0x55)                                        { ret false; }
-    if (!push_unwind_code(uw, 1, UWOP_PUSH_NONVOL, UWREG_RBP, 0, 0, 0)) { ret false; }
-    pos = 1;
-
-    if (pos + 3 > lim) { ret false; }
-    if (seg.bytes[base + pos] != 0x48 || seg.bytes[base + pos + 1] != 0x89 || seg.bytes[base + pos + 2] != 0xE5) {
-        ret false;
-    }
-    pos = pos + 3;
-    # no frame register is declared: this prologue leaves RSP fixed for the whole
-    # body, so RtlVirtualUnwind takes RSP as the offset base and the RSP-relative
-    # save offsets below stay valid. `mov rbp,rsp` needs no unwind code - RBP is
-    # restored by the UWOP_PUSH_NONVOL above. frame_reg/frame_off stay 0.
-
-    var alloc: usize = 0;
-    if (pos + 4 <= lim
-        && seg.bytes[base + pos] == 0x48
-        && seg.bytes[base + pos + 1] == 0x83
-        && seg.bytes[base + pos + 2] == 0xEC) {
-        alloc = seg.bytes[base + pos + 3]::usize;
-        if (!push_alloc_code(uw, (pos + 4)::u8, alloc)) { ret false; }
-        pos = pos + 4;
-    }
-    or (pos + 7 <= lim
-         && seg.bytes[base + pos] == 0x48
-         && seg.bytes[base + pos + 1] == 0x81
-         && seg.bytes[base + pos + 2] == 0xEC) {
-        alloc = bin.read_u32_le(seg.bytes, base + pos + 3)::usize;
-        if (!push_alloc_code(uw, (pos + 7)::u8, alloc)) { ret false; }
-        pos = pos + 7;
-    }
-
-    for (true) {
-        var cur: usize = pos;
-        if (cur + 3 > lim) { brk; }
-        var rex: u8 = 0;
-        if (seg.bytes[base + cur] >= 0x40 && seg.bytes[base + cur] <= 0x4F) {
-            rex = seg.bytes[base + cur];
-            cur = cur + 1;
-            if (cur + 2 > lim) { brk; }
+        if (stp.kind == of.FRAME_STEP_PUSH) {
+            if (!push_unwind_code(uw, end8, UWOP_PUSH_NONVOL, stp.reg & 0x0F, 0, 0, 0)) { ret false; }
         }
-        if (seg.bytes[base + cur] != 0x89) { brk; }
-        if ((rex & 8) == 0)                { brk; }
-        val modrm: u8 = seg.bytes[base + cur + 1];
-        val mod: u8 = modrm >> 6;
-        # rm==5 with mod 1|2 is [rbp+disp] only when REX.B is clear; with REX.B set
-        # it addresses [r13+disp], so a body `mov [r13+disp], r64` is not a save.
-        if ((modrm & 7) != 5 || (mod != 1 && mod != 2) || (rex & 1) != 0) { brk; }
-
-        var disp: i64 = 0;
-        var inst_len: usize = 0;
-        if (mod == 1) {
-            if (cur + 3 > lim) { brk; }
-            disp = (seg.bytes[base + cur + 2]::i8)::i64;
-            inst_len = 3;
+        or (stp.kind == of.FRAME_STEP_ALLOC) {
+            if (!push_alloc_code(uw, end8, stp.value::usize)) { ret false; }
+        }
+        or (stp.kind == of.FRAME_STEP_SET_FP) {
+            # the header nibbles carry the register and its scaled distance above
+            # RSP at establishment; the code slot marks WHEN it was established.
+            if ((stp.value & 15) != 0 || stp.value / 16 > 15) { ret false; }
+            uw.frame_reg = stp.reg & 0x0F;
+            uw.frame_off = (stp.value / 16)::u8;
+            if (!push_unwind_code(uw, end8, UWOP_SET_FPREG, 0, 0, 0, 0)) { ret false; }
+        }
+        or (stp.kind == of.FRAME_STEP_SAVE) {
+            if (!push_save_nonvol(uw, end8, stp.reg & 0x0F, stp.value::usize)) { ret false; }
+        }
+        or (stp.kind == of.FRAME_STEP_SAVE_VEC) {
+            if (!push_save_xmm128(uw, end8, stp.reg & 0x0F, stp.value::usize)) { ret false; }
         }
         or {
-            if (cur + 6 > lim) { brk; }
-            disp = (bin.read_u32_le(seg.bytes, base + cur + 2)::i32)::i64;
-            inst_len = 6;
+            ret false;
         }
-        if (disp >= 0) { brk; }
-
-        val off_rbp: usize = (-disp)::usize;
-        if (alloc < off_rbp) { ret false; }
-        val save_off: usize = alloc - off_rbp;
-        var reg: u8 = ((modrm >> 3) & 7);
-        if ((rex & 4) != 0)                                             { reg = reg + 8; }
-        if (!is_win64_nonvol_reg(reg))                                  { brk; }
-        if (!push_save_nonvol(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
-        pos = cur + inst_len;
-    }
-
-    # callee-saved XMM saves (`movaps [rbp-off], xmm`), emitted after the GP saves
-    # under win64. each is `[REX.R] 0F 29 modrm disp` storing an XMM6-15 to a
-    # 16-aligned frame slot; recorded as UWOP_SAVE_XMM128 so the unwinder restores
-    # the full register. parsing them here keeps the prologue size and the unwind
-    # codes complete (an unrecognized save would leave them silently invisible).
-    for (true) {
-        var cur: usize = pos;
-        if (cur + 4 > lim) { brk; }
-        var rex: u8 = 0;
-        if (seg.bytes[base + cur] >= 0x40 && seg.bytes[base + cur] <= 0x4F) {
-            rex = seg.bytes[base + cur];
-            cur = cur + 1;
-            if (cur + 4 > lim) { brk; }
-        }
-        # MOVAPS store is `0F 29 /r`; a REX.B extended base is not [rbp].
-        if (seg.bytes[base + cur] != 0x0F || seg.bytes[base + cur + 1] != 0x29) { brk; }
-        if ((rex & 1) != 0)                                                     { brk; }
-        val modrm: u8 = seg.bytes[base + cur + 2];
-        val mod: u8 = modrm >> 6;
-        if ((modrm & 7) != 5 || (mod != 1 && mod != 2)) { brk; }
-
-        var disp: i64 = 0;
-        var inst_len: usize = 0;
-        if (mod == 1) {
-            if (cur + 4 > lim) { brk; }
-            disp = (seg.bytes[base + cur + 3]::i8)::i64;
-            inst_len = 4;
-        }
-        or {
-            if (cur + 7 > lim) { brk; }
-            disp = (bin.read_u32_le(seg.bytes, base + cur + 3)::i32)::i64;
-            inst_len = 7;
-        }
-        if (disp >= 0) { brk; }
-
-        val off_rbp: usize = (-disp)::usize;
-        if (alloc < off_rbp) { ret false; }
-        val save_off: usize = alloc - off_rbp;
-        var reg: u8 = ((modrm >> 3) & 7);
-        if ((rex & 4) != 0)                                             { reg = reg + 8; }
-        if (!is_win64_nonvol_xmm(reg))                                  { brk; }
-        if (!push_save_xmm128(uw, (cur + inst_len)::u8, reg, save_off)) { ret false; }
-        pos = cur + inst_len;
+        i = i + 1;
     }
 
     if (uw.code_count == 0) { ret false; }
-    if (pos > 255)          { ret false; }
-    uw.prolog_size = pos::u8;
+    uw.prolog_size = prolog_end::u8;
     uw.xdata_size = bin.align_up(4 + uw.slot_count::usize * 2, 4);
     ret true;
 }
 
-# parse every emitted function into `out`, returning the
-# count whose prologue matched and that carry unwind data
+# build every emitted function's unwind data into `out` from its declared frame
+# record, returning the count that carry one
 fun collect_function_unwind(segs: *of.LoadSegment, seg_count: u32, funcs: *of.ExecFunction,
                             func_count: u32, exceptions: *of.Section, exception_count: u32,
                             image_base: u64, out: *FunctionUnwind) u32 {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < func_count) {
-        if (parse_function_unwind(?out[n], segs, seg_count, funcs, i)) {
+        if (build_function_unwind(?out[n], seg_count, funcs, i)) {
             val begin: u64 = segs[out[n].seg_index].vaddr - image_base
                             + out[n].seg_offset::u64;
             if (begin <= 0xFFFFFFFF
@@ -6019,10 +5931,15 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     segs[0].vaddr = base; segs[0].filesz = 14; segs[0].memsz = 14;
     segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
 
+    # the function's declared frame record, matching the prologue bytes above.
     var funcs: [1]of.ExecFunction;
     funcs[0].seg_index = 0;
     funcs[0].seg_offset = 0;
     funcs[0].size = 14;
+    funcs[0].step_count = 3;
+    funcs[0].steps[0].kind = of.FRAME_STEP_PUSH;  funcs[0].steps[0].reg = 5; funcs[0].steps[0].end_off = 1;  funcs[0].steps[0].value = 0;
+    funcs[0].steps[1].kind = of.FRAME_STEP_ALLOC; funcs[0].steps[1].reg = 0; funcs[0].steps[1].end_off = 8;  funcs[0].steps[1].value = 0x20;
+    funcs[0].steps[2].kind = of.FRAME_STEP_SAVE;  funcs[0].steps[2].reg = 3; funcs[0].steps[2].end_off = 12; funcs[0].steps[2].value = 0x18;
 
     val tf_r: R.Result[fs.TempFile, str] = fs.temp_create(?alloc, "coff_unw");
     if (R.is_err[fs.TempFile, str](tf_r)) { ret 1; }
@@ -6102,7 +6019,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
 }
 
 # foreign `.pdata` owns its runtime-function row when the same function also
-# matches mach's prologue recognizer. the writer publishes exactly one copied row
+# declares a frame-unwind record. the writer publishes exactly one copied row
 # and keeps the foreign `.xdata` in its ordinary read-only segment instead of
 # synthesizing a duplicate unwind record
 test "mach.lang.target.of.coff.coff_emit_exec:foreign_pdata_authoritative" {
@@ -6134,8 +6051,14 @@ test "mach.lang.target.of.coff.coff_emit_exec:foreign_pdata_authoritative" {
     segs[1].vaddr = image_base + 0x3000; segs[1].filesz = 8; segs[1].memsz = 8;
     segs[1].flags = of.SEG_FLAG_READ; segs[1].bytes = ?xdata_bytes[0];
 
+    # the function DECLARES a frame record, so the synthesized path would cover it -
+    # the foreign row must still win outright.
     var funcs: [1]of.ExecFunction;
     funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 14;
+    funcs[0].step_count = 3;
+    funcs[0].steps[0].kind = of.FRAME_STEP_PUSH;  funcs[0].steps[0].reg = 5; funcs[0].steps[0].end_off = 1;  funcs[0].steps[0].value = 0;
+    funcs[0].steps[1].kind = of.FRAME_STEP_ALLOC; funcs[0].steps[1].reg = 0; funcs[0].steps[1].end_off = 8;  funcs[0].steps[1].value = 0x20;
+    funcs[0].steps[2].kind = of.FRAME_STEP_SAVE;  funcs[0].steps[2].reg = 3; funcs[0].steps[2].end_off = 12; funcs[0].steps[2].value = 0x18;
 
     var pdata_bytes: [12]u8;
     bin.write_u32_le(?pdata_bytes[0], 0, 0x2000);
@@ -6255,28 +6178,22 @@ test "mach.lang.target.of.coff.push_save_nonvol:far_form_unscaled" {
     ret 0;
 }
 
-# parse_function_unwind decodes callee-saved XMM saves as SAVE_XMM128 (#1254)
-test "mach.lang.target.of.coff.parse_function_unwind:save_xmm128" {
-    # push rbp; mov rbp,rsp; sub rsp,0x40; mov [rbp-8],rbx;
-    # movaps [rbp-0x20],xmm6; movaps [rbp-0x30],xmm8 (REX.R); ret
-    var text_bytes: [22]u8;
-    text_bytes[0] = 0x55;
-    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
-    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x40;
-    text_bytes[8] = 0x48; text_bytes[9] = 0x89; text_bytes[10] = 0x5D; text_bytes[11] = 0xF8;
-    text_bytes[12] = 0x0F; text_bytes[13] = 0x29; text_bytes[14] = 0x75; text_bytes[15] = 0xE0;
-    text_bytes[16] = 0x44; text_bytes[17] = 0x0F; text_bytes[18] = 0x29; text_bytes[19] = 0x45; text_bytes[20] = 0xD0;
-    text_bytes[21] = 0xC3;
-
-    var segs: [1]of.LoadSegment;
-    segs[0].vaddr = 0x140000000; segs[0].filesz = 22; segs[0].memsz = 22;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
-
+# build_function_unwind encodes declared XMM callee saves as SAVE_XMM128 (#1254)
+test "mach.lang.target.of.coff.build_function_unwind:save_xmm128" {
+    # the record for `push rbp; mov rbp,rsp; sub rsp,0x40; mov [rbp-8],rbx;
+    # movaps [rbp-0x20],xmm6; movaps [rbp-0x30],xmm8; ret`, as the encoder
+    # declares it: save offsets measured from the final RSP.
     var funcs: [1]of.ExecFunction;
     funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 22;
+    funcs[0].step_count = 5;
+    funcs[0].steps[0].kind = of.FRAME_STEP_PUSH;     funcs[0].steps[0].reg = 5;  funcs[0].steps[0].end_off = 1;  funcs[0].steps[0].value = 0;
+    funcs[0].steps[1].kind = of.FRAME_STEP_ALLOC;    funcs[0].steps[1].reg = 0;  funcs[0].steps[1].end_off = 8;  funcs[0].steps[1].value = 0x40;
+    funcs[0].steps[2].kind = of.FRAME_STEP_SAVE;     funcs[0].steps[2].reg = 3;  funcs[0].steps[2].end_off = 12; funcs[0].steps[2].value = 0x38;
+    funcs[0].steps[3].kind = of.FRAME_STEP_SAVE_VEC; funcs[0].steps[3].reg = 6;  funcs[0].steps[3].end_off = 16; funcs[0].steps[3].value = 0x20;
+    funcs[0].steps[4].kind = of.FRAME_STEP_SAVE_VEC; funcs[0].steps[4].reg = 8;  funcs[0].steps[4].end_off = 21; funcs[0].steps[4].value = 0x10;
 
     var uw: FunctionUnwind;
-    if (!parse_function_unwind(?uw, ?segs[0], 1, ?funcs[0], 0)) { ret 1; }
+    if (!build_function_unwind(?uw, 1, ?funcs[0], 0)) { ret 1; }
     # PUSH_NONVOL, ALLOC_SMALL, SAVE_NONVOL(rbx), SAVE_XMM128(xmm6), SAVE_XMM128(xmm8).
     if (uw.code_count != 5) { ret 1; }
     if (uw.prolog_size != 21) { ret 1; }  # the whole prologue, including the XMM saves
@@ -6297,30 +6214,23 @@ test "mach.lang.target.of.coff.parse_function_unwind:save_xmm128" {
     ret 0;
 }
 
-# parse_function_unwind decodes the XMM14/15 float-scratch saves (#1254)
-test "mach.lang.target.of.coff.parse_function_unwind:save_xmm128_high" {
+# build_function_unwind encodes the declared XMM14/15 float-scratch saves (#1254)
+test "mach.lang.target.of.coff.build_function_unwind:save_xmm128_high" {
     # the callee-saved float scratch (XMM14/15) is preserved by any win64 function
-    # that performs float work; its prologue MOVAPS saves must decode to
-    # UWOP_SAVE_XMM128 just like the allocatable XMM6-13. both carry REX.R (reg >= 8).
-    # push rbp; mov rbp,rsp; sub rsp,0x40;
-    # movaps [rbp-0x10],xmm14 (44 0F 29 75 F0); movaps [rbp-0x20],xmm15 (44 0F 29 7D E0); ret
-    var text_bytes: [19]u8;
-    text_bytes[0] = 0x55;
-    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
-    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x40;
-    text_bytes[8] = 0x44; text_bytes[9] = 0x0F; text_bytes[10] = 0x29; text_bytes[11] = 0x75; text_bytes[12] = 0xF0;
-    text_bytes[13] = 0x44; text_bytes[14] = 0x0F; text_bytes[15] = 0x29; text_bytes[16] = 0x7D; text_bytes[17] = 0xE0;
-    text_bytes[18] = 0xC3;
-
-    var segs: [1]of.LoadSegment;
-    segs[0].vaddr = 0x140000000; segs[0].filesz = 19; segs[0].memsz = 19;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
-
+    # that performs float work; its declared saves must encode to UWOP_SAVE_XMM128
+    # just like the allocatable XMM6-13 (the info nibble carries reg >= 8).
+    # the record for `push rbp; mov rbp,rsp; sub rsp,0x40;
+    # movaps [rbp-0x10],xmm14; movaps [rbp-0x20],xmm15; ret`.
     var funcs: [1]of.ExecFunction;
     funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 19;
+    funcs[0].step_count = 4;
+    funcs[0].steps[0].kind = of.FRAME_STEP_PUSH;     funcs[0].steps[0].reg = 5;  funcs[0].steps[0].end_off = 1;  funcs[0].steps[0].value = 0;
+    funcs[0].steps[1].kind = of.FRAME_STEP_ALLOC;    funcs[0].steps[1].reg = 0;  funcs[0].steps[1].end_off = 8;  funcs[0].steps[1].value = 0x40;
+    funcs[0].steps[2].kind = of.FRAME_STEP_SAVE_VEC; funcs[0].steps[2].reg = 14; funcs[0].steps[2].end_off = 13; funcs[0].steps[2].value = 0x30;
+    funcs[0].steps[3].kind = of.FRAME_STEP_SAVE_VEC; funcs[0].steps[3].reg = 15; funcs[0].steps[3].end_off = 18; funcs[0].steps[3].value = 0x20;
 
     var uw: FunctionUnwind;
-    if (!parse_function_unwind(?uw, ?segs[0], 1, ?funcs[0], 0)) { ret 1; }
+    if (!build_function_unwind(?uw, 1, ?funcs[0], 0)) { ret 1; }
     # PUSH_NONVOL, ALLOC_SMALL, SAVE_XMM128(xmm14), SAVE_XMM128(xmm15).
     if (uw.code_count != 4)   { ret 1; }
     if (uw.prolog_size != 18) { ret 1; }
@@ -6363,32 +6273,65 @@ test "mach.lang.target.of.coff.push_save_xmm128:far_form_unscaled" {
 }
 
 # parse_function_unwind rejects an [r13+disp] store as a nonvolatile save (REX.B)
-test "mach.lang.target.of.coff.parse_function_unwind:rejects_r13_store" {
-    # push rbp; mov rbp,rsp; sub rsp,0x20; mov [r13-8],r12; ret
-    var text_bytes: [13]u8;
-    text_bytes[0] = 0x55;
-    text_bytes[1] = 0x48; text_bytes[2] = 0x89; text_bytes[3] = 0xE5;
-    text_bytes[4] = 0x48; text_bytes[5] = 0x83; text_bytes[6] = 0xEC; text_bytes[7] = 0x20;
-    text_bytes[8] = 0x4D; text_bytes[9] = 0x89; text_bytes[10] = 0x65; text_bytes[11] = 0xF8;
-    text_bytes[12] = 0xC3;
-
-    var segs: [1]of.LoadSegment;
-    segs[0].vaddr = 0x140000000; segs[0].filesz = 13; segs[0].memsz = 13;
-    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text_bytes[0];
-
+# a record-less function contributes no unwind data - a frame-omitting leaf, a
+# `#[naked]` body, and every foreign function take this exit, and no byte-pattern
+# fallback may resurrect one (#3096)
+test "mach.lang.target.of.coff.build_function_unwind:recordless_contributes_nothing" {
     var funcs: [1]of.ExecFunction;
     funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 13;
+    funcs[0].step_count = 0;
 
     var uw: FunctionUnwind;
-    if (!parse_function_unwind(?uw, ?segs[0], 1, ?funcs[0], 0)) { ret 1; }
-    # only PUSH_NONVOL + ALLOC_SMALL - the [r13-8] store must not become a save.
-    if (uw.code_count != 2) { ret 1; }
-    var k: u32 = 0;
-    for (k < uw.code_count) {
-        if (uw.codes[k].op == UWOP_SAVE_NONVOL || uw.codes[k].op == UWOP_SAVE_NONVOL_FAR) { ret 1; }
-        k = k + 1;
-    }
-    if (uw.prolog_size != 8) { ret 1; }  # prologue ends at the sub rsp; the r13 store is body
+    if (build_function_unwind(?uw, 1, ?funcs[0], 0)) { ret 1; }
+    ret 0;
+}
+
+# a probed >1-page frame's declared allocation encodes as one UWOP_ALLOC_LARGE of
+# the total - the page-walk is how RSP got there, not an unwind fact (#3096)
+test "mach.lang.target.of.coff.build_function_unwind:probed_alloc_large" {
+    # the record for the #3091 field shape: push rbp; mov rbp,rsp; then the
+    # 0x6040-byte probe walk ending at prologue offset 0x2D.
+    var funcs: [1]of.ExecFunction;
+    funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 0x200;
+    funcs[0].step_count = 2;
+    funcs[0].steps[0].kind = of.FRAME_STEP_PUSH;  funcs[0].steps[0].reg = 5; funcs[0].steps[0].end_off = 1;    funcs[0].steps[0].value = 0;
+    funcs[0].steps[1].kind = of.FRAME_STEP_ALLOC; funcs[0].steps[1].reg = 0; funcs[0].steps[1].end_off = 0x2D; funcs[0].steps[1].value = 0x6040;
+
+    var uw: FunctionUnwind;
+    if (!build_function_unwind(?uw, 1, ?funcs[0], 0)) { ret 1; }
+    if (uw.code_count != 2)    { ret 1; }
+    if (uw.prolog_size != 0x2D) { ret 1; }
+    if (uw.frame_reg != 0)     { ret 1; }
+
+    val a: *UnwindCode = ?uw.codes[1];
+    if (a.op != UWOP_ALLOC_LARGE)      { ret 1; }
+    if (a.info != 0)                   { ret 1; }  # one-slot scaled form
+    if (a.extra_slots != 1)            { ret 1; }
+    if (a.extra0 != (0x6040 / 8)::u16) { ret 1; }
+    if (a.end_off != 0x2D)             { ret 1; }
+    ret 0;
+}
+
+# a realigned frame's record declares the frame pointer: the header nibbles carry
+# RBP with a zero scaled offset and a UWOP_SET_FPREG slot marks its establishment,
+# so an unwinder recovers RSP through the register the mask could not move (#3096)
+test "mach.lang.target.of.coff.build_function_unwind:set_fpreg_realigned" {
+    var funcs: [1]of.ExecFunction;
+    funcs[0].seg_index = 0; funcs[0].seg_offset = 0; funcs[0].size = 0x80;
+    funcs[0].step_count = 2;
+    funcs[0].steps[0].kind = of.FRAME_STEP_PUSH;   funcs[0].steps[0].reg = 5; funcs[0].steps[0].end_off = 1; funcs[0].steps[0].value = 0;
+    funcs[0].steps[1].kind = of.FRAME_STEP_SET_FP; funcs[0].steps[1].reg = 5; funcs[0].steps[1].end_off = 4; funcs[0].steps[1].value = 0;
+
+    var uw: FunctionUnwind;
+    if (!build_function_unwind(?uw, 1, ?funcs[0], 0)) { ret 1; }
+    if (uw.code_count != 2)  { ret 1; }
+    if (uw.prolog_size != 4) { ret 1; }
+    if (uw.frame_reg != 5)   { ret 1; }
+    if (uw.frame_off != 0)   { ret 1; }
+
+    val c: *UnwindCode = ?uw.codes[1];
+    if (c.op != UWOP_SET_FPREG) { ret 1; }
+    if (c.end_off != 4)         { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/coff_unwind_runtime.mach
+++ b/src/lang/target/of/coff_unwind_runtime.mach
@@ -1,0 +1,132 @@
+# colocated runtime unwind suite for the PE writer's synthesized `.xdata`
+# (#3096). the structural test cross-checks the emitted unwind codes against the
+# prologue bytes; this suite asks the OS ITSELF: `RtlVirtualUnwind` - the engine
+# under SEH dispatch, stack walkers and profilers - virtually unwinds one frame
+# from a context captured inside a function under test, and the recovered
+# RSP/RBP must equal the caller's true values, which the caller captured of
+# itself immediately before the call. a probed (>1 page) frame is the shape the
+# old byte-matcher understated to a bare PUSH: unwinding it then recovered an
+# RSP short by the whole frame, which is exactly what the equality catches.
+#
+# an orphan module: `mach build` never reaches it, `mach test` runs each case as
+# its own process. the Rtl* imports bind to kernel32.dll (which exports all
+# three), the library mach-std already provides to every windows link, so the
+# suite needs no manifest change. windows-x86_64 only: other targets decline by
+# name below.
+#
+# verified under wine (which implements RtlVirtualUnwind) both ways during
+# #3096: a pre-fix compiler's probed frame fails the RSP equality, the declared
+# record passes; the windows CI leg is the authority.
+
+$if ($mach.build.arch == $mach.arch.x86_64 && $mach.build.os == $mach.os.windows) {
+    #[library("kernel32.dll")]
+    ext fun RtlCaptureContext(ctx: ptr);
+    #[library("kernel32.dll")]
+    ext fun RtlLookupFunctionEntry(pc: u64, image_base: *u64, history: ptr) ptr;
+    #[library("kernel32.dll")]
+    ext fun RtlVirtualUnwind(handler_type: u32, image_base: u64, pc: u64, entry: ptr,
+                             ctx: ptr, handler_data: *ptr, establisher: *u64, ctx_ptrs: ptr) ptr;
+
+    # x64 CONTEXT field offsets (winnt.h); the record is 1232 bytes, 16-aligned.
+    val CTX_RSP: u64 = 0x98;
+    val CTX_RBP: u64 = 0xA0;
+    val CTX_RIP: u64 = 0xF8;
+
+    fun ctx_read(base: u64, off: u64) u64 {
+        ret @((base + off)::*u64);
+    }
+
+    # virtually unwind ONE frame from the context at `a` - captured by the caller
+    # inside the function whose frame is under test, so this unwind is driven by
+    # that function's own `.xdata` - and compare the recovered registers with the
+    # grandcaller's true values
+    # ---
+    # a:          16-aligned CONTEXT base holding the captured state
+    # caller_rsp: the true RSP of the function-under-test's caller at the call
+    # caller_rbp: its true RBP
+    # ret:        0 on exact recovery, or a distinct code per failure
+    fun check_caller_recovery(a: u64, caller_rsp: u64, caller_rbp: u64) i64 {
+        val rip: u64 = ctx_read(a, CTX_RIP);
+        var image_base: u64 = 0;
+        val entry: ptr = RtlLookupFunctionEntry(rip, ?image_base, nil::ptr);
+        if (entry::u64 == 0) { ret 11; }
+        var hd: ptr = nil;
+        var est: u64 = 0;
+        RtlVirtualUnwind(0, image_base, rip, entry, a::ptr, ?hd, ?est, nil::ptr);
+        if (ctx_read(a, CTX_RSP) != caller_rsp) { ret 12; }
+        if (ctx_read(a, CTX_RBP) != caller_rbp) { ret 13; }
+        ret 0;
+    }
+
+    # the probed shape: a >1-page frame whose prologue is the mov r11 page-walk.
+    # the old byte-matcher declared only the push for it, so the unwound RSP came
+    # back short by the whole frame.
+    # ---
+    # caller_rsp: the caller's RSP at this call, captured by the caller itself
+    # caller_rbp: the caller's RBP
+    # ret:        0 on exact recovery
+    #[noinline]
+    fun probed_frame(caller_rsp: u64, caller_rbp: u64) i64 {
+        var big: [12000]u8;
+        big[0] = 1;
+        big[11999] = 2;
+        var raw: [1248]u8;
+        raw[0] = 0;
+        val a: u64 = ((?raw[0])::u64 + 15) & ~15::u64;
+        RtlCaptureContext(a::ptr);
+        val rc: i64 = check_caller_recovery(a, caller_rsp, caller_rbp);
+        if (rc != 0) { ret rc; }
+        ret big[0]::i64 + big[11999]::i64 - 3;
+    }
+
+    # the small shape: a bare `sub rsp, imm` frame, the one the byte-matcher did
+    # describe - held here so the record-driven writer proves it did not regress it.
+    # ---
+    # caller_rsp: the caller's RSP at this call
+    # caller_rbp: the caller's RBP
+    # ret:        0 on exact recovery
+    #[noinline]
+    fun small_frame(caller_rsp: u64, caller_rbp: u64) i64 {
+        var buf: [64]u8;
+        buf[0] = 3;
+        buf[63] = 4;
+        var raw: [1248]u8;
+        raw[0] = 0;
+        val a: u64 = ((?raw[0])::u64 + 15) & ~15::u64;
+        RtlCaptureContext(a::ptr);
+        val rc: i64 = check_caller_recovery(a, caller_rsp, caller_rbp);
+        if (rc != 0) { ret rc; }
+        ret buf[0]::i64 + buf[63]::i64 - 7;
+    }
+
+    test "mach.lang.target.of.coff_unwind_runtime:rtl_virtual_unwind_recovers_probed_frame" {
+        var raw: [1248]u8;
+        raw[0] = 0;
+        val a: u64 = ((?raw[0])::u64 + 15) & ~15::u64;
+        RtlCaptureContext(a::ptr);
+        val my_rsp: u64 = ctx_read(a, CTX_RSP);
+        val my_rbp: u64 = ctx_read(a, CTX_RBP);
+        val r: i64 = probed_frame(my_rsp, my_rbp);
+        if (r != 0) { ret r::i32; }
+        ret 0;
+    }
+
+    test "mach.lang.target.of.coff_unwind_runtime:rtl_virtual_unwind_recovers_small_frame" {
+        var raw: [1248]u8;
+        raw[0] = 0;
+        val a: u64 = ((?raw[0])::u64 + 15) & ~15::u64;
+        RtlCaptureContext(a::ptr);
+        val my_rsp: u64 = ctx_read(a, CTX_RSP);
+        val my_rbp: u64 = ctx_read(a, CTX_RBP);
+        val r: i64 = small_frame(my_rsp, my_rbp);
+        if (r != 0) { ret r::i32; }
+        ret 0;
+    }
+}
+$or {
+    # the suite drives the win64 unwinder over win64 frames; other targets have
+    # neither, and decline by name rather than passing vacuously.
+    test "mach.lang.target.of.coff_unwind_runtime:declines_off_win64" {
+        ret 0;
+    }
+}

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4822,6 +4822,13 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     if (buf == nil || out == nil || buf_size < 16) {
         ret R.err[bool, str]("elf: object too small");
     }
+    # start from a fully zeroed image before any field is set: the caller's slot is
+    # arbitrary heap or arena memory, and a field this parser does not know about -
+    # one added to `of.ObjectImage` after it was written - would otherwise carry
+    # garbage into every consumer that sums or walks it (#3096 shipped a garbage
+    # `frame_count` exactly this way; same field-drop class as #2813/#2828).
+    var blank: of.ObjectImage;
+    @out = blank;
     if (buf[0] != 0x7F || buf[1] != 0x45 || buf[2] != 0x4C || buf[3] != 0x46) {
         ret R.err[bool, str](bad_magic_message(itn, alloc, buf));
     }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -4002,6 +4002,13 @@ pub fun parse_object(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_s
     if (buf == nil || out == nil || buf_size < MACH_HEADER_64_SIZE) {
         ret R.err[bool, str]("macho: object too small");
     }
+    # start from a fully zeroed image before any field is set: the caller's slot is
+    # arbitrary heap or arena memory, and a field this parser does not know about -
+    # one added to `of.ObjectImage` after it was written - would otherwise carry
+    # garbage into every consumer that sums or walks it (#3096 shipped a garbage
+    # `frame_count` exactly this way; same field-drop class as #2813/#2828).
+    var blank: of.ObjectImage;
+    @out = blank;
     if (bin.read_u32_le(buf, 0) != MH_MAGIC_64) {
         ret R.err[bool, str]("macho: not a 64-bit Mach-O object (bad magic; expected 0xFEEDFACF)");
     }


### PR DESCRIPTION
Closes #3096

## What was wrong

`parse_function_unwind` synthesized each function's `.pdata`/`.xdata` by pattern-matching prologue bytes and only knew `push rbp; mov rbp, rsp; sub rsp, imm`. A probed prologue (frame > one page: `mov r11, total` + the page-walk) fell out after the push, so the record carried a bare `UWOP_PUSH_NONVOL RBP` - anything unwinding through the frame recovered an RSP short by the whole allocation. A realigned frame (`and rsp, -N`) got no record at all.

Before/after for the probed fixture function (`mov r11, 0x2f10` walk):

```
pre-fix   prolog=4  slots=1   end=1 PUSH_NONVOL rbp
post-fix  prolog=59 slots=7   end=59 SAVE_NONVOL rsi off=0x20
                              end=52 SAVE_NONVOL rbx off=0x28
                              end=45 ALLOC_LARGE size=0x2f10
                              end=1  PUSH_NONVOL rbp
```

## The fix: declared over derived

The prologue's unwind facts are known at emission, so the x64 encoder now records them as it emits (`of.FrameUnwind`, a per-function step list: push / one alloc of the total / frame-pointer establishment / GP+XMM save offsets). The record rides the existing per-function metadata seam end to end:

- `emit_prologue` (isa/x64/encode.mach) pushes steps onto the encoder state, keyed by the function's `.text` offset - the same key its `SymbolMark` carries;
- `pack_frames` (be/codegen.mach) re-homes each record through `site_placed` exactly as symbols and line rows are, so `#[section]` functions keep their records;
- `build_merged_image` (be/linker.mach) rebases records to the merged sections beside the symbols (bulk-copied, not grow-by-one - a record is ~16x a symbol);
- `build_exec_functions` joins them onto `of.ExecFunction` by (section, offset) via a sorted index;
- `build_function_unwind` (of/coff.mach) builds `UNWIND_INFO` from the record.

Frame model, as the prologues actually guarantee:

- **Fixed-RSP frames** (everything but realign): no frame register, RSP-based save offsets - byte-identical `.xdata` to what the matcher produced for small frames (the emit test's exact-byte assertions pass unchanged, now record-driven).
- **Probed frames**: one `UWOP_ALLOC_SMALL/LARGE` of the declared total, ending past the walk's `sub rsp, r11`. The walk is how RSP got there, not an unwind fact. (Mid-walk IPs are described as pre-alloc - the same imprecision window every inline-probe compiler has; the only fault inside the walk is the fatal stack overflow.)
- **Realigned frames**: `UWOP_SET_FPREG` (RBP, offset 0) at establishment, so the unwinder recovers RSP/RBP/return through the frame pointer the mask could not move. Save offsets in such a frame are RSP-relative *after* the mask and have no fixed distance from any unwind base, so callee-saved **values** stay undeclarable - strictly better than before (no record at all), and honest. Making them declarable needs the prologue to save before the mask; noted in the code.
- **Frame-omitting leaves / `#[naked]` / foreign functions**: record-less, contribute no RUNTIME_FUNCTION. Foreign `.pdata` passthrough (#2535) is untouched and still authoritative (its test now declares a record for the colliding function, proving the foreign row still wins).

## The byte-matcher is deleted, not demoted

Keeping it as a debug assertion would mean teaching a disassembler-shaped matcher the probe walk and the realign mask just to re-check facts the encoder wrote one call earlier - and the matcher was itself the thing under suspicion. The cross-check lives in the structural test instead, where it checks the *record against the bytes* rather than deriving the record from them. No path remains where a record-less function gets pattern-matched.

## Verification

- **Structural** (`mach.lang.driver:w64_xdata_declares_every_prologue_shape`): cross-compiles fixture functions covering every emitted allocation shape (imm8 sub / imm32 sub / probed walk), links through the shipping `linker.link_images`, and asserts each `.pdata` entry's `.xdata` declares **exactly one alloc code equal to the total the prologue's own bytes moved RSP by**, at the right end offset, with `push rbp` at offset 1. Unknown prologue shapes and unknown unwind codes fail the test rather than being skipped. **Fail-before proven**: cherry-picked onto current dev in a clean clone - `1549 passed, 1 failed` (exit 16, the probed frame's understated prolog). **Mutation-checked**: dropping the ALLOC step recording in `emit_prologue` fails it (exit 20: no alloc code); restored via reset, marker grepped gone.
- **Runtime** (`of/coff_unwind_runtime.mach`, windows-gated orphan suite): `RtlVirtualUnwind` itself unwinds one frame from a context captured inside a probed-frame function (and a small-frame control), and the recovered RSP/RBP must equal the caller's self-captured truth. Verified under wine both ways: pre-fix compiler exits 12 (wrong RSP through the probed frame), fixed compiler exits 0. Binds the Rtl* trio to kernel32.dll (which exports all three and which mach-std already provides), so no manifest change. The windows CI leg is the authority.
- **Unit** (of/coff.mach): the record-to-codes conversion - probed `ALLOC_LARGE` of the exact total, `SET_FPREG` header nibbles for realign, record-less contributes nothing, XMM save forms (rewritten from the old byte-parse tests, same expected codes).
- **Suite**: 1553/1553 on linux (dev baseline 1549 + 4: net +2 coff unit, +1 structural, +1 runtime decline; the windows leg runs 2 runtime cases instead of the decline). Self-build with the fixed compiler clean, suite green under generation B.

## Notes

- Records are recorded on all x64 targets (the facts are true everywhere); only the COFF writer consumes them today. ELF/Mach-O output is byte-unchanged.
- `obj.rehome_remap` copies the records explicitly (the #2813/#2828 parallel-codegen field-drop trap is documented at the site).
- windows is x86_64-only (coff declares x86_64 coverage; windows/aarch64 fails at composition), so no other-ISA COFF path exists to cover.
- Known follow-up, out of scope: a mach-emitted **`.o`** still carries no `.pdata`/`.xdata` (pre-existing - the matcher also never ran for `.o`s), so a mach object consumed by a foreign linker, or re-parsed from disk as an external link input, has no unwind data for its functions. The honest fix is emitting real `.pdata`/`.xdata` sections in `coff_emit_object` from these same records, which would flow back in through the #2535 passthrough. Happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MfQ6dUDKvvsGE9f9KBSEn

## Update: the windows CI failure, diagnosed and fixed

The first push failed all three windows legs with `error: out of memory` seconds into `mach.exe test .`, while every linux leg was green. Two defects, one loud and one silent, both mine and both now fixed and covered:

1. **Garbage `frame_count` from parsed objects (the OOM).** Every object parser fills the caller's `ObjectImage` field by field, so the new `frames`/`frame_count` fields carried whatever the heap held. The engine links the on-disk runtime object (`obj/std/runtime/windows/x86_64.o`) as a *parsed* input, its garbage `frame_count` summed into the merge's bulk allocation, and one VirtualAlloc asked for **1.35 TB** - which linux `mmap` overcommit absorbs silently (why every linux leg stayed green) and windows commit charging refuses. Found by instrumenting the windows allocator's failure path under wine and tripwiring the allocation sites (`INSTR S1` named the module). All parsers now **zero the whole image at entry** - the same field-drop class as the `rehome_remap` traps (#2813/#2828), closed for parsers as a class.

2. **Records vanished on every disk-linked binary (the silent one).** The test dispatcher *always* links from written `.o` files (engine → `write_objects` → `link_dispatcher`), and warm incremental links do the same - so in-memory-only records disappeared and the dispatcher shipped with **no `.pdata` at all**. The COFF emitter now serializes the records into a mach-private **`.mach.frames`** section (name-keyed by function symbol, so the #2125 weak-COMDAT split can't skew them; layout documented at the constant); `coff_parse_object` restores them and strips the section to zero length (slot kept, so section ordinals hold). ELF/Mach-O don't serialize them - nothing consumes records there yet; noted for when unwind synthesis reaches those formats.

Verification of the update, all under wine with a dev-built control (control: full suite runs, 1519/1549, no OOM - wine apparatus valid):
- fail-repro: my `mach.exe test .` OOM'd exactly as CI; after both fixes the full suite runs (1524/1555; the only mine-only failure is the structural driver test, which fails under wine the same way dev's own `a_manifest_stack_reserve_reaches_the_linked_pe` PE-link test does - a wine temp-file artifact, green on real windows for dev, CI adjudicates mine).
- the dispatcher now carries full `.pdata`/`.xdata`, and **both runtime `RtlVirtualUnwind` tests pass under wine through the disk-linked dispatcher** - the round-trip proven at the OS-unwinder level.
- new unit test `coff:frame_record_round_trip` pins the `.o` seam (plain + weak function, strip check); mutation-checked (decode dropped → exit 5, restored, marker grepped gone).
- linux suite 1554/1554 (baseline 1549 + 5: +2 coff unit, +1 round-trip, +1 structural, +1 runtime decline); self-build clean, suite green under generation B.
